### PR TITLE
Enable SwiftCompilerSources on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -736,6 +736,18 @@ option(SWIFT_ENABLE_BACKTRACING
 set(SWIFT_DARWIN_DEPLOYMENT_VERSION_MACCATALYST "14.5" CACHE STRING
   "Minimum deployment target version for macCatalyst")
 
+# A tempoarary hack: force enabling HOSTTOOLS mode on Windows.
+# Right now, SwiftCompilerSources cannot be enabled for lldb because on Windows
+# swift and lldb are built in a unified build and there is a missing dependency
+# on swiftrt.
+# Swift and lldb are configured with the same cmake invocation and therefore
+# enabling bootstrapping for swift and disabling it for lldb only works by
+# hardcoding the bootstrapping mode in the cmake file.
+# https://github.com/apple/swift/issues/73322
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  set(BOOTSTRAPPING_MODE "HOSTTOOLS")
+endif()
+
 #
 # End of user-configurable options.
 #
@@ -904,6 +916,10 @@ if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")
   # This is the normal case. We are not cross-compiling.
   set(SWIFT_NATIVE_SWIFT_TOOLS_PATH "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
   set(SWIFT_EXEC_FOR_SWIFT_MODULES "${CMAKE_Swift_COMPILER}")
+  if(NOT SWIFT_EXEC_FOR_SWIFT_MODULES)
+    message(WARNING "BOOSTRAPPING set to OFF because no Swift compiler is defined")
+    set(BOOTSTRAPPING_MODE "OFF")
+  endif()
 elseif(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
   # If cross-compiling, we don't have to bootstrap. We can just use the previously
   # built native swiftc to build the swift compiler modules.

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -106,6 +106,7 @@ function(add_swift_compiler_modules_library name)
       "-Xcc" "-std=c++17"
       "-Xcc" "-DCOMPILED_WITH_SWIFT" "-Xcc" "-DSWIFT_TARGET"
       "-Xcc" "-UIBOutlet" "-Xcc" "-UIBAction" "-Xcc" "-UIBInspectable")
+
   # Prior to 5.9, we have to use the experimental flag for C++ interop.
   if (CMAKE_Swift_COMPILER_VERSION VERSION_LESS 5.9)
     list(APPEND swift_compile_options "-Xfrontend" "-enable-experimental-cxx-interop")
@@ -167,7 +168,13 @@ function(add_swift_compiler_modules_library name)
   # under `include/swift`. These are either located next to the compiler (in case of open source toolchains) or
   # in the SDK (in case a Swift compiler from Xcode)
   get_filename_component(swift_exec_bin_dir ${ALS_SWIFT_EXEC} DIRECTORY)
-  list(APPEND sdk_option "-I" "${swift_exec_bin_dir}/../lib" "-I" "${sdk_path}/usr/lib")
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    list(APPEND swift_compile_options "-static")
+    list(APPEND sdk_option "-sdk" "${SWIFT_PATH_TO_SWIFT_SDK}")
+  else()
+    list(APPEND sdk_option "-I" "${swift_exec_bin_dir}/../lib" "-I" "${sdk_path}/usr/lib")
+  endif()
 
   set(all_obj_files)
   set(all_module_targets)

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -172,6 +172,10 @@ function(add_swift_compiler_modules_library name)
   if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     list(APPEND swift_compile_options "-static")
     list(APPEND sdk_option "-sdk" "${SWIFT_PATH_TO_SWIFT_SDK}")
+
+    # Workaround a crash in the LoadableByAddress pass
+    # https://github.com/apple/swift/issues/73254
+    list(APPEND swift_compile_options "-Xllvm" "-sil-disable-pass=loadable-address")
   else()
     list(APPEND sdk_option "-I" "${swift_exec_bin_dir}/../lib" "-I" "${sdk_path}/usr/lib")
   endif()

--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import BasicBridging
-import CxxStdlib
 
 /// The assert function to be used in the compiler.
 ///

--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -51,6 +51,9 @@ public extension NoReflectionChildren {
   var customMirror: Mirror { Mirror(self, children: []) }
 }
 
+#if !os(Windows)
+// TODO: https://github.com/apple/swift/issues/73252
+
 public var standardError = CFileStream(fp: stderr)
 
 #if os(Android) || canImport(Musl)
@@ -70,6 +73,8 @@ public struct CFileStream: TextOutputStream {
     fflush(fp)
   }
 }
+
+#endif
 
 //===----------------------------------------------------------------------===//
 //                              StringRef

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -121,7 +121,10 @@ private struct DiagnoseDependence {
   }
 
   func reportUnknown(operand: Operand) {
+#if !os(Windows)
+    // TODO: https://github.com/apple/swift/issues/73252
     standardError.write("Unknown use: \(operand)\n\(function)")
+#endif
     reportEscaping(operand: operand)
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyConvertEscapeToNoEscape.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyConvertEscapeToNoEscape.swift
@@ -28,6 +28,10 @@ private extension ConvertEscapeToNoEscapeInst {
   ///   %3 = thin_to_thick_function %1 to $@noescape () -> ()
 
   func tryCombineWithThinToThickOperand(_ context: SimplifyContext) {
+    // compiling bridged.getFunctionTypeWithNoEscape crashes the 5.10 Windows compiler
+#if !os(Windows)
+    // TODO: https://github.com/apple/swift/issues/73253
+
     if let thinToThick = fromFunction as? ThinToThickFunctionInst {
       let builder = Builder(before: self, context)
       let noEscapeFnType = thinToThick.type.getFunctionType(withNoEscape: true)
@@ -36,5 +40,6 @@ private extension ConvertEscapeToNoEscapeInst {
       uses.replaceAll(with: newThinToThick, context)
       context.erase(instruction: self)
     }
+#endif
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -197,7 +197,10 @@ private func functionTestThunk(
   let invocation = castToInvocation(fromOpaquePointer: erasedInvocation)
   let context = FunctionPassContext(_bridged: BridgedPassContext(invocation: passInvocation.invocation))
   invocation(function.function, arguments.native, context)
+#if !os(Windows)
+  // TODO: https://github.com/apple/swift/issues/73252
   fflush(stdout)
+#endif
 }
 
 /// Bitcast a thin test closure to void *.

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -142,9 +142,13 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
     return idx >= 0 ? idx : nil
   }
 
+// compiling bridged.getFunctionTypeWithNoEscape crashes the 5.10 Windows compiler
+#if !os(Windows)
+  // TODO: https://github.com/apple/swift/issues/73253
   public func getFunctionType(withNoEscape: Bool) -> Type {
     bridged.getFunctionTypeWithNoEscape(withNoEscape).type
   }
+#endif
 
   public var description: String {
     String(taking: bridged.getDebugDescription())

--- a/test/AutoDiff/SILOptimizer/vjp_and_pullback_inlining.swift
+++ b/test/AutoDiff/SILOptimizer/vjp_and_pullback_inlining.swift
@@ -4,6 +4,7 @@
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
+// UNSUPPORTED: OS=windows-msvc
 
 import _Differentiation
 #if canImport(Glibc)

--- a/test/IRGen/linker_set_low_level_exec.swift
+++ b/test/IRGen/linker_set_low_level_exec.swift
@@ -3,6 +3,9 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 
+// https://github.com/apple/swift/issues/73321
+// UNSUPPORTED: OS=windows-msvc
+
 @_used
 #if canImport(Darwin)
 @_section("__TEXT,__mysection")

--- a/test/IRGen/loadable_by_address_address_assignment.swift
+++ b/test/IRGen/loadable_by_address_address_assignment.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend %s  -O -Xllvm -sil-print-after=loadable-address -c -o %t/t.o 2>&1 | %FileCheck %s
 
-// XFAIL: OS=windows-msvc
-
 public struct LargeThing {
     var  s0 : String = ""
     var  s1 : String = ""

--- a/test/SILOptimizer/argument_conventions.sil
+++ b/test/SILOptimizer/argument_conventions.sil
@@ -5,6 +5,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// https://github.com/apple/swift/issues/73252
+// UNSUPPORTED: OS=windows-msvc
+
 import Builtin
 
 class C {}

--- a/test/SILOptimizer/borrow_introducer_unit.sil
+++ b/test/SILOptimizer/borrow_introducer_unit.sil
@@ -2,6 +2,9 @@
 //
 // REQUIRES: swift_in_compiler
 
+// https://github.com/apple/swift/issues/73252
+// UNSUPPORTED: OS=windows-msvc
+
 sil_stage raw
 
 import Builtin

--- a/test/SILOptimizer/enclosing_def_unit.sil
+++ b/test/SILOptimizer/enclosing_def_unit.sil
@@ -2,6 +2,9 @@
 //
 // REQUIRES: swift_in_compiler
 
+// https://github.com/apple/swift/issues/73252
+// UNSUPPORTED: OS=windows-msvc
+
 sil_stage raw
 
 import Builtin

--- a/test/SILOptimizer/forwarding_utils.sil
+++ b/test/SILOptimizer/forwarding_utils.sil
@@ -2,6 +2,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// https://github.com/apple/swift/issues/73252
+// UNSUPPORTED: OS=windows-msvc
+
 sil_stage raw
 
 import Builtin

--- a/test/SILOptimizer/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence_util.sil
@@ -7,6 +7,9 @@
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
+// https://github.com/apple/swift/issues/73252
+// UNSUPPORTED: OS=windows-msvc
+
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/opaque_values_unit.sil
+++ b/test/SILOptimizer/opaque_values_unit.sil
@@ -2,6 +2,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// https://github.com/apple/swift/issues/73252
+// UNSUPPORTED: OS=windows-msvc
+
 import Builtin
 
 class C {}

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -6,6 +6,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// https://github.com/apple/swift/issues/73252
+// UNSUPPORTED: OS=windows-msvc
+
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/simplify_convert_escape_to_noescape.sil
+++ b/test/SILOptimizer/simplify_convert_escape_to_noescape.sil
@@ -2,6 +2,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// https://github.com/apple/swift/issues/73253
+// UNSUPPORTED: OS=windows-msvc
+
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/test_specification_parsing.sil
+++ b/test/SILOptimizer/test_specification_parsing.sil
@@ -2,6 +2,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// https://github.com/apple/swift/issues/73252
+// UNSUPPORTED: OS=windows-msvc
+
 sil_stage raw
 
 import Builtin

--- a/test/embedded/optionset2.swift
+++ b/test/embedded/optionset2.swift
@@ -5,6 +5,9 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM
 
+// https://github.com/apple/swift/issues/73249
+// UNSUPPORTED: OS=windows-msvc
+
 protocol MyOptionSet: Equatable {
   init(rawValue: Int)
   init()

--- a/test/embedded/ouroboros-bug.swift
+++ b/test/embedded/ouroboros-bug.swift
@@ -10,6 +10,9 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM
 
+// https://github.com/apple/swift/issues/73249
+// UNSUPPORTED: OS=windows-msvc
+
 public func test() {}
 test()
 

--- a/test/embedded/stdlib-array.swift
+++ b/test/embedded/stdlib-array.swift
@@ -5,6 +5,9 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM
 
+// https://github.com/apple/swift/issues/73249
+// UNSUPPORTED: OS=windows-msvc
+
 public func test() {
   var array: [Int] = [1, 2, 3]
   array.append(42)

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -4,6 +4,9 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
 
+// https://github.com/apple/swift/issues/73249
+// UNSUPPORTED: OS=windows-msvc
+
 public func bool() -> Bool {
   return true
 }

--- a/test/embedded/stdlib-dictionary.swift
+++ b/test/embedded/stdlib-dictionary.swift
@@ -4,6 +4,9 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 
+// https://github.com/apple/swift/issues/73249
+// UNSUPPORTED: OS=windows-msvc
+
 public func test() {
   var d: [Int:Int] = [1: 2, 3: 4, 5: 6]
   d[8] = 9

--- a/test/embedded/stdlib-random.swift
+++ b/test/embedded/stdlib-random.swift
@@ -4,6 +4,9 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 
+// https://github.com/apple/swift/issues/73249
+// UNSUPPORTED: OS=windows-msvc
+
 public func test() {
   Bool.random()
   Int.random(in: 0 ..< 100)

--- a/test/embedded/stdlib-set.swift
+++ b/test/embedded/stdlib-set.swift
@@ -5,6 +5,9 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM
 
+// https://github.com/apple/swift/issues/73249
+// UNSUPPORTED: OS=windows-msvc
+
 public func test() {
   var s: Set<Int> = [1, 2, 3]
   s.insert(42)

--- a/test/embedded/stdlib-types.swift
+++ b/test/embedded/stdlib-types.swift
@@ -5,6 +5,9 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM
 
+// https://github.com/apple/swift/issues/73249
+// UNSUPPORTED: OS=windows-msvc
+
 class MyClass {}
 
 public func test() {

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -142,6 +142,12 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
     else()
       message(FATAL_ERROR "Unknown ASKD_BOOTSTRAPPING_MODE '${ASKD_BOOTSTRAPPING_MODE}'")
     endif()
+  elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS")
+    if(ASKD_BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS")
+      set(swiftrt_obj
+        ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH}/swiftrt${CMAKE_C_OUTPUT_EXTENSION})
+      target_link_libraries(${target} PRIVATE ${swiftrt_obj})
+    endif()
   endif()
 
   if(SWIFT_BUILD_SWIFT_SYNTAX)


### PR DESCRIPTION
With some hacks and workarounds I could get SwiftCompilerSources working on my local Windows machine.
To-do: also enable it in lldb (see my comment in the top-level CMakeLists file).
