### PR TITLE
[6.0] Sema: Remove internal imports by default from Swift 6

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -184,7 +184,6 @@ UPCOMING_FEATURE(BareSlashRegexLiterals, 354, 6)
 UPCOMING_FEATURE(DeprecateApplicationMain, 383, 6)
 UPCOMING_FEATURE(ImportObjcForwardDeclarations, 384, 6)
 UPCOMING_FEATURE(DisableOutwardActorInference, 401, 6)
-UPCOMING_FEATURE(InternalImportsByDefault, 409, 6)
 UPCOMING_FEATURE(IsolatedDefaultValues, 411, 6)
 UPCOMING_FEATURE(GlobalConcurrency, 412, 6)
 UPCOMING_FEATURE(InferSendableFromCaptures, 418, 6)
@@ -195,6 +194,7 @@ UPCOMING_FEATURE(MoveOnlyPartialConsumption, 429, 6)
 
 // Swift 7
 UPCOMING_FEATURE(ExistentialAny, 335, 7)
+UPCOMING_FEATURE(InternalImportsByDefault, 409, 7)
 
 EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)

--- a/test/ModuleInterface/imports-swift7.swift
+++ b/test/ModuleInterface/imports-swift7.swift
@@ -1,5 +1,4 @@
-/// Swift 6 variant to imports.swift. Both can be reintegrated once
-/// -swift-version 6 is accepted by release compilers.
+/// Swift 7 variant to imports.swift.
 
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t
@@ -7,12 +6,12 @@
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module -o %t/resilient.swiftmodule %t/empty.swift -enable-library-evolution
 
 /// Check errors.
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/clientWithError.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %t -verify -swift-version 6
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/clientWithError.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %t -verify -enable-upcoming-feature InternalImportsByDefault
 
-/// Check Swift 6 imports printed in swiftinterface from 2 source files.
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/main.swift %t/main-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 6
+/// Check Swift 7 imports printed in swiftinterface from 2 source files.
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/main.swift %t/main-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify -enable-upcoming-feature InternalImportsByDefault
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/imports-clang-modules/ -I %t
-// RUN: %FileCheck -implicit-check-not BAD -check-prefix CHECK-6 %s < %t.swiftinterface
+// RUN: %FileCheck -implicit-check-not BAD -check-prefix CHECK-7 %s < %t.swiftinterface
 
 //--- empty.swift
 
@@ -40,15 +39,15 @@ public import NotSoSecret // expected-warning {{'NotSoSecret' inconsistently imp
 //--- clientWithError.swift
 @_exported public import nonResilient // expected-error {{module 'nonResilient' was not compiled with library evolution support; using it means binary compatibility for 'clientWithError' can't be guaranteed}}
 
-// CHECK-6-NOT: import
-// CHECK-6: {{^}}public import A{{$}}
-// CHECK-6-NEXT: {{^}}public import B{{$}}
-// CHECK-6-NEXT: {{^}}public import B.B2{{$}}
-// CHECK-6-NEXT: {{^}}public import B.B3{{$}}
-// CHECK-6-NEXT: {{^}}public import C/*.c*/{{$}}
-// CHECK-6-NEXT: {{^}}public import D{{$}}
-// CHECK-6-NEXT: {{^}}public import NotSoSecret{{$}}
-// CHECK-6-NEXT: {{^}}public import NotSoSecret2{{$}}
-// CHECK-6-NEXT: {{^}}public import Swift{{$}}
-// CHECK-6-NEXT: {{^}}@_exported public import resilient{{$}}
-// CHECK-6-NOT: import
+// CHECK-7-NOT: import
+// CHECK-7: {{^}}public import A{{$}}
+// CHECK-7-NEXT: {{^}}public import B{{$}}
+// CHECK-7-NEXT: {{^}}public import B.B2{{$}}
+// CHECK-7-NEXT: {{^}}public import B.B3{{$}}
+// CHECK-7-NEXT: {{^}}public import C/*.c*/{{$}}
+// CHECK-7-NEXT: {{^}}public import D{{$}}
+// CHECK-7-NEXT: {{^}}public import NotSoSecret{{$}}
+// CHECK-7-NEXT: {{^}}public import NotSoSecret2{{$}}
+// CHECK-7-NEXT: {{^}}public import Swift{{$}}
+// CHECK-7-NEXT: {{^}}@_exported public import resilient{{$}}
+// CHECK-7-NOT: import

--- a/test/Sema/access-level-and-non-resilient-import.swift
+++ b/test/Sema/access-level-and-non-resilient-import.swift
@@ -19,9 +19,6 @@
 // RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
 // RUN:   -package-name pkg
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift6.swift -I %t \
-// RUN:   -enable-library-evolution -swift-version 6 -verify \
-// RUN:   -package-name pkg
-// RUN: %target-swift-frontend -typecheck %t/Client_Swift6.swift -I %t \
 // RUN:   -enable-library-evolution \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault \
 // RUN:   -verify -package-name pkg
@@ -30,9 +27,6 @@
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
 // RUN:   -swift-version 5 \
 // RUN:   -enable-experimental-feature AccessLevelOnImport \
-// RUN:   -package-name pkg
-// RUN: %target-swift-frontend -typecheck %t/Client_Swift6.swift -I %t \
-// RUN:   -swift-version 6 \
 // RUN:   -package-name pkg
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift6.swift -I %t \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault \

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -60,8 +60,6 @@ import Lib // expected-error {{ambiguous implicit access level for import of 'Li
 package import Lib // expected-note {{imported 'package' here}} @:1
 
 // RUN: %target-swift-frontend -typecheck %t/ManyFiles_AmbiguitySwift6_File?.swift -I %t \
-// RUN:   -verify -swift-version 6
-// RUN: %target-swift-frontend -typecheck %t/ManyFiles_AmbiguitySwift6_File?.swift -I %t \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault -verify
 //--- ManyFiles_AmbiguitySwift6_FileA.swift
 import Lib

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -25,10 +25,12 @@
 
 /// Check diagnostics.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -package-name pkg -Rmodule-api-import -swift-version 6 -verify \
+// RUN:   -package-name pkg -Rmodule-api-import \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault -verify \
 // RUN:   -experimental-spi-only-imports
 // RUN: %target-swift-frontend -typecheck %t/ClientOfClangModules.swift -I %t \
-// RUN:   -package-name pkg -Rmodule-api-import -swift-version 6 -verify
+// RUN:   -package-name pkg -Rmodule-api-import \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault -verify
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
 // RUN:   -swift-version 5 -verify
 
@@ -171,7 +173,7 @@ public func useConformance(_ a: any Proto = ConformingType()) {}
 // expected-remark @-3 {{struct 'ConformingType' is imported via 'ConformanceBaseTypes'}}
 // expected-remark @-4 {{initializer 'init()' is imported via 'ConformanceBaseTypes'}}
 
-@usableFromInline internal func usableFromInlineFunc(_ a: TypeUsedInSignature) {} // expected-remark {{struct 'TypeUsedInSignature' is imported via 'DepUsedInSignature'}}
+@usableFromInline internal func usableFromInlineFunc(_ a: TypeUsedInSignature) {}
 
 @inlinable
 public func publicFuncUsesPrivate() {


### PR DESCRIPTION
The language steering group has decided to revert their previous decision and remove this feature from Swift 6.

Scope: Bare import statements in Swift 6.
Risk: This will be source breaking for early adopters of Swift 6.
Reviewed by @tshortli and @nkcsgexi 
Cherry-pick of #73141
rdar://126318567