### PR TITLE
[embedded] Fix miscompile in IRGen in offset computation of Builtin.destroyArray

### DIFF
--- a/test/embedded/array-builtins-exec.swift
+++ b/test/embedded/array-builtins-exec.swift
@@ -31,6 +31,11 @@ struct Large : P {
   }
 }
 
+enum Enum {
+  case nontrivial(Noisy)
+  case trivial(Int)
+}
+
 func exerciseArrayValueWitnesses<T>(_ value: T) {
   let buf = UnsafeMutablePointer<T>.allocate(capacity: 5)
 
@@ -52,6 +57,8 @@ func test() {
     exerciseArrayValueWitnesses(44)
     exerciseArrayValueWitnesses(Noisy())
     exerciseArrayValueWitnesses(Large())
+    exerciseArrayValueWitnesses(Enum.trivial(42))
+    exerciseArrayValueWitnesses(Enum.nontrivial(Noisy()))
   }
   precondition(NoisyLifeCount == NoisyDeathCount)
   print("Checks out")

--- a/test/embedded/arrays-enums.swift
+++ b/test/embedded/arrays-enums.swift
@@ -1,0 +1,20 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+enum Node {
+  indirect case inner(Node, Node)
+  case leaf(Int)
+}
+
+@main
+struct Main {
+  static func main() {
+    _ = [Node.leaf(42), Node.leaf(42)]
+    print("OK!")
+    // CHECK: OK!
+  }
+}


### PR DESCRIPTION
In Embedded Swift, IRGen emits the loop to destroy values in the array directly. Turns out that the GEP we use to index into the individual elements of the array's storage is using the value's size and not the stride in some cases, concretely in cases where the type is an enum with payloads. E.g. this

```
struct S: ~Copyable {
    deinit {
        print("S deinitialized!")
    }
}

enum Node {
    case inner(S)
    case leaf(Int)
}
```

ends up being represented as this type in LLVM IR:

```
%T1a4NodeO = type <{ [8 x i8], [1 x i8] }>
```

...on which GEP will not do the right thing we want (stride). Let's compute the offset directly via ptrtoint, add, inttoptr.

Will add tests, but wanted to check that this is the right approach first.

rdar://126386301
