### PR TITLE
[Concurrency] Don't error on isolated property wrapper initializers inside `MainActor`-isolated structs.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -374,7 +374,7 @@ EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(MemberImportVisibility, true
 EXPERIMENTAL_FEATURE(IsolatedAny2, true)
 
 // Enable usability improvements for global-actor-isolated types.
-EXPERIMENTAL_FEATURE(GlobalActorIsolatedTypesUsability, false)
+EXPERIMENTAL_FEATURE(GlobalActorIsolatedTypesUsability, true)
 
 // Enable @implementation on extensions of ObjC classes.
 EXPERIMENTAL_FEATURE(ObjCImplementation, true)

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5117,17 +5117,6 @@ ActorIsolation ActorIsolationRequest::evaluate(
         llvm_unreachable("cannot infer erased isolation");
 
       case ActorIsolation::GlobalActor: {
-        // Stored properties of a struct don't need global-actor isolation.
-        if (ctx.isSwiftVersionAtLeast(6))
-          if (auto *var = dyn_cast<VarDecl>(value))
-            if (!var->isStatic() && var->isOrdinaryStoredProperty())
-              if (auto *varDC = var->getDeclContext())
-                if (auto *nominal = varDC->getSelfNominalTypeDecl())
-                  if (isa<StructDecl>(nominal) &&
-                      !isWrappedValueOfPropWrapper(var))
-                    return ActorIsolation::forUnspecified().withPreconcurrency(
-                        inferred.preconcurrency());
-
         auto typeExpr =
             TypeExpr::createImplicit(inferred.getGlobalActor(), ctx);
         auto attr =


### PR DESCRIPTION
This was caused by a rule that removed `@MainActor` from stored properties, which was gated behind `-swift-version 6`. This rule is incorrect, because the property can have an isolated default value. The proper rule for allowing `nonisolated` access to isolated stored properties of structs within the module is proposed in SE-0434, and implemented under `GlobalActorIsolatedTypesUsability`.