### PR TITLE
[Runtime] Use StackAllocatedDemangler in getLibPrespecializedMetadata.

### DIFF
--- a/stdlib/public/runtime/LibPrespecialized.cpp
+++ b/stdlib/public/runtime/LibPrespecialized.cpp
@@ -294,7 +294,7 @@ swift::getLibPrespecializedMetadata(const TypeContextDescriptor *description,
     }
   }
 
-  Demangler dem;
+  StackAllocatedDemangler<4096> dem;
   auto mangleNode = _buildDemanglingForGenericType(description, arguments, dem);
   if (!mangleNode) {
     LOG("failed to build demangling with descriptor %p.", description);


### PR DESCRIPTION
Reduce the amount of time spent freeing demangler slabs by starting out with a stack allocation that doesn't need to be freed.

rdar://126932780