### PR TITLE
[6.0] Requestify LifetimeDependenceInfo 

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
+++ b/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
@@ -271,14 +271,8 @@ extension FunctionConvention {
       return nil
     }
 
-    // In Sema's LifetimeDependenceInfo, 'self' is always index zero,
-    // whether it exists or not. In SILFunctionType, 'self' is the
-    // last parameter if it exists.
     private func bridgedIndex(parameterIndex: Int) -> Int {
-      if hasSelfParam, parameterIndex == (paramCount - 1) {
-        return 0
-      }
-      return parameterIndex + 1
+      return parameterIndex
     }
 
     public var description: String {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7301,6 +7301,7 @@ public:
 
   /// Add the given derivative function configuration.
   void addDerivativeFunctionConfiguration(const AutoDiffConfig &config);
+  std::optional<LifetimeDependenceInfo> getLifetimeDependenceInfo() const;
 
 protected:
   // If a function has a body at all, we have either a parsed body AST node or

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7880,7 +7880,7 @@ ERROR(lifetime_dependence_invalid_return_type, none,
 ERROR(lifetime_dependence_cannot_infer_ambiguous_candidate, none,
       "cannot infer lifetime dependence %0, multiple parameters qualifiy as a candidate", (StringRef))
  ERROR(lifetime_dependence_cannot_infer_no_candidates, none,
-       "cannot infer lifetime dependence %0, no parameters found that are "
+       "cannot infer lifetime dependence %0, no parameters found that are either "
        "~Escapable or Escapable with a borrowing ownership", (StringRef))
  ERROR(lifetime_dependence_ctor_non_self_or_nil_return, none,
        "expected nil or self as return values in an initializer with "

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -133,22 +133,26 @@ public:
 class LifetimeDependenceInfo {
   IndexSubset *inheritLifetimeParamIndices;
   IndexSubset *scopeLifetimeParamIndices;
-  bool isExplicit;
 
   static LifetimeDependenceInfo getForParamIndex(AbstractFunctionDecl *afd,
                                                  unsigned index,
                                                  LifetimeDependenceKind kind);
 
+  /// Builds LifetimeDependenceInfo from a swift decl
+  static std::optional<LifetimeDependenceInfo>
+  fromTypeRepr(AbstractFunctionDecl *afd);
+
+  /// Infer LifetimeDependenceInfo
+  static std::optional<LifetimeDependenceInfo> infer(AbstractFunctionDecl *afd);
+
 public:
   LifetimeDependenceInfo()
       : inheritLifetimeParamIndices(nullptr),
-        scopeLifetimeParamIndices(nullptr), isExplicit(false) {}
+        scopeLifetimeParamIndices(nullptr) {}
   LifetimeDependenceInfo(IndexSubset *inheritLifetimeParamIndices,
-                         IndexSubset *scopeLifetimeParamIndices,
-                         bool isExplicit = false)
+                         IndexSubset *scopeLifetimeParamIndices)
       : inheritLifetimeParamIndices(inheritLifetimeParamIndices),
-        scopeLifetimeParamIndices(scopeLifetimeParamIndices),
-        isExplicit(isExplicit) {
+        scopeLifetimeParamIndices(scopeLifetimeParamIndices) {
     assert(!empty());
     assert(!inheritLifetimeParamIndices ||
            !inheritLifetimeParamIndices->isEmpty());
@@ -161,8 +165,6 @@ public:
     return inheritLifetimeParamIndices == nullptr &&
            scopeLifetimeParamIndices == nullptr;
   }
-
-  bool isExplicitlySpecified() const { return isExplicit; }
 
   bool hasInheritLifetimeParamIndices() const {
     return inheritLifetimeParamIndices != nullptr;
@@ -191,27 +193,17 @@ public:
   /// Builds LifetimeDependenceInfo from a swift decl, either from the explicit
   /// lifetime dependence specifiers or by inference based on types and
   /// ownership modifiers.
-  static std::optional<LifetimeDependenceInfo>
-  get(AbstractFunctionDecl *decl, Type resultType, bool allowIndex = false);
+  static std::optional<LifetimeDependenceInfo> get(AbstractFunctionDecl *decl);
 
   /// Builds LifetimeDependenceInfo from the bitvectors passes as parameters.
   static LifetimeDependenceInfo
   get(ASTContext &ctx, const SmallBitVector &inheritLifetimeIndices,
       const SmallBitVector &scopeLifetimeIndices);
 
-  /// Builds LifetimeDependenceInfo from a swift decl
-  static std::optional<LifetimeDependenceInfo>
-  fromTypeRepr(AbstractFunctionDecl *afd, Type resultType, bool allowIndex);
-
   /// Builds LifetimeDependenceInfo from SIL
   static std::optional<LifetimeDependenceInfo>
   fromTypeRepr(LifetimeDependentReturnTypeRepr *lifetimeDependentRepr,
-               SmallVectorImpl<SILParameterInfo> &params, bool hasSelfParam,
-               DeclContext *dc);
-
-  /// Infer LifetimeDependenceInfo
-  static std::optional<LifetimeDependenceInfo> infer(AbstractFunctionDecl *afd,
-                                                     Type resultType);
+               SmallVectorImpl<SILParameterInfo> &params, DeclContext *dc);
 };
 
 } // namespace swift

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4866,6 +4866,25 @@ public:
   bool isCached() const { return true; }
 };
 
+class LifetimeDependenceInfoRequest
+    : public SimpleRequest<LifetimeDependenceInfoRequest,
+                           std::optional<LifetimeDependenceInfo>(
+                               AbstractFunctionDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  std::optional<LifetimeDependenceInfo>
+  evaluate(Evaluator &evaluator, AbstractFunctionDecl *AFD) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+};
+
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -566,3 +566,5 @@ SWIFT_REQUEST(TypeChecker, ImportDeclRequest,
               std::optional<AttributedImport<ImportedModule>>(
                   const SourceFile *sf, const ModuleDecl *mod),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, LifetimeDependenceInfoRequest,
+              LifetimeDependenceInfo(AbstractFunctionDecl *), Cached, NoLocationInfo)

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3089,7 +3089,7 @@ void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
     if (afd->hasImplicitSelfDecl()) {
       auto lifetimeDependenceKind =
           fn->getLifetimeDependenceInfo().getLifetimeDependenceOnParam(
-              /*paramIndex*/ 0);
+              /*selfIndex*/ afd->getParameters()->size());
       if (lifetimeDependenceKind) {
         appendLifetimeDependenceKind(*lifetimeDependenceKind,
                                      /*isSelfDependence*/ true);
@@ -3178,7 +3178,7 @@ void ASTMangler::appendFunctionInputType(
           Identifier(), type,
           getParameterFlagsForMangling(param.getParameterFlags(),
                                        defaultSpecifier),
-          lifetimeDependenceInfo.getLifetimeDependenceOnParam(/*paramIndex*/ 1),
+          lifetimeDependenceInfo.getLifetimeDependenceOnParam(/*paramIndex*/ 0),
           sig, nullptr);
       break;
     }
@@ -3190,7 +3190,7 @@ void ASTMangler::appendFunctionInputType(
 
   default:
     bool isFirstParam = true;
-    unsigned paramIndex = 1; /* 0 is reserved for self*/
+    unsigned paramIndex = 0;
     for (auto &param : params) {
       // Note that we pass `nullptr` as the `forDecl` argument, since the type
       // of the input is no longer directly the type of the declaration, so we

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10020,6 +10020,18 @@ void AbstractFunctionDecl::addDerivativeFunctionConfiguration(
   DerivativeFunctionConfigs->insert(config);
 }
 
+std::optional<LifetimeDependenceInfo>
+AbstractFunctionDecl::getLifetimeDependenceInfo() const {
+  if (!isa<FuncDecl>(this) && !isa<ConstructorDecl>(this)) {
+    return std::nullopt;
+  }
+
+  return evaluateOrDefault(
+      getASTContext().evaluator,
+      LifetimeDependenceInfoRequest{const_cast<AbstractFunctionDecl *>(this)},
+      std::nullopt);
+}
+
 void FuncDecl::setResultInterfaceType(Type type) {
   getASTContext().evaluator.cacheOutput(ResultTypeRequest{this},
                                         std::move(type));

--- a/lib/Sema/LifetimeDependence.cpp
+++ b/lib/Sema/LifetimeDependence.cpp
@@ -104,7 +104,9 @@ LifetimeDependenceInfo LifetimeDependenceInfo::getForParamIndex(
     AbstractFunctionDecl *afd, unsigned index, LifetimeDependenceKind kind) {
   auto *dc = afd->getDeclContext();
   auto &ctx = dc->getASTContext();
-  unsigned capacity = afd->getParameters()->size() + 1;
+  unsigned capacity = afd->hasImplicitSelfDecl()
+                          ? (afd->getParameters()->size() + 1)
+                          : afd->getParameters()->size();
   auto indexSubset = IndexSubset::get(ctx, capacity, {index});
   if (kind == LifetimeDependenceKind::Scope) {
     return LifetimeDependenceInfo{/*inheritLifetimeParamIndices*/ nullptr,
@@ -138,22 +140,23 @@ void LifetimeDependenceInfo::getConcatenatedData(
   }
 }
 
-static bool hasEscapableResultOrYield(AbstractFunctionDecl *afd,
-                                      Type resultType) {
-  Type resultTypeInContext = afd->mapTypeIntoContext(resultType);
-  std::optional<Type> yieldTyInContext;
-
+static bool hasEscapableResultOrYield(AbstractFunctionDecl *afd) {
   if (auto *accessor = dyn_cast<AccessorDecl>(afd)) {
     if (accessor->isCoroutine()) {
-      yieldTyInContext = accessor->getStorage()->getValueInterfaceType();
-      yieldTyInContext = accessor->mapTypeIntoContext(*yieldTyInContext);
+      auto yieldTyInContext = accessor->mapTypeIntoContext(
+          accessor->getStorage()->getValueInterfaceType());
+      return yieldTyInContext->isEscapable();
     }
   }
-  if (resultTypeInContext->isEscapable() &&
-      (!yieldTyInContext.has_value() || (*yieldTyInContext)->isEscapable())) {
-    return true;
+
+  Type resultType;
+  if (auto fn = dyn_cast<FuncDecl>(afd)) {
+    resultType = fn->getResultInterfaceType();
+  } else {
+    auto ctor = cast<ConstructorDecl>(afd);
+    resultType = ctor->getResultInterfaceType();
   }
-  return false;
+  return afd->mapTypeIntoContext(resultType)->isEscapable();
 }
 
 static LifetimeDependenceKind getLifetimeDependenceKindFromDecl(
@@ -170,17 +173,18 @@ static LifetimeDependenceKind getLifetimeDependenceKindFromDecl(
 }
 
 std::optional<LifetimeDependenceInfo>
-LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd, Type resultType,
-                                     bool allowIndex) {
+LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd) {
   auto *dc = afd->getDeclContext();
   auto &ctx = dc->getASTContext();
   auto *mod = afd->getModuleContext();
   auto &diags = ctx.Diags;
-  auto capacity = afd->getParameters()->size() + 1;
+  auto capacity = afd->hasImplicitSelfDecl()
+                      ? (afd->getParameters()->size() + 1)
+                      : afd->getParameters()->size();
   auto lifetimeDependentRepr =
       cast<LifetimeDependentReturnTypeRepr>(afd->getResultTypeRepr());
 
-  if (hasEscapableResultOrYield(afd, resultType)) {
+  if (hasEscapableResultOrYield(afd)) {
     diags.diagnose(lifetimeDependentRepr->getLoc(),
                    diag::lifetime_dependence_invalid_return_type);
     return std::nullopt;
@@ -252,7 +256,7 @@ LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd, Type resultType,
       for (auto *param : *afd->getParameters()) {
         if (param->getParameterName() == specifier.getName()) {
           if (updateLifetimeDependenceInfo(
-                  specifier, paramIndex + 1,
+                  specifier, paramIndex,
                   afd->mapTypeIntoContext(
                       param->toFunctionParam().getParameterType()),
                   param->getValueOwnership())) {
@@ -278,17 +282,14 @@ LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd, Type resultType,
                        diag::lifetime_dependence_invalid_param_index, index);
         return std::nullopt;
       }
-      if (index != 0) {
-        auto param = afd->getParameters()->get(index - 1);
-        auto ownership = param->getValueOwnership();
-        auto type = afd->mapTypeIntoContext(
-            param->toFunctionParam().getParameterType());
-        if (updateLifetimeDependenceInfo(specifier, index, type, ownership)) {
-          return std::nullopt;
-        }
-        break;
+      auto param = afd->getParameters()->get(index);
+      auto ownership = param->getValueOwnership();
+      auto type =
+          afd->mapTypeIntoContext(param->toFunctionParam().getParameterType());
+      if (updateLifetimeDependenceInfo(specifier, index, type, ownership)) {
+        return std::nullopt;
       }
-      LLVM_FALLTHROUGH;
+      break;
     }
     case LifetimeDependenceSpecifier::SpecifierKind::Self: {
       if (!afd->hasImplicitSelfDecl()) {
@@ -302,7 +303,7 @@ LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd, Type resultType,
         return std::nullopt;
       }
       if (updateLifetimeDependenceInfo(
-              specifier, /*selfIndex*/ 0,
+              specifier, /* selfIndex */ afd->getParameters()->size(),
               afd->getImplicitSelfDecl()->getTypeInContext(),
               afd->getImplicitSelfDecl()->getValueOwnership())) {
         return std::nullopt;
@@ -318,8 +319,7 @@ LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd, Type resultType,
           : nullptr,
       scopeLifetimeParamIndices.any()
           ? IndexSubset::get(ctx, scopeLifetimeParamIndices)
-          : nullptr,
-      /*isExplicit*/ true);
+          : nullptr);
 }
 
 // This utility is similar to its overloaded version that builds the
@@ -327,11 +327,10 @@ LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd, Type resultType,
 // apis on type and ownership is different in SIL compared to Sema.
 std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromTypeRepr(
     LifetimeDependentReturnTypeRepr *lifetimeDependentRepr,
-    SmallVectorImpl<SILParameterInfo> &params, bool hasSelfParam,
-    DeclContext *dc) {
+    SmallVectorImpl<SILParameterInfo> &params, DeclContext *dc) {
   auto &ctx = dc->getASTContext();
   auto &diags = ctx.Diags;
-  auto capacity = hasSelfParam ? params.size() : params.size() + 1;
+  auto capacity = params.size(); // SIL parameters include self
 
   SmallBitVector inheritLifetimeParamIndices(capacity);
   SmallBitVector scopeLifetimeParamIndices(capacity);
@@ -368,17 +367,12 @@ std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromTypeRepr(
     assert(specifier.getSpecifierKind() ==
            LifetimeDependenceSpecifier::SpecifierKind::Ordered);
     auto index = specifier.getIndex();
-    if (index > params.size()) {
+    if (index > capacity) {
       diags.diagnose(specifier.getLoc(),
                      diag::lifetime_dependence_invalid_param_index, index);
       return std::nullopt;
     }
-    if (index == 0 && !hasSelfParam) {
-      diags.diagnose(specifier.getLoc(),
-                     diag::lifetime_dependence_invalid_self_in_static);
-      return std::nullopt;
-    }
-    auto param = index == 0 ? params.back() : params[index - 1];
+    auto param = params[index];
     auto paramConvention = param.getConvention();
     if (updateLifetimeDependenceInfo(specifier, index, paramConvention)) {
       return std::nullopt;
@@ -391,12 +385,11 @@ std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromTypeRepr(
           : nullptr,
       scopeLifetimeParamIndices.any()
           ? IndexSubset::get(ctx, scopeLifetimeParamIndices)
-          : nullptr,
-      /*isExplicit*/ true);
+          : nullptr);
 }
 
 std::optional<LifetimeDependenceInfo>
-LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd, Type resultType) {
+LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd) {
   auto *dc = afd->getDeclContext();
   auto &ctx = dc->getASTContext();
   auto *mod = afd->getModuleContext();
@@ -414,7 +407,7 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd, Type resultType) {
   auto returnTypeRepr = afd->getResultTypeRepr();
   auto returnLoc = returnTypeRepr ? returnTypeRepr->getLoc() : afd->getLoc();
 
-  if (hasEscapableResultOrYield(afd, resultType)) {
+  if (hasEscapableResultOrYield(afd)) {
     return std::nullopt;
   }
 
@@ -429,7 +422,7 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd, Type resultType) {
     }
   }
 
-  if (afd->getKind() != DeclKind::Constructor && afd->hasImplicitSelfDecl()) {
+  if (!cd && afd->hasImplicitSelfDecl()) {
     Type selfTypeInContext = dc->getSelfTypeInContext();
     if (selfTypeInContext->isEscapable()) {
       if (ctx.LangOpts.hasFeature(Feature::BitwiseCopyable)) {
@@ -452,7 +445,8 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd, Type resultType) {
                      diag::lifetime_dependence_invalid_self_ownership);
       return std::nullopt;
     }
-    return LifetimeDependenceInfo::getForParamIndex(afd, /*selfIndex*/ 0, kind);
+    return LifetimeDependenceInfo::getForParamIndex(
+        afd, /*selfIndex*/ afd->getParameters()->size(), kind);
   }
 
   LifetimeDependenceInfo lifetimeDependenceInfo;
@@ -480,7 +474,7 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd, Type resultType) {
       continue;
     }
     if (candidateParam) {
-      if (afd->getKind() == DeclKind::Constructor && afd->isImplicit()) {
+      if (cd && afd->isImplicit()) {
         diags.diagnose(
             returnLoc,
             diag::lifetime_dependence_cannot_infer_ambiguous_candidate,
@@ -494,11 +488,11 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd, Type resultType) {
     }
     candidateParam = param;
     lifetimeDependenceInfo =
-        LifetimeDependenceInfo::getForParamIndex(afd, paramIndex + 1, lifetimeKind);
+        LifetimeDependenceInfo::getForParamIndex(afd, paramIndex, lifetimeKind);
   }
 
   if (!candidateParam && !hasParamError) {
-    if (afd->getKind() == DeclKind::Constructor && afd->isImplicit()) {
+    if (cd && afd->isImplicit()) {
       diags.diagnose(returnLoc,
                      diag::lifetime_dependence_cannot_infer_no_candidates,
                      "on implicit initializer");
@@ -513,13 +507,13 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd, Type resultType) {
 }
 
 std::optional<LifetimeDependenceInfo>
-LifetimeDependenceInfo::get(AbstractFunctionDecl *afd, Type resultType,
-                            bool allowIndex) {
+LifetimeDependenceInfo::get(AbstractFunctionDecl *afd) {
+  assert(isa<FuncDecl>(afd) || isa<ConstructorDecl>(afd));
   auto *returnTypeRepr = afd->getResultTypeRepr();
   if (isa_and_nonnull<LifetimeDependentReturnTypeRepr>(returnTypeRepr)) {
-    return LifetimeDependenceInfo::fromTypeRepr(afd, resultType, allowIndex);
+    return LifetimeDependenceInfo::fromTypeRepr(afd);
   }
-  return LifetimeDependenceInfo::infer(afd, resultType);
+  return LifetimeDependenceInfo::infer(afd);
 }
 
 LifetimeDependenceInfo

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2550,7 +2550,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       resultTy = TupleType::getEmpty(AFD->getASTContext());
     }
 
-    std::optional<LifetimeDependenceInfo> lifetimeDependenceInfo;
+    auto lifetimeDependenceInfo = AFD->getLifetimeDependenceInfo();
 
     // (Args...) -> Result
     Type funcTy;
@@ -2571,7 +2571,6 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
           infoBuilder = infoBuilder.withTransferringResult();
       }
 
-      lifetimeDependenceInfo = LifetimeDependenceInfo::get(AFD, resultTy);
       if (lifetimeDependenceInfo.has_value()) {
         infoBuilder =
             infoBuilder.withLifetimeDependenceInfo(*lifetimeDependenceInfo);
@@ -3097,4 +3096,10 @@ ImplicitKnownProtocolConformanceRequest::evaluate(Evaluator &evaluator,
   default:
     llvm_unreachable("non-implicitly derived KnownProtocol");
   }
+}
+
+std::optional<LifetimeDependenceInfo>
+LifetimeDependenceInfoRequest::evaluate(Evaluator &evaluator,
+                                        AbstractFunctionDecl *decl) const {
+  return LifetimeDependenceInfo::get(decl);
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4414,8 +4414,7 @@ NeverNullType TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
           dyn_cast<LifetimeDependentReturnTypeRepr>(
               repr->getResultTypeRepr())) {
     lifetimeDependenceInfo = LifetimeDependenceInfo::fromTypeRepr(
-        lifetimeDependentTypeRepr, params, extInfoBuilder.hasSelfParam(),
-        getDeclContext());
+        lifetimeDependentTypeRepr, params, getDeclContext());
     if (lifetimeDependenceInfo.has_value()) {
       extInfoBuilder =
           extInfoBuilder.withLifetimeDependenceInfo(*lifetimeDependenceInfo);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3620,14 +3620,12 @@ public:
     assert(bodyParams && "missing parameters for constructor");
     ctor->setParameters(bodyParams);
 
-    SmallVector<LifetimeDependenceSpecifier> specifierList;
-    if (MF.maybeReadLifetimeDependenceSpecifier(specifierList,
-                                                bodyParams->size())) {
-      auto SelfType = ctor->getDeclaredInterfaceType();
-      auto typeRepr = new (ctx) FixedTypeRepr(SelfType, SourceLoc());
-      auto lifetimeTypeRepr =
-          LifetimeDependentReturnTypeRepr::create(ctx, typeRepr, specifierList);
-      ctor->setDeserializedResultTypeLoc(TypeLoc(lifetimeTypeRepr, SelfType));
+    auto lifetimeDependenceInfo =
+        MF.maybeReadLifetimeDependenceInfo(bodyParams->size() + 1);
+
+    if (lifetimeDependenceInfo.has_value()) {
+      ctx.evaluator.cacheOutput(LifetimeDependenceInfoRequest{ctor},
+                                std::move(lifetimeDependenceInfo.value()));
     }
 
     if (auto errorConvention = MF.maybeReadForeignErrorConvention())
@@ -4198,13 +4196,13 @@ public:
 
     ParameterList *paramList = MF.readParameterList();
     fn->setParameters(paramList);
-    SmallVector<LifetimeDependenceSpecifier> specifierList;
-    if (MF.maybeReadLifetimeDependenceSpecifier(specifierList,
-                                                paramList->size())) {
-      auto typeRepr = new (ctx) FixedTypeRepr(resultType, SourceLoc());
-      auto lifetimeTypeRepr =
-          LifetimeDependentReturnTypeRepr::create(ctx, typeRepr, specifierList);
-      fn->setDeserializedResultTypeLoc(TypeLoc(lifetimeTypeRepr, resultType));
+
+    auto lifetimeDependenceInfo = MF.maybeReadLifetimeDependenceInfo(
+        fn->hasImplicitSelfDecl() ? paramList->size() + 1 : paramList->size());
+
+    if (lifetimeDependenceInfo.has_value()) {
+      ctx.evaluator.cacheOutput(LifetimeDependenceInfoRequest{fn},
+                                std::move(lifetimeDependenceInfo.value()));
     }
 
     if (auto errorConvention = MF.maybeReadForeignErrorConvention())
@@ -7568,8 +7566,7 @@ Expected<Type> DESERIALIZE_TYPE(SIL_FUNCTION_TYPE)(
   if (!patternSubsOrErr)
     return patternSubsOrErr.takeError();
 
-  auto lifetimeDependenceInfo = MF.maybeReadLifetimeDependenceInfo(
-      extInfo.hasSelfParam() ? numParams : numParams + 1);
+  auto lifetimeDependenceInfo = MF.maybeReadLifetimeDependenceInfo(numParams);
 
   if (lifetimeDependenceInfo.has_value()) {
     extInfo = extInfo.withLifetimeDependenceInfo(*lifetimeDependenceInfo);
@@ -8804,42 +8801,4 @@ ModuleFile::maybeReadLifetimeDependenceInfo(unsigned numParams) {
       hasScopeLifetimeParamIndices
           ? IndexSubset::get(ctx, scopeLifetimeParamIndices)
           : nullptr);
-}
-
-bool ModuleFile::maybeReadLifetimeDependenceSpecifier(
-    SmallVectorImpl<LifetimeDependenceSpecifier> &specifierList,
-    unsigned numDeclParams) {
-  using namespace decls_block;
-
-  SmallVector<uint64_t, 8> scratch;
-  if (!maybeReadLifetimeDependenceRecord(scratch)) {
-    return false;
-  }
-
-  bool hasInheritLifetimeParamIndices;
-  bool hasScopeLifetimeParamIndices;
-  ArrayRef<uint64_t> lifetimeDependenceData;
-  LifetimeDependenceLayout::readRecord(scratch, hasInheritLifetimeParamIndices,
-                                       hasScopeLifetimeParamIndices,
-                                       lifetimeDependenceData);
-
-  unsigned startIndex = 0;
-  auto pushData = [&](ParsedLifetimeDependenceKind kind) {
-    for (unsigned i = 0; i < numDeclParams + 1; i++) {
-      if (lifetimeDependenceData[startIndex + i]) {
-        specifierList.push_back(
-            LifetimeDependenceSpecifier::getOrderedLifetimeDependenceSpecifier(
-                SourceLoc(), kind, i));
-      }
-    }
-    startIndex += numDeclParams + 1;
-  };
-
-  if (hasInheritLifetimeParamIndices) {
-    pushData(ParsedLifetimeDependenceKind::Inherit);
-  }
-  if (hasScopeLifetimeParamIndices) {
-    pushData(ParsedLifetimeDependenceKind::Scope);
-  }
-  return true;
 }

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -1076,7 +1076,7 @@ public:
   // Reads lifetime dependence specifier from decl if present
   bool maybeReadLifetimeDependenceSpecifier(
       SmallVectorImpl<LifetimeDependenceSpecifier> &specifierList,
-      unsigned numDeclParams);
+      unsigned numDeclParams, bool hasSelf);
 
   /// Reads inlinable body text from \c DeclTypeCursor, if present.
   std::optional<StringRef> maybeReadInlinableBodyText();

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2518,10 +2518,7 @@ void Serializer::writeASTBlockEntity(const DeclContext *DC) {
 }
 
 void Serializer::writeLifetimeDependenceInfo(
-    LifetimeDependenceInfo lifetimeDependenceInfo, bool skipImplicit) {
-  if (skipImplicit && !lifetimeDependenceInfo.isExplicitlySpecified()) {
-    return;
-  }
+    LifetimeDependenceInfo lifetimeDependenceInfo) {
   using namespace decls_block;
   SmallVector<bool> paramIndices;
   lifetimeDependenceInfo.getConcatenatedData(paramIndices);
@@ -4535,8 +4532,7 @@ public:
     if (fnType) {
       if (auto *lifetimeDependenceInfo =
               fnType->getLifetimeDependenceInfoOrNull()) {
-        S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo,
-                                      /*skipImplicit*/ true);
+        S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo);
       }
     }
 
@@ -4663,8 +4659,7 @@ public:
     if (fnType) {
       if (auto *lifetimeDependenceInfo =
               fnType->getLifetimeDependenceInfoOrNull()) {
-        S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo,
-                                      /*skipImplicit*/ true);
+        S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo);
       }
     }
 
@@ -4834,8 +4829,7 @@ public:
     if (fnType) {
       if (auto *lifetimeDependenceInfo =
               fnType->getLifetimeDependenceInfoOrNull()) {
-        S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo,
-                                      /*skipImplicit*/ true);
+        S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo);
       }
     }
 

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -387,8 +387,7 @@ private:
 
   /// Writes lifetime dependence info
   void
-  writeLifetimeDependenceInfo(LifetimeDependenceInfo lifetimeDependenceInfo,
-                              bool skipImplicit = false);
+  writeLifetimeDependenceInfo(LifetimeDependenceInfo lifetimeDependenceInfo);
 
   /// Registers the abbreviation for the given decl or type layout.
   template <typename Layout>

--- a/test/Parse/explicit_lifetime_dependence_specifiers.swift
+++ b/test/Parse/explicit_lifetime_dependence_specifiers.swift
@@ -128,7 +128,7 @@ func invalidSpecifier3(_ x: borrowing BufferView) -> dependsOn(*) BufferView { /
 } 
 
 // TODO: Diagnose using param indices on func decls in sema
-func invalidSpecifier4(_ x: borrowing BufferView) -> dependsOn(0) BufferView { // expected-error{{invalid lifetime dependence specifier on non-existent self}}
+func invalidSpecifier4(_ x: borrowing BufferView) -> dependsOn(self) BufferView { // expected-error{{invalid lifetime dependence specifier on non-existent self}}
   return BufferView(x.ptr)
 }
 

--- a/test/SIL/Parser/lifetime_dependence.sil
+++ b/test/SIL/Parser/lifetime_dependence.sil
@@ -31,8 +31,8 @@ bb0(%0 : $UnsafeRawBufferPointer, %1 : $@thin BufferView.Type):
   return %8 : $BufferView                         
 } 
 
-// CHECK-LABEL: sil hidden @bufferviewtest2 : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(2) @owned BufferView {
-sil hidden @bufferviewtest2 : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(2) @owned BufferView {
+// CHECK-LABEL: sil hidden @bufferviewtest2 : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView {
+sil hidden @bufferviewtest2 : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView {
 bb0(%0 : $UnsafeRawBufferPointer, %1 : @noImplicitCopy $Array<Int>, %2 : $@thin BufferView.Type):
   %3 = alloc_stack [var_decl] $BufferView, var, name "self"
   %6 = begin_access [modify] [static] %3 : $*BufferView 
@@ -45,8 +45,8 @@ bb0(%0 : $UnsafeRawBufferPointer, %1 : @noImplicitCopy $Array<Int>, %2 : $@thin 
   return %10 : $BufferView                        
 } 
 
-// CHECK-LABEL: sil hidden @derive : $@convention(thin) (@guaranteed BufferView) -> _scope(1) @owned BufferView {
-sil hidden @derive : $@convention(thin) (@guaranteed BufferView) -> _scope(1) @owned BufferView {
+// CHECK-LABEL: sil hidden @derive : $@convention(thin) (@guaranteed BufferView) -> _scope(0) @owned BufferView {
+sil hidden @derive : $@convention(thin) (@guaranteed BufferView) -> _scope(0) @owned BufferView {
 bb0(%0 : @noImplicitCopy $BufferView):
   %2 = metatype $@thin BufferView.Type            
   %3 = struct_extract %0 : $BufferView, #BufferView.ptr 
@@ -55,8 +55,8 @@ bb0(%0 : @noImplicitCopy $BufferView):
   return %5 : $BufferView                         
 } 
 
-// CHECK-LABEL: sil hidden @consumeAndCreate : $@convention(thin) (@owned BufferView) -> _inherit(1) @owned BufferView {
-sil hidden @consumeAndCreate : $@convention(thin) (@owned BufferView) -> _inherit(1) @owned BufferView {
+// CHECK-LABEL: sil hidden @consumeAndCreate : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView {
+sil hidden @consumeAndCreate : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView {
 bb0(%0 : @noImplicitCopy @_eagerMove $BufferView):
   %1 = alloc_stack [var_decl] [moveable_value_debuginfo] $BufferView, var, name "x" 
   %2 = struct_extract %0 : $BufferView, #BufferView.ptr 

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -20,17 +20,17 @@ struct BufferView : ~Escapable {
     } 
     self.ptr = ptr
   }
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_SaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(2) @owned BufferView {
+// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_SaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) -> dependsOn(a) Self {
     self.ptr = ptr
     return self
   }
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_AA7WrapperVYlitcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @thin BufferView.Type) -> _inherit(2) @owned BufferView {
+// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_AA7WrapperVYlitcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @thin BufferView.Type) -> _inherit(1) @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: consuming Wrapper) -> dependsOn(a) Self {
     self.ptr = ptr
     return self
   }
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_AA7WrapperVYliSaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @guaranteed Array<Int>, @thin BufferView.Type) -> _inherit(2) _scope(3) @owned BufferView {
+// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_AA7WrapperVYliSaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @guaranteed Array<Int>, @thin BufferView.Type) -> _inherit(1) _scope(2) @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: consuming Wrapper, _ b: borrowing Array<Int>) -> dependsOn(a) dependsOn(b) Self {
     self.ptr = ptr
     return self
@@ -56,17 +56,17 @@ func testBasic() {
   }
 }
 
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers6deriveyAA10BufferViewVADYlsF : $@convention(thin) (@guaranteed BufferView) -> _scope(1) @owned BufferView {
+// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers6deriveyAA10BufferViewVADYlsF : $@convention(thin) (@guaranteed BufferView) -> _scope(0) @owned BufferView {
 func derive(_ x: borrowing BufferView) -> dependsOn(scoped x) BufferView {
   return BufferView(x.ptr)
 }
 
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(1) @owned BufferView {
+// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView {
 func consumeAndCreate(_ x: consuming BufferView) -> dependsOn(x) BufferView {
   return BufferView(x.ptr)
 }
 
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat1yAA10BufferViewVADYls_ADYlstF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(1, 2) @owned BufferView {
+// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat1yAA10BufferViewVADYls_ADYlstF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(0, 1) @owned BufferView {
 func deriveThisOrThat1(_ this: borrowing BufferView, _ that: borrowing BufferView) -> dependsOn(scoped this, that) BufferView {
   if (Int.random(in: 1..<100) == 0) {
     return BufferView(this.ptr)
@@ -74,7 +74,7 @@ func deriveThisOrThat1(_ this: borrowing BufferView, _ that: borrowing BufferVie
   return BufferView(that.ptr)
 }
 
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat2yAA10BufferViewVADYls_ADnYlitF : $@convention(thin) (@guaranteed BufferView, @owned BufferView) -> _inherit(2) _scope(1) @owned BufferView {
+// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat2yAA10BufferViewVADYls_ADnYlitF : $@convention(thin) (@guaranteed BufferView, @owned BufferView) -> _inherit(1) _scope(0) @owned BufferView {
 func deriveThisOrThat2(_ this: borrowing BufferView, _ that: consuming BufferView) -> dependsOn(scoped this) dependsOn(that) BufferView {
   if (Int.random(in: 1..<100) == 0) {
     return BufferView(this.ptr)
@@ -108,12 +108,12 @@ struct Container : ~Escapable {
  }
 }
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getConsumingViewyAA06BufferG0VAA9ContainerVnYliF : $@convention(thin) (@owned Container) -> _inherit(1) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getConsumingViewyAA06BufferG0VAA9ContainerVnYliF : $@convention(thin) (@owned Container) -> _inherit(0) @owned BufferView {
 func getConsumingView(_ x: consuming Container) -> dependsOn(x) BufferView {
   return BufferView(x.ptr)
 }
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getBorrowingViewyAA06BufferG0VAA9ContainerVYlsF : $@convention(thin) (@guaranteed Container) -> _scope(1) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getBorrowingViewyAA06BufferG0VAA9ContainerVYlsF : $@convention(thin) (@guaranteed Container) -> _scope(0) @owned BufferView {
 func getBorrowingView(_ x: borrowing Container) -> dependsOn(scoped x) BufferView {
   return BufferView(x.ptr)
 }

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -12,17 +12,17 @@ struct BufferView : ~Escapable {
     self.ptr = ptr
     self.c = c
   }
-// CHECK: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyA2ChYlicfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> _inherit(1) @owned BufferView {
+// CHECK: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyA2ChYlicfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> _inherit(0) @owned BufferView {
   init(_ otherBV: borrowing BufferView) {
     self.ptr = otherBV.ptr
     self.c = otherBV.c
   }
-// CHECK: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyA2CYlicfC : $@convention(method) (@owned BufferView, @thin BufferView.Type) -> _inherit(1) @owned BufferView {
+// CHECK: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyA2CYlicfC : $@convention(method) (@owned BufferView, @thin BufferView.Type) -> _inherit(0) @owned BufferView {
   init(_ otherBV: consuming BufferView) {
     self.ptr = otherBV.ptr
     self.c = otherBV.c
   }
-// CHECK: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyACSW_SaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(2) @owned BufferView {
+// CHECK: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyACSW_SaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) {
     self.ptr = ptr
     self.c = a.count
@@ -49,7 +49,7 @@ func testBasic() {
   }
 }
 
-// CHECK: sil hidden @$s28implicit_lifetime_dependence6deriveyAA10BufferViewVADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(1) @owned BufferView {
+// CHECK: sil hidden @$s28implicit_lifetime_dependence6deriveyAA10BufferViewVADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0) @owned BufferView {
 func derive(_ x: borrowing BufferView) -> BufferView {
   return BufferView(x.ptr, x.c)
 }
@@ -58,7 +58,7 @@ func derive(_ unused: Int, _ x: borrowing BufferView) -> BufferView {
   return BufferView(x.ptr, x.c)
 }
 
-// CHECK: sil hidden @$s28implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(1) @owned BufferView {
+// CHECK: sil hidden @$s28implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView {
 func consumeAndCreate(_ x: consuming BufferView) -> BufferView {
   return BufferView(x.ptr, x.c)
 }
@@ -77,7 +77,7 @@ struct Wrapper : ~Escapable {
       yield &_view
     }
   }
-// CHECK: sil hidden @$s28implicit_lifetime_dependence7WrapperVyAcA10BufferViewVYlicfC : $@convention(method) (@owned BufferView, @thin Wrapper.Type) -> _inherit(1) @owned Wrapper {
+// CHECK: sil hidden @$s28implicit_lifetime_dependence7WrapperVyAcA10BufferViewVYlicfC : $@convention(method) (@owned BufferView, @thin Wrapper.Type) -> _inherit(0) @owned Wrapper {
   init(_ view: consuming BufferView) {
     self._view = view
   }
@@ -128,7 +128,7 @@ struct GenericBufferView<Element> : ~Escapable {
   let baseAddress: Pointer
   let count: Int
 
-// CHECK: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewV11baseAddress5count9dependsOnACyxGSV_Siqd__hYlstclufC : $@convention(method) <Element><Storage> (UnsafeRawPointer, Int, @in_guaranteed Storage, @thin GenericBufferView<Element>.Type) -> _scope(3) @owned GenericBufferView<Element> {
+// CHECK: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewV11baseAddress5count9dependsOnACyxGSV_Siqd__hYlstclufC : $@convention(method) <Element><Storage> (UnsafeRawPointer, Int, @in_guaranteed Storage, @thin GenericBufferView<Element>.Type) -> _scope(2) @owned GenericBufferView<Element> {
   init<Storage>(baseAddress: Pointer,
                 count: Int,
                 dependsOn: borrowing Storage) {
@@ -152,7 +152,7 @@ struct GenericBufferView<Element> : ~Escapable {
       }
     }
   }
-// CHECK: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewVyACyxGAA9FakeRangeVySVGcig : $@convention(method) <Element> (FakeRange<UnsafeRawPointer>, @guaranteed GenericBufferView<Element>) -> _inherit(0) @owned GenericBufferView<Element> {
+// CHECK: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewVyACyxGAA9FakeRangeVySVGcig : $@convention(method) <Element> (FakeRange<UnsafeRawPointer>, @guaranteed GenericBufferView<Element>) -> _inherit(1) @owned GenericBufferView<Element> {
   subscript(bounds: FakeRange<Pointer>) -> Self {
     get {
       GenericBufferView(
@@ -163,7 +163,7 @@ struct GenericBufferView<Element> : ~Escapable {
   }
 }
 
-// CHECK: sil hidden @$s28implicit_lifetime_dependence23tupleLifetimeDependenceyAA10BufferViewV_ADtADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(1) (@owned BufferView, @owned BufferView) {
+// CHECK: sil hidden @$s28implicit_lifetime_dependence23tupleLifetimeDependenceyAA10BufferViewV_ADtADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0) (@owned BufferView, @owned BufferView) {
 func tupleLifetimeDependence(_ x: borrowing BufferView) -> (BufferView, BufferView) {
   return (BufferView(x.ptr, x.c), BufferView(x.ptr, x.c))
 }

--- a/test/SIL/lifetime_dependence_buffer_view_test.swift
+++ b/test/SIL/lifetime_dependence_buffer_view_test.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
-// RUN:   -disable-lifetime-dependence-diagnostics
+// RUN:   -enable-experimental-feature NoncopyableGenerics
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -34,4 +34,4 @@ public func test(pview: borrowing PView) -> dependsOn(pview) View {
 
 // CHECK: sil private [transparent] [thunk] @$s28lifetime_dependence_generics5PViewVAA1PA2aDP4getE1EQzyYLsFTW : $@convention(witness_method: P) (@in_guaranteed PView) -> _scope(0) @out View {
 
-// CHECK: sil @$s28lifetime_dependence_generics4test5pviewAA4ViewVAA5PViewVYls_tF : $@convention(thin) (PView) -> _scope(1) @owned View {
+// CHECK: sil @$s28lifetime_dependence_generics4test5pviewAA4ViewVAA5PViewVYls_tF : $@convention(thin) (PView) -> _scope(0) @owned View {

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -521,7 +521,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %pai : $@callee_owned () -> ()
 }
 
-sil @foo_dependence : $@convention(thin) (@guaranteed Foo) -> _scope(1) @owned Nonescapable
+sil @foo_dependence : $@convention(thin) (@guaranteed Foo) -> _scope(0) @owned Nonescapable
 sil @use_nonescapable : $@convention(thin) (@guaranteed Nonescapable) -> ()
 
 // Test that the pass does not crash when it sees a mark_dependence on an alloc_box base that does not have a partial_apply value.
@@ -537,8 +537,8 @@ bb0:
   store %13 to [init] %8 : $*Foo
   %16 = load_borrow %8 : $*Foo
 
-  %17 = function_ref @foo_dependence : $@convention(thin) (@guaranteed Foo) -> _scope(1) @owned Nonescapable
-  %18 = apply %17(%16) : $@convention(thin) (@guaranteed Foo) -> _scope(1) @owned Nonescapable
+  %17 = function_ref @foo_dependence : $@convention(thin) (@guaranteed Foo) -> _scope(0) @owned Nonescapable
+  %18 = apply %17(%16) : $@convention(thin) (@guaranteed Foo) -> _scope(0) @owned Nonescapable
 
   %19 = mark_dependence [unresolved] %18 : $Nonescapable on %6 : ${ let Foo }
   %20 = move_value [var_decl] %19 : $Nonescapable

--- a/test/SILOptimizer/lifetime_dependence.sil
+++ b/test/SILOptimizer/lifetime_dependence.sil
@@ -18,7 +18,7 @@ class C {}
 
 struct Nonescapable: ~Escapable {}
 
-sil @c_dependence : $@convention(thin) (@guaranteed C) -> _scope(1) @owned Nonescapable
+sil @c_dependence : $@convention(thin) (@guaranteed C) -> _scope(0) @owned Nonescapable
 
 // Test that SILType.isEscpable does not crash on a generic box when NoncopyableGenerics is enabled.
 sil shared [serialized] [ossa] @testLocalFunc : $@convention(thin) <T, U> (@guaranteed <τ_0_0> { var τ_0_0 } <U>) -> () {
@@ -31,8 +31,8 @@ bb0(%1 : @closureCapture @guaranteed $<τ_0_0> { var τ_0_0 } <U>):
 sil [ossa] @test_mark_dependence_store : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
   %stk = alloc_stack [var_decl] $Nonescapable
-  %f = function_ref @c_dependence : $@convention(thin) (@guaranteed C) -> _scope(1) @owned Nonescapable
-  %c = apply %f(%0) : $@convention(thin) (@guaranteed C) -> _scope(1) @owned Nonescapable
+  %f = function_ref @c_dependence : $@convention(thin) (@guaranteed C) -> _scope(0) @owned Nonescapable
+  %c = apply %f(%0) : $@convention(thin) (@guaranteed C) -> _scope(0) @owned Nonescapable
 
   %md = mark_dependence [nonescaping] %c : $Nonescapable on %0 : $C
   store %md to [init] %stk : $*Nonescapable

--- a/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
@@ -3,8 +3,8 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -enable-experimental-feature NoncopyableGenerics
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
@@ -53,4 +53,16 @@ func bv_get_consume(container: consuming NE) -> BV {
     // expected-note @-1{{it depends on this scoped access to variable 'container'}}
     // expected-note @-2{{this use causes the lifetime-dependent value to escape}}
 }
+
+struct Wrapper : ~Escapable {
+  let bv: BV
+}
+
+func bv_incorrect_annotation1(_ bv1: borrowing BV, _ bv2: borrowing BV) -> dependsOn(bv2) BV { // expected-error {{lifetime-dependent variable 'bv1' escapes its scope}}
+  return copy bv1                                                                              // expected-note @-1{{it depends on the lifetime of argument 'bv1'}}
+}                                                                                              // expected-note @-1{{this use causes the lifetime-dependent value to escape}}
+
+func bv_incorrect_annotation2(_ w1: borrowing Wrapper, _ w2: borrowing Wrapper) -> dependsOn(w2) BV { // expected-error {{lifetime-dependent variable 'w1' escapes its scope}}
+  return w1.bv                                                                                        // expected-note @-1{{it depends on the lifetime of argument 'w1'}}
+}                                                                                                     // expected-note @-1{{this use causes the lifetime-dependent value to escape}}
 

--- a/test/SILOptimizer/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence_closure.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 

--- a/test/SILOptimizer/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence_diagnostics.swift
@@ -62,9 +62,9 @@ func takeClosure(_: () -> ()) {}
 
 // No mark_dependence is needed for a inherited scope.
 //
-// CHECK-LABEL: sil hidden @$s4test14bv_borrow_copyyAA2BVVADYlsF : $@convention(thin) (@guaranteed BV) -> _scope(1) @owned BV {
+// CHECK-LABEL: sil hidden @$s4test14bv_borrow_copyyAA2BVVADYlsF : $@convention(thin) (@guaranteed BV) -> _scope(0) @owned BV {
 // CHECK:      bb0(%0 : @noImplicitCopy $BV):
-// CHECK:        apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> _inherit(1) @owned BV
+// CHECK:        apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> _inherit(0) @owned BV
 // CHECK-NEXT:   return %3 : $BV
 // CHECK-LABEL: } // end sil function '$s4test14bv_borrow_copyyAA2BVVADYlsF'
 func bv_borrow_copy(_ bv: borrowing BV) -> dependsOn(scoped bv) BV {
@@ -74,9 +74,9 @@ func bv_borrow_copy(_ bv: borrowing BV) -> dependsOn(scoped bv) BV {
 // The mark_dependence for the borrow scope should be marked
 // [nonescaping] after diagnostics.
 //
-// CHECK-LABEL: sil hidden @$s4test010bv_borrow_C00B0AA2BVVAEYls_tF : $@convention(thin) (@guaranteed BV) -> _scope(1) @owned BV {
+// CHECK-LABEL: sil hidden @$s4test010bv_borrow_C00B0AA2BVVAEYls_tF : $@convention(thin) (@guaranteed BV) -> _scope(0) @owned BV {
 // CHECK:       bb0(%0 : @noImplicitCopy $BV):
-// CHECK:         [[R:%.*]] = apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> _scope(1) @owned BV
+// CHECK:         [[R:%.*]] = apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> _scope(0) @owned BV
 // CHECK:         %{{.*}} = mark_dependence [nonescaping] [[R]] : $BV on %0 : $BV
 // CHECK-NEXT:    return %{{.*}} : $BV
 // CHECK-LABEL: } // end sil function '$s4test010bv_borrow_C00B0AA2BVVAEYls_tF'
@@ -95,8 +95,8 @@ func neint_throws(ncInt: borrowing NCInt) throws -> NEInt {
   return NEInt(owner: ncInt)
 }
 
-// CHECK-LABEL: sil hidden @$s4test9neint_try5ncIntAA5NEIntVAA5NCIntVYls_tKF : $@convention(thin) (@guaranteed NCInt) -> _scope(1)  (@owned NEInt, @error any Error) {
-// CHECK:   try_apply %{{.*}}(%0) : $@convention(thin) (@guaranteed NCInt) -> _scope(1)  (@owned NEInt, @error any Error), normal bb1, error bb2
+// CHECK-LABEL: sil hidden @$s4test9neint_try5ncIntAA5NEIntVAA5NCIntVYls_tKF : $@convention(thin) (@guaranteed NCInt) -> _scope(0)  (@owned NEInt, @error any Error) {
+// CHECK:   try_apply %{{.*}}(%0) : $@convention(thin) (@guaranteed NCInt) -> _scope(0)  (@owned NEInt, @error any Error), normal bb1, error bb2
 // CHECK: bb1([[R:%.*]] : $NEInt):
 // CHECK:   [[MD:%.*]] = mark_dependence [nonescaping] %5 : $NEInt on %0 : $NCInt
 // CHECK:   return [[MD]] : $NEInt

--- a/test/SILOptimizer/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope.swift
@@ -35,7 +35,7 @@ struct NC : ~Copyable {
 
 // Rewrite the mark_dependence to depend on the incoming argument rather than the nested access.
 //
-// CHECK-LABEL: sil hidden @$s4test13bv_get_mutate9containerAA2BVVAA2NCVzYls_tF : $@convention(thin) (@inout NC) -> _scope(1) @owned BV {
+// CHECK-LABEL: sil hidden @$s4test13bv_get_mutate9containerAA2BVVAA2NCVzYls_tF : $@convention(thin) (@inout NC) -> _scope(0) @owned BV {
 // CHECK: bb0(%0 : $*NC):
 // CHECK:   [[A:%.*]] = begin_access [read] [static] %0 : $*NC
 // CHECK:   [[L:%.*]] = load [[A]] : $*NC

--- a/test/Sema/implicit_lifetime_dependence.swift
+++ b/test/Sema/implicit_lifetime_dependence.swift
@@ -11,7 +11,7 @@ struct BufferView : ~Escapable, ~Copyable {
   }
 }
 
-struct ImplicitInit1 : ~Escapable { // expected-error{{cannot infer lifetime dependence on implicit initializer, no parameters found that are ~Escapable or Escapable with a borrowing ownership}}
+struct ImplicitInit1 : ~Escapable { // expected-error{{cannot infer lifetime dependence on implicit initializer, no parameters found that are either ~Escapable or Escapable with a borrowing ownership}}
   let ptr: UnsafeRawBufferPointer
 }
 
@@ -24,7 +24,7 @@ struct ImplicitInit3 : ~Escapable, ~Copyable { // expected-error{{cannot infer l
   let mbv2: BufferView
 }
 
-func foo() -> BufferView { // expected-error{{cannot infer lifetime dependence , no parameters found that are ~Escapable or Escapable with a borrowing ownership}}
+func foo() -> BufferView { // expected-error{{cannot infer lifetime dependence , no parameters found that are either ~Escapable or Escapable with a borrowing ownership}}
   return BufferView(nil, 0)
 }
 

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -46,9 +46,9 @@ func testReadAccessor() {
   }
 }
 
-// CHECK: sil @$s32def_explicit_lifetime_dependence6deriveyAA10BufferViewVADYlsF : $@convention(thin) (@guaranteed BufferView) -> _scope(1) @owned BufferView
-// CHECK: sil @$s32def_explicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(1) @owned BufferView
-// CHECK: sil @$s32def_explicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADYlsF : $@convention(thin) (@guaranteed BufferView) -> _scope(1) @owned BufferView
-// CHECK: sil @$s32def_explicit_lifetime_dependence16deriveThisOrThatyAA10BufferViewVADYls_ADYlstF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(1, 2) @owned BufferView
+// CHECK: sil @$s32def_explicit_lifetime_dependence6deriveyAA10BufferViewVADYlsF : $@convention(thin) (@guaranteed BufferView) -> _scope(0) @owned BufferView
+// CHECK: sil @$s32def_explicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView
+// CHECK: sil @$s32def_explicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADYlsF : $@convention(thin) (@guaranteed BufferView) -> _scope(0) @owned BufferView
+// CHECK: sil @$s32def_explicit_lifetime_dependence16deriveThisOrThatyAA10BufferViewVADYls_ADYlstF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(0, 1) @owned BufferView
 
-// CHECK: sil @$s32def_explicit_lifetime_dependence10BufferViewVyACSW_SaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(2) @owned BufferView
+// CHECK: sil @$s32def_explicit_lifetime_dependence10BufferViewVyACSW_SaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView

--- a/test/Serialization/implicit_lifetime_dependence.swift
+++ b/test/Serialization/implicit_lifetime_dependence.swift
@@ -62,13 +62,13 @@ func testReadMutateAccessors() {
   }
 }
 
-// CHECK: sil @$s32def_implicit_lifetime_dependence6deriveyAA10BufferViewVADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(1) @owned BufferView
+// CHECK: sil @$s32def_implicit_lifetime_dependence6deriveyAA10BufferViewVADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0) @owned BufferView
 
-// CHECK: sil @$s32def_implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(1) @owned BufferView
+// CHECK: sil @$s32def_implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView
 
-// CHECK: sil @$s32def_implicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(1) @owned BufferView
+// CHECK: sil @$s32def_implicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0) @owned BufferView
 
-// CHECK: sil @$s32def_implicit_lifetime_dependence10BufferViewVyA2ChYlicfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> _inherit(1) @owned BufferView
+// CHECK: sil @$s32def_implicit_lifetime_dependence10BufferViewVyA2ChYlicfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> _inherit(0) @owned BufferView
 
 // CHECK: sil @$s32def_implicit_lifetime_dependence9ContainerV4viewAA10BufferViewVvg : $@convention(method) (@guaranteed Container) -> _scope(0) @owned BufferView
 


### PR DESCRIPTION
Explanation:  Use the request evaluator method to query LifetimeDependenceInfo.
With this change, LifetimeDependenceInfo is serialized in both explicit and inferred cases. And on deserialization, LifetimeDependenceInfo is cached on the decl, so that InterfaceTypeRequest does not have to recompute this info.

Original PR: https://github.com/apple/swift/pull/72916

Issue: rdar://125938675

Scope: Effects lifetime dependence inference on deserialized decls

Risk: Low. Effects only experimental feature NonEscapableTypes

Testing: Unit tests

Reviewer: @slavapestov  

