### PR TITLE
[Distributed] Avoid infinite recursion in distributed thunk on protocol extensions

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2452,6 +2452,34 @@ public:
   // Distributed Actors
   //===---------------------------------------------------------------------===//
 
+  /// Determine if the target `func` should be replaced with a
+  /// 'distributed thunk'.
+  ///
+  /// This only applies to distributed functions when calls are made cross-actor
+  /// isolation. One notable exception is a distributed thunk calling the "real
+  /// underlying method", in which case (to avoid the thunk calling into itself,
+  /// the real method must be called).
+  ///
+  /// Witness calls which may need to be replaced with a distributed thunk call
+  /// happen either when the target type is generic, or if we are inside an
+  /// extension on a protocol. This method checks if we are in a context
+  /// where we should be calling the distributed thunk of the `func` or not.
+  /// Notably, if we are inside a distributed thunk already and are trying to
+  /// apply distributed method calls, all those must be to the "real" method,
+  /// because the thunks' responsibility is to call the real method, so this
+  /// replacement cannot be applied (or we'd recursively keep calling the same
+  /// thunk via witness).
+  ///
+  /// In situations which do not use a witness call, distributed methods are always
+  /// invoked Direct, and never ClassMethod, because distributed are effectively
+  /// final.
+  ///
+  /// \param func the target func that we are trying to "apply"
+  /// \return true when the function should be considered for replacement
+  ///         with distributed thunk when applying it
+  bool
+  shouldReplaceConstantForApplyWithDistributedThunk(FuncDecl *func) const;
+
   /// Initializes the implicit stored properties of a distributed actor that correspond to
   /// its transport and identity.
   void emitDistributedActorImplicitPropertyInits(

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_extension_concrete.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_extension_concrete.swift
@@ -23,14 +23,14 @@ protocol KappaProtocol : DistributedActor where ActorSystem == FakeRoundtripActo
   distributed func echo(name: String) -> String
 }
 
-extension KappaProtocol {
+distributed actor KappaProtocolImpl: KappaProtocol {
+  // empty, gets default impl from extension on this actor
+}
+
+extension KappaProtocolImpl {
   distributed func echo(name: String) -> String {
     return "Echo: \(name)"
   }
-}
-
-distributed actor KappaProtocolImpl: KappaProtocol {
-  // empty, gets default impl from extension on protocol
 }
 
 func test() async throws {
@@ -40,7 +40,7 @@ func test() async throws {
   let ref = try KappaProtocolImpl.resolve(id: local.id, using: system)
 
   let reply = try await ref.echo(name: "Caplin")
-  // CHECK: >> remoteCall: on:main.KappaProtocolImpl, target:main.$KappaProtocol.echo(name:), invocation:FakeInvocationEncoder(genericSubs: [main.KappaProtocolImpl], arguments: ["Caplin"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: >> remoteCall: on:main.KappaProtocolImpl, target:main.KappaProtocolImpl.echo(name:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Caplin"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
 
   // CHECK: << remoteCall return: Echo: Caplin
   print("reply: \(reply)")


### PR DESCRIPTION
Because of the new ways we handle distributed requirements to support distributed resolvable protocols, we now have protocol requirements for both the thunk and the real method. A distributed thunk inside a protocol extension now ended up calling "itself" through protocol witness, but instead should always call the "real" method.

Without this patch such situation would end up in an infinite recurstion executing such method from executeDistributedTarget when the method was a default impl provided by extension on a protocol.

This patch resolves this by becoming contextually aware of the distributed thunk, and allowing it to always call the "real" method.

resolves rdar://125445347
