### PR TITLE
[6.0 🍒] fix reverse cond-fail for SuppressedAssociatedTypes

### DIFF
--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -757,8 +757,11 @@ void swift::rewriting::applyInverses(
 
     // Inverses on associated types are experimental.
     if (!allowInverseOnAssocType && canSubject->is<DependentMemberType>()) {
-      errors.push_back(RequirementError::forInvalidInverseSubject(inverse));
-      continue;
+      // Special exception: allow if we're building the stdlib.
+      if (!ctx.MainModule->isStdlibModule()) {
+        errors.push_back(RequirementError::forInvalidInverseSubject(inverse));
+        continue;
+      }
     }
 
     // Noncopyable checking support for parameter packs is not implemented yet.

--- a/test/Sema/suppressed_assoc_stdlib.swift
+++ b/test/Sema/suppressed_assoc_stdlib.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib -module-name Swift -enable-experimental-feature NoncopyableGenerics
+
+public protocol Hello {
+  associatedtype Req: ~Copyable
+}


### PR DESCRIPTION
- Explanation: Allows the compiler to ingest older stdlib interface files that use ~Copyable on associated types, without those stdlibs being built with the experimental feature that it's now gated-behind.
- Scope: Changes how we infer a feature flag.
- Issue: rdar://126668752
- Original PR: https://github.com/apple/swift/pull/73111
- Risk: Virtually none.
- Testing: Building the stdlib should be sufficient.
- Reviewer: @tshortli 