### PR TITLE
[6.0] Two small cherry-picks to improve build stability

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -856,7 +856,10 @@ function(_compile_swift_files
   if(SWIFT_INCLUDE_TOOLS AND NOT BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE")
     # Depend on the binary itself, in addition to the symlink, unless
     # cross-compiling the compiler.
-    set(swift_compiler_tool_dep "swift-frontend${target_suffix}")
+    list(APPEND swift_compiler_tool_dep "swift-frontend${target_suffix}")
+
+    # If we aren't cross compiling, also depend on SwiftMacros.
+    list(APPEND swift_compiler_tool_dep SwiftMacros)
   endif()
 
   # If there are more than one output files, we assume that they are specified

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
 
+// REQUIRES: asserts
 // REQUIRES: concurrency
 // REQUIRES: swift_swift_parser
 


### PR DESCRIPTION
Explanation: This contains two small cherry-picks to improve build stability:

1. The first adds a missing cake dependency from the stdlib on SwiftMacros. We even on 6.0 use macros and without this we race in between building stdlibcore and SwiftMacros. This can cause non-deterministic failures. The commit just adds the dependency in the same manner that we already do for swift-frontend. rdar://126998047
2. This just adds REQUIRES: asserts to a test. This will prevent us from running the test without asserts and avoid compiler failure. rdar://126006489 

Original PRs:

- #73225
- https://github.com/apple/swift/pull/73226

Risk: Low.
Testing: Verified REQUIRES: asserts fixes the issue locally. Validated locally that the new dependency fixes the race.
Reviewer: N/A