### PR TITLE
[6.0][Macros] Don't use 'ExportedSourceFile' for macro definition checking

### DIFF
--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -73,8 +73,8 @@ bool swift_ASTGen_checkDefaultArgumentMacroExpression(
     const void *_Nonnull macroSourceLocation);
 
 ptrdiff_t swift_ASTGen_checkMacroDefinition(
-    void *_Nonnull diagEngine, void *_Nonnull sourceFile,
-    const void *_Nonnull macroSourceLocation,
+    void *_Nonnull diagEngine, BridgedStringRef sourceFileBuffer,
+    BridgedStringRef macroDeclText,
     BridgedStringRef *_Nonnull expansionSourceOutPtr,
     ptrdiff_t *_Nullable *_Nonnull replacementsPtr,
     ptrdiff_t *_Nonnull numReplacements,

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -21,6 +21,7 @@ fileprivate func emitDiagnosticParts(
   message: String,
   severity: DiagnosticSeverity,
   position: AbsolutePosition,
+  offset: Int,
   highlights: [Syntax] = [],
   fixItChanges: [FixIt.Change] = []
 ) {
@@ -28,7 +29,7 @@ fileprivate func emitDiagnosticParts(
   let bridgedSeverity = severity.bridged
 
   func bridgedSourceLoc(at position: AbsolutePosition) -> BridgedSourceLoc {
-    return BridgedSourceLoc(at: position, in: sourceFileBuffer)
+    return BridgedSourceLoc(at: position.advanced(by: offset), in: sourceFileBuffer)
   }
 
   // Emit the diagnostic
@@ -96,6 +97,7 @@ fileprivate func emitDiagnosticParts(
 func emitDiagnostic(
   diagnosticEngine: BridgedDiagnosticEngine,
   sourceFileBuffer: UnsafeBufferPointer<UInt8>,
+  sourceFileBufferOffset: Int = 0,
   diagnostic: Diagnostic,
   diagnosticSeverity: DiagnosticSeverity,
   messageSuffix: String? = nil
@@ -107,6 +109,7 @@ func emitDiagnostic(
     message: diagnostic.diagMessage.message + (messageSuffix ?? ""),
     severity: diagnosticSeverity,
     position: diagnostic.position,
+    offset: sourceFileBufferOffset,
     highlights: diagnostic.highlights
   )
 
@@ -118,6 +121,7 @@ func emitDiagnostic(
       message: fixIt.message.message,
       severity: .note,
       position: diagnostic.position,
+      offset: sourceFileBufferOffset,
       fixItChanges: fixIt.changes
     )
   }
@@ -129,7 +133,8 @@ func emitDiagnostic(
       sourceFileBuffer: sourceFileBuffer,
       message: note.message,
       severity: .note,
-      position: note.position
+      position: note.position,
+      offset: sourceFileBufferOffset
     )
   }
 }

--- a/test/Macros/lazy_parsing.swift
+++ b/test/Macros/lazy_parsing.swift
@@ -8,9 +8,6 @@
 // RUN: %empty-directory(%t/stats-lookup)
 // RUN: split-file %s %t
 
-// rdar://124548628 (additional ExportedSourceFileRequest(s) in `lazy_parsing.swift` (NCGenerics Enablement))
-// XFAIL: *
-
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
 // RUN: %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -stats-output-dir %t/stats-no-lookup -primary-file %t/b.swift %t/a.swift


### PR DESCRIPTION
Cherry-pick #73237 into release/6.0

* **Explanation**: Previously when type checking definition part of `macro` decl, type-checker used to use the parsed syntax tree of the entire source file. But since `macro` declarations are often appear in files that does not contain any expansions, including `.swiftinterface`, creating the syntax tree of the entire file was often a waste. Instead, only parse and create a syntax tree of  the declaration part.
* **Scope**: Macro defintion checking
* **Risk**: Low, no user observable functional change. The change is scoped and straightforward
* **Testing**: Passes current test suite
* **Issue**: rdar://127064641
* **Reviewer**: Hamish Knight (@hamishknight)
