### PR TITLE
Sema: Don't warn on package imports providing a type extended by a package extension

### DIFF
--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -17,6 +17,7 @@
 // RUN: %target-swift-frontend -emit-module %t/ExtendedDefinitionNonPublic.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/UnusedImport.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/UnusedPackageImport.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/ExtendedPackageTypeImport.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/ImportNotUseFromAPI.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/ImportUsedInPackage.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/ExportedUnused.swift -o %t -I %t
@@ -96,6 +97,9 @@ public struct NonPublicExtendedType {}
 //--- UnusedImport.swift
 
 //--- UnusedPackageImport.swift
+//--- ExtendedPackageTypeImport.swift
+
+public struct ExtendedPackageType {}
 
 //--- ImportNotUseFromAPI.swift
 public struct NotAnAPIType {}
@@ -143,6 +147,7 @@ package import UnusedImport // expected-warning {{package import of 'UnusedImpor
 // expected-warning @-1 {{module 'UnusedImport' is imported as 'public' from the same file; this 'package' access level will be ignored}}
 
 package import UnusedPackageImport // expected-warning {{package import of 'UnusedPackageImport' was not used in package declarations}} {{1-9=}}
+package import ExtendedPackageTypeImport
 public import ImportNotUseFromAPI // expected-warning {{public import of 'ImportNotUseFromAPI' was not used in public declarations or inlinable code}} {{1-8=}}
 public import ImportUsedInPackage // expected-warning {{public import of 'ImportUsedInPackage' was not used in public declarations or inlinable code}} {{1-7=package}}
 
@@ -239,6 +244,10 @@ public protocol Countable {
 }
 
 extension Extended: Countable { // expected-remark {{struct 'Extended' is imported via 'RetroactiveConformance'}}
+}
+
+extension ExtendedPackageType { // expected-remark {{struct 'ExtendedPackageType' is imported via 'ExtendedPackageTypeImport'}}
+  package func useExtendedPackageType() { }
 }
 
 /// Tests for imports of clang modules.


### PR DESCRIPTION
The warnings on superfluously public/package imports has a hole where it could report a package import as not being used by package decls even if it provides a type extended by a package extension. Since the exportability checker does not run on package decls it does not triggering the usual logic registering this reference.

Address this issue by adding a check specifically for package extensions. We can remove this check once we have exportability checking for package decls.

rdar://126712864