### PR TITLE
[embedded] Mark embedded/classes-indirect-return.swift test as 'REQUIRES: OS=macosx || OS=linux-gnu'

### DIFF
--- a/test/embedded/classes-indirect-return.swift
+++ b/test/embedded/classes-indirect-return.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-emit-sil %s -enable-experimental-feature Embedded -wmo | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
 
 // CHECK: sil @$s4main1XC3fooxyFSi_Tg5 : $@convention(method) (@guaranteed X<Int>) -> Int {
 


### PR DESCRIPTION
To resolve a CI failure: https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/6077/console

rdar://126878901