### PR TITLE
[RemoteInspection] Fix format of dumped spare bit mask

### DIFF
--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -921,7 +921,7 @@ void TypeRefBuilder::ReflectionTypeDescriptorFinder::
         }
         const uint8_t *p = descriptor->getPayloadSpareBits();
         for (unsigned i = 0; i < maskBytes; i++) {
-          stream << std::hex << std::setw(2) << std::setfill('0') << p[i];
+          stream << std::hex << std::setw(2) << std::setfill('0') << (int)p[i];
         }
         stream << std::dec << "\n";
       }


### PR DESCRIPTION
Even with `std::hex`, the `uint8_t` values are being printed as characters, not hex values. This change casts the value to `int`, which results in the hex representation being properly printed.