### PR TITLE
[6.0] Updates on lifetime dependence

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7873,37 +7873,31 @@ ERROR(lifetime_dependence_only_on_function_method_init_result, none,
        "functions, methods, initializers", ())
 ERROR(lifetime_dependence_invalid_return_type, none,
       "lifetime dependence can only be specified on ~Escapable results", ())
- ERROR(lifetime_dependence_cannot_infer_ambiguous_candidate, none,
-      "cannot infer lifetime dependence, multiple ~Escapable or ~Copyable "
-      "parameters with ownership modifiers, specify explicit lifetime "
-       "dependence", ())
-ERROR(lifetime_dependence_cannot_infer_no_candidates, none,
-       "cannot infer lifetime dependence, no parameters with ownership "
-       "modifiers present", ())
-ERROR(lifetime_dependence_ctor_non_self_or_nil_return, none,
-      "expected nil or self as return values in an initializer with "
-       "lifetime dependent specifiers", ())
-ERROR(lifetime_dependence_on_bitwise_copyable, none,
-      "invalid lifetime dependence on bitwise copyable type", ())
-ERROR(lifetime_dependence_cannot_infer_implicit_init, none,
-      "cannot infer lifetime dependence on implicit initializer of ~Escapable"
-      " type, define an initializer with explicit lifetime dependence"
-      " specifiers", ())
-ERROR(lifetime_dependence_cannot_be_applied_to_tuple_elt, none,
-      "lifetime dependence specifiers cannot be applied to tuple elements", ())
+ERROR(lifetime_dependence_cannot_infer_ambiguous_candidate, none,
+      "cannot infer lifetime dependence %0, multiple parameters qualifiy as a candidate", (StringRef))
+ ERROR(lifetime_dependence_cannot_infer_no_candidates, none,
+       "cannot infer lifetime dependence %0, no parameters found that are "
+       "~Escapable or Escapable with a borrowing ownership", (StringRef))
+ ERROR(lifetime_dependence_ctor_non_self_or_nil_return, none,
+       "expected nil or self as return values in an initializer with "
+       "lifetime dependent specifiers",
+       ())
+ ERROR(lifetime_dependence_on_bitwise_copyable, none,
+       "invalid lifetime dependence on bitwise copyable type", ())
+ ERROR(lifetime_dependence_cannot_be_applied_to_tuple_elt, none,
+       "lifetime dependence specifiers cannot be applied to tuple elements", ())
 
-//===----------------------------------------------------------------------===//
-//                             MARK: Transferring
-//===----------------------------------------------------------------------===//
+ //===----------------------------------------------------------------------===//
+ //                             MARK: Transferring
+ //===----------------------------------------------------------------------===//
 
-ERROR(transferring_unsupported_param_specifier, none,
-      "'%0' cannot be applied to a 'transferring' parameter", (StringRef))
+ ERROR(transferring_unsupported_param_specifier, none,
+       "'%0' cannot be applied to a 'transferring' parameter", (StringRef))
 
-ERROR(transferring_only_on_parameters_and_results, none,
-      "'transferring' may only be used on parameters and results", ())
-ERROR(transferring_cannot_be_applied_to_tuple_elt, none,
-      "'transferring' cannot be applied to tuple elements", ())
-
+ ERROR(transferring_only_on_parameters_and_results, none,
+       "'transferring' may only be used on parameters and results", ())
+ ERROR(transferring_cannot_be_applied_to_tuple_elt, none,
+       "'transferring' cannot be applied to tuple elements", ())
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2053,7 +2053,10 @@ static ValueDecl *getWithUnsafeContinuation(ASTContext &ctx,
   auto *fnTy = FunctionType::get(params, voidTy, extInfo);
 
   builder.addParameter(makeConcrete(fnTy));
-  builder.setResult(makeGenericParam());
+
+  auto resultTy = makeGenericParam();
+  builder.addConformanceRequirement(resultTy, KnownProtocolKind::Escapable);
+  builder.setResult(resultTy);
 
   builder.setAsync();
   if (throws)

--- a/test/SIL/type_lowering_unit.sil
+++ b/test/SIL/type_lowering_unit.sil
@@ -120,9 +120,6 @@ extension GSNC: Copyable where T: Copyable  {}
 
 struct GSNE<T: ~Escapable>: ~Escapable {
     var x: T
-
-    // 60_MERGE: an explicit initializer is temporarily required until initializer inferrence is merged.
-    init(x: consuming T) { self.x = x }
 }
 
 extension GSNE: Escapable where T: Escapable {}

--- a/test/SILGen/typelowering_inverses.swift
+++ b/test/SILGen/typelowering_inverses.swift
@@ -141,7 +141,6 @@ func check(_ t: inout any NoEscapeP & ~Escapable) {}
 struct MyStruct<T: ~Copyable & ~Escapable>: ~Copyable & ~Escapable {
   var x: T
 
-  // 60_MERGE: an explicit initializer is temporarily required until initializer inferrence is merged.
   init(x: consuming T) { self.x = x }
 }
 

--- a/test/Sema/explicit_lifetime_dependence_specifiers1.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers1.swift
@@ -56,6 +56,14 @@ struct BufferView : ~Escapable {
   consuming func consume() -> dependsOn(scoped self) BufferView { // expected-error{{invalid use of scoped lifetime dependence with consuming ownership}}
     return BufferView(self.ptr)
   }
+
+  func get() -> dependsOn(self) Self { // expected-note{{'get()' previously declared here}}
+    return self
+  }
+
+  func get() -> dependsOn(scoped self) Self { // expected-error{{invalid redeclaration of 'get()'}}
+    return self
+  }
 }
 
 struct MutableBufferView : ~Escapable, ~Copyable {
@@ -201,4 +209,12 @@ public struct GenericBufferView<Element> : ~Escapable {
     self.baseAddress = baseAddress
     self.count = count
   } 
+}
+
+func derive(_ x: BufferView) -> dependsOn(x) BufferView { // expected-note{{'derive' previously declared here}}
+  return BufferView(x.ptr)
+}
+
+func derive(_ x: BufferView) -> dependsOn(scoped x) BufferView { // expected-error{{invalid redeclaration of 'derive'}}
+  return BufferView(x.ptr)
 }

--- a/test/Sema/implicit_lifetime_dependence.swift
+++ b/test/Sema/implicit_lifetime_dependence.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics
+// REQUIRES: asserts
+
+struct BufferView : ~Escapable, ~Copyable {
+  let ptr: UnsafeRawBufferPointer
+  let c: Int
+  @_unsafeNonescapableResult
+  init(_ ptr: UnsafeRawBufferPointer, _ c: Int) {
+    self.ptr = ptr
+    self.c = c
+  }
+}
+
+struct ImplicitInit1 : ~Escapable { // expected-error{{cannot infer lifetime dependence on implicit initializer, no parameters found that are ~Escapable or Escapable with a borrowing ownership}}
+  let ptr: UnsafeRawBufferPointer
+}
+
+struct ImplicitInit2 : ~Escapable, ~Copyable {
+  let mbv: BufferView
+}
+
+struct ImplicitInit3 : ~Escapable, ~Copyable { // expected-error{{cannot infer lifetime dependence on implicit initializer, multiple parameters qualifiy as a candidate}}
+  let mbv1: BufferView
+  let mbv2: BufferView
+}


### PR DESCRIPTION
Explanation: Fixes lifetime dependence diagnostic message, inference and fixes types involved builtin in builtin definitions to be Escapable

Scope: 
- Some types involved in builtins are declared as Escapable. All other changes effect lifetime dependence which is enabled with the experimental flag for NonEscapable types

Original PR: https://github.com/apple/swift/pull/72569

Risk: Most of the changes are effective only with the experimental feature non escapable types

Testing: Unit tests added

Reviewer: @atrick 