### PR TITLE
[RemoteInspection] Ignore MetadataSource records with NULL source pointer.

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1989,6 +1989,9 @@ private:
   /// \param Builder Used to obtain offsets of elements known so far.
   bool isMetadataSourceReady(const MetadataSource *MS,
                              const RecordTypeInfoBuilder &Builder) {
+    if (!MS)
+      return false;
+
     switch (MS->getKind()) {
     case MetadataSourceKind::ClosureBinding:
       return true;


### PR DESCRIPTION
We'd crash on a call to getKind(). Ignore them instead by returning false from isMetadataSourceReady. If this causes getClosureContextInfo to fail to make forward progress, then it will in turn fail and return nullptr to its caller.

rdar://126866747