### PR TITLE
Revert "Add xrOS to silence -Wswitch violations (#71432)"

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -217,7 +217,6 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::ShaderModel:
   case llvm::Triple::Solaris:
   case llvm::Triple::Vulkan:
-  case llvm::Triple::XROS:
   case llvm::Triple::ZOS:
     return "";
   case llvm::Triple::Darwin:


### PR DESCRIPTION
This reverts commit 9e2b97c0fd675efaa5b815748d8567d781415c8c.

This did not merge nicely with the real introduction of visionOS and is no longer needed.