### PR TITLE
[6.0🍒] prevent uses of `Escapable` in general

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7665,7 +7665,7 @@ NOTE(add_explicit_protocol_for_conformance,none,
      "consider making %kind0 explicitly conform to the '%1' protocol",
      (const ValueDecl *, StringRef))
 ERROR(escapable_requires_feature_flag,none,
-      "type '~Escapable' requires -enable-experimental-feature NonescapableTypes",
+      "type 'Escapable' requires -enable-experimental-feature NonescapableTypes",
       ())
 ERROR(non_bitwise_copyable_type_class,none,
       "class cannot conform to 'BitwiseCopyable'", ())

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -124,10 +124,9 @@ public:
     auto ipk = getInvertibleProtocolKind(*kp);
     if (ipk) {
       // Gate the '~Escapable' type behind a specific flag for now.
+      // Uses of 'Escapable' itself are already diagnosed; return ErrorType.
       if (*ipk == InvertibleProtocolKind::Escapable &&
           !ctx.LangOpts.hasFeature(Feature::NonescapableTypes)) {
-        diagnoseInvalid(repr, repr.getLoc(),
-                        diag::escapable_requires_feature_flag);
         return ErrorType::get(ctx);
       }
 

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -171,6 +171,7 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 
 @_marker public protocol Copyable {}
 
+@_documentation(visibility: internal)
 @_marker public protocol Escapable {}
 
 #if $NoncopyableGenerics && $NonescapableTypes

--- a/test/Parse/inverse_escapable_feature.swift
+++ b/test/Parse/inverse_escapable_feature.swift
@@ -2,4 +2,8 @@
 
 
 
-struct S: ~Escapable {} // expected-error {{type '~Escapable' requires -enable-experimental-feature NonescapableTypes}}
+struct S: ~Escapable {} // expected-error {{type 'Escapable' requires -enable-experimental-feature NonescapableTypes}}
+
+func hello(_ t: some Escapable, _ u: any Escapable) {} // expected-error 2{{type 'Escapable' requires -enable-experimental-feature NonescapableTypes}}
+
+protocol Whatever: Escapable {} // expected-error {{type 'Escapable' requires -enable-experimental-feature NonescapableTypes}}

--- a/test/Sema/invertible_no_stdlib.swift
+++ b/test/Sema/invertible_no_stdlib.swift
@@ -14,7 +14,7 @@ func reqCopy2<T: Builtin.Copyable>(_ t: T) {} // expected-note {{generic paramet
 
 protocol P {}
 
-struct DataType: P, Builtin.Escapable {}
+struct DataType: P, Builtin.Escapable {} // expected-error {{type 'Escapable' requires -enable-experimental-feature NonescapableTypes}}
 struct DataTypeNC: ~Builtin.Copyable {}
 
 func main() {

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -398,6 +398,7 @@ extension B4 {
 extension Sendable {} // expected-error {{cannot extend protocol 'Sendable'}}
 extension Copyable {} // expected-error {{cannot extend protocol 'Copyable'}}
 extension Escapable {} // expected-error {{cannot extend protocol 'Escapable'}}
+// expected-error@-1 {{type 'Escapable' requires -enable-experimental-feature NonescapableTypes}}
 extension _BitwiseCopyable {} // expected-error {{cannot extend protocol '_BitwiseCopyable'}}
 
 @_marker protocol MyMarkerProto {}


### PR DESCRIPTION
- Explanation: The Escapable type shouldn't be usable in Swift programs without the NonescapableTypes feature flag, as it hasn't gone through evolution. Yet we cannot remove it as it is the foundation of that feature.
- Scope: Mildly source-breaking (nobody should have needed to refer to Escapable before, it's basically useless to have done so).
- Issue: rdar://126705184
- Original PR: https://github.com/apple/swift/pull/73133
- Risk: Low. Might break source if anyone was using this branch and decided they wanted to write useless constraints. The fix is for them to delete `Escapable` constraints or replace `any Escapable` with `Any`.
- Testing: Tests are included for the banishment of referring to the type.
- Reviewer: @amartini51 
