### PR TITLE
[DebugInfo] Emit declaration by checking both type and SIL func repr

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2948,7 +2948,12 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
   // Because there's no good way to cross the CU boundary to insert a nested
   // DISubprogram definition in one CU into a type defined in another CU when
   // doing LTO builds.
-  if (llvm::isa<llvm::DICompositeType>(Scope)) {
+  if (llvm::isa<llvm::DICompositeType>(Scope) &&
+      (Rep == SILFunctionTypeRepresentation::Method ||
+       Rep == SILFunctionTypeRepresentation::ObjCMethod ||
+       Rep == SILFunctionTypeRepresentation::WitnessMethod ||
+       Rep == SILFunctionTypeRepresentation::CXXMethod ||
+       Rep == SILFunctionTypeRepresentation::Thin)) {
     llvm::DISubprogram::DISPFlags SPFlags = llvm::DISubprogram::toSPFlags(
         /*IsLocalToUnit=*/Fn ? Fn->hasInternalLinkage() : true,
         /*IsDefinition=*/false, /*IsOptimized=*/Opts.shouldOptimize());


### PR DESCRIPTION
(cherry picked from commit e0e7a08a319c183d9f5628202407a2bfeccf5852)


Explanation: when compiling with LTO enabled, debug info generation needs to emit declarations of functions that are nested in types (methods, initializers, static methods, etc). This patch fixes this condition was too broad, and nesting free functions that were referenced inside types (like lazy initializers) which shouldn't be nested.
Scope: Small.
Issue: rdar://125729500
Original PRs: https://github.com/apple/swift/pull/72963
Risk: Low, only affects debug info generation of  LTO builds.
