### PR TITLE
[6.0][Concurrency] Don't error on isolated property wrapper initializers inside `MainActor`-isolated structs.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -379,7 +379,7 @@ EXPERIMENTAL_FEATURE(CImplementation, true)
 EXPERIMENTAL_FEATURE(DebugDescriptionMacro, true)
 
 // Enable usability improvements for global-actor-isolated types.
-EXPERIMENTAL_FEATURE(GlobalActorIsolatedTypesUsability, false)
+EXPERIMENTAL_FEATURE(GlobalActorIsolatedTypesUsability, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5115,17 +5115,6 @@ ActorIsolation ActorIsolationRequest::evaluate(
         llvm_unreachable("cannot infer erased isolation");
 
       case ActorIsolation::GlobalActor: {
-        // Stored properties of a struct don't need global-actor isolation.
-        if (ctx.isSwiftVersionAtLeast(6))
-          if (auto *var = dyn_cast<VarDecl>(value))
-            if (!var->isStatic() && var->isOrdinaryStoredProperty())
-              if (auto *varDC = var->getDeclContext())
-                if (auto *nominal = varDC->getSelfNominalTypeDecl())
-                  if (isa<StructDecl>(nominal) &&
-                      !isWrappedValueOfPropWrapper(var))
-                    return ActorIsolation::forUnspecified().withPreconcurrency(
-                        inferred.preconcurrency());
-
         auto typeExpr =
             TypeExpr::createImplicit(inferred.getGlobalActor(), ctx);
         auto attr =


### PR DESCRIPTION
* **Explanation**: The following code currently emits an error under `-swift-version 6`:

  ```swift
  @MainActor
  protocol InferMainActor {}

  @propertyWrapper @MainActor
  struct Wrapper<T> {
    var wrappedValue: T {
      fatalError()
    }

    init() {}
  }

  @MainActor
  class C {
    nonisolated init() {}
  }

  struct S: InferMainActor {
    @Wrapper var value: C // error: main actor isolated default value in a nonisolated context
  }
  ```

  This was caused by a rule that removed `@MainActor` from stored properties, which was gated behind `-swift-version 6`. This rule is incorrect, because the property can have an isolated default value. The proper rule for allowing `nonisolated` access to isolated stored properties of structs within the module is proposed in SE-0434, and implemented under `GlobalActorIsolatedTypesUsability`.
* **Scope**: Only impacts stored properties of global-actor-isolated structs under the Swift 6 language mode.
* **Risk**: Low; the change only impacts the Swift 6 language mode, which isn't yet in a shipping version of the Swift compiler.
* **Testing**: Add a test case.
* **Reviewer**: @xedin 
* **Main branch PR**: https://github.com/apple/swift/pull/73168