### PR TITLE
[6.0][region-isolation] Fix import pre concurrency support for region isolation

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -269,6 +269,9 @@ private:
   /// @_dynamicReplacement(for:) function.
   SILFunction *ReplacedFunction = nullptr;
 
+  /// The SILDeclRef that this function was created for by SILGen if one exists.
+  SILDeclRef DeclRef = SILDeclRef();
+
   /// This SILFunction REFerences an ad-hoc protocol requirement witness in
   /// order to keep it alive, such that it main be obtained in IRGen. Without
   /// this explicit reference, the witness would seem not-used, and not be
@@ -1114,6 +1117,12 @@ public:
   /// Get the source location of the function.
   const SILDebugScope *getDebugScope() const { return DebugScope; }
 
+  /// Return the SILDeclRef for this SILFunction if one was assigned by SILGen.
+  SILDeclRef getDeclRef() const { return DeclRef; }
+
+  /// Set the SILDeclRef for this SILFunction. Used mainly by SILGen.
+  void setDeclRef(SILDeclRef declRef) { DeclRef = declRef; }
+
   /// Get this function's bare attribute.
   IsBare_t isBare() const { return IsBare_t(Bare); }
   void setBare(IsBare_t isB) { Bare = isB; }
@@ -1375,6 +1384,9 @@ public:
   }
 
   ActorIsolation getActorIsolation() const { return actorIsolation; }
+
+  /// Return the source file that this SILFunction belongs to if it exists.
+  SourceFile *getSourceFile() const;
 
   //===--------------------------------------------------------------------===//
   // Block List Access

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -501,6 +501,8 @@ PASS(ReferenceBindingTransform, "sil-reference-binding-transform",
      "Check/transform reference bindings")
 PASS(DiagnosticDeadFunctionElimination, "sil-diagnostic-dead-function-elim",
      "Eliminate dead functions from early specialization optimizations before we run later diagnostics")
+PASS(DiagnoseUnnecessaryPreconcurrencyImports, "sil-diagnose-unnecessary-preconcurrency-imports",
+     "Diagnose any preconcurrency imports that Sema and TransferNonSendable did not use")
 PASS(PruneVTables, "prune-vtables",
      "Mark class methods that do not require vtable dispatch")
 PASS_RANGE(AllPasses, AADumper, PruneVTables)

--- a/include/swift/Sema/Concurrency.h
+++ b/include/swift/Sema/Concurrency.h
@@ -23,11 +23,17 @@
 namespace swift {
 
 class SourceFile;
+class NominalTypeDecl;
 
 /// If any of the imports in this source file was @preconcurrency but there were
 /// no diagnostics downgraded or suppressed due to that @preconcurrency, suggest
 /// that the attribute be removed.
 void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf);
+
+/// Determine whether the given nominal type has an explicit Sendable
+/// conformance (regardless of its availability).
+bool hasExplicitSendableConformance(NominalTypeDecl *nominal,
+                                    bool applyModuleDefault = true);
 
 } // namespace swift
 

--- a/include/swift/Sema/Concurrency.h
+++ b/include/swift/Sema/Concurrency.h
@@ -1,0 +1,34 @@
+//===--- Concurrency.h ----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file defines concurrency utility routines from Sema that are used by
+/// later parts of the compiler like the pass pipeline.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SEMA_CONCURRENCY_H
+#define SWIFT_SEMA_CONCURRENCY_H
+
+namespace swift {
+
+class SourceFile;
+
+/// If any of the imports in this source file was @preconcurrency but there were
+/// no diagnostics downgraded or suppressed due to that @preconcurrency, suggest
+/// that the attribute be removed.
+void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf);
+
+} // namespace swift
+
+#endif

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -1189,3 +1189,11 @@ bool SILFunction::argumentMayRead(Operand *argOp, SILValue addr) {
 
   return argumentMayReadFunction({this}, {argOp}, {addr});
 }
+
+SourceFile *SILFunction::getSourceFile() const {
+  auto declRef = getDeclRef();
+  if (!declRef)
+    return nullptr;
+
+  return declRef.getInnermostDeclContext()->getParentSourceFile();
+}

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1236,6 +1236,9 @@ void SILGenModule::preEmitFunction(SILDeclRef constant, SILFunction *F,
   // Create a debug scope for the function using astNode as source location.
   F->setDebugScope(new (M) SILDebugScope(Loc, F));
 
+  // Initialize F with the constant we created for it.
+  F->setDeclRef(constant);
+
   LLVM_DEBUG(llvm::dbgs() << "lowering ";
              F->printName(llvm::dbgs());
              llvm::dbgs() << " : ";

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(swiftSILOptimizer PRIVATE
   ConsumeOperatorCopyableValuesChecker.cpp
   PhiStorageOptimizer.cpp
   ConstantPropagation.cpp
+  DiagnoseUnnecessaryPreconcurrencyImports.cpp
   DebugInfoCanonicalizer.cpp
   DefiniteInitialization.cpp
   DIMemoryUseCollector.cpp

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnnecessaryPreconcurrencyImports.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnnecessaryPreconcurrencyImports.cpp
@@ -1,0 +1,79 @@
+//===--- DiagnoseUnnecessaryPreconcurrencyImports.cpp ---------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This is run after TransferNonSendable and uses Sema infrastructure to
+/// determine if in Sema or TransferNonSendable any of the preconcurrency import
+/// statements were not used.
+///
+/// This only runs when RegionIsolation is enabled. If RegionIsolation is
+/// disabled, we emit the unnecessary preconcurrency imports earlier during Sema
+/// since no later diagnostics will be emitted.
+///
+/// NOTE: This needs to be a module pass and run after TransferNonSendable so we
+/// can guarantee that we have run TransferNonSendable on all functions in our
+/// module before this runs.
+///
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/SourceFile.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/Sema/Concurrency.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                         MARK: Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class DiagnoseUnnecessaryPreconcurrencyImports : public SILModuleTransform {
+  void run() override {
+    // If region isolation is not enabled... return early.
+    if (!getModule()->getASTContext().LangOpts.hasFeature(
+            Feature::RegionBasedIsolation))
+      return;
+
+    std::vector<SourceFile *> data;
+    for (auto &fn : *getModule()) {
+      auto *sf = fn.getSourceFile();
+      if (!sf) {
+        continue;
+      }
+
+      data.push_back(sf);
+      assert(sf->getBufferID() != -1 && "Must have a buffer id");
+    }
+
+    // Sort unique by filename so our diagnostics are deterministic.
+    //
+    // TODO: If we cannot rely upon this, just sort by pointer address. Non
+    // determinism emission of diagnostics isn't great but it isn't fatal.
+    sortUnique(data, [](SourceFile *lhs, SourceFile *rhs) -> bool {
+      return lhs->getBufferID() < rhs->getBufferID();
+    });
+
+    // At this point, we know that we have our sorted unique list of source
+    // files.
+    for (auto *sf : data) {
+      diagnoseUnnecessaryPreconcurrencyImports(*sf);
+    }
+  }
+};
+
+} // namespace
+
+SILTransform *swift::createDiagnoseUnnecessaryPreconcurrencyImports() {
+  return new DiagnoseUnnecessaryPreconcurrencyImports();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -140,8 +140,11 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addTransferNonSendable();
 
   // Now that we have completed running passes that use region analysis, clear
-  // region analysis.
+  // region analysis and emit diagnostics for unnecessary preconcurrency
+  // imports.
   P.addRegionAnalysisInvalidationTransform();
+  P.addDiagnoseUnnecessaryPreconcurrencyImports();
+
   // Lower tuple addr constructor. Eventually this can be merged into later
   // passes. This ensures we do not need to update later passes for something
   // that is only needed by TransferNonSendable().

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -789,8 +789,8 @@ SendableCheckContext::implicitSendableDiagnosticBehavior() const {
 
 /// Determine whether the given nominal type has an explicit Sendable
 /// conformance (regardless of its availability).
-static bool hasExplicitSendableConformance(NominalTypeDecl *nominal,
-                                           bool applyModuleDefault = true) {
+bool swift::hasExplicitSendableConformance(NominalTypeDecl *nominal,
+                                           bool applyModuleDefault) {
   ASTContext &ctx = nominal->getASTContext();
   auto nominalModule = nominal->getParentModule();
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -23,6 +23,8 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Type.h"
+#include "swift/Sema/Concurrency.h"
+
 #include <cassert>
 
 namespace swift {
@@ -486,11 +488,6 @@ bool diagnoseNonSendableTypes(
 bool diagnoseSendabilityErrorBasedOn(
     NominalTypeDecl *nominal, SendableCheckContext fromContext,
     llvm::function_ref<bool(DiagnosticBehavior)> diagnose);
-
-/// If any of the imports in this source file was @preconcurrency but
-/// there were no diagnostics downgraded or suppressed due to that
-/// @preconcurrency, suggest that the attribute be removed.
-void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf);
 
 /// Given a set of custom attributes, pick out the global actor attributes
 /// and perform any necessary resolution and diagnostics, returning the

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -315,7 +315,11 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
     SF->typeCheckDelayedFunctions();
   }
 
-  diagnoseUnnecessaryPreconcurrencyImports(*SF);
+  // If region based isolation is enabled, we diagnose unnecessary
+  // preconcurrency imports in the SIL pipeline in the
+  // DiagnoseUnnecessaryPreconcurrencyImports pass.
+  if (!Ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation))
+    diagnoseUnnecessaryPreconcurrencyImports(*SF);
   diagnoseUnnecessaryPublicImports(*SF);
 
   // Check to see if there are any inconsistent imports.

--- a/test/Concurrency/Inputs/transfernonsendable_preconcurrency_checked.swift
+++ b/test/Concurrency/Inputs/transfernonsendable_preconcurrency_checked.swift
@@ -1,0 +1,4 @@
+
+public class NonSendableKlass {
+  public init() {}
+}

--- a/test/Concurrency/Inputs/transfernonsendable_preconcurrency_unchecked.swift
+++ b/test/Concurrency/Inputs/transfernonsendable_preconcurrency_unchecked.swift
@@ -1,0 +1,11 @@
+
+public class NonSendableKlass {
+  public init() {}
+}
+
+public class ExplicitlyNonSendableKlass {
+  public init() {}
+}
+
+@available(*, unavailable)
+extension ExplicitlyNonSendableKlass: Sendable {}

--- a/test/Concurrency/transfernonsendable_preconcurrency.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency.swift
@@ -1,0 +1,153 @@
+// RUN: %empty-directory(%t)
+
+// A swift 5 module /without/ concurrency checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/PreconcurrencyUnchecked.swiftmodule -module-name PreconcurrencyUnchecked %S/Inputs/transfernonsendable_preconcurrency_unchecked.swift -disable-availability-checking -swift-version 5
+
+// A swift 5 module /with/ concurrency checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/PreconcurrencyChecked.swiftmodule -module-name PreconcurrencyChecked %S/Inputs/transfernonsendable_preconcurrency_checked.swift -disable-availability-checking -swift-version 5 -strict-concurrency=complete
+
+// Test swift 5 with strict concurrency with region isolation disabled
+// RUN: %target-swift-frontend -swift-version 5 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-5-no-tns- -parse-as-library -I %t -strict-concurrency=complete -disable-availability-checking -disable-region-based-isolation-with-strict-concurrency
+
+// Test swift 5 with strict concurrency
+// RUN: %target-swift-frontend -swift-version 5 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-5- -parse-as-library -I %t -strict-concurrency=complete -disable-availability-checking
+
+// Test swift 6
+// RUN: %target-swift-frontend -swift-version 6 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-6- -parse-as-library -I %t -disable-availability-checking
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// README: This test is meant to test the interaction of transfernonsendable and
+// preconcurrency. Please only keep such tests in this file.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+@preconcurrency import PreconcurrencyUnchecked
+import PreconcurrencyChecked // expected-swift-5-no-tns-warning {{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'PreconcurrencyChecked'}}
+
+typealias PreCUncheckedNonSendableKlass = PreconcurrencyUnchecked.NonSendableKlass
+typealias PreCUncheckedExplicitlyNonSendableKlass = PreconcurrencyUnchecked.ExplicitlyNonSendableKlass
+typealias PostCUncheckedNonSendableKlass = PreconcurrencyChecked.NonSendableKlass
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+func transferToNonIsolated<T>(_ t: T) async {}
+@MainActor func transferToMain<T>(_ t: T) async {}
+@CustomActor func transferToCustom<T>(_ t: T) async {}
+func useValue<T>(_ t: T) {}
+func useValueAsync<T>(_ t: T) async {}
+@MainActor func useValueMain<T>(_ t: T) {}
+@MainActor func mainActorFunction() {}
+
+////////////////////////////////////
+// MARK: Use After Transfer Tests //
+////////////////////////////////////
+
+// In swift 5, this should be squelched and should emit a warning in swift 6.
+func testPreconcurrencyImplicitlyNonSendable() async {
+  let x = PreCUncheckedNonSendableKlass()
+  await transferToMain(x)
+  useValue(x)
+}
+
+// In swift 5 and swift 6, this should be a warning.
+func testPreconcurrencyExplicitlyNonSendable() async {
+  let x = PreCUncheckedExplicitlyNonSendableKlass()
+  await transferToMain(x)
+  // expected-swift-5-no-tns-warning @-1 {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-2 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-3 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-warning @-4 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-5 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  useValue(x)
+  // expected-swift-5-note @-1 {{use here could race}}
+  // expected-swift-6-note @-2 {{use here could race}}
+}
+
+// In swift 5 this is a warning and in swift 6 this is an error.
+func testNormal() async {
+  let x = PostCUncheckedNonSendableKlass()
+  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-error @-2 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-3 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-note @-4 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  useValue(x) // expected-swift-5-note {{use here could race}}
+  // expected-swift-6-note @-1 {{use here could race}}
+}
+
+func testOnlyErrorOnExactValue() async {
+  let x = PreCUncheckedNonSendableKlass()
+  let y = (x, x)
+  // We would squelch this if we transferred it directly. Also we error even
+  // though we use x later.
+  await transferToMain(y)
+  // expected-swift-5-no-tns-warning @-1 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-2 {{transferring 'y' may cause a data race}}
+  // expected-swift-5-note @-3 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-error @-4 {{transferring 'y' may cause a data race}}
+  // expected-swift-6-note @-5 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  useValue(x)
+  // expected-swift-5-note @-1 {{use here could race}}
+  // expected-swift-6-note @-2 {{use here could race}}
+}
+
+func testNoErrorIfUseInSameRegionLater() async {
+  let x = PreCUncheckedNonSendableKlass()
+  let y = (x, x)
+  // We squelch since we are transferring x.
+  await transferToMain(x)
+  useValue(y)
+}
+
+////////////////////////////////
+// MARK: Never Transfer Tests //
+////////////////////////////////
+
+func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
+  await transferToMain(x)
+}
+
+func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
+  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-warning @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+}
+
+func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
+  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+}
+
+// Inexact match => normal behavior.
+func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)) async {
+  await transferToMain(x) // expected-swift-5-no-tns-warning 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+}
+
+// Inexact match => normal behavior.
+func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
+  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type '(PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)' (aka '(ExplicitlyNonSendableKlass, ExplicitlyNonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+}
+
+

--- a/test/Concurrency/transfernonsendable_preconcurrency_transferring.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency_transferring.swift
@@ -1,0 +1,152 @@
+// RUN: %empty-directory(%t)
+
+// A swift 5 module /without/ concurrency checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/PreconcurrencyUnchecked.swiftmodule -module-name PreconcurrencyUnchecked %S/Inputs/transfernonsendable_preconcurrency_unchecked.swift -disable-availability-checking -swift-version 5
+
+// A swift 5 module /with/ concurrency checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/PreconcurrencyChecked.swiftmodule -module-name PreconcurrencyChecked %S/Inputs/transfernonsendable_preconcurrency_checked.swift -disable-availability-checking -swift-version 5 -strict-concurrency=complete
+
+// Test swift 5 with strict concurrency
+// RUN: %target-swift-frontend -swift-version 5 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-5- -parse-as-library -I %t -strict-concurrency=complete -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults
+
+// Test swift 6
+// RUN: %target-swift-frontend -swift-version 6 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-6- -parse-as-library -I %t -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// README: This test is meant to test the interaction of transfernonsendable,
+// preconcurrency, and transferring. Please only keep such tests in this file.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+@preconcurrency import PreconcurrencyUnchecked
+import PreconcurrencyChecked // expected-swift-5-no-tns-warning {{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'PreconcurrencyChecked'}}
+
+typealias PreCUncheckedNonSendableKlass = PreconcurrencyUnchecked.NonSendableKlass
+typealias PreCUncheckedExplicitlyNonSendableKlass = PreconcurrencyUnchecked.ExplicitlyNonSendableKlass
+typealias PostCUncheckedNonSendableKlass = PreconcurrencyChecked.NonSendableKlass
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+func transferToNonIsolated<T>(_ t: T) async {}
+@MainActor func transferToMain<T>(_ t: T) async {}
+@CustomActor func transferToCustom<T>(_ t: T) async {}
+func useValue<T>(_ t: T) {}
+func useValueAsync<T>(_ t: T) async {}
+@MainActor func useValueMain<T>(_ t: T) {}
+@MainActor func mainActorFunction() {}
+
+func transferArg<T>(_ t: transferring T) {}
+
+////////////////////////////////////
+// MARK: Use After Transfer Tests //
+////////////////////////////////////
+
+// In swift 5, this should be squelched and should emit a warning in swift 6.
+func testPreconcurrencyImplicitlyNonSendable() async {
+  let x = PreCUncheckedNonSendableKlass()
+  transferArg(x)
+  useValue(x)
+}
+
+// In swift 5 and swift 6, this should be a warning.
+func testPreconcurrencyExplicitlyNonSendable() async {
+  let x = PreCUncheckedExplicitlyNonSendableKlass()
+  transferArg(x)
+
+  // expected-swift-5-warning @-2 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-3 {{'x' used after being passed as a transferring parameter; Later uses could race}}
+  // expected-swift-6-warning @-4 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-5 {{'x' used after being passed as a transferring parameter; Later uses could race}}
+  useValue(x)
+  // expected-swift-5-note @-1 {{use here could race}}
+  // expected-swift-6-note @-2 {{use here could race}}
+}
+
+// In swift 5 this is a warning and in swift 6 this is an error.
+func testNormal() async {
+  let x = PostCUncheckedNonSendableKlass()
+  transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-error @-2 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-3 {{'x' used after being passed as a transferring parameter; Later uses could race}}
+  // expected-swift-6-note @-4 {{'x' used after being passed as a transferring parameter; Later uses could race}}
+  useValue(x) // expected-swift-5-note {{use here could race}}
+  // expected-swift-6-note @-1 {{use here could race}}
+}
+
+func testOnlyErrorOnExactValue() async {
+  let x = PreCUncheckedNonSendableKlass()
+  let y = (x, x)
+  // We would squelch this if we transferred it directly. Also we error even
+  // though we use x later.
+  transferArg(y)
+  // expected-swift-5-no-tns-warning @-1 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-2 {{transferring 'y' may cause a data race}}
+  // expected-swift-5-note @-3 {{'y' used after being passed as a transferring parameter; Later uses could race}}
+  // expected-swift-6-error @-4 {{transferring 'y' may cause a data race}}
+  // expected-swift-6-note @-5 {{'y' used after being passed as a transferring parameter; Later uses could race}}
+  useValue(x)
+  // expected-swift-5-note @-1 {{use here could race}}
+  // expected-swift-6-note @-2 {{use here could race}}
+}
+
+func testNoErrorIfUseInSameRegionLater() async {
+  let x = PreCUncheckedNonSendableKlass()
+  let y = (x, x)
+  // We squelch since we are transferring x.
+  transferArg(x)
+  useValue(y)
+}
+
+////////////////////////////////
+// MARK: Never Transfer Tests //
+////////////////////////////////
+
+func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
+  transferArg(x)
+}
+
+func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
+  transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-6-warning @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+}
+
+func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
+  transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+}
+
+// Inexact match => normal behavior.
+func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)) async {
+  transferArg(x) // expected-swift-5-no-tns-warning 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+}
+
+// Inexact match => normal behavior.
+func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
+  transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type '(PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)' (aka '(ExplicitlyNonSendableKlass, ExplicitlyNonSendableKlass)') into main actor-isolated context may introduce data races}}
+  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
+}
+
+


### PR DESCRIPTION
Explanation: This fixes the most important part of rdar://126804052, namely it makes sure that region isolation respect `@preconcurrency import`. I still need to fix `@preconcurrency` attached to nominal types/functions. But this is the most important.

- rdar://126804052

Original PRs:

- #73202
- #73212

Risk: Low. Only affects region isolation.
Testing: Added many functional and unit tests.
Reviewer: N/A