### PR TITLE
Fix dev-scripts/split-cmdline: quote ';' arguments

### DIFF
--- a/utils/dev-scripts/split-cmdline
+++ b/utils/dev-scripts/split-cmdline
@@ -69,7 +69,7 @@ def main():
                 first = True
                 continue
 
-            if " " in arg:
+            if " " in arg or ";" in arg:
                 print('"' + arg + '"', end="")
             else:
                 print(arg, end="")


### PR DESCRIPTION
When printing an argument that contains ';', add back the quotes that are normally stripped.

I regularly waste half a day building Swift only to find that I built the wrong thing because everything after the semicolon is dropped from the build script when it contains arguments like this:

'--llvm-install-components=libclang;libclang-headers'

Ideally, split-cmdline would just preserve the original quotes. But this quick fix solves the problem in the cases that I care about.
