### PR TITLE
[6.0][Concurrency] Don't diagnose `nonisolated(unsafe)` properties during flow isolation.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -507,6 +507,9 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
   bool accessWithinModule =
       (fromModule == var->getDeclContext()->getParentModule());
 
+  if (varIsolation.getKind() == ActorIsolation::NonisolatedUnsafe)
+    return true;
+
   if (!var->isLet()) {
     ASTContext &ctx = var->getASTContext();
     if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability)) {

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -1,8 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s
 // RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -enable-upcoming-feature RegionBasedIsolation
 
-// REQUIRES: asserts
-
 func randomBool() -> Bool { return false }
 func logTransaction(_ i: Int) {}
 
@@ -813,5 +811,22 @@ func testActorWithInitAccessorInit() {
       self.a = value // Ok (nonisolated)
       print(a) // Ok (nonisolated)
     }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor TestNonisolatedUnsafe {
+  private nonisolated(unsafe) var child: OtherActor!
+  init() {
+    child = OtherActor(parent: self)
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor OtherActor {
+  unowned nonisolated let parent: any Actor
+
+  init(parent: any Actor) {
+    self.parent = parent
   }
 }


### PR DESCRIPTION
* **Explanation**: Flow isolation was not allowing access to `nonisolated(unsafe)` properties inside actor inits/deinit, leading to warnings in the following code from https://github.com/apple/swift/issues/73294:

  ```swift
  actor A {
    private nonisolated(unsafe) var child: B!
    init() {
      child = B(parent: self) // warning: cannot access property 'child' here in non-isolated initializer; this is an error in the Swift 6 language mode
    }
  }
  actor B {
    unowned nonisolated let parent: any Actor

    init(parent: any Actor) {
      self.parent = parent
    }
  }
  ```

  This change prevents flow isolation from diagnosing `nonisolated(unsafe)` properties by checking for `ActorIsolation::NonisolatedUnsafe` in `varIsSafeAcrossActors`.

* **Scope**: Only impacts access to `nonisolated(unsafe)` properties inside actor `init`s and `deinit`s.
* **Risk**: Low; this change allows more code to compile under the Swift 6 language mode, and the only impact in other language modes is fewer warnings under `-strict-concurrency=complete`. This change has no impact on code that uses `-strict-concurrency=minimal`.
* **Testing**: Added a new test.
* **Main branch PR**: https://github.com/apple/swift/pull/73308