### PR TITLE
[6.0] Sema: Improve warnings and notes related to access-level on imports

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1164,6 +1164,14 @@ WARNING(implementation_only_requires_library_evolution,none,
         "using '@_implementationOnly' without enabling library evolution "
         "for %0 may lead to instability during execution",
         (Identifier))
+WARNING(implementation_only_deprecated_explicit,none,
+        "'@_implementationOnly' is deprecated, use 'internal import' "
+        "and family instead",
+        ())
+WARNING(implementation_only_deprecated_implicit,none,
+        "'@_implementationOnly' is deprecated, use a bare import "
+        "as 'InternalImportsByDefault' is enabled",
+        ())
 
 ERROR(module_allowable_client_violation,none,
       "module %0 doesn't allow importation from module %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3679,7 +3679,8 @@ ERROR(inconsistent_implicit_access_level_on_import,none,
       "'%select{private|fileprivate|internal|package|public|%error}1' elsewhere",
       (Identifier, AccessLevel))
 NOTE(inconsistent_implicit_access_level_on_import_silence,none,
-      "silence these warnings by adopting 'InternalImportsByDefault'",
+      "silence these warnings by adopting the upcoming feature "
+      "'InternalImportsByDefault'",
       ())
 NOTE(inconsistent_implicit_access_level_on_import_here,none,
      "imported "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3678,6 +3678,9 @@ ERROR(inconsistent_implicit_access_level_on_import,none,
       "ambiguous implicit access level for import of %0; it is imported as "
       "'%select{private|fileprivate|internal|package|public|%error}1' elsewhere",
       (Identifier, AccessLevel))
+NOTE(inconsistent_implicit_access_level_on_import_silence,none,
+      "silence these warnings by adopting 'InternalImportsByDefault'",
+      ())
 NOTE(inconsistent_implicit_access_level_on_import_here,none,
      "imported "
      "'%select{private|fileprivate|internal|package|public|%error}0' here",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1164,13 +1164,8 @@ WARNING(implementation_only_requires_library_evolution,none,
         "using '@_implementationOnly' without enabling library evolution "
         "for %0 may lead to instability during execution",
         (Identifier))
-WARNING(implementation_only_deprecated_explicit,none,
-        "'@_implementationOnly' is deprecated, use 'internal import' "
-        "and family instead",
-        ())
-WARNING(implementation_only_deprecated_implicit,none,
-        "'@_implementationOnly' is deprecated, use a bare import "
-        "as 'InternalImportsByDefault' is enabled",
+WARNING(implementation_only_deprecated,none,
+        "'@_implementationOnly' is deprecated, use 'internal import' instead",
         ())
 
 ERROR(module_allowable_client_violation,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2504,6 +2504,11 @@ NOTE(decl_import_via_here,none,
      "'%select{private|fileprivate|internal|package|%ERROR|%ERROR}1' "
      "from %2 here",
      (const Decl *, AccessLevel, const ModuleDecl*))
+NOTE(decl_import_via_local,none,
+     "%kind0 is imported by this file as "
+     "'%select{private|fileprivate|internal|package|%ERROR|%ERROR}1' "
+     "from %2",
+     (const Decl *, AccessLevel, const ModuleDecl*))
 
 // Opaque return types
 ERROR(opaque_type_invalid_constraint,none,

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -592,17 +592,22 @@ struct AttributedImport {
   /// if the access level was implicit or explicit.
   SourceRange accessLevelRange;
 
+  /// Location of the `@_implementationOnly` attribute if set.
+  SourceRange implementationOnlyRange;
+
   AttributedImport(ModuleInfo module, SourceLoc importLoc = SourceLoc(),
                    ImportOptions options = ImportOptions(),
                    StringRef filename = {}, ArrayRef<Identifier> spiGroups = {},
                    SourceRange preconcurrencyRange = {},
                    std::optional<AccessLevel> docVisibility = std::nullopt,
                    AccessLevel accessLevel = AccessLevel::Public,
-                   SourceRange accessLevelRange = SourceRange())
+                   SourceRange accessLevelRange = SourceRange(),
+                   SourceRange implementationOnlyRange = SourceRange())
       : module(module), importLoc(importLoc), options(options),
         sourceFileArg(filename), spiGroups(spiGroups),
         preconcurrencyRange(preconcurrencyRange), docVisibility(docVisibility),
-        accessLevel(accessLevel), accessLevelRange(accessLevelRange) {
+        accessLevel(accessLevel), accessLevelRange(accessLevelRange),
+        implementationOnlyRange(implementationOnlyRange) {
     assert(!(options.contains(ImportFlags::Exported) &&
              options.contains(ImportFlags::ImplementationOnly)) ||
            options.contains(ImportFlags::Reserved));
@@ -613,7 +618,8 @@ struct AttributedImport {
     : AttributedImport(module, other.importLoc, other.options,
                        other.sourceFileArg, other.spiGroups,
                        other.preconcurrencyRange, other.docVisibility,
-                       other.accessLevel, other.accessLevelRange) { }
+                       other.accessLevel, other.accessLevelRange,
+                       other.implementationOnlyRange) { }
 
   friend bool operator==(const AttributedImport<ModuleInfo> &lhs,
                          const AttributedImport<ModuleInfo> &rhs) {
@@ -623,7 +629,8 @@ struct AttributedImport {
            lhs.spiGroups == rhs.spiGroups &&
            lhs.docVisibility == rhs.docVisibility &&
            lhs.accessLevel == rhs.accessLevel &&
-           lhs.accessLevelRange == rhs.accessLevelRange;
+           lhs.accessLevelRange == rhs.accessLevelRange &&
+           lhs.implementationOnlyRange == rhs.implementationOnlyRange;
   }
 
   AttributedImport<ImportedModule> getLoaded(ModuleDecl *loadedModule) const {

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1066,11 +1066,16 @@ CheckInconsistentAccessLevelOnImport::evaluate(
     auto &diags = mod->getDiags();
     {
       InFlightDiagnostic error =
-        diags.diagnose(implicitImport, diag::inconsistent_implicit_access_level_on_import,
-                       implicitImport->getModule()->getName(), otherAccessLevel);
+        diags.diagnose(implicitImport,
+                       diag::inconsistent_implicit_access_level_on_import,
+                       implicitImport->getModule()->getName(),
+                       otherAccessLevel);
       error.fixItInsert(implicitImport->getStartLoc(),
                         diag::inconsistent_implicit_access_level_on_import_fixit,
                         otherAccessLevel);
+      error.flush();
+      diags.diagnose(implicitImport,
+                     diag::inconsistent_implicit_access_level_on_import_silence);
     }
 
     SourceLoc accessLevelLoc = otherImport->getStartLoc();

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -807,17 +807,10 @@ void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
       import.implementationOnlyRange.isValid()) {
     if (SF.getParentModule()->isResilient()) {
       // Encourage replacing `@_implementationOnly` with `internal import`.
-      if (ctx.LangOpts.hasFeature(Feature::InternalImportsByDefault)) {
-        auto inFlight =
-          ctx.Diags.diagnose(import.importLoc,
-                             diag::implementation_only_deprecated_implicit);
-        inFlight.fixItRemove(import.implementationOnlyRange);
-      } else {
-        auto inFlight =
-          ctx.Diags.diagnose(import.importLoc,
-                             diag::implementation_only_deprecated_explicit);
-        inFlight.fixItReplace(import.implementationOnlyRange, "internal");
-      }
+      auto inFlight =
+        ctx.Diags.diagnose(import.importLoc,
+                           diag::implementation_only_deprecated);
+      inFlight.fixItReplace(import.implementationOnlyRange, "internal");
     } else if ( // Non-resilient
       !(((targetName.str() == "CCryptoBoringSSL" ||
           targetName.str() == "CCryptoBoringSSLShims") &&

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -382,7 +382,8 @@ static void highlightOffendingType(InFlightDiagnostic &diag,
 
 /// Emit a note on \p limitImport when it restricted the access level
 /// of a type.
-static void noteLimitingImport(ASTContext &ctx,
+static void noteLimitingImport(const Decl *userDecl,
+                               ASTContext &ctx,
                                const ImportAccessLevel limitImport,
                                const TypeRepr *complainRepr) {
   if (!limitImport.has_value())
@@ -393,6 +394,16 @@ static void noteLimitingImport(ASTContext &ctx,
 
   if (auto *declRefTR = dyn_cast_or_null<DeclRefTypeRepr>(complainRepr)) {
     ValueDecl *VD = declRefTR->getBoundDecl();
+
+    // When using an IDE in a large file the decl_import_via_here note
+    // may be easy to miss on the import. Duplicate the information on the
+    // error line as well so it can't be missed.
+    if (userDecl)
+      userDecl->diagnose(diag::decl_import_via_local,
+                     VD,
+                     limitImport->accessLevel,
+                     limitImport->module.importedModule);
+
     ctx.Diags.diagnose(limitImport->importLoc,
                        diag::decl_import_via_here,
                        VD,
@@ -403,6 +414,16 @@ static void noteLimitingImport(ASTContext &ctx,
                        limitImport->module.importedModule,
                        limitImport->accessLevel);
   }
+}
+
+static void noteLimitingImport(const Decl *userDecl,
+                               const ImportAccessLevel limitImport,
+                               const TypeRepr *complainRepr) {
+  if (!limitImport.has_value())
+    return;
+
+  ASTContext &ctx = userDecl->getASTContext();
+  noteLimitingImport(userDecl, ctx, limitImport, complainRepr);
 }
 
 void AccessControlCheckerBase::checkGenericParamAccess(
@@ -483,7 +504,7 @@ void AccessControlCheckerBase::checkGenericParamAccess(
         Context.Diags.diagnose(ownerDecl, diagID, ownerDecl->getDescriptiveKind(),
                                accessControlErrorKind == ACEK::Requirement);
     highlightOffendingType(diag, complainRepr);
-    noteLimitingImport(Context, minImportLimit, complainRepr);
+    noteLimitingImport(/*userDecl*/nullptr, Context, minImportLimit, complainRepr);
     return;
   }
 
@@ -500,7 +521,7 @@ void AccessControlCheckerBase::checkGenericParamAccess(
       contextAccess, minAccess, isa<FileUnit>(DC),
       accessControlErrorKind == ACEK::Requirement);
   highlightOffendingType(diag, complainRepr);
-  noteLimitingImport(Context, minImportLimit, complainRepr);
+  noteLimitingImport(/*userDecl*/nullptr, Context, minImportLimit, complainRepr);
 }
 
 void AccessControlCheckerBase::checkGenericParamAccess(
@@ -532,7 +553,7 @@ void AccessControlCheckerBase::checkGlobalActorAccess(const Decl *D) {
           auto diag = D->diagnose(diag::global_actor_not_usable_from_inline,
                                   VD);
           highlightOffendingType(diag, complainRepr);
-          noteLimitingImport(D->getASTContext(), importLimit, complainRepr);
+          noteLimitingImport(D, importLimit, complainRepr);
           return;
         }
 
@@ -544,7 +565,7 @@ void AccessControlCheckerBase::checkGlobalActorAccess(const Decl *D) {
         auto diag = D->diagnose(diag::global_actor_access, declAccess, VD,
                                 typeAccess, globalActorDecl->getName());
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(D->getASTContext(), importLimit, complainRepr);
+        noteLimitingImport(D, importLimit, complainRepr);
       });
 }
 
@@ -630,7 +651,7 @@ public:
                   isTypeContext, isExplicit, theVarAccess,
                   isa<FileUnit>(theVar->getDeclContext()),
                   typeAccess, theVar->getInterfaceType());
-      noteLimitingImport(theVar->getASTContext(), importLimit, complainRepr);
+      noteLimitingImport(theVar, importLimit, complainRepr);
     });
   }
 
@@ -664,7 +685,7 @@ public:
           TP->getLoc(), diagID, anyVar->isLet(), isTypeContext, isExplicit,
           anyVarAccess, isa<FileUnit>(anyVar->getDeclContext()), typeAccess);
       highlightOffendingType(diag, complainRepr);
-      noteLimitingImport(anyVar->getASTContext(), importLimit, complainRepr);
+      noteLimitingImport(anyVar, importLimit, complainRepr);
     });
 
     // Check the property wrapper types.
@@ -691,7 +712,7 @@ public:
                                      isa<FileUnit>(anyVar->getDeclContext()),
                                      typeAccess);
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(anyVar->getASTContext(), importLimit, complainRepr);
+        noteLimitingImport(anyVar, importLimit, complainRepr);
       });
     }
   }
@@ -740,7 +761,7 @@ public:
       auto diag = TAD->diagnose(diagID, isExplicit, aliasAccess, typeAccess,
                                 isa<FileUnit>(TAD->getDeclContext()));
       highlightOffendingType(diag, complainRepr);
-      noteLimitingImport(TAD->getASTContext(), importLimit, complainRepr);
+      noteLimitingImport(TAD, importLimit, complainRepr);
     });
   }
 
@@ -826,8 +847,7 @@ public:
       auto diag = assocType->diagnose(diagID, assocType->getFormalAccess(),
                                       minAccess, accessControlErrorKind);
       highlightOffendingType(diag, complainRepr);
-      noteLimitingImport(assocType->getASTContext(), minImportLimit,
-                         complainRepr);
+      noteLimitingImport(assocType, minImportLimit, complainRepr);
     }
   }
 
@@ -863,7 +883,7 @@ public:
         auto diag = ED->diagnose(diagID, isExplicit, enumDeclAccess, typeAccess,
                                  isa<FileUnit>(ED->getDeclContext()));
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(ED->getASTContext(), importLimit, complainRepr);
+        noteLimitingImport(ED, importLimit, complainRepr);
       });
     }
   }
@@ -925,7 +945,7 @@ public:
                          isa<FileUnit>(CD->getDeclContext()),
                          superclassLocIter->getTypeRepr() != complainRepr);
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(CD->getASTContext(), importLimit, complainRepr);
+        noteLimitingImport(CD, importLimit, complainRepr);
       });
     }
   }
@@ -1018,7 +1038,7 @@ public:
           diagID, isExplicit, protoAccess, protocolControlErrorKind, minAccess,
           isa<FileUnit>(proto->getDeclContext()), declKind);
       highlightOffendingType(diag, complainRepr);
-      noteLimitingImport(proto->getASTContext(), minImportLimit, complainRepr);
+      noteLimitingImport(proto, minImportLimit, complainRepr);
     }
   }
 
@@ -1078,7 +1098,7 @@ public:
       auto diag = SD->diagnose(diagID, isExplicit, subscriptDeclAccess,
                                minAccess, problemIsElement);
       highlightOffendingType(diag, complainRepr);
-      noteLimitingImport(SD->getASTContext(), minImportLimit, complainRepr);
+      noteLimitingImport(SD, minImportLimit, complainRepr);
     }
   }
 
@@ -1205,7 +1225,7 @@ public:
                                functionKind, entityKind,
                                hasInaccessibleParameterWrapper);
       highlightOffendingType(diag, complainRepr);
-      noteLimitingImport(fn->getASTContext(), minImportLimit, complainRepr);
+      noteLimitingImport(fn, minImportLimit, complainRepr);
     }
   }
 
@@ -1225,8 +1245,7 @@ public:
             auto diag =
                 EED->diagnose(diagID, EED->getFormalAccess(), typeAccess);
             highlightOffendingType(diag, complainRepr);
-            noteLimitingImport(EED->getASTContext(), importLimit, 
-                               complainRepr);
+            noteLimitingImport(EED, importLimit, complainRepr);
           });
     }
   }
@@ -1289,7 +1308,7 @@ public:
       auto diag = MD->diagnose(diagID, isExplicit, macroDeclAccess,
                                minAccess, problemIsResult);
       highlightOffendingType(diag, complainRepr);
-      noteLimitingImport(MD->getASTContext(), minImportLimit, complainRepr);
+      noteLimitingImport(MD, minImportLimit, complainRepr);
     }
   }
 
@@ -1412,8 +1431,7 @@ public:
           }
           Ctx.Diags.diagnose(NP->getLoc(), diagID, theVar->isLet(),
                              isTypeContext, theVar->getInterfaceType());
-          noteLimitingImport(theVar->getASTContext(), importLimit,
-                             complainRepr);
+          noteLimitingImport(theVar, importLimit, complainRepr);
         });
   }
 
@@ -1452,8 +1470,7 @@ public:
           auto diag = Ctx.Diags.diagnose(TP->getLoc(), diagID, anyVar->isLet(),
                                          isTypeContext);
           highlightOffendingType(diag, complainRepr);
-          noteLimitingImport(anyVar->getASTContext(), importLimit,
-                             complainRepr);
+          noteLimitingImport(anyVar, importLimit, complainRepr);
         });
 
     for (auto attr : anyVar->getAttachedPropertyWrappers()) {
@@ -1469,7 +1486,7 @@ public:
             diag::property_wrapper_type_not_usable_from_inline,
             anyVar->isLet(), isTypeContext);
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(anyVar->getASTContext(), importLimit, complainRepr);
+        noteLimitingImport(anyVar, importLimit, complainRepr);
       });
     }
   }
@@ -1508,7 +1525,7 @@ public:
         diagID = diag::type_alias_underlying_type_not_usable_from_inline_warn;
       auto diag = TAD->diagnose(diagID);
       highlightOffendingType(diag, complainRepr);
-      noteLimitingImport(TAD->getASTContext(), importLimit, complainRepr);
+      noteLimitingImport(TAD, importLimit, complainRepr);
     });
   }
 
@@ -1530,8 +1547,7 @@ public:
           diagID = diag::associated_type_not_usable_from_inline_warn;
         auto diag = assocType->diagnose(diagID, ACEK_Requirement);
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(assocType->getASTContext(), importLimit,
-                           complainRepr);
+        noteLimitingImport(assocType, importLimit, complainRepr);
       });
     }
     checkTypeAccess(assocType->getDefaultDefinitionType(),
@@ -1546,8 +1562,7 @@ public:
         diagID = diag::associated_type_not_usable_from_inline_warn;
       auto diag = assocType->diagnose(diagID, ACEK_DefaultDefinition);
       highlightOffendingType(diag, complainRepr);
-      noteLimitingImport(assocType->getASTContext(), importLimit,
-                         complainRepr);
+      noteLimitingImport(assocType, importLimit, complainRepr);
     });
 
     if (assocType->getTrailingWhereClause()) {
@@ -1565,8 +1580,7 @@ public:
           diagID = diag::associated_type_not_usable_from_inline_warn;
         auto diag = assocType->diagnose(diagID, ACEK_Requirement);
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(assocType->getASTContext(), importLimit,
-                           complainRepr);
+        noteLimitingImport(assocType, importLimit, complainRepr);
       });
     }
   }
@@ -1597,7 +1611,7 @@ public:
           diagID = diag::enum_raw_type_not_usable_from_inline_warn;
         auto diag = ED->diagnose(diagID);
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(ED->getASTContext(), importLimit, complainRepr);
+        noteLimitingImport(ED, importLimit, complainRepr);
       });
     }
   }
@@ -1643,7 +1657,7 @@ public:
         auto diag = CD->diagnose(diagID, superclassLocIter->getTypeRepr() !=
                                              complainRepr);
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(CD->getASTContext(), importLimit, complainRepr);
+        noteLimitingImport(CD, importLimit, complainRepr);
       });
     }
   }
@@ -1666,7 +1680,7 @@ public:
           diagID = diag::protocol_usable_from_inline_warn;
         auto diag = proto->diagnose(diagID, PCEK_Refine);
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(proto->getASTContext(), importLimit, complainRepr);
+        noteLimitingImport(proto, importLimit, complainRepr);
       });
     }
 
@@ -1685,7 +1699,7 @@ public:
           diagID = diag::protocol_usable_from_inline_warn;
         auto diag = proto->diagnose(diagID, PCEK_Requirement);
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(proto->getASTContext(), importLimit, complainRepr);
+        noteLimitingImport(proto, importLimit, complainRepr);
       });
     }
   }
@@ -1704,7 +1718,7 @@ public:
               diagID = diag::subscript_type_usable_from_inline_warn;
             auto diag = SD->diagnose(diagID, /*problemIsElement=*/false);
             highlightOffendingType(diag, complainRepr);
-            noteLimitingImport(SD->getASTContext(), importLimit, complainRepr);
+            noteLimitingImport(SD, importLimit, complainRepr);
           });
     }
 
@@ -1719,7 +1733,7 @@ public:
         diagID = diag::subscript_type_usable_from_inline_warn;
       auto diag = SD->diagnose(diagID, /*problemIsElement=*/true);
       highlightOffendingType(diag, complainRepr);
-      noteLimitingImport(SD->getASTContext(), importLimit, complainRepr);
+      noteLimitingImport(SD, importLimit, complainRepr);
     });
   }
 
@@ -1757,8 +1771,7 @@ public:
                                          /*problemIsResult=*/false,
                                          /*inaccessibleWrapper=*/true);
                 highlightOffendingType(diag, complainRepr);
-                noteLimitingImport(fn->getASTContext(), importLimit,
-                                   complainRepr);
+                noteLimitingImport(fn, importLimit, complainRepr);
               });
         }
       }
@@ -1775,7 +1788,7 @@ public:
                                      /*problemIsResult=*/false,
                                      /*inaccessibleWrapper=*/false);
             highlightOffendingType(diag, complainRepr);
-            noteLimitingImport(fn->getASTContext(), importLimit, complainRepr);
+            noteLimitingImport(fn, importLimit, complainRepr);
           });
     }
 
@@ -1793,7 +1806,7 @@ public:
                                  /*problemIsResult=*/true,
                                  /*inaccessibleWrapper=*/false);
         highlightOffendingType(diag, complainRepr);
-        noteLimitingImport(fn->getASTContext(), importLimit, complainRepr);
+        noteLimitingImport(fn, importLimit, complainRepr);
       });
     }
   }
@@ -1816,8 +1829,7 @@ public:
               diagID = diag::enum_case_usable_from_inline_warn;
             auto diag = EED->diagnose(diagID);
             highlightOffendingType(diag, complainRepr);
-            noteLimitingImport(EED->getASTContext(), importLimit,
-                               complainRepr);
+            noteLimitingImport(EED, importLimit, complainRepr);
           });
     }
   }

--- a/test/Concurrency/preconcurrency_implementationonly_override.swift
+++ b/test/Concurrency/preconcurrency_implementationonly_override.swift
@@ -11,7 +11,7 @@
 // REQUIRES: asserts
 
 @_implementationOnly import ImplementationOnlyDefs
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 class D: C {
   @_implementationOnly

--- a/test/Concurrency/preconcurrency_implementationonly_override.swift
+++ b/test/Concurrency/preconcurrency_implementationonly_override.swift
@@ -11,6 +11,7 @@
 // REQUIRES: asserts
 
 @_implementationOnly import ImplementationOnlyDefs
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 class D: C {
   @_implementationOnly

--- a/test/ModuleInterface/module_shadowing.swift
+++ b/test/ModuleInterface/module_shadowing.swift
@@ -29,7 +29,7 @@
 import ShadowyHorror
 // OTHER-DAG: ShadowyHorror.module_shadowing:{{[0-9]+:[0-9]+}}: warning: public class 'ShadowyHorror.module_shadowing' shadows module 'module_shadowing', which may cause failures when importing 'module_shadowing' or its clients in some configurations; please rename either the class 'ShadowyHorror.module_shadowing' or the module 'module_shadowing', or see https://github.com/apple/swift/issues/56573 for workarounds{{$}}
 
-@_implementationOnly import TestModule
+internal import TestModule
 #endif
 
 public struct ShadowyHorror {

--- a/test/SPI/implementation_only_spi_import_exposability.swift
+++ b/test/SPI/implementation_only_spi_import_exposability.swift
@@ -27,7 +27,7 @@ public protocol IOIProtocol {}
 #elseif CLIENT
 
 @_spi(A) @_implementationOnly import Lib
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 @_spi(B) public func leakSPIStruct(_ a: SPIStruct) -> SPIStruct { fatalError() } // expected-warning 2 {{cannot use struct 'SPIStruct' here; 'Lib' has been imported as implementation-only}}
 @_spi(B) public func leakIOIStruct(_ a: IOIStruct) -> IOIStruct { fatalError() } // expected-warning 2 {{cannot use struct 'IOIStruct' here; 'Lib' has been imported as implementation-only}}

--- a/test/SPI/implementation_only_spi_import_exposability.swift
+++ b/test/SPI/implementation_only_spi_import_exposability.swift
@@ -27,6 +27,7 @@ public protocol IOIProtocol {}
 #elseif CLIENT
 
 @_spi(A) @_implementationOnly import Lib
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 @_spi(B) public func leakSPIStruct(_ a: SPIStruct) -> SPIStruct { fatalError() } // expected-warning 2 {{cannot use struct 'SPIStruct' here; 'Lib' has been imported as implementation-only}}
 @_spi(B) public func leakIOIStruct(_ a: IOIStruct) -> IOIStruct { fatalError() } // expected-warning 2 {{cannot use struct 'IOIStruct' here; 'Lib' has been imported as implementation-only}}

--- a/test/SPI/report-ioi-in-spi.swift
+++ b/test/SPI/report-ioi-in-spi.swift
@@ -26,7 +26,7 @@ public struct IOIStruct {
 //--- ClientSPIOnlyMode.swift
 
 @_implementationOnly import Lib
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 @_spi(X) public func spiClient(s: IOIStruct) -> IOIStruct { // expected-error 2 {{cannot use struct 'IOIStruct' here; 'Lib' has been imported as implementation-only}}
     return IOIStruct()
@@ -40,7 +40,7 @@ public struct IOIStruct {
 //--- ClientDefaultMode.swift
 
 @_implementationOnly import Lib
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 @_spi(X) public func spiClient(s: IOIStruct) -> IOIStruct { // expected-warning 2 {{cannot use struct 'IOIStruct' here; 'Lib' has been imported as implementation-only}}
     return IOIStruct()

--- a/test/SPI/report-ioi-in-spi.swift
+++ b/test/SPI/report-ioi-in-spi.swift
@@ -26,6 +26,7 @@ public struct IOIStruct {
 //--- ClientSPIOnlyMode.swift
 
 @_implementationOnly import Lib
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 @_spi(X) public func spiClient(s: IOIStruct) -> IOIStruct { // expected-error 2 {{cannot use struct 'IOIStruct' here; 'Lib' has been imported as implementation-only}}
     return IOIStruct()
@@ -39,6 +40,7 @@ public struct IOIStruct {
 //--- ClientDefaultMode.swift
 
 @_implementationOnly import Lib
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 @_spi(X) public func spiClient(s: IOIStruct) -> IOIStruct { // expected-warning 2 {{cannot use struct 'IOIStruct' here; 'Lib' has been imported as implementation-only}}
     return IOIStruct()

--- a/test/SPI/spi-only-import-conflicting.swift
+++ b/test/SPI/spi-only-import-conflicting.swift
@@ -60,6 +60,7 @@ import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
 // expected-warning @-1 {{'Lib' inconsistently imported as implementation-only}}
 @_implementationOnly import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
 // expected-note @-1 {{imported as implementation-only here}}
+// expected-warning @-2 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 /// Many confliciting imports lead to many diagnostics.
 //--- SPIOnly_IOI_Exported_Default.swift
@@ -67,6 +68,7 @@ import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
 // expected-warning @-1 {{'Lib' inconsistently imported as implementation-only}}
 @_implementationOnly import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
 // expected-note @-1 3 {{imported as implementation-only here}}
+// expected-warning @-2 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 @_exported import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
 // expected-warning @-1 {{'Lib' inconsistently imported as implementation-only}}
 import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
@@ -82,6 +84,7 @@ import Lib
 /// Different IOI in different files of the same module are still rejected.
 //--- IOI_Default_FileA.swift
 @_implementationOnly import Lib // expected-note {{imported as implementation-only here}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 //--- IOI_Default_FileB.swift
 import Lib // expected-warning {{'Lib' inconsistently imported as implementation-only}}

--- a/test/SPI/spi-only-import-conflicting.swift
+++ b/test/SPI/spi-only-import-conflicting.swift
@@ -60,7 +60,7 @@ import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
 // expected-warning @-1 {{'Lib' inconsistently imported as implementation-only}}
 @_implementationOnly import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
 // expected-note @-1 {{imported as implementation-only here}}
-// expected-warning @-2 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-2 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 /// Many confliciting imports lead to many diagnostics.
 //--- SPIOnly_IOI_Exported_Default.swift
@@ -68,7 +68,7 @@ import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
 // expected-warning @-1 {{'Lib' inconsistently imported as implementation-only}}
 @_implementationOnly import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
 // expected-note @-1 3 {{imported as implementation-only here}}
-// expected-warning @-2 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-2 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 @_exported import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
 // expected-warning @-1 {{'Lib' inconsistently imported as implementation-only}}
 import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
@@ -84,7 +84,7 @@ import Lib
 /// Different IOI in different files of the same module are still rejected.
 //--- IOI_Default_FileA.swift
 @_implementationOnly import Lib // expected-note {{imported as implementation-only here}}
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 //--- IOI_Default_FileB.swift
 import Lib // expected-warning {{'Lib' inconsistently imported as implementation-only}}

--- a/test/Sema/access-level-import-diag-priority.swift
+++ b/test/Sema/access-level-import-diag-priority.swift
@@ -46,23 +46,29 @@ private import PrivateLib // expected-note 1 {{struct 'PrivateImportType' import
 
 /// Simple ordering
 public func publicFuncUsesPrivate(_ a: PublicImportType, b: PackageImportType, c: InternalImportType, d: FileprivateImportType, e: PrivateImportType) { // expected-error {{function cannot be declared public because its parameter uses a fileprivate type}}
+// expected-note @-1 {{struct 'FileprivateImportType' is imported by this file as 'fileprivate' from 'FileprivateLib'}}
     var _: PrivateImportType
 }
 public func publicFuncUsesFileprivate(_ a: PublicImportType, b: PackageImportType, c: InternalImportType, d: FileprivateImportType) { // expected-error {{function cannot be declared public because its parameter uses a fileprivate type}}
+// expected-note @-1 {{struct 'FileprivateImportType' is imported by this file as 'fileprivate' from 'FileprivateLib'}}
     var _: PrivateImportType
 }
 public func publicFuncUsesInternal(_ a: PublicImportType, b: PackageImportType, c: InternalImportType) { // expected-error {{function cannot be declared public because its parameter uses an internal type}}
+// expected-note @-1 {{struct 'InternalImportType' is imported by this file as 'internal' from 'InternalLib'}}
     var _: PrivateImportType
 }
 public func publicFuncUsesPackage(_ a: PublicImportType, b: PackageImportType) { // expected-error {{function cannot be declared public because its parameter uses a package type}}
+// expected-note @-1 {{struct 'PackageImportType' is imported by this file as 'package' from 'PackageLib'}}
     var _: PrivateImportType
 }
 
 /// Disordered
 public func publicFuncUsesPrivateScambled(_ a: PublicImportType, b: PackageImportType, e: PrivateImportType, c: InternalImportType, d: FileprivateImportType) { // expected-error {{function cannot be declared public because its parameter uses a private type}}
+// expected-note @-1 {{struct 'PrivateImportType' is imported by this file as 'private' from 'PrivateLib'}}
     var _: PrivateImportType
 }
 public func publicFuncUsesPrivateScambled(_ a: PublicImportType, d: FileprivateImportType, b: PackageImportType, c: InternalImportType) { // expected-error {{function cannot be declared public because its parameter uses a fileprivate type}}
+// expected-note @-1 {{struct 'FileprivateImportType' is imported by this file as 'fileprivate' from 'FileprivateLib'}}
     var _: PrivateImportType
 }
 
@@ -98,3 +104,4 @@ public func localVsImportedType3(a: LocalType, b: FileprivateImportType) {} // e
 
 /// Only this one points to the imported type.
 public func localVsImportedType4(a: FileprivateImportType, b: LocalType) {} // expected-error {{function cannot be declared public because its parameter uses a fileprivate type}}
+// expected-note @-1 {{struct 'FileprivateImportType' is imported by this file as 'fileprivate' from 'FileprivateLib'}}

--- a/test/Sema/access-level-import-exportability.swift
+++ b/test/Sema/access-level-import-exportability.swift
@@ -122,10 +122,12 @@ fileprivate import FileprivateLib // expected-note {{class 'FileprivateImportCla
 private import PrivateLib
 
 public func PublicFuncUsesInternal(_: InternalImportType) { // expected-error {{function cannot be declared public because its parameter uses an internal type}}
+// expected-note @-1 {{struct 'InternalImportType' is imported by this file as 'internal' from 'InternalLib'}}
     var _: InternalImportType
 }
 
 public class PublicSubclassFileprivate : FileprivateImportClass {} // expected-error {{class cannot be declared public because its superclass is fileprivate}}
+// expected-note @-1 {{class 'FileprivateImportClass' is imported by this file as 'fileprivate' from 'FileprivateLib'}}
 
 /// More complete test.
 //--- CompletenessClient.swift
@@ -144,15 +146,19 @@ public func PublicFuncUsesPublic(_: PublicImportType) {
     var _: PublicImportType
 }
 public func PublicFuncUsesPackage(_: PackageImportType) { // expected-error {{function cannot be declared public because its parameter uses a package type}}
+// expected-note @-1 {{is imported by this file as}}
     var _: PackageImportType
 }
 public func PublicFuncUsesInternal(_: InternalImportType) { // expected-error {{function cannot be declared public because its parameter uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     var _: InternalImportType
 }
 public func PublicFuncUsesFileprivate(_: FileprivateImportType) { // expected-error {{function cannot be declared public because its parameter uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     var _: FileprivateImportType
 }
 public func PublicFuncUsesPrivate(_: PrivateImportType) { // expected-error {{function cannot be declared public because its parameter uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
     var _: PrivateImportType
 }
 
@@ -164,12 +170,15 @@ package func PackageFuncUsesPackage(_: PackageImportType) {
     var _: PackageImportType
 }
 package func PackageFuncUsesInternal(_: InternalImportType) { // expected-error {{function cannot be declared package because its parameter uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     var _: InternalImportType
 }
 package func PackageFuncUsesFileprivate(_: FileprivateImportType) { // expected-error {{function cannot be declared package because its parameter uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     var _: FileprivateImportType
 }
 package func PackageFuncUsesPrivate(_: PrivateImportType) { // expected-error {{function cannot be declared package because its parameter uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
     var _: PrivateImportType
 }
 
@@ -184,9 +193,11 @@ internal func InternalFuncUsesInternal(_: InternalImportType) {
     var _: InternalImportType
 }
 internal func InternalFuncUsesFileprivate(_: FileprivateImportType) { // expected-error {{function cannot be declared internal because its parameter uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     var _: FileprivateImportType
 }
 internal func InternalFuncUsesPrivate(_: PrivateImportType) { // expected-error {{function cannot be declared internal because its parameter uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
     var _: PrivateImportType
 }
 
@@ -228,15 +239,19 @@ public func PublicFuncReturnUsesPublic() -> PublicImportType {
     fatalError()
 }
 public func PublicFuncReturnUsesPackage() -> PackageImportType { // expected-error {{function cannot be declared public because its result uses a package type}}
+// expected-note @-1 {{is imported by this file as}}
     fatalError()
 }
 public func PublicFuncReturnUsesInternal() -> InternalImportType { // expected-error {{function cannot be declared public because its result uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     fatalError()
 }
 public func PublicFuncReturnUsesFileprivate() -> FileprivateImportType { // expected-error {{function cannot be declared public because its result uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     fatalError()
 }
 public func PublicFuncReturnUsesPrivate() -> PrivateImportType { // expected-error {{function cannot be declared public because its result uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
     fatalError()
 }
 
@@ -248,12 +263,15 @@ package func PackageFuncReturnUsesPackage() -> PackageImportType {
     fatalError()
 }
 package func PackageFuncReturnUsesInternal() -> InternalImportType { // expected-error {{function cannot be declared package because its result uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     fatalError()
 }
 package func PackageFuncReturnUsesFileprivate() -> FileprivateImportType { // expected-error {{function cannot be declared package because its result uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     fatalError()
 }
 package func PackageFuncReturnUsesPrivate() -> PrivateImportType { // expected-error {{function cannot be declared package because its result uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
     fatalError()
 }
 
@@ -268,9 +286,11 @@ internal func InternalFuncReturnUsesInternal() -> InternalImportType {
     fatalError()
 }
 internal func InternalFuncReturnUsesFileprivate() -> FileprivateImportType { // expected-error {{function cannot be declared internal because its result uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     fatalError()
 }
 internal func InternalFuncReturnUsesPrivate() -> PrivateImportType { // expected-error {{function cannot be declared internal because its result uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
     fatalError()
 }
 
@@ -316,22 +336,26 @@ public struct PublicSubscriptUsesPublic {
 }
 public struct PublicSubscriptUsesPackage {
     public subscript(index: PackageImportType) -> PackageImportType { // expected-error {{subscript cannot be declared public because its element type uses a package type}}
+// expected-note @-1 {{is imported by this file as}}
     // This error should be on the `index` like the other ones.
         fatalError()
     }
 }
 public struct PublicSubscriptUsesInternal {
     public subscript(index: InternalImportType) -> InternalImportType { // expected-error {{subscript cannot be declared public because its index uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
         fatalError()
     }
 }
 public struct PublicSubscriptUsesFileprivate {
     public subscript(index: FileprivateImportType) -> FileprivateImportType { // expected-error {{subscript cannot be declared public because its index uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
         fatalError()
     }
 }
 public struct PublicSubscriptUsesPrivate {
     public subscript(index: PrivateImportType) -> PrivateImportType { // expected-error {{subscript cannot be declared public because its index uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
         fatalError()
     }
 }
@@ -349,16 +373,19 @@ package struct PackageSubscriptUsesPackage {
 }
 package struct PackageSubscriptUsesInternal {
     package subscript(index: InternalImportType) -> InternalImportType { // expected-error {{subscript cannot be declared package because its index uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
         fatalError()
     }
 }
 package struct PackageSubscriptUsesFileprivate {
     package subscript(index: FileprivateImportType) -> FileprivateImportType { // expected-error {{subscript cannot be declared package because its index uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
         fatalError()
     }
 }
 package struct PackageSubscriptUsesPrivate {
     package subscript(index: PrivateImportType) -> PrivateImportType { // expected-error {{subscript cannot be declared package because its index uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
         fatalError()
     }
 }
@@ -381,11 +408,13 @@ internal struct InternalSubscriptUsesInternal {
 }
 internal struct InternalSubscriptUsesFileprivate {
     internal subscript(index: FileprivateImportType) -> FileprivateImportType { // expected-error {{subscript cannot be declared internal because its index uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
         fatalError()
     }
 }
 internal struct InternalSubscriptUsesPrivate {
     internal subscript(index: PrivateImportType) -> PrivateImportType { // expected-error {{subscript cannot be declared internal because its index uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
         fatalError()
     }
 }
@@ -446,59 +475,86 @@ private struct PrivateSubscriptUsesPrivate {
 
 public protocol PublicProtoUsesPublic: PublicImportProto where T == PublicImportType {}
 public protocol PublicProtoWherePackage: PublicImportProto where T == PackageImportType {} // expected-error {{public protocol's 'where' clause cannot use a package struct}}
+// expected-note @-1 {{is imported by this file as}}
 public protocol PublicProtoWhereInternal: PublicImportProto where T == InternalImportType {} // expected-error {{public protocol's 'where' clause cannot use an internal struct}}
+// expected-note @-1 {{is imported by this file as}}
 public protocol PublicProtoWhereFileprivate: PublicImportProto where T == FileprivateImportType {} // expected-error {{public protocol's 'where' clause cannot use a fileprivate struct}}
+// expected-note @-1 {{is imported by this file as}}
 public protocol PublicProtoWherePrivate: PublicImportProto where T == PrivateImportType {} // expected-error {{public protocol's 'where' clause cannot use a private struct}}
+// expected-note @-1 {{is imported by this file as}}
 
 public protocol PublicProtoRefinesPublic: PublicImportProto {}
 public protocol PublicProtoRefinesPackage: PackageImportProto {} // expected-error {{public protocol cannot refine a package protocol}}
+// expected-note @-1 {{is imported by this file as}}
 public protocol PublicProtoRefinesInternal: InternalImportProto {} // expected-error {{public protocol cannot refine an internal protocol}}
+// expected-note @-1 {{is imported by this file as}}
 public protocol PublicProtoRefinesFileprivate: FileprivateImportProto {} // expected-error {{public protocol cannot refine a fileprivate protocol}}
+// expected-note @-1 {{is imported by this file as}}
 public protocol PublicProtoRefinesPrivate: PrivateImportProto {} // expected-error {{public protocol cannot refine a private protocol}}
+// expected-note @-1 {{is imported by this file as}}
 
 public class PublicSubclassPublic : PublicImportClass {}
 public class PublicSubclassPackage : PackageImportClass {} // expected-error {{class cannot be declared public because its superclass is package}}
+// expected-note @-1 {{is imported by this file as}}
 public class PublicSubclassInternal : InternalImportClass {} // expected-error {{class cannot be declared public because its superclass is internal}}
+// expected-note @-1 {{is imported by this file as}}
 public class PublicSubclassFileprivate : FileprivateImportClass {} // expected-error {{class cannot be declared public because its superclass is fileprivate}}
+// expected-note @-1 {{is imported by this file as}}
 public class PublicSubclassPrivate : PrivateImportClass {} // expected-error {{class cannot be declared public because its superclass is private}}
+// expected-note @-1 {{is imported by this file as}}
 
 
 package protocol PackageProtoUsesPublic: PublicImportProto where T == PublicImportType {}
 package protocol PackageProtoWherePackage: PublicImportProto where T == PackageImportType {}
 package protocol PackageProtoWhereInternal: PublicImportProto where T == InternalImportType {} // expected-error {{package protocol's 'where' clause cannot use an internal struct}}
+// expected-note @-1 {{is imported by this file as}}
 package protocol PackageProtoWhereFileprivate: PublicImportProto where T == FileprivateImportType {} // expected-error {{package protocol's 'where' clause cannot use a fileprivate struct}}
+// expected-note @-1 {{is imported by this file as}}
 package protocol PackageProtoWherePrivate: PublicImportProto where T == PrivateImportType {} // expected-error {{package protocol's 'where' clause cannot use a private struct}}
+// expected-note @-1 {{is imported by this file as}}
 
 package protocol PackageProtoRefinesPublic: PublicImportProto {}
 package protocol PackageProtoRefinesPackage: PackageImportProto {}
 package protocol PackageProtoRefinesInternal: InternalImportProto {} // expected-error {{package protocol cannot refine an internal protocol}}
+// expected-note @-1 {{is imported by this file as}}
 package protocol PackageProtoRefinesFileprivate: FileprivateImportProto {} // expected-error {{package protocol cannot refine a fileprivate protocol}}
+// expected-note @-1 {{is imported by this file as}}
 package protocol PackageProtoRefinesPrivate: PrivateImportProto {} // expected-error {{package protocol cannot refine a private protocol}}
+// expected-note @-1 {{is imported by this file as}}
 
 package class PackageSubclassPublic : PublicImportClass {}
 package class PackageSubclassPackage : PackageImportClass {}
 package class PackageSubclassInternal : InternalImportClass {} // expected-error {{class cannot be declared package because its superclass is internal}}
+// expected-note @-1 {{is imported by this file as}}
 package class PackageSubclassFileprivate : FileprivateImportClass {} // expected-error {{class cannot be declared package because its superclass is fileprivate}}
+// expected-note @-1 {{is imported by this file as}}
 package class PackageSubclassPrivate : PrivateImportClass {} // expected-error {{class cannot be declared package because its superclass is private}}
+// expected-note @-1 {{is imported by this file as}}
 
 
 internal protocol InternalProtoUsesPublic: PublicImportProto where T == PublicImportType {}
 internal protocol InternalProtoWherePackage: PublicImportProto where T == PackageImportType {}
 internal protocol InternalProtoWhereInternal: PublicImportProto where T == InternalImportType {}
 internal protocol InternalProtoWhereFileprivate: PublicImportProto where T == FileprivateImportType {} // expected-error {{internal protocol's 'where' clause cannot use a fileprivate struct}}
+// expected-note @-1 {{is imported by this file as}}
 internal protocol InternalProtoWherePrivate: PublicImportProto where T == PrivateImportType {} // expected-error {{internal protocol's 'where' clause cannot use a private struct}}
+// expected-note @-1 {{is imported by this file as}}
 
 internal protocol InternalProtoRefinesPublic: PublicImportProto {}
 internal protocol InternalProtoRefinesPackage: PackageImportProto {}
 internal protocol InternalProtoRefinesInternal: InternalImportProto {}
 internal protocol InternalProtoRefinesFileprivate: FileprivateImportProto {} // expected-error {{internal protocol cannot refine a fileprivate protocol}}
+// expected-note @-1 {{is imported by this file as}}
 internal protocol InternalProtoRefinesPrivate: PrivateImportProto {} // expected-error {{internal protocol cannot refine a private protocol}}
+// expected-note @-1 {{is imported by this file as}}
 
 internal class InternalSubclassPublic : PublicImportClass {}
 internal class InternalSubclassPackage : PackageImportClass {}
 internal class InternalSubclassInternal : InternalImportClass {}
 internal class InternalSubclassFileprivate : FileprivateImportClass {} // expected-error {{class cannot be declared internal because its superclass is fileprivate}}
+// expected-note @-1 {{is imported by this file as}}
 internal class InternalSubclassPrivate : PrivateImportClass {} // expected-error {{class cannot be declared internal because its superclass is private}}
+// expected-note @-1 {{is imported by this file as}}
 
 
 fileprivate protocol FileprivateProtoUsesPublic: PublicImportProto where T == PublicImportType {}
@@ -541,17 +597,24 @@ private class PrivateSubclassPrivate : PrivateImportClass {}
 public struct PublicTypeAliasUses {
     public typealias TAPublic = PublicImportProto
     public typealias TAPackage = PackageImportProto // expected-error {{type alias cannot be declared public because its underlying type uses a package type}}
+// expected-note @-1 {{is imported by this file as}}
     public typealias TAInternal = InternalImportProto // expected-error {{type alias cannot be declared public because its underlying type uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     public typealias TAFileprivate = FileprivateImportProto // expected-error {{type alias cannot be declared public because its underlying type uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     public typealias TAPrivate = PrivateImportProto // expected-error {{type alias cannot be declared public because its underlying type uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 }
 
 package struct PackageTypeAliasUses {
     package typealias TAPublic = PublicImportProto
     package typealias TAPackage = PackageImportProto
     package typealias TAInternal = InternalImportProto // expected-error {{type alias cannot be declared package because its underlying type uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     package typealias TAFileprivate = FileprivateImportProto // expected-error {{type alias cannot be declared package because its underlying type uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     package typealias TAPrivate = PrivateImportProto // expected-error {{type alias cannot be declared package because its underlying type uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 }
 
 internal struct InternalTypeAliasUses {
@@ -559,7 +622,9 @@ internal struct InternalTypeAliasUses {
     internal typealias TAPackage = PackageImportProto
     internal typealias TAInternal = InternalImportProto
     internal typealias TAFileprivate = FileprivateImportProto // expected-error {{type alias cannot be declared internal because its underlying type uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     internal typealias TAPrivate = PrivateImportProto // expected-error {{type alias cannot be declared internal because its underlying type uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 }
 
 fileprivate struct FileprivateTypeAliasUses {
@@ -581,29 +646,43 @@ private struct PrivateTypeAliasUses {
 public protocol PublicProtocol {
     associatedtype ATDefaultPublic = PublicImportProto
     associatedtype ATDefaultPackage = PackageImportProto // expected-error {{associated type in a public protocol uses a package type in its default definition}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATDefaultInternal = InternalImportProto // expected-error {{associated type in a public protocol uses an internal type in its default definition}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATDefaultFileprivate = FileprivateImportProto // expected-error {{associated type in a public protocol uses a fileprivate type in its default definition}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATDefaultPrivate = PrivateImportProto // expected-error {{associated type in a public protocol uses a private type in its default definition}}
+// expected-note @-1 {{is imported by this file as}}
 
     associatedtype ATRequirePublic: PublicImportProto
     associatedtype ATRequirePackage: PackageImportProto // expected-error {{associated type in a public protocol uses a package type in its requirement}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATRequireInternal: InternalImportProto // expected-error {{associated type in a public protocol uses an internal type in its requirement}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATRequireFileprivate: FileprivateImportProto // expected-error {{associated type in a public protocol uses a fileprivate type in its requirement}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATRequirePrivate: PrivateImportProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+// expected-note @-1 {{is imported by this file as}}
 }
 
 package protocol PackageProtocol {
     associatedtype ATDefaultPublic = PublicImportProto
     associatedtype ATDefaultPackage = PackageImportProto
     associatedtype ATDefaultInternal = InternalImportProto // expected-error {{associated type in a package protocol uses an internal type in its default definition}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATDefaultFileprivate = FileprivateImportProto // expected-error {{associated type in a package protocol uses a fileprivate type in its default definition}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATDefaultPrivate = PrivateImportProto // expected-error {{associated type in a package protocol uses a private type in its default definition}}
+// expected-note @-1 {{is imported by this file as}}
 
     associatedtype ATRequirePublic: PublicImportProto
     associatedtype ATRequirePackage: PackageImportProto
     associatedtype ATRequireInternal: InternalImportProto // expected-error {{associated type in a package protocol uses an internal type in its requirement}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATRequireFileprivate: FileprivateImportProto // expected-error {{associated type in a package protocol uses a fileprivate type in its requirement}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATRequirePrivate: PrivateImportProto // expected-error {{associated type in a package protocol uses a private type in its requirement}}
+// expected-note @-1 {{is imported by this file as}}
 }
 
 internal protocol InternalProtocol {
@@ -611,13 +690,17 @@ internal protocol InternalProtocol {
     associatedtype ATDefaultPackage = PackageImportProto
     associatedtype ATDefaultInternal = InternalImportProto
     associatedtype ATDefaultFileprivate = FileprivateImportProto // expected-error {{associated type in an internal protocol uses a fileprivate type in its default definition}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATDefaultPrivate = PrivateImportProto // expected-error {{associated type in an internal protocol uses a private type in its default definition}}
+// expected-note @-1 {{is imported by this file as}}
 
     associatedtype ATRequirePublic: PublicImportProto
     associatedtype ATRequirePackage: PackageImportProto
     associatedtype ATRequireInternal: InternalImportProto
     associatedtype ATRequireFileprivate: FileprivateImportProto // expected-error {{associated type in an internal protocol uses a fileprivate type in its requirement}}
+// expected-note @-1 {{is imported by this file as}}
     associatedtype ATRequirePrivate: PrivateImportProto // expected-error {{associated type in an internal protocol uses a private type in its requirement}}
+// expected-note @-1 {{is imported by this file as}}
 }
 
 fileprivate protocol FileprivateProtocol {
@@ -652,20 +735,28 @@ private protocol PrivateProtocol {
 public struct PublicVars {
     public var a: PublicImportType
     public var b: PackageImportType // expected-error {{property cannot be declared public because its type uses a package type}}
+// expected-note @-1 {{is imported by this file as}}
     public var c: InternalImportType // expected-error {{property cannot be declared public because its type uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     public var d: FileprivateImportType // expected-error {{property cannot be declared public because its type uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     public var e: PrivateImportType // expected-error {{property cannot be declared public because its type uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 
     @PublicLibWrapper
     public var f: PublicImportType
     @PackageLibWrapper
     public var g: PublicImportType // expected-error {{property cannot be declared public because its property wrapper type uses a package type}}
+// expected-note @-1 {{is imported by this file as}}
     @InternalLibWrapper
     public var h: PublicImportType // expected-error {{property cannot be declared public because its property wrapper type uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     @FileprivateLibWrapper
     public var i: PublicImportType // expected-error {{property cannot be declared public because its property wrapper type uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     @PrivateLibWrapper
     public var j: PublicImportType // expected-error {{property cannot be declared public because its property wrapper type uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 
     public var k = PublicImportType()
     public var l = PackageImportType() // expected-error {{property cannot be declared public because its type 'PackageImportType' uses a package type}}
@@ -678,8 +769,11 @@ package struct PackageVars {
     package var a: PublicImportType
     package var b: PackageImportType
     package var c: InternalImportType // expected-error {{property cannot be declared package because its type uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     package var d: FileprivateImportType // expected-error {{property cannot be declared package because its type uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     package var e: PrivateImportType // expected-error {{property cannot be declared package because its type uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 
     @PublicLibWrapper
     package var f: PublicImportType
@@ -687,10 +781,13 @@ package struct PackageVars {
     package var g: PublicImportType
     @InternalLibWrapper
     package var h: PublicImportType // expected-error {{property cannot be declared package because its property wrapper type uses an internal type}}
+// expected-note @-1 {{is imported by this file as}}
     @FileprivateLibWrapper
     package var i: PublicImportType // expected-error {{property cannot be declared package because its property wrapper type uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     @PrivateLibWrapper
     package var j: PublicImportType // expected-error {{property cannot be declared package because its property wrapper type uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 
     package var k = PublicImportType()
     package var l = PackageImportType()
@@ -704,7 +801,9 @@ internal struct InternalVars {
     internal var b: PackageImportType
     internal var c: InternalImportType
     internal var d: FileprivateImportType // expected-error {{property cannot be declared internal because its type uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     internal var e: PrivateImportType // expected-error {{property cannot be declared internal because its type uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 
     @PublicLibWrapper
     internal var f: PublicImportType
@@ -714,8 +813,10 @@ internal struct InternalVars {
     internal var h: PublicImportType
     @FileprivateLibWrapper
     internal var i: PublicImportType // expected-error {{property cannot be declared internal because its property wrapper type uses a fileprivate type}}
+// expected-note @-1 {{is imported by this file as}}
     @PrivateLibWrapper
     internal var j: PublicImportType // expected-error {{property cannot be declared internal because its property wrapper type uses a private type}}
+// expected-note @-1 {{is imported by this file as}}
 
     internal var k = PublicImportType()
     internal var l = PackageImportType()

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -49,6 +49,7 @@ private import Lib
 // RUN:   -primary-file %t/ManyFiles_ImplicitVsInternal_FileA.swift -verify
 //--- ManyFiles_ImplicitVsInternal_FileA.swift
 import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'internal' elsewhere}}
+// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
 //--- ManyFiles_ImplicitVsInternal_FileB.swift
 internal import Lib // expected-note {{imported 'internal' here}}
 
@@ -56,6 +57,7 @@ internal import Lib // expected-note {{imported 'internal' here}}
 // RUN:   -primary-file %t/ManyFiles_ImplicitVsPackage_FileA.swift -verify
 //--- ManyFiles_ImplicitVsPackage_FileA.swift
 import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'package' elsewhere}}
+// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
 //--- ManyFiles_ImplicitVsPackage_FileB.swift
 package import Lib // expected-note {{imported 'package' here}} @:1
 

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -49,7 +49,7 @@ private import Lib
 // RUN:   -primary-file %t/ManyFiles_ImplicitVsInternal_FileA.swift -verify
 //--- ManyFiles_ImplicitVsInternal_FileA.swift
 import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'internal' elsewhere}}
-// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
+// expected-note @-1 {{silence these warnings by adopting the upcoming feature 'InternalImportsByDefault'}}
 //--- ManyFiles_ImplicitVsInternal_FileB.swift
 internal import Lib // expected-note {{imported 'internal' here}}
 
@@ -57,7 +57,7 @@ internal import Lib // expected-note {{imported 'internal' here}}
 // RUN:   -primary-file %t/ManyFiles_ImplicitVsPackage_FileA.swift -verify
 //--- ManyFiles_ImplicitVsPackage_FileA.swift
 import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'package' elsewhere}}
-// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
+// expected-note @-1 {{silence these warnings by adopting the upcoming feature 'InternalImportsByDefault'}}
 //--- ManyFiles_ImplicitVsPackage_FileB.swift
 package import Lib // expected-note {{imported 'package' here}} @:1
 

--- a/test/Sema/access-level-import-inconsistent-same-file.swift
+++ b/test/Sema/access-level-import-inconsistent-same-file.swift
@@ -57,7 +57,7 @@ public func dummyAPI(t1: Lib1.Type1, t2: Lib2.Type1, t3: Lib3.Type1) {}
 /// Simple public vs internal, imports defaults to public.
 import Lib1 // expected-note {{imported 'public' here}}
 // expected-error @-1 {{ambiguous implicit access level for import of 'Lib1'; it is imported as 'internal' elsewhere}}
-// expected-note @-2 {{silence these warnings by adopting 'InternalImportsByDefault'}}
+// expected-note @-2 {{silence these warnings by adopting the upcoming feature 'InternalImportsByDefault'}}
 internal import Lib1 // expected-warning {{module 'Lib1' is imported as 'public' from the same file; this 'internal' access level will be ignored}}
 // expected-note @-1 {{imported 'internal' here}}
 
@@ -66,7 +66,7 @@ public import Lib2
 // expected-note @-1 {{imported 'public' here}}
 import Lib2
 // expected-error @-1 {{ambiguous implicit access level for import of 'Lib2'; it is imported as 'public' elsewhere}}
-// expected-note @-2 {{silence these warnings by adopting 'InternalImportsByDefault'}}
+// expected-note @-2 {{silence these warnings by adopting the upcoming feature 'InternalImportsByDefault'}}
 
 public func dummyAPI(t: Lib1.Type1, t2: Lib2.Type1) {}
 

--- a/test/Sema/access-level-import-inconsistent-same-file.swift
+++ b/test/Sema/access-level-import-inconsistent-same-file.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
+// RUN: split-file %s %t --leading-lines
 
 /// Build the library.
 // RUN: %target-swift-frontend -emit-module %t/Lib.swift -module-name Lib1 -o %t
@@ -57,6 +57,7 @@ public func dummyAPI(t1: Lib1.Type1, t2: Lib2.Type1, t3: Lib3.Type1) {}
 /// Simple public vs internal, imports defaults to public.
 import Lib1 // expected-note {{imported 'public' here}}
 // expected-error @-1 {{ambiguous implicit access level for import of 'Lib1'; it is imported as 'internal' elsewhere}}
+// expected-note @-2 {{silence these warnings by adopting 'InternalImportsByDefault'}}
 internal import Lib1 // expected-warning {{module 'Lib1' is imported as 'public' from the same file; this 'internal' access level will be ignored}}
 // expected-note @-1 {{imported 'internal' here}}
 
@@ -65,6 +66,7 @@ public import Lib2
 // expected-note @-1 {{imported 'public' here}}
 import Lib2
 // expected-error @-1 {{ambiguous implicit access level for import of 'Lib2'; it is imported as 'public' elsewhere}}
+// expected-note @-2 {{silence these warnings by adopting 'InternalImportsByDefault'}}
 
 public func dummyAPI(t: Lib1.Type1, t2: Lib2.Type1) {}
 

--- a/test/Sema/access-level-import-inlinable.swift
+++ b/test/Sema/access-level-import-inlinable.swift
@@ -2,7 +2,7 @@
 // and frozen structs.
 
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
+// RUN: split-file %s %t --leading-lines
 
 /// Build the libraries.
 // RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t \
@@ -177,42 +177,51 @@ public struct GenericType<T, U> {}
 
 @frozen public struct BadFields1 {
   private var field: PrivateImportType // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'PrivateImportType' is imported by this file as 'private' from 'PrivateLib'}}
 }
 
 @_fixed_layout public struct FixedBadFields1 {
 // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
   private var field: PrivateImportType // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'PrivateImportType' is imported by this file as 'private' from 'PrivateLib'}}
 }
 
 @frozen public struct BadFields2 {
   private var field: PrivateImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'PrivateImportType' is imported by this file as 'private' from 'PrivateLib'}}
 }
 
 @_fixed_layout public struct FixedBadFields2 {
 // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
   private var field: PrivateImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'PrivateImportType' is imported by this file as 'private' from 'PrivateLib'}}
 }
 
 @frozen public struct BadFields3 {
   internal var field: PackageImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'PackageImportType' is imported by this file as 'package' from 'PackageLib'}}
 }
 
 @_fixed_layout public struct FixedBadFields3 {
 // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
   internal var field: PackageImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'PackageImportType' is imported by this file as 'package' from 'PackageLib'}}
 }
 
 @frozen @usableFromInline struct BadFields4 {
   internal var field: InternalImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'InternalImportType' is imported by this file as 'internal' from 'InternalLib'}}
 }
 
 @_fixed_layout @usableFromInline struct FixedBadFields4 {
 // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
   internal var field: InternalImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'InternalImportType' is imported by this file as 'internal' from 'InternalLib'}}
 }
 
 @frozen public struct BadFields5 {
   private var field: PrivateImportType? { // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'PrivateImportType' is imported by this file as 'private' from 'PrivateLib'}}
     didSet {}
   }
 }
@@ -220,12 +229,14 @@ public struct GenericType<T, U> {}
 @_fixed_layout public struct FixedBadFields5 {
 // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
   private var field: PrivateImportType? { // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'PrivateImportType' is imported by this file as 'private' from 'PrivateLib'}}
     didSet {}
   }
 }
 
 @frozen public struct BadFields6 {
   private var field: InternalImportFrozenType? { // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'InternalImportFrozenType' is imported by this file as 'internal' from 'InternalLib'}}
     didSet {}
   }
 }
@@ -233,12 +244,14 @@ public struct GenericType<T, U> {}
 @_fixed_layout public struct FixedBadFields6 {
 // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
   private var field: InternalImportFrozenType? { // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+  // expected-note @-1 {{struct 'InternalImportFrozenType' is imported by this file as 'internal' from 'InternalLib'}}
     didSet {}
   }
 }
 
 // expected-error@+1 {{the result of a '@usableFromInline' function must be '@usableFromInline' or public}}
 @usableFromInline func notReallyUsableFromInline() -> InternalImportType? { return nil }
+  // expected-note @-1 {{struct 'InternalImportType' is imported by this file as 'internal' from 'InternalLib'}}
 @frozen public struct BadFields7 {
   private var field = notReallyUsableFromInline() // expected-error {{type referenced from a stored property with inferred type 'InternalImportType?' in a '@frozen' struct must be '@usableFromInline' or public}}
 }

--- a/test/Sema/implementation-only-deprecated.swift
+++ b/test/Sema/implementation-only-deprecated.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module-path %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -verify -verify-additional-prefix swift-5-
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault \
+// RUN:   -verify -verify-additional-prefix default-to-internal-
+
+//--- Lib.swift
+public struct SomeType {}
+
+//--- Client.swift
+@_implementationOnly import Lib
+// expected-swift-5-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}} {{1-21=internal}}
+// expected-default-to-internal-warning @-2 {{'@_implementationOnly' is deprecated, use a bare import as 'InternalImportsByDefault' is enabled}} {{1-22=}}
+
+internal func foo(_: SomeType) {}

--- a/test/Sema/implementation-only-deprecated.swift
+++ b/test/Sema/implementation-only-deprecated.swift
@@ -6,18 +6,17 @@
 // RUN:   -emit-module-path %t/Lib.swiftmodule
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
 // RUN:   -enable-library-evolution -swift-version 5 \
-// RUN:   -verify -verify-additional-prefix swift-5-
+// RUN:   -verify
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
 // RUN:   -enable-library-evolution -swift-version 5 \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault \
-// RUN:   -verify -verify-additional-prefix default-to-internal-
+// RUN:   -verify
 
 //--- Lib.swift
 public struct SomeType {}
 
 //--- Client.swift
 @_implementationOnly import Lib
-// expected-swift-5-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}} {{1-21=internal}}
-// expected-default-to-internal-warning @-2 {{'@_implementationOnly' is deprecated, use a bare import as 'InternalImportsByDefault' is enabled}} {{1-22=}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}} {{1-21=internal}}
 
 internal func foo(_: SomeType) {}

--- a/test/Sema/implementation-only-import-from-non-resilient.swift
+++ b/test/Sema/implementation-only-import-from-non-resilient.swift
@@ -27,7 +27,7 @@ import B
 
 //--- client-resilient.swift
 @_implementationOnly import A
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 import B
 
 //--- Crypto.swift

--- a/test/Sema/implementation-only-import-from-non-resilient.swift
+++ b/test/Sema/implementation-only-import-from-non-resilient.swift
@@ -27,6 +27,7 @@ import B
 
 //--- client-resilient.swift
 @_implementationOnly import A
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 import B
 
 //--- Crypto.swift

--- a/test/Sema/implementation-only-import-in-decls.swift
+++ b/test/Sema/implementation-only-import-in-decls.swift
@@ -9,7 +9,7 @@
 
 import NormalLibrary
 @_implementationOnly import BADLibrary
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 public struct TestConformance: BadProto {} // expected-error {{cannot use protocol 'BadProto' here; 'BADLibrary' has been imported as implementation-only}}
 

--- a/test/Sema/implementation-only-import-in-decls.swift
+++ b/test/Sema/implementation-only-import-in-decls.swift
@@ -9,6 +9,7 @@
 
 import NormalLibrary
 @_implementationOnly import BADLibrary
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 public struct TestConformance: BadProto {} // expected-error {{cannot use protocol 'BadProto' here; 'BADLibrary' has been imported as implementation-only}}
 

--- a/test/Sema/implementation-only-import-inlinable-conformances.swift
+++ b/test/Sema/implementation-only-import-inlinable-conformances.swift
@@ -7,6 +7,7 @@
 // RUN: %target-typecheck-verify-swift -I %t -enable-library-evolution -swift-version 5
 
 @_implementationOnly import BADLibrary
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 import NormalLibrary
 
 @available(*, unavailable)

--- a/test/Sema/implementation-only-import-inlinable-conformances.swift
+++ b/test/Sema/implementation-only-import-inlinable-conformances.swift
@@ -7,7 +7,7 @@
 // RUN: %target-typecheck-verify-swift -I %t -enable-library-evolution -swift-version 5
 
 @_implementationOnly import BADLibrary
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 import NormalLibrary
 
 @available(*, unavailable)

--- a/test/Sema/implementation-only-import-inlinable-indirect.swift
+++ b/test/Sema/implementation-only-import-inlinable-indirect.swift
@@ -8,6 +8,7 @@
 // RUN:   -enable-library-evolution -swift-version 5
 
 @_implementationOnly import directs
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 // Types
 

--- a/test/Sema/implementation-only-import-inlinable-indirect.swift
+++ b/test/Sema/implementation-only-import-inlinable-indirect.swift
@@ -8,7 +8,7 @@
 // RUN:   -enable-library-evolution -swift-version 5
 
 @_implementationOnly import directs
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 // Types
 

--- a/test/Sema/implementation-only-import-inlinable-multifile.swift
+++ b/test/Sema/implementation-only-import-inlinable-multifile.swift
@@ -8,6 +8,7 @@
 // RUN:   -enable-library-evolution -swift-version 5
 
 @_implementationOnly import directs
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 // 'indirects' is imported for re-export in a secondary file
 
 // Types

--- a/test/Sema/implementation-only-import-inlinable-multifile.swift
+++ b/test/Sema/implementation-only-import-inlinable-multifile.swift
@@ -8,7 +8,7 @@
 // RUN:   -enable-library-evolution -swift-version 5
 
 @_implementationOnly import directs
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 // 'indirects' is imported for re-export in a secondary file
 
 // Types

--- a/test/Sema/implementation-only-import-inlinable.swift
+++ b/test/Sema/implementation-only-import-inlinable.swift
@@ -8,7 +8,7 @@
 // RUN:   -enable-library-evolution -swift-version 5
 
 @_implementationOnly import directs
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 import indirects
 
 // Types

--- a/test/Sema/implementation-only-import-inlinable.swift
+++ b/test/Sema/implementation-only-import-inlinable.swift
@@ -8,6 +8,7 @@
 // RUN:   -enable-library-evolution -swift-version 5
 
 @_implementationOnly import directs
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 import indirects
 
 // Types

--- a/test/Sema/implementation-only-import-library-evolution.swift
+++ b/test/Sema/implementation-only-import-library-evolution.swift
@@ -5,6 +5,7 @@
 // RUN: %target-typecheck-verify-swift -I %t -enable-library-evolution
 
 @_implementationOnly import BADLibrary
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 public struct PublicStructStoredProperties {
   public var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}

--- a/test/Sema/implementation-only-import-library-evolution.swift
+++ b/test/Sema/implementation-only-import-library-evolution.swift
@@ -5,7 +5,7 @@
 // RUN: %target-typecheck-verify-swift -I %t -enable-library-evolution
 
 @_implementationOnly import BADLibrary
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 public struct PublicStructStoredProperties {
   public var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}

--- a/test/Sema/missing-import-inlinable-code.swift
+++ b/test/Sema/missing-import-inlinable-code.swift
@@ -75,6 +75,7 @@ public import libA
 // BEGIN clientFileA-OldCheck.swift
 public import libA
 @_implementationOnly import empty
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 @inlinable public func bar() {
   let a = ImportedType()
@@ -102,6 +103,7 @@ public import libA
 
 // BEGIN clientFileB.swift
 @_implementationOnly import libB
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 public import libA
 extension ImportedType {
     public func localModuleMethod() {}

--- a/test/Sema/missing-import-inlinable-code.swift
+++ b/test/Sema/missing-import-inlinable-code.swift
@@ -75,7 +75,7 @@ public import libA
 // BEGIN clientFileA-OldCheck.swift
 public import libA
 @_implementationOnly import empty
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 @inlinable public func bar() {
   let a = ImportedType()
@@ -103,7 +103,7 @@ public import libA
 
 // BEGIN clientFileB.swift
 @_implementationOnly import libB
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 public import libA
 extension ImportedType {
     public func localModuleMethod() {}

--- a/test/Sema/missing-import-typealias.swift
+++ b/test/Sema/missing-import-typealias.swift
@@ -97,7 +97,7 @@ extension StructAlias {
 
 import Aliases
 @_implementationOnly import Original
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 @inlinable public func inlinableFunc() {
   // expected-warning@+1 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an '@inlinable' function because 'Original' has been imported as implementation-only; this is an error in the Swift 6 language mode}}

--- a/test/Sema/missing-import-typealias.swift
+++ b/test/Sema/missing-import-typealias.swift
@@ -97,6 +97,7 @@ extension StructAlias {
 
 import Aliases
 @_implementationOnly import Original
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 @inlinable public func inlinableFunc() {
   // expected-warning@+1 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an '@inlinable' function because 'Original' has been imported as implementation-only; this is an error in the Swift 6 language mode}}

--- a/test/Sema/restricted-imports-priorities.swift
+++ b/test/Sema/restricted-imports-priorities.swift
@@ -45,18 +45,22 @@ public struct LibAStruct {}
 
 //--- TwoIOI.swift
 @_implementationOnly import LibB
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 @_implementationOnly import LibC
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 public func foo(a: LibAStruct) {} // expected-error {{cannot use struct 'LibAStruct' here; 'LibA' has been imported as implementation-only}}
 
 //--- SPIOnlyAndIOI1.swift
 @_spiOnly import LibB
 @_implementationOnly import LibC
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 
 public func foo(a: LibAStruct) {} // expected-error {{cannot use struct 'LibAStruct' here; 'LibA' was imported for SPI only}}
 
 //--- SPIOnlyAndIOI2.swift
 @_implementationOnly import LibB
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
 @_spiOnly import LibC
 
 public func foo(a: LibAStruct) {} // expected-error {{cannot use struct 'LibAStruct' here; 'LibA' was imported for SPI only}}

--- a/test/Sema/restricted-imports-priorities.swift
+++ b/test/Sema/restricted-imports-priorities.swift
@@ -45,22 +45,22 @@ public struct LibAStruct {}
 
 //--- TwoIOI.swift
 @_implementationOnly import LibB
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 @_implementationOnly import LibC
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 public func foo(a: LibAStruct) {} // expected-error {{cannot use struct 'LibAStruct' here; 'LibA' has been imported as implementation-only}}
 
 //--- SPIOnlyAndIOI1.swift
 @_spiOnly import LibB
 @_implementationOnly import LibC
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 
 public func foo(a: LibAStruct) {} // expected-error {{cannot use struct 'LibAStruct' here; 'LibA' was imported for SPI only}}
 
 //--- SPIOnlyAndIOI2.swift
 @_implementationOnly import LibB
-// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' and family instead}}
+// expected-warning @-1 {{'@_implementationOnly' is deprecated, use 'internal import' instead}}
 @_spiOnly import LibC
 
 public func foo(a: LibAStruct) {} // expected-error {{cannot use struct 'LibAStruct' here; 'LibA' was imported for SPI only}}

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -17,6 +17,7 @@
 // RUN: %target-swift-frontend -emit-module %t/ExtendedDefinitionNonPublic.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/UnusedImport.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/UnusedPackageImport.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/ExtendedPackageTypeImport.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/ImportNotUseFromAPI.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/ImportUsedInPackage.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/ExportedUnused.swift -o %t -I %t
@@ -98,6 +99,9 @@ public struct NonPublicExtendedType {}
 //--- UnusedImport.swift
 
 //--- UnusedPackageImport.swift
+//--- ExtendedPackageTypeImport.swift
+
+public struct ExtendedPackageType {}
 
 //--- ImportNotUseFromAPI.swift
 public struct NotAnAPIType {}
@@ -145,6 +149,7 @@ package import UnusedImport // expected-warning {{package import of 'UnusedImpor
 // expected-warning @-1 {{module 'UnusedImport' is imported as 'public' from the same file; this 'package' access level will be ignored}}
 
 package import UnusedPackageImport // expected-warning {{package import of 'UnusedPackageImport' was not used in package declarations}} {{1-9=}}
+package import ExtendedPackageTypeImport
 public import ImportNotUseFromAPI // expected-warning {{public import of 'ImportNotUseFromAPI' was not used in public declarations or inlinable code}} {{1-8=}}
 public import ImportUsedInPackage // expected-warning {{public import of 'ImportUsedInPackage' was not used in public declarations or inlinable code}} {{1-7=package}}
 
@@ -241,6 +246,10 @@ public protocol Countable {
 }
 
 extension Extended: Countable { // expected-remark {{struct 'Extended' is imported via 'RetroactiveConformance'}}
+}
+
+extension ExtendedPackageType { // expected-remark {{struct 'ExtendedPackageType' is imported via 'ExtendedPackageTypeImport'}}
+  package func useExtendedPackageType() { }
 }
 
 /// Tests for imports of clang modules.

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -124,6 +124,7 @@ public struct Extended {
 //--- Client_Swift5.swift
 /// No diagnostics should be raised on the implicit access level.
 import UnusedImport // expected-error {{ambiguous implicit access level for import of 'UnusedImport'; it is imported as 'public' elsewhere}}
+// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
 public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-7=internal}}
 // expected-note @-1 {{imported 'public' here}}
 

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -124,7 +124,7 @@ public struct Extended {
 //--- Client_Swift5.swift
 /// No diagnostics should be raised on the implicit access level.
 import UnusedImport // expected-error {{ambiguous implicit access level for import of 'UnusedImport'; it is imported as 'public' elsewhere}}
-// expected-note @-1 {{silence these warnings by adopting 'InternalImportsByDefault'}}
+// expected-note @-1 {{silence these warnings by adopting the upcoming feature 'InternalImportsByDefault'}}
 public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-7=internal}}
 // expected-note @-1 {{imported 'public' here}}
 


### PR DESCRIPTION
General improvements to diagnostics around access-level on imports:
- Fix erroneous warning about superfluous package imports providing a type extended in the local file.
- Warn that @_implementationOnly imports are deprecated and offer fixit to replace with `internal import`.
- Note a way to silence warnings about ambiguous implicit access-level on imports. This will be a problem with internal imports by default being pushed out of Swift 6.
- Note what imports limit the access-level of a decl both on the import and the decl where it triggers an error to make sure it's visible in IDEs.

Scope: Users of access-level on imports.
Risk: Low, this only adds and removes warnings and notes.
Reviewed by @tshortli and @nkcsgexi
Cherry-pick of #73125, #73176, #73179 and #73183
Resolves rdar://126712864&119438201