### PR TITLE
[LifetimeCompletion] Complete coro token lifetimes with end_borrow.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -490,6 +490,7 @@ public:
     BeginBorrow,
     SILFunctionArgument,
     Phi,
+    BeginApplyToken,
   };
 
 private:
@@ -520,6 +521,13 @@ public:
       }
       return Kind::Phi;
     }
+    case ValueKind::MultipleValueInstructionResult:
+      if (!isaResultOf<BeginApplyInst>(value))
+        return Kind::Invalid;
+      if (value->isBeginApplyToken()) {
+        return Kind::BeginApplyToken;
+      }
+      return Kind::Invalid;
     }
   }
 
@@ -540,6 +548,7 @@ public:
     case BorrowedValueKind::BeginBorrow:
     case BorrowedValueKind::LoadBorrow:
     case BorrowedValueKind::Phi:
+    case BorrowedValueKind::BeginApplyToken:
       return true;
     case BorrowedValueKind::SILFunctionArgument:
       return false;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3163,6 +3163,7 @@ public:
 
 class EndApplyInst;
 class AbortApplyInst;
+class EndBorrowInst;
 
 /// BeginApplyInst - Represents the beginning of the full application of
 /// a yield_once coroutine (up until the coroutine yields a value back).
@@ -3216,10 +3217,13 @@ public:
 
   void getCoroutineEndPoints(
       SmallVectorImpl<EndApplyInst *> &endApplyInsts,
-      SmallVectorImpl<AbortApplyInst *> &abortApplyInsts) const;
+      SmallVectorImpl<AbortApplyInst *> &abortApplyInsts,
+      SmallVectorImpl<EndBorrowInst *> *endBorrowInsts = nullptr) const;
 
-  void getCoroutineEndPoints(SmallVectorImpl<Operand *> &endApplyInsts,
-                             SmallVectorImpl<Operand *> &abortApplyInsts) const;
+  void getCoroutineEndPoints(
+      SmallVectorImpl<Operand *> &endApplyInsts,
+      SmallVectorImpl<Operand *> &abortApplyInsts,
+      SmallVectorImpl<Operand *> *endBorrowInsts = nullptr) const;
 };
 
 /// AbortApplyInst - Unwind the full application of a yield_once coroutine.
@@ -4538,8 +4542,6 @@ public:
     sharedUInt8().StoreInst.ownershipQualifier = uint8_t(qualifier);
   }
 };
-
-class EndBorrowInst;
 
 /// Represents a load of a borrowed value. Must be paired with an end_borrow
 /// instruction in its use-def list.

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -590,6 +590,8 @@ public:
 
   bool isGuaranteedForwarding() const;
 
+  bool isBeginApplyToken() const;
+
   /// Unsafely eliminate moveonly from this value's type. Returns true if the
   /// value's underlying type was move only and thus was changed. Returns false
   /// otherwise.

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -191,6 +191,13 @@ bool ValueBase::isGuaranteedForwarding() const {
   return phi->isGuaranteedForwarding();
 }
 
+bool ValueBase::isBeginApplyToken() const {
+  auto *result = isaResultOf<BeginApplyInst>(this);
+  if (!result)
+    return false;
+  return result->isBeginApplyToken();
+}
+
 bool ValueBase::hasDebugTrace() const {
   for (auto *op : getUses()) {
     if (auto *debugValue = dyn_cast<DebugValueInst>(op->getUser())) {

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -913,6 +913,9 @@ void BorrowedValueKind::print(llvm::raw_ostream &os) const {
   case BorrowedValueKind::Phi:
     os << "Phi";
     return;
+  case BorrowedValueKind::BeginApplyToken:
+    os << "BeginApply";
+    return;
   }
   llvm_unreachable("Covered switch isn't covered?!");
 }
@@ -945,6 +948,7 @@ bool BorrowedValue::visitLocalScopeEndingUses(
   case BorrowedValueKind::LoadBorrow:
   case BorrowedValueKind::BeginBorrow:
   case BorrowedValueKind::Phi:
+  case BorrowedValueKind::BeginApplyToken:
     for (auto *use : lookThroughBorrowedFromUser(value)->getUses()) {
       if (use->isLifetimeEnding()) {
         if (!visitor(use))
@@ -1819,6 +1823,7 @@ public:
 
       case BorrowedValueKind::LoadBorrow:
       case BorrowedValueKind::SILFunctionArgument:
+      case BorrowedValueKind::BeginApplyToken:
         // There is no enclosing def on this path.
         return true;
       }
@@ -2037,6 +2042,7 @@ protected:
     }
     case BorrowedValueKind::LoadBorrow:
     case BorrowedValueKind::SILFunctionArgument:
+    case BorrowedValueKind::BeginApplyToken:
       // There is no enclosing def on this path.
       break;
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -447,7 +447,8 @@ static bool visitScopeEndsRequiringInit(
   if (auto bai =
           dyn_cast_or_null<BeginApplyInst>(operand->getDefiningInstruction())) {
     for (auto *inst : bai->getTokenResult()->getUsers()) {
-      assert(isa<EndApplyInst>(inst) || isa<AbortApplyInst>(inst));
+      assert(isa<EndApplyInst>(inst) || isa<AbortApplyInst>(inst) ||
+             isa<EndBorrowInst>(inst));
       visit(inst, ScopeRequiringFinalInit::Coroutine);
     }
     return true;

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -140,6 +140,7 @@ SILValue CanonicalizeBorrowScope::getCanonicalBorrowedDef(SILValue def) {
 
       case BorrowedValueKind::LoadBorrow:
       case BorrowedValueKind::Phi:
+      case BorrowedValueKind::BeginApplyToken:
         break;
       }
     }
@@ -170,6 +171,7 @@ bool CanonicalizeBorrowScope::computeBorrowLiveness() {
     // can handle persistentCopies.
     return false;
   case BorrowedValueKind::BeginBorrow:
+  case BorrowedValueKind::BeginApplyToken:
     break;
   }
   // Note that there is no need to look through any reborrows. The reborrowed

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -307,7 +307,8 @@ bool swift::canDuplicateLoopInstruction(SILLoop *L, SILInstruction *I) {
   if (auto BAI = dyn_cast<BeginApplyInst>(I)) {
     for (auto UI : BAI->getTokenResult()->getUses()) {
       auto User = UI->getUser();
-      assert(isa<EndApplyInst>(User) || isa<AbortApplyInst>(User));
+      assert(isa<EndApplyInst>(User) || isa<AbortApplyInst>(User) ||
+             isa<EndBorrowInst>(User));
       if (!L->contains(User))
         return false;
     }

--- a/test/SILOptimizer/inline_begin_apply.sil
+++ b/test/SILOptimizer/inline_begin_apply.sil
@@ -690,3 +690,118 @@ bb_unwind:
   unwind
 
 }
+
+sil [ossa] [transparent] @simplest_in_guaranteed : $@yield_once @convention(thin) () -> @yields @in_guaranteed () {
+entry:
+  %tuple = tuple ()
+  %addr = alloc_stack $()
+  store %tuple to [trivial] %addr : $*()
+  yield %addr : $*(), resume resume_block, unwind unwind_block
+
+resume_block:
+  dealloc_stack %addr : $*()
+  %retval = tuple ()
+  return %retval : $()
+
+unwind_block:
+  dealloc_stack %addr : $*()
+  unwind
+}
+
+// CHECK-LABEL: sil [ossa] @ends_1 : {{.*}} {
+// CHECK:         [[VOID:%[^,]+]] = tuple ()
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $()
+// CHECK:         store [[VOID]] to [trivial] [[ADDR]]
+// CHECK:         cond_br undef, [[GOOD:bb[0-9]+]], [[BAD:bb[0-9]+]]
+// CHECK:       [[GOOD]]:
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[BAD]]:
+// CHECK:         cond_br undef, [[NORMAL_BAD:bb[0-9]+]], [[REALLY_BAD:bb[0-9]+]]
+// CHECK:       [[NORMAL_BAD]]:
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[REALLY_BAD]]:
+// CHECK:         unreachable
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'ends_1'
+sil [ossa] @ends_1 : $@convention(thin) () -> () {
+entry:
+  %simplest = function_ref @simplest_in_guaranteed : $@yield_once @convention(thin) () -> @yields @in_guaranteed ()
+  (%_, %token) = begin_apply %simplest() : $@yield_once @convention(thin) () -> @yields @in_guaranteed ()
+  cond_br undef, good, bad
+
+good:
+  end_apply %token as $()
+  br exit
+
+bad:
+  cond_br undef, normal_bad, really_bad
+
+normal_bad:
+  abort_apply %token
+  br exit
+
+really_bad:
+  end_borrow %token : $Builtin.SILToken
+  unreachable
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Test handling for multiple end_borrows of a token.
+// CHECK-LABEL: sil [ossa] @ends_2 : {{.*}} {
+// CHECK:         [[VOID:%[^,]+]] = tuple ()
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $()
+// CHECK:         store [[VOID]] to [trivial] [[ADDR]] : $*()
+// CHECK:         cond_br undef, [[GOOD:bb[0-9]+]], [[BAD:bb[0-9]+]]
+// CHECK:       [[GOOD]]:
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[BAD]]:
+// CHECK:         cond_br undef, [[NORMAL_BAD:bb[0-9]+]], [[REALLY_BAD:bb[0-9]+]]
+// CHECK:       [[NORMAL_BAD]]:
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[REALLY_BAD]]:
+// CHECK:         cond_br undef, [[BAD_NEWS_BUNNIES:bb[0-9]+]], [[BAD_NEWS_BEARS:bb[0-9]+]]
+// CHECK:       [[BAD_NEWS_BUNNIES]]:
+// CHECK:         unreachable
+// CHECK:       [[BAD_NEWS_BEARS]]:
+// CHECK:         unreachable
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'ends_2'
+sil [ossa] @ends_2 : $@convention(thin) () -> () {
+entry:
+  %simplest = function_ref @simplest_in_guaranteed : $@yield_once @convention(thin) () -> @yields @in_guaranteed ()
+  (%_, %token) = begin_apply %simplest() : $@yield_once @convention(thin) () -> @yields @in_guaranteed ()
+  cond_br undef, good, bad
+
+good:
+  end_apply %token as $()
+  br exit
+
+bad:
+  cond_br undef, normal_bad, really_bad
+
+normal_bad:
+  abort_apply %token
+  br exit
+
+really_bad:
+  cond_br undef, bad_news_bunnies, bad_news_bears
+
+bad_news_bunnies:
+  end_borrow %token : $Builtin.SILToken
+  unreachable
+
+bad_news_bears:
+  end_borrow %token : $Builtin.SILToken
+  unreachable
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -513,3 +513,27 @@ entry(%instance : @owned $C):
   store %instance to [init] %addr : $*C
   unreachable
 }
+
+// CHECK-LABEL: sil [ossa] @begin_apply : {{.*}} {
+// CHECK:         ({{%[^,]+}}, [[TOKEN:%[^,]+]]) = begin_apply undef()
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         end_borrow [[TOKEN]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'begin_apply'
+sil [ossa] @begin_apply : $@convention(thin) () -> () {
+entry:
+  (%_, %token) = begin_apply undef() : $@yield_once @convention(thin) () -> (@yields @in_guaranteed ())
+  specify_test "ossa-lifetime-completion %token"
+  cond_br undef, left, right
+
+left:
+  end_apply %token as $()
+  %retval = tuple ()
+  return %retval : $()
+
+right:
+  unreachable
+}


### PR DESCRIPTION
Allow end_borrow uses of such values and update inlining to handle them.  Regard such values as BorrowedValues; completion then falls out.
