### PR TITLE
[SILGen] Fix a bug where the wrong convention was being used for computing the type of a closure thunk

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4110,8 +4110,8 @@ static CanSILFunctionType getUncachedSILFunctionTypeForConstant(
   }
 
   // The type of the native-to-foreign thunk for a swift closure.
-  if (shouldStoreClangType(TC.getDeclRefRepresentation(constant)) &&
-      constant.isForeign && constant.hasClosureExpr()) {
+  if (constant.isForeign && constant.hasClosureExpr() &&
+      shouldStoreClangType(TC.getDeclRefRepresentation(constant))) {
     auto clangType = TC.Context.getClangFunctionType(
         origLoweredInterfaceType->getParams(),
         origLoweredInterfaceType->getResult(),

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4109,6 +4109,19 @@ static CanSILFunctionType getUncachedSILFunctionTypeForConstant(
     }
   }
 
+  // The type of the native-to-foreign thunk for a swift closure.
+  if (shouldStoreClangType(TC.getDeclRefRepresentation(constant)) &&
+      constant.isForeign && constant.hasClosureExpr()) {
+    auto clangType = TC.Context.getClangFunctionType(
+        origLoweredInterfaceType->getParams(),
+        origLoweredInterfaceType->getResult(),
+        FunctionTypeRepresentation::CFunctionPointer);
+    AbstractionPattern pattern =
+        AbstractionPattern(origLoweredInterfaceType, clangType);
+    return getSILFunctionTypeForAbstractCFunction(
+        TC, pattern, origLoweredInterfaceType, extInfoBuilder, constant);
+  }
+
   // If the decl belongs to an ObjC method family, use that family's
   // ownership conventions.
   return getSILFunctionTypeForObjCSelectorFamily(

--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -12,10 +12,12 @@ void cfunc2(void (*fp)(NonTrivial)) {
   (*fp)(NonTrivial());
 }
 
+#if __OBJC__
 struct ARCStrong {
   id a;
 };
 
 void cfuncARCStrong(void (*_Nonnull)(ARCStrong));
+#endif
 
 #endif // __CLOSURE__

--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -12,4 +12,10 @@ void cfunc2(void (*fp)(NonTrivial)) {
   (*fp)(NonTrivial());
 }
 
+struct ARCStrong {
+  id a;
+};
+
+void cfuncARCStrong(void (*_Nonnull)(ARCStrong));
+
 #endif // __CLOSURE__

--- a/test/Interop/Cxx/class/closure-thunk-macosx.swift
+++ b/test/Interop/Cxx/class/closure-thunk-macosx.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swiftxx-frontend -I %S/Inputs -emit-silgen %s | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+import Closure
+
+// CHECK: sil [ossa] @$s4main20testClosureToFuncPtryyF : $@convention(thin) () -> () {
+// CHECK: %[[V0:.*]] = function_ref @$s4main20testClosureToFuncPtryyFySo9ARCStrongVcfU_To : $@convention(c) (@owned ARCStrong) -> ()
+// CHECK: %[[V1:.*]] = function_ref @_Z14cfuncARCStrongPFv9ARCStrongE : $@convention(c) (@convention(c) (@owned ARCStrong) -> ()) -> ()
+// CHECK: apply %[[V1]](%[[V0]]) : $@convention(c) (@convention(c) (@owned ARCStrong) -> ()) -> ()
+
+// CHECK: sil private [thunk] [ossa] @$s4main20testClosureToFuncPtryyFySo9ARCStrongVcfU_To : $@convention(c) (@owned ARCStrong) -> () {
+// CHECK: bb0(%[[V0:.*]] : @owned $ARCStrong):
+// CHECK: %[[V1:.*]] = begin_borrow %[[V0]] : $ARCStrong
+// CHECK: %[[V2:.*]] = function_ref @$s4main20testClosureToFuncPtryyFySo9ARCStrongVcfU_ : $@convention(thin) (@guaranteed ARCStrong) -> ()
+// CHECK: apply %[[V2]](%[[V1]]) : $@convention(thin) (@guaranteed ARCStrong) -> ()
+// CHECK: end_borrow %[[V1]] : $ARCStrong
+// CHECK: destroy_value %[[V0]] : $ARCStrong
+
+public func testClosureToFuncPtr() {
+ cfuncARCStrong({N in})
+}


### PR DESCRIPTION
The ObjC selector family convention was being used instead of the C function type convention.

rdar://127090209