### PR TITLE
[Runtime] Add the pointer location to the "failed to look up symbolic reference" error.

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -133,11 +133,13 @@ ResolveAsSymbolicReference::operator()(SymbolicReferenceKind kind,
       if (symInfo->getSymbolName())
         symbolName = symInfo->getSymbolName();
     }
+    uintptr_t ptrLocation = detail::applyRelativeOffset(base, offset);
     swift::fatalError(
         0,
         "Failed to look up symbolic reference at %p - offset %" PRId32
-        " - symbol %s in %s\n",
-        base, offset, symbolName, fileName);
+        " - symbol %s in %s - pointer at %#" PRIxPTR
+        " is likely a reference to a missing weak symbol\n",
+        base, offset, symbolName, fileName, ptrLocation);
   }
 
   // Figure out this symbolic reference's grammatical role.


### PR DESCRIPTION
The pointer location can be computed from the symbolic reference location and offset, which we already provide, but it's not clear that you should add them together, nor is it clear why this failure would occur. Add the location of the NULL pointer itself to the error message, and also mention that it's probably caused by a missing weak symbol.