### PR TITLE
[Windows] Build SwiftCompilerPlugin module when testing swift

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1023,7 +1023,7 @@ function Build-Compilers() {
       if ($TestLLD) { $Targets += @("check-lld") }
       if ($TestLLDB) { $Targets += @("check-lldb") }
       if ($TestLLVM) { $Targets += @("check-llvm") }
-      if ($TestSwift) { $Targets += @("check-swift") }
+      if ($TestSwift) { $Targets += @("check-swift", "SwiftCompilerPlugin") }
     } else {
       $Targets = @("distribution", "install-distribution")
       $TestingDefines = @{


### PR DESCRIPTION
`build.ps1` doesn't test executable plugins at all. That means it doesn't even try to compile `SwiftComplerPlugin` module. At least, let's build it when testing Swift so we can verify the build breakage in PR testing.
