### PR TITLE
SILGen: Move error values into indirect error returns in proper order with cleanups.

### DIFF
--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -221,6 +221,17 @@ public:
                              ArrayRef<SILValue> args = {},
                              ForUnwind_t forUnwind = NotForUnwind);
 
+  /// Emit a branch to the given jump destination,
+  /// threading out through any cleanups we need to run. This does not pop the
+  /// cleanup stack.
+  ///
+  /// \param dest       The destination scope and block.
+  /// \param branchLoc  The location of the branch instruction.
+  /// \param args       Arguments to pass to the destination block.
+  void emitCleanupsForBranch(JumpDest dest, SILLocation branchLoc,
+                             ArrayRef<SILValue> args = {},
+                             ForUnwind_t forUnwind = NotForUnwind);
+
   /// emitCleanupsForReturn - Emit the top-level cleanups needed prior to a
   /// return from the function.
   void emitCleanupsForReturn(CleanupLocation loc, ForUnwind_t forUnwind);

--- a/test/SILGen/typed_throws_reabstraction.swift
+++ b/test/SILGen/typed_throws_reabstraction.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+func test2() throws { // Not OK
+  // The literal closure below is in a generic error context, even though
+  // it statically throws `any Error`, leading it to be emitted with an
+  // indirect `any Error` out parameter.
+  try call { () throws in
+  // CHECK-LABEL: sil{{.*}} @{{.*}}5test2{{.*}}fU_
+    do {
+      try gorble()
+    }
+    // Make sure we stop borrowing the error value before forwarding it into
+    // the error return slot.
+    // CHECK: bb{{.*}}([[ERROR:%.*]] : @owned $any Error):
+    // CHECK:      [[ERROR_BORROW:%.*]] = begin_borrow [[ERROR]]
+    // CHECK: bb{{[0-9]+}}:
+    // CHECK: bb{{[0-9]+}}:
+    // CHECK:      end_borrow [[ERROR_BORROW]]
+    // CHECK-NEXT: store [[ERROR]] to [init]
+    // CHECK-NEXT: throw_addr
+
+    catch is E1 { /* ignore */ }
+  }
+}
+
+func call<E: Error, R>(
+  _ body: () throws(E) -> R
+) throws(E) -> R {
+  try body()
+}
+
+struct E1: Error {}
+
+func gorble() throws {}
+
+func test1() throws { // OK
+  try call { () throws in
+    try gorble()
+  }
+}


### PR DESCRIPTION
There's an unfortunate layering difference in the cleanup order between address-only and loadable error values during `catch` pattern matching: for address-only values, the value is copied into a temporary stack slot, and the stack slot is cleaned up on exit from the pattern match, meaning the value must be moved into the error return slot on the "no catch" case before cleanups run. But if it's a loadable value, then we borrow it for the duration of the switch, and the borrow is released during cleanup on exit from the pattern match, so the value must be forwarded after running cleanups.

The way the code is structured, it handles these cases properly when the convention of the function being emitted is in sync with the fundamental properties of the error type (when the error type is loadable and the error return is by value, or when the error type is address-only and the error return is indirect, in other words). But when a closure literal with a loadable error type is emitted in an argument context that expects a function with an indirect error return, we would try to forward the loadable error value into the error return slot while a borrow is still active on it, leading to verifier errors. Defer forwarding the value into memory until after cleanups are popped, fixing rdar://126576356.

A tidier solution might be to always emit the function body to use a bbarg on the throw block to pass the error value from the body emission to the epilog when the type is loadable, deferring the move into memory to the epilog block. This would make the right behavior fall out of the existing implementation, but would require a bit more invasive changes (pretty much everywhere that checks IndirectErrorReturn would need to check a different-tracked AddressOnlyErrorType bit instead or in addition). This change is more localized.