### PR TITLE
Test: add missing `import Swift` for Copyable

### DIFF
--- a/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
@@ -9,14 +9,13 @@
 // RUN: | %FileCheck %s
 
 import Builtin
+import Swift
 
-@_moveOnly
-struct M {
+struct M: ~Copyable {
   deinit {}
 }
 
-@_moveOnly
-struct M4 {
+struct M4: ~Copyable {
   let s1: M
   let s2: M
   let s3: M

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -9,6 +9,7 @@
 sil_stage canonical
 
 import Builtin
+import Swift
 
 struct NCInt : ~Copyable {
   var i: Builtin.Int64


### PR DESCRIPTION
When NoncopyableGenerics is enabled, we will actually attempt to lookup the protocol Copyable. So this is future-proofing the test.