### PR TITLE
[6.0] Fix a crash when serializing variadic generic tuple code under -wmo

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -293,14 +293,18 @@ public:
         continue;
       }
 
-      // Substitute the shape class of the expansion.
+      // Substitute the shape class of the expansion.  If this doesn't
+      // give us a pack (e.g. if this isn't a substituting clone),
+      // we're never erasing tuple structure.
       auto newShapeClass = getOpASTType(expansion.getCountType());
       auto newShapePack = dyn_cast<PackType>(newShapeClass);
+      if (!newShapePack)
+        return false;
 
       // If the element has a name, then the tuple sticks around unless
       // the expansion disappears completely.
       if (type->getElement(index).hasName()) {
-        if (newShapePack && newShapePack->getNumElements() == 0)
+        if (newShapePack->getNumElements() == 0)
           continue;
         return false;
       }

--- a/test/SILOptimizer/Inputs/cross-module/cross-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/cross-module.swift
@@ -295,3 +295,13 @@ public func getEmptySet() -> Set<Int> {
   return Set()
 }
 
+public protocol Visitable {
+  func visit()
+}
+@available(SwiftStdlib 6.0, *)
+public struct S<each T : Visitable> {
+  var storage: (repeat each T)
+  public func visit() {
+    _ = (repeat (each storage).visit())
+  }
+}


### PR DESCRIPTION
Explanation: When serializing SIL under WMO, we invoke the SILCloner using a no-op transformation in order to visit the types used in the function.  The SILCloner for `tuple_pack_element_addr` expects the result of transforming a pack archetype to be a pack type and gets confused.
Scope: Fixes a crash when serializing a common variadic generic code pattern under WMO
Original PR: https://github.com/apple/swift/pull/72990
Risk: Low
Testing: New regression test
Issue: #72117
Reviewer: @eeckstein