### PR TITLE
Fix a crash when serializing variadic generic tuple code under -wmo

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -293,14 +293,18 @@ public:
         continue;
       }
 
-      // Substitute the shape class of the expansion.
+      // Substitute the shape class of the expansion.  If this doesn't
+      // give us a pack (e.g. if this isn't a substituting clone),
+      // we're never erasing tuple structure.
       auto newShapeClass = getOpASTType(expansion.getCountType());
       auto newShapePack = dyn_cast<PackType>(newShapeClass);
+      if (!newShapePack)
+        return false;
 
       // If the element has a name, then the tuple sticks around unless
       // the expansion disappears completely.
       if (type->getElement(index).hasName()) {
-        if (newShapePack && newShapePack->getNumElements() == 0)
+        if (newShapePack->getNumElements() == 0)
           continue;
         return false;
       }

--- a/test/SILOptimizer/Inputs/cross-module/cross-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/cross-module.swift
@@ -295,3 +295,13 @@ public func getEmptySet() -> Set<Int> {
   return Set()
 }
 
+public protocol Visitable {
+  func visit()
+}
+@available(SwiftStdlib 6.0, *)
+public struct S<each T : Visitable> {
+  var storage: (repeat each T)
+  public func visit() {
+    _ = (repeat (each storage).visit())
+  }
+}


### PR DESCRIPTION
It seems really unfortunate that we use SILCloner to, basically, implement a recursive visitor of the types used in a SIL function, but apparently it's what we do.

Fixes #72117.