### PR TITLE
[SILCombine] Dominance check for inject_enum_addr.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -204,6 +204,11 @@ static llvm::cl::opt<DebugOnlyPassNumberOpt, true,
               llvm::cl::location(DebugOnlyPassNumberOptLoc),
               llvm::cl::ValueRequired);
 
+static llvm::cl::opt<bool> SILPrintEverySubpass(
+    "sil-print-every-subpass", llvm::cl::init(false),
+    llvm::cl::desc("Print the function before every subpass run of passes that "
+                   "have multiple subpasses"));
+
 static bool isInPrintFunctionList(SILFunction *F) {
   for (const std::string &printFnName : SILPrintFunction) {
     if (printFnName == F->getName())
@@ -478,13 +483,22 @@ bool SILPassManager::continueTransforming() {
 bool SILPassManager::continueWithNextSubpassRun(SILInstruction *forInst,
                                                 SILFunction *function,
                                                 SILTransform *trans) {
+  unsigned subPass = numSubpassesRun++;
+
+  if (forInst && isFunctionSelectedForPrinting(function) &&
+      SILPrintEverySubpass) {
+    dumpPassInfo("*** SIL function before ", trans, function);
+    if (forInst) {
+      llvm::dbgs() << "  *** sub-pass " << subPass << " for " << *forInst;
+    }
+    function->dump(getOptions().EmitVerboseSIL);
+  }
+
   if (isMandatory)
     return true;
   if (NumPassesRun != maxNumPassesToRun - 1)
     return true;
 
-  unsigned subPass = numSubpassesRun++;
-  
   if (subPass == maxNumSubpassesToRun - 1 && SILPrintLast) {
     dumpPassInfo("*** SIL function before ", trans, function);
     if (forInst) {

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -865,14 +865,20 @@ SILInstruction *SILCombiner::visitCondFailInst(CondFailInst *CFI) {
   return nullptr;
 }
 
-/// Create a value from stores to an address.
+/// Whether there exists a unique value to which \p addr is always initialized
+/// at \p forInst.
 ///
-/// If there are only stores to \p addr, return the stored value. Also, if there
-/// are address projections, create aggregate instructions for it.
-/// If builder is null, it's just a dry-run to check if it's possible.
-static SILValue createValueFromAddr(SILValue addr, SILBuilder *builder,
-                                    SILLocation loc) {
-  SmallVector<SILValue, 4> elems;
+/// If \p builder is passed, create the value using it.  If \p addr is
+/// initialized piecewise via initializations of tuple element memory, the full
+/// tuple is constructed via the builder.
+///
+/// A best effort.
+/// TODO: Construct structs.
+///       Handle stores of identical values on multiple paths.
+static std::optional<std::pair<SILValue, SILInstruction *>>
+createValueFromAddr(SILValue addr, SILInstruction *forInst, DominanceInfo *DI,
+                    SILBuilder *builder, SILLocation loc) {
+  SmallVector<std::optional<std::pair<SILValue, SILInstruction *>>, 4> pairs;
   enum Kind {
     none, store, tuple
   } kind = none;
@@ -884,7 +890,7 @@ static SILValue createValueFromAddr(SILValue addr, SILBuilder *builder,
 
     auto *st = dyn_cast<StoreInst>(user);
     if (st && kind == none && st->getDest() == addr) {
-      elems.push_back(st->getSrc());
+      pairs.push_back({{st->getSrc(), st}});
       kind = store;
       // We cannot just return st->getSrc() here because we also have to check
       // if the store destination is the only use of addr.
@@ -893,35 +899,55 @@ static SILValue createValueFromAddr(SILValue addr, SILBuilder *builder,
 
     if (auto *telem = dyn_cast<TupleElementAddrInst>(user)) {
       if (kind == none) {
-        elems.resize(addr->getType().castTo<TupleType>()->getNumElements());
+        pairs.resize(addr->getType().castTo<TupleType>()->getNumElements());
         kind = tuple;
       }
       if (kind == tuple) {
-        if (elems[telem->getFieldIndex()])
-          return SILValue();
-        elems[telem->getFieldIndex()] = createValueFromAddr(telem, builder, loc);
+        if (pairs[telem->getFieldIndex()]) {
+          // Already found a tuple_element_addr at this index.  Assume that a
+          // different value is stored to addr by it.
+          return std::nullopt;
+        }
+        pairs[telem->getFieldIndex()] =
+            createValueFromAddr(telem, forInst, DI, builder, loc);
         continue;
       }
     }
     // TODO: handle StructElementAddrInst to create structs.
 
-    return SILValue();
+    return std::nullopt;
   }
   switch (kind) {
   case none:
-    return SILValue();
+    return std::nullopt;
   case store:
-    assert(elems.size() == 1);
-    return elems[0];
+    assert(pairs.size() == 1);
+    {
+      auto pair = pairs[0];
+      assert(pair.has_value());
+      bool isEmpty = pair->first->getType().isEmpty(*addr->getFunction());
+      if (isEmpty && !DI->properlyDominates(pair->second, forInst))
+        return std::nullopt;
+      return pair;
+    }
   case tuple:
-    if (std::any_of(elems.begin(), elems.end(),
-                    [](SILValue v){ return !(bool)v; }))
-      return SILValue();
+    if (std::any_of(pairs.begin(), pairs.end(), [&](auto pair) {
+          return !pair.has_value() ||
+                 (pair->first->getType().isEmpty(*addr->getFunction()) &&
+                  !DI->properlyDominates(pair->second, forInst));
+        }))
+      return std::nullopt;
     if (builder) {
-      return builder->createTuple(loc, addr->getType().getObjectType(), elems);
+      SmallVector<SILValue, 4> elements;
+      for (auto pair : pairs) {
+        elements.push_back(pair->first);
+      }
+      auto *tuple =
+          builder->createTuple(loc, addr->getType().getObjectType(), elements);
+      return {{tuple, tuple}};
     }
     // Just return anything not null for the dry-run.
-    return elems[0];
+    return pairs[0];
   }
   llvm_unreachable("invalid kind");
 }
@@ -1185,9 +1211,12 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
   //   store %payload1 to %elem1_addr
   //   inject_enum_addr %enum_addr, $EnumType.case
   //
-  if (createValueFromAddr(DataAddrInst, nullptr, DataAddrInst->getLoc())) {
-    SILValue en =
-      createValueFromAddr(DataAddrInst, &Builder, DataAddrInst->getLoc());
+  auto DI = DA->get(IEAI->getFunction());
+  if (createValueFromAddr(DataAddrInst, IEAI, DI, nullptr,
+                          DataAddrInst->getLoc())) {
+    SILValue en = createValueFromAddr(DataAddrInst, IEAI, DI, &Builder,
+                                      DataAddrInst->getLoc())
+                      ->first;
     assert(en);
 
     // In that case, create the payload enum/store.
@@ -1224,7 +1253,14 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
   //  store %1 to %nopayload_addr
   //
   auto *AI = dyn_cast_or_null<ApplyInst>(getSingleNonDebugUser(DataAddrInst));
-  if (!AI)
+  bool hasEmptyAssociatedType =
+      IEAI->getElement()->hasAssociatedValues()
+          ? IEAI->getOperand()
+                ->getType()
+                .getEnumElementType(IEAI->getElement(), func)
+                .isEmpty(*func)
+          : false;
+  if (!AI || (hasEmptyAssociatedType && !DI->properlyDominates(AI, IEAI)))
     return nullptr;
 
   unsigned ArgIdx = 0;

--- a/test/SILOptimizer/sil_combine_enum_addr.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr.sil
@@ -392,3 +392,328 @@ bb3:
   %8 = tuple ()
   return %8 : $()
 }
+
+sil @getVoidOut : $@convention(thin) () -> @out ()
+sil @getIntOut : $@convention(thin) () -> @out Int
+
+// CHECK-LABEL: sil @empty_nondominating_apply : {{.*}} {
+// CHECK:         inject_enum_addr
+// CHECK-LABEL: } // end sil function 'empty_nondominating_apply'
+sil @empty_nondominating_apply : $@convention(thin) (Builtin.Int1) -> () {
+entry(%cond : $Builtin.Int1):
+  %addr = alloc_stack $Optional<()>
+  %some_addr = init_enum_data_addr %addr : $*Optional<()>, #Optional.some!enumelt
+  cond_br %cond, left, right
+
+left:
+  br middle
+
+right:
+  %get = function_ref @getVoidOut : $@convention(thin) () -> @out ()
+  apply %get(%some_addr) : $@convention(thin) () -> @out ()
+  br middle
+
+middle:
+  inject_enum_addr %addr : $*Optional<()>, #Optional.some!enumelt
+  %o = load %addr : $*Optional<()>
+  switch_enum %o : $Optional<()>, case #Optional.some!enumelt: some_block, case #Optional.none!enumelt: none_block
+
+some_block(%avoid : $()):
+  br exit
+
+none_block:
+  br exit
+
+exit:
+  dealloc_stack %addr : $*Optional<()>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @check_dominating_apply_unreachable : {{.*}} {
+// CHECK-NOT:     inject_enum_addr
+// CHECK-LABEL: } // end sil function 'check_dominating_apply_unreachable'
+sil @check_dominating_apply_unreachable : $@convention(thin) (Builtin.Int1) -> () {
+entry(%cond : $Builtin.Int1):
+  %addr = alloc_stack $Optional<()>
+  %some_addr = init_enum_data_addr %addr : $*Optional<()>, #Optional.some!enumelt
+  cond_br %cond, left, right
+
+left:
+  %get = function_ref @getVoidOut : $@convention(thin) () -> @out ()
+  apply %get(%some_addr) : $@convention(thin) () -> @out ()
+  br middle
+
+right:
+  unreachable
+
+middle:
+  inject_enum_addr %addr : $*Optional<()>, #Optional.some!enumelt
+  %o = load %addr : $*Optional<()>
+  switch_enum %o : $Optional<()>, case #Optional.some!enumelt: some_block, case #Optional.none!enumelt: none_block
+
+some_block(%avoid : $()):
+  br exit
+
+none_block:
+  br exit
+
+exit:
+  dealloc_stack %addr : $*Optional<()>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @check_dominating_apply_unreachable_nonempty : {{.*}} {
+// CHECK-NOT:     inject_enum_addr
+// CHECK-LABEL: } // end sil function 'check_dominating_apply_unreachable_nonempty'
+sil @check_dominating_apply_unreachable_nonempty : $@convention(thin) (Builtin.Int1) -> () {
+entry(%cond : $Builtin.Int1):
+  %addr = alloc_stack $Optional<Int>
+  %some_addr = init_enum_data_addr %addr : $*Optional<Int>, #Optional.some!enumelt
+  cond_br %cond, left, right
+
+left:
+  %get = function_ref @getIntOut : $@convention(thin) () -> @out Int
+  apply %get(%some_addr) : $@convention(thin) () -> @out Int
+  br middle
+
+right:
+  unreachable
+
+middle:
+  inject_enum_addr %addr : $*Optional<Int>, #Optional.some!enumelt
+  %o = load %addr : $*Optional<Int>
+  switch_enum %o : $Optional<Int>, case #Optional.some!enumelt: some_block, case #Optional.none!enumelt: none_block
+
+some_block(%avoid : $Int):
+  br exit
+
+none_block:
+  br exit
+
+exit:
+  dealloc_stack %addr : $*Optional<Int>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @empty_nondominating_store : {{.*}} {
+// CHECK:         inject_enum_addr
+// CHECK-LABEL: } // end sil function 'empty_nondominating_store'
+sil @empty_nondominating_store : $@convention(thin) (Builtin.Int1) -> () {
+entry(%cond : $Builtin.Int1):
+  %addr = alloc_stack $Optional<()>
+  %some_addr = init_enum_data_addr %addr : $*Optional<()>, #Optional.some!enumelt
+  cond_br %cond, left, right
+
+left:
+  br middle
+
+right:
+  %void = tuple ()
+  store %void to %some_addr : $*()
+  br middle
+
+middle:
+  inject_enum_addr %addr : $*Optional<()>, #Optional.some!enumelt
+  %o = load %addr : $*Optional<()>
+  switch_enum %o : $Optional<()>, case #Optional.some!enumelt: some_block, case #Optional.none!enumelt: none_block
+
+some_block(%avoid : $()):
+  br exit
+
+none_block:
+  br exit
+
+exit:
+  dealloc_stack %addr : $*Optional<()>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @empty_nondominating_tuple_store_neither : {{.*}} {
+// CHECK:         inject_enum_addr
+// CHECK-LABEL: } // end sil function 'empty_nondominating_tuple_store_neither'
+sil @empty_nondominating_tuple_store_neither : $@convention(thin) (Builtin.Int1) -> () {
+entry(%cond : $Builtin.Int1):
+  %addr = alloc_stack $Optional<((), ())>
+  %some_addr = init_enum_data_addr %addr : $*Optional<((), ())>, #Optional.some!enumelt
+  %left_addr = tuple_element_addr %some_addr : $*((), ()), 0
+  %right_addr = tuple_element_addr %some_addr : $*((), ()), 1
+  cond_br %cond, left, right
+
+left:
+  br middle
+
+right:
+  %void = tuple ()
+  store %void to %left_addr : $*()
+  store %void to %right_addr : $*()
+  br middle
+
+middle:
+  inject_enum_addr %addr : $*Optional<((), ())>, #Optional.some!enumelt
+  %o = load %addr : $*Optional<((), ())>
+  switch_enum %o : $Optional<((), ())>, case #Optional.some!enumelt: some_block, case #Optional.none!enumelt: none_block
+
+some_block(%avoid : $((), ())):
+  br exit
+
+none_block:
+  br exit
+
+exit:
+  dealloc_stack %addr : $*Optional<((), ())>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @empty_nondominating_tuple_store_left : {{.*}} {
+// CHECK:         inject_enum_addr
+// CHECK-LABEL: } // end sil function 'empty_nondominating_tuple_store_left'
+sil @empty_nondominating_tuple_store_left : $@convention(thin) (Builtin.Int1) -> () {
+entry(%cond : $Builtin.Int1):
+  %addr = alloc_stack $Optional<((), ())>
+  %some_addr = init_enum_data_addr %addr : $*Optional<((), ())>, #Optional.some!enumelt
+  %left_addr = tuple_element_addr %some_addr : $*((), ()), 0
+  %right_addr = tuple_element_addr %some_addr : $*((), ()), 1
+  %void = tuple ()
+  cond_br %cond, left, right
+
+left:
+  br middle
+
+right:
+  store %void to %left_addr : $*()
+  br middle
+
+middle:
+  store %void to %right_addr : $*()
+  inject_enum_addr %addr : $*Optional<((), ())>, #Optional.some!enumelt
+  %o = load %addr : $*Optional<((), ())>
+  switch_enum %o : $Optional<((), ())>, case #Optional.some!enumelt: some_block, case #Optional.none!enumelt: none_block
+
+some_block(%avoid : $((), ())):
+  br exit
+
+none_block:
+  br exit
+
+exit:
+  dealloc_stack %addr : $*Optional<((), ())>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @empty_nondominating_tuple_store_right : {{.*}} {
+// CHECK:         inject_enum_addr
+// CHECK-LABEL: } // end sil function 'empty_nondominating_tuple_store_right'
+sil @empty_nondominating_tuple_store_right : $@convention(thin) (Builtin.Int1) -> () {
+entry(%cond : $Builtin.Int1):
+  %addr = alloc_stack $Optional<((), ())>
+  %some_addr = init_enum_data_addr %addr : $*Optional<((), ())>, #Optional.some!enumelt
+  %left_addr = tuple_element_addr %some_addr : $*((), ()), 0
+  %right_addr = tuple_element_addr %some_addr : $*((), ()), 1
+  %void = tuple ()
+  cond_br %cond, left, right
+
+left:
+  br middle
+
+right:
+  store %void to %right_addr : $*()
+  br middle
+
+middle:
+  store %void to %left_addr : $*()
+  inject_enum_addr %addr : $*Optional<((), ())>, #Optional.some!enumelt
+  %o = load %addr : $*Optional<((), ())>
+  switch_enum %o : $Optional<((), ())>, case #Optional.some!enumelt: some_block, case #Optional.none!enumelt: none_block
+
+some_block(%avoid : $((), ())):
+  br exit
+
+none_block:
+  br exit
+
+exit:
+  dealloc_stack %addr : $*Optional<((), ())>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @check_partially_dominating_tuple_stores : {{.*}} {
+// CHECK:         inject_enum_addr
+// CHECK-LABEL: } // end sil function 'check_partially_dominating_tuple_stores'
+sil @check_partially_dominating_tuple_stores : $@convention(thin) (Builtin.Int1) -> () {
+entry(%cond : $Builtin.Int1):
+  %addr = alloc_stack $Optional<(Builtin.Int1, ())>
+  %some_addr = init_enum_data_addr %addr : $*Optional<(Builtin.Int1, ())>, #Optional.some!enumelt
+  %left_addr = tuple_element_addr %some_addr : $*(Builtin.Int1, ()), 0
+  %false = integer_literal $Builtin.Int1, 0
+  store %false to %left_addr : $*Builtin.Int1
+  %right_addr = tuple_element_addr %some_addr : $*(Builtin.Int1, ()), 1
+  cond_br %cond, left, right
+
+left:
+  br middle
+
+right:
+  %void = tuple ()
+  store %void to %right_addr : $*()
+  br middle
+
+middle:
+  inject_enum_addr %addr : $*Optional<(Builtin.Int1, ())>, #Optional.some!enumelt
+  %o = load %addr : $*Optional<(Builtin.Int1, ())>
+  switch_enum %o : $Optional<(Builtin.Int1, ())>, case #Optional.some!enumelt: some_block, case #Optional.none!enumelt: none_block
+
+some_block(%avoid : $(Builtin.Int1, ())):
+  br exit
+
+none_block:
+  br exit
+
+exit:
+  dealloc_stack %addr : $*Optional<(Builtin.Int1, ())>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @empty_dominating_tuple_stores : {{.*}} {
+// CHECK-NOT:     inject_enum_addr
+// CHECK-LABEL: } // end sil function 'empty_dominating_tuple_stores'
+sil @empty_dominating_tuple_stores : $@convention(thin) (Builtin.Int1) -> () {
+entry(%cond : $Builtin.Int1):
+  %addr = alloc_stack $Optional<((), ())>
+  %some_addr = init_enum_data_addr %addr : $*Optional<((), ())>, #Optional.some!enumelt
+  %left_addr = tuple_element_addr %some_addr : $*((), ()), 0
+  %right_addr = tuple_element_addr %some_addr : $*((), ()), 1
+  %void = tuple ()
+  cond_br %cond, left, right
+
+left:
+  br middle
+
+right:
+  br middle
+
+middle:
+  store %void to %right_addr : $*()
+  store %void to %left_addr : $*()
+  inject_enum_addr %addr : $*Optional<((), ())>, #Optional.some!enumelt
+  %o = load %addr : $*Optional<((), ())>
+  switch_enum %o : $Optional<((), ())>, case #Optional.some!enumelt: some_block, case #Optional.none!enumelt: none_block
+
+some_block(%avoid : $((), ())):
+  br exit
+
+none_block:
+  br exit
+
+exit:
+  dealloc_stack %addr : $*Optional<((), ())>
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
If stores of empty values to the address don't dominate the `inject_enum_addr`, the `inject_enum_addr` can't be eliminated--it's the only indication of the case that's in the address.
