### PR TITLE
🍒[cxx-interop] Test symbolic interface generation for new features

### DIFF
--- a/test/Interop/Cxx/symbolic-imports/print-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/print-symbolic-module-interface.swift
@@ -60,6 +60,19 @@ public:
     };
 };
 
+#define IMMORTAL_FRT                                                         \
+    __attribute__((swift_attr("import_reference")))                              \
+    __attribute__((swift_attr("retain:immortal")))                               \
+    __attribute__((swift_attr("release:immortal")))
+
+struct IMMORTAL_FRT MyImmortal {
+    virtual void foo() const {};
+};
+
+struct NonCopyable {
+    NonCopyable(const NonCopyable& other) = delete;
+};
+
 // CHECK:     enum ns {
 // CHECK-NEXT: struct B {
 // CHECK-NEXT:    init()
@@ -97,4 +110,11 @@ public:
 // CHECK-NEXT:     var x2: Any
 // CHECK-NEXT:     typealias Y = Any
 // CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK: class MyImmortal {
+// CHECK-NEXT:   func foo()
+// CHECK-NEXT: }
+// CHECK-NEXT: struct NonCopyable {
+// CHECK-NEXT:   @available(*, deprecated, message:
+// CHECK-NEXT:   init()
 // CHECK-NEXT: }


### PR DESCRIPTION
**Explanation**: This is a test-only change that ensures that a symbolic interface for a C++ module will include these features: move-only types and virtual methods.
**Scope**: Only tests were changed.
**Risk**: Low.
**Issue**: rdar://125816549

Original PR: https://github.com/apple/swift/pull/73248
