### PR TITLE
Change objcImpl syntax to `@objc @implementation`

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2422,6 +2422,9 @@ public:
 
 class ObjCImplementationAttr final : public DeclAttribute {
 public:
+  /// Name of the category being implemented. This should only be used with
+  /// the early adopter \@\_objcImplementation syntax, but we support it there
+  /// for backwards compatibility.
   Identifier CategoryName;
 
   ObjCImplementationAttr(Identifier CategoryName, SourceLoc AtLoc,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1025,6 +1025,10 @@ public:
   /// Returns the source range of the declaration including its attributes.
   SourceRange getSourceRangeIncludingAttrs() const;
 
+  /// Retrieve the location at which we should insert a new attribute or
+  /// modifier.
+  SourceLoc getAttributeInsertionLoc(bool forModifier) const;
+
   using ImportAccessLevel = std::optional<AttributedImport<ImportedModule>>;
 
   /// Returns the import that may restrict the access to this decl
@@ -3171,10 +3175,6 @@ public:
   /// predicates will be false for declarations that either categorically
   /// can't be "static" or are in a context where "static" doesn't make sense.
   bool isStatic() const;
-
-  /// Retrieve the location at which we should insert a new attribute or
-  /// modifier.
-  SourceLoc getAttributeInsertionLoc(bool forModifier) const;
 
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_ValueDecl &&

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4199,6 +4199,12 @@ public:
   /// Retrieve the set of extensions of this type.
   ExtensionRange getExtensions();
 
+  /// Retrieve the extension most recently added to this type. Helpful to
+  /// determine if an extension has been added.
+  ExtensionDecl *getLastExtension() const {
+    return LastExtension;
+  }
+
   /// Special-behaviour flags passed to lookupDirect()
   enum class LookupDirectFlags {
     /// Whether to include @_implements members.
@@ -5063,6 +5069,11 @@ public:
   /// category by that name.
   llvm::TinyPtrVector<Decl *>
   getImportedObjCCategory(Identifier name) const;
+
+  /// Return a map of category names to extensions with that category name,
+  /// whether imported or otherwise. 
+  llvm::DenseMap<Identifier, llvm::TinyPtrVector<ExtensionDecl *>>
+  getObjCCategoryNameMap();
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1912,11 +1912,6 @@ public:
   /// \endcode
   bool isWrittenWithConstraints() const;
 
-  /// Returns the name of the category specified by the \c \@_objcImplementation
-  /// attribute, or \c None if the name is invalid or
-  /// \c isObjCImplementation() is false.
-  std::optional<Identifier> getCategoryNameForObjCImplementation() const;
-
   /// If this extension represents an imported Objective-C category, returns the
   /// category's name. Otherwise returns the empty identifier.
   Identifier getObjCCategoryName() const;

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -136,12 +136,10 @@ WARNING(api_pattern_attr_ignored, none,
         (StringRef, StringRef))
 
 ERROR(objc_implementation_two_impls, none,
-      "duplicate implementation of Objective-C %select{|category %0 on }0"
-      "%kind1",
-      (Identifier, Decl *))
-
+      "duplicate implementation of imported %kind0",
+      (Decl *))
 NOTE(previous_objc_implementation, none,
-     "previously implemented by extension here", ())
+     "previously implemented here", ())
 
 NOTE(macro_not_imported_unsupported_operator, none, "operator not supported in macro arithmetic", ())
 NOTE(macro_not_imported_unsupported_named_operator, none, "operator '%0' not supported in macro arithmetic", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6450,6 +6450,12 @@ ERROR(objc_redecl_same,none,
       "previous declaration with the same Objective-C selector",
       (unsigned, DeclName, unsigned, DeclName, ObjCSelector))
 
+ERROR(objc_redecl_category_name,none,
+      "%select{|imported }0extension with Objective-C category name %2 "
+      "conflicts with previous %select{|imported }1extension with the same "
+      "category name",
+      (bool, bool, Identifier))
+
 ERROR(objc_override_other,none,
       OBJC_DIAG_SELECT " with Objective-C selector %4 conflicts with "
       OBJC_DIAG_SELECT_2 " from superclass %5 with the same Objective-C "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -763,6 +763,9 @@ ERROR(expr_selector_not_objc,none,
 NOTE(make_decl_objc,none,
      "add '@objc' to expose this %0 to Objective-C",
      (DescriptiveDeclKind))
+NOTE(make_decl_objc_for_implementation,none,
+     "add '@objc' to implement an Objective-C %0",
+     (DescriptiveDeclKind))
 
 // Selectors-as-string-literals.
 WARNING(selector_literal_invalid,none,
@@ -1760,10 +1763,6 @@ WARNING(objc_implementation_early_spelling_deprecated,none,
 ERROR(attr_objc_implementation_must_be_unconditional,none,
       "only unconditional extensions can implement an Objective-C '@interface'",
       ())
-ERROR(attr_objc_implementation_must_extend_class,none,
-      "cannot mark extension of %kind0 with '@_objcImplementation'; it is not "
-      "an imported Objective-C class",
-      (ValueDecl *))
 ERROR(attr_objc_implementation_must_be_imported,none,
       "'@_objcImplementation' cannot be used to extend %kind0 because it was "
       "defined by a Swift 'class' declaration, not an imported Objective-C "
@@ -1800,6 +1799,14 @@ ERROR(attr_objc_implementation_raise_minimum_deployment_target,none,
       "'@implementation' of an Objective-C class requires a minimum deployment "
       "target of at least %0 %1",
       (StringRef, llvm::VersionTuple))
+ERROR(attr_implementation_requires_language,none,
+      "'@implementation' used without specifying the language being "
+      "implemented",
+      ())
+ERROR(attr_implementation_category_goes_on_objc_attr,none,
+      "Objective-C category should be specified on '@objc', not "
+      "'@implementation'",
+      ())
 
 ERROR(member_of_objc_implementation_not_objc_or_final,none,
       "%kind0 does not match any %kindonly0 declared in the headers for %1; "
@@ -6295,7 +6302,7 @@ ERROR(objc_extension_not_class,none,
       "'@objc' can only be applied to an extension of a class", ())
 
 // If you change this, also change enum ObjCReason
-#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @objcMembers|marked @IBOutlet|marked @IBAction|marked @IBSegueAction|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override|an implementation of an @objc requirement|marked @IBInspectable|marked @GKInspectable|in an @objc extension of a class (without @nonobjc)|in an @_objcImplementation extension of a class (without final or @nonobjc)|marked @objc by an access note}"
+#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @objcMembers|marked @IBOutlet|marked @IBAction|marked @IBSegueAction|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override|an implementation of an @objc requirement|marked @IBInspectable|marked @GKInspectable|in an @objc extension of a class (without @nonobjc)|in an @objc @implementation extension of a class (without final or @nonobjc)|marked @objc by an access note}"
 
 ERROR(objc_invalid_on_var,none,
       "property cannot be %" OBJC_ATTR_SELECT "0 "

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -970,6 +970,39 @@ public:
   bool isCached() const { return true; }
 };
 
+using ObjCCategoryNameMap =
+  llvm::DenseMap<Identifier, llvm::TinyPtrVector<ExtensionDecl *>>;
+
+/// Generate a map of all known extensions of the given class that have an
+/// explicit category name. This request does not force clang categories that
+/// haven't been imported already, but it will generate a new map if new
+/// categories have been imported since the cached value was generated.
+///
+/// \seeAlso ClassDecl::getObjCCategoryNameMap()
+class ObjCCategoryNameMapRequest
+    : public SimpleRequest<ObjCCategoryNameMapRequest,
+                           ObjCCategoryNameMap(ClassDecl *, ExtensionDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+  // Convenience to automatically extract `lastExtension`.
+  ObjCCategoryNameMapRequest(ClassDecl *classDecl)
+    : ObjCCategoryNameMapRequest(classDecl, classDecl->getLastExtension())
+  {}
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ObjCCategoryNameMap evaluate(Evaluator &evaluator,
+                               ClassDecl *classDecl,
+                               ExtensionDecl *lastExtension) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 #define SWIFT_TYPEID_ZONE NameLookup
 #define SWIFT_TYPEID_HEADER "swift/AST/NameLookupTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -116,3 +116,5 @@ SWIFT_REQUEST(NameLookup, ImplementsAttrProtocolRequest,
               ProtocolDecl *(const ImplementsAttr *, DeclContext *), Cached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, LookupIntrinsicRequest,
               FuncDecl *(ModuleDecl *, Identifier), Cached, NoLocationInfo)
+SWIFT_REQUEST(NameLookup, ObjCCategoryNameMapRequest,
+              ObjCCategoryNameMap(ClassDecl *, ExtensionDecl *), Cached, NoLocationInfo)

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -359,6 +359,10 @@ public:
   /// List of Objective-C member conflicts we have found during type checking.
   llvm::SetVector<ObjCMethodConflict> ObjCMethodConflicts;
 
+  /// Categories (extensions with explicit @objc names) declared in this
+  /// source file. They need to be checked for conflicts after type checking.
+  llvm::TinyPtrVector<ExtensionDecl *> ObjCCategories;
+
   /// List of attributes added by access notes, used to emit remarks for valid
   /// ones.
   llvm::DenseMap<ValueDecl *, std::vector<DeclAttribute *>>

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -256,7 +256,7 @@ struct ObjCInterfaceAndImplementation final {
   ObjCInterfaceAndImplementation()
       : interfaceDecls(), implementationDecl(nullptr) {}
 
-  operator bool() const {
+  bool empty() const {
     return interfaceDecls.empty();
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1891,16 +1891,6 @@ bool Decl::isObjCImplementation() const {
   return getAttrs().hasAttribute<ObjCImplementationAttr>(/*AllowInvalid=*/true);
 }
 
-std::optional<Identifier>
-ExtensionDecl::getCategoryNameForObjCImplementation() const {
-  auto attr = getAttrs()
-                  .getAttribute<ObjCImplementationAttr>(/*AllowInvalid=*/true);
-  if (!attr || attr->isCategoryNameInvalid())
-    return std::nullopt;
-
-  return attr->CategoryName;
-}
-
 PatternBindingDecl::PatternBindingDecl(SourceLoc StaticLoc,
                                        StaticSpellingKind StaticSpelling,
                                        SourceLoc VarLoc,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3717,12 +3717,6 @@ Identifier ExtensionDecl::getObjCCategoryName() const {
     return Identifier();
   }
 
-  // Fall back to @_objcImplementation attribute.
-  if (auto implAttr =
-       getAttrs().getAttribute<ObjCImplementationAttr>(/*AllowInvalid=*/true)) {
-    return implAttr->CategoryName;
-  }
-
   // Not a category, evidently.
   return Identifier();
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3718,12 +3718,9 @@ Identifier ExtensionDecl::getObjCCategoryName() const {
   }
 
   // Fall back to @_objcImplementation attribute.
-  if (auto attr =
+  if (auto implAttr =
        getAttrs().getAttribute<ObjCImplementationAttr>(/*AllowInvalid=*/true)) {
-    if (!attr->isCategoryNameInvalid())
-      return attr->CategoryName;
-
-    return Identifier();
+    return implAttr->CategoryName;
   }
 
   // Not a category, evidently.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11291,7 +11291,7 @@ void swift::simple_display(llvm::raw_ostream &out, const Decl *decl) {
   }
 
   if (auto value = dyn_cast<ValueDecl>(decl)) {
-    simple_display(out, value);
+    return simple_display(out, value);
   } else if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
     out << "extension of ";
     if (auto typeRepr = ext->getExtendedTypeRepr())
@@ -11301,12 +11301,12 @@ void swift::simple_display(llvm::raw_ostream &out, const Decl *decl) {
   } else if (auto med = dyn_cast<MacroExpansionDecl>(decl)) {
     out << '#' << med->getMacroName() << " in ";
     printContext(out, med->getDeclContext());
-    if (med->getLoc().isValid()) {
-      out << '@';
-      med->getLoc().print(out, med->getASTContext().SourceMgr);
-    }
   } else {
     out << "(unknown decl)";
+  }
+  if (decl->getLoc().isValid()) {
+    out << '@';
+    decl->getLoc().print(out, decl->getASTContext().SourceMgr);
   }
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5969,32 +5969,6 @@ struct OrderDecls {
 };
 }
 
-Identifier ExtensionDecl::getObjCCategoryName() const {
-  // Could it be an imported category?
-  if (!hasClangNode()) {
-    // Nope, not imported. Is it an @implementation extension?
-    auto attr = getAttrs()
-                    .getAttribute<ObjCImplementationAttr>(/*AllowInvalid=*/true);
-    if (attr && !attr->isCategoryNameInvalid())
-      return attr->CategoryName;
-
-    return Identifier();
-  }
-
-  auto category = dyn_cast<clang::ObjCCategoryDecl>(getClangDecl());
-  if (!category)
-    // Nope, not a category.
-    return Identifier();
-
-  // We'll look for an implementation with this category name.
-  auto clangCategoryName = category->getName();
-  if (clangCategoryName.empty())
-    // Class extension (has an empty name).
-    return Identifier();
-  
-  return getASTContext().getIdentifier(clangCategoryName);
-}
-
 static ObjCInterfaceAndImplementation
 constructResult(const llvm::TinyPtrVector<Decl *> &interfaces,
                 llvm::TinyPtrVector<Decl *> &impls,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5984,10 +5984,15 @@ constructResult(const llvm::TinyPtrVector<Decl *> &interfaces,
       auto attr = extraImpl->getAttrs().getAttribute<ObjCImplementationAttr>();
       attr->setCategoryNameInvalid();
 
-      diags.diagnose(attr->getLocation(), diag::objc_implementation_two_impls,
-                     categoryName, diagnoseOn)
-        .fixItRemove(attr->getRangeWithAt());
-      diags.diagnose(impls.front(), diag::previous_objc_implementation);
+      // @objc @implementations for categories are diagnosed as category
+      // conflicts, so we're only concerned with main class bodies and
+      // non-category implementations here.
+      if (categoryName.empty() || !isa<ExtensionDecl>(impls.front())) {
+        diags.diagnose(attr->getLocation(), diag::objc_implementation_two_impls,
+                       diagnoseOn)
+          .fixItRemove(attr->getRangeWithAt());
+        diags.diagnose(impls.front(), diag::previous_objc_implementation);
+      }
     }
   }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6139,15 +6139,15 @@ evaluate(Evaluator &evaluator, Decl *decl) const {
 
 void swift::simple_display(llvm::raw_ostream &out,
                            const ObjCInterfaceAndImplementation &pair) {
-  if (!pair) {
+  if (pair.empty()) {
     out << "no clang interface or @_objcImplementation";
     return;
   }
 
-  out << "clang interface ";
-  simple_display(out, pair.interfaceDecls);
-  out << " with @_objcImplementation ";
+  out << "@implementation ";
   simple_display(out, pair.implementationDecl);
+  out << " matches clang interfaces ";
+  simple_display(out, pair.interfaceDecls);
 }
 
 SourceLoc
@@ -6163,7 +6163,8 @@ llvm::TinyPtrVector<Decl *> Decl::getAllImplementedObjCDecls() const {
     return {};
 
   ObjCInterfaceAndImplementationRequest req{const_cast<Decl *>(this)};
-  return evaluateOrDefault(getASTContext().evaluator, req, {}).interfaceDecls;
+  auto result = evaluateOrDefault(getASTContext().evaluator, req, {});
+  return result.interfaceDecls;
 }
 
 DeclContext *DeclContext::getImplementedObjCContext() const {
@@ -6179,8 +6180,8 @@ Decl *Decl::getObjCImplementationDecl() const {
     return nullptr;
 
   ObjCInterfaceAndImplementationRequest req{const_cast<Decl *>(this)};
-  return evaluateOrDefault(getASTContext().evaluator, req, {})
-             .implementationDecl;
+  auto result = evaluateOrDefault(getASTContext().evaluator, req, {});
+  return result.implementationDecl;
 }
 
 llvm::TinyPtrVector<Decl *>

--- a/lib/ClangImporter/ClangImporterRequests.cpp
+++ b/lib/ClangImporter/ClangImporterRequests.cpp
@@ -25,12 +25,14 @@ using namespace swift;
 std::optional<ObjCInterfaceAndImplementation>
 ObjCInterfaceAndImplementationRequest::getCachedResult() const {
   auto passedDecl = std::get<0>(getStorage());
-  if (!passedDecl)
+  if (!passedDecl) {
     return {};
+  }
 
-  if (!passedDecl->getCachedLacksObjCInterfaceOrImplementation())
+  if (passedDecl->getCachedLacksObjCInterfaceOrImplementation()) {
     // We've computed this request and found that this is a normal declaration.
     return {};
+  }
 
   // Either we've computed this request and cached a result in the ImporterImpl,
   // or we haven't computed this request. Check the caches.
@@ -44,20 +46,21 @@ ObjCInterfaceAndImplementationRequest::getCachedResult() const {
   // `ImplementationsByInterface`.
 
   Decl *implDecl = nullptr;
-  if (!passedDecl->hasClangNode()) {
-    // `passedDecl` *could* be an implementation.
+  if (passedDecl->hasClangNode()) {
+    // `passedDecl` *could* be an interface.
     auto iter = impl.ImplementationsByInterface.find(passedDecl);
     if (iter != impl.ImplementationsByInterface.end())
       implDecl = iter->second;
   } else {
-    // `passedDecl` *could* be an interface.
+    // `passedDecl` *could* be an implementation.
     implDecl = passedDecl;
   }
 
   if (implDecl) {
     auto iter = impl.InterfacesByImplementation.find(implDecl);
-    if (iter != impl.InterfacesByImplementation.end())
+    if (iter != impl.InterfacesByImplementation.end()) {
       return ObjCInterfaceAndImplementation(iter->second, implDecl);
+    }
   }
 
   // Nothing in the caches, so we must need to compute this.
@@ -68,7 +71,7 @@ void ObjCInterfaceAndImplementationRequest::
 cacheResult(ObjCInterfaceAndImplementation value) const {
   Decl *passedDecl = std::get<0>(getStorage());
 
-  if (!value) {
+  if (value.empty()) {
     // `decl` is neither an interface nor an implementation; remember this.
     passedDecl->setCachedLacksObjCInterfaceOrImplementation(true);
     return;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4132,14 +4132,16 @@ namespace {
     /// selector.
     ///
     /// The importer should use this rather than adding the attribute directly.
-    void addObjCAttribute(ValueDecl *decl, std::optional<ObjCSelector> name) {
+    void addObjCAttribute(Decl *decl, std::optional<ObjCSelector> name) {
       auto &ctx = Impl.SwiftContext;
       if (name) {
         decl->getAttrs().add(ObjCAttr::create(ctx, name,
                                               /*implicitName=*/true));
       }
-      decl->setIsObjC(true);
-      decl->setIsDynamic(true);
+      if (auto VD = dyn_cast<ValueDecl>(decl)) {
+        VD->setIsObjC(true);
+        VD->setIsDynamic(true);
+      }
 
       // If the declaration we attached the 'objc' attribute to is within a
       // type, record it in the type.
@@ -4157,7 +4159,7 @@ namespace {
     /// selector.
     ///
     /// The importer should use this rather than adding the attribute directly.
-    void addObjCAttribute(ValueDecl *decl, Identifier name) {
+    void addObjCAttribute(Decl *decl, Identifier name) {
       addObjCAttribute(decl, ObjCSelector(Impl.SwiftContext, 0, name));
     }
 
@@ -4778,6 +4780,11 @@ namespace {
                                               objcClass->getDeclaredType());
       Impl.SwiftContext.evaluator.cacheOutput(ExtendedNominalRequest{result},
                                               std::move(objcClass));
+      
+      Identifier categoryName;
+      if (!decl->getName().empty())
+        categoryName = Impl.SwiftContext.getIdentifier(decl->getName());
+      addObjCAttribute(result, categoryName);
 
       // Create the extension declaration and record it.
       objcClass->addExtension(result);

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1138,8 +1138,8 @@ namespace {
       return pair.second;
     }
 
-    std::optional<StringRef> getObjCImplCategoryName() const {
-      if (!TheExtension || !TheExtension->isObjCImplementation())
+    std::optional<StringRef> getCustomCategoryName() const {
+      if (!TheExtension)
         return std::nullopt;
       assert(!TheExtension->hasClangNode());
       auto ident = TheExtension->getObjCCategoryName();
@@ -1426,8 +1426,8 @@ namespace {
     void buildCategoryName(SmallVectorImpl<char> &s) {
       llvm::raw_svector_ostream os(s);
 
-      if (auto implementationCategoryName = getObjCImplCategoryName()) {
-        os << *implementationCategoryName;
+      if (auto customCategoryName = getCustomCategoryName()) {
+        os << *customCategoryName;
         return;
       }
 
@@ -2449,8 +2449,8 @@ namespace {
         os << "@";
         TheExtension->getLoc().print(os, IGM.Context.SourceMgr);
       }
-      if (auto name = getObjCImplCategoryName()) {
-        os << " objc_impl_category_name=" << *name;
+      if (auto name = getCustomCategoryName()) {
+        os << " custom_category_name=" << *name;
       }
       
       if (HasNonTrivialConstructor)

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1141,9 +1141,10 @@ namespace {
     std::optional<StringRef> getObjCImplCategoryName() const {
       if (!TheExtension || !TheExtension->isObjCImplementation())
         return std::nullopt;
-      if (auto ident = TheExtension->getCategoryNameForObjCImplementation()) {
-        assert(!ident->empty());
-        return ident->str();
+      assert(!TheExtension->hasClangNode());
+      auto ident = TheExtension->getObjCCategoryName();
+      if (!ident.empty()) {
+        return ident.str();
       }
       return std::nullopt;
     }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5860,7 +5860,7 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
 
 static bool shouldEmitCategory(IRGenModule &IGM, ExtensionDecl *ext) {
   if (ext->isObjCImplementation()) {
-    assert(ext->getCategoryNameForObjCImplementation() != Identifier());
+    assert(!ext->getObjCCategoryName().empty());
     return true;
   }
 
@@ -5904,8 +5904,7 @@ void IRGenModule::emitExtension(ExtensionDecl *ext) {
   if (!origClass)
     return;
 
-  if (ext->isObjCImplementation()
-        && ext->getCategoryNameForObjCImplementation() == Identifier()) {
+  if (ext->isObjCImplementation() && ext->getObjCCategoryName().empty()) {
     // This is the @_objcImplementation for the class--generate its class
     // metadata.
     emitClassDecl(origClass);

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -829,6 +829,10 @@ private:
   void buildCategoryName(const ExtensionDecl *ext, const ClassDecl *cls,
                          SmallVectorImpl<char> &s) {
     llvm::raw_svector_ostream os(s);
+    if (!ext->getObjCCategoryName().empty()) {
+      os << ext->getObjCCategoryName();
+      return;
+    }
     ModuleDecl *module = ext->getParentModule();
     os << module->getName();
     unsigned categoryCount = CategoryCounts[{cls, module}]++;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7124,6 +7124,20 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     status |= whereStatus;
   }
 
+  // @implementation requires an explicit @objc attribute, but
+  // @_objcImplementation didn't. Insert one if necessary.
+  auto implAttr = Attributes.getAttribute<ObjCImplementationAttr>();
+  if (implAttr && implAttr->isEarlyAdopter()
+        && !Attributes.hasAttribute<ObjCAttr>()) {
+    ObjCAttr *objcAttr;
+    if (implAttr->CategoryName.empty())
+      objcAttr = ObjCAttr::createUnnamedImplicit(Context);
+    else
+      objcAttr = ObjCAttr::createNullary(Context, implAttr->CategoryName,
+                                         /*isNameImplicit=*/false);
+    Attributes.add(objcAttr);
+  }
+
   ExtensionDecl *ext = ExtensionDecl::create(Context, ExtensionLoc,
                                              extendedType.getPtrOrNull(),
                                              Context.AllocateCopy(Inherited),

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -403,7 +403,10 @@ private:
       os << "\n";
     os << "@interface " << getNameForObjC(baseClass);
     maybePrintObjCGenericParameters(baseClass);
-    os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
+    if (ED->getObjCCategoryName().empty())
+      os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
+    else
+      os << " (" << ED->getObjCCategoryName() << ")";
     printProtocols(ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
     printMembers(ED->getMembers());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1438,6 +1438,12 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
                                     attr->getLParenLoc(), firstNameLoc,
                                     objcName->getSelectorPieces()[0],
                                     attr->getRParenLoc()));
+      } else if (auto Ext = dyn_cast<ExtensionDecl>(D)) {
+        assert(Ext->getSelfClassDecl());
+        // This is an extension with an explicit, and otherwise valid, category
+        // name. Schedule it to be checked for name conflicts later.
+        if (auto *SF = Ext->getParentSourceFile())
+          SF->ObjCCategories.push_back(Ext);
       }
     } else if (isa<SubscriptDecl>(D) || isa<DestructorDecl>(D)) {
       SourceLoc diagLoc = attr->getLParenLoc();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1536,7 +1536,9 @@ void AttributeChecker::visitNonObjCAttr(NonObjCAttr *attr) {
 
 static bool hasObjCImplementationFeature(Decl *D, ObjCImplementationAttr *attr,
                                          Feature requiredFeature) {
-  if (D->getASTContext().LangOpts.hasFeature(requiredFeature))
+  auto &ctx = D->getASTContext();
+
+  if (ctx.LangOpts.hasFeature(requiredFeature))
     return true;
 
   // Allow the use of @_objcImplementation *without* Feature::ObjCImplementation
@@ -1547,17 +1549,72 @@ static bool hasObjCImplementationFeature(Decl *D, ObjCImplementationAttr *attr,
 
   // Either you're using Feature::ObjCImplementation without the early adopter
   // syntax, or you're using Feature::CImplementation. Either way, no go.
-  swift::diagnoseAndRemoveAttr(D, attr, diag::requires_experimental_feature,
-                               attr->getAttrName(), attr->isDeclModifier(),
-                               getFeatureName(requiredFeature));
+  ctx.Diags.diagnose(attr->getLocation(), diag::requires_experimental_feature,
+                     attr->getAttrName(), attr->isDeclModifier(),
+                     getFeatureName(requiredFeature));
   return false;
+}
+
+static SourceRange getArgListRange(ASTContext &Ctx, DeclAttribute *attr) {
+  // attr->getRange() covers the attr name and argument list; adjust it to
+  // exclude the first token.
+  auto newStart = Lexer::getLocForEndOfToken(Ctx.SourceMgr,
+                                             attr->getRange().Start);
+  if (attr->getRange().contains(newStart)) {
+    return SourceRange(newStart, attr->getRange().End);
+  }
+  return SourceRange();
 }
 
 void AttributeChecker::
 visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
+  DeclAttribute * langAttr =
+    D->getAttrs().getAttribute<ObjCAttr>(/*AllowInvalid=*/true);
+  if (!langAttr)
+    langAttr = D->getAttrs().getAttribute<CDeclAttr>(/*AllowInvalid=*/true);
+
+  if (!langAttr) {
+    diagnose(attr->getLocation(), diag::attr_implementation_requires_language);
+
+    // If this is an extension, suggest '@objc'.
+    if (auto ED = dyn_cast<ExtensionDecl>(D)) {
+      auto diag = diagnose(attr->getLocation(),
+                           diag::make_decl_objc_for_implementation,
+                           D->getDescriptiveKind());
+
+      ObjCSelector correctSelector(Ctx, 0, {attr->CategoryName});
+      fixDeclarationObjCName(diag, ED, ObjCSelector(), correctSelector);
+    }
+
+    return;
+  }
+
   if (auto ED = dyn_cast<ExtensionDecl>(D)) {
     if (!hasObjCImplementationFeature(D, attr, Feature::ObjCImplementation))
       return;
+
+    auto objcLangAttr = dyn_cast<ObjCAttr>(langAttr);
+    assert(objcLangAttr && "extension with @_cdecl or another lang attr???");
+
+    // Only early adopters should specify the category name on the attribute;
+    // the stabilized syntax uses @objc(CustomName) for that.
+    if (!attr->isEarlyAdopter() && !attr->CategoryName.empty()) {
+      auto diag = diagnose(attr->getLocation(),
+                           diag::attr_implementation_category_goes_on_objc_attr);
+
+      ObjCSelector correctSelector(Ctx, 0, {attr->CategoryName});
+      auto argListRange = getArgListRange(Ctx, attr);
+      if (argListRange.isValid()) {
+        diag.fixItRemove(argListRange);
+        fixDeclarationObjCName(diag, ED, objcLangAttr->getName(),
+                               correctSelector);
+      }
+      objcLangAttr->setName(correctSelector, /*implicit=*/false);
+
+      attr->setCategoryNameInvalid();
+
+      return;
+    }
 
     if (ED->isConstrainedExtension())
       diagnoseAndRemoveAttr(attr,
@@ -1565,11 +1622,8 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
 
     auto CD = dyn_cast<ClassDecl>(ED->getExtendedNominal());
     if (!CD) {
-      diagnoseAndRemoveAttr(attr,
-                            diag::attr_objc_implementation_must_extend_class,
-                            ED->getExtendedNominal());
-      ED->getExtendedNominal()->diagnose(diag::decl_declared_here,
-                                         ED->getExtendedNominal());
+      // This will be diagnosed as diag::objc_extension_not_class.
+      attr->setInvalid();
       return;
     }
 
@@ -1581,35 +1635,36 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
     }
 
     if (!CD->hasSuperclass()) {
-      diagnoseAndRemoveAttr(attr, diag::attr_objc_implementation_must_have_super,
-                            CD);
+      diagnoseAndRemoveAttr(attr,
+                            diag::attr_objc_implementation_must_have_super, CD);
       CD->diagnose(diag::decl_declared_here, CD);
       return;
     }
 
     if (CD->isTypeErasedGenericClass()) {
-      diagnoseAndRemoveAttr(attr, diag::objc_implementation_cannot_have_generics,
-                            CD);
+      diagnoseAndRemoveAttr(attr,
+                            diag::objc_implementation_cannot_have_generics, CD);
       CD->diagnose(diag::decl_declared_here, CD);
+      return;
     }
 
     if (!attr->isCategoryNameInvalid() && !ED->getImplementedObjCDecl()) {
       diagnose(attr->getLocation(),
                diag::attr_objc_implementation_category_not_found,
-               attr->CategoryName, CD);
+               ED->getObjCCategoryName(), CD);
 
-      // attr->getRange() covers the attr name and argument list; adjust it to
-      // exclude the first token.
-      auto newStart = Lexer::getLocForEndOfToken(Ctx.SourceMgr,
-                                                 attr->getRange().Start);
-      if (attr->getRange().contains(newStart)) {
-        auto argListRange = SourceRange(newStart, attr->getRange().End);
+      SourceRange argListRange;
+      if (attr->CategoryName.empty())
+        argListRange = getArgListRange(Ctx, langAttr);
+      else
+        argListRange = getArgListRange(Ctx, attr);
+      if (argListRange.isValid()) {
         diagnose(attr->getLocation(),
                  diag::attr_objc_implementation_fixit_remove_category_name)
             .fixItRemove(argListRange);
       }
 
-      attr->setCategoryNameInvalid();
+      attr->setInvalid();
 
       return;
     }
@@ -1634,12 +1689,8 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
           diagnose(attr->getLocation(),
                    diag::attr_objc_implementation_no_category_for_func, AFD);
 
-      // attr->getRange() covers the attr name and argument list; adjust it to
-      // exclude the first token.
-      auto newStart = Lexer::getLocForEndOfToken(Ctx.SourceMgr,
-                                                 attr->getRange().Start);
-      if (attr->getRange().contains(newStart)) {
-        auto argListRange = SourceRange(newStart, attr->getRange().End);
+      auto argListRange = getArgListRange(Ctx, attr);
+      if (argListRange.isValid()) {
         diagnostic.fixItRemove(argListRange);
       }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1841,26 +1841,15 @@ static void fixAvailabilityForDecl(SourceRange ReferenceRange, const Decl *D,
   // parsing.
   const Decl *ConcDecl = concreteSyntaxDeclForAvailableAttribute(D);
 
-  DescriptiveDeclKind KindForDiagnostic = ConcDecl->getDescriptiveKind();
-  SourceLoc InsertLoc;
-
   // To avoid exposing the pattern binding declaration to the user, get the
-  // descriptive kind from one of the VarDecls. We get the Fix-It location
-  // from the PatternBindingDecl unless the VarDecl has attributes,
-  // in which case we get the start location of the VarDecl attributes.
-  DeclAttributes AttrsForLoc;
+  // descriptive kind from one of the VarDecls.
+  DescriptiveDeclKind KindForDiagnostic = ConcDecl->getDescriptiveKind();
   if (KindForDiagnostic == DescriptiveDeclKind::PatternBinding) {
     KindForDiagnostic = D->getDescriptiveKind();
-    AttrsForLoc = D->getAttrs();
-  } else {
-    InsertLoc = ConcDecl->getAttrs().getStartLoc(/*forModifiers=*/false);
   }
 
-  InsertLoc = D->getAttrs().getStartLoc(/*forModifiers=*/false);
-  if (InsertLoc.isInvalid()) {
-    InsertLoc = ConcDecl->getStartLoc();
-  }
-
+  SourceLoc InsertLoc =
+      ConcDecl->getAttributeInsertionLoc(/*forModifier=*/false);
   if (InsertLoc.isInvalid())
     return;
 
@@ -4489,10 +4478,7 @@ void swift::checkExplicitAvailability(Decl *decl) {
 
     auto suggestPlatform = ctx.LangOpts.RequireExplicitAvailabilityTarget;
     if (!suggestPlatform.empty()) {
-      auto InsertLoc = decl->getAttrs().getStartLoc(/*forModifiers=*/false);
-      if (InsertLoc.isInvalid())
-        InsertLoc = decl->getStartLoc();
-
+      auto InsertLoc = decl->getAttributeInsertionLoc(/*forModifiers=*/false);
       if (InsertLoc.isInvalid())
         return;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -960,11 +960,6 @@ IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
     return true;
   }
 
-  // @_objcImplementation extension member implementations are implicitly
-  // dynamic.
-  if (decl->isObjCMemberImplementation())
-    return true;
-
   if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
     // Runtime-replaceable accessors are dynamic when their storage declaration
     // is dynamic and they were explicitly defined or they are implicitly defined

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2208,7 +2208,7 @@ bool swift::fixDeclarationObjCName(InFlightDiagnostic &diag,
 namespace {
   /// Produce a deterministic ordering of the given declarations.
   struct OrderDeclarations {
-    bool operator()(ValueDecl *lhs, ValueDecl *rhs) const {
+    bool operator()(Decl *lhs, Decl *rhs) const {
       // If the declarations come from different modules, order based on the
       // module.
       ModuleDecl *lhsModule = lhs->getDeclContext()->getParentModule();
@@ -2233,9 +2233,77 @@ namespace {
       }
 
       // The declarations are in different source files (or unknown source
-      // files) of the same module. Order based on name.
+      // files) of the same module. Let's just try to find *something* to
+      // differentiate them.
+      auto leftName = getName(lhs);
+      auto rightName = getName(rhs);
+      if (leftName != rightName) {
+        // Order based on name, sorting named decls before unnamed decls.
+        // (std::optional's < sorts nullopt before other values, which is the
+        // opposite of what we want here.)
+        if (!leftName.has_value() || !rightName.has_value())
+          return leftName > rightName;
+        return leftName.value() < rightName.value();
+      }
+
+      auto leftTy = getExtendedType(lhs);
+      auto rightTy = getExtendedType(rhs);
+      if (leftTy || rightTy) {
+        // Order based on extended type, sorting extension decls before other
+        // decls.
+        if (!leftTy || !rightTy)
+          return leftTy;
+
+        auto normal = (*this)(leftTy, rightTy);
+        auto opposite = (*this)(rightTy, leftTy);
+        if (normal != opposite)
+          return normal;
+      }
+
+      // Try to differentiate by parents.
+      DeclContext *leftContext = lhs->getDeclContext();
+      DeclContext *rightContext = rhs->getDeclContext();
+      while (leftContext || rightContext) {
+        if (!rightContext)
+          return true;
+        if (!leftContext)
+          return false;
+
+        auto leftDecl = leftContext->getAsDecl();
+        auto rightDecl = rightContext->getAsDecl();
+        if (!rightDecl)
+          return true;
+        if (!leftDecl)
+          return false;
+
+        auto normal = (*this)(leftDecl, rightDecl);
+        auto opposite = (*this)(rightDecl, leftDecl);
+        if (normal != opposite)
+          return normal;
+      }
+
+      // Final tiebreaker: Kind
       // FIXME: This isn't a total ordering.
-      return lhs->getName() < rhs->getName();
+      return lhs->getKind() < rhs->getKind();
+    }
+
+  private:
+    std::optional<DeclName> getName(Decl *D) const {
+      if (auto VD = dyn_cast<ValueDecl>(D))
+        return VD->getName();
+      if (auto OD = dyn_cast<OperatorDecl>(D))
+        return OD->getName();
+      if (auto PD = dyn_cast<PrecedenceGroupDecl>(D))
+        return PD->getName();
+      if (auto MD = dyn_cast<MissingMemberDecl>(D))
+        return MD->getName();
+      return std::nullopt;
+    }
+
+    NominalTypeDecl *getExtendedType(Decl *D) const {
+      if (auto ED = dyn_cast<ExtensionDecl>(D))
+        return ED->getExtendedNominal();
+      return nullptr;
     }
   };
 } // end anonymous namespace
@@ -2382,8 +2450,8 @@ static ObjCAttr *getObjCAttrIfFromAccessNote(ValueDecl *VD) {
   return nullptr;
 }
 
-static bool hasCustomObjCName(AbstractFunctionDecl *afd) {
-  if (auto objc = afd->getAttrs().getAttribute<ObjCAttr>())
+static bool hasCustomObjCName(Decl *D) {
+  if (auto objc = D->getAttrs().getAttribute<ObjCAttr>())
     return objc->hasName();
   return false;
 }
@@ -2574,6 +2642,153 @@ bool swift::diagnoseObjCMethodConflicts(SourceFile &sf) {
       else
         Ctx.Diags.diagnose(originalDecl, diag::objc_declared_here,
                            origDiagInfo.first, origDiagInfo.second);
+    }
+  }
+
+  return anyConflicts;
+}
+
+/// Figure out how to resolve a specific Objective-C category name conflict.
+/// The list will be sorted so that the first extension is the "best" one
+/// and the others can be diagnosed as conflicts with that one.
+/// Extensions which aren't really conflicting will be removed.
+static void resolveObjCCategoryConflict(
+      llvm::SmallVectorImpl<ExtensionDecl *> &exts) {
+  assert(exts.size() > 1);
+
+  // Sort the conflicting categories from the "strongest" claim to the "weakest".
+  // This puts the "best" categories at exts.front() so that others will be
+  // diagnosed as conflicts with that one, and it helps ensure that individual
+  // categories in a conflict set are diagnosed in a deterministic order.
+  llvm::stable_sort(exts, [](ExtensionDecl *a, ExtensionDecl *b) {
+    #define RULE(aCriterion, bCriterion) do { \
+      bool _aCriterion = (aCriterion), _bCriterion = (bCriterion); \
+      if (!_aCriterion && _bCriterion) \
+        return false; \
+      if (_aCriterion && !_bCriterion) \
+        return true; \
+    } while (0)
+
+    // Is one of these from Objective-C and the other from Swift?
+    // NOTE: Inserting another rule above this will break the hasClangNode()
+    // filtering below.
+    RULE(a->hasClangNode(),
+         b->hasClangNode());
+
+    // Does one of these use plain @objc and the other @objc(selector)?
+    RULE(!hasCustomObjCName(a),
+         !hasCustomObjCName(b));
+
+    // Neither has a "stronger" claim, so just try to put them in some sort of
+    // consistent order.
+    OrderDeclarations ordering;
+    return ordering(a, b);
+
+    #undef RULE
+  });
+
+  // If the best extension is imported from clang, remove some false conflicts.
+  ExtensionDecl *best = exts.front();
+  if (!best->hasClangNode())
+    return;
+
+  llvm::erase_if(exts, [&](ExtensionDecl *ext) {
+    // If there are other extensions imported from ObjC, remove them; conflicts
+    // purely involving ObjC headers are clang's to complain about.
+    if (ext != best && ext->hasClangNode())
+      return true;
+
+    // If the best extension has an implementation that's also in the list,
+    // remove the implementation; it's not a conflict.
+    if (ext == best->getObjCImplementationDecl())
+      return true;
+
+    // If there's an @implementation attribute but something about the category
+    // name has already been diagnosed, don't diagnose a conflict.
+    auto implAttr = ext->getAttrs().getAttribute<ObjCImplementationAttr>(
+                                                         /*AllowInvalid=*/true);
+    if (implAttr && implAttr->isCategoryNameInvalid())
+      return true;
+
+    return false;
+  });
+}
+
+bool swift::diagnoseObjCCategoryConflicts(SourceFile &sf) {
+  // If there were no categories to check, we're done.
+  if (sf.ObjCCategories.empty())
+    return false;
+
+  // Assume one category with a given name (no conflicts)
+  using Categories = llvm::TinyPtrVector<ExtensionDecl *>;
+  // Assume many categories on a given type
+  using CategoriesByName = llvm::SmallDenseMap<Identifier, Categories, 8>;
+  // Assume a couple of types in a given source file
+  using CategoriesByNameAndClass =
+    llvm::SmallDenseMap<ClassDecl *, CategoriesByName, 2>;
+
+  auto &Ctx = sf.getASTContext();
+  DiagnosticStateRAII diagState(Ctx.Diags);
+
+  // Group together the categories we need to check.
+  CategoriesByNameAndClass categoriesByClass;
+  for (auto category : sf.ObjCCategories) {
+    auto classDecl = category->getSelfClassDecl();
+    auto catName = category->getObjCCategoryName();
+
+    categoriesByClass[classDecl][catName].push_back(category);
+  }
+
+  bool anyConflicts = false;
+
+  // Check each class's categories for conflicts.
+  for (const auto &classPair : categoriesByClass) {
+    ClassDecl *classDecl = classPair.first;
+    const CategoriesByName &categoriesByNameToCheck = classPair.second;
+
+    llvm::DenseMap<Identifier, llvm::TinyPtrVector<ExtensionDecl *>>
+        categoryMap = classDecl->getObjCCategoryNameMap();
+
+    for (const auto &namePair : categoriesByNameToCheck) {
+      const auto &catName = namePair.first;
+      const auto &categoriesToCheck = namePair.second;
+      const llvm::TinyPtrVector<ExtensionDecl *> &allCategories = categoryMap[catName];
+
+      if (allCategories.size() < 2)
+        // Definitely no conflicts.
+        continue;
+
+      // Okay, figure out how to resolve this.
+      llvm::SmallVector<ExtensionDecl *, 4> resolvedCategories;
+      llvm::copy(allCategories, std::back_inserter(resolvedCategories));
+      resolveObjCCategoryConflict(resolvedCategories);
+
+      // Now figure out how to diagnose the categories that happen to be in this
+      // file.
+      for (auto catToCheck : categoriesToCheck) {
+        auto it = llvm::find(resolvedCategories, catToCheck);
+
+        // If this is the best category, or it's not in the list, nothing
+        // to diagnose.
+        if (it == resolvedCategories.begin() || it == resolvedCategories.end())
+          continue;
+
+        // Diagnose the conflict.
+        anyConflicts = true;
+
+        auto bestCat = resolvedCategories.front();
+        if (auto implCat = dyn_cast_or_null<ExtensionDecl>(
+                                       bestCat->getObjCImplementationDecl()))
+          if (implCat != catToCheck)
+            bestCat = implCat;
+
+        Ctx.Diags.diagnose(catToCheck, diag::objc_redecl_category_name,
+                           catToCheck->hasClangNode(),
+                           bestCat->hasClangNode(), catName)
+          .warnUntilSwiftVersion(6);
+
+        Ctx.Diags.diagnose(bestCat, diag::invalid_redecl_prev_name, catName);
+      }
     }
   }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2128,7 +2128,7 @@ bool swift::fixDeclarationName(InFlightDiagnostic &diag, const ValueDecl *decl,
 }
 
 bool swift::fixDeclarationObjCName(InFlightDiagnostic &diag,
-                                   const ValueDecl *decl,
+                                   const Decl *decl,
                                    std::optional<ObjCSelector> nameOpt,
                                    std::optional<ObjCSelector> targetNameOpt,
                                    bool ignoreImpliedName) {

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -71,7 +71,7 @@ public:
     ExplicitlyGKInspectable,
     /// Is it a member of an @objc extension of a class.
     MemberOfObjCExtension,
-    /// Is it a member of an \@\_objcImplementation extension.
+    /// Is it a member of an \@objc \@implementation extension.
     MemberOfObjCImplementationExtension,
     /// Has an explicit '@objc' attribute added by an access note, rather than
     /// written in source code.

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -212,7 +212,7 @@ bool fixDeclarationName(InFlightDiagnostic &diag, const ValueDecl *decl,
 ///
 /// For properties, the selector should be a zero-parameter selector of the
 /// given property's name.
-bool fixDeclarationObjCName(InFlightDiagnostic &diag, const ValueDecl *decl,
+bool fixDeclarationObjCName(InFlightDiagnostic &diag, const Decl *decl,
                             std::optional<ObjCSelector> nameOpt,
                             std::optional<ObjCSelector> targetNameOpt,
                             bool ignoreImpliedName = false);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3510,8 +3510,7 @@ static void finishStorageImplInfo(AbstractStorageDecl *storage,
 
       // @_objcImplementation extensions on a non-category can declare stored
       // properties; StoredPropertiesRequest knows to look for them there.
-      if (ext->isObjCImplementation() &&
-          ext->getCategoryNameForObjCImplementation() == Identifier())
+      if (ext->isObjCImplementation() && ext->getObjCCategoryName().empty())
         return;
 
       storage->diagnose(diag::extension_stored_property);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -380,6 +380,7 @@ void swift::performWholeModuleTypeChecking(SourceFile &SF) {
   case SourceFileKind::Main:
   case SourceFileKind::MacroExpansion:
     diagnoseObjCMethodConflicts(SF);
+    diagnoseObjCCategoryConflicts(SF);
     diagnoseObjCUnsatisfiedOptReqConflicts(SF);
     diagnoseUnintendedObjCMethodOverrides(SF);
     diagnoseAttrsAddedByAccessNote(SF);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1425,6 +1425,14 @@ bool diagnoseUnintendedObjCMethodOverrides(SourceFile &sf);
 /// \returns true if there were any conflicts diagnosed.
 bool diagnoseObjCMethodConflicts(SourceFile &sf);
 
+/// Diagnose all conflicts between extensions of the same class that have the
+/// same Objective-C category name.
+///
+/// \param sf The source file for which we are diagnosing conflicts.
+///
+/// \returns true if there were any conflicts diagnosed.
+bool diagnoseObjCCategoryConflicts(SourceFile &sf);
+
 /// Diagnose any unsatisfied @objc optional requirements of
 /// protocols that conflict with methods.
 bool diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf);

--- a/test/APIJSON/extension.swift
+++ b/test/APIJSON/extension.swift
@@ -45,6 +45,12 @@ extension B {
   public func fun() {}
 }
 
+// This creates a category with a custom name.
+@objc(CustomCategoryName)
+extension B {
+  public func doIt() {}
+}
+
 // CHECK:      "interfaces": [
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "name": "_TtC8MyModule1B",
@@ -65,6 +71,23 @@ extension B {
 // CHECK-NEXT:    }
 // CHECK-NEXT:  ],
 // CHECK-NEXT:  "categories": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "name": "CustomCategoryName",
+// CHECK-NEXT:      "access": "public",
+// CHECK-EXTRACT-NEXT:  "file": "/@input/MyModule.swiftinterface",
+// CHECK-EMIT-NEXT:     "file": "SOURCE_DIR/test/APIJSON/extension.swift",
+// CHECK-NEXT:      "linkage": "exported",
+// CHECK-NEXT:      "interface": "_TtC8MyModule1B",
+// CHECK-NEXT:      "instanceMethods": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "name": "doIt",
+// CHECK-NEXT:          "access": "public",
+// CHECK-EXTRACT-NEXT:  "file": "/@input/MyModule.swiftinterface"
+// CHECK-EMIT-NEXT:     "file": "SOURCE_DIR/test/APIJSON/extension.swift"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      ],
+// CHECK-NEXT:      "classMethods": []
+// CHECK-NEXT:    },
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "name": "MyModule",
 // CHECK-NEXT:      "access": "public",

--- a/test/ClangImporter/Inputs/frameworks/Module.framework/Headers/Module.h
+++ b/test/ClangImporter/Inputs/frameworks/Module.framework/Headers/Module.h
@@ -3,7 +3,9 @@
 #define MODULE_H
 const char *getModuleVersion(void);
 
-@interface Module
+@interface ModuleRoot @end
+
+@interface Module : ModuleRoot
 +(const char *)version; // retrieve module version
 +alloc;
 @end

--- a/test/ClangImporter/diags_from_module.swift
+++ b/test/ClangImporter/diags_from_module.swift
@@ -37,7 +37,7 @@ import Module
 // CHECK-PRIMARY: diags_from_module.swift:[[@LINE-4]]:8: error: could not build Objective-C module 'Module'
 
 // CHECK-WARN: Sub2.h:7:2: warning: here is some warning about something
-// CHECK-WARN: Module.h:22:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h'
+// CHECK-WARN: Module.h:24:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h'
 // FIXME: show [-Wincomplete-umbrella]
 
 // CHECK-NO-WARN-NOT: warning about something

--- a/test/ClangImporter/rdar123543707.swift
+++ b/test/ClangImporter/rdar123543707.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-typecheck-verify-swift -F %S/Inputs/frameworks -module-cache-path %t/mcp1
+// RUN: %target-typecheck-verify-swift -F %S/Inputs/frameworks -module-cache-path %t/mcp1  -target %target-stable-abi-triple
 
 // REQUIRES: objc_interop
 
@@ -7,9 +7,8 @@ import Module
 import Module_Private.Sub4
 
 @_objcImplementation extension Module {
-  // expected-error@-1 {{'@_objcImplementation' cannot be used to implement root class 'Module'}}
-  // expected-warning@-2 {{extension for main class interface should provide implementation for class method 'version()'}}
-  // expected-warning@-3 {{extension for main class interface should provide implementation for class method 'alloc()'}}
+  // expected-warning@-1 {{extension for main class interface should provide implementation for class method 'version()'}}
+  // expected-warning@-2 {{extension for main class interface should provide implementation for class method 'alloc()'}}
 }
 
 extension Module: @retroactive ModuleProto {} // no-error

--- a/test/IRGen/objc_extensions.swift
+++ b/test/IRGen/objc_extensions.swift
@@ -78,6 +78,24 @@ extension Gizmo {
 }
 
 /*
+ * Make sure that extensions of an ObjC class with `@objc(CustomName)` get the
+ * indicated category name.
+ */
+// CHECK: @"_CATEGORY_Gizmo_$_WidgetMaker" = internal constant
+// CHECK:   ptr @.str.11.WidgetMaker,
+// CHECK:   ptr @"OBJC_CLASS_$_Gizmo",
+// CHECK:   {{.*}} @"_CATEGORY_INSTANCE_METHODS_Gizmo_$_WidgetMaker",
+// CHECK:   {{.*}} ptr null,
+// CHECK:   ptr null,
+// CHECK:   ptr null
+// CHECK: }, section "__DATA, {{.*}}", align 8
+
+@objc(WidgetMaker) extension Gizmo {
+  func makeWidget() {
+  }
+}
+
+/*
  * Check that extensions of Swift subclasses of ObjC objects get categories.
  */
 

--- a/test/Interpreter/objc_implementation_resilience.swift
+++ b/test/Interpreter/objc_implementation_resilience.swift
@@ -2,6 +2,12 @@
 // Will not execute correctly without ObjC runtime support.
 // REQUIRES: rdar109171643
 
-// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/objc_implementation.h -D TOP_LEVEL_CODE -D RESILIENCE -swift-version 5 -enable-experimental-feature CImplementation -enable-experimental-feature ObjCImplementationWithResilientStorage -target %target-future-triple) %S/objc_implementation.swift | %FileCheck %S/objc_implementation.swift --check-prefixes CHECK,CHECK-RESILIENCE
+// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/objc_implementation.h -D RESILIENCE -swift-version 5 -enable-experimental-feature CImplementation -enable-experimental-feature ObjCImplementationWithResilientStorage -target %target-future-triple %S/objc_implementation.swift) | %FileCheck %S/objc_implementation.swift --check-prefixes CHECK,CHECK-RESILIENCE
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+
+@main struct Main {
+  static func main() {
+    ImplClass.runTests()
+  }
+}

--- a/test/Interpreter/objc_implementation_resilience_swift_client.swift
+++ b/test/Interpreter/objc_implementation_resilience_swift_client.swift
@@ -37,3 +37,16 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+
+@main struct Main {
+  static func main() {
+    ImplClass.runTests()
+    
+    do {
+      print("*** SwiftClientSubclass init ***")
+      let swiftClientSub = SwiftClientSubclass()
+      swiftClientSub.testSelf()
+      print("*** SwiftClientSubclass end ***")
+    }
+  }
+}

--- a/test/Interpreter/objc_implementation_swift_client.swift
+++ b/test/Interpreter/objc_implementation_swift_client.swift
@@ -58,7 +58,6 @@ class SwiftClientSubclass: ImplClass {
 #if RESILIENCE
   override class func makeResilientImpl() -> ImplClassWithResilientStoredProperty {
     SwiftResilientStoredClientSubclass()
-    fatalError()
   }
 #endif
 }

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -3,8 +3,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-sil-ownership-verifier -emit-module -o %t %s -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-sil-ownership-verifier -parse-as-library %t/extensions.swiftmodule -typecheck -emit-objc-header-path %t/extensions.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
-// RUN: %FileCheck %s < %t/extensions.h
-// RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/extensions.h
+// RUN: %FileCheck %s --input-file %t/extensions.h
+// RUN: %FileCheck --check-prefix=NEGATIVE %s --input-file %t/extensions.h
 // RUN: %check-in-clang %t/extensions.h
 
 // This test generates invalid SIL. It will cause a compiler assert in
@@ -121,6 +121,13 @@ extension NotObjC {}
 // CHECK-NEXT: @end
 extension NSObject {
   @objc var some: Int { return 1 }
+}
+
+// CHECK-LABEL: @interface NSString (CustomName)
+// CHECK-NEXT: - (void)test3;
+// CHECK-NEXT: @end
+@objc(CustomName) extension NSString {
+  func test3() {}
 }
 
 // NEGATIVE-NOT: @class NSString;

--- a/test/SILOptimizer/let_properties_opts_objc.swift
+++ b/test/SILOptimizer/let_properties_opts_objc.swift
@@ -16,12 +16,12 @@ public func testObjcInterface(_ x: ObjcInterface) -> Int {
   return x.i
 }
 
-// Test optimization of a private constant. This constant must be declared in a separate type without other fields.
+// Test that private @objc constants aren't optimized, but instead continue to pass through ObjC message dispatch.
 @_objcImplementation extension ObjcInterfaceConstInit {
   private let constant: Int = 0
 
   // CHECK-LABEL: sil hidden @$sSo22ObjcInterfaceConstInitC4testE0E15PrivateConstantSiyF : $@convention(method) (@guaranteed ObjcInterfaceConstInit) -> Int {
-  // CHECK: ref_element_addr [immutable] %0 : $ObjcInterfaceConstInit, #ObjcInterfaceConstInit.constant
+  // CHECK: objc_method %0 : $ObjcInterfaceConstInit, #ObjcInterfaceConstInit.constant!getter.foreign
   // CHECK-LABEL: } // end sil function '$sSo22ObjcInterfaceConstInitC4testE0E15PrivateConstantSiyF'
   final func testPrivateConstant() -> Int {
     return constant

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -384,6 +384,17 @@ protocol subject_containerObjCProtocol2 {
   subscript(i: String) -> Int { get set}
 }
 
+@objc(ConflictingName)
+extension subject_class1 {}
+// expected-note@-1 {{'ConflictingName' previously declared here}}
+
+@objc(ConflictingName)
+extension subject_class2 {}
+
+@objc(ConflictingName)
+extension subject_class1 {}
+// expected-warning@-1 {{extension with Objective-C category name 'ConflictingName' conflicts with previous extension with the same category name; this is an error in the Swift 6 language mode}}
+
 protocol nonObjCProtocol {
   @objc // bad-access-note-move{{nonObjCProtocol.objcRequirement()}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   func objcRequirement()
@@ -2018,6 +2029,9 @@ class BadClass1 { }
 
 @objc(Protocol:) // bad-access-note-move{{BadProto1}} expected-error{{'@objc' protocol must have a simple name}}{{15-16=}}
 protocol BadProto1 { }
+
+@objc(Extension:) // expected-error{{'@objc' extension must have a simple name}}{{16-17=}}
+extension PlainClass {}
 
 @objc(Enum:) // bad-access-note-move{{BadEnum1}} expected-error{{'@objc' enum must have a simple name}}{{11-12=}}
 enum BadEnum1: Int { case X }

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -191,6 +191,15 @@
 
 @end
 
+@interface ObjCBadClass : NSObject
+@end
+
+@interface ObjCBadClass (BadCategory1)
+@end
+
+@interface ObjCBadClass (BadCategory2)
+@end
+
 @protocol EmptyObjCProto
 @end
 

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -4,7 +4,7 @@
 protocol EmptySwiftProto {}
 
 @_objcImplementation extension ObjCClass: EmptySwiftProto, EmptyObjCProto {
-  // expected-note@-1 {{previously implemented by extension here}}
+  // expected-note@-1 {{previously implemented here}}
   // expected-warning@-2 {{extension for main class interface should provide implementation for instance method 'method(fromHeader4:)'}}
   // expected-warning@-3 {{extension for main class interface should provide implementation for property 'propertyFromHeader9'}}
   // FIXME: give better diagnostic expected-warning@-4 {{extension for main class interface should provide implementation for property 'propertyFromHeader8'}}
@@ -232,7 +232,7 @@ protocol EmptySwiftProto {}
 }
 
 @_objcImplementation(PresentAdditions) extension ObjCClass {
-  // expected-note@-1 {{previously implemented by extension here}}
+  // expected-note@-1 {{'PresentAdditions' previously declared here}}
   // expected-warning@-2 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader4:)'; this will become an error after adopting '@implementation'}}
   // FIXME: give better diagnostic expected-warning@-3 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader3:)'; this will become an error after adopting '@implementation'}}
 
@@ -453,10 +453,10 @@ protocol EmptySwiftProto {}
 }
 
 @_objcImplementation extension ObjCClass {}
-// expected-error@-1 {{duplicate implementation of Objective-C class 'ObjCClass'}}
+// expected-error@-1 {{duplicate implementation of imported class 'ObjCClass'}}
 
 @_objcImplementation(PresentAdditions) extension ObjCClass {}
-// expected-error@-1 {{duplicate implementation of Objective-C category 'PresentAdditions' on class 'ObjCClass'}}
+// expected-warning@-1 {{extension with Objective-C category name 'PresentAdditions' conflicts with previous extension with the same category name; this is an error in the Swift 6 language mode}}
 
 @_objcImplementation(MissingAdditions) extension ObjCClass {}
 // expected-error@-1 {{could not find category 'MissingAdditions' on Objective-C class 'ObjCClass'; make sure your umbrella or bridging header imports the header that declares it}}

--- a/test/decl/ext/objc_implementation_early_adopter.swift
+++ b/test/decl/ext/objc_implementation_early_adopter.swift
@@ -428,17 +428,17 @@ protocol EmptySwiftProto {}
   func nullableResult() -> Any { fatalError() } // expected-warning {{instance method 'nullableResult()' of type '() -> Any' does not match type '() -> Any?' declared by the header}}
   func nullableArgument(_: Any) {} // expected-warning {{instance method 'nullableArgument' of type '(Any) -> ()' does not match type '(Any?) -> Void' declared by the header}}
 
-  func nonPointerResult() -> CInt! { fatalError() } // expected-error{{method cannot be in an @_objcImplementation extension of a class (without final or @nonobjc) because its result type cannot be represented in Objective-C}}
-  func nonPointerArgument(_: CInt!) {} // expected-error {{method cannot be in an @_objcImplementation extension of a class (without final or @nonobjc) because the type of the parameter cannot be represented in Objective-C}}
+  func nonPointerResult() -> CInt! { fatalError() } // expected-error{{method cannot be in an @objc @implementation extension of a class (without final or @nonobjc) because its result type cannot be represented in Objective-C}}
+  func nonPointerArgument(_: CInt!) {} // expected-error {{method cannot be in an @objc @implementation extension of a class (without final or @nonobjc) because the type of the parameter cannot be represented in Objective-C}}
 }
 
 // Intentionally using `@_objcImplementation` for this test; do not upgrade!
 @_objcImplementation(EmptyCategory) extension ObjCClass {
-  // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{2-21=implementation}}
+  // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{1-36=@implementation}} {{1-1=@objc(EmptyCategory) }}
 }
 
 @_objcImplementation extension ObjCImplSubclass {
-  // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{2-21=implementation}}
+  // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{1-21=@implementation}} {{1-1=@objc }}
   @objc(initFromProtocol1:)
     required public init?(fromProtocol1: CInt) {
       // OK
@@ -446,7 +446,7 @@ protocol EmptySwiftProto {}
 }
 
 @_objcImplementation extension ObjCBasicInitClass {
-  // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{2-21=implementation}}
+  // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{1-21=@implementation}} {{1-1=@objc }}
   init() {
     // OK
   }
@@ -463,10 +463,10 @@ protocol EmptySwiftProto {}
 // expected-note@-2 {{remove arguments to implement the main '@interface' for this class}} {{21-39=}}
 
 @_objcImplementation extension ObjCStruct {}
-// expected-error@-1 {{cannot mark extension of struct 'ObjCStruct' with '@_objcImplementation'; it is not an imported Objective-C class}} {{1-22=}}
+// expected-error@-1 {{'@objc' can only be applied to an extension of a class}}
 
 @_objcImplementation(CantWork) extension ObjCStruct {}
-// expected-error@-1 {{cannot mark extension of struct 'ObjCStruct' with '@_objcImplementation'; it is not an imported Objective-C class}} {{1-32=}}
+// expected-error@-1 {{'@objc' can only be applied to an extension of a class}}
 
 @objc class SwiftClass {}
 // expected-note@-1 2 {{'SwiftClass' declared here}}

--- a/test/decl/ext/objc_implementation_early_adopter.swift
+++ b/test/decl/ext/objc_implementation_early_adopter.swift
@@ -3,16 +3,16 @@
 
 protocol EmptySwiftProto {}
 
-@implementation extension ObjCClass: EmptySwiftProto, EmptyObjCProto {
+@_objcImplementation extension ObjCClass: EmptySwiftProto, EmptyObjCProto {
   // expected-note@-1 {{previously implemented here}}
-  // expected-error@-2 {{extension for main class interface should provide implementation for instance method 'method(fromHeader4:)'}}
-  // expected-error@-3 {{extension for main class interface should provide implementation for property 'propertyFromHeader9'}}
-  // FIXME: give better diagnostic expected-error@-4 {{extension for main class interface should provide implementation for property 'propertyFromHeader8'}}
-  // FIXME: give better diagnostic expected-error@-5 {{extension for main class interface should provide implementation for property 'propertyFromHeader7'}}
-  // FIXME: give better diagnostic expected-error@-6 {{extension for main class interface should provide implementation for instance method 'method(fromHeader3:)'}}
-  // expected-error@-7 {{'@_objcImplementation' extension cannot add conformance to 'EmptySwiftProto'; add this conformance with an ordinary extension}}
-  // expected-error@-8 {{'@_objcImplementation' extension cannot add conformance to 'EmptyObjCProto'; add this conformance in the Objective-C header}}
-  // expected-error@-9 {{extension for main class interface should provide implementation for instance method 'extensionMethod(fromHeader2:)'}}
+  // expected-warning@-2 {{extension for main class interface should provide implementation for instance method 'method(fromHeader4:)'}}
+  // expected-warning@-3 {{extension for main class interface should provide implementation for property 'propertyFromHeader9'}}
+  // FIXME: give better diagnostic expected-warning@-4 {{extension for main class interface should provide implementation for property 'propertyFromHeader8'}}
+  // FIXME: give better diagnostic expected-warning@-5 {{extension for main class interface should provide implementation for property 'propertyFromHeader7'}}
+  // FIXME: give better diagnostic expected-warning@-6 {{extension for main class interface should provide implementation for instance method 'method(fromHeader3:)'}}
+  // expected-warning@-7 {{'@_objcImplementation' extension cannot add conformance to 'EmptySwiftProto'; add this conformance with an ordinary extension}}
+  // expected-warning@-8 {{'@_objcImplementation' extension cannot add conformance to 'EmptyObjCProto'; add this conformance in the Objective-C header}}
+  // expected-warning@-9 {{extension for main class interface should provide implementation for instance method 'extensionMethod(fromHeader2:)'}}
 
   func method(fromHeader1: CInt) {
     // OK, provides an implementation for the header's method.
@@ -24,7 +24,7 @@ protocol EmptySwiftProto {}
 
   func categoryMethod(fromHeader3: CInt) {
     // FIXME: should emit expected-DISABLED-error@-1 {{instance method 'categoryMethod(fromHeader3:)' should be implemented in extension for category 'PresentAdditions', not main class interface}}
-    // FIXME: expected-error@-2 {{instance method 'categoryMethod(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // FIXME: expected-warning@-2 {{instance method 'categoryMethod(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error after adopting '@implementation'}}
     // FIXME: expected-note@-3 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // FIXME: expected-note@-4 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
@@ -38,16 +38,16 @@ protocol EmptySwiftProto {}
   }
 
   func methodNot(fromHeader3: CInt) {
-    // expected-error@-1 {{instance method 'methodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // expected-warning@-1 {{instance method 'methodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error after adopting '@implementation'}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // expected-note@-3 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
 
   var methodFromHeader5: CInt
-  // expected-error@-1 {{property 'methodFromHeader5' does not match the instance method declared by the header}}
+  // expected-warning@-1 {{property 'methodFromHeader5' does not match the instance method declared by the header}}
 
   func method(fromHeader6: Double) {
-    // expected-error@-1 {{instance method 'method(fromHeader6:)' of type '(Double) -> ()' does not match type '(Int32) -> Void' declared by the header}}
+    // expected-warning@-1 {{instance method 'method(fromHeader6:)' of type '(Double) -> ()' does not match type '(Int32) -> Void' declared by the header}}
   }
 
   var propertyFromHeader1: CInt
@@ -69,10 +69,10 @@ protocol EmptySwiftProto {}
   }
 
   @objc let propertyFromHeader5: CInt
-  // expected-error@-1 {{property 'propertyFromHeader5' should be settable to match the settable property declared by the header}}
+  // expected-warning@-1 {{property 'propertyFromHeader5' should be settable to match the settable property declared by the header}}
 
   @objc var propertyFromHeader6: CInt {
-    // expected-error@-1 {{property 'propertyFromHeader6' should be settable to match the settable property declared by the header}}
+    // expected-warning@-1 {{property 'propertyFromHeader6' should be settable to match the settable property declared by the header}}
     get { return 1 }
   }
 
@@ -80,12 +80,12 @@ protocol EmptySwiftProto {}
   // FIXME: Should complain about final not fulfilling the @objc requirement
 
   func propertyFromHeader10() -> CInt {
-    // expected-error@-1 {{instance method 'propertyFromHeader10()' does not match the property declared by the header}}
+    // expected-warning@-1 {{instance method 'propertyFromHeader10()' does not match the property declared by the header}}
     return 1
   }
 
   var propertyFromHeader11: Float
-  // expected-error@-1 {{property 'propertyFromHeader11' of type 'Float' does not match type 'Int32' declared by the header}}
+  // expected-warning@-1 {{property 'propertyFromHeader11' of type 'Float' does not match type 'Int32' declared by the header}}
 
   var readonlyPropertyFromHeader1: CInt
   // OK, provides an implementation with a stored property that's nonpublicly settable
@@ -114,7 +114,7 @@ protocol EmptySwiftProto {}
   }
 
   internal var propertyNotFromHeader1: CInt
-  // expected-error@-1 {{property 'propertyNotFromHeader1' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?}}
+  // expected-warning@-1 {{property 'propertyNotFromHeader1' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?; this will become an error after adopting '@implementation'}}
   // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible property not declared in the header}} {{3-11=private}}
   // expected-note@-3 {{add 'final' to define a Swift property that cannot be overridden}} {{3-3=final }}
 
@@ -157,12 +157,12 @@ protocol EmptySwiftProto {}
 
   @objc(initFromProtocol2:)
   public init?(fromProtocol2: CInt) {
-    // expected-error@-1 {{initializer 'init(fromProtocol2:)' should be 'required' to match initializer declared by the header}} {{3-3=required }}
+    // expected-warning@-1 {{initializer 'init(fromProtocol2:)' should be 'required' to match initializer declared by the header}} {{3-3=required }}
   }
 
   @objc(initNotFromProtocol:)
   required public init?(notFromProtocol: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromProtocol:)' should not be 'required' to match initializer declared by the header}} {{3-12=}}
+    // expected-warning@-1 {{initializer 'init(notFromProtocol:)' should not be 'required' to match initializer declared by the header}} {{3-12=}}
   }
 
   class func classMethod1(_: CInt) {
@@ -170,11 +170,11 @@ protocol EmptySwiftProto {}
   }
 
   func classMethod2(_: CInt) {
-    // expected-error@-1 {{instance method 'classMethod2' does not match class method declared in header}} {{3-3=class }}
+    // expected-warning@-1 {{instance method 'classMethod2' does not match class method declared in header; this will become an error after adopting '@implementation'}} {{3-3=class }}
   }
 
   class func classMethod3(_: Float) {
-    // expected-error@-1 {{class method 'classMethod3' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
+    // expected-warning@-1 {{class method 'classMethod3' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
   }
 
   func instanceMethod1(_: CInt) {
@@ -182,34 +182,34 @@ protocol EmptySwiftProto {}
   }
 
   class func instanceMethod2(_: CInt) {
-    // expected-error@-1 {{class method 'instanceMethod2' does not match instance method declared in header}} {{3-9=}}
+    // expected-warning@-1 {{class method 'instanceMethod2' does not match instance method declared in header; this will become an error after adopting '@implementation'}} {{3-9=}}
   }
 
   public init(notFromHeader1: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader1:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader1:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible initializer not declared in the header}} {{3-9=private}}
     // expected-note@-3 {{add '@nonobjc' to define a Swift-only initializer}} {{3-3=@nonobjc }}
   }
 
   public required init(notFromHeader2: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader2:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader2:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible initializer not declared in the header}} {{3-9=private}}
     // expected-note@-3 {{add '@nonobjc' to define a Swift-only initializer}} {{3-3=@nonobjc }}
   }
 
   public convenience init(notFromHeader3: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader3:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader3:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible initializer not declared in the header}} {{3-9=private}}
     // expected-note@-3 {{add '@nonobjc' to define a Swift-only initializer}} {{3-3=@nonobjc }}
   }
 
   @nonobjc public init(notFromHeader4: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader4:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override designated initializers}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader4:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override designated initializers}}
     // expected-note@-2 {{add 'convenience' keyword to make this a convenience initializer}} {{12-12=convenience }}
   }
 
   @nonobjc public required init(notFromHeader5: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader5:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override required initializers}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader5:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override required initializers}}
     // expected-note@-2 {{replace 'required' keyword with 'convenience' to make this a convenience initializer}} {{19-27=convenience}}
   }
 
@@ -228,24 +228,24 @@ protocol EmptySwiftProto {}
 
   // rdar://122280735 - crash when the parameter of a block property needs @escaping
   let rdar122280735: (() -> ()) -> Void = { _ in }
-  // expected-error@-1 {{property 'rdar122280735' of type '(() -> ()) -> Void' does not match type '(@escaping () -> Void) -> Void' declared by the header}}
+  // expected-warning@-1 {{property 'rdar122280735' of type '(() -> ()) -> Void' does not match type '(@escaping () -> Void) -> Void' declared by the header}}
 }
 
-@implementation(PresentAdditions) extension ObjCClass {
+@_objcImplementation(PresentAdditions) extension ObjCClass {
   // expected-note@-1 {{'PresentAdditions' previously declared here}}
-  // expected-error@-2 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader4:)'}}
-  // FIXME: give better diagnostic expected-error@-3 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader3:)'}}
+  // expected-warning@-2 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader4:)'; this will become an error after adopting '@implementation'}}
+  // FIXME: give better diagnostic expected-warning@-3 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader3:)'; this will become an error after adopting '@implementation'}}
 
   func method(fromHeader3: CInt) {
     // FIXME: should emit expected-DISABLED-error@-1 {{instance method 'method(fromHeader3:)' should be implemented in extension for main class interface, not category 'PresentAdditions'}}
-    // FIXME: expected-error@-2 {{instance method 'method(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // FIXME: expected-warning@-2 {{instance method 'method(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error after adopting '@implementation'}}
     // FIXME: expected-note@-3 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // FIXME: expected-note@-4 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
 
   var propertyFromHeader7: CInt {
     // FIXME: should emit expected-DISABLED-error@-1 {{property 'propertyFromHeader7' should be implemented in extension for main class interface, not category 'PresentAdditions'}}
-    // FIXME: expected-error@-2 {{property 'propertyFromHeader7' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?}}
+    // FIXME: expected-warning@-2 {{property 'propertyFromHeader7' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?; this will become an error after adopting '@implementation'}}
     // FIXME: expected-note@-3 {{add 'private' or 'fileprivate' to define an Objective-C-compatible property not declared in the header}} {{3-3=private }}
     // FIXME: expected-note@-4 {{add 'final' to define a Swift property that cannot be overridden}} {{3-3=final }}
     get { return 1 }
@@ -268,7 +268,7 @@ protocol EmptySwiftProto {}
   }
 
   func categoryMethodNot(fromHeader3: CInt) {
-    // expected-error@-1 {{instance method 'categoryMethodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // expected-warning@-1 {{instance method 'categoryMethodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error after adopting '@implementation'}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // expected-note@-3 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
@@ -292,11 +292,11 @@ protocol EmptySwiftProto {}
   }
 }
 
-@implementation(SwiftNameTests) extension ObjCClass {
-  // expected-error@-1 {{extension for category 'SwiftNameTests' should provide implementation for instance method 'methodSwiftName6B()'}}
+@_objcImplementation(SwiftNameTests) extension ObjCClass {
+  // expected-warning@-1 {{extension for category 'SwiftNameTests' should provide implementation for instance method 'methodSwiftName6B()'; this will become an error after adopting '@implementation'}}
 
   func methodSwiftName1() {
-    // expected-error@-1 {{selector 'methodSwiftName1' for instance method 'methodSwiftName1()' not found in header; did you mean 'methodObjCName1'?}} {{3-3=@objc(methodObjCName1) }}
+    // expected-warning@-1 {{selector 'methodSwiftName1' for instance method 'methodSwiftName1()' not found in header; did you mean 'methodObjCName1'?; this will become an error after adopting '@implementation'}} {{3-3=@objc(methodObjCName1) }}
   }
 
   @objc(methodObjCName2) func methodSwiftName2() {
@@ -304,34 +304,34 @@ protocol EmptySwiftProto {}
   }
 
   func methodObjCName3() {
-    // expected-error@-1 {{selector 'methodObjCName3' used in header by instance method with a different name; did you mean 'methodSwiftName3()'?}} {{8-23=methodSwiftName3}} {{3-3=@objc(methodObjCName3) }}
+    // expected-warning@-1 {{selector 'methodObjCName3' used in header by instance method with a different name; did you mean 'methodSwiftName3()'?}} {{8-23=methodSwiftName3}} {{3-3=@objc(methodObjCName3) }}
     // FIXME: probably needs an @objc too, since the name is not explicit
   }
 
   @objc(methodWrongObjCName4) func methodSwiftName4() {
-    // expected-error@-1 {{selector 'methodWrongObjCName4' for instance method 'methodSwiftName4()' not found in header; did you mean 'methodObjCName4'?}} {{9-29=methodObjCName4}}
+    // expected-warning@-1 {{selector 'methodWrongObjCName4' for instance method 'methodSwiftName4()' not found in header; did you mean 'methodObjCName4'?; this will become an error after adopting '@implementation'}} {{9-29=methodObjCName4}}
   }
 
   @objc(methodObjCName5) func methodWrongSwiftName5() {
-    // expected-error@-1 {{selector 'methodObjCName5' used in header by instance method with a different name; did you mean 'methodSwiftName5()'?}} {{31-52=methodSwiftName5}}
+    // expected-warning@-1 {{selector 'methodObjCName5' used in header by instance method with a different name; did you mean 'methodSwiftName5()'?}} {{31-52=methodSwiftName5}}
   }
 
   @objc(methodObjCName6A) func methodSwiftName6B() {
-    // expected-error@-1 {{selector 'methodObjCName6A' used in header by instance method with a different name; did you mean 'methodSwiftName6A()'?}} {{32-49=methodSwiftName6A}}
+    // expected-warning@-1 {{selector 'methodObjCName6A' used in header by instance method with a different name; did you mean 'methodSwiftName6A()'?}} {{32-49=methodSwiftName6A}}
   }
 }
 
-@implementation(AmbiguousMethods) extension ObjCClass {
-  // expected-error@-1 {{found multiple implementations that could match instance method 'ambiguousMethod4(with:)' with selector 'ambiguousMethod4WithCInt:'}}
+@_objcImplementation(AmbiguousMethods) extension ObjCClass {
+  // expected-warning@-1 {{found multiple implementations that could match instance method 'ambiguousMethod4(with:)' with selector 'ambiguousMethod4WithCInt:'; this will become an error after adopting '@implementation'}}
 
   @objc func ambiguousMethod1(with: CInt) {
-    // expected-error@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header}}
+    // expected-warning@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header; this will become an error after adopting '@implementation'}}
     // expected-note@-2 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCInt:') is a potential match; insert '@objc(ambiguousMethod1WithCInt:)' to use it}} {{8-8=(ambiguousMethod1WithCInt:)}}
     // expected-note@-3 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCChar:') is a potential match; insert '@objc(ambiguousMethod1WithCChar:)' to use it}} {{8-8=(ambiguousMethod1WithCChar:)}}
   }
 
   func ambiguousMethod1(with: CChar) {
-    // expected-error@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header}}
+    // expected-warning@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header; this will become an error after adopting '@implementation'}}
     // expected-note@-2 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCInt:') is a potential match; insert '@objc(ambiguousMethod1WithCInt:)' to use it}} {{3-3=@objc(ambiguousMethod1WithCInt:) }}
     // expected-note@-3 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCChar:') is a potential match; insert '@objc(ambiguousMethod1WithCChar:)' to use it}} {{3-3=@objc(ambiguousMethod1WithCChar:) }}
   }
@@ -342,11 +342,11 @@ protocol EmptySwiftProto {}
 
   func ambiguousMethod2(with: CChar) {
     // FIXME: OK, matches -ambiguousMethod2WithCChar: because the WithCInt: variant has been eliminated
-    // FIXME: expected-error@-2 {{selector 'ambiguousMethod2With:' for instance method 'ambiguousMethod2(with:)' not found in header; did you mean 'ambiguousMethod2WithCChar:'?}}
+    // FIXME: expected-warning@-2 {{selector 'ambiguousMethod2With:' for instance method 'ambiguousMethod2(with:)' not found in header; did you mean 'ambiguousMethod2WithCChar:'?; this will become an error after adopting '@implementation'}}
   }
 
   func ambiguousMethod3(with: CInt) {
-    // expected-error@-1 {{instance method 'ambiguousMethod3(with:)' could match several different members declared in the header}}
+    // expected-warning@-1 {{instance method 'ambiguousMethod3(with:)' could match several different members declared in the header; this will become an error after adopting '@implementation'}}
     // expected-note@-2 {{instance method 'ambiguousMethod3(with:)' (with selector 'ambiguousMethod3WithCInt:') is a potential match; insert '@objc(ambiguousMethod3WithCInt:)' to use it}} {{3-3=@objc(ambiguousMethod3WithCInt:) }}
     // expected-note@-3 {{instance method 'ambiguousMethod3(with:)' (with selector 'ambiguousMethod3WithCChar:') is a potential match; insert '@objc(ambiguousMethod3WithCChar:)' to use it}} {{3-3=@objc(ambiguousMethod3WithCChar:) }}
   }
@@ -360,7 +360,7 @@ protocol EmptySwiftProto {}
   }
 }
 
-@implementation(Effects) extension ObjCClass {
+@_objcImplementation(Effects) extension ObjCClass {
   @available(SwiftStdlib 5.1, *)
   public func doSomethingAsynchronous() async throws -> Any {
     return self
@@ -394,17 +394,17 @@ protocol EmptySwiftProto {}
 
   @objc(doSomethingThatCanFailWithWeirdParameterWithHandler::)
   public func doSomethingThatCanFailWithWeirdParameter(handler: @escaping () -> Void) throws {
-    // expected-error@-1 {{instance method 'doSomethingThatCanFailWithWeirdParameter(handler:)' does not match the declaration in the header because it uses parameter #1 for the error, not parameter #2; a selector part called 'error:' can control which parameter to use}}
+    // expected-warning@-1 {{instance method 'doSomethingThatCanFailWithWeirdParameter(handler:)' does not match the declaration in the header because it uses parameter #1 for the error, not parameter #2; a selector part called 'error:' can control which parameter to use}}
   }
 
   @objc(doSomethingThatCanFailWithWeirdReturnCodeWithError:)
   public func doSomethingThatCanFailWithWeirdReturnCode() throws {
-    // expected-error@-1 {{instance method 'doSomethingThatCanFailWithWeirdReturnCode()' does not match the declaration in the header because it indicates an error by returning zero, rather than by returning non-zero}}
+    // expected-warning@-1 {{instance method 'doSomethingThatCanFailWithWeirdReturnCode()' does not match the declaration in the header because it indicates an error by returning zero, rather than by returning non-zero}}
   }
 }
 
-@implementation(Conformance) extension ObjCClass {
-  // expected-error@-1 {{extension for category 'Conformance' should provide implementation for instance method 'requiredMethod2()'}}
+@_objcImplementation(Conformance) extension ObjCClass {
+  // expected-warning@-1 {{extension for category 'Conformance' should provide implementation for instance method 'requiredMethod2()'; this will become an error after adopting '@implementation'}}
   // no-error concerning 'optionalMethod2()'
 
   func requiredMethod1() {}
@@ -412,21 +412,21 @@ protocol EmptySwiftProto {}
   func optionalMethod1() {}
 }
 
-@implementation(TypeMatchOptionality) extension ObjCClass {
+@_objcImplementation(TypeMatchOptionality) extension ObjCClass {
   func nullableResultAndArg(_: Any?) -> Any? { fatalError() } // no-error
   func nonnullResultAndArg(_: Any) -> Any { fatalError() } // no-error
   func nullUnspecifiedResultAndArg(_: Any!) -> Any! { fatalError() } // no-error
 
   func nonnullResult1() -> Any { fatalError() } // no-error
-  func nonnullResult2() -> Any? { fatalError() } // expected-error {{instance method 'nonnullResult2()' of type '() -> Any?' does not match type '() -> Any' declared by the header}}
+  func nonnullResult2() -> Any? { fatalError() } // expected-warning {{instance method 'nonnullResult2()' of type '() -> Any?' does not match type '() -> Any' declared by the header}}
   func nonnullResult3() -> Any! { fatalError() } // no-error (special case)
 
   func nonnullArgument1(_: Any) {} // no-error
-  func nonnullArgument2(_: Any?) {} // expected-error {{instance method 'nonnullArgument2' of type '(Any?) -> ()' does not match type '(Any) -> Void' declared by the header}}
+  func nonnullArgument2(_: Any?) {} // expected-warning {{instance method 'nonnullArgument2' of type '(Any?) -> ()' does not match type '(Any) -> Void' declared by the header}}
   func nonnullArgument3(_: Any!) {} // no-error (special case)
 
-  func nullableResult() -> Any { fatalError() } // expected-error {{instance method 'nullableResult()' of type '() -> Any' does not match type '() -> Any?' declared by the header}}
-  func nullableArgument(_: Any) {} // expected-error {{instance method 'nullableArgument' of type '(Any) -> ()' does not match type '(Any?) -> Void' declared by the header}}
+  func nullableResult() -> Any { fatalError() } // expected-warning {{instance method 'nullableResult()' of type '() -> Any' does not match type '() -> Any?' declared by the header}}
+  func nullableArgument(_: Any) {} // expected-warning {{instance method 'nullableArgument' of type '(Any) -> ()' does not match type '(Any?) -> Void' declared by the header}}
 
   func nonPointerResult() -> CInt! { fatalError() } // expected-error{{method cannot be in an @_objcImplementation extension of a class (without final or @nonobjc) because its result type cannot be represented in Objective-C}}
   func nonPointerArgument(_: CInt!) {} // expected-error {{method cannot be in an @_objcImplementation extension of a class (without final or @nonobjc) because the type of the parameter cannot be represented in Objective-C}}
@@ -437,49 +437,51 @@ protocol EmptySwiftProto {}
   // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{2-21=implementation}}
 }
 
-@implementation extension ObjCImplSubclass {
+@_objcImplementation extension ObjCImplSubclass {
+  // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{2-21=implementation}}
   @objc(initFromProtocol1:)
     required public init?(fromProtocol1: CInt) {
       // OK
     }
 }
 
-@implementation extension ObjCBasicInitClass {
+@_objcImplementation extension ObjCBasicInitClass {
+  // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{2-21=implementation}}
   init() {
     // OK
   }
 }
 
-@implementation extension ObjCClass {}
+@_objcImplementation extension ObjCClass {}
 // expected-error@-1 {{duplicate implementation of imported class 'ObjCClass'}}
 
-@implementation(PresentAdditions) extension ObjCClass {}
+@_objcImplementation(PresentAdditions) extension ObjCClass {}
 // expected-warning@-1 {{extension with Objective-C category name 'PresentAdditions' conflicts with previous extension with the same category name; this is an error in the Swift 6 language mode}}
 
-@implementation(MissingAdditions) extension ObjCClass {}
+@_objcImplementation(MissingAdditions) extension ObjCClass {}
 // expected-error@-1 {{could not find category 'MissingAdditions' on Objective-C class 'ObjCClass'; make sure your umbrella or bridging header imports the header that declares it}}
-// expected-note@-2 {{remove arguments to implement the main '@interface' for this class}} {{16-34=}}
+// expected-note@-2 {{remove arguments to implement the main '@interface' for this class}} {{21-39=}}
 
-@implementation extension ObjCStruct {}
-// expected-error@-1 {{cannot mark extension of struct 'ObjCStruct' with '@_objcImplementation'; it is not an imported Objective-C class}} {{1-17=}}
+@_objcImplementation extension ObjCStruct {}
+// expected-error@-1 {{cannot mark extension of struct 'ObjCStruct' with '@_objcImplementation'; it is not an imported Objective-C class}} {{1-22=}}
 
-@implementation(CantWork) extension ObjCStruct {}
-// expected-error@-1 {{cannot mark extension of struct 'ObjCStruct' with '@_objcImplementation'; it is not an imported Objective-C class}} {{1-27=}}
+@_objcImplementation(CantWork) extension ObjCStruct {}
+// expected-error@-1 {{cannot mark extension of struct 'ObjCStruct' with '@_objcImplementation'; it is not an imported Objective-C class}} {{1-32=}}
 
 @objc class SwiftClass {}
 // expected-note@-1 2 {{'SwiftClass' declared here}}
 
-@implementation extension SwiftClass {}
-// expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{1-17=}}
-
-@implementation(WTF) extension SwiftClass {} // expected
+@_objcImplementation extension SwiftClass {}
 // expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{1-22=}}
 
-@implementation extension ObjCImplRootClass {
+@_objcImplementation(WTF) extension SwiftClass {} // expected
+// expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{1-27=}}
+
+@_objcImplementation extension ObjCImplRootClass {
   // expected-error@-1 {{'@_objcImplementation' cannot be used to implement root class 'ObjCImplRootClass'; declare its superclass in the header}}
 }
 
-@implementation extension ObjCImplGenericClass {
+@_objcImplementation extension ObjCImplGenericClass {
   // expected-error@-1 {{'@_objcImplementation' cannot be used to implement generic class 'ObjCImplGenericClass'}}
 }
 
@@ -487,79 +489,79 @@ protocol EmptySwiftProto {}
 // @_cdecl for global functions
 //
 
-@implementation @_cdecl("CImplFunc1")
+@_objcImplementation @_cdecl("CImplFunc1")
 func CImplFunc1(_: Int32) {
   // OK
 }
 
-@implementation(BadCategory) @_cdecl("CImplFunc2")
+@_objcImplementation(BadCategory) @_cdecl("CImplFunc2")
 func CImplFunc2(_: Int32) {
-  // expected-error@-2 {{global function 'CImplFunc2' does not belong to an Objective-C category; remove the category name from this attribute}} {{16-29=}}
+  // expected-error@-2 {{global function 'CImplFunc2' does not belong to an Objective-C category; remove the category name from this attribute}} {{21-34=}}
 }
 
-@implementation @_cdecl("CImplFuncMissing")
+@_objcImplementation @_cdecl("CImplFuncMissing")
 func CImplFuncMissing(_: Int32) {
   // expected-error@-2 {{could not find imported function 'CImplFuncMissing' matching global function 'CImplFuncMissing'; make sure your umbrella or bridging header imports the header that declares it}}
 }
 
-@implementation @_cdecl("CImplFuncMismatch1")
+@_objcImplementation @_cdecl("CImplFuncMismatch1")
 func CImplFuncMismatch1(_: Float) {
-  // expected-error@-1 {{global function 'CImplFuncMismatch1' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
+  // expected-warning@-1 {{global function 'CImplFuncMismatch1' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
 }
 
-@implementation @_cdecl("CImplFuncMismatch2")
+@_objcImplementation @_cdecl("CImplFuncMismatch2")
 func CImplFuncMismatch2(_: Int32) -> Float {
-  // expected-error@-1 {{global function 'CImplFuncMismatch2' of type '(Int32) -> Float' does not match type '(Int32) -> Void' declared by the header}}
+  // expected-warning@-1 {{global function 'CImplFuncMismatch2' of type '(Int32) -> Float' does not match type '(Int32) -> Void' declared by the header}}
 }
 
-@implementation @_cdecl("CImplFuncMismatch3")
+@_objcImplementation @_cdecl("CImplFuncMismatch3")
 func CImplFuncMismatch3(_: Any?) {
   // OK
 }
 
-@implementation @_cdecl("CImplFuncMismatch4")
+@_objcImplementation @_cdecl("CImplFuncMismatch4")
 func CImplFuncMismatch4(_: Any) {
-  // expected-error@-1 {{global function 'CImplFuncMismatch4' of type '(Any) -> ()' does not match type '(Any?) -> Void' declared by the header}}
+  // expected-warning@-1 {{global function 'CImplFuncMismatch4' of type '(Any) -> ()' does not match type '(Any?) -> Void' declared by the header}}
 }
 
-@implementation @_cdecl("CImplFuncMismatch5")
+@_objcImplementation @_cdecl("CImplFuncMismatch5")
 func CImplFuncMismatch5(_: Any) {
   // OK
 }
 
-@implementation @_cdecl("CImplFuncMismatch6")
+@_objcImplementation @_cdecl("CImplFuncMismatch6")
 func CImplFuncMismatch6(_: Any!) {
   // OK, mismatch allowed
 }
 
 
-@implementation @_cdecl("CImplFuncMismatch3a")
+@_objcImplementation @_cdecl("CImplFuncMismatch3a")
 func CImplFuncMismatch3a(_: Int32) -> Any? {
   // OK
 }
 
-@implementation @_cdecl("CImplFuncMismatch4a")
+@_objcImplementation @_cdecl("CImplFuncMismatch4a")
 func CImplFuncMismatch4a(_: Int32) -> Any {
-  // expected-error@-1 {{global function 'CImplFuncMismatch4a' of type '(Int32) -> Any' does not match type '(Int32) -> Any?' declared by the header}}
+  // expected-warning@-1 {{global function 'CImplFuncMismatch4a' of type '(Int32) -> Any' does not match type '(Int32) -> Any?' declared by the header}}
 }
 
-@implementation @_cdecl("CImplFuncMismatch5a")
+@_objcImplementation @_cdecl("CImplFuncMismatch5a")
 func CImplFuncMismatch5a(_: Int32) -> Any {
   // OK
 }
 
-@implementation @_cdecl("CImplFuncMismatch6a")
+@_objcImplementation @_cdecl("CImplFuncMismatch6a")
 func CImplFuncMismatch6a(_: Int32) -> Any! {
   // OK, mismatch allowed
 }
 
-@implementation @_cdecl("CImplFuncNameMismatch1")
+@_objcImplementation @_cdecl("CImplFuncNameMismatch1")
 func mismatchedName1(_: Int32) {
   // expected-error@-2 {{could not find imported function 'CImplFuncNameMismatch1' matching global function 'mismatchedName1'; make sure your umbrella or bridging header imports the header that declares it}}
   // FIXME: Improve diagnostic for a partial match.
 }
 
-@implementation @_cdecl("mismatchedName2")
+@_objcImplementation @_cdecl("mismatchedName2")
 func CImplFuncNameMismatch2(_: Int32) {
   // expected-error@-2 {{could not find imported function 'mismatchedName2' matching global function 'CImplFuncNameMismatch2'; make sure your umbrella or bridging header imports the header that declares it}}
   // FIXME: Improve diagnostic for a partial match.
@@ -569,14 +571,14 @@ func CImplFuncNameMismatch2(_: Int32) {
 // TODO: @_cdecl for global functions imported as computed vars
 //
 var cImplComputedGlobal1: Int32 {
-  @implementation @_cdecl("CImplGetComputedGlobal1")
+  @_objcImplementation @_cdecl("CImplGetComputedGlobal1")
   get {
     // FIXME: Lookup for vars isn't working yet
     // expected-error@-3 {{could not find imported function 'CImplGetComputedGlobal1' matching getter for var 'cImplComputedGlobal1'; make sure your umbrella or bridging header imports the header that declares it}}
     return 0
   }
 
-  @implementation @_cdecl("CImplSetComputedGlobal1")
+  @_objcImplementation @_cdecl("CImplSetComputedGlobal1")
   set {
     // FIXME: Lookup for vars isn't working yet
     // expected-error@-3 {{could not find imported function 'CImplSetComputedGlobal1' matching setter for var 'cImplComputedGlobal1'; make sure your umbrella or bridging header imports the header that declares it}}
@@ -588,7 +590,7 @@ var cImplComputedGlobal1: Int32 {
 // TODO: @_cdecl for import-as-member functions
 //
 extension CImplStruct {
-  @implementation @_cdecl("CImplStructStaticFunc1")
+  @_objcImplementation @_cdecl("CImplStructStaticFunc1")
   static func staticFunc1(_: Int32) {
     // FIXME: Add underlying support for this
     // expected-error@-3 {{@_cdecl can only be applied to global functions}}

--- a/test/decl/ext/objc_implementation_features.swift
+++ b/test/decl/ext/objc_implementation_features.swift
@@ -14,4 +14,4 @@
 // CHECK-DAG: objc_implementation_features.swift:[[@LINE+3]]:{{[0-9]+}}: error: extension for main class interface should provide implementation for initializer 'init()'{{$}}
 // NO-DAG: objc_implementation_features.swift:[[@LINE+2]]:{{[0-9]+}}: error: 'implementation' attribute is only valid when experimental feature ObjCImplementation is enabled
 // YES-NOT: objc_implementation_features.swift:[[@LINE+1]]:{{[0-9]+}}: error: 'implementation' attribute is only valid when experimental feature ObjCImplementation is enabled
-@implementation extension ObjCBasicInitClass {}
+@objc @implementation extension ObjCBasicInitClass {}


### PR DESCRIPTION
This PR changes the type-checking rules for objcImpl to require an `@objc` attribute. It also moves the category name from the `@implementation` attribute to the `@objc` attribute. Backwards compatibility is maintained for the pre-stabilization `@_objcImplementation` syntax.

As part of this change, plain `@objc(CustomName)` on an `extension` now changes its category name when it is printed through `PrintAsClang` or IRGen'd; the name previously was parsed and partially validated but ignored. The only new diagnostic related to this is a warning in Swift 5 mode but will be an error in Swift 6 mode.

~~This draft currently incorporates commits from #73128 and will need to be rebased once that lands, so don't worry about the gigantic Reviewers list it has right now.~~