### PR TITLE
Fix functions not being kept for debugger

### DIFF
--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -147,6 +147,10 @@ public:
   /// might be referenced from outside the current compilation unit.
   bool isPossiblyUsedExternally() const;
 
+  /// Returns true if this global variable should be preserved so it can
+  /// potentially be inspected by the debugger.
+  bool shouldBePreservedForDebugger() const;
+
   /// Get this global variable's serialized attribute.
   IsSerialized_t isSerialized() const;
   void setSerialized(IsSerialized_t isSerialized);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2841,6 +2841,8 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
     // Mark as llvm.used if @_used, set section if @_section
     if (var->markedAsUsed())
       addUsedGlobal(gvar);
+    else if (var->shouldBePreservedForDebugger() && forDefinition) 
+      addUsedGlobal(gvar);
     if (auto *sectionAttr = var->getSectionAttr())
       gvar->setSection(sectionAttr->Name);
   }
@@ -3710,7 +3712,7 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
 
   // Also mark as llvm.used any functions that should be kept for the debugger.
   // Only definitions should be kept.
-  if (f->shouldBePreservedForDebugger() && !fn->isDeclaration())
+  if (f->shouldBePreservedForDebugger() && forDefinition)
     addUsedGlobal(fn);
 
   // If `hasCReferences` is true, then the function is either marked with

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -16,6 +16,7 @@
 #include "swift/AST/Availability.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/IRGenOptions.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Stmt.h"
 #include "swift/Basic/OptimizationMode.h"
@@ -958,6 +959,17 @@ bool SILFunction::shouldBePreservedForDebugger() const {
   // Only preserve for the debugger at Onone.
   if (getEffectiveOptimizationMode() != OptimizationMode::NoOptimization)
     return false;
+
+  if (getModule().getASTContext().LangOpts.hasFeature(Feature::Embedded))
+    return false;
+
+  if (const IRGenOptions *options = getModule().getIRGenOptionsOrNull()) {
+    if (options->WitnessMethodElimination ||
+        options->VirtualFunctionElimination ||
+        options->LLVMLTOKind != IRGenLLVMLTOKind::None) {
+      return false;
+    }
+  }
 
   if (isAvailableExternally())
     return false;

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -61,8 +61,18 @@ SILGlobalVariable::~SILGlobalVariable() {
 }
 
 bool SILGlobalVariable::isPossiblyUsedExternally() const {
+  if (shouldBePreservedForDebugger())
+    return true;
+
   SILLinkage linkage = getLinkage();
   return swift::isPossiblyUsedExternally(linkage, getModule().isWholeModule());
+}
+
+bool SILGlobalVariable::shouldBePreservedForDebugger() const {
+  if (getModule().getOptions().OptMode != OptimizationMode::NoOptimization)
+    return false;
+  // Keep any language-level global variables for the debugger.
+  return VDecl != nullptr;
 }
 
 /// Get this global variable's fragile attribute.

--- a/test/IRGen/conditional-dead-strip-exec.swift
+++ b/test/IRGen/conditional-dead-strip-exec.swift
@@ -25,6 +25,7 @@
 @inline(never) func func1_used() { print("func1_used") }
 
 // (2) unused
+@_semantics("no.preserve.debugger")
 @inline(never) func func2_dead() { print("func2_dead") }
 
 // (3) completely unused
@@ -35,6 +36,7 @@ protocol TheProtocol { }
 
 // (5) unused class
 class MyClass: TheProtocol {
+  	@_semantics("no.preserve.debugger")
 	func unused_method() {}
 }
 

--- a/test/IRGen/objc_pointers.swift
+++ b/test/IRGen/objc_pointers.swift
@@ -20,6 +20,7 @@ import Foundation
 }
 
 // CHECK-LABEL: s13objc_pointers14returnNSObject3objSo0D0CAE_tF
+@_semantics("no.preserve.debugger")
 func returnNSObject(obj: NSObject) -> NSObject {
   // CHECK-NOT: return
   // CHECK: @llvm.objc.retain

--- a/test/IRGen/preserve_for_debugger.swift
+++ b/test/IRGen/preserve_for_debugger.swift
@@ -1,8 +1,15 @@
 // RUN: %target-swiftc_driver %s -g -Onone -emit-ir | %FileCheck %s
 
+
+// Check that unused globals are preserved at Onone.
+
+private let number = 42
+// CHECK: distinct !DIGlobalVariable(name: "number",
+
 // Check that unused functions are preserved at Onone.
 func unused() {
 }
+// CHECK: !DISubprogram(name: "unused", linkageName: "$s21preserve_for_debugger6unusedyyF"
 
 // Property wrappers generate transparent getters, which we would like to check still exist at Onone.
 @propertyWrapper
@@ -24,5 +31,36 @@ public class User {
 let c = User()
 c.f()
 
-// CHECK: !DISubprogram(name: "unused", linkageName: "$s21preserve_for_debugger6unusedyyF"
 // CHECK: !DISubprogram(name: "number.get"
+
+protocol Foo {}
+
+@propertyWrapper
+struct Bar<ObjectType: Foo> {
+    var storage: ObjectType
+
+    public init(wrappedValue: ObjectType) {
+      storage = wrappedValue
+    }
+
+    public var wrappedValue: ObjectType {
+        return storage
+    }
+
+}
+
+class Baz: Foo {
+  let x = 42
+}
+
+struct Qux {
+  @Bar(wrappedValue: Baz()) private var baz: Baz
+
+    func f() {
+        print(self.baz) // break here
+    }
+}
+let qux = Qux()
+qux.f()
+
+// CHECK: !DISubprogram(name: "baz.get"

--- a/test/IRGen/section.swift
+++ b/test/IRGen/section.swift
@@ -9,11 +9,11 @@
 @_section("__DATA,__mysection") public var g3: Bool = true
 @_section("__DATA,__mysection") var g4: UnsafeMutablePointer<Int>? = nil
 @_section("__DATA,__mysection") var g5: UnsafeMutablePointer<Int>? = UnsafeMutablePointer(bitPattern: 0x42424242)
-@_section("__TEXT,__mysection") func foo() {}
+@_section("__TEXT,__mysection") @_used func foo() {}
 
 struct MyStruct {
 	@_section("__DATA,__mysection") static var static0: Int = 1
-	@_section("__TEXT,__mysection") func foo() {}
+	@_section("__TEXT,__mysection") @_used func foo() {}
 }
 
 // SIL: @_section("__DATA,__mysection") @_hasStorage @_hasInitialValue var g0: Int { get set }
@@ -22,10 +22,10 @@ struct MyStruct {
 // SIL: @_section("__DATA,__mysection") @_hasStorage @_hasInitialValue public var g3: Bool { get set }
 // SIL: @_section("__DATA,__mysection") @_hasStorage @_hasInitialValue var g4: UnsafeMutablePointer<Int>? { get set }
 // SIL: @_section("__DATA,__mysection") @_hasStorage @_hasInitialValue var g5: UnsafeMutablePointer<Int>? { get set }
-// SIL: @_section("__TEXT,__mysection") func foo()
+// SIL: @_section("__TEXT,__mysection") @_used func foo()
 // SIL: struct MyStruct {
 // SIL:   @_section("__DATA,__mysection") @_hasStorage @_hasInitialValue static var static0: Int { get set }
-// SIL:   @_section("__TEXT,__mysection") func foo()
+// SIL:   @_section("__TEXT,__mysection") @_used func foo()
 
 // SIL: sil private [global_init_once_fn] [perf_constraint] @$s7section2g0_WZ : $@convention(c)
 // SIL: sil hidden [global_init] @$s7section2g0Sivau : $@convention(thin)
@@ -39,10 +39,10 @@ struct MyStruct {
 // SIL: sil hidden [global_init] @$s7section2g4SpySiGSgvau : $@convention(thin)
 // SIL: sil private [global_init_once_fn] [perf_constraint] @$s7section2g5_WZ : $@convention(c)
 // SIL: sil hidden [global_init] @$s7section2g5SpySiGSgvau : $@convention(thin)
-// SIL: sil hidden [section "__TEXT,__mysection"] @$s7section3fooyyF : $@convention(thin)
+// SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section3fooyyF : $@convention(thin)
 // SIL: sil private [global_init_once_fn] [perf_constraint] @$s7section8MyStructV7static0_WZ : $@convention(c)
 // SIL: sil hidden [global_init] @$s7section8MyStructV7static0Sivau : $@convention(thin)
-// SIL: sil hidden [section "__TEXT,__mysection"] @$s7section8MyStructV3fooyyF : $@convention(method)
+// SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section8MyStructV3fooyyF : $@convention(method)
 
 // IR:  @"$s7section2g0Sivp" = hidden global %TSi <{ {{(i64|i32)}} 1 }>, section "__DATA,__mysection"
 // IR:  @"$s7section2g1Si_Sitvp" = hidden global <{ %TSi, %TSi }> <{ %TSi <{ {{(i64|i32)}} 42 }>, %TSi <{ {{(i64|i32)}} 43 }> }>, section "__DATA,__mysection"

--- a/test/IRGen/section_asm.swift
+++ b/test/IRGen/section_asm.swift
@@ -27,26 +27,22 @@
 // CHECK-NOT: .section
 // CHECK: $s7section8MyStructV7static0SivpZ:
 
-// CHECKELF: .section{{.*}}"__TEXT,__mysection","ax"
+// CHECKELF: .section{{.*}}"__TEXT,__mysection","axR"
 // CHECKELF-NOT: .section
 // CHECKELF: $s7section3fooyyF:
 
-// CHECKELF: .section{{.*}}"__TEXT,__mysection","ax"
+// CHECKELF: .section{{.*}}"__TEXT,__mysection","axR"
 // CHECKELF-NOT: .section
 // CHECKELF: $s7section8MyStructV3fooyyF:
 
-// CHECKELF: .section{{.*}}"__DATA,__mysection","aw"
+// CHECKELF: .section{{.*}}"__DATA,__mysection","awR"
 // CHECKELF-NOT: .section
 // CHECKELF: $s7section2g0Sivp:
-// CHECKELF-NOT: .section
 // CHECKELF: $s7section2g1Si_Sitvp:
-// CHECKELF-NOT: .section
 // CHECKELF: $s7section2g2Sbvp:
 // CHECKELF: .section{{.*}}"__DATA,__mysection","awR"
 // CHECKELF: $s7section2g3Sbvp:
-// CHECKELF: .section{{.*}}"__DATA,__mysection","aw"
+// CHECKELF: .section{{.*}}"__DATA,__mysection","awR"
 // CHECKELF: $s7section2g4SpySiGSgvp:
-// CHECKELF-NOT: .section
 // CHECKELF: $s7section2g5SpySiGSgvp:
-// CHECKELF-NOT: .section
 // CHECKELF: $s7section8MyStructV7static0SivpZ:

--- a/test/embedded/accessor-unavailable.swift
+++ b/test/embedded/accessor-unavailable.swift
@@ -15,5 +15,8 @@ struct Foo {
   }
 }
 
+let foo = Foo()
+let _ = foo[5]
+
 // CHECK: $s4main3FooVyS2icig
 // CHECK-NOT: $s4main3FooVyS2icis

--- a/test/embedded/value-type-deinits.swift
+++ b/test/embedded/value-type-deinits.swift
@@ -27,7 +27,7 @@ public struct Foo<Element> : ~Copyable {
 
 import MyModule
 
-func test() {
+public func test() {
   createFoo(x: 1)
 }
 


### PR DESCRIPTION
At Onone, many types of functions (anything user written, compiler
generated setters and getters, etc), should be kept in the final
binary so they're accessible by the debugger.

rdar://126763340
