### PR TITLE
[IRGen] Fix misalignment of conditional invertible requirement counts

### DIFF
--- a/include/swift/ABI/GenericContext.h
+++ b/include/swift/ABI/GenericContext.h
@@ -23,6 +23,7 @@
 #include "swift/ABI/MetadataRef.h"
 #include "swift/ABI/InvertibleProtocols.h"
 #include "swift/ABI/TrailingObjects.h"
+#include "swift/Basic/MathUtils.h"
 #include "swift/Demangling/Demangle.h"
 
 namespace swift {
@@ -696,7 +697,7 @@ protected:
     if (!asSelf()->hasConditionalInvertedProtocols())
       return 0;
 
-    return __builtin_popcount(getConditionalInvertedProtocols().rawBits());
+    return popcount(getConditionalInvertedProtocols().rawBits());
   }
 
   size_t numTrailingObjects(

--- a/include/swift/ABI/GenericContext.h
+++ b/include/swift/ABI/GenericContext.h
@@ -696,7 +696,7 @@ protected:
     if (!asSelf()->hasConditionalInvertedProtocols())
       return 0;
 
-    return countBitsUsed(getConditionalInvertedProtocols().rawBits());
+    return __builtin_popcount(getConditionalInvertedProtocols().rawBits());
   }
 
   size_t numTrailingObjects(

--- a/include/swift/Basic/MathUtils.h
+++ b/include/swift/Basic/MathUtils.h
@@ -19,6 +19,10 @@
 
 #include <cstddef>
 
+#if SWIFT_COMPILER_IS_MSVC
+#include <intrin.h>
+#endif
+
 namespace swift {
 
 /// Round the given value up to the given alignment, as a power of two.
@@ -31,6 +35,15 @@ static inline constexpr T roundUpToAlignment(T offset, T alignment) {
 /// power of two minus one).
 static inline size_t roundUpToAlignMask(size_t size, size_t alignMask) {
   return (size + alignMask) & ~alignMask;
+}
+
+static inline unsigned popcount(unsigned value) {
+#if SWIFT_COMPILER_IS_MSVC
+  return __popcnt(value);
+#else
+  // Assume we have a compiler with this intrinsic.
+  return __builtin_popcount(value);
+#endif
 }
 
 } // namespace swift

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1334,6 +1334,13 @@ namespace {
             B.addPlaceholderWithSize(IGM.Int16Ty));
       }
 
+      // The conditional invertible protocol set is alone as a 16 bit slot, so
+      // an even amount of conditional invertible protocols will cause an uneven
+      // alignment.
+      if ((numProtocols & 1) == 0) {
+        B.addInt16(0);
+      }
+
       // Emit the generic requirements for the conditional conformance
       // to each invertible protocol.
       auto nominal = cast<NominalTypeDecl>(Type);


### PR DESCRIPTION
The conditional invertible protocol set is alone as a 16 bit slot in the generic context, but items here are expected to be 4 bytes large, so some padding needs to accompany this value. If the number of invertible protocols that we're conditional on is even, we can stick a 0 after all of the requirement counts. Also, we were using `countBitsUsed` to determine how many requirement counts there were, but this is really testing the first bit in [1, 64] that is turned on instead of actually saying how many bits are turned on.