### PR TITLE
Add reference for Copyable (Swift 6) 🍒

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -176,9 +176,9 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 /// You don't generally need to write an explicit conformance to `Copyable`.
 /// The following places implicitly include `Copyable` conformance:
 ///
-/// * Structures declarations,
+/// * Structure declarations,
 ///   unless it has a noncopyable stored property
-/// * Enumerations declarations,
+/// * Enumeration declarations,
 ///   unless it has a case whose associated value isn't copyable
 /// * Class declarations
 /// * Actor declarations

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -171,7 +171,13 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 
 /// A type whose values can be implicitly or explicitly copied.
 ///
-/// XXX this protocol has no symbol requirements, but it does have semantic requirements
+/// Although this protocol doesn’t have any required methods or properties,
+/// it does have semantic requirements that are enforced at compile time.
+/// These requirements are listed in the sections below.
+/// XXX what are the requirements -- just that copying is ok?
+/// Conformance to `Copyable` must be declared
+/// in the same file as the type's declaration.
+/// <!-- XXX TR: Confirm previous sentence; borrowed from Sendable docs -->
 ///
 /// Conformance to the `Copyable` protocol
 /// is implicitly included in the following places:
@@ -216,7 +222,12 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 ///
 /// Extensions on the `Copyable` protocol are not allowed.
 ///
-/// XXX xref to TSPL
+/// XXX link to the right chapter
+/// For information about the language-level concurrency model that `Task` is part of,
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
+///
+/// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
+/// [tspl]: https://docs.swift.org/swift-book/
 @_marker public protocol Copyable {}
 
 @_documentation(visibility: internal)

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -169,6 +169,54 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
   try fn()
 }
 
+/// A type whose values can be implicitly or explicitly copied.
+///
+/// XXX this protocol has no symbol requirements, but it does have semantic requirements
+///
+/// Conformance to the `Copyable` protocol
+/// is implicitly included in the following places:
+///
+/// * Structures declarations
+/// * Enumerations declarations
+/// * Class declarations
+/// * Protocol declarations
+/// * Associated type declarations
+/// * The `Self` type in a protocol extension
+///
+/// In a declaration that includes generic type parameters,
+/// each generic type parameter implicitly includes `Copyable`
+/// in its list of requirements.
+/// Metatypes and tuples of copyable types are also implicitly copyable.
+/// For example,
+/// all of the following pairs of declarations are equivalent:
+///
+/// ```swift
+/// struct MyStructure { }
+/// struct MyStructere: Copyable { }
+///
+/// protocol MyProtocol { }
+/// protocol MyProtocol: Copyable { }
+///
+/// XXX example of assoc type or Self
+///
+/// func genericFunction<T>(t: T) { }
+/// func genericFunction<T>(t: T) where T: Copyable { }
+/// ```
+///
+/// To suppress an implicit conformance to `Copyable`
+/// you write `~Copyable`.
+/// For example,
+/// only copyable types can conform to `MyProtocol` in the example above,
+/// but both copyable and noncopyable types
+/// can conform to the following protocol:
+///
+/// ```swift
+/// protocol NoRequirements: ~Copyable { }
+/// ```
+///
+/// Extensions on the `Copyable` protocol are not allowed.
+///
+/// XXX xref to TSPL
 @_marker public protocol Copyable {}
 
 @_documentation(visibility: internal)

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -199,24 +199,22 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 /// For example,
 /// all of the following pairs of declarations are equivalent:
 ///
-/// ```swift
-/// struct MyStructure { }
-/// struct MyStructere: Copyable { }
+///     struct MyStructure { }
+///     struct MyStructere: Copyable { }
 ///
-/// protocol MyProtocol { }
-/// protocol MyProtocol: Copyable { }
+///     protocol MyProtocol { }
+///     protocol MyProtocol: Copyable { }
 ///
-/// protocol AnotherProtocol {
-///     associatedtype MyType
-///     associatedtype MyType: Copyable
-/// }
+///     protocol AnotherProtocol {
+///         associatedtype MyType
+///         associatedtype MyType: Copyable
+///     }
 ///
-/// func genericFunction<T>(t: T) { }
-/// func genericFunction<T>(t: T) where T: Copyable { }
+///     func genericFunction<T>(t: T) { }
+///     func genericFunction<T>(t: T) where T: Copyable { }
 ///
-/// let x = any MyProtocol
-/// let x = any MyProtocol & Copyable
-/// ```
+///     let x = any MyProtocol
+///     let x = any MyProtocol & Copyable
 ///
 /// To suppress an implicit conformance to `Copyable` you write `~Copyable`.
 /// For example,
@@ -224,9 +222,7 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 /// but both copyable and noncopyable types
 /// can conform `NoRequirements` in the example below:
 ///
-/// ```swift
-/// protocol NoRequirements: ~Copyable { }
-/// ```
+///     protocol NoRequirements: ~Copyable { }
 ///
 /// Extensions to the `Copyable` protocol are not allowed.
 @_marker public protocol Copyable {}

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -185,6 +185,7 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 /// * Protocol declarations
 /// * Associated type declarations
 /// * The `Self` type in a protocol extension
+/// * In an extension, the generic parameters of the type being extended
 ///
 /// A class or actor can contain noncopyable stored properties,
 /// while still being copyable itself ---

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -213,8 +213,8 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 ///     func genericFunction<T>(t: T) { }
 ///     func genericFunction<T>(t: T) where T: Copyable { }
 ///
-///     let x = any MyProtocol
-///     let x = any MyProtocol & Copyable
+///     let x: any MyProtocol
+///     let x: any MyProtocol & Copyable
 ///
 /// To suppress an implicit conformance to `Copyable` you write `~Copyable`.
 /// For example,

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -171,28 +171,30 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 
 /// A type whose values can be implicitly or explicitly copied.
 ///
-/// Although this protocol doesn’t have any required methods or properties,
-/// it does have semantic requirements that are enforced at compile time.
-/// These requirements are listed in the sections below.
-/// XXX what are the requirements -- just that copying is ok?
-/// Conformance to `Copyable` must be declared
-/// in the same file as the type's declaration.
-/// <!-- XXX TR: Confirm previous sentence; borrowed from Sendable docs -->
+/// Conforming to this protocol indicates that a type's value can be copied;
+/// this protocol doesn’t have any required methods or properties.
+/// You don't generally need to write an explicit conformance to `Copyable`.
+/// The following places implicitly include `Copyable` conformance:
 ///
-/// Conformance to the `Copyable` protocol
-/// is implicitly included in the following places:
-///
-/// * Structures declarations
-/// * Enumerations declarations
+/// * Structures declarations,
+///   unless it has a noncopyable stored property
+/// * Enumerations declarations,
+///   unless it has a case whose associated value isn't copyable
 /// * Class declarations
+/// * Actor declarations
 /// * Protocol declarations
 /// * Associated type declarations
 /// * The `Self` type in a protocol extension
 ///
+/// A class or actor can contain noncopyable stored properties,
+/// while still being copyable itself ---
+/// classes and actors are copied by retaining and releasing references.
+///
 /// In a declaration that includes generic type parameters,
 /// each generic type parameter implicitly includes `Copyable`
 /// in its list of requirements.
-/// Metatypes and tuples of copyable types are also implicitly copyable.
+/// Metatypes and tuples of copyable types are also implicitly copyable,
+/// as are boxed protocol types.
 /// For example,
 /// all of the following pairs of declarations are equivalent:
 ///
@@ -203,31 +205,29 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 /// protocol MyProtocol { }
 /// protocol MyProtocol: Copyable { }
 ///
-/// XXX example of assoc type or Self
+/// protocol AnotherProtocol {
+///     associatedtype MyType
+///     associatedtype MyType: Copyable
+/// }
 ///
 /// func genericFunction<T>(t: T) { }
 /// func genericFunction<T>(t: T) where T: Copyable { }
+///
+/// let x = any MyProtocol
+/// let x = any MyProtocol & Copyable
 /// ```
 ///
-/// To suppress an implicit conformance to `Copyable`
-/// you write `~Copyable`.
+/// To suppress an implicit conformance to `Copyable` you write `~Copyable`.
 /// For example,
 /// only copyable types can conform to `MyProtocol` in the example above,
 /// but both copyable and noncopyable types
-/// can conform to the following protocol:
+/// can conform `NoRequirements` in the example below:
 ///
 /// ```swift
 /// protocol NoRequirements: ~Copyable { }
 /// ```
 ///
-/// Extensions on the `Copyable` protocol are not allowed.
-///
-/// XXX link to the right chapter
-/// For information about the language-level concurrency model that `Task` is part of,
-/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
-///
-/// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
-/// [tspl]: https://docs.swift.org/swift-book/
+/// Extensions to the `Copyable` protocol are not allowed.
 @_marker public protocol Copyable {}
 
 @_documentation(visibility: internal)


### PR DESCRIPTION
**Description:** Documentation-only change:  Cherry pick of the changes from https://github.com/apple/swift/pull/73238 onto the Swift 6 release branch.

**Risk:** None, only changes comments.

**Verified by:** Kavon

**Fixes:** rdar://126377559