### PR TITLE
[ScanDependency] Allow continue searching for testable module

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1200,7 +1200,7 @@ REMARK(module_api_import_aliases,none,
        (const Decl *, ModuleDecl *, ModuleDecl *, bool))
 
 REMARK(skip_module_invalid,none,"skip invalid swiftmodule: %0", (StringRef))
-REMARK(skip_module_testable,none,"skip swiftmodule built with '-enable-testing': %0", (StringRef))
+WARNING(skip_module_not_testable,none,"ignore swiftmodule built without '-enable-testing': %0", (StringRef))
 
 REMARK(macro_loaded,none,
        "loaded macro implementation module %0 from "

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -454,6 +454,12 @@ SerializedModuleLoaderBase::scanModuleFile(Twine modulePath, bool isFramework,
                            modulePath.str());
       return std::make_error_code(std::errc::no_such_file_or_directory);
     }
+
+    if (isTestableImport && !loadedModuleFile->isTestable()) {
+      Ctx.Diags.diagnose(SourceLoc(), diag::skip_module_not_testable,
+                         modulePath.str());
+      return std::make_error_code(std::errc::no_such_file_or_directory);
+    }
   }
 
   // Some transitive dependencies of binary modules are not required to be


### PR DESCRIPTION
When swift dependency scanner first finds a binary module for a testable import, verify if the module is built for enable-testing or not. If not, keeps searching in case there is a second testable binary module in the search path.

Previously, the first binary module will always be accepted by scanner and rely on the importer to provide a good diagnostics. Now the scanner will emit a warning before continue searching, so user understands why the binary in the search path is not taken.

