### PR TITLE
[6.0] IRGen: Fix key path generic environment marshalling for external property descriptors.

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -83,14 +83,12 @@ irgen::bindPolymorphicArgumentsFromComponentIndices(IRGenFunction &IGF,
   // The generic environment is marshaled into the end of the component
   // argument area inside the instance. Bind the generic information out of
   // the buffer.
-  if (hasSubscriptIndices) {
-    auto genericArgsSize = llvm::ConstantInt::get(IGF.IGM.SizeTy,
-      requirements.size() * IGF.IGM.getPointerSize().getValue());
+  auto genericArgsSize = llvm::ConstantInt::get(IGF.IGM.SizeTy,
+    requirements.size() * IGF.IGM.getPointerSize().getValue());
 
-    auto genericArgsOffset = IGF.Builder.CreateSub(size, genericArgsSize);
-    args =
-        IGF.Builder.CreateInBoundsGEP(IGF.IGM.Int8Ty, args, genericArgsOffset);
-  }
+  auto genericArgsOffset = IGF.Builder.CreateSub(size, genericArgsSize);
+  args =
+      IGF.Builder.CreateInBoundsGEP(IGF.IGM.Int8Ty, args, genericArgsOffset);
 
   bindFromGenericRequirementsBuffer(
       IGF, requirements,

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2775,7 +2775,6 @@ internal func _getTypeByMangledNameInEnvironmentOrContext(
   genericEnvironmentOrContext: UnsafeRawPointer?,
   genericArguments: UnsafeRawPointer?)
   -> Any.Type? {
-
   let taggedPointer = UInt(bitPattern: genericEnvironmentOrContext)
   if taggedPointer & 1 == 0 {
     return _getTypeByMangledNameInEnvironment(name, nameLength,

--- a/test/stdlib/Inputs/KeyPathMultiModule_b.swift
+++ b/test/stdlib/Inputs/KeyPathMultiModule_b.swift
@@ -1,5 +1,18 @@
 import StdlibUnittest
 
+// rdar://125886333
+public struct GenericExternalKeyPathTest<E> {
+    public private(set) var property: String {
+        get {
+            return "\(E.self)"
+        }
+        set {
+        }
+    }
+
+    public init() {}
+}
+
 public struct A {
   public var x: Int { return 0 }
 

--- a/test/stdlib/KeyPathMultiModule.swift
+++ b/test/stdlib/KeyPathMultiModule.swift
@@ -221,4 +221,18 @@ keyPathMultiModule.test("identity across multiple modules") {
   }
 }
 
+@inline(never) @_optimize(none)
+func testGenericExternalPropertyKeyPath<A, B, C>(
+    a: A, b: B, c: C
+) -> KeyPath<GenericExternalKeyPathTest<C>, String> {
+    return \GenericExternalKeyPathTest<C>.property
+}
+
+keyPathMultiModule.test("external generic property keypath accessed from different generic context") {
+    let kp = testGenericExternalPropertyKeyPath(a: 1, b: 1.0, c: "one")
+
+    expectEqual(GenericExternalKeyPathTest<String>()[keyPath: kp],
+                "\(String.self)")
+}
+
 runAllTests()


### PR DESCRIPTION
Explanation: Fixes a miscompile that would lead to incorrect runtime behavior when a library exports a generic property that is then referenced by a key path literal in a generic context in another module with different generic parameters from the original property declaration.
Scope: Bug fix addressing a miscompile.
Issue: rdar://125886333
Original PR: https://github.com/apple/swift/pull/73259
Risk: Low. Fixes a bug in a bit of an edge case involving key paths, in a way that shouldn't affect already-working uses of key paths.
Testing: Swift CI, test case from bug report
Reviewer: @slavapestov, @aschwaighofer 