### PR TITLE
[Caching] Adopt -finclude-tree-preserve-pch-path to fix -gmodules with

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -124,6 +124,11 @@ static std::vector<std::string> getClangDepScanningInvocationArguments(
   // ObjectFilePCHContainer and contain -gmodules debug info.
   commandLineArgs.push_back("-gmodules");
 
+  // To use -gmodules we need to have a real path for the PCH; this option has
+  // no effect if caching is disabled.
+  commandLineArgs.push_back("-Xclang");
+  commandLineArgs.push_back("-finclude-tree-preserve-pch-path");
+
   return commandLineArgs;
 }
 

--- a/test/CAS/bridging-header.swift
+++ b/test/CAS/bridging-header.swift
@@ -13,6 +13,8 @@
 // CHECK-NEXT:    "A"
 // CHECK-NEXT:  ],
 // CHECK-NEXT:  "commandLine": [
+// CHECK:         "-fmodule-format=obj"
+// CHECK:         "-dwarf-ext-refs"
 // CHECK:         "-fmodule-file-cache-key",
 // CHECK-NEXT:    "-Xcc",
 // CHECK-NEXT:    "{{.*}}{{/|\\}}A-{{.*}}.pcm", 

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -173,11 +173,18 @@ import SubE
 // CHECK: "contextHash"
 // CHECK-SAME: "{{.*}}"
 
+// CHECK: "commandLine": [
+// CHECK:   "-fmodule-format=obj"
+// CHECK:   "-dwarf-ext-refs"
+
 /// --------Clang module B
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}B-{{.*}}.pcm",
 // CHECK: "contextHash": "[[B_CONTEXT:.*]]",
-// CHECK: "-o"
+// CHECK: "commandLine": [
+// CHECK:      "-o"
 // CHECK-NEXT: B-{{.*}}[[B_CONTEXT]].pcm
+// CHECK:      "-fmodule-format=obj"
+// CHECK:      "-dwarf-ext-refs"
 
 // Check make-style dependencies
 // CHECK-MAKE-DEPS: module_deps_include_tree.swift


### PR DESCRIPTION
* **Explanation**: This fixes debugging of code built with Swift caching for types that come from clang modules and bridging headers. It does so by adopting the new clang `-cc1` option `-finclude-tree-preserve-pch-path` that was designed to allow Swift to use `-gmodules` in caching builds as a stop gap until a full solution for Clang -gmodules caching is developed (the usage from Swift is simpler than for arbitrary Clang builds).  Note: requires corresponding Clang change https://github.com/apple/llvm-project/pull/8575
* **Scope**: Fixes common debugging scenario (using types from clang modules or bridging header) and should have no negative impact.
* **Issue**: rdar://126370706
* **Original PR:** #73014
* **Risk**: Low. This flag only impacts caching builds. The specific change should make caching builds behave more like non-caching builds in this area.
* **Testing**: Regression tests for both Swift and Clang changes, manually tested that caching builds now can debug with clang modules + bridging header types.
* **Reviewers**: @artemcm @cachemeifyoucan 