### PR TITLE
[IRGen] Deadends don't need dealloc_pack_metadata.

### DIFF
--- a/validation-test/IRGen/gh72536.swift
+++ b/validation-test/IRGen/gh72536.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-emit-ir \
+// RUN:     %s                \
+// RUN:     -disable-availability-checking
+
+func foo<each S>(_ s: repeat each S) async {}
+await foo(true)
+


### PR DESCRIPTION
There is a debug-build-only verification that is done for alloc_pack_metadata instructions that checks that there exist paired dealloc_pack_metadata instructions which will be keyed off of to clean up the on-stack variadic metadata packs corresponding to (the instruction after) the alloc_pack_metadata.

StackNesting omits the deallocation instruction (as does PackMetadataMarkerInserter) if it would be created in a dead end block. If all blocks in the dominance frontier of the alloc_pack_metadata instruction are dead-end blocks, then the verification will incorrectly fail.  It should not fail because it is not necessary to clean up the on-stack pack metadata (or any other stack allocations) in such a case.

If all such blocks are dead-end blocks, however, the alloc_pack_metadata's block itself is a dead-end block as well.  So during the verification, check whether the alloc_pack_metadata occurs in a dead-end block and do not fail verification if it does.

rdar://125265980
