### PR TITLE
[SE-0428] NFC: Rename `_DistributedProtocol` macro into `Resolvable`

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
@@ -13,7 +13,7 @@
 add_swift_macro_library(SwiftMacros
   OptionSetMacro.swift
   DebugDescriptionMacro.swift
-  DistributedProtocolMacro.swift
+  DistributedResolvableMacro.swift
   SWIFT_DEPENDENCIES
     SwiftDiagnostics
     SwiftOperators

--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -18,13 +18,13 @@ import SwiftSyntaxBuilder
 /// Introduces:
 /// - `distributed actor $MyDistributedActor<ActorSystem>: $MyDistributedActor, _DistributedActorStub where ...`
 /// - `extension MyDistributedActor where Self: _DistributedActorStub {}`
-public struct DistributedProtocolMacro: ExtensionMacro, PeerMacro {
+public struct DistributedResolvableMacro: ExtensionMacro, PeerMacro {
 }
 
 // ===== -----------------------------------------------------------------------
 // MARK: Default Stub implementations Extension
 
-extension DistributedProtocolMacro {
+extension DistributedResolvableMacro {
 
   /// Introduce the `extension MyDistributedActor` which contains default
   /// implementations of the protocol's requirements.
@@ -116,7 +116,7 @@ extension DistributedProtocolMacro {
 // ===== -----------------------------------------------------------------------
 // MARK: Distributed Actor Stub type
 
-extension DistributedProtocolMacro {
+extension DistributedResolvableMacro {
 
   /// Introduce the `distributed actor` stub type.
   public static func expansion(
@@ -263,9 +263,9 @@ extension DeclModifierSyntax {
 }
 
 // ===== -----------------------------------------------------------------------
-// MARK: DistributedProtocol macro errors
+// MARK: @Distributed.Resolvable macro errors
 
-extension DistributedProtocolMacro {
+extension DistributedResolvableMacro {
   static func throwIllegalTargetDecl(node: AttributeSyntax, _ declaration: some DeclSyntaxProtocol) throws -> Never {
     let kind: String
     if declaration.isClass {
@@ -282,11 +282,11 @@ extension DistributedProtocolMacro {
 
     throw DiagnosticsError(
       syntax: node,
-      message: "'@DistributedProtocol' can only be applied to 'protocol', but was attached to '\(kind)'", id: .invalidApplication)
+      message: "'@Resolvable' can only be applied to 'protocol', but was attached to '\(kind)'", id: .invalidApplication)
   }
 }
 
-struct DistributedProtocolMacroDiagnostic: DiagnosticMessage {
+struct DistributedResolvableMacroDiagnostic: DiagnosticMessage {
   enum ID: String {
     case invalidApplication = "invalid type"
     case missingInitializer = "missing initializer"
@@ -314,12 +314,12 @@ extension DiagnosticsError {
     syntax: S,
     message: String,
     domain: String = "Distributed",
-    id: DistributedProtocolMacroDiagnostic.ID,
+    id: DistributedResolvableMacroDiagnostic.ID,
     severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
     self.init(diagnostics: [
       Diagnostic(
         node: Syntax(syntax),
-        message: DistributedProtocolMacroDiagnostic(
+        message: DistributedResolvableMacroDiagnostic(
           message: message,
           domain: domain,
           id: id,

--- a/stdlib/public/Distributed/DistributedMacros.swift
+++ b/stdlib/public/Distributed/DistributedMacros.swift
@@ -28,7 +28,7 @@ import _Concurrency
 /// in such way that the system's `SerializationRequirement` is statically known.
 @attached(peer, names: prefixed(`$`)) // provides $Greeter concrete stub type
 @attached(extension, names: arbitrary) // provides extension for Greeter & _DistributedActorStub
-public macro _DistributedProtocol() =
-  #externalMacro(module: "SwiftMacros", type: "DistributedProtocolMacro")
+public macro Resolvable() =
+  #externalMacro(module: "SwiftMacros", type: "DistributedResolvableMacro")
 
 #endif

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
@@ -12,26 +12,26 @@
 
 import Distributed
 
-@_DistributedProtocol // expected-error{{'@DistributedProtocol' can only be applied to 'protocol', but was attached to 'struct' (from macro '_DistributedProtocol')}}
+@Resolvable // expected-error{{'@Resolvable' can only be applied to 'protocol', but was attached to 'struct' (from macro 'Resolvable')}}
 struct Struct {}
 
-@_DistributedProtocol // expected-error{{'@DistributedProtocol' can only be applied to 'protocol', but was attached to 'class' (from macro '_DistributedProtocol')}}
+@Resolvable // expected-error{{'@Resolvable' can only be applied to 'protocol', but was attached to 'class' (from macro 'Resolvable')}}
 class Clazz {}
 
-@_DistributedProtocol // expected-error{{'@DistributedProtocol' can only be applied to 'protocol', but was attached to 'actor' (from macro '_DistributedProtocol')}}
+@Resolvable // expected-error{{'@Resolvable' can only be applied to 'protocol', but was attached to 'actor' (from macro 'Resolvable')}}
 actor Act {}
 
-@_DistributedProtocol // expected-error{{'@DistributedProtocol' can only be applied to 'protocol', but was attached to 'actor' (from macro '_DistributedProtocol')}}
+@Resolvable // expected-error{{'@Resolvable' can only be applied to 'protocol', but was attached to 'actor' (from macro 'Resolvable')}}
 distributed actor Caplin {
   typealias ActorSystem = FakeActorSystem
 }
 
-@_DistributedProtocol // expected-error{{Distributed protocol must declare actor system with SerializationRequirement}}
+@Resolvable // expected-error{{Distributed protocol must declare actor system with SerializationRequirement}}
 protocol Fail: DistributedActor {
   distributed func method() -> String
 }
 
-@_DistributedProtocol // expected-note{{in expansion of macro '_DistributedProtocol' on protocol 'SomeRoot' here}}
+@Resolvable // expected-note{{in expansion of macro 'Resolvable' on protocol 'SomeRoot' here}}
 public protocol SomeRoot: DistributedActor, Sendable
   where ActorSystem: DistributedActorSystem<any Codable> {
 

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
@@ -13,7 +13,7 @@ import Distributed
 
 typealias System = LocalTestingDistributedActorSystem
 
-@_DistributedProtocol
+@Resolvable
 protocol Base: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
   distributed func base() -> Int
 }
@@ -35,7 +35,7 @@ protocol Base: DistributedActor where ActorSystem: DistributedActorSystem<any Co
 
 // ==== ------------------------------------------------------------------------
 
-@_DistributedProtocol
+@Resolvable
 protocol G3<ActorSystem>: DistributedActor, Base where ActorSystem: DistributedActorSystem<any Codable> {
   distributed func get() -> String
   distributed func greet(name: String) -> String

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
@@ -11,12 +11,12 @@
 
 import Distributed
 
-@_DistributedProtocol
+@Resolvable
 protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
   distributed func greet(name: String) -> String
 }
 
-// @_DistributedProtocol ->
+// @Resolvable ->
 
 // CHECK: distributed actor $Greeter<ActorSystem>: Greeter,
 // CHECK-NEXT: Distributed._DistributedActorStub
@@ -35,7 +35,7 @@ protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any
 // CHECK-NEXT: }
 
 // Macro should be able to handle complex properties
-@_DistributedProtocol
+@Resolvable
 public protocol GetSet: DistributedActor, Sendable
   where ActorSystem: DistributedActorSystem<any Codable> {
 

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
@@ -12,7 +12,7 @@
 
 import Distributed
 
-@_DistributedProtocol
+@Resolvable
 protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
   distributed func greet(name: String) -> String
 }
@@ -32,7 +32,7 @@ protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
 // CHECK:   }
 // CHECK: }
 
-@_DistributedProtocol
+@Resolvable
 protocol Greeter2: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
   distributed func greet(name: String) -> String
 }
@@ -57,7 +57,7 @@ extension String: CustomSerializationProtocol {
   public static func fromBytes(_ bytes: [UInt8]) throws -> Self { "" }
 }
 
-@_DistributedProtocol
+@Resolvable
 protocol Greeter3: DistributedActor where ActorSystem: DistributedActorSystem<any CustomSerializationProtocol> {
   distributed func greet(name: String) -> String
 }
@@ -77,7 +77,7 @@ protocol Greeter3: DistributedActor where ActorSystem: DistributedActorSystem<an
 // CHECK:   }
 // CHECK: }
 
-@_DistributedProtocol
+@Resolvable
 public protocol Greeter4: DistributedActor where ActorSystem == FakeActorSystem {
   distributed func greet(name: String) -> String
 }
@@ -97,7 +97,7 @@ public protocol Greeter4: DistributedActor where ActorSystem == FakeActorSystem 
 // CHECK:   }
 // CHECK: }
 
-@_DistributedProtocol
+@Resolvable
 public protocol GreeterMore: DistributedActor where ActorSystem == FakeActorSystem {
   distributed var name: String { get }
   distributed func greet(name: String) -> String

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
@@ -19,7 +19,7 @@
  
 import Distributed
 
-@_DistributedProtocol
+@Resolvable
 @available(SwiftStdlib 6.0, *)
 protocol WorkerProtocol: DistributedActor where ActorSystem == LocalTestingDistributedActorSystem {
   distributed func distributedMethod() -> String

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_protocol_method.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_protocol_method.swift
@@ -20,7 +20,7 @@ import FakeDistributedActorSystems
 
 // ==== Known actor system -----------------------------------------------------
 
-@_DistributedProtocol
+@Resolvable
 protocol GreeterDefinedSystemProtocol: DistributedActor where ActorSystem == FakeRoundtripActorSystem {
   distributed func greet() -> String
 }

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_protocol_method_in_presence_of_multiple_systems.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_protocol_method_in_presence_of_multiple_systems.swift
@@ -18,7 +18,7 @@
 import Distributed
 import FakeDistributedActorSystems
 
-@_DistributedProtocol
+@Resolvable
 protocol GreeterProtocol: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
   distributed func greet() -> String
 }


### PR DESCRIPTION
The proposal was [accepted with modifications](https://forums.swift.org/t/accepted-with-modifications-se-0428-resolve-distributedactor-protocols/71366)

The decision was made to change the spelling of the attached macro in the proposal from
`@DistributedProtocol` to `@Resolvable` (or `@Distributed.Resolvable` if disambiguation is needed).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
