### PR TITLE
stdlib: Fix more typed throws and non-copyable generics condfails

### DIFF
--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -29,8 +29,9 @@ public func withExtendedLifetime<T: ~Copyable, Result: ~Copyable>(
 }
 
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@_silgen_name("$ss20withExtendedLifetimeyq_x_q_yKXEtKr0_lF")
 @usableFromInline
-internal func withExtendedLifetime<T, Result>(
+internal func __abi_withExtendedLifetime<T, Result>(
   _ x: T,
   _ body: () throws -> Result // FIXME: Typed throws rdar://126576356
 ) rethrows -> Result {
@@ -56,8 +57,9 @@ public func withExtendedLifetime<T, Result: ~Copyable>(
 }
 
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@_silgen_name("$ss20withExtendedLifetimeyq_x_q_xKXEtKr0_lF")
 @usableFromInline
-internal func withExtendedLifetime<T, Result>(
+internal func __abi_withExtendedLifetime<T, Result>(
   _ x: T, _ body: (T) throws -> Result // FIXME: Typed throws rdar://126576356
 ) rethrows -> Result {
   defer { _fixLifetime(x) }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -235,7 +235,7 @@ extension Optional where Wrapped: ~Copyable {
   ) throws(E) -> U? {
     #if $NoncopyableGenerics
     switch self {
-    case .some(borrowing y):
+    case .some(_borrowing y):
       return .some(try transform(y))
     case .none:
       return .none
@@ -316,7 +316,7 @@ extension Optional where Wrapped: ~Copyable {
     _ transform: (borrowing Wrapped) throws(E) -> U?
   ) throws(E) -> U? {
     switch self {
-    case .some(borrowing y):
+    case .some(_borrowing y):
       return try transform(y)
     case .none:
       return .none

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -64,8 +64,9 @@ extension Result {
   }
 
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$ss6ResultO3mapyAByqd__q_Gqd__xXElF")
   @usableFromInline
-  internal func map<NewSuccess>(
+  internal func __abi_map<NewSuccess>(
     _ transform: (Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
     switch self {
@@ -205,8 +206,9 @@ extension Result {
   }
 
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @_silgen_name("$ss6ResultO7flatMapyAByqd__q_GADxXElF")
   @usableFromInline
-  internal func flatMap<NewSuccess>(
+  internal func __abi_flatMap<NewSuccess>(
     _ transform: (Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {
     switch self {
@@ -272,7 +274,7 @@ extension Result {
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @_silgen_name("$ss6ResultO12flatMapErroryAByxqd__GADq_XEs0D0Rd__lF")
   @usableFromInline
-  internal func flatMapError<NewFailure>(
+  internal func __abi_flatMapError<NewFailure>(
     _ transform: (Failure) -> Result<Success, NewFailure>
   ) -> Result<Success, NewFailure> {
     switch self {


### PR DESCRIPTION
There were two categories of problem for older compilers that consume the stdlib `.swiftinterface`:

- The `case .some(borrowing x)` syntax isn't accepted; use `_borrowing`
- Various functions that addopted `~Copyable` generic constraints conflict with the `@usableFromInline` ABI stubs that were left in to preserve compatibility when the functions are printed with `~Copyable` constraints stripped. The stubs need to have different names to get out of the way.

Fixes fallout from https://github.com/apple/swift/pull/73045.

Resolves rdar://127132742
