### PR TITLE
Fix typo introduced in 56bf85c.

### DIFF
--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1218,7 +1218,7 @@ struct r19874152S6 {
   // Cannot handle implicit synth of this yet.
   let (a,b) = (1,2)   // expected-error {{unsupported}}
 }
-_ = r19874152S5()  // ok
+_ = r19874152S6()  // ok
 
 
 


### PR DESCRIPTION
I stumbled upon this the other day and thought it looked strange. Would appreciate if someone else could have a look at this to confirm whether it's actually a typo or not.