### PR TITLE
[stdlib] Optional.map, .flatMap: Remove @_disfavoredOverload

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -186,9 +186,6 @@ extension Optional {
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
   @_alwaysEmitIntoClient
-  @_disfavoredOverload // FIXME: Workaround for source compat issue with
-                       // functions that used to shadow the original map
-                       // (rdar://125016028)
   public func map<E: Error, U: ~Copyable>(
     _ transform: (Wrapped) throws(E) -> U
   ) throws(E) -> U? {
@@ -267,9 +264,6 @@ extension Optional {
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
   @_alwaysEmitIntoClient
-  @_disfavoredOverload // FIXME: Workaround for source compat issue with
-                       // functions that used to shadow the original flatMap
-                       // (rdar://125016028)
   public func flatMap<E: Error, U: ~Copyable>(
     _ transform: (Wrapped) throws(E) -> U?
   ) throws(E) -> U? {


### PR DESCRIPTION
We don’t need this to work around the known source compat issue, and it is triggering “expression too complex” errors, causing harm.

rdar://127015095
