### PR TITLE
[DebugInfo] Improve documentation & Fix discovered bugs

### DIFF
--- a/docs/HowToUpdateDebugInfo.md
+++ b/docs/HowToUpdateDebugInfo.md
@@ -1,6 +1,6 @@
-## How to update Debug Info in the Swift Compiler
+# How to update Debug Info in the Swift Compiler
 
-### Introduction
+## Introduction
 
 This document describes how debug info works at the SIL level and how to
 correctly update debug info in SIL optimization passes. This document is
@@ -8,7 +8,7 @@ inspired by its LLVM analog, [How to Update Debug Info: A Guide for LLVM Pass
 Authors](https://llvm.org/docs/HowToUpdateDebugInfo.html), which is recommended
 reading, since all of the concepts discussed there also apply to SIL.
 
-### Source Locations
+## Source Locations
 
 Contrary to LLVM IR, SIL makes source locations and lexical scopes mandatory on
 all instructions. SIL transformations should follow the LLVM guide for when to
@@ -16,35 +16,256 @@ merge drop and copy locations, since all the same considerations apply. Helpers
 like `SILBuilderWithScope` make it easy to copy source locations when expanding
 SIL instructions.
 
-### Variables, Variable Locations
-
-Source variables are represented by `debug_value` instructions, and may also be
-described in variable-carrying instructions (`alloc_stack`, `alloc_box`). There
-is no semantic difference between describing a variable in an allocation
-instruction directly or describing it in an `debug_value` following the
-allocation instruction. Variables are uniquely identified via their lexical
-scope, which also includes inline information, and their name and binding kind.
+## Variables
 
 Each `debug_value` (and variable-carrying instruction) defines an update point
 for the location of (part of) that source variable. A variable location is an
-SSA value or constant, modified by a debug expression that can transform that
-value, yielding the value of that variable. The debug expressions get lowered
-into LLVM [DIExpressions](https://llvm.org/docs/LangRef.html#diexpression) which
-get lowered into [DWARF](https://dwarfstd.org) expressions. Optimizations like
-SROA may split a source variable into multiple smaller fragments. An
-`op_fragment` is used to denote a location of a partial variable. Each variable
-(fragment) location is valid until the end of the current basic block, or until
-another `debug_value` describes another location for a variable fragment for the
-same unique variable that overlaps with that (fragment of the) variable.
-Variables may be undefined, in which case the SSA value is `undef`.
+SSA value, modified by a debug expression that can transform that value,
+yielding the value of that variable. Optimizations like SROA may split a source
+variable into multiple smaller fragments, other optimizations such as Mem2Reg
+may split a debug value describing an address into multiple debug values
+describing different SSA values. Each variable (fragment) location is valid
+until the end of the current basic block, or until another `debug_value`
+describes another location for a variable fragment for the same unique variable
+that overlaps with that (fragment of the) variable.
 
-### Rules of thumb
+### Debug variable-carrying instructions
+
+Source variables are represented by `debug_value` instructions, and may also be
+described in debug variable-carrying instructions (`alloc_stack`, `alloc_box`).
+There is no semantic difference between describing a variable in an allocation
+instruction directly or describing it in an `debug_value` following the
+allocation instruction.
+
+This is equivalent, and should be optimized similarly:
+```
+%0 = alloc_stack $T, var, name "value", loc "a.swift":4:2, scope 1
+// equivalent to:
+%0 = alloc_stack $T, loc "a.swift":4:2, scope 1
+debug_value %0 : $*T, var, name "value", expr op_deref, loc "a.swift":4:2, scope 1
+```
+
+> [!Note]
+> In the future, we may want to remove the debug variable from the `alloc_stack`
+> to only use the second form, in order to simplify SIL. Additionally, we could
+> then move the `debug_value` instruction to the point where the variable is
+> initialized to avoid showing ununitialized memory in the debugger. This would
+> be a change in SILGen, which should not affect the optimizer.
+
+For now, the `DebugVarCarryingInst` type can be used to handle both cases.
+
+### Variable identity, location and scope
+
+Variables are uniquely identified via their debug scope, their location, and
+their name.
+
+The debug scope, is the range in which the variable is declared and available.
+More information about debug scopes is available on
+[the Swift blog](https://www.swift.org/blog/whats-new-swift-debugging-5.9/#fine-grained-scope-information)
+For arguments, this will be the function's scope, otherwise, this will be a
+subscope within a function. When a function is inlined, a new scope is created,
+including information about the inlined function, and in which function it was
+inlined (inlined_at).
+
+The location of the variable is the source location where the variable was
+declared.
+
+If the location and scope of a debug variable isn't set, it will use the scope
+and location of the instruction, which is correct in most cases. However, if a
+`debug_value` describes a modification of a variable, the instruction should
+have the location of the update point, and the variable must keep the location
+of the variable declaration:
+
+```
+%0 = integer_literal $Int, 2
+debug_value %0 : $Int, var, name "a", loc "a.swift":2:5, scope 2
+%2 = integer_literal $Int, 3
+debug_value %2 : $Int, var, (name "a", loc "a.swift":2:5, scope 2), loc "a.swift":3:3, scope 2
+```
+For this code:
+```swift
+var a = 2
+a = 3
+```
+
+### Variable types
+
+By default the type of the variable will be the object type of the SSA value.
+If this is not the correct type, a type must be attached to the debug variable
+to override it.
+
+Example:
+
+```
+debug_value %0 : $*T, let, name "address", type $UnsafeRawPointer
+```
+
+The variable will usually have an associated expression yielding the correct
+type.
+
+### Variable expressions
+
+A variable can have an associated expression if the value needs computation.
+This can be for dereferencing a pointer, arithmetic, or for splitting structs.
+An expression is a sequence of operations to be executed left to right. Debug
+expressions get lowered into LLVM
+[DIExpressions](https://llvm.org/docs/LangRef.html#diexpression) which get
+lowered into [DWARF](https://dwarfstd.org) expressions.
+
+#### Address types and op_deref
+
+A variable's expression may include an `op_deref`, usually at the beginning, in
+which case the SSA value is a pointer that must be dereferenced to access the
+value of the variable.
+
+In this example, the value returned by the `alloc_stack` is an address that must
+be dereferenced.
+```
+%0 = alloc_stack $T
+debug_value %0 : $*T, var, name "value", expr op_deref
+```
+
+SILGen can use `SILBuilder::createDebugValue` and
+`SILBuilder::createDebugValueAddr` to create debug values, respectively without
+and with an op_deref, or use `SILBuilder::emitDebugDescription` which will
+automatically choose the correct one depending on the type of the SSA value. As
+there are no pointers in Swift, this should always do the right thing.
+
+> [!Warning]
+> At the optimizer level, Swift `Unsafe*Pointer` types can be simplified
+> to address types. As such, a `debug_value` with an address type without an
+> `op_deref` can be valid. SIL passes must not assume that `op_deref` and
+> address types correlate.
+
+Even if `op_deref` is usually at the beginning, it doesn't have to be:
+```
+debug_value %0 : $*UInt8, let, name "hello", expr op_constu:3:op_plus:op_deref
+```
+This will add `3` to the pointer contained in `%0`, then dereference the result.
+
+#### Fragments
+
+If a variable is partially updated, a fragment can be used to specify that this
+update refers to an element of an aggregate type.
+
+> [!Tip]
+> When using fragments, always specify the type of the variable, as it will be
+> different from the SSA value.
+
+When SROA is splitting a struct or tuple, it will also split the debug values,
+and add a fragment to specify which field is being updated.
+
+```
+struct Pair { var a, b: Int }
+
+alloc_stack $Pair, var, name "pair"
+// -->
+alloc_stack $Int, var, name "pair", type $Pair, expr op_fragment:#Pair.a
+alloc_stack $Int, var, name "pair", type $Pair, expr op_fragment:#Pair.b
+// -->
+alloc_stack $Builtin.Int64, var, name "pair", type $Pair, expr op_fragment:#Pair.a:op_fragment:#Int._value
+alloc_stack $Builtin.Int64, var, name "pair", type $Pair, expr op_fragment:#Pair.b:op_fragment:#Int._value
+```
+
+Here, Pair is a struct containing two Ints, so each `alloc_stack` will receive a
+fragment with the field it is describing. Int, in Swift, is itself a struct
+containing one Builtin.Int64 (on 64 bits systems), so it can itself be SROA'ed.
+Fragments can be chained to describe this.
+
+Tuple fragments use a different syntax, but work similarly:
+
+```
+alloc_stack $(Int, Int), var, name "pair"
+// -->
+alloc_stack $Int, var, name "pair", type $(Int, Int), expr op_tuple_fragment:$(Int, Int):0
+alloc_stack $Int, var, name "pair", type $(Int, Int), expr op_tuple_fragment:$(Int, Int):1
+// -->
+alloc_stack $Builtin.Int64, var, name "pair", type $(Int, Int), expr op_tuple_fragment:$(Int, Int):0:op_fragment:#Int._value
+alloc_stack $Builtin.Int64, var, name "pair", type $(Int, Int), expr op_tuple_fragment:$(Int, Int):1:op_fragment:#Int._value
+```
+
+Tuple fragments and struct fragments can be mixed freely, however, they must all
+be at the end of the expression. That is because the fragment operator can be
+seen as returning a struct containing a single element, with the rest undefined,
+and, except fragments, no debug expression operator take a struct as input.
+
+> [!Note]
+> When multiple fragments are present, they are evaluated in the reverse way —
+> from the field within the variable first, to the SSA's type at the end
+
+#### Arithmetic
+
+An expression can add or subtract a constant offset to a value. To do so, an
+`op_constu` or `op_consts` can be used to push a constant integer to the stack,
+respectively unsigned and signed. Then, the `op_plus` and `op_minus` operators
+can be used to sum or subtract the two values on the stack.
+
+```
+debug_value %0 : $Builtin.Int64, var, name "previous", type $Int, expr op_consts:1:op_minus:op_fragment:#Int._value
+debug_value %0 : $Builtin.Int64, var, name "next", type $Int, expr op_consts:1:op_plus:op_fragment:#Int._value
+```
+
+> [!Caution]
+> This currently doesn't work, an implicit op_deref is added.
+
+#### Constants
+
+If a `debug_value` is describing a constant, such as in `let x = 1`, and the
+value is optimized out, we can keep it, using a constant expression, and no SSA
+value.
+
+```
+debug_value undef : $Int, let, name "x", expr op_consts:1:op_fragment:#Int._value
+```
+
+> [!Caution]
+> This currently doesn't work, such debug values are dropped.
+
+### Undef variables
+
+If the value of the variable cannot be recovered as the value is entirely
+optimized away, an undef debug value should still be kept:
+
+```
+debug_value undef : $Int, let, name "x"
+```
+
+> [!Caution]
+> This currently doesn't work, such debug values are dropped.
+
+Additionally, if a previous `debug_value` exists for the variable, a debug value
+of undef invalidates the previous value, in case the value of the variable isn't
+known anymore:
+
+```
+debug_value %0 : $Int, var, name "x" // var x = a
+...
+debug_value undef : $Int, var, name "x" // x = <optimized out>
+```
+
+Combined with fragments, some parts of the variable can be undefined and some
+not:
+
+```
+... // pair = ?
+debug_value %0 : $Int, var, name "pair", type $Pair, expr op_fragment:#Pair.a // pair.a = x
+debug_value %0 : $Int, var, name "pair", type $Pair, expr op_fragment:#Pair.b // pair.b = x
+... // pair = (x, x)
+debug_value undef : $Pair, var, name "pair", expr op_fragment:#Pair.a // pair.a = <optimized out>
+... // pair = (?, x)
+debug_value undef : $Pair, var, name "pair" // pair = <optimized out>
+... // pair = ?
+debug_value %1 : $Int, var, name "pair", type $Pair, expr op_fragment:#Pair.a // pair.a = y
+... // pair = (y, ?)
+```
+
+## Rules of thumb
 - Optimization passes may never drop a variable entirely. If a variable is
   entirely optimized away, an `undef` debug value should still be kept.
 - A `debug_value` must always describe a correct value for that source variable
   at that source location. If a value is only correct on some paths through that
   instruction, it must be replaced with `undef`. Debug info never speculates.
-- When a SIL instruction referenced by a `debug_value` is (really, any
-  instruction) deleted, call salvageDebugInfo(). It will try to capture the
-  effect of the deleted instruction in a debug expression, so the location can
-  be preserved.
+- When a SIL instruction is deleted, call salvageDebugInfo(). It will try to
+  capture the effect of the deleted instruction in a debug expression, so the
+  location can be preserved. You can also use an `InstructionDeleter` which will
+  automatically call `salvageDebugInfo`.

--- a/docs/HowToUpdateDebugInfo.md
+++ b/docs/HowToUpdateDebugInfo.md
@@ -206,7 +206,7 @@ debug_value %0 : $Builtin.Int64, var, name "next", type $Int, expr op_consts:1:o
 ```
 
 > [!Caution]
-> This currently doesn't work, an implicit op_deref is added.
+> This currently doesn't work if a fragment is present.
 
 #### Constants
 
@@ -219,7 +219,7 @@ debug_value undef : $Int, let, name "x", expr op_consts:1:op_fragment:#Int._valu
 ```
 
 > [!Caution]
-> This currently doesn't work, an implicit op_deref is added.
+> This currently doesn't work, these variables are dropped by IRGen.
 
 ### Undef variables
 

--- a/docs/HowToUpdateDebugInfo.md
+++ b/docs/HowToUpdateDebugInfo.md
@@ -219,7 +219,7 @@ debug_value undef : $Int, let, name "x", expr op_consts:1:op_fragment:#Int._valu
 ```
 
 > [!Caution]
-> This currently doesn't work, such debug values are dropped.
+> This currently doesn't work, an implicit op_deref is added.
 
 ### Undef variables
 
@@ -229,9 +229,6 @@ optimized away, an undef debug value should still be kept:
 ```
 debug_value undef : $Int, let, name "x"
 ```
-
-> [!Caution]
-> This currently doesn't work, such debug values are dropped.
 
 Additionally, if a previous `debug_value` exists for the variable, a debug value
 of undef invalidates the previous value, in case the value of the variable isn't

--- a/docs/HowToUpdateDebugInfo.md
+++ b/docs/HowToUpdateDebugInfo.md
@@ -218,9 +218,6 @@ value.
 debug_value undef : $Int, let, name "x", expr op_consts:1:op_fragment:#Int._value
 ```
 
-> [!Caution]
-> This currently doesn't work, these variables are dropped by IRGen.
-
 ### Undef variables
 
 If the value of the variable cannot be recovered as the value is entirely

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3138,6 +3138,9 @@ bool IRGenDebugInfoImpl::buildDebugInfoExpression(
       return false;
     }
   }
+  if (Operands.size() && Operands.back() != llvm::dwarf::DW_OP_deref) {
+    Operands.push_back(llvm::dwarf::DW_OP_stack_value);
+  }
   return true;
 }
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3432,6 +3432,16 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
   // /always/ emit an llvm.dbg.value of undef.
   // If we have undef, always emit a llvm.dbg.value in the current position.
   if (isa<llvm::UndefValue>(Storage)) {
+    if (Expr->getNumElements() &&
+        (Expr->getElement(0) == llvm::dwarf::DW_OP_consts
+         || Expr->getElement(0) == llvm::dwarf::DW_OP_constu)) {
+      /// Convert `undef, expr op_consts:N:...` to `N, expr ...`
+      Storage = llvm::ConstantInt::get(
+          llvm::IntegerType::getInt64Ty(Builder.getContext()),
+          Expr->getElement(1));
+      Expr = llvm::DIExpression::get(Builder.getContext(),
+                                     Expr->getElements().drop_front(2));
+    }
     DBuilder.insertDbgValueIntrinsic(Storage, Var, Expr, DL, ParentBlock);
     return;
   }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5598,11 +5598,10 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
 
   auto VarInfo = i->getVarInfo();
   assert(VarInfo && "debug_value without debug info");
-  if (isa<SILUndef>(SILVal)) {
+  if (isa<SILUndef>(SILVal) && VarInfo->Name == "$error") {
     // We cannot track the location of inlined error arguments because it has no
     // representation in SIL.
-    if (!IsAddrVal &&
-        !i->getDebugScope()->InlinedCallSite && VarInfo->Name == "$error") {
+    if (!IsAddrVal && !i->getDebugScope()->InlinedCallSite) {
       auto funcTy = CurSILFn->getLoweredFunctionType();
       emitErrorResultVar(funcTy, funcTy->getErrorResult(), i);
     }

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -77,8 +77,10 @@ static bool seemsUseful(SILInstruction *I) {
   }
 
   // Is useful if it's associating with a function argument
+  // If undef, it is useful and it doesn't cost anything.
   if (isa<DebugValueInst>(I))
-    return isa<SILFunctionArgument>(I->getOperand(0));
+    return isa<SILFunctionArgument>(I->getOperand(0))
+      || isa<SILUndef>(I->getOperand(0));
 
   return false;
 }

--- a/test/DebugInfo/irgen_undef.sil
+++ b/test/DebugInfo/irgen_undef.sil
@@ -16,16 +16,33 @@ return %0 : $Builtin.Int64
 sil @arithmetic : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64) {
 bb0(%0 : $Builtin.Int64):
 // CHECK: call void @llvm.dbg.value(metadata i64 %0, metadata ![[CURRENT_VAR:[0-9]+]], metadata !DIExpression())
-debug_value %0 : $Builtin.Int64, var, name "current", type $Int, expr op_fragment:#Int._value
+debug_value %0 : $Builtin.Int64, var, name "current", type $Int64, expr op_fragment:#Int64._value
 // FIXME: It should work with the fragment, as it should be noop.
 // CHECK: call void @llvm.dbg.value(metadata i64 %0, metadata ![[PREVIOUS_VAR:[0-9]+]], metadata !DIExpression(DW_OP_consts, 1, DW_OP_minus, DW_OP_stack_value))
-debug_value %0 : $Builtin.Int64, var, name "previous", type $Int, expr op_consts:1:op_minus //:op_fragment:#Int._value
+debug_value %0 : $Builtin.Int64, var, name "previous", type $Int64, expr op_consts:1:op_minus //:op_fragment:#Int64._value
 // CHECK: call void @llvm.dbg.value(metadata i64 %0, metadata ![[NEXT_VAR:[0-9]+]], metadata !DIExpression(DW_OP_constu, 12, DW_OP_plus, DW_OP_stack_value))
-debug_value %0 : $Builtin.Int64, var, name "next", type $Int, expr op_constu:12:op_plus //:op_fragment:#Int._value
+debug_value %0 : $Builtin.Int64, var, name "next", type $Int64, expr op_constu:12:op_plus //:op_fragment:#Int64._value
 return %0 : $Builtin.Int64
 }
+
+// CHECK-LABEL: define {{.*}} @constant
+sil @constant : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64) {
+bb0(%0 : $Builtin.Int64):
+// CHECK: call void @llvm.dbg.value(metadata i64 42, metadata ![[CONST_VAR:[0-9]+]], metadata !DIExpression(DW_OP_stack_value))
+debug_value undef : $Builtin.Int64, var, name "const", expr op_consts:42
+// CHECK: call void @llvm.dbg.value(metadata i64 3645, metadata ![[CONSTINT_VAR:[0-9]+]], metadata !DIExpression(DW_OP_stack_value))
+debug_value undef : $Builtin.Int64, var, name "constint", type $Int64, expr op_constu:3645:op_fragment:#Int64._value
+// CHECK: call void @llvm.dbg.value(metadata i64 6, metadata ![[CONSTUPLE_VAR:[0-9]+]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64))
+debug_value undef : $Builtin.Int64, var, name "constuple", type $(Int64, Int64), expr op_consts:6:op_tuple_fragment:$(Int64, Int64):0:op_fragment:#Int64._value
+
+return %0 : $Builtin.Int64
+}
+
 
 // CHECK: ![[JUST_UNDEF_VAR]] = !DILocalVariable(name: "optimizedout"
 // CHECK: ![[CURRENT_VAR]] = !DILocalVariable(name: "current"
 // CHECK: ![[PREVIOUS_VAR]] = !DILocalVariable(name: "previous"
 // CHECK: ![[NEXT_VAR]] = !DILocalVariable(name: "next"
+// CHECK: ![[CONST_VAR]] = !DILocalVariable(name: "const"
+// CHECK: ![[CONSTINT_VAR]] = !DILocalVariable(name: "constint"
+// CHECK: ![[CONSTUPLE_VAR]] = !DILocalVariable(name: "constuple"

--- a/test/DebugInfo/irgen_undef.sil
+++ b/test/DebugInfo/irgen_undef.sil
@@ -12,4 +12,20 @@ debug_value undef : $Builtin.Int64, var, name "optimizedout"
 return %0 : $Builtin.Int64
 }
 
+// CHECK-LABEL: define {{.*}} @arithmetic
+sil @arithmetic : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64) {
+bb0(%0 : $Builtin.Int64):
+// CHECK: call void @llvm.dbg.value(metadata i64 %0, metadata ![[CURRENT_VAR:[0-9]+]], metadata !DIExpression())
+debug_value %0 : $Builtin.Int64, var, name "current", type $Int, expr op_fragment:#Int._value
+// FIXME: It should work with the fragment, as it should be noop.
+// CHECK: call void @llvm.dbg.value(metadata i64 %0, metadata ![[PREVIOUS_VAR:[0-9]+]], metadata !DIExpression(DW_OP_consts, 1, DW_OP_minus, DW_OP_stack_value))
+debug_value %0 : $Builtin.Int64, var, name "previous", type $Int, expr op_consts:1:op_minus //:op_fragment:#Int._value
+// CHECK: call void @llvm.dbg.value(metadata i64 %0, metadata ![[NEXT_VAR:[0-9]+]], metadata !DIExpression(DW_OP_constu, 12, DW_OP_plus, DW_OP_stack_value))
+debug_value %0 : $Builtin.Int64, var, name "next", type $Int, expr op_constu:12:op_plus //:op_fragment:#Int._value
+return %0 : $Builtin.Int64
+}
+
 // CHECK: ![[JUST_UNDEF_VAR]] = !DILocalVariable(name: "optimizedout"
+// CHECK: ![[CURRENT_VAR]] = !DILocalVariable(name: "current"
+// CHECK: ![[PREVIOUS_VAR]] = !DILocalVariable(name: "previous"
+// CHECK: ![[NEXT_VAR]] = !DILocalVariable(name: "next"

--- a/test/DebugInfo/irgen_undef.sil
+++ b/test/DebugInfo/irgen_undef.sil
@@ -1,0 +1,15 @@
+// RUN: %target-swiftc_driver -Xfrontend -disable-debugger-shadow-copies -O -g -emit-ir %s | %FileCheck %s
+sil_stage canonical
+
+import Swift
+import Builtin
+
+// CHECK-LABEL: define {{.*}} @just_undef
+sil @just_undef : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64) {
+bb0(%0 : $Builtin.Int64):
+// CHECK: call void @llvm.dbg.value(metadata i64 undef, metadata ![[JUST_UNDEF_VAR:[0-9]+]], metadata !DIExpression())
+debug_value undef : $Builtin.Int64, var, name "optimizedout"
+return %0 : $Builtin.Int64
+}
+
+// CHECK: ![[JUST_UNDEF_VAR]] = !DILocalVariable(name: "optimizedout"

--- a/test/DebugInfo/salvage-integer-literal.swift
+++ b/test/DebugInfo/salvage-integer-literal.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -O -g -emit-sil %s | %FileCheck %s
+
+// In optimized code, a + b will be folded to 5, but we should still keep their
+// debug values.
+
+// CHECK-LABEL: sil
+public func f() -> Int {
+  let a = 2
+  let b = 3
+  // CHECK: debug_value undef : $Builtin.Int64, let, name "a", type $Int, expr op_constu:2:op_fragment:#Int._value
+  // CHECK: debug_value undef : $Builtin.Int64, let, name "b", type $Int, expr op_constu:3:op_fragment:#Int._value
+  return a + b
+}

--- a/test/SILOptimizer/dead_alloc.swift
+++ b/test/SILOptimizer/dead_alloc.swift
@@ -52,6 +52,7 @@ public func deadClassInstance() {
 
 // CHECK-LABEL: sil @$s10dead_alloc0A13ManagedBufferyyF :
 // CHECK:       bb0:
+// CHECK-NEXT:    debug_value undef
 // CHECK-NEXT:    tuple
 // CHECK-NEXT:    return
 // CHECK-NEXT:  } // end sil function '$s10dead_alloc0A13ManagedBufferyyF'

--- a/test/SILOptimizer/dead_array_elim.swift
+++ b/test/SILOptimizer/dead_array_elim.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -emit-sil -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -primary-file %s | grep -v debug_value | %FileCheck %s
 
 // REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: swift_in_compiler
@@ -62,9 +62,7 @@ func testDeadArrayElimWithAddressOnlyValues<T>(x: T, y: T) {
 // RLE needs to handle the new init pattern - rdar://117751668
 // TODO-LABEL: sil hidden {{.*}}@$s15dead_array_elim31testDeadArrayAfterOptimizationsySiSSF
 // TODO:      bb0(%0 : $String):
-// TODO-NEXT:   debug_value
 // TODO-NEXT:   integer_literal $Builtin.Int{{[0-9]+}}, 21
-// TODO-NEXT:   debug_value
 // TODO-NEXT:   struct $Int
 // TODO-NEXT:   return
 // TODO:      } // end sil function '$s15dead_array_elim31testDeadArrayAfterOptimizationsySiSSF'
@@ -85,7 +83,6 @@ func testDeadArrayAfterOptimizations(_ stringParameter: String) -> Int {
 // CHECK-LABEL: sil hidden @$s15dead_array_elim15testNestedArraySiyF
 // CHECK:      bb0:
 // CHECK-NEXT:   integer_literal $Builtin.Int{{[0-9]+}}, 3
-// CHECK-NEXT:   debug_value
 // CHECK-NEXT:   struct $Int
 // CHECK-NEXT:   return
 // CHECK:      } // end sil function '$s15dead_array_elim15testNestedArraySiyF'

--- a/test/SILOptimizer/optionset.swift
+++ b/test/SILOptimizer/optionset.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -O -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
-// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -Osize -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -O -sil-verify-all -module-name=test -emit-sil | grep -v debug_value | %FileCheck %s
+// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -Osize -sil-verify-all -module-name=test -emit-sil | grep -v debug_value | %FileCheck %s
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: swift_in_compiler
 


### PR DESCRIPTION
Adds more documentation about updating debug values, and debug value expressions.

Fixes a few bugs: undef debug values being removed, constant debug values not working, arithmetic without a deref not working.
Add support for salvaging integer literals.

This increases the number of debug variables in the standard library by 1.7%

The biggest improvements in the amount of lost variables are: constant propagation (-81%), sil combine (-50%), dead code elimination (-31%), copy propagation (-59%), common subexpression elimination (-24%)