### PR TITLE
Revert "[SIL] Require `TransformIterator` support random access"

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -259,7 +259,7 @@ public:
   }
 };
 
-/// An iterator that transforms the result of an underlying random access
+/// An iterator that transforms the result of an underlying bidirectional
 /// iterator with a given operation.
 ///
 /// Slightly different semantics from llvm::map_iterator, but we should
@@ -281,7 +281,7 @@ class TransformIterator {
   using OpTraits = function_traits<Operation>;
 
 public:
-  using iterator_category = std::random_access_iterator_tag;
+  using iterator_category = std::bidirectional_iterator_tag;
   using value_type = typename OpTraits::result_type;
   using reference = value_type;
   using pointer = void; // FIXME: Should provide a pointer proxy.
@@ -318,17 +318,6 @@ public:
     --*this;
     return old;
   }
-
-  int operator-(const TransformIterator &rhs) const {
-    return Current - rhs.Current;
-  }
-
-  TransformIterator &operator+=(int rhs) {
-    Current = Current + rhs;
-    return *this;
-  }
-
-  TransformIterator &operator-=(int rhs) { return operator+=(-rhs); }
 
   friend bool operator==(TransformIterator lhs, TransformIterator rhs) {
     return lhs.Current == rhs.Current;

--- a/include/swift/SIL/LoopInfo.h
+++ b/include/swift/SIL/LoopInfo.h
@@ -24,9 +24,13 @@ namespace swift {
   class SILPassManager;
 }
 
-// Implementation in llvm/Support/GenericLoopInfoImpl.h
-extern template class llvm::LoopBase<swift::SILBasicBlock, swift::SILLoop>;
-extern template class llvm::LoopInfoBase<swift::SILBasicBlock, swift::SILLoop>;
+// Implementation in LoopInfoImpl.h
+#ifdef __GNUC__
+__extension__ extern template
+class llvm::LoopBase<swift::SILBasicBlock, swift::SILLoop>;
+__extension__ extern template
+class llvm::LoopInfoBase<swift::SILBasicBlock, swift::SILLoop>;
+#endif
 
 namespace swift {
 


### PR DESCRIPTION
This reverts commit 095028562e5b99ac5ea72068bfe183cfb17cc575.