### PR TITLE
[SIL] Only verify ownership when not disabled.

### DIFF
--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -914,6 +914,8 @@ void SILModule::verifyOwnership() const {
 void SILFunction::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {
   if (DisableOwnershipVerification)
     return;
+  if (!getModule().getOptions().VerifySILOwnership)
+    return;
 
 #ifdef NDEBUG
   // When compiling without asserts enabled, only verify ownership if


### PR DESCRIPTION
The option -disable-sil-ownership-verifier should almost never be used. But if it is, it should result in ownership verification being disabled, even when done via direct calls to `SILFunction::verifyOwnership`.

There are still a couple of test cases that use -disable-sil-ownership-verifier.
