### PR TITLE
[Debugging] Make DebugDescriptionMacro feature available in prod

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -377,7 +377,7 @@ EXPERIMENTAL_FEATURE(ObjCImplementation, true)
 EXPERIMENTAL_FEATURE(CImplementation, true)
 
 // Enable the stdlib @DebugDescription macro.
-EXPERIMENTAL_FEATURE(DebugDescriptionMacro, false)
+EXPERIMENTAL_FEATURE(DebugDescriptionMacro, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE


### PR DESCRIPTION
Amendment of https://github.com/apple/swift/pull/73070. I did not understand the effects of the `AvailableInProd` boolean flag, until @drodriguez [pointed out the issue ](https://github.com/apple/swift/pull/73070#issuecomment-2062758324).