### PR TITLE
[region-isolation] Suppress non-Sendable region isolation errors appropriately when the type is imported by using @preconcurrency import.

### DIFF
--- a/include/swift/Sema/Concurrency.h
+++ b/include/swift/Sema/Concurrency.h
@@ -23,11 +23,17 @@
 namespace swift {
 
 class SourceFile;
+class NominalTypeDecl;
 
 /// If any of the imports in this source file was @preconcurrency but there were
 /// no diagnostics downgraded or suppressed due to that @preconcurrency, suggest
 /// that the attribute be removed.
 void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf);
+
+/// Determine whether the given nominal type has an explicit Sendable
+/// conformance (regardless of its availability).
+bool hasExplicitSendableConformance(NominalTypeDecl *nominal,
+                                    bool applyModuleDefault = true);
 
 } // namespace swift
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -789,8 +789,8 @@ SendableCheckContext::implicitSendableDiagnosticBehavior() const {
 
 /// Determine whether the given nominal type has an explicit Sendable
 /// conformance (regardless of its availability).
-static bool hasExplicitSendableConformance(NominalTypeDecl *nominal,
-                                           bool applyModuleDefault = true) {
+bool swift::hasExplicitSendableConformance(NominalTypeDecl *nominal,
+                                           bool applyModuleDefault) {
   ASTContext &ctx = nominal->getASTContext();
   auto nominalModule = nominal->getParentModule();
 

--- a/test/Concurrency/Inputs/transfernonsendable_preconcurrency_checked.swift
+++ b/test/Concurrency/Inputs/transfernonsendable_preconcurrency_checked.swift
@@ -1,0 +1,4 @@
+
+public class NonSendableKlass {
+  public init() {}
+}

--- a/test/Concurrency/Inputs/transfernonsendable_preconcurrency_unchecked.swift
+++ b/test/Concurrency/Inputs/transfernonsendable_preconcurrency_unchecked.swift
@@ -1,0 +1,11 @@
+
+public class NonSendableKlass {
+  public init() {}
+}
+
+public class ExplicitlyNonSendableKlass {
+  public init() {}
+}
+
+@available(*, unavailable)
+extension ExplicitlyNonSendableKlass: Sendable {}

--- a/test/Concurrency/transfernonsendable_preconcurrency.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency.swift
@@ -1,0 +1,153 @@
+// RUN: %empty-directory(%t)
+
+// A swift 5 module /without/ concurrency checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/PreconcurrencyUnchecked.swiftmodule -module-name PreconcurrencyUnchecked %S/Inputs/transfernonsendable_preconcurrency_unchecked.swift -disable-availability-checking -swift-version 5
+
+// A swift 5 module /with/ concurrency checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/PreconcurrencyChecked.swiftmodule -module-name PreconcurrencyChecked %S/Inputs/transfernonsendable_preconcurrency_checked.swift -disable-availability-checking -swift-version 5 -strict-concurrency=complete
+
+// Test swift 5 with strict concurrency with region isolation disabled
+// RUN: %target-swift-frontend -swift-version 5 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-5-no-tns- -parse-as-library -I %t -strict-concurrency=complete -disable-availability-checking -disable-region-based-isolation-with-strict-concurrency
+
+// Test swift 5 with strict concurrency
+// RUN: %target-swift-frontend -swift-version 5 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-5- -parse-as-library -I %t -strict-concurrency=complete -disable-availability-checking
+
+// Test swift 6
+// RUN: %target-swift-frontend -swift-version 6 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-6- -parse-as-library -I %t -disable-availability-checking
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// README: This test is meant to test the interaction of transfernonsendable and
+// preconcurrency. Please only keep such tests in this file.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+@preconcurrency import PreconcurrencyUnchecked
+import PreconcurrencyChecked // expected-swift-5-no-tns-warning {{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'PreconcurrencyChecked'}}
+
+typealias PreCUncheckedNonSendableKlass = PreconcurrencyUnchecked.NonSendableKlass
+typealias PreCUncheckedExplicitlyNonSendableKlass = PreconcurrencyUnchecked.ExplicitlyNonSendableKlass
+typealias PostCUncheckedNonSendableKlass = PreconcurrencyChecked.NonSendableKlass
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+func transferToNonIsolated<T>(_ t: T) async {}
+@MainActor func transferToMain<T>(_ t: T) async {}
+@CustomActor func transferToCustom<T>(_ t: T) async {}
+func useValue<T>(_ t: T) {}
+func useValueAsync<T>(_ t: T) async {}
+@MainActor func useValueMain<T>(_ t: T) {}
+@MainActor func mainActorFunction() {}
+
+////////////////////////////////////
+// MARK: Use After Transfer Tests //
+////////////////////////////////////
+
+// In swift 5, this should be squelched and should emit a warning in swift 6.
+func testPreconcurrencyImplicitlyNonSendable() async {
+  let x = PreCUncheckedNonSendableKlass()
+  await transferToMain(x)
+  useValue(x)
+}
+
+// In swift 5 and swift 6, this should be a warning.
+func testPreconcurrencyExplicitlyNonSendable() async {
+  let x = PreCUncheckedExplicitlyNonSendableKlass()
+  await transferToMain(x)
+  // expected-swift-5-no-tns-warning @-1 {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-2 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-3 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-warning @-4 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-5 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  useValue(x)
+  // expected-swift-5-note @-1 {{use here could race}}
+  // expected-swift-6-note @-2 {{use here could race}}
+}
+
+// In swift 5 this is a warning and in swift 6 this is an error.
+func testNormal() async {
+  let x = PostCUncheckedNonSendableKlass()
+  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-error @-2 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-3 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-note @-4 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  useValue(x) // expected-swift-5-note {{use here could race}}
+  // expected-swift-6-note @-1 {{use here could race}}
+}
+
+func testOnlyErrorOnExactValue() async {
+  let x = PreCUncheckedNonSendableKlass()
+  let y = (x, x)
+  // We would squelch this if we transferred it directly. Also we error even
+  // though we use x later.
+  await transferToMain(y)
+  // expected-swift-5-no-tns-warning @-1 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-2 {{transferring 'y' may cause a data race}}
+  // expected-swift-5-note @-3 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-error @-4 {{transferring 'y' may cause a data race}}
+  // expected-swift-6-note @-5 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  useValue(x)
+  // expected-swift-5-note @-1 {{use here could race}}
+  // expected-swift-6-note @-2 {{use here could race}}
+}
+
+func testNoErrorIfUseInSameRegionLater() async {
+  let x = PreCUncheckedNonSendableKlass()
+  let y = (x, x)
+  // We squelch since we are transferring x.
+  await transferToMain(x)
+  useValue(y)
+}
+
+////////////////////////////////
+// MARK: Never Transfer Tests //
+////////////////////////////////
+
+func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
+  await transferToMain(x)
+}
+
+func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
+  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-warning @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+}
+
+func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
+  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+}
+
+// Inexact match => normal behavior.
+func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)) async {
+  await transferToMain(x) // expected-swift-5-no-tns-warning 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+}
+
+// Inexact match => normal behavior.
+func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
+  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type '(PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)' (aka '(ExplicitlyNonSendableKlass, ExplicitlyNonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+}
+
+

--- a/test/Concurrency/transfernonsendable_preconcurrency_transferring.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency_transferring.swift
@@ -1,0 +1,152 @@
+// RUN: %empty-directory(%t)
+
+// A swift 5 module /without/ concurrency checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/PreconcurrencyUnchecked.swiftmodule -module-name PreconcurrencyUnchecked %S/Inputs/transfernonsendable_preconcurrency_unchecked.swift -disable-availability-checking -swift-version 5
+
+// A swift 5 module /with/ concurrency checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/PreconcurrencyChecked.swiftmodule -module-name PreconcurrencyChecked %S/Inputs/transfernonsendable_preconcurrency_checked.swift -disable-availability-checking -swift-version 5 -strict-concurrency=complete
+
+// Test swift 5 with strict concurrency
+// RUN: %target-swift-frontend -swift-version 5 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-5- -parse-as-library -I %t -strict-concurrency=complete -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults
+
+// Test swift 6
+// RUN: %target-swift-frontend -swift-version 6 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-6- -parse-as-library -I %t -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// README: This test is meant to test the interaction of transfernonsendable,
+// preconcurrency, and transferring. Please only keep such tests in this file.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+@preconcurrency import PreconcurrencyUnchecked
+import PreconcurrencyChecked // expected-swift-5-no-tns-warning {{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'PreconcurrencyChecked'}}
+
+typealias PreCUncheckedNonSendableKlass = PreconcurrencyUnchecked.NonSendableKlass
+typealias PreCUncheckedExplicitlyNonSendableKlass = PreconcurrencyUnchecked.ExplicitlyNonSendableKlass
+typealias PostCUncheckedNonSendableKlass = PreconcurrencyChecked.NonSendableKlass
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+func transferToNonIsolated<T>(_ t: T) async {}
+@MainActor func transferToMain<T>(_ t: T) async {}
+@CustomActor func transferToCustom<T>(_ t: T) async {}
+func useValue<T>(_ t: T) {}
+func useValueAsync<T>(_ t: T) async {}
+@MainActor func useValueMain<T>(_ t: T) {}
+@MainActor func mainActorFunction() {}
+
+func transferArg<T>(_ t: transferring T) {}
+
+////////////////////////////////////
+// MARK: Use After Transfer Tests //
+////////////////////////////////////
+
+// In swift 5, this should be squelched and should emit a warning in swift 6.
+func testPreconcurrencyImplicitlyNonSendable() async {
+  let x = PreCUncheckedNonSendableKlass()
+  transferArg(x)
+  useValue(x)
+}
+
+// In swift 5 and swift 6, this should be a warning.
+func testPreconcurrencyExplicitlyNonSendable() async {
+  let x = PreCUncheckedExplicitlyNonSendableKlass()
+  transferArg(x)
+
+  // expected-swift-5-warning @-2 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-3 {{'x' used after being passed as a transferring parameter; Later uses could race}}
+  // expected-swift-6-warning @-4 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-5 {{'x' used after being passed as a transferring parameter; Later uses could race}}
+  useValue(x)
+  // expected-swift-5-note @-1 {{use here could race}}
+  // expected-swift-6-note @-2 {{use here could race}}
+}
+
+// In swift 5 this is a warning and in swift 6 this is an error.
+func testNormal() async {
+  let x = PostCUncheckedNonSendableKlass()
+  transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-error @-2 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-3 {{'x' used after being passed as a transferring parameter; Later uses could race}}
+  // expected-swift-6-note @-4 {{'x' used after being passed as a transferring parameter; Later uses could race}}
+  useValue(x) // expected-swift-5-note {{use here could race}}
+  // expected-swift-6-note @-1 {{use here could race}}
+}
+
+func testOnlyErrorOnExactValue() async {
+  let x = PreCUncheckedNonSendableKlass()
+  let y = (x, x)
+  // We would squelch this if we transferred it directly. Also we error even
+  // though we use x later.
+  transferArg(y)
+  // expected-swift-5-no-tns-warning @-1 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-2 {{transferring 'y' may cause a data race}}
+  // expected-swift-5-note @-3 {{'y' used after being passed as a transferring parameter; Later uses could race}}
+  // expected-swift-6-error @-4 {{transferring 'y' may cause a data race}}
+  // expected-swift-6-note @-5 {{'y' used after being passed as a transferring parameter; Later uses could race}}
+  useValue(x)
+  // expected-swift-5-note @-1 {{use here could race}}
+  // expected-swift-6-note @-2 {{use here could race}}
+}
+
+func testNoErrorIfUseInSameRegionLater() async {
+  let x = PreCUncheckedNonSendableKlass()
+  let y = (x, x)
+  // We squelch since we are transferring x.
+  transferArg(x)
+  useValue(y)
+}
+
+////////////////////////////////
+// MARK: Never Transfer Tests //
+////////////////////////////////
+
+func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
+  transferArg(x)
+}
+
+func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
+  transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-6-warning @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+}
+
+func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
+  transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+}
+
+// Inexact match => normal behavior.
+func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)) async {
+  transferArg(x) // expected-swift-5-no-tns-warning 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+}
+
+// Inexact match => normal behavior.
+func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
+  transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type '(PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)' (aka '(ExplicitlyNonSendableKlass, ExplicitlyNonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+}
+
+


### PR DESCRIPTION
[region-isolation] Suppress non-Sendable region isolation errors appropriately when the type is imported by using @preconcurrency import.

This translates the rules for @preconcurrency import from SE-0337 into the region isolation world. Specifically if a module is compiled without strict concurrency checking and imported with @preconcurrency:

1. All types from that module that are implicitly non-Sendable have diagnostics suppressed in swift 5 and swift 6.

2. All types from that module that are explicitly non-Sendable emit warnings in both swift 5 and swift 6.

rdar://126804052

----

I still need to handle the `@MainActor` removal cases.