### PR TITLE
[Debugging] Add DebugDescriptionMacro experimental feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -386,7 +386,7 @@ EXPERIMENTAL_FEATURE(CImplementation, true)
 EXPERIMENTAL_FEATURE(Sensitive, true)
 
 // Enable the stdlib @DebugDescription macro.
-EXPERIMENTAL_FEATURE(DebugDescriptionMacro, false)
+EXPERIMENTAL_FEATURE(DebugDescriptionMacro, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -385,6 +385,9 @@ EXPERIMENTAL_FEATURE(CImplementation, true)
 // Enable @sensitive attribute.
 EXPERIMENTAL_FEATURE(Sensitive, true)
 
+// Enable the stdlib @DebugDescription macro.
+EXPERIMENTAL_FEATURE(DebugDescriptionMacro, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -710,6 +710,8 @@ static bool usesFeatureSensitive(Decl *decl) {
   return decl->getAttrs().hasAttribute<SensitiveAttr>();
 }
 
+UNINTERESTING_FEATURE(DebugDescriptionMacro)
+
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet
 // ----------------------------------------------------------------------------

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1538,6 +1538,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableDynamicActorIsolation |=
       Args.hasArg(OPT_disable_dynamic_actor_isolation);
 
+  // @DebugDescription uses @_section and @_used attributes.
+  if (Opts.hasFeature(Feature::DebugDescriptionMacro))
+    Opts.enableFeature(Feature::SymbolLinkageMarkers);
+
 #if SWIFT_ENABLE_EXPERIMENTAL_PARSER_VALIDATION
   /// Enable round trip parsing via the new swift parser unless it is disabled
   /// explicitly. The new Swift parser can have mismatches with C++ parser -

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -329,7 +329,7 @@ endif()
 
 list(APPEND swift_stdlib_compile_flags "-external-plugin-path"
   "${swift_lib_dir}/swift/host/plugins#${swift_bin_dir}/swift-plugin-server")
-list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "SymbolLinkageMarkers")
+list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "DebugDescriptionMacro")
 
 set(swift_core_incorporate_object_libraries)
 list(APPEND swift_core_incorporate_object_libraries swiftRuntime)

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -13,7 +13,7 @@
 import SwiftShims
 
 // Macros are disabled when Swift is built without swift-syntax.
-#if $Macros && hasAttribute(attached)
+#if $Macros && $DebugDescriptionMacro && hasAttribute(attached)
 
 /// Converts description definitions to a debugger Type Summary.
 ///
@@ -65,10 +65,10 @@ import SwiftShims
 ///   logic and computed properties are not supported.
 /// * Overloaded string interpolation cannot be used.
 @attached(memberAttribute)
-public macro _DebugDescription() =
+public macro DebugDescription() =
   #externalMacro(module: "SwiftMacros", type: "DebugDescriptionMacro")
 
-/// Internal-only macro. See `@_DebugDescription`.
+/// Internal-only macro. See `@DebugDescription`.
 @attached(peer, names: named(_lldb_summary))
 public macro _DebugDescriptionProperty(_ debugIdentifier: String, _ computedProperties: [String]) =
   #externalMacro(module: "SwiftMacros", type: "_DebugDescriptionPropertyMacro")

--- a/stdlib/public/core/ObjectIdentifier+DebugDescription.swift
+++ b/stdlib/public/core/ObjectIdentifier+DebugDescription.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if !$Embedded
-@_DebugDescription
+@DebugDescription
 extension ObjectIdentifier {
   var _debugDescription: String {
     return "ObjectIdentifier(\(_value))"

--- a/test/Macros/DebugDescription/error_complex_implementation.swift
+++ b/test/Macros/DebugDescription/error_complex_implementation.swift
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -verify -plugin-path %swift-plugin-dir
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct {
   var flag: Bool
 

--- a/test/Macros/DebugDescription/error_computed_properties.swift
+++ b/test/Macros/DebugDescription/error_computed_properties.swift
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -verify -plugin-path %swift-plugin-dir
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct {
   var name: String { "thirty" }
 

--- a/test/Macros/DebugDescription/error_custom_interpolation.swift
+++ b/test/Macros/DebugDescription/error_custom_interpolation.swift
@@ -8,13 +8,13 @@ extension DefaultStringInterpolation {
   fileprivate func appendInterpolation<A, B>(_ a: A, _ b: B) {}
 }
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct1 {
   // expected-error @+1 {{unsupported custom string interpolation expression}}
   var debugDescription: String { "\(custom: 30)" }
 }
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct2 {
   // expected-error @+1 {{unsupported custom string interpolation expression}}
   var debugDescription: String { "\(30, true)" }

--- a/test/Macros/DebugDescription/error_interpolation_expression.swift
+++ b/test/Macros/DebugDescription/error_interpolation_expression.swift
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -verify -plugin-path %swift-plugin-dir
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct {
   // expected-error @+1 {{only references to stored properties are allowed}}
   var debugDescription: String { "\(1)" }

--- a/test/Macros/DebugDescription/error_protocol.swift
+++ b/test/Macros/DebugDescription/error_protocol.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -verify -plugin-path %swift-plugin-dir
 
 // expected-error @+1 {{cannot be attached to a protocol}}
-@_DebugDescription
+@DebugDescription
 protocol MyProto {
   func action()
 }

--- a/test/Macros/DebugDescription/explicit_self_property.swift
+++ b/test/Macros/DebugDescription/explicit_self_property.swift
@@ -1,10 +1,10 @@
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature SymbolLinkageMarkers -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct: CustomDebugStringConvertible {
   var name: String = "thirty"
   var debugDescription: String { "name: \(self.name)" }
@@ -16,7 +16,7 @@ struct MyStruct: CustomDebugStringConvertible {
 // CHECK:     /* "name: ${var.name}" */ 18 as UInt8, 110 as UInt8, 97 as UInt8, 109 as UInt8, 101 as UInt8, 58 as UInt8, 32 as UInt8, 36 as UInt8, 123 as UInt8, 118 as UInt8, 97 as UInt8, 114 as UInt8, 46 as UInt8, 110 as UInt8, 97 as UInt8, 109 as UInt8, 101 as UInt8, 125 as UInt8, 0 as UInt8
 // CHECK: )
 
-@_DebugDescription
+@DebugDescription
 class MyClass: CustomDebugStringConvertible {
   var name: String = "thirty"
   var debugDescription: String { "name: \(self.name)" }

--- a/test/Macros/DebugDescription/extension.swift
+++ b/test/Macros/DebugDescription/extension.swift
@@ -1,12 +1,12 @@
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature SymbolLinkageMarkers -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
 struct MyStruct {}
 
-@_DebugDescription
+@DebugDescription
 extension MyStruct {
   var debugDescription: String { "thirty" }
 }

--- a/test/Macros/DebugDescription/implicit_self_property.swift
+++ b/test/Macros/DebugDescription/implicit_self_property.swift
@@ -1,10 +1,10 @@
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature SymbolLinkageMarkers -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct: CustomDebugStringConvertible {
   var name: String = "thirty"
   var debugDescription: String { "name: \(name)" }
@@ -16,7 +16,7 @@ struct MyStruct: CustomDebugStringConvertible {
 // CHECK:     /* "name: ${var.name}" */ 18 as UInt8, 110 as UInt8, 97 as UInt8, 109 as UInt8, 101 as UInt8, 58 as UInt8, 32 as UInt8, 36 as UInt8, 123 as UInt8, 118 as UInt8, 97 as UInt8, 114 as UInt8, 46 as UInt8, 110 as UInt8, 97 as UInt8, 109 as UInt8, 101 as UInt8, 125 as UInt8, 0 as UInt8
 // CHECK: )
 
-@_DebugDescription
+@DebugDescription
 class MyClass: CustomDebugStringConvertible {
   var name: String = "thirty"
   var debugDescription: String { "name: \(name)" }

--- a/test/Macros/DebugDescription/linkage.swift
+++ b/test/Macros/DebugDescription/linkage.swift
@@ -1,10 +1,10 @@
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature SymbolLinkageMarkers -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct: CustomDebugStringConvertible {
   var debugDescription: String { "thirty" }
 }

--- a/test/Macros/DebugDescription/long_string.swift
+++ b/test/Macros/DebugDescription/long_string.swift
@@ -1,10 +1,10 @@
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature SymbolLinkageMarkers -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct: CustomDebugStringConvertible {
   var debugDescription: String {
     """

--- a/test/Macros/DebugDescription/property_chain.swift
+++ b/test/Macros/DebugDescription/property_chain.swift
@@ -1,10 +1,10 @@
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature SymbolLinkageMarkers -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct: CustomDebugStringConvertible {
   var name: String = "thirty"
   var debugDescription: String { "\(self.name.count) \(name.count)" }
@@ -16,7 +16,7 @@ struct MyStruct: CustomDebugStringConvertible {
 // CHECK:     /* "${var.name.count} ${var.name.count}" */ 36 as UInt8, 36 as UInt8, 123 as UInt8, 118 as UInt8, 97 as UInt8, 114 as UInt8, 46 as UInt8, 110 as UInt8, 97 as UInt8, 109 as UInt8, 101 as UInt8, 46 as UInt8, 99 as UInt8, 111 as UInt8, 117 as UInt8, 110 as UInt8, 116 as UInt8, 125 as UInt8, 32 as UInt8, 36 as UInt8, 123 as UInt8, 118 as UInt8, 97 as UInt8, 114 as UInt8, 46 as UInt8, 110 as UInt8, 97 as UInt8, 109 as UInt8, 101 as UInt8, 46 as UInt8, 99 as UInt8, 111 as UInt8, 117 as UInt8, 110 as UInt8, 116 as UInt8, 125 as UInt8, 0 as UInt8
 // CHECK: )
 
-@_DebugDescription
+@DebugDescription
 class MyClass: CustomDebugStringConvertible {
   var name: String = "thirty"
   var debugDescription: String { "\(self.name.count) \(name.count)" }

--- a/test/Macros/DebugDescription/static_string.swift
+++ b/test/Macros/DebugDescription/static_string.swift
@@ -1,10 +1,10 @@
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature SymbolLinkageMarkers -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct: CustomDebugStringConvertible {
   var debugDescription: String { "thirty" }
 }
@@ -15,7 +15,7 @@ struct MyStruct: CustomDebugStringConvertible {
 // CHECK:     /* "thirty" */ 7 as UInt8, 116 as UInt8, 104 as UInt8, 105 as UInt8, 114 as UInt8, 116 as UInt8, 121 as UInt8, 0 as UInt8
 // CHECK: )
 
-@_DebugDescription
+@DebugDescription
 class MyClass: CustomDebugStringConvertible {
   var debugDescription: String { "thirty" }
 }
@@ -26,7 +26,7 @@ class MyClass: CustomDebugStringConvertible {
 // CHECK:     /* "thirty" */ 7 as UInt8, 116 as UInt8, 104 as UInt8, 105 as UInt8, 114 as UInt8, 116 as UInt8, 121 as UInt8, 0 as UInt8
 // CHECK: )
 
-@_DebugDescription
+@DebugDescription
 class MyEnum: CustomDebugStringConvertible {
   var debugDescription: String { "thirty" }
 }

--- a/test/Macros/DebugDescription/supported_description.swift
+++ b/test/Macros/DebugDescription/supported_description.swift
@@ -1,10 +1,10 @@
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature SymbolLinkageMarkers -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck %s < %t/expansions-dump.txt
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct1: CustomStringConvertible {
   var description: String { "thirty" }
 }
@@ -15,7 +15,7 @@ struct MyStruct1: CustomStringConvertible {
 // CHECK:     /* "thirty" */ 7 as UInt8, 116 as UInt8, 104 as UInt8, 105 as UInt8, 114 as UInt8, 116 as UInt8, 121 as UInt8, 0 as UInt8
 // CHECK: )
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct2: CustomDebugStringConvertible {
   var description: String { "thirty" }
   var debugDescription: String { "eleven" }
@@ -27,7 +27,7 @@ struct MyStruct2: CustomDebugStringConvertible {
 // CHECK:     /* "eleven" */ 7 as UInt8, 101 as UInt8, 108 as UInt8, 101 as UInt8, 118 as UInt8, 101 as UInt8, 110 as UInt8, 0 as UInt8
 // CHECK: )
 
-@_DebugDescription
+@DebugDescription
 struct MyStruct3: CustomDebugStringConvertible {
   var description: String { "thirty" }
   var debugDescription: String { "eleven" }


### PR DESCRIPTION
This removes the leading underscore from the macro.

(cherry picked from commit 4ccf31501eb13057fcace23cf4f6bc3c4df0440a)
