### PR TITLE
[Observation] Optimize cancellation path to avoid excessive copies

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -163,12 +163,10 @@ public struct ObservationRegistrar: Sendable {
     internal mutating func cancel(_ id: Int) {
       if let observation = observations.removeValue(forKey: id) {
         for keyPath in observation.properties {
-          if var ids = lookups[keyPath] {
-            ids.remove(id)
-            if ids.count == 0 {
-              lookups.removeValue(forKey: keyPath)
-            } else {
-              lookups[keyPath] = ids
+          if let index = lookups.index(forKey: keyPath) {
+            lookups.values[index].remove(id)
+            if lookups.values[index].isEmpty {
+              lookups.remove(at: index)
             }
           }
         }


### PR DESCRIPTION
The existing code could potentially mis-optimize and create copies of the set for the cancellation tokens. This mutates it in-place to avoid those copies.

Resolves: rdar://127018986