### PR TITLE
[6.0] Accept `borrowing` in pattern matches without underscore.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -996,8 +996,10 @@ ERROR(extra_var_in_multiple_pattern_list,none,
       "%0 must be bound in every pattern", (Identifier))
 ERROR(let_pattern_in_immutable_context,none,
       "'let' pattern cannot appear nested in an already immutable context", ())
+WARNING(borrowing_syntax_change,none,
+      "'_borrowing' spelling is deprecated; use 'borrowing' without the underscore", ())
 ERROR(borrowing_subpattern_unsupported,none,
-      "'_borrowing' pattern modifier must be directly applied to pattern variable name", ())
+      "'borrowing' pattern modifier must be directly applied to pattern variable name", ())
 ERROR(specifier_must_have_type,none,
       "%0 arguments must have a type specified", (StringRef))
 ERROR(expected_rparen_parameter,PointsToFirstBadToken,

--- a/test/Inputs/Swiftskell.swift
+++ b/test/Inputs/Swiftskell.swift
@@ -67,7 +67,7 @@ extension Maybe: Copyable {}
 extension Maybe: Show where Value: Show & ~Copyable {
   public borrowing func show() -> String {
     switch self {
-      case let .just(_borrowing elm):
+      case let .just(borrowing elm):
         return elm.show()
       case .nothing:
         return "<nothing>"
@@ -78,9 +78,9 @@ extension Maybe: Show where Value: Show & ~Copyable {
 extension Maybe: Eq where Value: Eq, Value: ~Copyable {
   public static func ==(_ a: borrowing Self, _ b: borrowing Self) -> Bool {
     switch a {
-      case let .just(_borrowing a1):
+      case let .just(borrowing a1):
         switch b {
-          case let .just(_borrowing b1):
+          case let .just(borrowing b1):
             return a1 == b1
           case .nothing:
             return false

--- a/test/Parse/pattern_borrow_bindings.swift
+++ b/test/Parse/pattern_borrow_bindings.swift
@@ -23,7 +23,7 @@ struct SourceBreakTest {
     func callAsFunction() -> Bar { fatalError() }
 }
 
-let _borrowing = SourceBreakTest()
+let borrowing = SourceBreakTest()
 
 func ~=(_: borrowing Bar, _: borrowing Bar) -> Bool { fatalError() }
 
@@ -33,19 +33,22 @@ func useBorrowPayload(_: borrowing Payload) { fatalError() }
 
 func testBorrowingPatterns(bar: borrowing Bar) {
     switch bar {
-    case _borrowing .foo(): // parses as `_borrowing.foo()` as before
+    case borrowing .foo(): // parses as `borrowing.foo()` as before
         break
-    case _borrowing (): // parses as `_borrowing()` as before
+    case borrowing (): // parses as `borrowing()` as before
         break
 
-    case _borrowing x: 
+    case borrowing x: 
         useBorrowBar(x)
 
-    case .payload(_borrowing x):
+    case .payload(borrowing x):
         useBorrowFoo(x)
 
-    case _borrowing x.member: // expected-error{{'_borrowing' pattern modifier must be directly applied to pattern variable name}} expected-error{{cannot find 'x' in scope}}
+    case borrowing x.member: // expected-error{{'borrowing' pattern modifier must be directly applied to pattern variable name}} expected-error{{cannot find 'x' in scope}}
         break
+
+    case _borrowing x: // expected-warning{{'_borrowing' spelling is deprecated}} {{10-20=borrowing}}
+        useBorrowBar(x)
 
     default:
         break

--- a/test/SILOptimizer/moveonly_borrowing_switch_copyable_subpattern.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_copyable_subpattern.swift
@@ -32,25 +32,25 @@ func test(borrowing foo: borrowing Foo) {
         eat(x)
         nibble(x)
 
-    // `_borrowing` match variables impose the no-implicit-copy constraint
+    // `borrowing` match variables impose the no-implicit-copy constraint
     // like `borrowing` parameters do.
-    case .copyablePayload(_borrowing x) // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .copyablePayload(borrowing x) // expected-error{{'x' is borrowed and cannot be consumed}}
       where hungryCondition(x): // expected-note{{consumed here}}
         eat(x) // expected-note{{consumed here}}
         nibble(x)
 
-    case .copyablePayload(_borrowing x) // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .copyablePayload(borrowing x) // expected-error{{'x' is borrowed and cannot be consumed}}
       where condition(x):
         eat(x) // expected-note{{consumed here}}
         nibble(x)
 
     // Explicit copies are OK.
-    case .copyablePayload(_borrowing x)
+    case .copyablePayload(borrowing x)
       where hungryCondition(copy x):
         eat(copy x)
         nibble(x)
 
-    case .copyablePayload(_borrowing x):
+    case .copyablePayload(borrowing x):
         nibble(x)
     }
 }


### PR DESCRIPTION
Explanation: Allows borrowing x in addition to _borrowing x in pattern matches when the BorrowingSwitch experimental feature flag is enabled.
Scope: New feature enablement
Issue: rdar://126305009
Original PR: https://github.com/apple/swift/pull/72995
Risk: Low. The new syntax is enabled in a way that should keep the keyword usage contextual so that existing code does not break.
Testing: Swift CI, compatibility test suite
Reviewer: @atrick 