### PR TITLE
[6.0] Fix name lookup in nested protocol inheritance clauses

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1087,7 +1087,8 @@ static DirectlyReferencedTypeDecls
 directReferencesForTypeRepr(Evaluator &evaluator, ASTContext &ctx,
                             TypeRepr *typeRepr, DeclContext *dc,
                             bool allowUsableFromInline,
-                            bool rhsOfSelfRequirement);
+                            bool rhsOfSelfRequirement,
+                            bool allowProtocolMembers);
 
 /// Retrieve the set of type declarations that are directly referenced from
 /// the given type.
@@ -1148,7 +1149,8 @@ SelfBounds SelfBoundsFromWhereClauseRequest::evaluate(
       rhsDecls = directReferencesForTypeRepr(evaluator, ctx, typeRepr,
                                              const_cast<DeclContext *>(dc),
                                              /*allowUsableFromInline=*/false,
-                                             /*rhsOfSelfRequirement=*/true);
+                                             /*rhsOfSelfRequirement=*/true,
+                                             /*allowProtocolMembers=*/true);
     }
 
     SmallVector<ModuleDecl *, 2> modulesFound;
@@ -1212,7 +1214,8 @@ TypeDeclsFromWhereClauseRequest::evaluate(Evaluator &evaluator,
   auto resolve = [&](TypeRepr *typeRepr) {
     auto decls = directReferencesForTypeRepr(evaluator, ctx, typeRepr, ext,
                                              /*allowUsableFromInline=*/false,
-                                             /*rhsOfSelfRequirement=*/false);
+                                             /*rhsOfSelfRequirement=*/false,
+                                             /*allowProtocolMembers=*/true);
     result.first.insert(result.first.end(),
                         decls.first.begin(),
                         decls.first.end());
@@ -2843,10 +2846,11 @@ directReferencesForUnqualifiedTypeLookup(DeclNameRef name,
                                          SourceLoc loc, DeclContext *dc,
                                          LookupOuterResults lookupOuter,
                                          bool allowUsableFromInline,
-                                         bool rhsOfSelfRequirement) {
-  UnqualifiedLookupOptions options =
-      UnqualifiedLookupFlags::TypeLookup |
-      UnqualifiedLookupFlags::AllowProtocolMembers;
+                                         bool rhsOfSelfRequirement,
+                                         bool allowProtocolMembers) {
+  UnqualifiedLookupOptions options = UnqualifiedLookupFlags::TypeLookup;
+  if (allowProtocolMembers)
+      options |= UnqualifiedLookupFlags::AllowProtocolMembers;
   if (lookupOuter == LookupOuterResults::Included)
     options |= UnqualifiedLookupFlags::IncludeOuterResults;
 
@@ -2960,11 +2964,12 @@ static DirectlyReferencedTypeDecls
 directReferencesForDeclRefTypeRepr(Evaluator &evaluator, ASTContext &ctx,
                                    DeclRefTypeRepr *repr, DeclContext *dc,
                                    bool allowUsableFromInline,
-                                   bool rhsOfSelfRequirement) {
+                                   bool rhsOfSelfRequirement,
+                                   bool allowProtocolMembers) {
   if (auto *qualIdentTR = dyn_cast<QualifiedIdentTypeRepr>(repr)) {
     auto result = directReferencesForTypeRepr(
         evaluator, ctx, qualIdentTR->getBase(), dc,
-        allowUsableFromInline, rhsOfSelfRequirement);
+        allowUsableFromInline, rhsOfSelfRequirement, allowProtocolMembers);
 
     // For a qualified identifier, perform qualified name lookup.
     result.first = directReferencesForQualifiedTypeLookup(
@@ -2977,14 +2982,15 @@ directReferencesForDeclRefTypeRepr(Evaluator &evaluator, ASTContext &ctx,
   // For an unqualified identifier, perform unqualified name lookup.
   return directReferencesForUnqualifiedTypeLookup(
       repr->getNameRef(), repr->getLoc(), dc, LookupOuterResults::Excluded,
-      allowUsableFromInline, rhsOfSelfRequirement);
+      allowUsableFromInline, rhsOfSelfRequirement, allowProtocolMembers);
 }
 
 static DirectlyReferencedTypeDecls
 directReferencesForTypeRepr(Evaluator &evaluator,
                             ASTContext &ctx, TypeRepr *typeRepr,
                             DeclContext *dc, bool allowUsableFromInline,
-                            bool rhsOfSelfRequirement) {
+                            bool rhsOfSelfRequirement,
+                            bool allowProtocolMembers) {
   DirectlyReferencedTypeDecls result;
 
   switch (typeRepr->getKind()) {
@@ -2997,7 +3003,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     return directReferencesForTypeRepr(evaluator, ctx,
                                        attributed->getTypeRepr(), dc,
                                        allowUsableFromInline,
-                                       rhsOfSelfRequirement);
+                                       rhsOfSelfRequirement,
+                                       allowProtocolMembers);
   }
 
   case TypeReprKind::Composition: {
@@ -3006,7 +3013,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
       auto componentResult =
           directReferencesForTypeRepr(evaluator, ctx, component, dc,
                                       allowUsableFromInline,
-                                      rhsOfSelfRequirement);
+                                      rhsOfSelfRequirement,
+                                      allowProtocolMembers);
       result.first.insert(result.first.end(),
                           componentResult.first.begin(),
                           componentResult.first.end());
@@ -3022,7 +3030,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     return directReferencesForDeclRefTypeRepr(evaluator, ctx,
                                               cast<DeclRefTypeRepr>(typeRepr),
                                               dc, allowUsableFromInline,
-                                              rhsOfSelfRequirement);
+                                              rhsOfSelfRequirement,
+                                              allowProtocolMembers);
 
   case TypeReprKind::Dictionary:
     result.first.push_back(ctx.getDictionaryDecl());
@@ -3034,7 +3043,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
       result = directReferencesForTypeRepr(evaluator, ctx,
                                            tupleRepr->getElementType(0), dc,
                                            allowUsableFromInline,
-                                           rhsOfSelfRequirement);
+                                           rhsOfSelfRequirement,
+                                           allowProtocolMembers);
     } else {
       result.first.push_back(ctx.getBuiltinTupleDecl());
     }
@@ -3046,7 +3056,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     return directReferencesForTypeRepr(evaluator, ctx,
                                        packExpansionRepr->getElementType(), dc,
                                        allowUsableFromInline,
-                                       rhsOfSelfRequirement);
+                                       rhsOfSelfRequirement,
+                                       allowProtocolMembers);
   }
 
   case TypeReprKind::PackExpansion: {
@@ -3054,7 +3065,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     return directReferencesForTypeRepr(evaluator, ctx,
                                        packExpansionRepr->getPatternType(), dc,
                                        allowUsableFromInline,
-                                       rhsOfSelfRequirement);
+                                       rhsOfSelfRequirement,
+                                       allowProtocolMembers);
   }
 
   case TypeReprKind::PackElement: {
@@ -3062,7 +3074,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     return directReferencesForTypeRepr(evaluator, ctx,
                                        packReferenceRepr->getPackType(), dc,
                                        allowUsableFromInline,
-                                       rhsOfSelfRequirement);
+                                       rhsOfSelfRequirement,
+                                       allowProtocolMembers);
   }
 
   case TypeReprKind::Inverse: {
@@ -3072,7 +3085,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     auto innerResult = directReferencesForTypeRepr(evaluator, ctx,
                                                    inverseRepr->getConstraint(), dc,
                                                    allowUsableFromInline,
-                                                   rhsOfSelfRequirement);
+                                                   rhsOfSelfRequirement,
+                                                   allowProtocolMembers);
     if (innerResult.first.size() == 1) {
       if (auto *proto = dyn_cast<ProtocolDecl>(innerResult.first[0])) {
         if (auto ip = proto->getInvertibleProtocolKind()) {
@@ -3182,10 +3196,16 @@ DirectlyReferencedTypeDecls InheritedDeclsReferencedRequest::evaluate(
     else
       dc = (DeclContext *)decl.get<const ExtensionDecl *>();
 
+    // If looking at a protocol's inheritance list,
+    // do not look at protocol members to avoid circularity.
+    // Protocols cannot inherit from any protocol members anyway.
+    bool allowProtocolMembers = (dc->getSelfProtocolDecl() == nullptr);
+
     return directReferencesForTypeRepr(evaluator, dc->getASTContext(), typeRepr,
                                        const_cast<DeclContext *>(dc),
                                        /*allowUsableFromInline=*/false,
-                                       /*rhsOfSelfRequirement=*/false);
+                                       /*rhsOfSelfRequirement=*/false,
+                                       allowProtocolMembers);
   }
 
   // Fall back to semantic types.
@@ -3206,7 +3226,8 @@ DirectlyReferencedTypeDecls UnderlyingTypeDeclsReferencedRequest::evaluate(
     return directReferencesForTypeRepr(evaluator, typealias->getASTContext(),
                                        typeRepr, typealias,
                                        /*allowUsableFromInline=*/false,
-                                       /*rhsOfSelfRequirement=*/false);
+                                       /*rhsOfSelfRequirement=*/false,
+                                       /*allowProtocolMembers=*/true);
   }
 
   // Fall back to semantic types.
@@ -3373,7 +3394,8 @@ ExtendedNominalRequest::evaluate(Evaluator &evaluator,
   DirectlyReferencedTypeDecls referenced =
     directReferencesForTypeRepr(evaluator, ctx, typeRepr, ext->getParent(),
                                 ext->isInSpecializeExtensionContext(),
-                                /*rhsOfSelfRequirement=*/false);
+                                /*rhsOfSelfRequirement=*/false,
+                                /*allowProtocolMembers=*/true);
 
   // Resolve those type declarations to nominal type declarations.
   SmallVector<ModuleDecl *, 2> modulesFound;
@@ -3423,7 +3445,8 @@ bool TypeRepr::isProtocolOrProtocolComposition(DeclContext *dc) {
   auto &ctx = dc->getASTContext();
   auto references = directReferencesForTypeRepr(ctx.evaluator, ctx, this, dc,
                                                 /*allowUsableFromInline=*/false,
-                                                /*rhsOfSelfRequirement=*/false);
+                                                /*rhsOfSelfRequirement=*/false,
+                                                /*allowProtocolMembers=*/true);
   return declsAreProtocols(references.first);
 }
 
@@ -3458,7 +3481,8 @@ createTupleExtensionGenericParams(ASTContext &ctx,
                                 extendedTypeRepr,
                                 ext->getParent(),
                                 /*allowUsableFromInline=*/false,
-                                /*rhsOfSelfRequirement=*/false);
+                                /*rhsOfSelfRequirement=*/false,
+                                /*allowProtocolMembers=*/true);
   assert(referenced.second.empty() && "Implement me");
   if (referenced.first.size() != 1 || !isa<TypeAliasDecl>(referenced.first[0]))
     return nullptr;
@@ -3733,7 +3757,8 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
     decls = directReferencesForTypeRepr(
         evaluator, ctx, typeRepr, dc,
         /*allowUsableFromInline=*/false,
-        /*rhsOfSelfRequirement=*/false);
+        /*rhsOfSelfRequirement=*/false,
+        /*allowProtocolMembers=*/true);
   } else if (Type type = attr->getType()) {
     decls = directReferencesForType(type);
   }
@@ -3764,7 +3789,8 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
         decls = directReferencesForUnqualifiedTypeLookup(
             name, loc, dc, LookupOuterResults::Included,
             /*allowUsableFromInline=*/false,
-            /*rhsOfSelfRequirement=*/false);
+            /*rhsOfSelfRequirement=*/false,
+            /*allowProtocolMembers*/true);
         nominals = resolveTypeDeclsToNominal(evaluator, ctx, decls.first,
                                              ResolveToNominalOptions(),
                                              modulesFound, anyObject);
@@ -4002,7 +4028,8 @@ ProtocolDecl *ImplementsAttrProtocolRequest::evaluate(
   DirectlyReferencedTypeDecls referenced =
     directReferencesForTypeRepr(evaluator, ctx, typeRepr, dc,
                                 /*allowUsableFromInline=*/false,
-                                /*rhsOfSelfRequirement=*/false);
+                                /*rhsOfSelfRequirement=*/false,
+                                /*allowProtocolMembers=*/true);
 
   // Resolve those type declarations to nominal type declarations.
   SmallVector<ModuleDecl *, 2> modulesFound;

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -44,6 +44,46 @@ class OuterClass {
   protocol InnerProtocol : OuterClass { }
 }
 
+// Name lookup circularity tests.
+
+protocol SomeBaseProtocol {}
+
+struct ConformanceOnDecl: ConformanceOnDecl.P {
+    protocol P: SomeBaseProtocol {}
+}
+struct ConformanceOnDecl_2: ConformanceOnDecl_2.P {
+    protocol P where Self: SomeBaseProtocol {}
+}
+struct ConformanceOnDecl_3: Self.P {
+    protocol P: SomeBaseProtocol {}
+}
+struct ConformanceOnDecl_4: ConformanceOnDecl_4.Q {
+    protocol P: SomeBaseProtocol {}
+    protocol Q: P {}
+}
+
+
+struct ConformanceInExtension {
+    protocol P: SomeBaseProtocol {}
+}
+extension ConformanceInExtension: ConformanceInExtension.P {}
+
+struct ConformanceInExtension_2 {
+    protocol P where Self: SomeBaseProtocol {}
+}
+extension ConformanceInExtension_2: ConformanceInExtension_2.P {}
+
+struct ConformanceInExtension_3 {
+    protocol P: SomeBaseProtocol {}
+}
+extension ConformanceInExtension_3: Self.P {}
+
+struct ConformanceInExtension_4 {
+    protocol P: SomeBaseProtocol {}
+    protocol Q: P {}
+}
+extension ConformanceInExtension_4: ConformanceInExtension_4.Q {}
+
 // Protocols can be nested in actors.
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)


### PR DESCRIPTION
**Explanation**: Fix an issue with name lookup that prevents nested protocols from being able to refine protocols in outer scopes (reported on the forums - https://forums.swift.org/t/circular-reference-in-protocol-nesting/70336)
**Scope**: Name lookup
**Risk**: low -- the behaviour change is tightly scoped
**Testing**: CI

**Reviewed By**: @slavapestov in #72713 