### PR TITLE
[Frontend] Allow building without host Swift

### DIFF
--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -576,7 +576,9 @@ PrintingDiagnosticConsumer::PrintingDiagnosticConsumer(
     : Stream(stream) {}
 
 PrintingDiagnosticConsumer::~PrintingDiagnosticConsumer() {
+#if SWIFT_BUILD_SWIFT_SYNTAX
   for (const auto &sourceFileSyntax : sourceFileSyntax) {
     swift_ASTGen_destroySourceFile(sourceFileSyntax.second);
   }
+#endif
 }


### PR DESCRIPTION
There's no `swift_ASTGen_destroySourceFile` when we're not building ASTGen.