### PR TITLE
[Caching] Adopt -finclude-tree-preserve-pch-path to fix -gmodules with

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -124,6 +124,11 @@ static std::vector<std::string> getClangDepScanningInvocationArguments(
   // ObjectFilePCHContainer and contain -gmodules debug info.
   commandLineArgs.push_back("-gmodules");
 
+  // To use -gmodules we need to have a real path for the PCH; this option has
+  // no effect if caching is disabled.
+  commandLineArgs.push_back("-Xclang");
+  commandLineArgs.push_back("-finclude-tree-preserve-pch-path");
+
   return commandLineArgs;
 }
 

--- a/test/CAS/bridging-header.swift
+++ b/test/CAS/bridging-header.swift
@@ -13,6 +13,8 @@
 // CHECK-NEXT:    "A"
 // CHECK-NEXT:  ],
 // CHECK-NEXT:  "commandLine": [
+// CHECK:         "-fmodule-format=obj"
+// CHECK:         "-dwarf-ext-refs"
 // CHECK:         "-fmodule-file-cache-key",
 // CHECK-NEXT:    "-Xcc",
 // CHECK-NEXT:    "{{.*}}{{/|\\}}A-{{.*}}.pcm", 

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -173,11 +173,18 @@ import SubE
 // CHECK: "contextHash"
 // CHECK-SAME: "{{.*}}"
 
+// CHECK: "commandLine": [
+// CHECK:   "-fmodule-format=obj"
+// CHECK:   "-dwarf-ext-refs"
+
 /// --------Clang module B
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}B-{{.*}}.pcm",
 // CHECK: "contextHash": "[[B_CONTEXT:.*]]",
-// CHECK: "-o"
+// CHECK: "commandLine": [
+// CHECK:      "-o"
 // CHECK-NEXT: B-{{.*}}[[B_CONTEXT]].pcm
+// CHECK:      "-fmodule-format=obj"
+// CHECK:      "-dwarf-ext-refs"
 
 // Check make-style dependencies
 // CHECK-MAKE-DEPS: module_deps_include_tree.swift


### PR DESCRIPTION
This fixes -gmodules when caching by adopting the new clang -cc1 option -finclude-tree-preserve-pch-path. -gmodules is required to make debugging work when examining types that come from clang modules or bridging headers, but was previously being disabled by clang's caching support.

rdar://126370706

Requires https://github.com/apple/llvm-project/pull/8570