### PR TITLE
[6.0][Caching] Add fast swift instance setup for cache replay

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -691,6 +691,10 @@ public:
   bool setup(const CompilerInvocation &Invocation, std::string &Error,
              ArrayRef<const char *> Args = {});
 
+  /// The fast setup function for cache replay.
+  bool setupForReplay(const CompilerInvocation &Invocation, std::string &Error,
+                      ArrayRef<const char *> Args = {});
+
   const CompilerInvocation &getInvocation() const { return Invocation; }
 
   /// If a IDE inspection buffer has been set, returns the corresponding source

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -562,6 +562,23 @@ bool CompilerInstance::setup(const CompilerInvocation &Invoke,
   return false;
 }
 
+bool CompilerInstance::setupForReplay(const CompilerInvocation &Invoke,
+                                      std::string &Error,
+                                      ArrayRef<const char *> Args) {
+  // This is the fast path for setup an instance for replay but cannot run
+  // regular compilation.
+  Invocation = Invoke;
+
+  if (setupCASIfNeeded(Args)) {
+    Error = "Setting up CAS failed";
+    return true;
+  }
+
+  setupOutputBackend();
+  setupCachingDiagnosticsProcessorIfNeeded();
+  return false;
+}
+
 bool CompilerInstance::setUpVirtualFileSystemOverlays() {
   if (Invocation.getCASOptions().requireCASFS()) {
     const auto &Opts = getInvocation().getCASOptions();

--- a/tools/libSwiftScan/SwiftCaching.cpp
+++ b/tools/libSwiftScan/SwiftCaching.cpp
@@ -932,7 +932,8 @@ static llvm::Error replayCompilation(SwiftScanReplayInstance &Instance,
       Invocation.getDiagnosticOptions().EmitMacroExpansionFiles);
 
   std::string InstanceSetupError;
-  if (Inst.setup(Instance.Invocation, InstanceSetupError, Instance.Args))
+  if (Inst.setupForReplay(Instance.Invocation, InstanceSetupError,
+                          Instance.Args))
     return createStringError(inconvertibleErrorCode(), InstanceSetupError);
 
   auto *CDP = Inst.getCachingDiagnosticsProcessor();


### PR DESCRIPTION
* Explanation: add a fast path for swift compiler instance setup when replay cached result.
* Scope: this allows fast replay without expensive input construction from built system
* Original PR: https://github.com/apple/swift/pull/73265
* Issue: rdar://127062609
* Risk: Low. Performance improvement for swift caching.
* Testing: Correct test already covered by existing tests
* Reviewer: @benlangmuir 
