### PR TITLE
[6.0] CMake: add a missing dependency to fix the bootstrapping build

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -306,7 +306,7 @@ else()
 
   elseif(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
 
-    set(b0_deps swift-frontend-bootstrapping0 symlink-headers-bootstrapping0)
+    set(b0_deps swift-frontend-bootstrapping0 symlink-headers-bootstrapping0 copy-legacy-layouts)
     set(b1_deps swift-frontend-bootstrapping1 symlink-headers-bootstrapping1)
     if(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
       list(APPEND b0_deps swiftCore-bootstrapping0)


### PR DESCRIPTION
* **Explanation**: Legacy layouts must be copied before the bootstrapping compiler is used to build the SwiftCompilerSources Fixes a sporadic build failure due to missing legacy layout files
* **Scope**: Only affects the compiler build process
* **Risk**: very low. The only change is an additional CMake build dependency
* **Testing**: Tested by various CI jobs
* **Issue**: rdar://126305248
* **Reviewer**:  @edymtt
* **Main branch PR**: https://github.com/apple/swift/pull/73000





