### PR TITLE
6.0: [IRGen] Deadends don't need dealloc_pack_metadata.

### DIFF
--- a/validation-test/IRGen/gh72536.swift
+++ b/validation-test/IRGen/gh72536.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-emit-ir \
+// RUN:     %s                \
+// RUN:     -disable-availability-checking
+
+func foo<each S>(_ s: repeat each S) async {}
+await foo(true)
+


### PR DESCRIPTION
**Explanation**: Fix a false-positive assertion failure for variadic generics.

When a SIL instruction involving variadic generic types is lowered, pack metadata may be allocated.  As an optimization, that metadata is allocated on the stack.  To correctly nest these on-stack pack allocations, there are matching `alloc_pack_metadata` and `dealloc_pack_metadata` instructions.

To catch issues with bad nesting, some verification is run in asserts builds during IRGen.  This patch corrects a false positive that was being flagged by that verification.

Specifically, the verification was checking that for any `alloc_pack_metadata` instruction for which metadata was indeed allocated during IRGen that there was at least one matching `dealloc_pack_metadata` instruction which would clean it up.  Such a cleanup instruction need not and does not exist, however, if the `alloc_pack_metadata` is in a "dead end block" (all paths passing through the `alloc_pack_metadata` instruction end in `unreachable`--caused, for example, by a call to `fatalError()`).  This patch adds a check for whether the `alloc_pack_metadata` instruction is in a dead end block and does not require there to be a matching `dealloc_pack_metadata` if so.
**Scope**: Affects asserts builds only.  Affects variadic generic code.
**Issue**: rdar://125265980
**Original PR**: https://github.com/apple/swift/pull/73191
**Risk**: Very low.  Only affects asserts builds.
**Testing**: Added regression test.
**Reviewer**: Arnold Schwaighofer ( @aschwaighofer )
