### PR TITLE
[IDE] Resolve `[.]Type` completion for `(any P).` to produce singleton metatype instead of existential metatype

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2475,8 +2475,16 @@ void CompletionLookup::getPostfixKeywordCompletions(Type ExprType,
       if (instanceTy->isAnyExistentialType()) {
         addKeyword("Protocol", MetatypeType::get(instanceTy),
                    SemanticContextKind::CurrentNominal);
-        addKeyword("Type", ExistentialMetatypeType::get(instanceTy),
-                   SemanticContextKind::CurrentNominal);
+        if (auto *typeExpr = dyn_cast<TypeExpr>(ParsedExpr)) {
+          if (auto *typeRepr = typeExpr->getTypeRepr()) {
+            if (typeRepr->isParenType())
+              addKeyword("Type", MetatypeType::get(instanceTy),
+                         SemanticContextKind::CurrentNominal);
+            else
+              addKeyword("Type", ExistentialMetatypeType::get(instanceTy),
+                         SemanticContextKind::CurrentNominal);
+          }
+        }
       } else {
         addKeyword("Type", MetatypeType::get(instanceTy),
                    SemanticContextKind::CurrentNominal);

--- a/test/IDE/complete_issue-65843.swift
+++ b/test/IDE/complete_issue-65843.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+protocol P {}
+
+(any P).#^COMPLETE?^#
+// COMPLETE: Begin completions, 3 items
+// COMPLETE: Keyword[self]/CurrNominal:          self[#(any P).Type#]; name=self
+// COMPLETE: Keyword/CurrNominal:                Protocol[#(any P).Type#]; name=Protocol
+// COMPLETE: Keyword/CurrNominal:                Type[#(any P).Type#]; name=Type
+
+
+P.Type.#^PROTOCOLTYPE_DOT_1?^#
+// PROTOCOLTYPE_DOT_1: Begin completions, 3 items
+// PROTOCOLTYPE_DOT_1: Keyword[self]/CurrNominal:          self[#(any P.Type).Type#]; name=self
+// PROTOCOLTYPE_DOT_1: Keyword/CurrNominal:                Protocol[#(any P.Type).Type#]; name=Protocol
+// PROTOCOLTYPE_DOT_1: Keyword/CurrNominal:                Type[#any P.Type.Type#]; name=Type
+
+(P).Type.#^PROTOCOLTYPE_DOT_2?^#
+// PROTOCOLTYPE_DOT_2: Begin completions, 3 items
+// PROTOCOLTYPE_DOT_2: Keyword[self]/CurrNominal:          self[#(any P.Type).Type#]; name=self
+// PROTOCOLTYPE_DOT_2: Keyword/CurrNominal:                Protocol[#(any P.Type).Type#]; name=Protocol
+// PROTOCOLTYPE_DOT_2: Keyword/CurrNominal:                Type[#any P.Type.Type#]; name=Type


### PR DESCRIPTION
Resolves #65843

The type completion for `(any P).` is a singleton meta type which currently falsely produces `any P.`, i.e, an existential meta type.