### PR TITLE
IRGen: Fix key path generic environment marshalling for external property descriptors.

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -83,14 +83,12 @@ irgen::bindPolymorphicArgumentsFromComponentIndices(IRGenFunction &IGF,
   // The generic environment is marshaled into the end of the component
   // argument area inside the instance. Bind the generic information out of
   // the buffer.
-  if (hasSubscriptIndices) {
-    auto genericArgsSize = llvm::ConstantInt::get(IGF.IGM.SizeTy,
-      requirements.size() * IGF.IGM.getPointerSize().getValue());
+  auto genericArgsSize = llvm::ConstantInt::get(IGF.IGM.SizeTy,
+    requirements.size() * IGF.IGM.getPointerSize().getValue());
 
-    auto genericArgsOffset = IGF.Builder.CreateSub(size, genericArgsSize);
-    args =
-        IGF.Builder.CreateInBoundsGEP(IGF.IGM.Int8Ty, args, genericArgsOffset);
-  }
+  auto genericArgsOffset = IGF.Builder.CreateSub(size, genericArgsSize);
+  args =
+      IGF.Builder.CreateInBoundsGEP(IGF.IGM.Int8Ty, args, genericArgsOffset);
 
   bindFromGenericRequirementsBuffer(
       IGF, requirements,

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2787,7 +2787,6 @@ internal func _getTypeByMangledNameInEnvironmentOrContext(
   genericEnvironmentOrContext: UnsafeRawPointer?,
   genericArguments: UnsafeRawPointer?)
   -> Any.Type? {
-
   let taggedPointer = UInt(bitPattern: genericEnvironmentOrContext)
   if taggedPointer & 1 == 0 {
     return _getTypeByMangledNameInEnvironment(name, nameLength,

--- a/test/stdlib/Inputs/KeyPathMultiModule_b.swift
+++ b/test/stdlib/Inputs/KeyPathMultiModule_b.swift
@@ -1,5 +1,18 @@
 import StdlibUnittest
 
+// rdar://125886333
+public struct GenericExternalKeyPathTest<E> {
+    public private(set) var property: String {
+        get {
+            return "\(E.self)"
+        }
+        set {
+        }
+    }
+
+    public init() {}
+}
+
 public struct A {
   public var x: Int { return 0 }
 

--- a/test/stdlib/KeyPathMultiModule.swift
+++ b/test/stdlib/KeyPathMultiModule.swift
@@ -221,4 +221,18 @@ keyPathMultiModule.test("identity across multiple modules") {
   }
 }
 
+@inline(never) @_optimize(none)
+func testGenericExternalPropertyKeyPath<A, B, C>(
+    a: A, b: B, c: C
+) -> KeyPath<GenericExternalKeyPathTest<C>, String> {
+    return \GenericExternalKeyPathTest<C>.property
+}
+
+keyPathMultiModule.test("external generic property keypath accessed from different generic context") {
+    let kp = testGenericExternalPropertyKeyPath(a: 1, b: 1.0, c: "one")
+
+    expectEqual(GenericExternalKeyPathTest<String>()[keyPath: kp],
+                "\(String.self)")
+}
+
 runAllTests()


### PR DESCRIPTION
The layout of a computed key path component carries an argument buffer for captures, which has the following layout:

```
---
captured values (subscript indices)
---
generic arguments
---
```

When we reference an externally-defined public property or subscript from a key path, and the external declaration has a property descriptor, then the generic arguments for the external declaration get appended to the end of this buffer, giving:

```
---
captured values (subscript indices)
---
generic arguments
---
external property's generic arguments
---
```

The convention for key path accessors to bind their generic environment is thus to unpack them from the end of the argument buffer, so that the external keypath's accessors can find the arguments to bind the external generic environment while still allowing the enclosing key path to save the original captured generic environment (which may be necessary to capture the appropriate conditional and/or retroactive `Equatable` and `Hashable` conformances for subscript indices).

However, our code generation for binding the generic arguments out of the argument buffer contained a flawed optimization: for a property, we know there are never any captured values, so I had assumed that the generic parameters could always be bound from the beginning of the argument buffer, assuming that the generic parameters make up the totality of the buffer. This falls over for external property descriptor references when the key path itself captures a generic environment, since the external property's expected generic environment appears after the key path's original generic environment. We can fix this by removing the conditional entirely, and always adjusting the offset we load the generic environment from to look at the end of the buffer. Fixes rdar://125886333.