### PR TITLE
[6.0 cherry-pick][embedded] Fix miscompile in IRGen in offset computation of Builtin.destroyArray

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1095,6 +1095,9 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     auto valueTy = getLoweredTypeAndTypeInfo(IGF.IGM,
                                              substitutions.getReplacementTypes()[0]);
 
+    // In Embedded Swift we don't have metadata and witness tables, so we can't
+    // just use TypeInfo's destroyArray, which needs metadata to emit a call to
+    // swift_arrayDestroy. Emit a loop to destroy elements directly instead.
     if (IGF.IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
       SILType elemTy = valueTy.first;
       const TypeInfo &elemTI = valueTy.second;
@@ -1105,7 +1108,7 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
 
       llvm::Value *firstElem =
           IGF.Builder.CreatePtrToInt(IGF.Builder.CreateBitCast(
-              ptr, elemTI.getStorageType()->getPointerTo()));
+              ptr, elemTI.getStorageType()->getPointerTo()), IGF.IGM.IntPtrTy);
 
       auto *origBB = IGF.Builder.GetInsertBlock();
       auto *headerBB = IGF.createBasicBlock("loop_header");
@@ -1162,6 +1165,9 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     llvm::Value *src = args.claimNext();
     llvm::Value *count = args.claimNext();
 
+    // In Embedded Swift we don't have metadata and witness tables, so we can't
+    // just use TypeInfo's initialize... and assign... APIs, which need
+    // metadata to emit calls. Emit a loop to process elements directly instead.
     if (IGF.IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
       auto tyPair = getLoweredTypeAndTypeInfo(
           IGF.IGM, substitutions.getReplacementTypes()[0]);
@@ -1177,10 +1183,14 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
           return;
       }
 
-      llvm::Value *firstSrcElem = IGF.Builder.CreateBitCast(
-          src, elemTI.getStorageType()->getPointerTo());
-      llvm::Value *firstDestElem = IGF.Builder.CreateBitCast(
-          dest, elemTI.getStorageType()->getPointerTo());
+      llvm::Value *firstSrcElem = IGF.Builder.CreatePtrToInt(
+          IGF.Builder.CreateBitCast(src,
+                                    elemTI.getStorageType()->getPointerTo()),
+          IGF.IGM.IntPtrTy);
+      llvm::Value *firstDestElem = IGF.Builder.CreatePtrToInt(
+          IGF.Builder.CreateBitCast(dest,
+                                    elemTI.getStorageType()->getPointerTo()),
+          IGF.IGM.IntPtrTy);
 
       auto *origBB = IGF.Builder.GetInsertBlock();
       auto *headerBB = IGF.createBasicBlock("loop_header");
@@ -1208,10 +1218,16 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
         break;
       }
 
-      auto *srcElem = IGF.Builder.CreateInBoundsGEP(elemTI.getStorageType(),
-                                                    firstSrcElem, idx);
-      auto *destElem = IGF.Builder.CreateInBoundsGEP(elemTI.getStorageType(),
-                                                     firstDestElem, idx);
+      llvm::Value *offset =
+           IGF.Builder.CreateMul(idx, elemTI.getStaticStride(IGF.IGM));
+
+      llvm::Value *srcAdded = IGF.Builder.CreateAdd(firstSrcElem, offset);
+      auto *srcElem = IGF.Builder.CreateIntToPtr(
+          srcAdded, elemTI.getStorageType()->getPointerTo());
+      llvm::Value *dstAdded = IGF.Builder.CreateAdd(firstDestElem, offset);
+      auto *destElem = IGF.Builder.CreateIntToPtr(
+          dstAdded, elemTI.getStorageType()->getPointerTo());
+
       Address destAddr = elemTI.getAddressForPointer(destElem);
       Address srcAddr = elemTI.getAddressForPointer(srcElem);
 

--- a/test/embedded/array-builtins-exec.swift
+++ b/test/embedded/array-builtins-exec.swift
@@ -31,6 +31,11 @@ struct Large : P {
   }
 }
 
+enum Enum {
+  case nontrivial(Noisy)
+  case trivial(Int)
+}
+
 func exerciseArrayValueWitnesses<T>(_ value: T) {
   let buf = UnsafeMutablePointer<T>.allocate(capacity: 5)
 
@@ -52,6 +57,8 @@ func test() {
     exerciseArrayValueWitnesses(44)
     exerciseArrayValueWitnesses(Noisy())
     exerciseArrayValueWitnesses(Large())
+    exerciseArrayValueWitnesses(Enum.trivial(42))
+    exerciseArrayValueWitnesses(Enum.nontrivial(Noisy()))
   }
   precondition(NoisyLifeCount == NoisyDeathCount)
   print("Checks out")

--- a/test/embedded/arrays-enums.swift
+++ b/test/embedded/arrays-enums.swift
@@ -1,0 +1,20 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+enum Node {
+  indirect case inner(Node, Node)
+  case leaf(Int)
+}
+
+@main
+struct Main {
+  static func main() {
+    _ = [Node.leaf(42), Node.leaf(42)]
+    print("OK!")
+    // CHECK: OK!
+  }
+}


### PR DESCRIPTION
* **Explanation**: In Embedded Swift, we have custom IRGen code to handle init/take/copy/destroy of array builtins. We had a miscompile (a GEP uses to index into the individual elements of the array's storage is using the value's size and not the stride) that triggers for non-POD array element types where size!=stride (e.g. where the type is an enum with payloads). Fix is to fix the IRGen to emit a valid set of instructions to correctly index using the stride. https://github.com/apple/swift/pull/73130
* **Scope**: Embedded Swift only.
* **Risk**: Low, all changes only apply to Embedded Swift.
* **Testing**: Added test case.
* **Issue**: rdar://126386301
* **Reviewer**: @eeckstein, @aschwaighofer  on https://github.com/apple/swift/pull/73130
