### PR TITLE
[Runtime] Fix CVW for genreic single payload enums with no extra inha…

### DIFF
--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -413,6 +413,10 @@ static void singlePayloadEnumGeneric(const Metadata *metadata,
 
       if (tagBytes) {
         xiType = nullptr;
+      } else if (!xiType) {
+        // If there are no inhabitants and the extra tag bits are not set,
+        // we have a payload.
+        return;
       }
     }
 
@@ -633,6 +637,10 @@ static void singlePayloadEnumGeneric(const Metadata *metadata,
 
       if (tagBytes) {
         xiType = nullptr;
+      } else if (!xiType) {
+        // If there are no inhabitants and the extra tag bits are not set,
+        // we have a payload.
+        return;
       }
     }
 

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -305,10 +305,10 @@ void swift::swift_initEnumMetadataSinglePayloadWithLayoutString(
   _swift_addRefCountStringForMetatype(writer, flags, payloadType, fullOffset,
                                       previousFieldOffset);
 
-  writer.writeBytes((uint64_t)previousFieldOffset);
+  writer.writeBytes((uint64_t)previousFieldOffset + extraTagBytes);
 
   writer.offset = skipBytesOffset;
-  writer.writeBytes(size - previousFieldOffset);
+  writer.writeBytes(payloadSize - previousFieldOffset);
 
   // we mask out HasRelativePointers, because at this point they have all been
   // resolved to metadata pointers

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -347,6 +347,11 @@ public struct ContainsSinglePayloadSimpleClassEnum {
     }
 }
 
+public enum TestOptional<T> {
+    case empty
+    case nonEmpty(T)
+}
+
 public enum SinglePayloadEnum<T> {
     case empty
     case nonEmpty(Int, T?)

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -1260,10 +1260,10 @@ func testWeakRefOptionalObjc() {
         testGenericDestroy(ptr, of: TestOptional<WeakObjcWrapper>.self)
         testGenericDestroy(ptr2, of: TestOptional<WeakObjcWrapper>.self)
 
-        // CHECK: Before deinit
+        // CHECK-macosx: Before deinit
         print("Before deinit")
 
-        // CHECK-NEXT: ObjcClass deinitialized!
+        // CHECK-macosx-NEXT: ObjcClass deinitialized!
     }
 
     ptr.deallocate()

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -1181,27 +1181,48 @@ func testTupleAlignment() {
 
 testTupleAlignment()
 
+func testWeakRefOptionalNative() {
+    let ptr = allocateInternalGenericPtr(of: TestOptional<WeakNativeWrapper>.self)
+    let ptr2 = allocateInternalGenericPtr(of: TestOptional<WeakNativeWrapper>.self)
+
+    do {
+        let classInstance = SimpleClass(x: 23)
+
+        do {
+            let x = TestOptional.nonEmpty(WeakNativeWrapper(x: classInstance))
+            let y = TestOptional.nonEmpty(WeakNativeWrapper(x: classInstance))
+            testGenericInit(ptr, to: x)
+            testGenericInit(ptr2, to: y)
+        }
+
+        testGenericDestroy(ptr, of: TestOptional<WeakNativeWrapper>.self)
+        testGenericDestroy(ptr2, of: TestOptional<WeakNativeWrapper>.self)
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+    }
+
+    ptr.deallocate()
+}
+
+testWeakRefOptionalNative()
+
 #if os(macOS)
 
 import Foundation
-
-@objc
-final class ObjcClass: NSObject {
-    deinit {
-        print("ObjcClass deinitialized!")
-    }
-}
 
 func testGenericObjc() {
     let ptr = allocateInternalGenericPtr(of: ObjcClass.self)
 
     do {
-        let x = ObjcClass()
+        let x = ObjcClass(x: 23)
         testGenericInit(ptr, to: x)
     }
 
     do {
-        let y = ObjcClass()
+        let y = ObjcClass(x: 32)
         // CHECK-macosx: Before deinit
         print("Before deinit")
 
@@ -1219,5 +1240,35 @@ func testGenericObjc() {
 }
 
 testGenericObjc()
+
+import Darwin
+
+func testWeakRefOptionalObjc() {
+    let ptr = allocateInternalGenericPtr(of: TestOptional<WeakObjcWrapper>.self)
+    let ptr2 = allocateInternalGenericPtr(of: TestOptional<WeakObjcWrapper>.self)
+
+    do {
+        let classInstance = ObjcClass(x: 23)
+
+        do {
+            let x = TestOptional.nonEmpty(WeakObjcWrapper(x: classInstance))
+            let y = TestOptional.nonEmpty(WeakObjcWrapper(x: classInstance))
+            testGenericInit(ptr, to: x)
+            testGenericInit(ptr2, to: y)
+        }
+
+        testGenericDestroy(ptr, of: TestOptional<WeakObjcWrapper>.self)
+        testGenericDestroy(ptr2, of: TestOptional<WeakObjcWrapper>.self)
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: ObjcClass deinitialized!
+    }
+
+    ptr.deallocate()
+}
+
+testWeakRefOptionalObjc()
 
 #endif


### PR DESCRIPTION
…bitants

rdar://126728925

When the payload of a generic SPE did not have any extra inhabitants, we erroneously always treated it as the no payload case. Additionally the offset and skip values were improperly computed.
