### PR TITLE
Add -a/--no-asserts option to build a no-asserts (production) toolchain

### DIFF
--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -26,6 +26,9 @@ function usage() {
   echo "-t --test"
   echo "Run tests."
   echo ""
+  echo "-a --no-assert"
+  echo "No assertions"
+  echo ""
   echo "--distcc"
   echo "Build with distcc to speed up the toolchain build"
   echo ""
@@ -56,6 +59,7 @@ PRESET_PREFIX=
 NO_TEST=",no_test"
 USE_OS_RUNTIME=
 MACOS_ONLY=
+NO_ASSERTIONS=
 
 case $(uname -s) in
   Darwin)
@@ -101,6 +105,9 @@ while [ $# -ne 0 ]; do
   ;;
     --macos-only)
       MACOS_ONLY=",macos_only"
+  ;;
+    -a|--no-assert)
+      NO_ASSERTIONS=",no_assertions"
   ;;
   -h|--help)
     usage
@@ -152,7 +159,7 @@ SCCACHE_FLAG="${SCCACHE_FLAG}"
 
 ./utils/build-script ${DRY_RUN} ${DISTCC_FLAG} ${PRESET_FILE_FLAGS} \
         ${SCCACHE_FLAG} \
-        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${NO_TEST}${USE_OS_RUNTIME}${MACOS_ONLY}" \
+        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${NO_ASSERTIONS}${NO_TEST}${USE_OS_RUNTIME}${MACOS_ONLY}" \
         install_destdir="${SWIFT_INSTALL_DIR}" \
         installable_package="${SWIFT_INSTALLABLE_PACKAGE}" \
         install_toolchain_dir="${SWIFT_TOOLCHAIN_DIR}" \


### PR DESCRIPTION
I recently needed to build a no-asserts toolchain for some testing.