### PR TITLE
[Concurrency] Stage in new `Async{Throwing}Stream.init(unfolding:)` errors as warnings.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -507,6 +507,9 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
   bool accessWithinModule =
       (fromModule == var->getDeclContext()->getParentModule());
 
+  if (varIsolation.getKind() == ActorIsolation::NonisolatedUnsafe)
+    return true;
+
   if (!var->isLet()) {
     ASTContext &ctx = var->getASTContext();
     if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability)) {

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1183,6 +1183,13 @@ public:
     return Classification();
   }
 
+  bool isContextPreconcurrency() const {
+    if (!DC)
+      return false;
+
+    return getActorIsolationOfContext(DC).preconcurrency();
+  }
+
   /// Whether a missing 'await' error on accessing an async var should be
   /// downgraded to a warning.
   ///
@@ -1190,7 +1197,7 @@ public:
   /// global or static 'let' variables, which was previously accepted in
   /// compiler versions before 5.10, or for declarations marked preconcurrency.
   bool downgradeAsyncAccessToWarning(Decl *decl) {
-    if (decl->preconcurrency()) {
+    if (decl->preconcurrency() || isContextPreconcurrency()) {
       return true;
     }
 
@@ -1339,7 +1346,8 @@ public:
 
     // Downgrade missing 'await' errors for preconcurrency references.
     result.setDowngradeToWarning(
-        result.hasAsync() && fnRef.isPreconcurrency());
+        result.hasAsync() &&
+        (fnRef.isPreconcurrency() || isContextPreconcurrency()));
 
     auto classifyApplyEffect = [&](EffectKind kind) {
       if (!fnType->hasEffect(kind) &&

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -330,20 +330,9 @@ public struct AsyncStream<Element> {
   ///     }
   ///
   ///
-  @_alwaysEmitIntoClient
+  @preconcurrency
   public init(
     unfolding produce: @escaping @Sendable () async -> Element?,
-    onCancel: (@Sendable () -> Void)? = nil
-  ) {
-    self.init(
-      unfolding: produce as () async -> Element?,
-      onCancel: onCancel
-    )
-  }
-
-  @usableFromInline
-  internal init(
-    unfolding produce: @escaping () async -> Element?,
     onCancel: (@Sendable () -> Void)? = nil
   ) {
     let storage: _AsyncStreamCriticalStorage<Optional<() async -> Element?>>

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -330,7 +330,8 @@ public struct AsyncStream<Element> {
   ///     }
   ///
   ///
-  @preconcurrency
+  @_silgen_name("$sScS9unfolding8onCancelScSyxGxSgyYac_yyYbcSgtcfC")
+  @preconcurrency // Original API had `@Sendable` only on `onCancel`
   public init(
     unfolding produce: @escaping @Sendable () async -> Element?,
     onCancel: (@Sendable () -> Void)? = nil

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -369,18 +369,9 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   ///         print(error)
   ///     }
   ///
-  @_alwaysEmitIntoClient
+  @preconcurrency
   public init(
     unfolding produce: @escaping @Sendable () async throws -> Element?
-  ) where Failure == Error {
-    self.init(
-      unfolding: produce as () async throws -> Element?
-    )
-  }
-
-  @usableFromInline
-  internal init(
-    unfolding produce: @escaping () async throws -> Element?
   ) where Failure == Error {
     let storage: _AsyncStreamCriticalStorage<Optional<() async throws -> Element?>>
       = .create(produce)

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -1,8 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s
 // RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -enable-upcoming-feature RegionBasedIsolation
 
-// REQUIRES: asserts
-
 func randomBool() -> Bool { return false }
 func logTransaction(_ i: Int) {}
 
@@ -813,5 +811,22 @@ func testActorWithInitAccessorInit() {
       self.a = value // Ok (nonisolated)
       print(a) // Ok (nonisolated)
     }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor TestNonisolatedUnsafe {
+  private nonisolated(unsafe) var child: OtherActor!
+  init() {
+    child = OtherActor(parent: self)
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor OtherActor {
+  unowned nonisolated let parent: any Actor
+
+  init(parent: any Actor) {
+    self.parent = parent
   }
 }

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -91,6 +91,9 @@ Func withCheckedThrowingContinuation(function:_:) has parameter 1 type change fr
 Func withCheckedContinuation(function:_:) has been renamed to Func withCheckedContinuation(isolation:function:_:)
 Func withCheckedContinuation(function:_:) has mangled name changing from '_Concurrency.withCheckedContinuation<A>(function: Swift.String, _: (Swift.CheckedContinuation<A, Swift.Never>) -> ()) async -> A' to '_Concurrency.withCheckedContinuation<A>(isolation: isolated Swift.Optional<Swift.Actor>, function: Swift.String, _: (Swift.CheckedContinuation<A, Swift.Never>) -> ()) async -> A'
 
+// AsyncStream.init(unfolding:onCancel:) uses @_silgen_name to preserve mangling after adding @preconcurrency.
+Constructor AsyncStream.init(unfolding:onCancel:) has mangled name changing from 'Swift.AsyncStream.init(unfolding: () async -> Swift.Optional<A>, onCancel: Swift.Optional<@Sendable () -> ()>) -> Swift.AsyncStream<A>' to 'Swift.AsyncStream.init(unfolding: () async -> Swift.Optional<A>, onCancel: Swift.Optional<() -> ()>) -> Swift.AsyncStream<A>'
+
 // SerialExecutor gained `enqueue(_: __owned Job)`, protocol requirements got default implementations
 Func SerialExecutor.enqueue(_:) has been added as a protocol requirement
 


### PR DESCRIPTION
Marking the closure parameter to these inits as `@Sendable` changed the inferred isolation of closure arguments in actor-isolated contexts, which caused new effects checker errors when accessing isolated properties and methods without `await`. Mark these `init`s as `@preconcurrency`, and fix the effects checker to downgrade those errors to warnings when the context of the call is `@preconcurrency`.

Note that this PR builds on https://github.com/apple/swift/pull/73308

Resolves: rdar://127145741, rdar://126929825