### PR TITLE
DiagnoseUnreachable: consider borrowed-from instructions when deleting block arguments

### DIFF
--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnose-unreachable -sil-print-debuginfo | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -update-borrowed-from -diagnose-unreachable -sil-print-debuginfo | %FileCheck %s
 
 import Builtin
 import Swift


### PR DESCRIPTION
Fixes a crash when propagating guaranteed phi arguments.

This is a follow-up of https://github.com/apple/swift/pull/71176

rdar://126274522

