### PR TITLE
[6.0][Distributed][Macro] Handle more edge cases with distributed protocol macro

### DIFF
--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
@@ -31,3 +31,12 @@ protocol Fail: DistributedActor {
   distributed func method() -> String
 }
 
+@_DistributedProtocol // expected-note{{in expansion of macro '_DistributedProtocol' on protocol 'SomeRoot' here}}
+public protocol SomeRoot: DistributedActor, Sendable
+  where ActorSystem: DistributedActorSystem<any Codable> {
+
+  // TODO(distributed): we could diagnose this better?
+  associatedtype AssociatedSomething: Sendable // expected-note{{protocol requires nested type 'AssociatedSomething'; add nested type 'AssociatedSomething' for conformance}}
+  static var staticValue: String { get }
+  var value: String { get }
+}

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
@@ -33,3 +33,15 @@ protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+
+// Macro should be able to handle complex properties
+@_DistributedProtocol
+public protocol GetSet: DistributedActor, Sendable
+  where ActorSystem: DistributedActorSystem<any Codable> {
+
+  distributed var dist: String { get }
+
+  var getSet: String { get set }
+
+  var asyncGetSet: String { get async throws }
+}


### PR DESCRIPTION
**Description**: The new distributed protocol macro creates stubs from protocols. We need to handle some more complex protocol requirements, such as properties with effects etc.

**Scope/Impact**: Low, just impacts adopters of the distributed protocol macro.
**Risk:** Low, just cleanups in edge cases of the _DistributedProtocol macro

**Testing**: CI testing
**Reviewed by**: @xedin 

**Original PR:**  https://github.com/apple/swift/pull/73046
**Radar:** **Radar:** rdar://126311284