### PR TITLE
Update symbol visibility test for Linux to reflect libstdc++ 14 changes.

### DIFF
--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -262,7 +262,7 @@
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEiEUlPcmE_EEvmT_ \
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEjEUlPcmE_EEvmT_ \
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEmEUlPcmE_EEvmT_ \
-// RUN              -e _ZNSt10_HashtableImSt4pairIKmSt8optionalINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEESaISA_ENSt8__detail10_Select1stESt8equal_toImESt4hashImENSC_18_Mod_range_hashingENSC_20_Default_ranged_hashENSC_20_Prime_rehash_policyENSC_17_Hashtable_traitsILb0ELb0ELb1EEEE9_M_rehashEmSt17integral_constantIbLb1EE \
+// RUN:              -e _ZNSt10_HashtableImSt4pairIKmSt8optionalINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEESaISA_ENSt8__detail10_Select1stESt8equal_toImESt4hashImENSC_18_Mod_range_hashingENSC_20_Default_ranged_hashENSC_20_Prime_rehash_policyENSC_17_Hashtable_traitsILb0ELb0ELb1EEEE9_M_rehashEmSt17integral_constantIbLb1EE \
 // RUN:   > %t/swiftCore-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftCore) > %t/swiftCore-no-weak.txt
 // RUN: diff -u %t/swiftCore-all.txt %t/swiftCore-no-weak.txt
@@ -529,7 +529,7 @@
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEiEUlPcmE_EEvmT_ \
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEjEUlPcmE_EEvmT_ \
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEmEUlPcmE_EEvmT_ \
-// RUN              -e _ZNSt10_HashtableImSt4pairIKmSt8optionalINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEESaISA_ENSt8__detail10_Select1stESt8equal_toImESt4hashImENSC_18_Mod_range_hashingENSC_20_Default_ranged_hashENSC_20_Prime_rehash_policyENSC_17_Hashtable_traitsILb0ELb0ELb1EEEE9_M_rehashEmSt17integral_constantIbLb1EE \
+// RUN:             -e _ZNSt10_HashtableImSt4pairIKmSt8optionalINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEESaISA_ENSt8__detail10_Select1stESt8equal_toImESt4hashImENSC_18_Mod_range_hashingENSC_20_Default_ranged_hashENSC_20_Prime_rehash_policyENSC_17_Hashtable_traitsILb0ELb0ELb1EEEE9_M_rehashEmSt17integral_constantIbLb1EE \
 // RUN:   > %t/swiftRemoteMirror-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftRemoteMirror) > %t/swiftRemoteMirror-no-weak.txt
 // RUN: diff -u %t/swiftRemoteMirror-all.txt %t/swiftRemoteMirror-no-weak.txt

--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -256,6 +256,13 @@
 // RUN:             -e _ZNSt8__detail9__variant15__erased_assignIRSt9monostateOS2_EEvPvS5_ \
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE15_M_replace_coldEPcmPKcmm \
 // RUN:             -e _ZSt12__str_concatINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEET_PKNS6_10value_typeENS6_9size_typeES9_SA_RKNS6_14allocator_typeE \
+// RUN:             -e _ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_realloc_appendIJS5_EEEvDpOT_ \
+// RUN:             -e _ZNSt6vectorISt10unique_ptrIKvSt8functionIFvPS1_EEESaIS6_EE17_M_realloc_appendIJS6_EEEvDpOT_ \
+// RUN:             -e _ZNSt6vectorISt8optionalISt4pairINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbEESaIS9_EE17_M_realloc_appendIJRKS9_EEEvDpOT_ \
+// RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEiEUlPcmE_EEvmT_ \
+// RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEjEUlPcmE_EEvmT_ \
+// RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEmEUlPcmE_EEvmT_ \
+// RUN              -e _ZNSt10_HashtableImSt4pairIKmSt8optionalINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEESaISA_ENSt8__detail10_Select1stESt8equal_toImESt4hashImENSC_18_Mod_range_hashingENSC_20_Default_ranged_hashENSC_20_Prime_rehash_policyENSC_17_Hashtable_traitsILb0ELb0ELb1EEEE9_M_rehashEmSt17integral_constantIbLb1EE \
 // RUN:   > %t/swiftCore-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftCore) > %t/swiftCore-no-weak.txt
 // RUN: diff -u %t/swiftCore-all.txt %t/swiftCore-no-weak.txt
@@ -516,6 +523,13 @@
 // RUN:             -e _ZNSt10_HashtableImSt4pairIKmSt8optionalISsEESaIS4_ENSt8__detail10_Select1stESt8equal_toImESt4hashImENS6_18_Mod_range_hashingENS6_20_Default_ranged_hashENS6_20_Prime_rehash_policyENS6_17_Hashtable_traitsILb0ELb0ELb1EEEE13_M_rehash_auxEmSt17integral_constantIbLb1EE \
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE15_M_replace_coldEPcmPKcmm \
 // RUN:             -e _ZSt12__str_concatINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEET_PKNS6_10value_typeENS6_9size_typeES9_SA_RKNS6_14allocator_typeE \
+// RUN:             -e _ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_realloc_appendIJS5_EEEvDpOT_ \
+// RUN:             -e _ZNSt6vectorISt10unique_ptrIKvSt8functionIFvPS1_EEESaIS6_EE17_M_realloc_appendIJS6_EEEvDpOT_ \
+// RUN:             -e _ZNSt6vectorISt8optionalISt4pairINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbEESaIS9_EE17_M_realloc_appendIJRKS9_EEEvDpOT_ \
+// RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEiEUlPcmE_EEvmT_ \
+// RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEjEUlPcmE_EEvmT_ \
+// RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEmEUlPcmE_EEvmT_ \
+// RUN              -e _ZNSt10_HashtableImSt4pairIKmSt8optionalINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEESaISA_ENSt8__detail10_Select1stESt8equal_toImESt4hashImENSC_18_Mod_range_hashingENSC_20_Default_ranged_hashENSC_20_Prime_rehash_policyENSC_17_Hashtable_traitsILb0ELb0ELb1EEEE9_M_rehashEmSt17integral_constantIbLb1EE \
 // RUN:   > %t/swiftRemoteMirror-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftRemoteMirror) > %t/swiftRemoteMirror-no-weak.txt
 // RUN: diff -u %t/swiftRemoteMirror-all.txt %t/swiftRemoteMirror-no-weak.txt


### PR DESCRIPTION
Several new symbols were added to the libstdc++ 14 library. This version is applied in several of the latest distributions, such as Ubuntu 24.04 and Fedora 40.

Relevant commits in gcc repository:
https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=1d82fc2e6824bf83159389729c31a942f7b91b04
  * include/bits/stl_vector.h (_M_realloc_append): New member function.

https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=95c2b0cc9eaa5b9fbec34e8c5399c7d8f07f329b
  * include/bits/basic_string.h (__resize_and_overwrite): New function.

https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=d71308d5a681de008888ea291136c162e5b46c7c
  * include/bits/hashtable.h (_M_rehash_aux): Rename into _M_rehash.

Fixes https://github.com/swiftlang/swift/issues/75328