### PR TITLE
[6.0][stdlib] Round out ~Copyable generalizations in stdlib primitives

### DIFF
--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -202,7 +202,7 @@ extension OpaquePointer {
   /// Converts a typed `UnsafeMutablePointer` to an opaque C pointer.
   @_transparent
   @_preInverseGenerics
-  public init<T>(@_nonEphemeral _ from: UnsafeMutablePointer<T>) {
+  public init<T: ~Copyable>(@_nonEphemeral _ from: UnsafeMutablePointer<T>) {
     self._rawValue = from._rawValue
   }
 
@@ -211,7 +211,7 @@ extension OpaquePointer {
   /// The result is `nil` if `from` is `nil`.
   @_transparent
   @_preInverseGenerics
-  public init?<T>(@_nonEphemeral _ from: UnsafeMutablePointer<T>?) {
+  public init?<T: ~Copyable>(@_nonEphemeral _ from: UnsafeMutablePointer<T>?) {
     guard let unwrapped = from else { return nil }
     self.init(unwrapped)
   }

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -20,10 +20,10 @@
 ///     return value for the `withExtendedLifetime(_:_:)` method.
 /// - Returns: The return value, if any, of the `body` closure parameter.
 @_alwaysEmitIntoClient
-public func withExtendedLifetime<T: ~Copyable, E: Error, Result: ~Copyable>(
+public func withExtendedLifetime<T: ~Copyable, Result: ~Copyable>(
   _ x: borrowing T,
-  _ body: () throws(E) -> Result
-) throws(E) -> Result {
+  _ body: () throws -> Result // FIXME: Typed throws rdar://126576356
+) rethrows -> Result {
   defer { _fixLifetime(x) }
   return try body()
 }
@@ -32,7 +32,7 @@ public func withExtendedLifetime<T: ~Copyable, E: Error, Result: ~Copyable>(
 @usableFromInline
 internal func withExtendedLifetime<T, Result>(
   _ x: T,
-  _ body: () throws -> Result
+  _ body: () throws -> Result // FIXME: Typed throws rdar://126576356
 ) rethrows -> Result {
   defer { _fixLifetime(x) }
   return try body()
@@ -48,9 +48,9 @@ internal func withExtendedLifetime<T, Result>(
 ///     return value for the `withExtendedLifetime(_:_:)` method.
 /// - Returns: The return value, if any, of the `body` closure parameter.
 @_alwaysEmitIntoClient
-public func withExtendedLifetime<T, E: Error, Result: ~Copyable>(
-  _ x: T, _ body: (T) throws(E) -> Result
-) throws(E) -> Result {
+public func withExtendedLifetime<T, Result: ~Copyable>(
+  _ x: T, _ body: (T) throws -> Result // FIXME: Typed throws rdar://126576356
+) rethrows -> Result {
   defer { _fixLifetime(x) }
   return try body(x)
 }
@@ -58,7 +58,7 @@ public func withExtendedLifetime<T, E: Error, Result: ~Copyable>(
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @usableFromInline
 internal func withExtendedLifetime<T, Result>(
-  _ x: T, _ body: (T) throws -> Result
+  _ x: T, _ body: (T) throws -> Result // FIXME: Typed throws rdar://126576356
 ) rethrows -> Result {
   defer { _fixLifetime(x) }
   return try body(x)

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -19,10 +19,19 @@
 ///     extended. If `body` has a return value, that value is also used as the
 ///     return value for the `withExtendedLifetime(_:_:)` method.
 /// - Returns: The return value, if any, of the `body` closure parameter.
-@inlinable
-@_preInverseGenerics
-public func withExtendedLifetime<T: ~Copyable, Result: ~Copyable>(
+@_alwaysEmitIntoClient
+public func withExtendedLifetime<T: ~Copyable, E: Error, Result: ~Copyable>(
   _ x: borrowing T,
+  _ body: () throws(E) -> Result
+) throws(E) -> Result {
+  defer { _fixLifetime(x) }
+  return try body()
+}
+
+@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@usableFromInline
+internal func withExtendedLifetime<T, Result>(
+  _ x: T,
   _ body: () throws -> Result
 ) rethrows -> Result {
   defer { _fixLifetime(x) }
@@ -38,9 +47,17 @@ public func withExtendedLifetime<T: ~Copyable, Result: ~Copyable>(
 ///     extended. If `body` has a return value, that value is also used as the
 ///     return value for the `withExtendedLifetime(_:_:)` method.
 /// - Returns: The return value, if any, of the `body` closure parameter.
-@inlinable
-public func withExtendedLifetime<T, Result>(
-  // FIXME(NCG): This should have T, Result as ~Copyable, but then the closure would need to take a borrow
+@_alwaysEmitIntoClient
+public func withExtendedLifetime<T, E: Error, Result: ~Copyable>(
+  _ x: T, _ body: (T) throws(E) -> Result
+) throws(E) -> Result {
+  defer { _fixLifetime(x) }
+  return try body(x)
+}
+
+@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@usableFromInline
+internal func withExtendedLifetime<T, Result>(
   _ x: T, _ body: (T) throws -> Result
 ) rethrows -> Result {
   defer { _fixLifetime(x) }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -232,7 +232,7 @@ extension Optional where Wrapped: ~Copyable {
   ) throws(E) -> U? {
     #if $NoncopyableGenerics
     switch self {
-    case .some(_borrowing y):
+    case .some(borrowing y):
       return .some(try transform(y))
     case .none:
       return .none
@@ -310,7 +310,7 @@ extension Optional where Wrapped: ~Copyable {
     _ transform: (borrowing Wrapped) throws(E) -> U?
   ) throws(E) -> U? {
     switch self {
-    case .some(_borrowing y):
+    case .some(borrowing y):
       return try transform(y)
     case .none:
       return .none

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -186,6 +186,9 @@ extension Optional {
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
   @_alwaysEmitIntoClient
+  @_disfavoredOverload // FIXME: Workaround for source compat issue with
+                       // functions that used to shadow the original map
+                       // (rdar://125016028)
   public func map<E: Error, U: ~Copyable>(
     _ transform: (Wrapped) throws(E) -> U
   ) throws(E) -> U? {
@@ -264,6 +267,9 @@ extension Optional {
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
   @_alwaysEmitIntoClient
+  @_disfavoredOverload // FIXME: Workaround for source compat issue with
+                       // functions that used to shadow the original flatMap
+                       // (rdar://125016028)
   public func flatMap<E: Error, U: ~Copyable>(
     _ transform: (Wrapped) throws(E) -> U?
   ) throws(E) -> U? {

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -185,9 +185,21 @@ extension Optional {
   ///   of the instance.
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
-  @inlinable
-  public func map<U>(
-    // FIXME: This needs to support typed throws.
+  @_alwaysEmitIntoClient
+  public func map<E: Error, U: ~Copyable>(
+    _ transform: (Wrapped) throws(E) -> U
+  ) throws(E) -> U? {
+    switch self {
+    case .some(let y):
+      return .some(try transform(y))
+    case .none:
+      return .none
+    }
+  }
+
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  internal func map<U>(
     _ transform: (Wrapped) throws -> U
   ) rethrows -> U? {
     switch self {
@@ -251,9 +263,21 @@ extension Optional {
   ///   of the instance.
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
-  @inlinable
-  public func flatMap<U>(
-    // FIXME: This needs to support typed throws.
+  @_alwaysEmitIntoClient
+  public func flatMap<E: Error, U: ~Copyable>(
+    _ transform: (Wrapped) throws(E) -> U?
+  ) throws(E) -> U? {
+    switch self {
+    case .some(let y):
+      return try transform(y)
+    case .none:
+      return .none
+    }
+  }
+
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  internal func flatMap<U>(
     _ transform: (Wrapped) throws -> U?
   ) rethrows -> U? {
     switch self {
@@ -770,10 +794,9 @@ extension Optional where Wrapped: ~Copyable {
 ///     type as the `Wrapped` type of `optional`.
 @_transparent
 @_alwaysEmitIntoClient
-// FIXME: This needs to support typed throws.
 public func ?? <T: ~Copyable>(
   optional: consuming T?,
-  defaultValue: @autoclosure () throws -> T
+  defaultValue: @autoclosure () throws -> T // FIXME: typed throw
 ) rethrows -> T {
   switch consume optional {
   case .some(let value):
@@ -784,8 +807,9 @@ public func ?? <T: ~Copyable>(
 }
 
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@_silgen_name("$ss2qqoiyxxSg_xyKXKtKlF")
 @usableFromInline
-internal func ?? <T>(
+internal func _legacy_abi_optionalNilCoalescingOperator <T>(
   optional: T?,
   defaultValue: @autoclosure () throws -> T
 ) rethrows -> T {

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -48,8 +48,21 @@ extension Result {
   ///   instance.
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new success value if this instance represents a success.
-  @inlinable
-  public func map<NewSuccess>(
+  @_alwaysEmitIntoClient
+  public func map<NewSuccess: ~Copyable>(
+    _ transform: (Success) -> NewSuccess
+  ) -> Result<NewSuccess, Failure> {
+    switch self {
+    case let .success(success):
+      return .success(transform(success))
+    case let .failure(failure):
+      return .failure(failure)
+    }
+  }
+
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  internal func map<NewSuccess>(
     _ transform: (Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
     switch self {
@@ -173,8 +186,21 @@ extension Result {
   ///   instance.
   /// - Returns: A `Result` instance, either from the closure or the previous
   ///   `.failure`.
-  @inlinable
-  public func flatMap<NewSuccess>(
+  @_alwaysEmitIntoClient
+  public func flatMap<NewSuccess: ~Copyable>(
+    _ transform: (Success) -> Result<NewSuccess, Failure>
+  ) -> Result<NewSuccess, Failure> {
+    switch self {
+    case let .success(success):
+      return transform(success)
+    case let .failure(failure):
+      return .failure(failure)
+    }
+  }
+
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  internal func flatMap<NewSuccess>(
     _ transform: (Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {
     switch self {
@@ -215,7 +241,7 @@ extension Result where Success: ~Copyable {
   }
 }
 
-extension Result {
+extension Result where Success: ~Copyable {
   /// Returns a new result, mapping any failure value using the given
   /// transformation and unwrapping the produced result.
   ///
@@ -223,8 +249,24 @@ extension Result {
   ///   instance.
   /// - Returns: A `Result` instance, either from the closure or the previous
   ///   `.success`.
-  @inlinable
-  public func flatMapError<NewFailure>(
+  @_alwaysEmitIntoClient
+  public consuming func flatMapError<NewFailure>(
+    _ transform: (Failure) -> Result<Success, NewFailure>
+  ) -> Result<Success, NewFailure> {
+    switch consume self {
+    case let .success(success):
+      return .success(success)
+    case let .failure(failure):
+      return transform(failure)
+    }
+  }
+}
+
+extension Result {
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$ss6ResultO12flatMapErroryAByxqd__GADq_XEs0D0Rd__lF")
+  @usableFromInline
+  internal func flatMapError<NewFailure>(
     _ transform: (Failure) -> Result<Success, NewFailure>
   ) -> Result<Success, NewFailure> {
     switch self {

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -95,7 +95,7 @@ extension Result where Success: ~Copyable {
     _ transform: (borrowing Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
     switch self {
-    case .success(_borrowing success):
+    case .success(borrowing success):
       return .success(transform(success))
     case let .failure(failure):
       return .failure(failure)
@@ -233,7 +233,7 @@ extension Result where Success: ~Copyable {
     _ transform: (borrowing Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {
     switch self {
-    case .success(_borrowing success):
+    case .success(borrowing success):
       return transform(success)
     case let .failure(failure):
       return .failure(failure)

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -49,6 +49,9 @@ extension Result {
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new success value if this instance represents a success.
   @_alwaysEmitIntoClient
+  @_disfavoredOverload // FIXME: Workaround for source compat issue with
+                       // functions that used to shadow the original map
+                       // (rdar://125016028)
   public func map<NewSuccess: ~Copyable>(
     _ transform: (Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
@@ -187,6 +190,9 @@ extension Result {
   /// - Returns: A `Result` instance, either from the closure or the previous
   ///   `.failure`.
   @_alwaysEmitIntoClient
+  @_disfavoredOverload // FIXME: Workaround for source compat issue with
+                       // functions that used to shadow the original flatMap
+                       // (rdar://125016028)
   public func flatMap<NewSuccess: ~Copyable>(
     _ transform: (Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -124,8 +124,9 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
 /// This function encapsulates the various calls to builtins required by
 /// `withUnsafeTemporaryAllocation()`.
 @_alwaysEmitIntoClient @_transparent
-// FIXME(NCG): R needs to be ~Copyable too, but that leads to lifetime failures (rdar://124571365).
-internal func _withUnsafeTemporaryAllocation<T: ~Copyable, R>(
+internal func _withUnsafeTemporaryAllocation<
+  T: ~Copyable, R: ~Copyable
+>(
   of type: T.Type,
   capacity: Int,
   alignment: Int,
@@ -169,8 +170,7 @@ internal func _withUnsafeTemporaryAllocation<T: ~Copyable, R>(
 
 @_alwaysEmitIntoClient @_transparent
 internal func _withUnprotectedUnsafeTemporaryAllocation<
-  // FIXME(NCG): R needs to be ~Copyable too, but that leads to lifetime failures (rdar://124571365).
-  T: ~Copyable, R
+  T: ~Copyable, R: ~Copyable
 >(
   of type: T.Type,
   capacity: Int,
@@ -267,8 +267,7 @@ internal func _fallBackToHeapAllocation<R: ~Copyable>(
 /// the buffer) must not escape. It will be deallocated when `body` returns and
 /// cannot be used afterward.
 @_alwaysEmitIntoClient @_transparent
-// FIXME(NCG): R needs to be ~Copyable, but that leads to lifetime failures (rdar://124571365).
-public func withUnsafeTemporaryAllocation<R>(
+public func withUnsafeTemporaryAllocation<R: ~Copyable>(
   byteCount: Int,
   alignment: Int,
   _ body: (UnsafeMutableRawBufferPointer) throws -> R
@@ -292,8 +291,7 @@ public func withUnsafeTemporaryAllocation<R>(
 /// This function is similar to `withUnsafeTemporaryAllocation`, except that it
 /// doesn't trigger stack protection for the stack allocated memory.
 @_alwaysEmitIntoClient @_transparent
-// FIXME(NCG): R needs to be ~Copyable, but that leads to lifetime failures (rdar://124571365).
-public func _withUnprotectedUnsafeTemporaryAllocation<R>(
+public func _withUnprotectedUnsafeTemporaryAllocation<R: ~Copyable>(
   byteCount: Int,
   alignment: Int,
   _ body: (UnsafeMutableRawBufferPointer) throws -> R
@@ -343,8 +341,9 @@ public func _withUnprotectedUnsafeTemporaryAllocation<R>(
 /// the buffer) must not escape. It will be deallocated when `body` returns and
 /// cannot be used afterward.
 @_alwaysEmitIntoClient @_transparent
-// FIXME(NCG): R needs to be ~Copyable too, but that leads to lifetime failures (rdar://124571365).
-public func withUnsafeTemporaryAllocation<T: ~Copyable, R>(
+public func withUnsafeTemporaryAllocation<
+  T: ~Copyable,R: ~Copyable
+>(
   of type: T.Type,
   capacity: Int,
   _ body: (UnsafeMutableBufferPointer<T>) throws -> R
@@ -369,8 +368,9 @@ public func withUnsafeTemporaryAllocation<T: ~Copyable, R>(
 /// This function is similar to `withUnsafeTemporaryAllocation`, except that it
 /// doesn't trigger stack protection for the stack allocated memory.
 @_alwaysEmitIntoClient @_transparent
-// FIXME(NCG): R needs to be ~Copyable too, but that leads to lifetime failures (rdar://124571365).
-public func _withUnprotectedUnsafeTemporaryAllocation<T: ~Copyable, R>(
+public func _withUnprotectedUnsafeTemporaryAllocation<
+  T: ~Copyable, R: ~Copyable
+>(
   of type: T.Type,
   capacity: Int,
   _ body: (UnsafeMutableBufferPointer<T>) throws -> R

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -1262,10 +1262,10 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///   - buffer: The buffer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
-  public func withMemoryRebound<T: ~Copyable, Result: ~Copyable>(
+  public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
     to type: T.Type,
-    _ body: (_ buffer: ${Self}<T>) throws -> Result
-  ) rethrows -> Result {
+    _ body: (_ buffer: ${Self}<T>) throws(E) -> Result
+  ) throws(E) -> Result {
     guard let base = _position?._rawValue else {
       return try body(.init(start: nil, count: 0))
     }
@@ -1314,8 +1314,11 @@ extension Unsafe${Mutable}BufferPointer {
 }
 
 @_unavailableInEmbedded
-extension Unsafe${Mutable}BufferPointer: CustomDebugStringConvertible {
+@_preInverseGenerics
+extension Unsafe${Mutable}BufferPointer: CustomDebugStringConvertible
+where Element: ~Copyable {
   /// A textual representation of the buffer, suitable for debugging.
+  @_preInverseGenerics
   public var debugDescription: String {
     return "Unsafe${Mutable}BufferPointer"
       + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -394,11 +394,11 @@ extension UnsafePointer where Pointee: ~Copyable {
   ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
-  public func withMemoryRebound<T: ~Copyable, Result: ~Copyable>(
+  public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     capacity count: Int,
-    _ body: (_ pointer: UnsafePointer<T>) throws -> Result
-  ) rethrows -> Result {
+    _ body: (_ pointer: UnsafePointer<T>) throws(E) -> Result
+  ) throws(E) -> Result {
     _debugPrecondition(
       Int(bitPattern: .init(_rawValue)) & (MemoryLayout<T>.alignment-1) == 0 &&
       ( count == 1 ||
@@ -1237,11 +1237,11 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
-  public func withMemoryRebound<T: ~Copyable, Result: ~Copyable>(
+  public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
     to type: T.Type,
     capacity count: Int,
-    _ body: (_ pointer: UnsafeMutablePointer<T>) throws -> Result
-  ) rethrows -> Result {
+    _ body: (_ pointer: UnsafeMutablePointer<T>) throws(E) -> Result
+  ) throws(E) -> Result {
     _debugPrecondition(
       Int(bitPattern: .init(_rawValue)) & (MemoryLayout<T>.alignment-1) == 0 &&
       ( count == 1 ||

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -379,7 +379,7 @@ let _ = [0].map {
 func rdar21078316() {
   var foo : [String : String]?
   var bar : [(String, String)]?
-  bar = foo.map { ($0, $1) }  // expected-error {{contextual closure type '([String : String]) throws -> [(String, String)]' expects 1 argument, but 2 were used in closure body}}
+  bar = foo.map { ($0, $1) }  // expected-error {{contextual closure type '([String : String]) -> [(String, String)]' expects 1 argument, but 2 were used in closure body}}
   // expected-error@-1{{cannot convert value of type '(Dictionary<String, String>, _)' to closure result type '[(String, String)]'}}
 }
 

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -155,8 +155,8 @@ class C4 {
 // UNRESOLVED_3_OPT-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Convertible]: nil[#SomeEnum1?#]; name=nil
 // UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: none[#Optional<SomeEnum1>#]; name=none
 // UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: some({#SomeEnum1#})[#Optional<SomeEnum1>#];
-// UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws -> U) -> U?#];
-// UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws -> U?) -> U?#];
+// UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws(Error) -> ~Copyable) -> ~Copyable?#]; name=map(:)
+// UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws(Error) -> ~Copyable?) -> ~Copyable?#];
 // UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem/TypeRelation[Invalid]: hash({#(self): Optional<SomeEnum1>#})[#(into: inout Hasher) -> Void#];
 
 // Exhaustive to make sure we don't include `init({#(some):` or `init({#nilLiteral:` entries
@@ -167,8 +167,8 @@ class C4 {
 // UNRESOLVED_3_OPTOPTOPT-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Convertible]: nil[#SomeEnum1???#]; name=nil
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: none[#Optional<SomeEnum1??>#]; name=none
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: some({#SomeEnum1??#})[#Optional<SomeEnum1??>#];
-// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1??>#})[#((SomeEnum1??) throws -> U) -> U?#];
-// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<SomeEnum1??>#})[#((SomeEnum1??) throws -> U?) -> U?#];
+// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1??>#})[#((SomeEnum1??) throws(Error) -> ~Copyable) -> ~Copyable?#];
+// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<SomeEnum1??>#})[#((SomeEnum1??) throws(Error) -> ~Copyable?) -> ~Copyable?#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem/TypeRelation[Invalid]: hash({#(self): Optional<SomeEnum1??>#})[#(into: inout Hasher) -> Void#];
 
 enum Somewhere {
@@ -189,8 +189,8 @@ func testOptionalWithCustomExtension() {
 // UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: some({#Somewhere#})[#Optional<Somewhere>#];
 // UNRESOLVED_OPT_4-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init({#str: String#})[#Optional<Somewhere>#]; name=init(str:)
 // UNRESOLVED_OPT_4-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: nowhere[#Optional<Somewhere>#]; name=nowhere
-// UNRESOLVED_OPT_4-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<Somewhere>#})[#((Somewhere) throws -> U) -> U?#];
-// UNRESOLVED_OPT_4-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<Somewhere>#})[#((Somewhere) throws -> U?) -> U?#];
+// UNRESOLVED_OPT_4-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<Somewhere>#})[#((Somewhere) throws(Error) -> ~Copyable) -> ~Copyable?#];
+// UNRESOLVED_OPT_4-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<Somewhere>#})[#((Somewhere) throws(Error) -> ~Copyable?) -> ~Copyable?#];
 // UNRESOLVED_OPT_4-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem/TypeRelation[Invalid]: hash({#(self): Optional<Somewhere>#})[#(into: inout Hasher) -> Void#];
 // UNRESOLVED_OPT_4-NOT: init({#(some):
 // UNRESOLVED_OPT_4-NOT: init({#nilLiteral:
@@ -695,8 +695,8 @@ func testSameType() {
 // SUGAR_TYPE-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Convertible]: nil[#SomeEnum1?#];
 // SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: none[#Optional<SomeEnum1>#];
 // SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: some({#SomeEnum1#})[#Optional<SomeEnum1>#];
-// SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws -> U) -> U?#];
-// SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws -> U?) -> U?#];
+// SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws(Error) -> ~Copyable) -> ~Copyable?#];
+// SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws(Error) -> ~Copyable?) -> ~Copyable?#];
 // SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem/TypeRelation[Invalid]: hash({#(self): Optional<SomeEnum1>#})[#(into: inout Hasher) -> Void#];
 }
 

--- a/test/SILOptimizer/closure_lifetime_fixup.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup.swift
@@ -97,8 +97,8 @@ public func dontCrash<In, Out>(test: Bool, body: @escaping ((In) -> Out, In) -> 
 // CHECK-LABEL: sil @$s22closure_lifetime_fixup28to_stack_of_convert_function1pySvSg_tF
 // CHECK:  [[FN:%.*]] = function_ref @$s22closure_lifetime_fixup28to_stack_of_convert_function1pySvSg_tFSSSvcfu_ :
 // CHECK:  [[PA:%.*]] = thin_to_thick_function [[FN]]
-// CHECK:  [[MAP:%.*]] = function_ref @$sSq3mapyqd__Sgqd__xKXEKlF
-// CHECK:  try_apply [[MAP]]<UnsafeMutableRawPointer, String>({{.*}}, [[PA]], {{.*}})
+// CHECK:  [[MAP:%.*]] = function_ref @$sSq3mapyqd_0_Sgqd_0_xqd__YKXEqd__YKs5ErrorRd__Ri_d_0_r0_lF
+// CHECK:  try_apply [[MAP]]<UnsafeMutableRawPointer, Never, String>({{.*}}, [[PA]], {{.*}})
 public func to_stack_of_convert_function(p: UnsafeMutableRawPointer?) {
   _ = p.map(String.init(describing:))
 }

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -342,6 +342,5 @@ Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) has generic signatur
 Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) is now without @rethrows
 Func UnsafePointer.withMemoryRebound(to:capacity:_:) has generic signature change from <Pointee, T, Result> to <Pointee, T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
 Func UnsafePointer.withMemoryRebound(to:capacity:_:) is now without @rethrows
-Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, Result : ~Copyable>
-Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
-Func withExtendedLifetime(_:_:) is now without @rethrows
+Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to <T, Result where Result : ~Copyable>
+Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to <T, Result where T : ~Copyable, Result : ~Copyable>

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -264,7 +264,6 @@ Func UnsafeBufferPointer.index(_:offsetBy:) has generic signature change from <E
 Func UnsafeBufferPointer.index(_:offsetBy:limitedBy:) has generic signature change from <Element> to <Element where Element : ~Copyable>
 Func UnsafeBufferPointer.index(after:) has generic signature change from <Element> to <Element where Element : ~Copyable>
 Func UnsafeBufferPointer.index(before:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeBufferPointer.withMemoryRebound(to:_:) has generic signature change from <Element, T, Result> to <Element, T, Result where T : ~Copyable, Result : ~Copyable>
 Func UnsafeMutableBufferPointer.allocate(capacity:) has generic signature change from <Element> to <Element where Element : ~Copyable>
 Func UnsafeMutableBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable>
 Func UnsafeMutableBufferPointer.distance(from:to:) has generic signature change from <Element> to <Element where Element : ~Copyable>
@@ -275,7 +274,6 @@ Func UnsafeMutableBufferPointer.index(_:offsetBy:limitedBy:) has generic signatu
 Func UnsafeMutableBufferPointer.index(after:) has generic signature change from <Element> to <Element where Element : ~Copyable>
 Func UnsafeMutableBufferPointer.index(before:) has generic signature change from <Element> to <Element where Element : ~Copyable>
 Func UnsafeMutableBufferPointer.swapAt(_:_:) has generic signature change from <Element> to <Element where Element : ~Copyable>
-Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) has generic signature change from <Element, T, Result> to <Element, T, Result where T : ~Copyable, Result : ~Copyable>
 Func UnsafeMutablePointer.allocate(capacity:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
 Func UnsafeMutablePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
 Func UnsafeMutablePointer.deinitialize(count:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
@@ -283,18 +281,15 @@ Func UnsafeMutablePointer.initialize(to:) has generic signature change from <Poi
 Func UnsafeMutablePointer.initialize(to:) has parameter 0 changing from Default to Owned
 Func UnsafeMutablePointer.move() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
 Func UnsafeMutablePointer.moveInitialize(from:count:) has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) has generic signature change from <Pointee, T, Result> to <Pointee, T, Result where T : ~Copyable, Result : ~Copyable>
 Func UnsafeMutableRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeMutableRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeMutableRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafePointer.deallocate() has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
-Func UnsafePointer.withMemoryRebound(to:capacity:_:) has generic signature change from <Pointee, T, Result> to <Pointee, T, Result where T : ~Copyable, Result : ~Copyable>
 Func UnsafeRawBufferPointer.bindMemory(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeRawPointer.assumingMemoryBound(to:) has generic signature change from <T> to <T where T : ~Copyable>
 Func UnsafeRawPointer.bindMemory(to:capacity:) has generic signature change from <T> to <T where T : ~Copyable>
 Func swap(_:_:) has generic signature change from <T> to <T where T : ~Copyable>
-Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to <T, Result where T : ~Copyable, Result : ~Copyable>
 Func withExtendedLifetime(_:_:) has parameter 0 changing from Default to Shared
 Func withUnsafeBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
 Func withUnsafeBytes(of:_:) has parameter 0 changing from Default to Shared
@@ -318,3 +313,35 @@ TypeAlias UnsafePointer.Distance has generic signature change from <Pointee> to 
 TypeAlias UnsafePointer.Pointee has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
 TypeAlias UnsafePointer.Stride has generic signature change from <Pointee> to <Pointee where Pointee : ~Copyable>
 Func FixedWidthInteger.&*(_:_:) has been added as a protocol requirement
+Accessor UnsafeBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
+Accessor UnsafeMutableBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
+Func ManagedBuffer.withUnsafeMutablePointerToElements(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, R : ~Copyable>
+Func ManagedBuffer.withUnsafeMutablePointerToElements(_:) is now without @rethrows
+Func ManagedBuffer.withUnsafeMutablePointerToHeader(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, R : ~Copyable>
+Func ManagedBuffer.withUnsafeMutablePointerToHeader(_:) is now without @rethrows
+Func ManagedBuffer.withUnsafeMutablePointers(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, R : ~Copyable>
+Func ManagedBuffer.withUnsafeMutablePointers(_:) is now without @rethrows
+Func ManagedBufferPointer.withUnsafeMutablePointerToElements(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, R : ~Copyable>
+Func ManagedBufferPointer.withUnsafeMutablePointerToElements(_:) is now without @rethrows
+Func ManagedBufferPointer.withUnsafeMutablePointerToHeader(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, R : ~Copyable>
+Func ManagedBufferPointer.withUnsafeMutablePointerToHeader(_:) is now without @rethrows
+Func ManagedBufferPointer.withUnsafeMutablePointers(_:) has generic signature change from <Header, Element, R> to <Header, Element, E, R where E : Swift.Error, R : ~Copyable>
+Func ManagedBufferPointer.withUnsafeMutablePointers(_:) is now without @rethrows
+Func Optional.flatMap(_:) has generic signature change from <Wrapped, U> to <Wrapped, E, U where E : Swift.Error, U : ~Copyable>
+Func Optional.flatMap(_:) is now without @rethrows
+Func Optional.map(_:) has generic signature change from <Wrapped, U> to <Wrapped, E, U where E : Swift.Error, U : ~Copyable>
+Func Optional.map(_:) is now without @rethrows
+Func Result.flatMap(_:) has generic signature change from <Success, Failure, NewSuccess where Failure : Swift.Error> to <Success, Failure, NewSuccess where Failure : Swift.Error, NewSuccess : ~Copyable>
+Func Result.flatMapError(_:) has self access kind changing from NonMutating to Consuming
+Func Result.map(_:) has generic signature change from <Success, Failure, NewSuccess where Failure : Swift.Error> to <Success, Failure, NewSuccess where Failure : Swift.Error, NewSuccess : ~Copyable>
+Func UnsafeBufferPointer.withMemoryRebound(to:_:) has generic signature change from <Element, T, Result> to <Element, T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
+Func UnsafeBufferPointer.withMemoryRebound(to:_:) is now without @rethrows
+Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) has generic signature change from <Element, T, Result> to <Element, T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
+Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) is now without @rethrows
+Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) has generic signature change from <Pointee, T, Result> to <Pointee, T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
+Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) is now without @rethrows
+Func UnsafePointer.withMemoryRebound(to:capacity:_:) has generic signature change from <Pointee, T, Result> to <Pointee, T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
+Func UnsafePointer.withMemoryRebound(to:capacity:_:) is now without @rethrows
+Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, Result : ~Copyable>
+Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error, T : ~Copyable, Result : ~Copyable>
+Func withExtendedLifetime(_:_:) is now without @rethrows

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -556,12 +556,9 @@ Func ??(_:_:) has been removed
 Func ManagedBuffer.create(minimumCapacity:makingHeaderWith:) has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
 Func ManagedBuffer.create(minimumCapacity:makingHeaderWith:) has mangled name changing from 'static Swift.ManagedBuffer.create(minimumCapacity: Swift.Int, makingHeaderWith: (Swift.ManagedBuffer<A, B>) throws -> A) throws -> Swift.ManagedBuffer<A, B>' to 'static (extension in Swift):Swift.ManagedBuffer< where B: ~Swift.Copyable>.create(minimumCapacity: Swift.Int, makingHeaderWith: (Swift.ManagedBuffer<A, B>) throws -> A) throws -> Swift.ManagedBuffer<A, B>'
 Func ManagedBuffer.create(minimumCapacity:makingHeaderWith:) is now with @_preInverseGenerics
-Func ManagedBuffer.withUnsafeMutablePointerToElements(_:) has mangled name changing from 'Swift.ManagedBuffer.withUnsafeMutablePointerToElements<A>((Swift.UnsafeMutablePointer<B>) throws -> A1) throws -> A1' to '(extension in Swift):Swift.ManagedBuffer< where B: ~Swift.Copyable>.withUnsafeMutablePointerToElements<A>((Swift.UnsafeMutablePointer<B>) throws -> A1) throws -> A1'
-Func ManagedBuffer.withUnsafeMutablePointerToElements(_:) is now with @_preInverseGenerics
-Func ManagedBuffer.withUnsafeMutablePointerToHeader(_:) has mangled name changing from 'Swift.ManagedBuffer.withUnsafeMutablePointerToHeader<A>((Swift.UnsafeMutablePointer<A>) throws -> A1) throws -> A1' to '(extension in Swift):Swift.ManagedBuffer< where B: ~Swift.Copyable>.withUnsafeMutablePointerToHeader<A>((Swift.UnsafeMutablePointer<A>) throws -> A1) throws -> A1'
-Func ManagedBuffer.withUnsafeMutablePointerToHeader(_:) is now with @_preInverseGenerics
-Func ManagedBuffer.withUnsafeMutablePointers(_:) has mangled name changing from 'Swift.ManagedBuffer.withUnsafeMutablePointers<A>((Swift.UnsafeMutablePointer<A>, Swift.UnsafeMutablePointer<B>) throws -> A1) throws -> A1' to '(extension in Swift):Swift.ManagedBuffer< where B: ~Swift.Copyable>.withUnsafeMutablePointers<A>((Swift.UnsafeMutablePointer<A>, Swift.UnsafeMutablePointer<B>) throws -> A1) throws -> A1'
-Func ManagedBuffer.withUnsafeMutablePointers(_:) is now with @_preInverseGenerics
+Func ManagedBuffer.withUnsafeMutablePointerToElements(_:) has been removed
+Func ManagedBuffer.withUnsafeMutablePointerToHeader(_:) has been removed
+Func ManagedBuffer.withUnsafeMutablePointers(_:) has been removed
 Func ManagedBufferPointer._checkValidBufferClass(_:creating:) has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
 Func ManagedBufferPointer._checkValidBufferClass(_:creating:) has mangled name changing from 'static Swift.ManagedBufferPointer._checkValidBufferClass(_: Swift.AnyObject.Type, creating: Swift.Bool) -> ()' to 'static (extension in Swift):Swift.ManagedBufferPointer< where B: ~Swift.Copyable>._checkValidBufferClass(_: Swift.AnyObject.Type, creating: Swift.Bool) -> ()'
 Func ManagedBufferPointer._checkValidBufferClass(_:creating:) is now with @_preInverseGenerics
@@ -571,12 +568,9 @@ Func ManagedBufferPointer._internalInvariantValidBufferClass(_:creating:) is now
 Func ManagedBufferPointer.isUniqueReference() has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
 Func ManagedBufferPointer.isUniqueReference() has mangled name changing from 'Swift.ManagedBufferPointer.isUniqueReference() -> Swift.Bool' to '(extension in Swift):Swift.ManagedBufferPointer< where B: ~Swift.Copyable>.isUniqueReference() -> Swift.Bool'
 Func ManagedBufferPointer.isUniqueReference() is now with @_preInverseGenerics
-Func ManagedBufferPointer.withUnsafeMutablePointerToElements(_:) has mangled name changing from 'Swift.ManagedBufferPointer.withUnsafeMutablePointerToElements<A>((Swift.UnsafeMutablePointer<B>) throws -> A1) throws -> A1' to '(extension in Swift):Swift.ManagedBufferPointer< where B: ~Swift.Copyable>.withUnsafeMutablePointerToElements<A>((Swift.UnsafeMutablePointer<B>) throws -> A1) throws -> A1'
-Func ManagedBufferPointer.withUnsafeMutablePointerToElements(_:) is now with @_preInverseGenerics
-Func ManagedBufferPointer.withUnsafeMutablePointerToHeader(_:) has mangled name changing from 'Swift.ManagedBufferPointer.withUnsafeMutablePointerToHeader<A>((Swift.UnsafeMutablePointer<A>) throws -> A1) throws -> A1' to '(extension in Swift):Swift.ManagedBufferPointer< where B: ~Swift.Copyable>.withUnsafeMutablePointerToHeader<A>((Swift.UnsafeMutablePointer<A>) throws -> A1) throws -> A1'
-Func ManagedBufferPointer.withUnsafeMutablePointerToHeader(_:) is now with @_preInverseGenerics
-Func ManagedBufferPointer.withUnsafeMutablePointers(_:) has mangled name changing from 'Swift.ManagedBufferPointer.withUnsafeMutablePointers<A>((Swift.UnsafeMutablePointer<A>, Swift.UnsafeMutablePointer<B>) throws -> A1) throws -> A1' to '(extension in Swift):Swift.ManagedBufferPointer< where B: ~Swift.Copyable>.withUnsafeMutablePointers<A>((Swift.UnsafeMutablePointer<A>, Swift.UnsafeMutablePointer<B>) throws -> A1) throws -> A1'
-Func ManagedBufferPointer.withUnsafeMutablePointers(_:) is now with @_preInverseGenerics
+Func ManagedBufferPointer.withUnsafeMutablePointerToElements(_:) has been removed
+Func ManagedBufferPointer.withUnsafeMutablePointerToHeader(_:) has been removed
+Func ManagedBufferPointer.withUnsafeMutablePointers(_:) has been removed
 Func MemoryLayout.alignment(ofValue:) has generic signature change from <T> to <T where T : ~Copyable>
 Func MemoryLayout.alignment(ofValue:) has mangled name changing from 'static Swift.MemoryLayout.alignment(ofValue: A) -> Swift.Int' to 'static (extension in Swift):Swift.MemoryLayout< where A: ~Swift.Copyable>.alignment(ofValue: A) -> Swift.Int'
 Func MemoryLayout.alignment(ofValue:) has parameter 0 changing from Default to Shared
@@ -708,10 +702,6 @@ Func _fixLifetime(_:) is now with @_preInverseGenerics
 Func swap(_:_:) has generic signature change from <T> to <T where T : ~Copyable>
 Func swap(_:_:) has mangled name changing from 'Swift.swap<A>(inout A, inout A) -> ()' to 'Swift.swap<A where A: ~Swift.Copyable>(inout A, inout A) -> ()'
 Func swap(_:_:) is now with @_preInverseGenerics
-Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to <T, Result where T : ~Copyable, Result : ~Copyable>
-Func withExtendedLifetime(_:_:) has mangled name changing from 'Swift.withExtendedLifetime<A, B>(A, () throws -> B) throws -> B' to 'Swift.withExtendedLifetime<A, B where A: ~Swift.Copyable, B: ~Swift.Copyable>(A, () throws -> B) throws -> B'
-Func withExtendedLifetime(_:_:) has parameter 0 changing from Default to Shared
-Func withExtendedLifetime(_:_:) is now with @_preInverseGenerics
 Func withUnsafeBytes(of:_:) has been renamed to Func __abi_se0413_withUnsafeBytes(of:_:)
 Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeBytes<A, B>(of: A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeBytes<A, B>(of: A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
 Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
@@ -807,6 +797,23 @@ Var UnsafePointer._rawValue is now with @_preInverseGenerics
 Var UnsafePointer.hashValue has mangled name changing from 'Swift.UnsafePointer.hashValue : Swift.Int' to '(extension in Swift):Swift.UnsafePointer< where A: ~Swift.Copyable>.hashValue : Swift.Int'
 Var UnsafePointer.hashValue is now with @_preInverseGenerics
 Var UnsafePointer.pointee has been removed
+Accessor UnsafeBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
+Accessor UnsafeBufferPointer.debugDescription.Get() has mangled name changing from 'Swift.UnsafeBufferPointer.debugDescription.getter : Swift.String' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.debugDescription.getter : Swift.String'
+Accessor UnsafeMutableBufferPointer.debugDescription.Get() has generic signature change from <Element> to <Element where Element : ~Copyable>
+Accessor UnsafeMutableBufferPointer.debugDescription.Get() has mangled name changing from 'Swift.UnsafeMutableBufferPointer.debugDescription.getter : Swift.String' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.debugDescription.getter : Swift.String'
+Constructor OpaquePointer.init(_:) has mangled name changing from 'Swift.OpaquePointer.init<A>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.OpaquePointer>' to 'Swift.OpaquePointer.init<A where A: ~Swift.Copyable>(Swift.Optional<Swift.UnsafeMutablePointer<A>>) -> Swift.Optional<Swift.OpaquePointer>'
+Constructor OpaquePointer.init(_:) has mangled name changing from 'Swift.OpaquePointer.init<A>(Swift.UnsafeMutablePointer<A>) -> Swift.OpaquePointer' to 'Swift.OpaquePointer.init<A where A: ~Swift.Copyable>(Swift.UnsafeMutablePointer<A>) -> Swift.OpaquePointer'
+Func Optional.flatMap(_:) has been removed
+Func Optional.map(_:) has been removed
+Func Result.flatMap(_:) has been removed
+Func Result.flatMapError(_:) has been removed
+Func Result.map(_:) has been removed
+Func withExtendedLifetime(_:_:) has been removed
+Var UnsafeBufferPointer.debugDescription has mangled name changing from 'Swift.UnsafeBufferPointer.debugDescription : Swift.String' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.debugDescription : Swift.String'
+Var UnsafeBufferPointer.debugDescription is now with @_preInverseGenerics
+Var UnsafeMutableBufferPointer.debugDescription has mangled name changing from 'Swift.UnsafeMutableBufferPointer.debugDescription : Swift.String' to '(extension in Swift):Swift.UnsafeMutableBufferPointer< where A: ~Swift.Copyable>.debugDescription : Swift.String'
+Var UnsafeMutableBufferPointer.debugDescription is now with @_preInverseGenerics
+
 Func FixedWidthInteger.&*(_:_:) has been added as a protocol requirement
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
- Explanation: This is a followup to [#71688](https://github.com/apple/swift/pull/71688)/[#72436](https://github.com/apple/swift/pull/72436) that resolves usability issues and obvious omissions that were uncovered while using the new primitives.
- Issue: rdar://117753275&117753867
- Original PR: #73045 
- Risk: This is a high risk change. It changes core parts of the Standard Library, triggering brand new code paths in the compiler, and carrying nontrivial source and binary compatibility risks.
- Testing: Regression tests using the in-tree test suite, at-desk manual code analysis, and source compatibility test runs to validate compatibility with open source projects.
- Reviewer: @glessard