### PR TITLE
SILGen: Provide compatibility with prior `BorrowingSwitch` behavior.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -21,6 +21,12 @@
 #include "DefineDiagnosticMacros.h"
 
 // SILGen issues.
+WARNING(return_borrowing_switch_binding,none,
+        "returning the non-'Copyable' value of a pattern binding from a "
+        "switch that borrows by default; the switch will be performed as a "
+        "consume for compatibility for now, but this will require an explicit "
+        "'switch consume' in the future", ())
+
 ERROR(bridging_module_missing,none,
       "unable to find module '%0' for implicit conversion function '%0.%1'",
       (StringRef, StringRef))

--- a/test/SILGen/borrowing_switch_return_binding_compat.swift
+++ b/test/SILGen/borrowing_switch_return_binding_compat.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -verify %s
+func orElse<T: ~Copyable>(
+    x: consuming T?,
+    defaultValue: @autoclosure () throws -> T?
+) rethrows -> T? {
+  switch x {
+  case .some(let value):
+    return value // expected-warning{{returning the non-'Copyable' value of a pattern binding from a switch that borrows by default}}
+  case .none:
+    return try defaultValue()
+  }
+}


### PR DESCRIPTION
To avoid breaking early adopters of this feature, accept attempts to `return` a `let` binding in a noncopyable `switch` when it would be treated as a borrow normally, with a warning that this behavior will change soon. rdar://126775241
