### PR TITLE
[SymbolGraphGen] Correctly handle exported imports in swift-symbolgraph-extract

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -18,6 +18,7 @@
 #define SWIFT_MODULE_H
 
 #include "swift/AST/AccessNotes.h"
+#include "swift/AST/AttrKind.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/Identifier.h"
@@ -551,7 +552,7 @@ public:
   ModuleDecl *getUnderlyingModuleIfOverlay() const;
 
   /// Returns true if this module is the Clang overlay of \p other.
-  bool isClangOverlayOf(ModuleDecl *other);
+  bool isClangOverlayOf(ModuleDecl *other) const;
 
   /// Returns true if this module is the same module or either module is a clang
   /// overlay of the other.
@@ -1084,6 +1085,24 @@ public:
   /// for that.
   void getDisplayDecls(SmallVectorImpl<Decl*> &results, bool recursive = false) const;
 
+  struct ImportCollector {
+    SmallPtrSet<const ModuleDecl *, 4> imports;
+    llvm::SmallDenseMap<const ModuleDecl *, SmallPtrSet<Decl *, 4>, 4>
+        qualifiedImports;
+    AccessLevel minimumDocVisibility = AccessLevel::Private;
+    llvm::function_ref<bool(const ModuleDecl *)> importFilter = nullptr;
+
+    void collect(const ImportedModule &importedModule);
+
+    ImportCollector() = default;
+    ImportCollector(AccessLevel minimumDocVisibility)
+        : minimumDocVisibility(minimumDocVisibility) {}
+  };
+
+  void
+  getDisplayDeclsRecursivelyAndImports(SmallVectorImpl<Decl *> &results,
+                                       ImportCollector &importCollector) const;
+
   using LinkLibraryCallback = llvm::function_ref<void(LinkLibrary)>;
 
   /// Generate the list of libraries needed to link this module, based on its
@@ -1262,12 +1281,6 @@ inline bool DeclContext::isPackageContext() const {
 inline SourceLoc extractNearestSourceLoc(const ModuleDecl *mod) {
   return extractNearestSourceLoc(static_cast<const Decl *>(mod));
 }
-
-/// Collects modules that this module imports via `@_exported import`.
-void collectParsedExportedImports(const ModuleDecl *M,
-                                  SmallPtrSetImpl<ModuleDecl *> &Imports,
-                                  llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> &QualifiedImports,
-                                  llvm::function_ref<bool(AttributedImport<ImportedModule>)> includeImport = nullptr);
 
 /// If the import that would make the given declaration visibile is absent,
 /// emit a diagnostic and a fix-it suggesting adding the missing import.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1573,6 +1573,10 @@ def output_dir : Separate<["-"], "output-dir">,
   HelpText<"Output directory">,
   MetaVarName<"<dir>">;
 
+def experimental_allowed_reexported_modules: CommaJoined<["-"], "experimental_allowed_reexported_modules">,
+  Flags<[NoDriverOption, SwiftSymbolGraphExtractOption]>,
+  HelpText<"Allow reexporting symbols from the provided modules if they are themselves exported from the main module. This is a comma separated list of module names.">;
+
 def skip_synthesized_members: Flag<[ "-" ], "skip-synthesized-members">,
   Flags<[NoDriverOption, SwiftSymbolGraphExtractOption]>,
   HelpText<"Skip members inherited through classes or default implementations">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1573,7 +1573,7 @@ def output_dir : Separate<["-"], "output-dir">,
   HelpText<"Output directory">,
   MetaVarName<"<dir>">;
 
-def experimental_allowed_reexported_modules: CommaJoined<["-"], "experimental_allowed_reexported_modules">,
+def experimental_allowed_reexported_modules: CommaJoined<["-"], "experimental-allowed-reexported-modules=">,
   Flags<[NoDriverOption, SwiftSymbolGraphExtractOption]>,
   HelpText<"Allow reexporting symbols from the provided modules if they are themselves exported from the main module. This is a comma separated list of module names.">;
 

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -162,6 +162,15 @@ namespace swift {
   void
   getTopLevelDeclsForDisplay(ModuleDecl *M, SmallVectorImpl<Decl*> &Results, bool Recursive = false);
 
+  /// Get all of the top-level declarations that should be printed as part of
+  /// this module. This may force synthesis of top-level declarations that
+  /// \p getDisplayDeclsForModule would only return if previous
+  /// work happened to have synthesized them.
+  void getTopLevelDeclsForDisplay(
+      ModuleDecl *M, SmallVectorImpl<Decl *> &Results,
+      llvm::function_ref<void(ModuleDecl *, SmallVectorImpl<Decl *> &)>
+          getDisplayDeclsForModule);
+
   struct ExtensionInfo {
     // The extension with the declarations to apply.
     ExtensionDecl *Ext;

--- a/include/swift/SymbolGraphGen/SymbolGraphOptions.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphOptions.h
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/TargetParser/Triple.h"
+#include "llvm/ADT/ArrayRef.h"
+
 #include "swift/AST/AttrKind.h"
 
 #ifndef SWIFT_SYMBOLGRAPHGEN_SYMBOLGRAPHOPTIONS_H
@@ -63,6 +65,10 @@ struct SymbolGraphOptions {
   /// but SourceKit should be able to load the information when pulling symbol
   /// information for individual queries.
   bool PrintPrivateStdlibSymbols = false;
+
+  /// If this has a value specifies an explicit allow list of reexported module
+  /// names that should be included symbol graph.
+  std::optional<llvm::ArrayRef<StringRef>> AllowedReexportedModules = {};
 };
 
 } // end namespace symbolgraphgen

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1567,14 +1567,15 @@ void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results, bool Recursive
   if (Recursive) {
     ImportCollector importCollector;
     this->getDisplayDeclsRecursivelyAndImports(Results, importCollector);
+  } else {
+    // FIXME: Should this do extra access control filtering?
+    FORWARD(getDisplayDecls, (Results));
   }
-  // FIXME: Should this do extra access control filtering?
-  FORWARD(getDisplayDecls, (Results));
 }
 
 void ModuleDecl::getDisplayDeclsRecursivelyAndImports(
     SmallVectorImpl<Decl *> &results, ImportCollector &importCollector) const {
-  this->getDisplayDecls(results);
+  this->getDisplayDecls(results, /*Recursive=*/false);
 
   // Look up imports recursively.
   collectExportedImports(this, importCollector);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/Import.h"
 #include "swift/AST/ImportCache.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/LinkLibrary.h"
@@ -39,6 +40,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/SynthesizedFileUnit.h"
+#include "swift/AST/Type.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/SourceManager.h"
@@ -1287,42 +1289,6 @@ bool ModuleDecl::shouldCollectDisplayDecls() const {
   return true;
 }
 
-void swift::collectParsedExportedImports(const ModuleDecl *M,
-                                         SmallPtrSetImpl<ModuleDecl *> &Imports,
-                                         llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> &QualifiedImports,
-                                         llvm::function_ref<bool(AttributedImport<ImportedModule>)> includeImport) {
-  for (const FileUnit *file : M->getFiles()) {
-    if (const SourceFile *source = dyn_cast<SourceFile>(file)) {
-      if (source->hasImports()) {
-        for (auto import : source->getImports()) {
-          if (import.options.contains(ImportFlags::Exported) &&
-              (!includeImport || includeImport(import)) &&
-              import.module.importedModule->shouldCollectDisplayDecls()) {
-            auto *TheModule = import.module.importedModule;
-
-            if (import.module.getAccessPath().size() > 0) {
-              if (QualifiedImports.find(TheModule) == QualifiedImports.end()) {
-                QualifiedImports.try_emplace(TheModule);
-              }
-              auto collectDecls = [&](ValueDecl *VD,
-                                      DeclVisibilityKind reason) {
-                if (reason == DeclVisibilityKind::VisibleAtTopLevel)
-                  QualifiedImports[TheModule].insert(VD);
-              };
-              auto consumer = makeDeclConsumer(std::move(collectDecls));
-              TheModule->lookupVisibleDecls(
-                  import.module.getAccessPath(), consumer,
-                  NLKind::UnqualifiedLookup);
-            } else if (!Imports.contains(TheModule)) {
-              Imports.insert(TheModule);
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
 void ModuleDecl::getLocalTypeDecls(SmallVectorImpl<TypeDecl*> &Results) const {
   FORWARD(getLocalTypeDecls, (Results));
 }
@@ -1543,40 +1509,100 @@ SourceFile::getExternalRawLocsForDecl(const Decl *D) const {
   return Result;
 }
 
-void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results, bool Recursive) const {
-  if (Recursive && isParsedModule(this)) {
-    SmallPtrSet<ModuleDecl *, 4> Modules;
-    llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> QualifiedImports;
-    collectParsedExportedImports(this, Modules, QualifiedImports);
-    for (const auto &QI : QualifiedImports) {
-      auto Module = QI.getFirst();
-      if (Modules.contains(Module)) continue;
+void ModuleDecl::ImportCollector::collect(
+    const ImportedModule &importedModule) {
+  auto *module = importedModule.importedModule;
 
-      auto &Decls = QI.getSecond();
-      Results.append(Decls.begin(), Decls.end());
+  if (!module->shouldCollectDisplayDecls())
+    return;
+
+  if (importFilter && !importFilter(module))
+    return;
+
+  if (importedModule.getAccessPath().size() > 0) {
+    auto collectDecls = [&](ValueDecl *VD, DeclVisibilityKind reason) {
+      if (reason == DeclVisibilityKind::VisibleAtTopLevel)
+        this->qualifiedImports[module].insert(VD);
+    };
+    auto consumer = makeDeclConsumer(std::move(collectDecls));
+    module->lookupVisibleDecls(importedModule.getAccessPath(), consumer,
+                               NLKind::UnqualifiedLookup);
+  } else {
+    imports.insert(module);
+  }
+}
+
+static void
+collectExportedImports(const ModuleDecl *module,
+                       ModuleDecl::ImportCollector &importCollector) {
+  for (const FileUnit *file : module->getFiles()) {
+    if (const SourceFile *source = dyn_cast<SourceFile>(file)) {
+      if (source->hasImports()) {
+        for (const auto &import : source->getImports()) {
+          if (import.options.contains(ImportFlags::Exported) &&
+              import.docVisibility.value_or(AccessLevel::Public) >=
+                  importCollector.minimumDocVisibility) {
+            importCollector.collect(import.module);
+            collectExportedImports(import.module.importedModule,
+                                   importCollector);
+          }
+        }
+      }
+    } else {
+      SmallVector<ImportedModule, 8> exportedImports;
+      file->getImportedModules(exportedImports,
+                               ModuleDecl::ImportFilterKind::Exported);
+      for (const auto &im : exportedImports) {
+        // Skip collecting the underlying clang module as we already have the relevant import.
+        if (module->isClangOverlayOf(im.importedModule))
+          continue;
+        importCollector.collect(im);
+        collectExportedImports(im.importedModule, importCollector);
+      }
     }
-    for (const ModuleDecl *import : Modules) {
-      import->getDisplayDecls(Results, Recursive);
-    }
+  }
+}
+
+void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results, bool Recursive) const {
+  if (Recursive) {
+    ImportCollector importCollector;
+    this->getDisplayDeclsRecursivelyAndImports(Results, importCollector);
   }
   // FIXME: Should this do extra access control filtering?
   FORWARD(getDisplayDecls, (Results));
+}
+
+void ModuleDecl::getDisplayDeclsRecursivelyAndImports(
+    SmallVectorImpl<Decl *> &results, ImportCollector &importCollector) const {
+  this->getDisplayDecls(results);
+
+  // Look up imports recursively.
+  collectExportedImports(this, importCollector);
+  for (const auto &QI : importCollector.qualifiedImports) {
+    auto Module = QI.getFirst();
+    if (importCollector.imports.contains(Module))
+      continue;
+
+    auto &Decls = QI.getSecond();
+    results.append(Decls.begin(), Decls.end());
+  }
+
+  for (const ModuleDecl *import : importCollector.imports)
+    import->getDisplayDecls(results);
 
 #ifndef NDEBUG
-  if (Recursive) {
-    llvm::DenseSet<Decl *> visited;
-    for (auto *D : Results) {
-      // decls synthesized from implicit clang decls may appear multiple times;
-      // e.g. if multiple modules with underlying clang modules are re-exported.
-      // including duplicates of these is harmless, so skip them when counting
-      // this assertion
-      if (const auto *CD = D->getClangDecl()) {
-        if (CD->isImplicit()) continue;
-      }
-
-      auto inserted = visited.insert(D).second;
-      assert(inserted && "there should be no duplicate decls");
+  llvm::DenseSet<Decl *> visited;
+  for (auto *D : results) {
+    // decls synthesized from implicit clang decls may appear multiple times;
+    // e.g. if multiple modules with underlying clang modules are re-exported.
+    // including duplicates of these is harmless, so skip them when counting
+    // this assertion
+    if (const auto *CD = D->getClangDecl()) {
+      if (CD->isImplicit())
+        continue;
     }
+    auto inserted = visited.insert(D).second;
+    assert(inserted && "there should be no duplicate decls");
   }
 #endif
 }
@@ -2393,7 +2419,7 @@ ModuleDecl::getDeclaringModuleAndBystander() {
   return *(declaringModuleAndBystander = {nullptr, Identifier()});
 }
 
-bool ModuleDecl::isClangOverlayOf(ModuleDecl *potentialUnderlying) {
+bool ModuleDecl::isClangOverlayOf(ModuleDecl *potentialUnderlying) const {
   return getUnderlyingModuleIfOverlay() == potentialUnderlying;
 }
 

--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -163,6 +163,13 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
     }
   }
 
+  SmallVector<StringRef, 4> AllowedRexports;
+  if (auto *A =
+          ParsedArgs.getLastArg(OPT_experimental_allowed_reexported_modules)) {
+    for (const auto *val : A->getValues())
+      AllowedRexports.emplace_back(val);
+  }
+
   symbolgraphgen::SymbolGraphOptions Options;
   Options.OutputDir = OutputDir;
   Options.Target = Target;
@@ -175,6 +182,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
   Options.EmitExtensionBlockSymbols =
       ParsedArgs.hasFlag(OPT_emit_extension_block_symbols,
                          OPT_omit_extension_block_symbols, /*default=*/false);
+  Options.AllowedReexportedModules = AllowedRexports;
 
   if (auto *A = ParsedArgs.getLastArg(OPT_minimum_access_level)) {
     Options.MinimumAccessLevel =

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -43,9 +43,14 @@ bool areModulesEqual(const ModuleDecl *lhs, const ModuleDecl *rhs, bool isClangE
 
 } // anonymous namespace
 
+SymbolGraphASTWalker::SymbolGraphASTWalker(ModuleDecl &M,
+                                           const SymbolGraphOptions &Options)
+    : Options(Options), M(M), MainGraph(*this, M, std::nullopt, Ctx) {}
+
 SymbolGraphASTWalker::SymbolGraphASTWalker(
-    ModuleDecl &M, const SmallPtrSet<ModuleDecl *, 4> ExportedImportedModules,
-    const llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4>
+    ModuleDecl &M,
+    const SmallPtrSet<const ModuleDecl *, 4> ExportedImportedModules,
+    const llvm::SmallDenseMap<const ModuleDecl *, SmallPtrSet<Decl *, 4>, 4>
         QualifiedExportedImports,
     const SymbolGraphOptions &Options)
     : Options(Options), M(M), ExportedImportedModules(ExportedImportedModules),

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.h
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.h
@@ -48,9 +48,10 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   const ModuleDecl &M;
 
   // FIXME: these should be tracked per-graph, rather than at the top level
-  const SmallPtrSet<ModuleDecl *, 4> ExportedImportedModules;
+  const SmallPtrSet<const ModuleDecl *, 4> ExportedImportedModules;
 
-  const llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> QualifiedExportedImports;
+  const llvm::SmallDenseMap<const ModuleDecl *, SmallPtrSet<Decl *, 4>, 4>
+      QualifiedExportedImports;
 
   /// The symbol graph for the main module of interest.
   SymbolGraph MainGraph;
@@ -59,11 +60,15 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   llvm::StringMap<SymbolGraph *> ExtendedModuleGraphs;
 
   // MARK: - Initialization
-  
-  SymbolGraphASTWalker(ModuleDecl &M,
-                       const SmallPtrSet<ModuleDecl *, 4> ExportedImportedModules,
-                       const llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> QualifiedExportedImports,
-                       const SymbolGraphOptions &Options);
+
+  SymbolGraphASTWalker(
+      ModuleDecl &M,
+      const SmallPtrSet<const ModuleDecl *, 4> ExportedImportedModules,
+      const llvm::SmallDenseMap<const ModuleDecl *, SmallPtrSet<Decl *, 4>, 4>
+          QualifiedExportedImports,
+      const SymbolGraphOptions &Options);
+
+  SymbolGraphASTWalker(ModuleDecl &M, const SymbolGraphOptions &Options);
   virtual ~SymbolGraphASTWalker() {}
 
   // MARK: - Utilities

--- a/test/SymbolGraph/ClangImporter/ExportedImport.swift
+++ b/test/SymbolGraph/ClangImporter/ExportedImport.swift
@@ -1,8 +1,12 @@
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-generated)
 // RUN: cp -r %S/Inputs/ExportedImport/ObjcProperty.framework %t
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t/ObjcProperty.framework/Modules/ObjcProperty.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name ObjcProperty %S/Inputs/ExportedImport/A.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t/ExportedImport.swiftmodule -F %t -module-name ExportedImport %s -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %target-swift-frontend -emit-module -o %t/ExportedImport.swiftmodule -F %t -module-name ExportedImport %s -emit-symbol-graph -emit-symbol-graph-dir %t
 // RUN: %FileCheck %s --input-file %t/ExportedImport.symbols.json
+// RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -module-name ExportedImport -I %t \
+// RUN:     -output-dir %t/module-generated/ -experimental-allowed-reexported-modules=ObjcProperty
+// RUN: %FileCheck %s --input-file %t/module-generated/ExportedImport.symbols.json
 
 // REQUIRES: objc_interop
 

--- a/test/SymbolGraph/Module/DocAttrExportedImport.swift
+++ b/test/SymbolGraph/Module/DocAttrExportedImport.swift
@@ -23,8 +23,8 @@
 // INTERNAL-DAG: "precise":"s:1A11SymbolFromAV"
 // INTERNAL-DAG: "precise":"s:1B9StructOneV"
 
-// FIXME: Symbols from `@_exported import` do not get emitted when using swift-symbolgraph-extract
-// This is tracked by https://github.com/apple/swift-docc/issues/179.
+// FIXME: Functionality doesn't currently work swift-symbolgraph-extract as documentation visibility attribute isn't
+// exposed in the module interface
 
 // FILES-NOT: DocAttrExportedImport@A.symbols.json
 

--- a/test/SymbolGraph/Module/DuplicateExportedImport.swift
+++ b/test/SymbolGraph/Module/DuplicateExportedImport.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-generated)
 // RUN: %target-swift-frontend %S/Inputs/DuplicateExportedImport/A.swift -module-name A -emit-module -emit-module-path %t/A.swiftmodule
-// RUN: %target-swift-frontend %s -module-name DuplicateExportedImport -emit-module -emit-module-path /dev/null -I %t -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %target-swift-frontend %s -module-name DuplicateExportedImport -emit-module -emit-module-path \
+// RUN:     %t/DuplicateExportedImport.swiftmodule -I %t -emit-symbol-graph -emit-symbol-graph-dir %t/
 // RUN: %FileCheck %s --input-file %t/DuplicateExportedImport.symbols.json
+// RUN: %target-swift-symbolgraph-extract -module-name DuplicateExportedImport -I %t -output-dir %t/module-generated/ \
+// RUN:     -experimental-allowed-reexported-modules=A
+// RUN: %FileCheck %s --input-file %t/module-generated/DuplicateExportedImport.symbols.json
 
 // REQUIRES: asserts
 

--- a/test/SymbolGraph/Module/ExportedImport.swift
+++ b/test/SymbolGraph/Module/ExportedImport.swift
@@ -1,9 +1,15 @@
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-generated)
 // RUN: %target-swift-frontend %S/Inputs/ExportedImport/A.swift -module-name A -emit-module -emit-module-path %t/A.swiftmodule
 // RUN: %target-swift-frontend %S/Inputs/ExportedImport/B.swift -module-name B -emit-module -emit-module-path %t/B.swiftmodule
-// RUN: %target-swift-frontend %s -module-name ExportedImport -emit-module -emit-module-path /dev/null -I %t -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %target-swift-frontend %s -module-name ExportedImport -emit-module -emit-module-path \
+// RUN:     %t/ExportedImport.swiftmodule -I %t -emit-symbol-graph -emit-symbol-graph-dir %t/
 // RUN: %FileCheck %s --input-file %t/ExportedImport.symbols.json
+// RUN: %target-swift-symbolgraph-extract -module-name ExportedImport -I %t -output-dir \
+// RUN:     %t/module-generated/ -experimental-allowed-reexported-modules=A,B
+// RUN: %FileCheck %s --input-file %t/module-generated/ExportedImport.symbols.json
 // RUN: ls %t | %FileCheck %s --check-prefix FILES
+// RUN: ls %t/module-generated/ | %FileCheck %s --check-prefix FILES
 
 @_exported import A
 @_exported import struct B.StructOne
@@ -12,8 +18,5 @@
 // CHECK-NOT: StructTwo
 // CHECK-DAG: "precise":"s:1A11SymbolFromAV"
 // CHECK-DAG: "precise":"s:1B9StructOneV"
-
-// FIXME: Symbols from `@_exported import` do not get emitted when using swift-symbolgraph-extract
-// This is tracked by https://github.com/apple/swift-docc/issues/179.
 
 // FILES-NOT: ExportedImport@A.symbols.json

--- a/test/SymbolGraph/Module/NestedExportedImport.swift
+++ b/test/SymbolGraph/Module/NestedExportedImport.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-generated)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend %t/A.swift -module-name A -emit-module -emit-module-path %t/A.swiftmodule
+// RUN: %target-swift-frontend %t/B.swift -module-name B -emit-module -emit-module-path %t/B.swiftmodule -I %t
+// RUN: %target-swift-frontend %t/C.swift -module-name C -emit-module -emit-module-path %t/C.swiftmodule -I %t \
+// RUN:     -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %target-swift-symbolgraph-extract -module-name C -I %t -output-dir \
+// RUN:     %t/module-generated/ -experimental-allowed-reexported-modules=A,B
+// RUN: %FileCheck %s --input-file %t/C.symbols.json
+// RUN: %FileCheck %s --input-file %t/module-generated/C.symbols.json
+
+//--- A.swift
+public struct A {}
+public func AFunc() -> Void {}
+
+//--- B.swift
+@_exported import A
+public struct B {}
+public func BFunc() -> Void {}
+
+//--- C.swift
+@_exported import B
+public struct C {}
+public func CFunc() -> Void {}
+
+// CHECK-DAG: "precise":"s:1CAAV"
+// CHECK-DAG: "precise":"s:1BAAV"
+// CHECK-DAG: "precise":"s:1AAAV"


### PR DESCRIPTION
This sets up the necessary stuff to include symbols from exported imported modules in symbol graphs generated using the `swift-symbolgraph-extract` tool

Changes include:
- Add option to provide an allow list of reexported modules for swift-symbolgraph-extract
- Recursively collect exported imports to allow fetching all visible Decls for symbol graph generation
- Enable collection of exported imports that originate from non `SourceFile` file units for the purpose of `ModuleDecl::getDisplayDecl`

Resolves #59920 
rdar://89687175

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
