### PR TITLE
SILGen: Emit references to noncopyable global storage directly as a borrow.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3278,7 +3278,20 @@ Expr *SILGenFunction::findStorageReferenceExprForMoveOnly(Expr *argExpr,
     if (auto *declRef = dyn_cast<DeclRefExpr>(argExpr)) {
       assert(!declRef->getType()->is<LValueType>() &&
              "Shouldn't ever have an lvalue type here!");
-      return nullptr;
+      
+      // Proceed if the storage references a global or static let.
+      // TODO: We should treat any storage reference as a borrow, it seems, but
+      // that currently disrupts what the move checker expects. It would also
+      // be valuable to borrow copyable global lets, but this is a targeted
+      // fix to allow noncopyable globals to work properly.
+      bool isGlobal = false;
+      if (auto vd = dyn_cast<VarDecl>(declRef->getDecl())) {
+        isGlobal = vd->isGlobalStorage();
+      }
+      
+      if (!isGlobal) {
+        return nullptr;
+      }
     }
   }
 

--- a/test/SILOptimizer/moveonly_global_let.swift
+++ b/test/SILOptimizer/moveonly_global_let.swift
@@ -1,0 +1,60 @@
+// RUN: %target-swift-frontend -parse-as-library -DADDRESS_ONLY -emit-sil -verify %s
+// RUN: %target-swift-frontend -parse-as-library -DLOADABLE -emit-sil -verify %s
+// RUN: %target-swift-frontend -parse-as-library -DTRIVIAL -emit-sil -verify %s
+// RUN: %target-swift-frontend -parse-as-library -DEMPTY -emit-sil -verify %s
+
+// RUN: %target-swift-frontend -DADDRESS_ONLY -emit-sil -verify %s
+// RUN: %target-swift-frontend -DLOADABLE -emit-sil -verify %s
+// RUN: %target-swift-frontend -DTRIVIAL -emit-sil -verify %s
+// RUN: %target-swift-frontend -DEMPTY -emit-sil -verify %s
+
+struct Butt: ~Copyable {
+#if ADDRESS_ONLY
+    var x: Any
+#elseif LOADABLE
+    var x: AnyObject
+#elseif TRIVIAL
+    var x: Int
+#elseif EMPTY
+#else
+  #error("pick one")
+#endif
+
+    init() { fatalError() }
+
+    borrowing func method() {}
+}
+
+func freefunc(_: borrowing Butt) {}
+
+let global = Butt()
+
+struct StaticHolder {
+    static let staticMember = Butt()
+}
+
+func foo() {
+    freefunc(global)
+    freefunc(StaticHolder.staticMember)
+    global.method()
+    StaticHolder.staticMember.method()
+}
+
+func consume(_: consuming Butt) {}
+
+func tryConsume() {
+    // FIXME: gives different diagnostics for parse-as-library vs script global
+    consume(global) // expected-error{{}} expected-note *{{}}
+    consume(StaticHolder.staticMember) // expected-error{{cannot be consumed}} expected-note{{consumed here}}
+}
+
+var globalVar = Butt()
+
+func mutate(_: inout Butt) {}
+
+func manipulateGlobalVar() {
+    freefunc(globalVar)
+    mutate(&globalVar)
+    // FIXME: gives different diagnostics for parse-as-library vs script global
+    consume(globalVar) // expected-error{{consume}}
+}


### PR DESCRIPTION
Later analyses are too conservative to remove a copy, but it should be fairly safe to elide the copy for noncopyable globals, since accesses are tightly scoped and dynamically checked, so consumes aren't possible, and borrows and inout accesses of mutable globals are dynamically guarded and not subject to exclusivity checks. rdar://114329759