### PR TITLE
[6.0][CodeCompletion] Always print argument ':' in filterName

### DIFF
--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -425,14 +425,16 @@ public:
 
   void addCallArgument(Identifier Name, Identifier LocalName, Type Ty,
                        Type ContextTy, bool IsVarArg, bool IsInOut, bool IsIUO,
-                       bool IsAutoClosure, bool UseUnderscoreLabel,
-                       bool IsLabeledTrailingClosure, bool HasDefault);
+                       bool IsAutoClosure, bool IsLabeledTrailingClosure,
+                       bool IsForOperator, bool HasDefault);
 
-  void addCallArgument(Identifier Name, Type Ty, Type ContextTy = Type()) {
+  void addCallArgument(Identifier Name, Type Ty, Type ContextTy = Type(),
+                       bool IsForOperator = false) {
     addCallArgument(Name, Identifier(), Ty, ContextTy,
                     /*IsVarArg=*/false, /*IsInOut=*/false, /*IsIUO=*/false,
-                    /*IsAutoClosure=*/false, /*UseUnderscoreLabel=*/false,
-                    /*IsLabeledTrailingClosure=*/false, /*HasDefault=*/false);
+                    /*IsAutoClosure=*/false,
+                    /*IsLabeledTrailingClosure=*/false, IsForOperator,
+                    /*HasDefault=*/false);
   }
 
   void addGenericParameter(StringRef Name) {

--- a/lib/IDE/CodeCompletionResultPrinter.cpp
+++ b/lib/IDE/CodeCompletionResultPrinter.cpp
@@ -516,8 +516,7 @@ static void printCodeCompletionResultFilterName(
       case ChunkKind::CallArgumentColon:
       case ChunkKind::ParameterDeclColon:
         // Since we don't add the type, also don't add the space after ':'.
-        if (shouldPrint)
-          OS << ":";
+        OS << ":";
         ++i;
         continue;
       case ChunkKind::Text:

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1073,8 +1073,8 @@ bool CompletionLookup::addCallArgumentPatterns(
     Builder.addCallArgument(argName, bodyName,
                             eraseArchetypes(paramTy, genericSig), contextTy,
                             isVariadic, isInOut, isIUO, isAutoclosure,
-                            /*UseUnderscoreLabel=*/false,
-                            /*IsLabeledTrailingClosure=*/false, hasDefault);
+                            /*IsLabeledTrailingClosure=*/false,
+                            /*IsForOperator=*/false, hasDefault);
 
     modifiedBuilder = true;
     needComma = true;
@@ -2560,7 +2560,8 @@ void CompletionLookup::addAssignmentOperator(Type RHSType) {
   Type contextTy;
   if (auto typeContext = CurrDeclContext->getInnermostTypeContext())
     contextTy = typeContext->getDeclaredTypeInContext();
-  builder.addCallArgument(Identifier(), RHSType, contextTy);
+  builder.addCallArgument(Identifier(), RHSType, contextTy,
+                          /*IsForOperator=*/true);
 }
 
 void CompletionLookup::addInfixOperatorCompletion(OperatorDecl *op,
@@ -2584,7 +2585,8 @@ void CompletionLookup::addInfixOperatorCompletion(OperatorDecl *op,
     Type contextTy;
     if (auto typeContext = CurrDeclContext->getInnermostTypeContext())
       contextTy = typeContext->getDeclaredTypeInContext();
-    builder.addCallArgument(Identifier(), RHSType, contextTy);
+    builder.addCallArgument(Identifier(), RHSType, contextTy,
+                            /*IsForOperator=*/true);
   }
   if (resultType)
     addTypeAnnotation(builder, resultType);
@@ -2913,8 +2915,9 @@ void CompletionLookup::addCallArgumentCompletionResults(
     Builder.addCallArgument(Arg->getLabel(), Identifier(), Arg->getPlainType(),
                             ContextType, Arg->isVariadic(), Arg->isInOut(),
                             /*IsIUO=*/false, Arg->isAutoClosure(),
-                            /*UseUnderscoreLabel=*/true,
-                            isLabeledTrailingClosure, /*HasDefault=*/false);
+                            isLabeledTrailingClosure,
+                            /*IsForOperator=*/false,
+                            /*HasDefault=*/false);
     Builder.addFlair(CodeCompletionFlairBit::ArgumentLabels);
     auto Ty = Arg->getPlainType();
     if (Arg->isInOut()) {

--- a/test/IDE/complete_annotation.swift
+++ b/test/IDE/complete_annotation.swift
@@ -2,12 +2,14 @@
 
 struct MyStruct {
   init(x: Int) {}
+  init<T, U>(_: T.Type, _: U.Type, value: Int = 1) {}
   var propNormal: Int { fatalError() }
   var propFunction: () -> MyStruct { fatalError() }
   func labelNameParamName(label param: (inout Int) throws -> MyStruct) rethrows {}
   func labelName(label: (@autoclosure () -> Int) -> Int) {}
   func sameName(label label: inout Int) {}
   func paramName(_ param: Int) {}
+  func emptyName<T>(_: T.Type) {}
   subscript(param: Int) -> Int { 1 }
   subscript(label param: Int) -> Int { 1 }
 
@@ -54,7 +56,7 @@ func testType(value: #^GLOBAL_TYPE^#) {}
 func testMember(value: MyStruct) {
   value.#^EXPR_MEMBER^#
 }
-// EXPR_MEMBER: Begin completions, 7 items
+// EXPR_MEMBER: Begin completions, 8 items
 // EXPR_MEMBER-DAG: Keyword[self]/CurrNominal:          <keyword>self</keyword>; typename=<typeid.user>MyStruct</typeid.user>;
 // EXPR_MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      <name>propNormal</name>; typename=<typeid.sys>Int</typeid.sys>;
 // EXPR_MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      <name>propFunction</name>; typename=() -&gt; <typeid.user>MyStruct</typeid.user>;
@@ -62,11 +64,12 @@ func testMember(value: MyStruct) {
 // EXPR_MEMBER-DAG: Decl[InstanceMethod]/CurrNominal: <name>labelName</name>(<callarg><callarg.label>label</callarg.label>: <callarg.type>(<attribute>@autoclosure</attribute> () -&gt; <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.sys>Void</typeid.sys>;
 // EXPR_MEMBER-DAG: Decl[InstanceMethod]/CurrNominal: <name>sameName</name>(<callarg><callarg.label>label</callarg.label>: &amp;<callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.sys>Void</typeid.sys>;
 // EXPR_MEMBER-DAG: Decl[InstanceMethod]/CurrNominal: <name>paramName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>param</callarg.param>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.sys>Void</typeid.sys>;
+// EXPR_MEMBER-DAG: Decl[InstanceMethod]/CurrNominal:   <name>emptyName</name>(<callarg><callarg.label>_</callarg.label>: <callarg.type><typeid.user>T</typeid.user>.Type</callarg.type></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=emptyName(:); sourcetext=emptyName(<#T##T.Type#>)
 
 func testPostfix(value: MyStruct) {
   value #^EXPR_POSTFIX^#
 }
-// EXPR_POSTFIX: Begin completions, 10 items
+// EXPR_POSTFIX: Begin completions, 11 items
 // EXPR_POSTFIX-DAG: Decl[InstanceVar]/CurrNominal:      <name>propNormal</name>; typename=<typeid.sys>Int</typeid.sys>;
 // EXPR_POSTFIX-DAG: Decl[InstanceVar]/CurrNominal:      <name>propFunction</name>; typename=() -&gt; <typeid.user>MyStruct</typeid.user>;
 // EXPR_POSTFIX-DAG: Decl[InstanceMethod]/CurrNominal:   <name>labelNameParamName</name>(<callarg><callarg.label>label</callarg.label> <callarg.param>param</callarg.param>: <callarg.type>(<keyword>inout</keyword> <typeid.sys>Int</typeid.sys>) <keyword>throws</keyword> -&gt; <typeid.user>MyStruct</typeid.user></callarg.type></callarg>) <keyword>rethrows</keyword>; typename=<typeid.sys>Void</typeid.sys>;
@@ -77,17 +80,21 @@ func testPostfix(value: MyStruct) {
 // EXPR_POSTFIX-DAG: Decl[Subscript]/CurrNominal:        [<callarg><callarg.label>label</callarg.label> <callarg.param>param</callarg.param>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>]; typename=<typeid.sys>Int</typeid.sys>;
 // EXPR_POSTFIX-DAG: Keyword[self]/CurrNominal:          <keyword>self</keyword>; typename=<typeid.user>MyStruct</typeid.user>;
 // EXPR_POSTFIX-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]/IsSystem: <name>+</name>; typename=<typeid.user>MyStruct</typeid.user>;
+// EXPR_POSTFIX-DAG: Decl[InstanceMethod]/CurrNominal:   <name>emptyName</name>(<callarg><callarg.label>_</callarg.label>: <callarg.type><typeid.user>T</typeid.user>.Type</callarg.type></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=emptyName(:); sourcetext=.emptyName(<#T##T.Type#>)
 
 func testImplicitMember() -> MyStruct {
   return .#^EXPR_IMPLICITMEMBER^#
 }
-// EXPR_IMPLICITMEMBER: Begin completions, 7 items
+// EXPR_IMPLICITMEMBER: Begin completions, 10 items
 // EXPR_IMPLICITMEMBER-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: <name>init</name>(<callarg><callarg.label>x</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.user>MyStruct</typeid.user>;
+// EXPR_IMPLICITMEMBER-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: <name>init</name>(<callarg><callarg.label>_</callarg.label>: <callarg.type><typeid.user>T</typeid.user>.Type</callarg.type></callarg>, <callarg><callarg.label>_</callarg.label>: <callarg.type><typeid.user>U</typeid.user>.Type</callarg.type></callarg>); typename=<typeid.user>MyStruct</typeid.user>; name=init(::); sourcetext=init(<#T##T.Type#>, <#T##U.Type#>)
+// EXPR_IMPLICITMEMBER-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: <name>init</name>(<callarg><callarg.label>_</callarg.label>: <callarg.type><typeid.user>T</typeid.user>.Type</callarg.type></callarg>, <callarg><callarg.label>_</callarg.label>: <callarg.type><typeid.user>U</typeid.user>.Type</callarg.type></callarg>, <callarg><callarg.label>value</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type><callarg.default/></callarg>); typename=<typeid.user>MyStruct</typeid.user>; name=init(::value:); sourcetext=init(<#T##T.Type#>, <#T##U.Type#>, value: <#T##Int#>)
 // EXPR_IMPLICITMEMBER-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: <name>instance</name>; typename=<typeid.user>MyStruct</typeid.user>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>labelNameParamName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(label: (<keyword>inout</keyword> <typeid.sys>Int</typeid.sys>) <keyword>throws</keyword> -&gt; <typeid.user>MyStruct</typeid.user>) -&gt; <typeid.sys>Void</typeid.sys>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>labelName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(label: (<attribute>@autoclosure</attribute> () -&gt; <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>sameName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(label: <keyword>inout</keyword> <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>paramName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(<typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>;
+// EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>emptyName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(<typeid.user>T</typeid.user>.Type) -&gt; <typeid.sys>Void</typeid.sys>; name=emptyName(:); sourcetext=emptyName(<#T##self: MyStruct##MyStruct#>)
 // EXPR_IMPLICITMEMBER-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: <name>create</name>(<callarg><callarg.label>x</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.user>MyStruct</typeid.user>;
 
 func testArgument() -> MyStruct {


### PR DESCRIPTION
Cherry-pick #72887 into release/6.0

* **Explanation**: In code completion's call patterns, when a parameter has empty parameter name and argument name i.e. `(_:)`, `filterName` didn't emit `:`. This PR changes it to always emit `:`, so that clients know the number of parameters from it.
* **Scope**: Code completion
* **Risk**: Low. The change only affects code completion
* **Testing**: Added regression test cases
* **Issue**: rdar://124667867
* **Reviewer**: Hamish Knight (@hamishknight) Alex Hoppen (@ahoppen) 