### PR TITLE
[Const Extract] Extract property wrapper details even when no default init is present

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -421,14 +421,19 @@ extractPropertyWrapperAttrValues(VarDecl *propertyDecl) {
 
 static ConstValueTypePropertyInfo
 extractTypePropertyInfo(VarDecl *propertyDecl) {
+  std::optional<AttrValueVector> propertyWrapperValues;
+  if (propertyDecl->hasAttachedPropertyWrapper())
+    propertyWrapperValues = extractPropertyWrapperAttrValues(propertyDecl);
+
   if (const auto binding = propertyDecl->getParentPatternBinding()) {
     if (const auto originalInit = binding->getInit(0)) {
       if (propertyDecl->hasAttachedPropertyWrapper()) {
         return {propertyDecl, extractCompileTimeValue(originalInit),
-                extractPropertyWrapperAttrValues(propertyDecl)};
+                propertyWrapperValues};
       }
 
-      return {propertyDecl, extractCompileTimeValue(originalInit)};
+      return {propertyDecl, extractCompileTimeValue(originalInit),
+              propertyWrapperValues};
     }
   }
 
@@ -438,7 +443,8 @@ extractTypePropertyInfo(VarDecl *propertyDecl) {
       if (auto *stmt = node.dyn_cast<Stmt *>()) {
         if (stmt->getKind() == StmtKind::Return) {
           return {propertyDecl,
-                  extractCompileTimeValue(cast<ReturnStmt>(stmt)->getResult())};
+                  extractCompileTimeValue(cast<ReturnStmt>(stmt)->getResult()),
+                  propertyWrapperValues};
         }
       }
     }

--- a/test/ConstExtraction/ExtractLiterals.swift
+++ b/test/ConstExtraction/ExtractLiterals.swift
@@ -43,6 +43,9 @@ public struct PropertyWrappers : MyProto {
 
     @Buffered @Clamping(min: 0, max: 255)
     var propertyWrapper3: Int = 128
+
+    @Buffered
+    var propertyWrapper4: String    
 }
 
 @propertyWrapper
@@ -373,6 +376,16 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:        }
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "_propertyWrapper4",
+// CHECK-NEXT:        "type": "ExtractLiterals.Buffered<Swift.String>",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 48,
+// CHECK-NEXT:        "valueKind": "Runtime"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "propertyWrapper1",
 // CHECK-NEXT:        "type": "Swift.String",
 // CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
@@ -544,7 +557,35 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
 // CHECK-NEXT:        "line": 45,
 // CHECK-NEXT:        "valueKind": "Runtime"
-// CHECK-NEXT:      }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "propertyWrapper4",
+// CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 48,
+// CHECK-NEXT:        "valueKind": "Runtime",
+// CHECK-NEXT:        "propertyWrappers": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "type": "ExtractLiterals.Buffered",
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:            "line": 47,
+// CHECK-NEXT:            "arguments": []
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "$propertyWrapper4",
+// CHECK-NEXT:        "type": "(Swift.String, Swift.Optional<Swift.String>)",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 48,
+// CHECK-NEXT:        "valueKind": "Runtime"
+// CHECK-NEXT:      } 
 // CHECK-NEXT:    ]
 // CHECK-NEXT:  }
 // CHECK-NEXT:]


### PR DESCRIPTION
This change adds the ability to extract info about a property's Property Wrapper even when it has no default initializer. We missed extracting wrapper details by-accident and have found use-cases where this is required.