### PR TITLE
[6.0][Distributed] Avoid infinite recursion in distributed thunk on protocol extension

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -616,6 +616,69 @@ public:
     return result;
   }
 
+
+  /// Determine if the target `func` should be replaced with a
+  /// 'distributed thunk'.
+  ///
+  /// This only applies to distributed functions when calls are made cross-actor
+  /// isolation. One notable exception is a distributed thunk calling the "real
+  /// underlying method", in which case (to avoid the thunk calling into itself,
+  /// the real method must be called).
+  ///
+  /// Witness calls which may need to be replaced with a distributed thunk call
+  /// happen either when the target type is generic, or if we are inside an
+  /// extension on a protocol. This method checks if we are in a context
+  /// where we should be calling the distributed thunk of the `func` or not.
+  /// Notably, if we are inside a distributed thunk already and are trying to
+  /// apply distributed method calls, all those must be to the "real" method,
+  /// because the thunks' responsibility is to call the real method, so this
+  /// replacement cannot be applied (or we'd recursively keep calling the same
+  /// thunk via witness).
+  ///
+  /// In situations which do not use a witness call, distributed methods are always
+  /// invoked Direct, and never ClassMethod, because distributed are effectively
+  /// final.
+  ///
+  /// \param constant the target that we want to dispatch to
+  /// \return true when the function should be considered for replacement
+  ///         with distributed thunk when applying it
+  bool shouldDispatchWitnessViaDistributedThunk(
+      SILGenFunction &SGF,
+      std::optional<SILDeclRef> constant
+      ) const {
+    if (!constant.has_value())
+      return false;
+
+    auto func = dyn_cast<FuncDecl>(constant->getDecl());
+    if (!func)
+      return false;
+
+    auto isDistributedFuncOrAccessor =
+        func->isDistributed();
+    if (auto acc = dyn_cast<AccessorDecl>(func)) {
+      isDistributedFuncOrAccessor =
+          acc->getStorage()->isDistributed();
+    }
+
+    if (!isDistributedFuncOrAccessor)
+      return false;
+
+    // If we are inside a distributed thunk, we want to call the "real" method,
+    // in order to avoid infinitely recursively calling the thunk from itself.
+    if (SGF.F.isDistributed() && SGF.F.isThunk())
+      return false;
+
+    // If caller and called func are isolated to the same (distributed) actor,
+    // (i.e. we are "inside the distributed actor"), there is no need to call
+    // the thunk.
+    if (isSameActorIsolated(func, SGF.FunctionDC))
+      return false;
+
+    // In all other situations, we may have to replace the called function,
+    // depending on isolation (to be checked in SILGenApply).
+    return true;
+  }
+
   ManagedValue getFnValue(SILGenFunction &SGF,
                           std::optional<ManagedValue> borrowedSelf) const & {
     std::optional<SILDeclRef> constant = std::nullopt;
@@ -681,11 +744,12 @@ public:
       return fn;
     }
     case Kind::WitnessMethod: {
-      if (auto func = constant->getFuncDecl()) {
-        if (SGF.shouldReplaceConstantForApplyWithDistributedThunk(func)) {
-          auto thunk = func->getDistributedThunk();
-          constant = SILDeclRef(thunk).asDistributed();
-        }
+      if (shouldDispatchWitnessViaDistributedThunk(SGF, constant)) {
+        auto func = dyn_cast<FuncDecl>(constant->getDecl());
+        assert(func); // guaranteed be non-null if shouldDispatch returned true
+
+        auto thunk = func->getDistributedThunk();
+        constant = SILDeclRef(thunk).asDistributed();
       }
 
       auto constantInfo =
@@ -772,7 +836,7 @@ public:
     }
     case Kind::WitnessMethod: {
       if (auto func = constant->getFuncDecl()) {
-        if (SGF.shouldReplaceConstantForApplyWithDistributedThunk(func)) {
+        if (shouldDispatchWitnessViaDistributedThunk(SGF, constant)) {
           constant = constant->asDistributed();
         }
       }

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -274,34 +274,6 @@ void InitializeDistActorIdentity::dump(SILGenFunction &) const {
 #endif
 }
 
-bool SILGenFunction::shouldReplaceConstantForApplyWithDistributedThunk(
-    FuncDecl *func) const {
-  auto isDistributedFuncOrAccessor =
-      func->isDistributed();
-  if (auto acc = dyn_cast<AccessorDecl>(func)) {
-    isDistributedFuncOrAccessor =
-        acc->getStorage()->isDistributed();
-  }
-
-  if (!isDistributedFuncOrAccessor)
-    return false;
-
-  // If we are inside a distributed thunk, we want to call the "real" method,
-  // in order to avoid infinitely recursively calling the thunk from itself.
-  if (F.isDistributed() && F.isThunk())
-    return false;
-
-  // If caller and called func are isolated to the same (distributed) actor,
-  // (i.e. we are "inside the distributed actor"), there is no need to call
-  // the thunk.
-  if (isSameActorIsolated(func, FunctionDC))
-    return false;
-
-  // In all other situations, we may have to replace the called function,
-  // depending on isolation (to be checked in SILGenApply).
-  return true;
-}
-
 void SILGenFunction::emitDistributedActorImplicitPropertyInits(
     ConstructorDecl *ctor, ManagedValue selfArg) {
   // Only designated initializers should perform this initialization.

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2452,6 +2452,34 @@ public:
   // Distributed Actors
   //===---------------------------------------------------------------------===//
 
+  /// Determine if the target `func` should be replaced with a
+  /// 'distributed thunk'.
+  ///
+  /// This only applies to distributed functions when calls are made cross-actor
+  /// isolation. One notable exception is a distributed thunk calling the "real
+  /// underlying method", in which case (to avoid the thunk calling into itself,
+  /// the real method must be called).
+  ///
+  /// Witness calls which may need to be replaced with a distributed thunk call
+  /// happen either when the target type is generic, or if we are inside an
+  /// extension on a protocol. This method checks if we are in a context
+  /// where we should be calling the distributed thunk of the `func` or not.
+  /// Notably, if we are inside a distributed thunk already and are trying to
+  /// apply distributed method calls, all those must be to the "real" method,
+  /// because the thunks' responsibility is to call the real method, so this
+  /// replacement cannot be applied (or we'd recursively keep calling the same
+  /// thunk via witness).
+  ///
+  /// In situations which do not use a witness call, distributed methods are always
+  /// invoked Direct, and never ClassMethod, because distributed are effectively
+  /// final.
+  ///
+  /// \param func the target func that we are trying to "apply"
+  /// \return true when the function should be considered for replacement
+  ///         with distributed thunk when applying it
+  bool
+  shouldReplaceConstantForApplyWithDistributedThunk(FuncDecl *func) const;
+
   /// Initializes the implicit stored properties of a distributed actor that correspond to
   /// its transport and identity.
   void emitDistributedActorImplicitPropertyInits(

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2452,34 +2452,6 @@ public:
   // Distributed Actors
   //===---------------------------------------------------------------------===//
 
-  /// Determine if the target `func` should be replaced with a
-  /// 'distributed thunk'.
-  ///
-  /// This only applies to distributed functions when calls are made cross-actor
-  /// isolation. One notable exception is a distributed thunk calling the "real
-  /// underlying method", in which case (to avoid the thunk calling into itself,
-  /// the real method must be called).
-  ///
-  /// Witness calls which may need to be replaced with a distributed thunk call
-  /// happen either when the target type is generic, or if we are inside an
-  /// extension on a protocol. This method checks if we are in a context
-  /// where we should be calling the distributed thunk of the `func` or not.
-  /// Notably, if we are inside a distributed thunk already and are trying to
-  /// apply distributed method calls, all those must be to the "real" method,
-  /// because the thunks' responsibility is to call the real method, so this
-  /// replacement cannot be applied (or we'd recursively keep calling the same
-  /// thunk via witness).
-  ///
-  /// In situations which do not use a witness call, distributed methods are always
-  /// invoked Direct, and never ClassMethod, because distributed are effectively
-  /// final.
-  ///
-  /// \param func the target func that we are trying to "apply"
-  /// \return true when the function should be considered for replacement
-  ///         with distributed thunk when applying it
-  bool
-  shouldReplaceConstantForApplyWithDistributedThunk(FuncDecl *func) const;
-
   /// Initializes the implicit stored properties of a distributed actor that correspond to
   /// its transport and identity.
   void emitDistributedActorImplicitPropertyInits(

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_extension_concrete.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_extension_concrete.swift
@@ -23,14 +23,14 @@ protocol KappaProtocol : DistributedActor where ActorSystem == FakeRoundtripActo
   distributed func echo(name: String) -> String
 }
 
-extension KappaProtocol {
+distributed actor KappaProtocolImpl: KappaProtocol {
+  // empty, gets default impl from extension on this actor
+}
+
+extension KappaProtocolImpl {
   distributed func echo(name: String) -> String {
     return "Echo: \(name)"
   }
-}
-
-distributed actor KappaProtocolImpl: KappaProtocol {
-  // empty, gets default impl from extension on protocol
 }
 
 func test() async throws {
@@ -40,7 +40,7 @@ func test() async throws {
   let ref = try KappaProtocolImpl.resolve(id: local.id, using: system)
 
   let reply = try await ref.echo(name: "Caplin")
-  // CHECK: >> remoteCall: on:main.KappaProtocolImpl, target:main.$KappaProtocol.echo(name:), invocation:FakeInvocationEncoder(genericSubs: [main.KappaProtocolImpl], arguments: ["Caplin"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: >> remoteCall: on:main.KappaProtocolImpl, target:main.KappaProtocolImpl.echo(name:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Caplin"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
 
   // CHECK: << remoteCall return: Echo: Caplin
   print("reply: \(reply)")


### PR DESCRIPTION
**Description**: Because of the new ways we handle distributed requirements to support distributed resolvable protocols, we now have protocol requirements for both the thunk and the real method. A distributed thunk inside a protocol extension now ended up calling "itself" through protocol witness, but instead should always call the "real" method.

Without this patch such situation would end up in an infinite recurstion executing such method from executeDistributedTarget when the method was a default impl provided by extension on a protocol.

This patch resolves this by becoming contextually aware of the distributed thunk, and allowing it to always call the "real" method.

**Scope of the issue**: The issue specifically affects Swift 6.x (since introduction of @_DistributedProtocol), and specifically `distributed func` declared in an `extension` of a `protocol`.
**Risk:** Low, no impact on other code than the described situation.
**Testing**: CI testing, manually verified the reproducer as well.
**Reviewed by**: @xedin 

**Original PR:** https://github.com/apple/swift/pull/73032
**Radar:** rdar://125445347