### PR TITLE
Respect the module ABI name when mangling for the debugger

### DIFF
--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -26,6 +26,9 @@ constexpr static const StringLiteral SWIFT_ONONE_SUPPORT = "SwiftOnoneSupport";
 constexpr static const StringLiteral SWIFT_CONCURRENCY_NAME = "_Concurrency";
 /// The name of the Concurrency Shims Clang module
 constexpr static const StringLiteral SWIFT_CONCURRENCY_SHIMS_NAME = "_SwiftConcurrencyShims";
+/// The unique ABI prefix that swift-syntax uses when it's built as part of the
+/// compiler.
+constexpr static const StringLiteral SWIFT_MODULE_ABI_NAME_PREFIX = "Compiler";
 /// The name of the Distributed module, which supports that extension.
 constexpr static const StringLiteral SWIFT_DISTRIBUTED_NAME = "Distributed";
 /// The name of the StringProcessing module, which supports that extension.

--- a/test/DebugInfo/module_abi_name.swift
+++ b/test/DebugInfo/module_abi_name.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -module-name=Hello -module-abi-name Goodbye -emit-ir -o - | %FileCheck %s
+
+class SomeClass {}
+// CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "SomeClass",{{.*}}runtimeLang: DW_LANG_Swift, identifier: "$s7Goodbye9SomeClassCD"
+
+@available(macOS 10.13, *)
+@_originallyDefinedIn(module: "ThirdModule", OSX 10.12)
+class DefinedElsewhere {}
+// CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "DefinedElsewhere",{{.*}}runtimeLang: DW_LANG_Swift, identifier: "$s7Goodbye16DefinedElsewhereCD")
+
+let v1 = SomeClass()
+let v2 = DefinedElsewhere()
+


### PR DESCRIPTION
The mangled name produced for the debugger should match the one emitted in reflection metadata, otherwise LLDB will not be able to lookup types when the module is compiled with the -module-abi-name flag.

rdar://125848324
