### PR TITLE
[Concurrency] Don't diagnose `nonisolated(unsafe)` properties during flow isolation.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -507,6 +507,9 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
   bool accessWithinModule =
       (fromModule == var->getDeclContext()->getParentModule());
 
+  if (varIsolation.getKind() == ActorIsolation::NonisolatedUnsafe)
+    return true;
+
   if (!var->isLet()) {
     ASTContext &ctx = var->getASTContext();
     if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability)) {

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -1,8 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s
 // RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -enable-upcoming-feature RegionBasedIsolation
 
-// REQUIRES: asserts
-
 func randomBool() -> Bool { return false }
 func logTransaction(_ i: Int) {}
 
@@ -813,5 +811,22 @@ func testActorWithInitAccessorInit() {
       self.a = value // Ok (nonisolated)
       print(a) // Ok (nonisolated)
     }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor TestNonisolatedUnsafe {
+  private nonisolated(unsafe) var child: OtherActor!
+  init() {
+    child = OtherActor(parent: self)
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor OtherActor {
+  unowned nonisolated let parent: any Actor
+
+  init(parent: any Actor) {
+    self.parent = parent
   }
 }


### PR DESCRIPTION
Properties declared with `nonisolated(unsafe)` are always safe to access from anywhere.

Resolves https://github.com/apple/swift/issues/73294