### PR TITLE
6.0: [MoveOnlyAddressChecker] Fix empty deiniting struct representation.

### DIFF
--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -71,14 +71,14 @@ TypeSubElementCount::TypeSubElementCount(SILType type, SILModule &mod,
           type.getFieldType(fieldDecl, mod, context), mod, context);
     number = numElements;
 
+    // If we do not have any elements, just set our size to 1.
+    if (number == 0)
+      number = 1;
     if (type.isValueTypeWithDeinit()) {
       // 'self' has its own liveness represented as an additional field at the
       // end of the structure.
       ++number;
     }
-    // If we do not have any elements, just set our size to 1.
-    if (number == 0)
-      number = 1;
 
     return;
   }
@@ -449,6 +449,9 @@ void TypeTreeLeafTypeRange::constructFilteredProjections(
       auto newValue = builder.createStructElementAddr(loc, value, varDecl);
       callback(newValue, TypeTreeLeafTypeRange(start, next), NeedsDestroy);
       start = next;
+    }
+    if (start == 0) {
+      ++start;
     }
     if (type.isValueTypeWithDeinit()) {
       // 'self' has its own liveness

--- a/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
@@ -8,6 +8,7 @@
 // RUN: | %FileCheck %s
 
 import Builtin
+import Swift
 
 @_moveOnly
 struct M {
@@ -202,4 +203,37 @@ bb0(%s_addr : $*S):
   destroy_value %om : $Builtin.NativeObject
   %retval = tuple ()
   return %retval : $()
+}
+
+sil @getter : $@convention(thin) (@guaranteed M) -> @owned String
+sil @die : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @owned String) -> Never
+
+// CHECK-LABEL: sil [ossa] @partial_apply_of_borrow_of_deinitless_empty_struct : {{.*}} {
+// CHECK:       bb0([[M_IN:%[^,]+]] :
+// CHECK:         [[STACK:%[^,]+]] = alloc_stack $M
+// CHECK:         store [[M_IN]] to [init] [[STACK]]
+// CHECK:         [[ADDR:%[^,]+]] = drop_deinit [[STACK]]
+// CHECK:         [[MB:%[^,]+]] = load_borrow [[ADDR]]
+// CHECK:         [[GETTER:%[^,]+]] = function_ref @getter
+// CHECK:         [[PA:%[^,]+]] = partial_apply [callee_guaranteed] [on_stack] [[GETTER]]([[MB]])
+// CHECK:         [[DIE:%[^,]+]] = function_ref @die
+// CHECK:         apply [[DIE]]([[PA]])
+// CHECK:         destroy_value [[PA]]
+// CHECK:         end_borrow [[MB]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'partial_apply_of_borrow_of_deinitless_empty_struct'
+sil [ossa] @partial_apply_of_borrow_of_deinitless_empty_struct : $@convention(method) (@owned M) -> () {
+bb0(%m_in : @owned $M):
+  %stack = alloc_stack $M
+  %addr1 = mark_unresolved_non_copyable_value [consumable_and_assignable] %stack : $*M
+  store %m_in to [init] %addr1 : $*M
+  %nodeinit = drop_deinit %addr1 : $*M
+  %addr = mark_unresolved_non_copyable_value [no_consume_or_assign] %nodeinit : $*M
+  %m = load [copy] %addr : $*M
+  %mb = begin_borrow %m : $M
+  %getter = function_ref @getter : $@convention(thin) (@guaranteed M) -> @owned String
+  %pa = partial_apply [callee_guaranteed] [on_stack] %getter(%mb) : $@convention(thin) (@guaranteed M) -> @owned String
+  %die = function_ref @die : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @owned String) -> Never
+  apply %die(%pa) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @owned String) -> Never
+  unreachable
 }

--- a/validation-test/SILOptimizer/gh68328.swift
+++ b/validation-test/SILOptimizer/gh68328.swift
@@ -7,7 +7,7 @@
 // REQUIRES: executable_test
 
 struct Example: ~Copyable {
-    private var failureString: String = "Goodbye."
+    private var failureString: String { "Goodbye." }
     deinit { fatalError("FATAL ERROR: \(failureString)") }
 }
 


### PR DESCRIPTION
**Explanation**: Fix MoveOnlyAddressChecker miscompile caused by not representing empty struct with deinit.

The checker represents each type as a bitfield.  An empty struct without a deinit gets a single bit--that bit corresponds to the whole struct.  That allows the checker to track uses of the whole struct as a use of some bit.

Previously, the checker only represented an empty struct with a deinit as a single bit too.  The single bit in this case corresponds to the deinit.  When the deinit is dropped via discard, there is still an empty struct whose lifetime needs representation in bits--it should have the same number of bits as an empty struct without a deinit--i.e. two.

Here, the problem is fixed by giving an empty struct with a deinit two bits.
**Scope**: Affects noncopyable code.
**Issue**: rdar://126863003
**Original PR**: https://github.com/apple/swift/pull/73174
**Risk**: Low.
**Testing**: Added and updated unit tests.
**Reviewer**: @kavon
