### PR TITLE
Account for different module ABI name when reconstructing a type

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1181,6 +1181,11 @@ public:
 
   ModuleDecl *getModuleByIdentifier(Identifier ModuleID);
 
+  /// Looks up an already loaded module by its ABI name.
+  ///
+  /// \returns The module if found, nullptr otherwise.
+  ModuleDecl *getLoadedModuleByABIName(StringRef ModuleName);
+
   /// Returns the standard library module, or null if the library isn't present.
   ///
   /// If \p loadIfAbsent is true, the ASTContext will attempt to load the module

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2550,6 +2550,14 @@ ModuleDecl *ASTContext::getModuleByIdentifier(Identifier ModuleID) {
   return getModule(builder.get());
 }
 
+ModuleDecl *ASTContext::getLoadedModuleByABIName(StringRef ModuleName) {
+  for (auto &[_, module] : getLoadedModules()) {
+    if (ModuleName == module->getABIName().str())
+      return module;
+  }
+  return nullptr;
+}
+
 ModuleDecl *ASTContext::getStdlibModule(bool loadIfAbsent) {
   if (TheStdlibModule)
     return TheStdlibModule;

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1105,16 +1105,15 @@ ASTBuilder::createTypeDecl(NodePointer node,
   return dyn_cast<GenericTypeDecl>(DC);
 }
 
-ModuleDecl *
-ASTBuilder::findModule(NodePointer node) {
+ModuleDecl *ASTBuilder::findModule(NodePointer node) {
   assert(node->getKind() == Demangle::Node::Kind::Module);
   const auto moduleName = node->getText();
-  // Respect the main module's ABI name when we're trying to resolve
+  // Respect the module's ABI name when we're trying to resolve
   // mangled names. But don't touch anything under the Swift stdlib's
-  // umbrella. 
-  if (Ctx.MainModule && Ctx.MainModule->getABIName().is(moduleName))
-    if (!Ctx.MainModule->getABIName().is(STDLIB_NAME))
-      return Ctx.MainModule;
+  // umbrella.
+  if (moduleName != STDLIB_NAME)
+    if (auto *Module = Ctx.getLoadedModuleByABIName(moduleName))
+      return Module;
 
   return Ctx.getModuleByName(moduleName);
 }

--- a/test/TypeDecoder/different_abi_name.swift
+++ b/test/TypeDecoder/different_abi_name.swift
@@ -1,0 +1,31 @@
+// Tests that reconstructing a type from a mangled name whose type is defined 
+// in a separate module which has a different ABI name compared to its regular 
+// name works.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: cd %t
+
+// RUN: %target-build-swift -emit-library -emit-module -parse-as-library -module-abi-name Other -g %t/TheModule.swift 
+// RUN: %target-build-swift -emit-executable -I %t -L %t -lTheModule %s -g -o %t/user -emit-module
+
+
+// RUN: sed -ne '/\/\/ *DEMANGLE-TYPE: /s/\/\/ *DEMANGLE-TYPE: *//p' < %s > %t/input
+// RUN: %lldb-moduleimport-test-with-sdk %t/user -qualify-types=1 -type-from-mangled=%t/input | %FileCheck %s --check-prefix=CHECK-TYPE
+
+//--- TheModule.swift
+public class Foo {
+  let i = 42
+  public init() {
+  }
+}
+
+//--- user.swift
+
+import TheModule
+
+let c = TheModule.Foo()
+
+// DEMANGLE-TYPE: $s5Other3FooCD
+// CHECK-TYPE: TheModule.Foo
+


### PR DESCRIPTION
A type's mangled name will store the module's ABI name, not the module's regular name. When reconstructing a type from a mangled name, the demangler needs to take that into account.

rdar://126953614
