### PR TITLE
[6.0][stdlib] Optional.map, .flatMap: Remove @_disfavoredOverload

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -186,9 +186,6 @@ extension Optional {
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
   @_alwaysEmitIntoClient
-  @_disfavoredOverload // FIXME: Workaround for source compat issue with
-                       // functions that used to shadow the original map
-                       // (rdar://125016028)
   public func map<E: Error, U: ~Copyable>(
     _ transform: (Wrapped) throws(E) -> U
   ) throws(E) -> U? {
@@ -267,9 +264,6 @@ extension Optional {
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
   @_alwaysEmitIntoClient
-  @_disfavoredOverload // FIXME: Workaround for source compat issue with
-                       // functions that used to shadow the original flatMap
-                       // (rdar://125016028)
   public func flatMap<E: Error, U: ~Copyable>(
     _ transform: (Wrapped) throws(E) -> U?
   ) throws(E) -> U? {


### PR DESCRIPTION
- **Explanation:** Reverts the addition of `@_disfavoredOverload` on the retroactive generalizations of `Optional.map` and `Optional.flatMap`. The attribute was added speculatively to defend against potential source breaks while rdar://125016028 is being investigated; however, it leads to "expression too complex" issues that are non-hypothetical source breaks.

- **Scope:** Impacts usages and external reimplementations of `Optional.map` and `Optional.flatMap`.

- **Risk:** Low. This resolves regressions that have come to light, although it does potentially introduce ambiguity issues in code that have local definitions for `Optional.map`/`.flatMap` that used to shadow the originals.

- **Testing:** Source compat suite. 

- **Reviewer:** @slavapestov 

- **Main branch PR:** https://github.com/apple/swift/pull/73296

- **Issue:**  rdar://127015095&127015541
