### PR TITLE
stdlib: avoid a condfail by using @_moveOnly

### DIFF
--- a/stdlib/public/Synchronization/Atomic.swift
+++ b/stdlib/public/Synchronization/Atomic.swift
@@ -17,7 +17,8 @@ import Builtin
 @frozen
 @_rawLayout(like: Value.AtomicRepresentation)
 @_staticExclusiveOnly
-public struct Atomic<Value: AtomicRepresentable>: ~Copyable {
+@_moveOnly
+public struct Atomic<Value: AtomicRepresentable> {
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent

--- a/stdlib/public/Synchronization/AtomicLazyReference.swift
+++ b/stdlib/public/Synchronization/AtomicLazyReference.swift
@@ -17,7 +17,8 @@
 @available(SwiftStdlib 6.0, *)
 @frozen
 @_staticExclusiveOnly
-public struct AtomicLazyReference<Instance: AnyObject>: ~Copyable {
+@_moveOnly
+public struct AtomicLazyReference<Instance: AnyObject> {
   @usableFromInline
   let storage: Atomic<Unmanaged<Instance>?>
 


### PR DESCRIPTION
This is a temporary measure and does not need to be in `main`.

rdar://126877535