### PR TITLE
Sema: Ban uncallable protocol member operators

### DIFF
--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -85,7 +85,7 @@ public protocol PSub: PSuper {
 public let GlobalVar = 1
 
 public extension P1 {
-  static func +(lhs: P1, rhs: P1) -> P1 { return lhs }
+  static func +(lhs: Self, rhs: Self) -> Self { return lhs }
 }
 
 infix operator ..*..

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -54,26 +54,23 @@
             "children": [
               {
                 "kind": "TypeNominal",
-                "name": "P1",
-                "printedName": "any cake.P1",
-                "usr": "s:4cake2P1P"
+                "name": "GenericTypeParam",
+                "printedName": "τ_0_0"
               },
               {
                 "kind": "TypeNominal",
-                "name": "P1",
-                "printedName": "any cake.P1",
-                "usr": "s:4cake2P1P"
+                "name": "GenericTypeParam",
+                "printedName": "τ_0_0"
               },
               {
                 "kind": "TypeNominal",
-                "name": "P1",
-                "printedName": "any cake.P1",
-                "usr": "s:4cake2P1P"
+                "name": "GenericTypeParam",
+                "printedName": "τ_0_0"
               }
             ],
             "declKind": "Func",
-            "usr": "s:4cake2P1PAAE1poiyAaB_pAaB_p_AaB_ptFZ",
-            "mangledName": "$s4cake2P1PAAE1poiyAaB_pAaB_p_AaB_ptFZ",
+            "usr": "s:4cake2P1PAAE1poiyxx_xtFZ",
+            "mangledName": "$s4cake2P1PAAE1poiyxx_xtFZ",
             "moduleName": "cake",
             "genericSig": "<τ_0_0 where τ_0_0 : cake.P1>",
             "sugared_genericSig": "<Self where Self : cake.P1>",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -54,26 +54,23 @@
             "children": [
               {
                 "kind": "TypeNominal",
-                "name": "P1",
-                "printedName": "any cake.P1",
-                "usr": "s:4cake2P1P"
+                "name": "GenericTypeParam",
+                "printedName": "Self"
               },
               {
                 "kind": "TypeNominal",
-                "name": "P1",
-                "printedName": "any cake.P1",
-                "usr": "s:4cake2P1P"
+                "name": "GenericTypeParam",
+                "printedName": "Self"
               },
               {
                 "kind": "TypeNominal",
-                "name": "P1",
-                "printedName": "any cake.P1",
-                "usr": "s:4cake2P1P"
+                "name": "GenericTypeParam",
+                "printedName": "Self"
               }
             ],
             "declKind": "Func",
-            "usr": "s:4cake2P1PAAE1poiyAaB_pAaB_p_AaB_ptFZ",
-            "mangledName": "$s4cake2P1PAAE1poiyAaB_pAaB_p_AaB_ptFZ",
+            "usr": "s:4cake2P1PAAE1poiyxx_xtFZ",
+            "mangledName": "$s4cake2P1PAAE1poiyxx_xtFZ",
             "moduleName": "cake",
             "genericSig": "<Self where Self : cake.P1>",
             "static": true,

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -380,13 +380,15 @@ extension P2 {
 }
 
 protocol P3 {
-  // Okay: refers to P3
+  // Not allowed: there's no way to infer 'Self' from this interface type
   static func %%%(lhs: P3, rhs: Unrelated) -> Unrelated
+  // expected-error@-1 {{member operator '%%%' of protocol 'P3' must have at least one argument of type 'Self'}}
 }
 
 extension P3 {
-  // Okay: refers to P3
+  // Not allowed: there's no way to infer 'Self' from this interface type
   static func %%%%(lhs: P3, rhs: Unrelated) -> Unrelated { }
+  // expected-error@-1 {{member operator '%%%%' of protocol 'P3' must have at least one argument of type 'Self'}}
 }
 
 // rdar://problem/27940842 - recovery with a non-static '=='.


### PR DESCRIPTION
Member operators of concrete nominal types must declare at least one parameter with that type, like

```
struct S {
  static func +(lhs: S, rhs: Int) -> S {}
}
```

For protocol member operators, we would look for a parameter of type `Self`, or an existential type `any P`. While the latter was consistent with the concrete nominal type case, it was actually wrong because then the resulting interface type does not give the type checker any way to bind the `Self` type parameter.

There were two existing test cases that now produce errors, which I believe is now correct. While this is technically a source break, because these bogus operators seemingly cannot be witnessed or called, such a protocol probably had no conforming types.

Fixes https://github.com/apple/swift/issues/73201.