### PR TITLE
[6.0 cherry-pick][embedded] Consider move_value/copy_value as removable for keypath optimization

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyKeyPath.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyKeyPath.swift
@@ -31,10 +31,19 @@ extension KeyPathInst : OnoneSimplifyable {
 fileprivate func allUsesRemovable(instruction: Instruction) -> Bool {
   for result in instruction.results {
     for use in result.uses {
-      if !(use.instruction is UpcastInst || use.instruction is DestroyValueInst || use.instruction is BeginBorrowInst || use.instruction is EndBorrowInst) {
-        return false
-      }
-      if !allUsesRemovable(instruction: use.instruction) {
+      switch use.instruction {
+      case is UpcastInst,
+           is DestroyValueInst,
+           is BeginBorrowInst,
+           is EndBorrowInst,
+           is MoveValueInst,
+           is CopyValueInst:
+        // This is a removable instruction type, continue descending into uses
+        if !allUsesRemovable(instruction: use.instruction) {
+          return false
+        }
+
+      default:
         return false
       }
     }

--- a/test/embedded/keypaths2.swift
+++ b/test/embedded/keypaths2.swift
@@ -1,0 +1,43 @@
+// RUN: %target-run-simple-swift(   -enable-experimental-feature Embedded -wmo -runtime-compatibility-version none) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -wmo -runtime-compatibility-version none) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+@dynamicMemberLookup
+public struct Box<T>: ~Copyable {
+    init() {
+        self.value = UnsafeMutablePointer<T>.allocate(capacity: 1)
+    }
+
+    subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> U {
+        @_transparent
+        get { return self.value.pointer(to: member)!.pointee }
+
+        @_transparent
+        set { self.value.pointer(to: member)!.pointee = newValue }
+    }
+
+    var value: UnsafeMutablePointer<T>
+}
+
+public struct Foo {
+    var a: Int
+    var b: Int
+}
+
+public func test_read(x: inout Box<Foo>) -> Int {
+    return x.b
+}
+
+public func test_write(x: inout Box<Foo>) {
+    x.b = 42
+}
+
+var box = Box<Foo>()
+_ = test_read(x: &box)
+test_write(x: &box)
+print(box.b)
+// CHECK: 42

--- a/test/embedded/keypaths3.swift
+++ b/test/embedded/keypaths3.swift
@@ -1,0 +1,64 @@
+// RUN: %target-run-simple-swift(   -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+@dynamicMemberLookup
+public struct Box<T>: ~Copyable {
+    internal init(from t: T) {
+        self.value = UnsafeMutablePointer<InnerBox<T>>.allocate(capacity: 1)
+        self.value.pointee = .init(t)
+    }
+
+    public subscript<Value>(dynamicMember member: WritableKeyPath<InnerBox<T>, Value>) -> Value
+    {
+        @_transparent
+        @inline(__always)
+        get { return self.value.pointer(to: member)!.pointee }
+
+        @_transparent
+        @inline(__always)
+        set { self.value.pointer(to: member)!.pointee = newValue }
+    }
+
+    public struct InnerBox<V> {
+        public init(_ value: V) { self.innerValue = value }
+        public var innerValue: V
+    }
+
+    @usableFromInline
+    internal var value: UnsafeMutablePointer<InnerBox<T>>
+}
+
+struct Foo {
+    var a: Int
+    var b: Int
+}
+
+@inline(never)
+public func test() -> Int {
+    var x = Box<Foo>(from: Foo(a: 0, b: 0))
+    x.innerValue.b = 42
+    return x.innerValue.b
+}
+
+precondition(test() == 42)
+print("OK!")
+// CHECK: OK!
+
+public func test_read(x: inout Box<Foo>) -> Int {
+    return x.innerValue.b
+}
+
+public func test_write(x: inout Box<Foo>) {
+    x.innerValue.b = 42
+}
+
+var box = Box<Foo>(from: Foo(a: 0, b: 0))
+_ = test_read(x: &box)
+test_write(x: &box)
+print(box.innerValue.b)
+// CHECK: 42


### PR DESCRIPTION
* **Explanation**: Embedded Swift allows keypaths as long as they don't require any runtime instances to exist. This PR fixes a problem when using keypaths in @dynamicMemberLookup subscript setters, where we end up having move_value or copy_value instructions on the keypath values in SIL. https://github.com/apple/swift/pull/73184
* **Scope**: The problem that this change solves exists in Embedded Swift only, but the fix is in the SIL mandatory optimization pipeline which is used in regular compilations too.
* **Risk**: Well-understood simple fix in a specific optimization pass.
* **Testing**: Added test case.
* **Issue**: rdar://126655571
* **Reviewer**: @eeckstein on https://github.com/apple/swift/pull/73184
