### PR TITLE
6.0: [NoncopyablePartialConsumption] Promote to upcoming feature.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -190,6 +190,7 @@ UPCOMING_FEATURE(GlobalConcurrency, 412, 6)
 UPCOMING_FEATURE(InferSendableFromCaptures, 418, 6)
 UPCOMING_FEATURE(ImplicitOpenExistentials, 352, 6)
 UPCOMING_FEATURE(RegionBasedIsolation, 414, 6)
+UPCOMING_FEATURE(MoveOnlyPartialConsumption, 429, 6)
 
 // Swift 7
 UPCOMING_FEATURE(ExistentialAny, 335, 7)
@@ -216,7 +217,6 @@ EXPERIMENTAL_FEATURE(NoImplicitCopy, true)
 EXPERIMENTAL_FEATURE(OldOwnershipOperatorSpellings, true)
 EXPERIMENTAL_FEATURE(MoveOnlyEnumDeinits, true)
 EXPERIMENTAL_FEATURE(MoveOnlyTuples, true)
-EXPERIMENTAL_FEATURE(MoveOnlyPartialConsumption, true)
 EXPERIMENTAL_FEATURE(MoveOnlyPartialReinitialization, true)
 
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -448,10 +448,8 @@ static bool usesFeatureMoveOnlyEnumDeinits(Decl *decl) {
 
 UNINTERESTING_FEATURE(MoveOnlyTuples)
 
-static bool usesFeatureMoveOnlyPartialConsumption(Decl *decl) {
-  // Partial consumption does not affect declarations directly.
-  return false;
-}
+// Partial consumption does not affect declarations directly.
+UNINTERESTING_FEATURE(MoveOnlyPartialConsumption)
 
 UNINTERESTING_FEATURE(MoveOnlyPartialReinitialization)
 

--- a/test/Interpreter/move_expr_moveonly_partial_consumption.swift
+++ b/test/Interpreter/move_expr_moveonly_partial_consumption.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
-// RUN: %target-run-simple-swift(-parse-as-library -O -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -sil-verify-all -enable-upcoming-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -O -Xfrontend -sil-verify-all -enable-upcoming-feature MoveOnlyPartialConsumption) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/move_expr_moveonly_partial_consumption_addr.swift
+++ b/test/Interpreter/move_expr_moveonly_partial_consumption_addr.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
-// RUN: %target-run-simple-swift(-parse-as-library -O -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -sil-verify-all -enable-upcoming-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -O -Xfrontend -sil-verify-all -enable-upcoming-feature MoveOnlyPartialConsumption) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/moveonly_address_maximize.swift
+++ b/test/Interpreter/moveonly_address_maximize.swift
@@ -1,8 +1,8 @@
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-upcoming-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-upcoming-feature MoveOnlyPartialConsumption) | %FileCheck %s
 
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -Xfrontend -sil-verify-all -enable-upcoming-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-all -enable-upcoming-feature MoveOnlyPartialConsumption) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/moveonly_partial_consume_value.swift
+++ b/test/Interpreter/moveonly_partial_consume_value.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-upcoming-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-upcoming-feature MoveOnlyPartialConsumption) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/SILGen/moveonly_consuming_switch.swift
+++ b/test/SILGen/moveonly_consuming_switch.swift
@@ -2,7 +2,7 @@
 // RUN:     -emit-silgen                                            \
 // RUN:     %s                                                      \
 // RUN:     -enable-experimental-feature BorrowingSwitch            \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -enable-experimental-feature NoncopyableGenerics        \
 // RUN: | %FileCheck %s
 

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-library-evolution %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -O -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-library-evolution %s
+// RUN: %target-swift-emit-silgen -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-library-evolution %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-library-evolution %s
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/SILGen/moveonly_optional_operations_2.swift
+++ b/test/SILGen/moveonly_optional_operations_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature MoveOnlyPartialConsumption -parse-stdlib -module-name Swift %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NoncopyableGenerics -enable-upcoming-feature MoveOnlyPartialConsumption -parse-stdlib -module-name Swift %s | %FileCheck %s
 
 @_marker protocol Copyable {}
 @_marker protocol Escapable {}

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name moveonly_addresschecker -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyPartialConsumption -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -module-name moveonly_addresschecker -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-upcoming-feature MoveOnlyPartialConsumption -enable-sil-verify-all %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/moveonly_addresschecker.swift
+++ b/test/SILOptimizer/moveonly_addresschecker.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s -Xllvm -sil-print-final-ossa-module | %FileCheck %s
-// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s -Xllvm -sil-print-final-ossa-module | %FileCheck %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
 
 // This file contains tests that used to crash due to verifier errors. It must
 // be separate from moveonly_addresschecker_diagnostics since when we fail on

--- a/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
+// RUN: %target-swift-emit-sil -enable-upcoming-feature MoveOnlyPartialConsumption -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -enable-upcoming-feature MoveOnlyPartialConsumption -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
 
 // This test validates that we properly emit errors if we partially invalidate
 // through a type with a deinit.

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -1,8 +1,8 @@
-// RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -verify
-// RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-move-only-address-checker -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -verify
+// RUN: %target-sil-opt -sil-move-only-address-checker -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
 
-// RUN: %target-sil-opt -enable-experimental-feature NoncopyableGenerics -sil-move-only-address-checker -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -verify
-// RUN: %target-sil-opt -enable-experimental-feature NoncopyableGenerics -sil-move-only-address-checker -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-experimental-feature NoncopyableGenerics -sil-move-only-address-checker -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -verify
+// RUN: %target-sil-opt -enable-experimental-feature NoncopyableGenerics -sil-move-only-address-checker -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
 
 // This file contains specific SIL test cases that we expect to emit
 // diagnostics. These are cases where we want to make it easy to validate

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -O -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature BorrowingSwitch -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -O -sil-verify-all -verify -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_ufi.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_ufi.swift
@@ -3,14 +3,14 @@
 // RUN:     %s                                                      \
 // RUN:     -emit-sil -verify -verify-additional-prefix fragile-    \
 // RUN:     -sil-verify-all                                         \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -module-name Library
 // RUN: %target-swift-frontend                                      \
 // RUN:     %s                                                      \
 // RUN:     -emit-sil -verify -verify-additional-prefix resilient-  \
 // RUN:     -sil-verify-all                                         \
 // RUN:     -enable-library-evolution                               \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -module-name Library
 
 public func take(_ u: consuming Ur) {}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_resilient.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_resilient.swift
@@ -5,7 +5,7 @@
 // RUN:     %t/Library.swift                                        \
 // RUN:     -emit-module                                            \
 // RUN:     -enable-library-evolution                               \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -module-name Library                                    \
 // RUN:     -emit-module-path %t/Library.swiftmodule
 
@@ -14,7 +14,7 @@
 // RUN:     -emit-sil -verify                                       \
 // RUN:     -debug-diagnostic-names                                 \
 // RUN:     -sil-verify-all                                         \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -I %t
 
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial_reinit.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial_reinit.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyPartialConsumption %s
-// RUN: %target-swift-emit-sil  -enable-experimental-feature NoncopyableGenerics -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyPartialConsumption %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-upcoming-feature MoveOnlyPartialConsumption %s
+// RUN: %target-swift-emit-sil  -enable-experimental-feature NoncopyableGenerics -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-upcoming-feature MoveOnlyPartialConsumption %s
 
 // Test diagnostics for partial-consumption without partial-reinitialization.
 

--- a/test/SILOptimizer/moveonly_addresschecker_maximize.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_maximize.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyPartialConsumption -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-move-only-address-checker -enable-upcoming-feature MoveOnlyPartialConsumption -enable-sil-verify-all %s | %FileCheck %s
 sil_stage raw
 
 import Builtin

--- a/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
@@ -2,7 +2,7 @@
 // RUN:     -sil-move-only-address-checker                             \
 // RUN:     %s                                                         \
 // RUN:     -module-name moveonly_addresschecker                       \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption    \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption    \
 // RUN:     -enable-experimental-feature MoveOnlyClasses               \
 // RUN:     -enable-sil-verify-all                                     \
 // RUN:     -move-only-address-checker-disable-lifetime-extension=true \

--- a/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-upcoming-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -enable-upcoming-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
 
 
 class CopyableKlass {}

--- a/test/SILOptimizer/moveonly_borrowing_switch_mode_with_partial_consume.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_mode_with_partial_consume.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -verify -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -parse-as-library %s
+// RUN: %target-swift-frontend -emit-sil -verify -enable-experimental-feature BorrowingSwitch -enable-upcoming-feature MoveOnlyPartialConsumption -parse-as-library %s
 
 func foo() {
     let node = Node()

--- a/test/SILOptimizer/moveonly_borrowing_switch_yield.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_yield.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -parse-as-library -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -enable-upcoming-feature MoveOnlyPartialConsumption -parse-as-library -O -emit-sil -verify %s
 
 extension List {
     var peek: Element {

--- a/test/SILOptimizer/moveonly_consuming_switch.swift
+++ b/test/SILOptimizer/moveonly_consuming_switch.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -verify %s
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -enable-upcoming-feature MoveOnlyPartialConsumption -verify %s
 
 // TODO: Remove this and just use the real `UnsafeMutablePointer` when
 // noncopyable type support has been upstreamed.

--- a/test/SILOptimizer/moveonly_consuming_switch_2.swift
+++ b/test/SILOptimizer/moveonly_consuming_switch_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -verify %s
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BorrowingSwitch -enable-upcoming-feature MoveOnlyPartialConsumption -verify %s
 
 struct Box: ~Copyable {
     let ptr: UnsafeMutablePointer<Int>

--- a/test/SILOptimizer/moveonly_generics_basic.swift
+++ b/test/SILOptimizer/moveonly_generics_basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-swift-frontend %s -sil-verify-all -verify -emit-sil -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoncopyableGenerics
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/moveonly_generics_complex.swift
+++ b/test/SILOptimizer/moveonly_generics_complex.swift
@@ -3,7 +3,7 @@
 // RUN:     %s                                                      \
 // RUN:     -enable-experimental-feature BuiltinModule              \
 // RUN:     -enable-experimental-feature NoncopyableGenerics        \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -sil-verify-all
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-upcoming-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
 
 class CopyableKlass {}
 

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-upcoming-feature MoveOnlyPartialConsumption -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_partial_consumption_deinit.swift
+++ b/test/SILOptimizer/moveonly_partial_consumption_deinit.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-emit-sil \
 // RUN:     %s \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -sil-verify-all \
 // RUN:     -verify

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -sil-verify-all -verify %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -enable-upcoming-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -sil-verify-all -verify %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-upcoming-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -enable-upcoming-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume.swift
+++ b/test/SILOptimizer/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume.swift
@@ -5,7 +5,7 @@
 // RUN:     %t/Library.swift                                        \
 // RUN:     -emit-module                                            \
 // RUN:     -package-name Package                                   \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -module-name Library                                    \
 // RUN:     -emit-module-path %t/Library.swiftmodule
 
@@ -15,7 +15,7 @@
 // RUN:     -sil-verify-all                                         \
 // RUN:     -package-name Package                                   \
 // RUN:     -debug-diagnostic-names                                 \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -I %t
 
 // RUN: %empty-directory(%t)
@@ -26,7 +26,7 @@
 // RUN:     -emit-module                                            \
 // RUN:     -package-name Package                                   \
 // RUN:     -enable-library-evolution                               \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -module-name Library                                    \
 // RUN:     -emit-module-path %t/Library.swiftmodule
 
@@ -36,7 +36,7 @@
 // RUN:     -sil-verify-all                                         \
 // RUN:     -package-name Package                                   \
 // RUN:     -debug-diagnostic-names                                 \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -I %t
 
 //--- Library.swift

--- a/test/Sema/move_expr_moveonly_partial_consumption.swift
+++ b/test/Sema/move_expr_moveonly_partial_consumption.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift                              \
 // RUN:     -disable-availability-checking                          \
 // RUN:     -enable-experimental-feature NoImplicitCopy             \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -enable-experimental-feature NoncopyableGenerics        \
 // RUN:     -debug-diagnostic-names
 

--- a/validation-test/IRGen/moveonly_partial_consumption_linked_list.swift
+++ b/validation-test/IRGen/moveonly_partial_consumption_linked_list.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-emit-ir \
 // RUN:     %s \
 // RUN:     -enable-builtin-module \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -enable-experimental-feature BorrowingSwitch \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -sil-verify-all \

--- a/validation-test/SILOptimizer/moveonly_partial_consumption_linked_list.swift
+++ b/validation-test/SILOptimizer/moveonly_partial_consumption_linked_list.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-emit-sil \
 // RUN:     %s \
 // RUN:     -enable-builtin-module \
-// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-upcoming-feature MoveOnlyPartialConsumption \
 // RUN:     -enable-experimental-feature BorrowingSwitch \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -sil-verify-all \


### PR DESCRIPTION
**Explanation**: Promote the noncopyable partial consumption feature from "experimental" to "upcoming".

SE-429 was accepted.
**Scope**: Affects noncopyable code.
**Issue**: rdar://126275392
**Original PR**: https://github.com/apple/swift/pull/72978
**Risk**: Very low.
**Testing**: Existing unit tests were updated to use -enable-upcoming-feature.
**Reviewer**: Tim Kientzle ( @tbkka )
