### PR TITLE
Fix regression from CaptureInfoRequest

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -75,13 +75,6 @@ public:
     return TheFunction.get<AbstractClosureExpr *>()->getCaptureInfo();
   }
 
-  void setCaptureInfo(CaptureInfo captures) const {
-    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
-      AFD->setCaptureInfo(captures);
-      return;
-    }
-    TheFunction.get<AbstractClosureExpr *>()->setCaptureInfo(captures);
-  }
 
   bool hasType() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -627,16 +627,16 @@ public:
 
 CaptureInfo CaptureInfoRequest::evaluate(Evaluator &evaluator,
                                          AbstractFunctionDecl *AFD) const {
-  BraceStmt *body = AFD->getTypecheckedBody();
-
   auto type = AFD->getInterfaceType();
-  if (type->is<ErrorType>() || body == nullptr)
+  if (type->is<ErrorType>())
     return CaptureInfo::empty();
 
   bool isNoEscape = type->castTo<AnyFunctionType>()->isNoEscape();
   FindCapturedVars finder(AFD->getLoc(), AFD, isNoEscape,
                           AFD->isObjC(), AFD->isGeneric());
-  body->walk(finder);
+
+  if (auto *body = AFD->getTypecheckedBody())
+    body->walk(finder);
 
   if (!AFD->isObjC()) {
     finder.checkType(type, AFD->getLoc());

--- a/test/SILGen/skip_local_function_bodies.swift
+++ b/test/SILGen/skip_local_function_bodies.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -experimental-skip-non-inlinable-function-bodies-without-types %s -emit-module-path %t/skip_local_function_bodies.swiftmodule
+
+public protocol P {
+    init()
+}
+
+extension P {
+    public func f() {
+        typealias T = Self
+
+        func g(_ x: T) {}
+	g(self)
+    }
+}
+


### PR DESCRIPTION
If a generic local function declares a local type and another local function, we would crash if the outer function body was not skipped, and the local function was skipped.