### PR TITLE
[6.0] Disable SILCombine::visitInjectEnumAddrInst for empty tuple types

### DIFF
--- a/test/SILOptimizer/sil_combine_enum_addr.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr.sil
@@ -260,7 +260,7 @@ bb22:
 sil @no_init : $@convention(thin) () -> (@out ())
 
 // CHECK-LABEL: sil @test_empty_tuple_uninintialized : $@convention(thin) () -> () {
-// CHECK-NOT: inject_enum_addr
+// TODO-NOT: inject_enum_addr
 // CHECK-LABEL: } // end sil function 'test_empty_tuple_uninintialized'
 sil @test_empty_tuple_uninintialized : $@convention(thin) () -> () {
 bb0:
@@ -287,7 +287,7 @@ bb3:
 sil @no_init_nested_tuple : $@convention(thin) () -> (@out ((), ()))
 
 // CHECK-LABEL: sil @test_empty_nested_tuple_uninintialized : $@convention(thin) () -> () {
-// CHECK-NOT: inject_enum_addr
+// TODO-NOT: inject_enum_addr
 // CHECK-LABEL: } // end sil function 'test_empty_nested_tuple_uninintialized'
 sil @test_empty_nested_tuple_uninintialized : $@convention(thin) () -> () {
 bb0:
@@ -314,7 +314,7 @@ bb3:
 sil @no_init_struct : $@convention(thin) () -> (@out ResilientEmptyStruct)
 
 // CHECK-LABEL: sil @test_empty_struct_uninitialized : $@convention(thin) () -> () {
-// CHECK-NOT: switch_enum_addr
+// TODO-NOT: switch_enum_addr
 // CHECK-LABEL: } // end sil function 'test_empty_struct_uninitialized'
 sil @test_empty_struct_uninitialized : $@convention(thin) () -> () {
 bb0:
@@ -340,7 +340,7 @@ bb3:
 sil @no_init_c_union : $@convention(thin) () -> (@out EmptyCUnion)
 
 // CHECK-LABEL: sil @test_empty_c_union : $@convention(thin) () -> () {
-// CHECK: inject_enum_addr
+// TODO: inject_enum_addr
 // CHECK-LABEL: } // end sil function 'test_empty_c_union'
 sil @test_empty_c_union : $@convention(thin) () -> () {
 bb0:
@@ -370,7 +370,7 @@ struct NestedUnreferenceableStorage {
 sil @no_init_nested_c_union : $@convention(thin) () -> (@out NestedUnreferenceableStorage)
 
 // CHECK-LABEL: sil @test_empty_nested_c_union : $@convention(thin) () -> () {
-// CHECK: inject_enum_addr
+// TODO: inject_enum_addr
 // CHECK-LABEL: } // end sil function 'test_empty_nested_c_union'
 sil @test_empty_nested_c_union : $@convention(thin) () -> () {
 bb0:


### PR DESCRIPTION
Explanation:   `SILCombine::visitInjectEnumAddrInst` deletes `init_enum_data_addr ` and `inject_enum_addr ` and creates an empty value to store into the destination addr when legal. Optional empty types can be initialized with `init_enum_data_addr` but `inject_enum_addr` can be present only on some control flow paths. Applying this optimization can result in uninitialized tag information on some paths leading to miscompilations.

Issue:  rdar://126231554 

Scope: Effects optionals of empty type which are fairly common due to some frameworks

Risk: Low. Disabling an optimization recently enabled.

Testing: Unit tests

Reviewer: @aschwaighofer 