### PR TITLE
[Embedded] Add armv4t to list of recognized architectures

### DIFF
--- a/cmake/modules/SwiftSetIfArchBitness.cmake
+++ b/cmake/modules/SwiftSetIfArchBitness.cmake
@@ -9,6 +9,7 @@ function(set_if_arch_bitness var_name)
   if("${SIA_ARCH}" STREQUAL "i386" OR
      "${SIA_ARCH}" STREQUAL "i686" OR
      "${SIA_ARCH}" STREQUAL "x86" OR
+     "${SIA_ARCH}" STREQUAL "armv4t" OR
      "${SIA_ARCH}" STREQUAL "armv5" OR
      "${SIA_ARCH}" STREQUAL "armv6" OR
      "${SIA_ARCH}" STREQUAL "armv6m" OR

--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -60,6 +60,8 @@ static std::string adjustClangTriple(StringRef TripleStr) {
     OS << "armv5"; break;
   case llvm::Triple::SubArchType::ARMSubArch_v5te:
     OS << "armv5te"; break;
+  case llvm::Triple::SubArchType::ARMSubArch_v4t:
+    OS << "armv4t"; break;
   default:
     // Adjust i386-macosx to x86_64 because there is no Swift stdlib for i386.
     if ((Triple.getOS() == llvm::Triple::MacOSX ||

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -183,6 +183,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   # the following are all ELF targets
   if("ARM" IN_LIST LLVM_TARGETS_TO_BUILD)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+      "armv4t   armv4t-none-none-eabi     armv4t-none-none-eabi"
       "armv6    armv6-none-none-eabi      armv6-none-none-eabi"
       "armv6m   armv6m-none-none-eabi     armv6m-none-none-eabi"
       "armv7    armv7-none-none-eabi      armv7-none-none-eabi"


### PR DESCRIPTION
<!-- What's in this pull request? -->

This adds armv4t as a recognized embedded architecture and builds a stdlib module for it.
Since LLVM natively supports armv4t, this is all that's needed to write Swift for the Game Boy Advance, if you combine it with the GBA LLVM toolkit from https://github.com/stuij/gba-llvm-devkit.