### PR TITLE
[Test] Add swift_system_overlay_opt to %host-build-swift substitution

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -592,12 +592,13 @@ else:
     if kIsWindows:
         config.swift_driver += " -libc " + config.swift_stdlib_msvc_runtime
     config.swiftc_driver = (
-        "%r %s %s %s %s" % (
+        "%r %s %s %s %s %s" % (
             config.swiftc,
             '' if kIsWindows else '-toolchain-stdlib-rpath',
             mcp_opt,
             config.swift_test_options,
             config.swift_driver_test_options,
+            config.swift_system_overlay_opt,
         )
     )
     toolchain_lib_dir = make_path(config.swift_lib_dir, 'swift', host_os)


### PR DESCRIPTION
`-vfsoverlay` for system's modulemap is required for finding system clang modules in Windows.
