### PR TITLE
[python] Replace deprecated assertEquals with assertEqual in build graph test

### DIFF
--- a/utils/swift_build_support/tests/test_build_graph.py
+++ b/utils/swift_build_support/tests/test_build_graph.py
@@ -54,4 +54,4 @@ class BuildGraphTestCase(unittest.TestCase):
         selectedProducts = [products['swiftpm']]
         schedule = build_graph.produce_scheduled_build(selectedProducts)
         names = [x.name for x in schedule[0]]
-        self.assertEquals(['cmark', 'llvm', 'swift', 'swiftpm'], names)
+        self.assertEqual(['cmark', 'llvm', 'swift', 'swiftpm'], names)


### PR DESCRIPTION
`unitest.assertEquals` is deprecated in Python 3.2 and finally removed in Python 3.12 [1]. Due to this, this test files in recent Linux distros, like Ubuntu 24.04 or Fedora 38+ fail. This patch replaces the deprecated function with `assertEqual`.

[1] https://docs.python.org/3/whatsnew/3.12.html