### PR TITLE
[IRGen] Normalize case of AccessorKind names

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -613,10 +613,10 @@ private:
           Kind = ".set";
           break;
         case AccessorKind::WillSet:
-          Kind = ".willset";
+          Kind = ".willSet";
           break;
         case AccessorKind::DidSet:
-          Kind = ".didset";
+          Kind = ".didSet";
           break;
         case AccessorKind::Address:
           Kind = ".addressor";


### PR DESCRIPTION
When generating `willSet`/`didSet` debug info, use the same casing as the language uses. This will allow breakpoints to be set by name on `someProperty.willSet` and `someProperty.didSet`.