### PR TITLE
[SILGen] Fix a bug where the wrong convention was being used for lowering a closure to a C++ function pointer

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3758,8 +3758,14 @@ static CanSILFunctionType getSILFunctionTypeForAbstractCFunction(
     TypeConverter &TC, AbstractionPattern origType,
     CanAnyFunctionType substType, SILExtInfoBuilder extInfoBuilder,
     std::optional<SILDeclRef> constant) {
-  if (origType.isClangType()) {
-    auto clangType = origType.getClangType();
+  const clang::Type *clangType = nullptr;
+
+  if (origType.isClangType())
+    clangType = origType.getClangType();
+  else
+    clangType = extInfoBuilder.getClangTypeInfo().getType();
+
+  if (clangType) {
     const clang::FunctionType *fnType;
     if (auto blockPtr = clangType->getAs<clang::BlockPointerType>()) {
       fnType = blockPtr->getPointeeType()->castAs<clang::FunctionType>();

--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -1,0 +1,15 @@
+#ifndef __CLOSURE__
+#define __CLOSURE__
+
+struct NonTrivial {
+  NonTrivial() { p = new int(123); }
+  ~NonTrivial() { delete p; }
+  NonTrivial(const NonTrivial &other);
+  int *p;
+};
+
+void cfunc2(void (*fp)(NonTrivial)) {
+  (*fp)(NonTrivial());
+}
+
+#endif // __CLOSURE__

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -141,3 +141,8 @@ module CopyMoveAssignment {
   header "copy-move-assignment.h"
   requires cplusplus
 }
+
+module Closure {
+  header "closure.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/closure-thunk-executable.swift
+++ b/test/Interop/Cxx/class/closure-thunk-executable.swift
@@ -1,0 +1,18 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default)
+//
+// REQUIRES: executable_test
+
+// The test is enabled only on windows until https://github.com/apple/swift/pull/73019
+// is fixed.
+// REQUIRES: OS=windows-msvc
+
+import StdlibUnittest
+import Closure
+
+var ClosureTestSuite = TestSuite("Closure")
+
+ClosureTestSuite.test("ConvertToFunctionPointer") {
+  cfunc2({N in})
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/closure-thunk.swift
+++ b/test/Interop/Cxx/class/closure-thunk.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swiftxx-frontend -I %S/Inputs -emit-silgen %s | %FileCheck %s
+
+import Closure
+
+// CHECK: sil [ossa] @$s4main20testClosureToFuncPtryyF : $@convention(thin) () -> () {
+// CHECK: %[[V0:.*]] = function_ref @$s4main20testClosureToFuncPtryyFySo10NonTrivialVcfU_To : $@convention(c) (@in NonTrivial) -> ()
+// CHECK: %[[V1:.*]] = enum $Optional<@convention(c) (@in NonTrivial) -> ()>, #Optional.some!enumelt, %[[V0]] : $@convention(c) (@in NonTrivial) -> ()
+// CHECK: %[[V2:.*]] = function_ref @{{.*}}cfunc2{{.*}}NonTrivial{{.*}} : $@convention(c) (Optional<@convention(c) (@in NonTrivial) -> ()>) -> ()
+// CHECK: %[[V3:.*]] = apply %[[V2]](%[[V1]]) : $@convention(c) (Optional<@convention(c) (@in NonTrivial) -> ()>) -> ()
+
+// CHECK: sil private [ossa] @$s4main20testClosureToFuncPtryyFySo10NonTrivialVcfU_ : $@convention(thin) (@in_guaranteed NonTrivial) -> () {
+
+// CHECK: sil private [thunk] [ossa] @$s4main20testClosureToFuncPtryyFySo10NonTrivialVcfU_To : $@convention(c) (@in NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+// CHECK: %[[V1:.*]] = function_ref @$s4main20testClosureToFuncPtryyFySo10NonTrivialVcfU_ : $@convention(thin) (@in_guaranteed NonTrivial) -> ()
+// CHECK: %[[V2:.*]] = apply %[[V1]](%[[V0]]) : $@convention(thin) (@in_guaranteed NonTrivial) -> ()
+// CHECK: destroy_addr %[[V0]] : $*NonTrivial
+
+public func testClosureToFuncPtr() {
+ cfunc2({N in})
+}


### PR DESCRIPTION
Use the C function pointer convention instead of the block convention.

rdar://122977380
(cherry picked from commit d76dbb1a64cc48d8dd3813797c54d53b9dbee668)