### PR TITLE
[cmake] Check correctly for different flags. Do check twice -Wall

### DIFF
--- a/stdlib/toolchain/CMakeLists.txt
+++ b/stdlib/toolchain/CMakeLists.txt
@@ -8,17 +8,6 @@ set(CXX_COMPILE_FLAGS)
 set(CXX_LINK_FLAGS)
 
 
-set(compile_flags
-  # Build the runtime with -Wall to catch, e.g., uninitialized variables
-  # warnings.
-  "-Wall"
-
-  # C++ code in the runtime and standard library should generally avoid
-  # introducing static constructors or destructors.
-  "-Wglobal-constructors"
-  "-Wexit-time-destructors")
-
-
 # Build the runtime with -Wall to catch, e.g., uninitialized variables
 # warnings.
 if(SWIFT_COMPILER_IS_MSVC_LIKE)
@@ -27,10 +16,15 @@ else()
   list(APPEND compile_flags "-Wall")
 endif()
 
+list(APPEND compile_flags
+  # C++ code in the runtime and standard library should generally avoid
+  # introducing static constructors or destructors.
+  "-Wglobal-constructors"
+  "-Wexit-time-destructors")
 
 foreach(flag ${compile_flags})
-  check_cxx_compiler_flag("${flag}" is_supported)
-  if(is_supported)
+  check_cxx_compiler_flag("${flag}" cxx_compiler_flag_${flag}_is_supported)
+  if(cxx_compiler_flag_${flag}_is_supported)
     list(APPEND CXX_COMPILE_FLAGS "${flag}")
   endif()
 endforeach()


### PR DESCRIPTION
check_cxx_compiler_flag caches its results for the same variable, since all the flags were using the same variable, only the first check was done, and the rest of the flags were just using the result of the first flag.

Make each of the check_cxx_compiler_flag use a different variable (by interpolating the flag name) and reorder the list of compiler flags to check. -Wall was added twice, and in the case of MSVC, the equivalent was added last.

It doesn't really seem to affect a lot of things.