### PR TITLE
[Runtime] Make swift_unreachable more debuggable by trapping immediately.

### DIFF
--- a/include/swift/Basic/Unreachable.h
+++ b/include/swift/Basic/Unreachable.h
@@ -35,11 +35,10 @@
 
 #include "swift/Runtime/Config.h"
 
-SWIFT_RUNTIME_ATTRIBUTE_NORETURN
+SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_ALWAYS_INLINE
 inline static void swift_unreachable(const char *msg) {
-  assert(false && msg);
   (void)msg;
-  abort();
+  SWIFT_RUNTIME_BUILTIN_TRAP;
 }
 
 #endif


### PR DESCRIPTION
Calling `abort` takes us a few layers deep into libc before we crash, which overwrites a bunch of register state. Instead, we trap directly within swift_unreachable, and mark it always-inline, to hopefully keep the full register state intact when we generate a crash log from this.