### PR TITLE
[6.0] embedded: fix a crash when specializing a generic class method with an indirect return value

### DIFF
--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -813,7 +813,7 @@ getReturnTypeCategory(const SILResultInfo &RI,
                   const SILFunctionConventions &substConv,
                   TypeExpansionContext typeExpansion) {
   auto ResultTy = substConv.getSILType(RI, typeExpansion);
-  ResultTy = Callee->mapTypeIntoContext(ResultTy);
+  ResultTy = mapTypeIntoContext(ResultTy);
   auto &TL = getModule().Types.getTypeLowering(ResultTy, typeExpansion);
 
   if (!TL.isLoadable())

--- a/test/embedded/classes-indirect-return.swift
+++ b/test/embedded/classes-indirect-return.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-emit-sil %s -enable-experimental-feature Embedded -wmo | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
 
 // CHECK: sil @$s4main1XC3fooxyFSi_Tg5 : $@convention(method) (@guaranteed X<Int>) -> Int {
 

--- a/test/embedded/classes-indirect-return.swift
+++ b/test/embedded/classes-indirect-return.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-sil %s -enable-experimental-feature Embedded -wmo | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+// CHECK: sil @$s4main1XC3fooxyFSi_Tg5 : $@convention(method) (@guaranteed X<Int>) -> Int {
+
+// CHECK-LABEL: sil_vtable $X<Int>
+// CHECK:         #X.foo: <T> (X<T>) -> () -> T : @$s4main1XC3fooxyFSi_Tg5
+// CHECK:       }
+
+open class X<T> {
+
+  var t: T
+
+  init(t: T) {
+    self.t = t
+  }
+
+  open func foo() -> T { t }
+}
+
+func testit() -> Int {
+  let x = X(t: 27)
+  return x.foo()
+}


### PR DESCRIPTION
* **Explanation**: This fixes a compiler crash which can only happen in embedded swift: when specializing generic class methods, there is no callee function available. The fix is to use the `ReabstractionInfo::mapTypeIntoContext` utility function which checks for a null callee function pointer.
* **Scope**: Only affects embedded swift
* **Risk**: very low. The change is trivial and only affects the case where it was crashing without the fix
* **Testing**: Tested by a test case
* **Issue**: rdar://126762162
* **Reviewer**:  @kubamracek
* **Main branch PR**: https://github.com/apple/swift/pull/73172 (and https://github.com/apple/swift/pull/73194 for a fix in the test)