### PR TITLE
[DNM] Add overload to String.init(describing:) for metatypes that skips dynamic casting

### DIFF
--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -771,6 +771,50 @@ extension String {
     self.init()
     _debugPrint_unlocked(subject, &self)
   }
+
+  /// Creates a string representing the given value.
+  ///
+  /// Use this initializer to convert an instance of any type to its preferred
+  /// representation as a `String` instance. The initializer creates the
+  /// string representation of `instance` in one of the following ways,
+  /// depending on its protocol conformance:
+  ///
+  /// - If `instance` conforms to the `TextOutputStreamable` protocol, the
+  ///   result is obtained by calling `instance.write(to: s)` on an empty
+  ///   string `s`.
+  /// - If `instance` conforms to the `CustomStringConvertible` protocol, the
+  ///   result is `instance.description`.
+  /// - If `instance` conforms to the `CustomDebugStringConvertible` protocol,
+  ///   the result is `instance.debugDescription`.
+  /// - An unspecified result is supplied automatically by the Swift standard
+  ///   library.
+  ///
+  /// For example, this custom `Point` struct uses the default representation
+  /// supplied by the standard library.
+  ///
+  ///     struct Point {
+  ///         let x: Int, y: Int
+  ///     }
+  ///
+  ///     let p = Point(x: 21, y: 30)
+  ///     print(String(describing: p))
+  ///     // Prints "Point(x: 21, y: 30)"
+  ///
+  /// After adding `CustomStringConvertible` conformance by implementing the
+  /// `description` property, `Point` provides its own custom representation.
+  ///
+  ///     extension Point: CustomStringConvertible {
+  ///         var description: String {
+  ///             return "(\(x), \(y))"
+  ///         }
+  ///     }
+  ///
+  ///     print(String(describing: p))
+  ///     // Prints "(21, 30)"
+  @_alwaysEmitIntoClient
+  public init<Subject>(describing metatype: Subject.Type) {
+    self = _typeName(metatype, qualified: false)
+  }
 }
 
 #if SWIFT_ENABLE_REFLECTION


### PR DESCRIPTION
This is an experiment to add an `@_alwaysEmitIntoClient` overload of `String.init(describing:)` that delegates directly to `_typeName`. This should have equivalent behavior to `String.init(describing:)`, which does an unqualified print of metatypes after resolving through `Mirror`.