### PR TITLE
[cxx-interop] Do not try to import `std::tzdb`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2650,6 +2650,13 @@ namespace {
         return nullptr;
       }
 
+      // Bail if this is `std::tzdb`. This type causes issues in copy
+      // constructor instantiation.
+      // FIXME: https://github.com/apple/swift/issues/73037
+      if (decl->isInStdNamespace() && decl->getIdentifier() &&
+          decl->getName() == "tzdb")
+        return nullptr;
+
       auto &clangSema = Impl.getClangSema();
       // Make Clang define any implicit constructors it may need (copy,
       // default). Make sure we only do this if the class has been fully defined


### PR DESCRIPTION
In libstdc++13 on Ubuntu 23.10 the type `std::tzdb` is non-copyable but does not explicitly delete its copy constructor. It instead triggers template instantiation errors when trying to use the copy constructor. This is problematic for Swift, since we try to instantiate copy constructors for most C++ types we import.

This disables the import of `std::tzdb` to unblock nightly toolchains for Ubuntu 23.10 until we come up with a better solution.

rdar://126486849 / https://github.com/apple/swift/issues/73037