### PR TITLE
Fix typo in Result.swift

### DIFF
--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -170,7 +170,7 @@ extension Result {
   /// produces another `Result` type.
   ///
   /// In this example, note the difference in the result of using `map` and
-  /// `flatMap` with a transformation that returns an result type.
+  /// `flatMap` with a transformation that returns a result type.
   ///
   ///     func getNextInteger() -> Result<Int, Error> {
   ///         .success(4)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix the wrong indefinite article among comments inside Result.swift.
Change "an result type" to "a result type".
