### PR TITLE
[6.0] Serialization: Protect against most errors in contexts for calls to `AnyObject` variables

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2726,7 +2726,9 @@ Expected<DeclContext *>ModuleFile::getLocalDeclContext(LocalDeclContextID DCID) 
                                                        implicit,
                                                        discriminator,
                                                        parentID);
-    DeclContext *parent = getDeclContext(parentID);
+    DeclContext *parent;
+    UNWRAP(getDeclContextChecked(parentID), parent);
+
     auto type = getType(closureTypeID);
 
     declContextOrOffset = new (ctx)
@@ -2738,7 +2740,8 @@ Expected<DeclContext *>ModuleFile::getLocalDeclContext(LocalDeclContextID DCID) 
     DeclContextID parentID;
     decls_block::TopLevelCodeDeclContextLayout::readRecord(scratch,
                                                            parentID);
-    DeclContext *parent = getDeclContext(parentID);
+    DeclContext *parent;
+    UNWRAP(getDeclContextChecked(parentID), parent);
 
     declContextOrOffset = new (ctx) SerializedTopLevelCodeDeclContext(parent);
     break;
@@ -2768,7 +2771,8 @@ Expected<DeclContext *>ModuleFile::getLocalDeclContext(LocalDeclContextID DCID) 
     decls_block::DefaultArgumentInitializerLayout::readRecord(scratch,
                                                               parentID,
                                                               index);
-    DeclContext *parent = getDeclContext(parentID);
+    DeclContext *parent;
+    UNWRAP(getDeclContextChecked(parentID), parent);
 
     declContextOrOffset = new (ctx) DefaultArgumentInitializer(parent, index);
     break;
@@ -3343,7 +3347,8 @@ public:
       }
     }
 
-    auto DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
 
     auto genericParams = MF.maybeReadGenericParams(DC);
     if (declOrOffset.isComplete())
@@ -3415,7 +3420,9 @@ public:
                                                       isImplicit,
                                                       rawOverriddenIDs);
 
-    auto DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
+
     if (declOrOffset.isComplete())
       return declOrOffset;
 
@@ -3598,7 +3605,9 @@ public:
       }
     }
 
-    auto parent = MF.getDeclContext(contextID);
+    DeclContext *parent;
+    UNWRAP(MF.getDeclContextChecked(contextID), parent);
+
     if (declOrOffset.isComplete())
       return declOrOffset;
 
@@ -3762,7 +3771,9 @@ public:
       }
     }
 
-    auto DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
+
     if (declOrOffset.isComplete())
       return declOrOffset;
 
@@ -3918,7 +3929,9 @@ public:
     auto paramName = MF.getIdentifier(paramNameID);
     PrettySupplementalDeclNameTrace trace(paramName);
 
-    auto DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
+
     if (declOrOffset.isComplete())
       return declOrOffset;
 
@@ -4134,7 +4147,9 @@ public:
       }
     }
 
-    auto DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
+
     if (declOrOffset.isComplete())
       return declOrOffset;
 
@@ -4356,7 +4371,9 @@ public:
                                               rawAccessLevel,
                                               exportUnderlyingType);
     
-    auto declContext = MF.getDeclContext(contextID);
+    DeclContext *declContext;
+    UNWRAP(MF.getDeclContextChecked(contextID), declContext);
+
     auto interfaceSigOrErr = MF.getGenericSignatureChecked(interfaceSigID);
     if (!interfaceSigOrErr)
       return interfaceSigOrErr.takeError();
@@ -4459,7 +4476,8 @@ public:
     if (!StaticSpelling.has_value())
       return MF.diagnoseFatal();
 
-    auto dc = MF.getDeclContext(contextID);
+    DeclContext *dc;
+    UNWRAP(MF.getDeclContextChecked(contextID), dc);
 
     SmallVector<std::pair<Pattern *, DeclContextID>, 4> patterns;
     for (unsigned i = 0; i != numPatterns; ++i) {
@@ -4495,8 +4513,11 @@ public:
 
     for (unsigned i = 0; i != patterns.size(); ++i) {
       binding->setPattern(i, patterns[i].first);
-      if (auto *context = MF.getDeclContext(patterns[i].second))
-        binding->setInitContext(i, cast<PatternBindingInitializer>(context));
+
+      DeclContext *dcPattern;
+      UNWRAP(MF.getDeclContextChecked(patterns[i].second), dcPattern);
+      if (dcPattern)
+        binding->setInitContext(i, cast<PatternBindingInitializer>(dcPattern));
     }
 
     return binding;
@@ -4529,7 +4550,9 @@ public:
       }
     }
 
-    auto DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
+
     if (declOrOffset.isComplete())
       return declOrOffset;
 
@@ -4600,7 +4623,8 @@ public:
     Identifier name = MF.getIdentifier(nameID);
     PrettySupplementalDeclNameTrace trace(name);
 
-    auto DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
 
     auto result = MF.createDecl<OperatorDecl>(
         DC, SourceLoc(), name, SourceLoc());
@@ -4636,7 +4660,8 @@ public:
     if (!precedenceGroup)
       return precedenceGroup.takeError();
 
-    auto DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
 
     auto result = MF.createDecl<InfixOperatorDecl>(
         DC, SourceLoc(), name, SourceLoc(), SourceLoc(), Identifier(),
@@ -4663,7 +4688,8 @@ public:
                                                    assignment, numHigherThan,
                                                    rawRelations);
 
-    auto DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
 
     auto associativity = getActualAssociativity(rawAssociativity);
     if (!associativity.has_value())
@@ -4746,7 +4772,9 @@ public:
       }
     }
 
-    auto DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
+
     if (declOrOffset.isComplete())
       return declOrOffset;
 
@@ -4907,7 +4935,9 @@ public:
       }
     }
 
-    DeclContext *DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
+
     if (declOrOffset.isComplete())
       return declOrOffset;
 
@@ -5014,7 +5044,9 @@ public:
       }
     }
 
-    auto parent = MF.getDeclContext(contextID);
+    DeclContext *parent;
+    UNWRAP(MF.getDeclContextChecked(contextID), parent);
+
     if (declOrOffset.isComplete())
       return declOrOffset;
 
@@ -5089,7 +5121,8 @@ public:
                                              numConformances, numInherited,
                                              data);
 
-    auto DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
 
     auto conformanceIDs = data.slice(0, numConformances);
     data = data.slice(numConformances);
@@ -5176,7 +5209,9 @@ public:
                                               isImplicit, isObjC,
                                               genericSigID);
 
-    DeclContext *DC = MF.getDeclContext(contextID);
+    DeclContext *DC;
+    UNWRAP(MF.getDeclContextChecked(contextID), DC);
+
     if (declOrOffset.isComplete())
       return declOrOffset;
 
@@ -5251,7 +5286,9 @@ public:
       }
     }
 
-    auto parent = MF.getDeclContext(contextID);
+    DeclContext *parent;
+    UNWRAP(MF.getDeclContextChecked(contextID), parent);
+
     if (declOrOffset.isComplete())
       return declOrOffset;
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -52,6 +52,16 @@
 
 #define DEBUG_TYPE "Serialization"
 
+// Unwrap an Expected<> variable following the typical deserialization pattern:
+// - On a value, assign it to Output.
+// - On an error, return it to bubble it up to the caller.
+#define UNWRAP(Input, Output) { \
+  auto ValueOrError = Input; \
+  if (!ValueOrError) \
+      return ValueOrError.takeError(); \
+  Output = ValueOrError.get(); \
+}
+
 STATISTIC(NumDeclsLoaded, "# of decls deserialized");
 STATISTIC(NumMemberListsLoaded,
           "# of nominals/extensions whose members were loaded");


### PR DESCRIPTION
Recover from deserialization errors in accesses to the context in all `deserialize*` functions. Calls on a `AnyObject` typed variable triggers access to all loaded class members directly. The context of these members can be non-public or broken by a context change. Make sure most context accesses can recover from this and bubble up any error instead of crashing.

* Scope: Recovers from more error at deserialization.
* Risk: Low, affects only paths where the compiler used to crash.
* Cherry-pick of #73113
* Review by @tshortli 
* Resolves rdar://126138660