### PR TITLE
Platform: add UserEnv module to WinSDK

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -468,6 +468,12 @@ module WinSDK [system] {
     link "User32.Lib"
   }
 
+  module UserEnv {
+    header "UserEnv.h"
+    export *
+    link "UserEnv.Lib"
+  }
+
   module WER {
     header "WerApi.h"
     export *


### PR DESCRIPTION
This allows access to the `GetUserProfileDirectoryW` API which is required for the swift-foundation implementation on Windows.