### PR TITLE
Respect the module ABI name when mangling for the debugger

### DIFF
--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -26,6 +26,9 @@ constexpr static const StringLiteral SWIFT_ONONE_SUPPORT = "SwiftOnoneSupport";
 constexpr static const StringLiteral SWIFT_CONCURRENCY_NAME = "_Concurrency";
 /// The name of the Concurrency Shims Clang module
 constexpr static const StringLiteral SWIFT_CONCURRENCY_SHIMS_NAME = "_SwiftConcurrencyShims";
+/// The unique ABI prefix that swift-syntax uses when it's built as part of the
+/// compiler.
+constexpr static const StringLiteral SWIFT_MODULE_ABI_NAME_PREFIX = "Compiler";
 /// The name of the Distributed module, which supports that extension.
 constexpr static const StringLiteral SWIFT_DISTRIBUTED_NAME = "Distributed";
 /// The name of the StringProcessing module, which supports that extension.

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2509,10 +2509,19 @@ void ASTMangler::appendModule(const ModuleDecl *module,
   // For example, if a module Foo has 'import Bar', and '-module-alias Bar=Baz'
   // was passed, the name 'Baz' will be used for mangling besides loading.
   StringRef ModName = module->getRealName().str();
-  if (RespectOriginallyDefinedIn &&
-      module->getABIName() != module->getName()) { // check if the ABI name is set
+
+  // If RespectOriginallyDefinedIn is not set, ignore the ABI name only for
+  // _Concurrency and swift-syntax (which adds "Compiler" as a prefix when
+  // building swift-syntax as part of the compiler).
+  // TODO: Mangling for the debugger should respect originally defined in, but
+  // as of right now there is not enough information in the mangled name to
+  // reconstruct AST types from mangled names when using that attribute.
+  if ((RespectOriginallyDefinedIn ||
+       (module->getName().str() != SWIFT_CONCURRENCY_NAME &&
+        !module->getABIName().str().starts_with(
+            SWIFT_MODULE_ABI_NAME_PREFIX))) &&
+      module->getABIName() != module->getName())
     ModName = module->getABIName().str();
-  }
 
   // Try the special 'swift' substitution.
   if (ModName == STDLIB_NAME) {

--- a/test/DebugInfo/module_abi_name.swift
+++ b/test/DebugInfo/module_abi_name.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -module-name=Hello -module-abi-name Goodbye -emit-ir -o - | %FileCheck %s
+
+class SomeClass {}
+// CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "SomeClass",{{.*}}runtimeLang: DW_LANG_Swift, identifier: "$s7Goodbye9SomeClassCD"
+
+@available(macOS 10.13, *)
+@_originallyDefinedIn(module: "ThirdModule", OSX 10.12)
+class DefinedElsewhere {}
+// CHECK: DICompositeType(tag: DW_TAG_structure_type, name: "DefinedElsewhere",{{.*}}runtimeLang: DW_LANG_Swift, identifier: "$s7Goodbye16DefinedElsewhereCD")
+
+let v1 = SomeClass()
+let v2 = DefinedElsewhere()
+


### PR DESCRIPTION
The mangled name produced for the debugger should match the one emitted in reflection metadata, otherwise LLDB will not be able to lookup types when the module is compiled with the -module-abi-name flag.

rdar://125848324
(cherry picked from commit 01bd68e8a2e6c26f465df1ac2240834ae3ae614b)

Explanation: LLDB needs the mangled names of types stored in debug info to match those in reflection metadata, otherwise it won't be able to look up those types.
Scope: Small.
Issue: rdar://125848324
Original PRs: [https://github.com/apple/swift/pull/72335 & https://github.com/apple/swift/pull/72624](https://github.com/apple/swift/pull/73090)
Risk: Low, this only debugging and when swift-programs are compiled with `-module-abi-name`.
Testing: Added DebugInfo/module_abi_name.swift
Reviewer: @adrian-prantl 