### PR TITLE
6.0: [LICM] Bail on unreferenceable storage.

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -1048,8 +1048,13 @@ computeInnerAccessPath(AccessPath::PathNode outerPath,
   if (outerPath == innerPath)
     return true;
 
-  if (!isa<StructElementAddrInst>(innerAddress)
-      && !isa<TupleElementAddrInst>(innerAddress)) {
+  auto *sea = dyn_cast<StructElementAddrInst>(innerAddress);
+
+  if (sea && sea->getStructDecl()->hasUnreferenceableStorage()) {
+    return false;
+  }
+
+  if (!sea && !isa<TupleElementAddrInst>(innerAddress)) {
     return false;
   }
   assert(ProjectionIndex(innerAddress).Index

--- a/test/SILOptimizer/licm_unreferenceablestorage.sil
+++ b/test/SILOptimizer/licm_unreferenceablestorage.sil
@@ -1,0 +1,49 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -licm | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+//--- input.sil
+sil_stage canonical
+
+import Builtin
+import Swift
+import Foundation
+
+typealias Mantissa = (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)
+
+// CHECK-LABEL: sil @struct_extract_from_decimal : {{.*}} {
+// CHECK:       bb0([[POINTER:%[^,]+]] :
+// CHECK-SAME:      [[NEW_MANTISSA:%[^,]+]] :
+// CHECK:       [[ADDR:%[^,]+]] = pointer_to_address [[POINTER]]
+// CHECK:       [[A_ADDR:%[^,]+]] = struct_element_addr [[ADDR]]
+// CHECK-SAME:      #Decimal._mantissa
+// CHECK:       br [[BODY:bb[0-9]+]]
+// CHECK:     [[BODY]]:
+// CHECK:       [[VALUE_2:%[^,]+]] = load [[ADDR]] : $*Decimal
+// CHECK:       [[MANTISSA:%[^,]+]] = struct_extract [[VALUE_2]]
+// CHECK-SAME:      #Decimal._mantissa
+// CHECK:       store [[NEW_MANTISSA]] to [[A_ADDR]]
+// CHECK:       cond_br undef, [[BACKEDGE:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK:     [[BACKEDGE]]:
+// CHECK:       br [[BODY]]
+// CHECK:     [[EXIT]]:
+// CHECK:       return [[MANTISSA]]
+// CHECK-LABEL: } // end sil function 'struct_extract_from_decimal'
+sil @struct_extract_from_decimal : $@convention(thin) (Builtin.RawPointer, Mantissa) -> (Mantissa) {
+bb0(%pointer : $Builtin.RawPointer, %newMantissa : $Mantissa):
+  %addr = pointer_to_address %pointer : $Builtin.RawPointer to $*Decimal
+  br bb1
+
+bb1:
+  %value2 = load %addr : $*Decimal
+  %a = struct_extract %value2 : $Decimal, #Decimal._mantissa
+  %a_addr = struct_element_addr %addr : $*Decimal, #Decimal._mantissa
+  store %newMantissa to %a_addr : $*Mantissa
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  return %a : $Mantissa
+}


### PR DESCRIPTION
**Explanation**: Fix a compiler crash caused by an insufficiently conservative optimization.

Some structs that are imported from C have storage that can't be referenced in Swift.  For example, `Foundation.Decimal`.  Such structs cannot be formed in SIL via the `struct` instruction.

LICM moves code out of loops.  Part of this involves forming values which were previously in addresses.  To form a struct value, the `struct` instruction is used.  This isn't legal if the struct in question has storage that can't be referenced in Swift.

Here, a bailout is added to check whether any struct which would need to be formed during the pass has unreferenceable storage.
**Scope**: Affects code involving imported types with unreferenceable storage in release builds.
**Issue**: rdar://127013278
**Original PR**: https://github.com/apple/swift/pull/73240
**Risk**: Low.  Introduces a new bailout to a pass.
**Testing**: Added regression test.
**Reviewer**: Andrew Trick ( @atrick ), Meghana Gupta ( @meg-gupta )
