### PR TITLE
[Debugging] Exclude DebugDescriptionMacro feature from swiftinterface

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -376,7 +376,7 @@ EXPERIMENTAL_FEATURE(ObjCImplementation, true)
 EXPERIMENTAL_FEATURE(CImplementation, true)
 
 // Enable the stdlib @DebugDescription macro.
-EXPERIMENTAL_FEATURE(DebugDescriptionMacro, true)
+EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(DebugDescriptionMacro, true)
 
 // Enable usability improvements for global-actor-isolated types.
 EXPERIMENTAL_FEATURE(GlobalActorIsolatedTypesUsability, true)


### PR DESCRIPTION
The effect of `DebugDescriptionMacro` is to emit serialized summary strings into the binary. The macro makes no changes interface of a data type. The feature flag can be excluded from Swift interfaces.