### PR TITLE
[SIL] Verify complete lifetimes when option set.

### DIFF
--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -635,7 +635,9 @@ void CopyPropagation::run() {
     accessBlockAnalysis->unlockInvalidation();
     if (f->getModule().getOptions().VerifySILOwnership) {
       auto *deBlocksAnalysis = getAnalysis<DeadEndBlocksAnalysis>();
-      f->verifyOwnership(deBlocksAnalysis->get(f));
+      f->verifyOwnership(f->getModule().getOptions().OSSAVerifyComplete
+                             ? nullptr
+                             : deBlocksAnalysis->get(f));
     }
   }
 }

--- a/lib/SILOptimizer/UtilityPasses/OwnershipVerifierTextualErrorDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/OwnershipVerifierTextualErrorDumper.cpp
@@ -23,6 +23,7 @@
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 
@@ -37,8 +38,10 @@ namespace {
 class OwnershipVerifierTextualErrorDumper : public SILFunctionTransform {
   void run() override {
     SILFunction *f = getFunction();
-    DeadEndBlocks deadEndBlocks(f);
-    f->verifyOwnership(&deadEndBlocks);
+    auto *deBlocksAnalysis = getAnalysis<DeadEndBlocksAnalysis>();
+    f->verifyOwnership(f->getModule().getOptions().OSSAVerifyComplete
+                           ? nullptr
+                           : deBlocksAnalysis->get(f));
   }
 };
 


### PR DESCRIPTION
Only pass DeadEndBlocks to verifyOwnership if OSSAVerifyComplete is not set.  The verifier keys off of the nullness of DeadEndBlocks to decide whether to verify complete lifetimes or not.