### PR TITLE
[ScanDependency] Handle blocklist'ed interface in scanner

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1198,6 +1198,8 @@ REMARK(module_api_import_aliases,none,
 
 REMARK(skip_module_invalid,none,"skip invalid swiftmodule: %0", (StringRef))
 REMARK(skip_module_testable,none,"skip swiftmodule built with '-enable-testing': %0", (StringRef))
+WARNING(warn_no_valid_binary_module,none,
+        "no valid binary module found for ignored interface: '%0'", (StringRef))
 
 REMARK(macro_loaded,none,
        "loaded macro implementation module %0 from "

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -187,10 +187,16 @@ struct SubCompilerInstanceInfo {
   ArrayRef<StringRef> ExtraPCMArgs;
 };
 
+struct CandidateModules {
+  std::string adjacentModule;
+  std::string prebuiltModule;
+  bool interfaceIgnored = false;
+};
+
 /// Abstract interface for a checker of module interfaces and prebuilt modules.
 class ModuleInterfaceChecker {
 public:
-  virtual std::vector<std::string>
+  virtual CandidateModules
   getCompiledModuleCandidatesForInterface(StringRef moduleName,
                                           StringRef interfacePath) = 0;
 

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -522,7 +522,7 @@ public:
                                 RequireOSSAModules_t requiresOSSAModules):
     ModuleInterfaceCheckerImpl(Ctx, cacheDir, prebuiltCacheDir, StringRef(),
                                opts, requiresOSSAModules) {}
-  std::vector<std::string>
+  CandidateModules
   getCompiledModuleCandidatesForInterface(StringRef moduleName,
                                           StringRef interfacePath) override;
 


### PR DESCRIPTION
Handle blocklist'ed interface file better in the scanner when it does binary module validation and found no valid binary module with it. Instead of the current behavior that it will try to build the interface anyway, change it to warn and continue searching.
