### PR TITLE
Sema: Offer solution to silence inconsistent import access-level warnings

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3685,6 +3685,9 @@ ERROR(inconsistent_implicit_access_level_on_import,none,
       "ambiguous implicit access level for import of %0; it is imported as "
       "'%select{private|fileprivate|internal|package|public|%error}1' elsewhere",
       (Identifier, AccessLevel))
+NOTE(inconsistent_implicit_access_level_on_import_silence,none,
+      "silence these warnings by adopting 'InternalImportsByDefault'",
+      ())
 NOTE(inconsistent_implicit_access_level_on_import_here,none,
      "imported "
      "'%select{private|fileprivate|internal|package|public|%error}0' here",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3686,7 +3686,8 @@ ERROR(inconsistent_implicit_access_level_on_import,none,
       "'%select{private|fileprivate|internal|package|public|%error}1' elsewhere",
       (Identifier, AccessLevel))
 NOTE(inconsistent_implicit_access_level_on_import_silence,none,
-      "silence these warnings by adopting 'InternalImportsByDefault'",
+      "silence these warnings by adopting the upcoming feature "
+      "'InternalImportsByDefault'",
       ())
 NOTE(inconsistent_implicit_access_level_on_import_here,none,
      "imported "

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1075,11 +1075,16 @@ CheckInconsistentAccessLevelOnImport::evaluate(
     auto &diags = mod->getDiags();
     {
       InFlightDiagnostic error =
-        diags.diagnose(implicitImport, diag::inconsistent_implicit_access_level_on_import,
-                       implicitImport->getModule()->getName(), otherAccessLevel);
+        diags.diagnose(implicitImport,
+                       diag::inconsistent_implicit_access_level_on_import,
+                       implicitImport->getModule()->getName(),
+                       otherAccessLevel);
       error.fixItInsert(implicitImport->getStartLoc(),
                         diag::inconsistent_implicit_access_level_on_import_fixit,
                         otherAccessLevel);
+      error.flush();
+      diags.diagnose(implicitImport,
+                     diag::inconsistent_implicit_access_level_on_import_silence);
     }
 
     SourceLoc accessLevelLoc = otherImport->getStartLoc();

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -49,6 +49,7 @@ private import Lib
 // RUN:   -primary-file %t/ManyFiles_ImplicitVsInternal_FileA.swift -verify
 //--- ManyFiles_ImplicitVsInternal_FileA.swift
 import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'internal' elsewhere}}
+// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
 //--- ManyFiles_ImplicitVsInternal_FileB.swift
 internal import Lib // expected-note {{imported 'internal' here}}
 
@@ -56,6 +57,7 @@ internal import Lib // expected-note {{imported 'internal' here}}
 // RUN:   -primary-file %t/ManyFiles_ImplicitVsPackage_FileA.swift -verify
 //--- ManyFiles_ImplicitVsPackage_FileA.swift
 import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'package' elsewhere}}
+// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
 //--- ManyFiles_ImplicitVsPackage_FileB.swift
 package import Lib // expected-note {{imported 'package' here}} @:1
 

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -49,7 +49,7 @@ private import Lib
 // RUN:   -primary-file %t/ManyFiles_ImplicitVsInternal_FileA.swift -verify
 //--- ManyFiles_ImplicitVsInternal_FileA.swift
 import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'internal' elsewhere}}
-// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
+// expected-note @-1 {{silence these warnings by adopting the upcoming feature 'InternalImportsByDefault'}}
 //--- ManyFiles_ImplicitVsInternal_FileB.swift
 internal import Lib // expected-note {{imported 'internal' here}}
 
@@ -57,7 +57,7 @@ internal import Lib // expected-note {{imported 'internal' here}}
 // RUN:   -primary-file %t/ManyFiles_ImplicitVsPackage_FileA.swift -verify
 //--- ManyFiles_ImplicitVsPackage_FileA.swift
 import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'package' elsewhere}}
-// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
+// expected-note @-1 {{silence these warnings by adopting the upcoming feature 'InternalImportsByDefault'}}
 //--- ManyFiles_ImplicitVsPackage_FileB.swift
 package import Lib // expected-note {{imported 'package' here}} @:1
 

--- a/test/Sema/access-level-import-inconsistent-same-file.swift
+++ b/test/Sema/access-level-import-inconsistent-same-file.swift
@@ -57,7 +57,7 @@ public func dummyAPI(t1: Lib1.Type1, t2: Lib2.Type1, t3: Lib3.Type1) {}
 /// Simple public vs internal, imports defaults to public.
 import Lib1 // expected-note {{imported 'public' here}}
 // expected-error @-1 {{ambiguous implicit access level for import of 'Lib1'; it is imported as 'internal' elsewhere}}
-// expected-note @-2 {{silence these warnings by adopting 'InternalImportsByDefault'}}
+// expected-note @-2 {{silence these warnings by adopting the upcoming feature 'InternalImportsByDefault'}}
 internal import Lib1 // expected-warning {{module 'Lib1' is imported as 'public' from the same file; this 'internal' access level will be ignored}}
 // expected-note @-1 {{imported 'internal' here}}
 
@@ -66,7 +66,7 @@ public import Lib2
 // expected-note @-1 {{imported 'public' here}}
 import Lib2
 // expected-error @-1 {{ambiguous implicit access level for import of 'Lib2'; it is imported as 'public' elsewhere}}
-// expected-note @-2 {{silence these warnings by adopting 'InternalImportsByDefault'}}
+// expected-note @-2 {{silence these warnings by adopting the upcoming feature 'InternalImportsByDefault'}}
 
 public func dummyAPI(t: Lib1.Type1, t2: Lib2.Type1) {}
 

--- a/test/Sema/access-level-import-inconsistent-same-file.swift
+++ b/test/Sema/access-level-import-inconsistent-same-file.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
+// RUN: split-file %s %t --leading-lines
 
 /// Build the library.
 // RUN: %target-swift-frontend -emit-module %t/Lib.swift -module-name Lib1 -o %t
@@ -57,6 +57,7 @@ public func dummyAPI(t1: Lib1.Type1, t2: Lib2.Type1, t3: Lib3.Type1) {}
 /// Simple public vs internal, imports defaults to public.
 import Lib1 // expected-note {{imported 'public' here}}
 // expected-error @-1 {{ambiguous implicit access level for import of 'Lib1'; it is imported as 'internal' elsewhere}}
+// expected-note @-2 {{silence these warnings by adopting 'InternalImportsByDefault'}}
 internal import Lib1 // expected-warning {{module 'Lib1' is imported as 'public' from the same file; this 'internal' access level will be ignored}}
 // expected-note @-1 {{imported 'internal' here}}
 
@@ -65,6 +66,7 @@ public import Lib2
 // expected-note @-1 {{imported 'public' here}}
 import Lib2
 // expected-error @-1 {{ambiguous implicit access level for import of 'Lib2'; it is imported as 'public' elsewhere}}
+// expected-note @-2 {{silence these warnings by adopting 'InternalImportsByDefault'}}
 
 public func dummyAPI(t: Lib1.Type1, t2: Lib2.Type1) {}
 

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -118,6 +118,7 @@ public struct Extended {
 //--- Client_Swift5.swift
 /// No diagnostics should be raised on the implicit access level.
 import UnusedImport // expected-error {{ambiguous implicit access level for import of 'UnusedImport'; it is imported as 'public' elsewhere}}
+// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
 public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-7=internal}}
 // expected-note @-1 {{imported 'public' here}}
 

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -118,7 +118,7 @@ public struct Extended {
 //--- Client_Swift5.swift
 /// No diagnostics should be raised on the implicit access level.
 import UnusedImport // expected-error {{ambiguous implicit access level for import of 'UnusedImport'; it is imported as 'public' elsewhere}}
-// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
+// expected-note @-1 {{silence these warnings by adopting the upcoming feature 'InternalImportsByDefault'}}
 public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-7=internal}}
 // expected-note @-1 {{imported 'public' here}}
 


### PR DESCRIPTION
With the push back of internal imports by default out of Swift 6 we have to review issues that were expected to be temporary with SE-409 but will now remain for the foreseeable future. Here we address the warning about ambiguous implicit access-level on imports between files. This warning is in place to avoid inserting public dependencies by mistake and is usually silenced by using an explicit `public import` where desired.

This PR adds a note to suggest adopting `InternalImportsByDefault` as a way to silence these warnings module-wide. That mode provides a safe access-level to imports by default, as such ambiguities are not a risk and showing this warning is superflous.