### PR TITLE
[region-isolation] When RegionIsolation is enabled, delay the preconcurrency import not used diagnostic to the SIL pipeline.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -269,6 +269,9 @@ private:
   /// @_dynamicReplacement(for:) function.
   SILFunction *ReplacedFunction = nullptr;
 
+  /// The SILDeclRef that this function was created for by SILGen if one exists.
+  SILDeclRef DeclRef = SILDeclRef();
+
   /// This SILFunction REFerences an ad-hoc protocol requirement witness in
   /// order to keep it alive, such that it main be obtained in IRGen. Without
   /// this explicit reference, the witness would seem not-used, and not be
@@ -1114,6 +1117,12 @@ public:
   /// Get the source location of the function.
   const SILDebugScope *getDebugScope() const { return DebugScope; }
 
+  /// Return the SILDeclRef for this SILFunction if one was assigned by SILGen.
+  SILDeclRef getDeclRef() const { return DeclRef; }
+
+  /// Set the SILDeclRef for this SILFunction. Used mainly by SILGen.
+  void setDeclRef(SILDeclRef declRef) { DeclRef = declRef; }
+
   /// Get this function's bare attribute.
   IsBare_t isBare() const { return IsBare_t(Bare); }
   void setBare(IsBare_t isB) { Bare = isB; }
@@ -1389,6 +1398,9 @@ public:
   }
 
   ActorIsolation getActorIsolation() const { return actorIsolation; }
+
+  /// Return the source file that this SILFunction belongs to if it exists.
+  SourceFile *getSourceFile() const;
 
   //===--------------------------------------------------------------------===//
   // Block List Access

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -503,6 +503,8 @@ PASS(DiagnosticDeadFunctionElimination, "sil-diagnostic-dead-function-elim",
      "Eliminate dead functions from early specialization optimizations before we run later diagnostics")
 SWIFT_FUNCTION_PASS(UpdateBorrowedFrom, "update-borrowed-from",
      "Test pass for update borrowed-from instructions")
+PASS(DiagnoseUnnecessaryPreconcurrencyImports, "sil-diagnose-unnecessary-preconcurrency-imports",
+     "Diagnose any preconcurrency imports that Sema and TransferNonSendable did not use")
 PASS(PruneVTables, "prune-vtables",
      "Mark class methods that do not require vtable dispatch")
 PASS_RANGE(AllPasses, AADumper, PruneVTables)

--- a/include/swift/Sema/Concurrency.h
+++ b/include/swift/Sema/Concurrency.h
@@ -1,0 +1,34 @@
+//===--- Concurrency.h ----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file defines concurrency utility routines from Sema that are used by
+/// later parts of the compiler like the pass pipeline.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SEMA_CONCURRENCY_H
+#define SWIFT_SEMA_CONCURRENCY_H
+
+namespace swift {
+
+class SourceFile;
+
+/// If any of the imports in this source file was @preconcurrency but there were
+/// no diagnostics downgraded or suppressed due to that @preconcurrency, suggest
+/// that the attribute be removed.
+void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf);
+
+} // namespace swift
+
+#endif

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -1189,3 +1189,11 @@ bool SILFunction::argumentMayRead(Operand *argOp, SILValue addr) {
 
   return argumentMayReadFunction({this}, {argOp}, {addr});
 }
+
+SourceFile *SILFunction::getSourceFile() const {
+  auto declRef = getDeclRef();
+  if (!declRef)
+    return nullptr;
+
+  return declRef.getInnermostDeclContext()->getParentSourceFile();
+}

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1236,6 +1236,9 @@ void SILGenModule::preEmitFunction(SILDeclRef constant, SILFunction *F,
   // Create a debug scope for the function using astNode as source location.
   F->setDebugScope(new (M) SILDebugScope(Loc, F));
 
+  // Initialize F with the constant we created for it.
+  F->setDeclRef(constant);
+
   LLVM_DEBUG(llvm::dbgs() << "lowering ";
              F->printName(llvm::dbgs());
              llvm::dbgs() << " : ";

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(swiftSILOptimizer PRIVATE
   ConsumeOperatorCopyableValuesChecker.cpp
   PhiStorageOptimizer.cpp
   ConstantPropagation.cpp
+  DiagnoseUnnecessaryPreconcurrencyImports.cpp
   DebugInfoCanonicalizer.cpp
   DefiniteInitialization.cpp
   DIMemoryUseCollector.cpp

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnnecessaryPreconcurrencyImports.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnnecessaryPreconcurrencyImports.cpp
@@ -1,0 +1,79 @@
+//===--- DiagnoseUnnecessaryPreconcurrencyImports.cpp ---------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This is run after TransferNonSendable and uses Sema infrastructure to
+/// determine if in Sema or TransferNonSendable any of the preconcurrency import
+/// statements were not used.
+///
+/// This only runs when RegionIsolation is enabled. If RegionIsolation is
+/// disabled, we emit the unnecessary preconcurrency imports earlier during Sema
+/// since no later diagnostics will be emitted.
+///
+/// NOTE: This needs to be a module pass and run after TransferNonSendable so we
+/// can guarantee that we have run TransferNonSendable on all functions in our
+/// module before this runs.
+///
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/SourceFile.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/Sema/Concurrency.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                         MARK: Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class DiagnoseUnnecessaryPreconcurrencyImports : public SILModuleTransform {
+  void run() override {
+    // If region isolation is not enabled... return early.
+    if (!getModule()->getASTContext().LangOpts.hasFeature(
+            Feature::RegionBasedIsolation))
+      return;
+
+    std::vector<SourceFile *> data;
+    for (auto &fn : *getModule()) {
+      auto *sf = fn.getSourceFile();
+      if (!sf) {
+        continue;
+      }
+
+      data.push_back(sf);
+      assert(sf->getBufferID() != -1 && "Must have a buffer id");
+    }
+
+    // Sort unique by filename so our diagnostics are deterministic.
+    //
+    // TODO: If we cannot rely upon this, just sort by pointer address. Non
+    // determinism emission of diagnostics isn't great but it isn't fatal.
+    sortUnique(data, [](SourceFile *lhs, SourceFile *rhs) -> bool {
+      return lhs->getBufferID() < rhs->getBufferID();
+    });
+
+    // At this point, we know that we have our sorted unique list of source
+    // files.
+    for (auto *sf : data) {
+      diagnoseUnnecessaryPreconcurrencyImports(*sf);
+    }
+  }
+};
+
+} // namespace
+
+SILTransform *swift::createDiagnoseUnnecessaryPreconcurrencyImports() {
+  return new DiagnoseUnnecessaryPreconcurrencyImports();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -140,8 +140,11 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addTransferNonSendable();
 
   // Now that we have completed running passes that use region analysis, clear
-  // region analysis.
+  // region analysis and emit diagnostics for unnecessary preconcurrency
+  // imports.
   P.addRegionAnalysisInvalidationTransform();
+  P.addDiagnoseUnnecessaryPreconcurrencyImports();
+
   // Lower tuple addr constructor. Eventually this can be merged into later
   // passes. This ensures we do not need to update later passes for something
   // that is only needed by TransferNonSendable().

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -23,6 +23,8 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Type.h"
+#include "swift/Sema/Concurrency.h"
+
 #include <cassert>
 
 namespace swift {
@@ -486,11 +488,6 @@ bool diagnoseNonSendableTypes(
 bool diagnoseSendabilityErrorBasedOn(
     NominalTypeDecl *nominal, SendableCheckContext fromContext,
     llvm::function_ref<bool(DiagnosticBehavior)> diagnose);
-
-/// If any of the imports in this source file was @preconcurrency but
-/// there were no diagnostics downgraded or suppressed due to that
-/// @preconcurrency, suggest that the attribute be removed.
-void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf);
 
 /// Given a set of custom attributes, pick out the global actor attributes
 /// and perform any necessary resolution and diagnostics, returning the

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -315,7 +315,11 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
     SF->typeCheckDelayedFunctions();
   }
 
-  diagnoseUnnecessaryPreconcurrencyImports(*SF);
+  // If region based isolation is enabled, we diagnose unnecessary
+  // preconcurrency imports in the SIL pipeline in the
+  // DiagnoseUnnecessaryPreconcurrencyImports pass.
+  if (!Ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation))
+    diagnoseUnnecessaryPreconcurrencyImports(*SF);
   diagnoseUnnecessaryPublicImports(*SF);
 
   // Check to see if there are any inconsistent imports.


### PR DESCRIPTION
The reason why I am doing this is that I am going to be adding support for
preconcurrency imports to TransferNonSendable. That implies that we can have
preconcurrency import suppression in the SIL pipeline and thus that emitting the
diagnostic in Sema is too early.

To do this, I introduced a new module pass called
DiagnoseUnnecessaryPreconcurrencyImports that runs after the SILFunction pass
TransferNonSendable. The reason why I use a module pass is to ensure that
TransferNonSendable has run on all functions before we attempt to emit these
diagnostics. Then in that pass, we iterate over all of the modules functions and
construct a uniqued array of SourceFiles for these functions. Then we iterate
over the uniqued SourceFiles and use the already constructed Sema machinery to
emit the diagnostic using the source files.

rdar://126928265

