### PR TITLE
[SourceKit] Cancel in-flight builds on `editor.close`

### DIFF
--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -1105,7 +1105,8 @@ public:
                                  SourceKitCancellationToken CancellationToken,
                                  std::shared_ptr<EditorConsumer> Consumer) = 0;
 
-  virtual void editorClose(StringRef Name, bool RemoveCache) = 0;
+  virtual void editorClose(StringRef Name, bool CancelBuilds,
+                           bool RemoveCache) = 0;
 
   virtual void editorReplaceText(StringRef Name, llvm::MemoryBuffer *Buf,
                                  unsigned Offset, unsigned Length,

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -313,6 +313,7 @@ public:
                                       bool AllowInputs = true);
 
   void removeCachedAST(SwiftInvocationRef Invok);
+  void cancelBuildsForCachedAST(SwiftInvocationRef Invok);
 
   struct Implementation;
   Implementation &Impl;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2447,25 +2447,24 @@ void SwiftLangSupport::editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
 // EditorClose
 //===----------------------------------------------------------------------===//
 
-void SwiftLangSupport::editorClose(StringRef Name, bool RemoveCache) {
+void SwiftLangSupport::editorClose(StringRef Name, bool CancelBuilds,
+                                   bool RemoveCache) {
   auto Removed = EditorDocuments->remove(Name);
-  if (Removed) {
-    --Stats->numOpenDocs;
-  } else {
+  if (!Removed) {
+    // FIXME: Report error if Name did not apply to anything ?
     IFaceGenContexts.remove(Name);
+    return;
   }
+  --Stats->numOpenDocs;
 
-  if (Removed) {
-    // Cancel any in-flight builds for the given AST.
+  // Cancel any in-flight builds for the given AST if needed.
+  if (CancelBuilds)
     Removed->cancelBuildsForCachedAST();
 
-    // Then remove the cached AST if we've been asked to do so.
-    if (RemoveCache)
-      Removed->removeCachedAST();
-  }
-  // FIXME: Report error if Name did not apply to anything ?
+  // Then remove the cached AST if we've been asked to do so.
+  if (RemoveCache)
+    Removed->removeCachedAST();
 }
-
 
 //===----------------------------------------------------------------------===//
 // EditorReplaceText

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -107,6 +107,7 @@ public:
   void updateSemaInfo(SourceKitCancellationToken CancellationToken);
 
   void removeCachedAST();
+  void cancelBuildsForCachedAST();
 
   ImmutableTextSnapshotRef getLatestSnapshot() const;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -615,7 +615,8 @@ public:
       SourceKitCancellationToken CancellationToken,
       std::shared_ptr<EditorConsumer> Consumer) override;
 
-  void editorClose(StringRef Name, bool RemoveCache) override;
+  void editorClose(StringRef Name, bool CancelBuilds,
+                   bool RemoveCache) override;
 
   void editorReplaceText(StringRef Name, llvm::MemoryBuffer *Buf,
                          unsigned Offset, unsigned Length,

--- a/unittests/SourceKit/SwiftLang/CMakeLists.txt
+++ b/unittests/SourceKit/SwiftLang/CMakeLists.txt
@@ -1,6 +1,7 @@
 if(NOT SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_EMBEDDED_VARIANTS}")
   add_swift_unittest(SourceKitSwiftLangTests
     CursorInfoTest.cpp
+    CloseTest.cpp
     EditingTest.cpp
     )
   target_link_libraries(SourceKitSwiftLangTests PRIVATE SourceKitSwiftLang)

--- a/unittests/SourceKit/SwiftLang/CloseTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CloseTest.cpp
@@ -1,0 +1,180 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "NullEditorConsumer.h"
+#include "SourceKit/Core/Context.h"
+#include "SourceKit/Core/LangSupport.h"
+#include "SourceKit/Core/NotificationCenter.h"
+#include "SourceKit/Support/Concurrency.h"
+#include "SourceKit/SwiftLang/Factory.h"
+#include "swift/Basic/LLVMInitialize.h"
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+using namespace SourceKit;
+using namespace llvm;
+
+static StringRef getRuntimeLibPath() {
+  return sys::path::parent_path(SWIFTLIB_DIR);
+}
+
+static SmallString<128> getSwiftExecutablePath() {
+  SmallString<128> path = sys::path::parent_path(getRuntimeLibPath());
+  sys::path::append(path, "bin", "swift-frontend");
+  return path;
+}
+
+namespace {
+class CompileTrackingConsumer final : public trace::TraceConsumer {
+  std::mutex Mtx;
+  std::condition_variable CV;
+  bool HasStarted = false;
+
+public:
+  CompileTrackingConsumer() {}
+  CompileTrackingConsumer(const CompileTrackingConsumer &) = delete;
+
+  void operationStarted(uint64_t OpId, trace::OperationKind OpKind,
+                        const trace::SwiftInvocation &Inv,
+                        const trace::StringPairs &OpArgs) override {
+    std::unique_lock<std::mutex> lk(Mtx);
+    HasStarted = true;
+    CV.notify_all();
+  }
+
+  void waitForBuildToStart() {
+    std::unique_lock<std::mutex> lk(Mtx);
+    auto secondsToWait = std::chrono::seconds(20);
+    auto when = std::chrono::system_clock::now() + secondsToWait;
+    CV.wait_until(lk, when, [&]() { return HasStarted; });
+    HasStarted = false;
+  }
+
+  void operationFinished(uint64_t OpId, trace::OperationKind OpKind,
+                         ArrayRef<DiagnosticEntryInfo> Diagnostics) override {}
+
+  swift::OptionSet<trace::OperationKind> desiredOperations() override {
+    return trace::OperationKind::PerformSema;
+  }
+};
+
+class CloseTest : public ::testing::Test {
+  std::shared_ptr<SourceKit::Context> Ctx;
+  std::shared_ptr<CompileTrackingConsumer> CompileTracker;
+
+  NullEditorConsumer Consumer;
+
+public:
+  CloseTest() {
+    INITIALIZE_LLVM();
+    Ctx = std::make_shared<SourceKit::Context>(
+        getSwiftExecutablePath(), getRuntimeLibPath(),
+        /*diagnosticDocumentationPath*/ "", SourceKit::createSwiftLangSupport,
+        /*dispatchOnMain=*/false);
+  }
+
+  CompileTrackingConsumer &getCompileTracker() const { return *CompileTracker; }
+  LangSupport &getLang() { return Ctx->getSwiftLangSupport(); }
+
+  void SetUp() override {
+    CompileTracker = std::make_shared<CompileTrackingConsumer>();
+    trace::registerConsumer(CompileTracker.get());
+  }
+
+  void TearDown() override {
+    trace::unregisterConsumer(CompileTracker.get());
+    CompileTracker = nullptr;
+  }
+
+  void open(const char *DocName, StringRef Text, ArrayRef<const char *> CArgs) {
+    auto Args = makeArgs(DocName, CArgs);
+    auto Buf = MemoryBuffer::getMemBufferCopy(Text, DocName);
+    getLang().editorOpen(DocName, Buf.get(), Consumer, Args, std::nullopt);
+  }
+
+  void close(const char *DocName, bool removeCache) {
+    getLang().editorClose(DocName, removeCache);
+  }
+
+  void getDiagnosticsAsync(
+      const char *DocName, ArrayRef<const char *> CArgs,
+      llvm::function_ref<void(const RequestResult<DiagnosticsResult> &)>
+          callback) {
+    auto Args = makeArgs(DocName, CArgs);
+    getLang().getDiagnostics(DocName, Args, /*VFSOpts*/ std::nullopt,
+                             /*CancelToken*/ {}, callback);
+  }
+
+private:
+  std::vector<const char *> makeArgs(const char *DocName,
+                                     ArrayRef<const char *> CArgs) {
+    std::vector<const char *> Args = CArgs;
+    Args.push_back(DocName);
+    return Args;
+  }
+};
+
+} // end anonymous namespace
+
+static const char *getComplexSourceText() {
+  // best of luck, type-checker
+  return
+    "struct A: ExpressibleByIntegerLiteral { init(integerLiteral value: Int) {} }\n"
+    "struct B: ExpressibleByIntegerLiteral { init(integerLiteral value: Int) {} }\n"
+    "struct C: ExpressibleByIntegerLiteral { init(integerLiteral value: Int) {} }\n"
+
+    "func + (lhs: A, rhs: B) -> A { fatalError() }\n"
+    "func + (lhs: B, rhs: C) -> A { fatalError() }\n"
+    "func + (lhs: C, rhs: A) -> A { fatalError() }\n"
+
+    "func + (lhs: B, rhs: A) -> B { fatalError() }\n"
+    "func + (lhs: C, rhs: B) -> B { fatalError() }\n"
+    "func + (lhs: A, rhs: C) -> B { fatalError() }\n"
+
+    "func + (lhs: C, rhs: B) -> C { fatalError() }\n"
+    "func + (lhs: B, rhs: C) -> C { fatalError() }\n"
+    "func + (lhs: A, rhs: A) -> C { fatalError() }\n"
+
+    "let x: C = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8\n";
+}
+
+TEST_F(CloseTest, Cancel) {
+  const char *DocName = "test.swift";
+  auto *Contents = getComplexSourceText();
+  const char *Args[] = {"-parse-as-library"};
+
+  // Test twice with RemoveCache = false to test both the prior state of
+  // the ASTProducer being cached and not cached.
+  for (auto RemoveCache : {true, false, false}) {
+    open(DocName, Contents, Args);
+
+    Semaphore BuildResultSema(0);
+
+    getDiagnosticsAsync(DocName, Args,
+                        [&](const RequestResult<DiagnosticsResult> &Result) {
+      EXPECT_TRUE(Result.isCancelled());
+      BuildResultSema.signal();
+    });
+
+    getCompileTracker().waitForBuildToStart();
+
+    close(DocName, RemoveCache);
+
+    bool Expired = BuildResultSema.wait(30 * 1000);
+    if (Expired)
+      llvm::report_fatal_error("Did not receive a response for the request");
+  }
+}

--- a/unittests/SourceKit/SwiftLang/CloseTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CloseTest.cpp
@@ -105,8 +105,8 @@ public:
     getLang().editorOpen(DocName, Buf.get(), Consumer, Args, std::nullopt);
   }
 
-  void close(const char *DocName, bool removeCache) {
-    getLang().editorClose(DocName, removeCache);
+  void close(const char *DocName, bool CancelBuilds, bool RemoveCache) {
+    getLang().editorClose(DocName, CancelBuilds, RemoveCache);
   }
 
   void getDiagnosticsAsync(
@@ -171,7 +171,7 @@ TEST_F(CloseTest, Cancel) {
 
     getCompileTracker().waitForBuildToStart();
 
-    close(DocName, RemoveCache);
+    close(DocName, /*CancelBuilds*/ true, RemoveCache);
 
     bool Expired = BuildResultSema.wait(30 * 1000);
     if (Expired)

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "NullEditorConsumer.h"
 #include "SourceKit/Core/Context.h"
 #include "SourceKit/Core/LangSupport.h"
 #include "SourceKit/Core/NotificationCenter.h"
@@ -40,61 +41,6 @@ static void *createCancellationToken() {
 }
 
 namespace {
-
-class NullEditorConsumer : public EditorConsumer {
-  bool needsSemanticInfo() override { return needsSema; }
-
-  void handleRequestError(const char *Description) override {
-    llvm_unreachable("unexpected error");
-  }
-
-  bool syntaxMapEnabled() override { return true; }
-
-  void handleSyntaxMap(unsigned Offset, unsigned Length, UIdent Kind) override {
-  }
-
-  void handleSemanticAnnotation(unsigned Offset, unsigned Length, UIdent Kind,
-                                bool isSystem) override {}
-
-  bool documentStructureEnabled() override { return false; }
-
-  void beginDocumentSubStructure(unsigned Offset, unsigned Length,
-                                 UIdent Kind, UIdent AccessLevel,
-                                 UIdent SetterAccessLevel,
-                                 unsigned NameOffset,
-                                 unsigned NameLength,
-                                 unsigned BodyOffset,
-                                 unsigned BodyLength,
-                                 unsigned DocOffset,
-                                 unsigned DocLength,
-                                 StringRef DisplayName,
-                                 StringRef TypeName,
-                                 StringRef RuntimeName,
-                                 StringRef SelectorName,
-                                 ArrayRef<StringRef> InheritedTypes,
-                                 ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) override {
-  }
-
-  void endDocumentSubStructure() override {}
-
-  void handleDocumentSubStructureElement(UIdent Kind, unsigned Offset,
-                                         unsigned Length) override {}
-
-  void recordAffectedRange(unsigned Offset, unsigned Length) override {}
-
-  void recordAffectedLineRange(unsigned Line, unsigned Length) override {}
-
-  bool diagnosticsEnabled() override { return false; }
-
-  void handleDiagnostics(ArrayRef<DiagnosticEntryInfo> DiagInfos,
-                         UIdent DiagStage) override {}
-  void recordFormattedText(StringRef Text) override {}
-
-  void handleSourceText(StringRef Text) override {}
-
-public:
-  bool needsSema = false;
-};
 
 struct TestCursorInfo {
   // Empty if no error.

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -16,6 +16,7 @@
 #include "SourceKit/Core/NotificationCenter.h"
 #include "SourceKit/Support/Concurrency.h"
 #include "SourceKit/SwiftLang/Factory.h"
+#include "swift/Basic/LLVMInitialize.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/TargetSelect.h"
@@ -63,10 +64,6 @@ public:
   LangSupport &getLang() { return getContext().getSwiftLangSupport(); }
 
   void SetUp() override {
-    llvm::InitializeAllTargets();
-    llvm::InitializeAllTargetMCs();
-    llvm::InitializeAllAsmPrinters();
-    llvm::InitializeAllAsmParsers();
     NumTasks = 0;
   }
 
@@ -76,6 +73,7 @@ public:
                                     /*diagnosticDocumentationPath*/ "",
                                     SourceKit::createSwiftLangSupport,
                                     /*dispatchOnMain=*/false)) {
+    INITIALIZE_LLVM();
     // This is avoiding destroying \p SourceKit::Context because another
     // thread may be active trying to use it to post notifications.
     // FIXME: Use shared_ptr ownership to avoid such issues.

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -166,7 +166,8 @@ public:
   }
 
   void close(const char *DocName) {
-    getLang().editorClose(DocName, /*removeCache=*/false);
+    getLang().editorClose(DocName, /*CancelBuilds*/ true,
+                          /*RemoveCache*/ false);
   }
 
   void replaceText(StringRef DocName, unsigned Offset, unsigned Length,

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -15,6 +15,7 @@
 #include "SourceKit/Core/NotificationCenter.h"
 #include "SourceKit/Support/Concurrency.h"
 #include "SourceKit/SwiftLang/Factory.h"
+#include "swift/Basic/LLVMInitialize.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/TargetSelect.h"
@@ -121,6 +122,7 @@ class EditTest : public ::testing::Test {
 
 public:
   EditTest() {
+    INITIALIZE_LLVM();
     // This is avoiding destroying \p SourceKit::Context because another
     // thread may be active trying to use it to post notifications.
     // FIXME: Use shared_ptr ownership to avoid such issues.
@@ -140,13 +142,6 @@ public:
   }
 
   LangSupport &getLang() { return Ctx->getSwiftLangSupport(); }
-
-  void SetUp() override {
-    llvm::InitializeAllTargets();
-    llvm::InitializeAllTargetMCs();
-    llvm::InitializeAllAsmPrinters();
-    llvm::InitializeAllAsmParsers();
-  }
 
   void addNotificationReceiver(DocumentUpdateNotificationReceiver Receiver) {
     Ctx->getNotificationCenter()->addDocumentUpdateNotificationReceiver(Receiver);

--- a/unittests/SourceKit/SwiftLang/NullEditorConsumer.h
+++ b/unittests/SourceKit/SwiftLang/NullEditorConsumer.h
@@ -21,7 +21,7 @@ class NullEditorConsumer : public EditorConsumer {
     llvm_unreachable("unexpected error");
   }
 
-  bool syntaxMapEnabled() override { return true; }
+  bool syntaxMapEnabled() override { return false; }
 
   void handleSyntaxMap(unsigned Offset, unsigned Length, UIdent Kind) override {
   }

--- a/unittests/SourceKit/SwiftLang/NullEditorConsumer.h
+++ b/unittests/SourceKit/SwiftLang/NullEditorConsumer.h
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SourceKit/Core/LangSupport.h"
+
+namespace SourceKit {
+
+class NullEditorConsumer : public EditorConsumer {
+  bool needsSemanticInfo() override { return needsSema; }
+
+  void handleRequestError(const char *Description) override {
+    llvm_unreachable("unexpected error");
+  }
+
+  bool syntaxMapEnabled() override { return true; }
+
+  void handleSyntaxMap(unsigned Offset, unsigned Length, UIdent Kind) override {
+  }
+
+  void handleSemanticAnnotation(unsigned Offset, unsigned Length, UIdent Kind,
+                                bool isSystem) override {}
+
+  bool documentStructureEnabled() override { return false; }
+
+  void beginDocumentSubStructure(
+      unsigned Offset, unsigned Length, UIdent Kind, UIdent AccessLevel,
+      UIdent SetterAccessLevel, unsigned NameOffset, unsigned NameLength,
+      unsigned BodyOffset, unsigned BodyLength, unsigned DocOffset,
+      unsigned DocLength, StringRef DisplayName, StringRef TypeName,
+      StringRef RuntimeName, StringRef SelectorName,
+      ArrayRef<StringRef> InheritedTypes,
+      ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) override {}
+
+  void endDocumentSubStructure() override {}
+
+  void handleDocumentSubStructureElement(UIdent Kind, unsigned Offset,
+                                         unsigned Length) override {}
+
+  void recordAffectedRange(unsigned Offset, unsigned Length) override {}
+
+  void recordAffectedLineRange(unsigned Line, unsigned Length) override {}
+
+  bool diagnosticsEnabled() override { return false; }
+
+  void handleDiagnostics(ArrayRef<DiagnosticEntryInfo> DiagInfos,
+                         UIdent DiagStage) override {}
+  void recordFormattedText(StringRef Text) override {}
+
+  void handleSourceText(StringRef Text) override {}
+
+public:
+  bool needsSema = false;
+};
+
+} // end namespace SourceKit

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -116,6 +116,7 @@ UID_KEYS = [
     KEY('Introduced', 'key.introduced'),
     KEY('Deprecated', 'key.deprecated'),
     KEY('Obsoleted', 'key.obsoleted'),
+    KEY('CancelBuilds', 'key.cancel_builds'),
     KEY('RemoveCache', 'key.removecache'),
     KEY('TypeUsr', 'key.typeusr'),
     KEY('ContainerTypeUsr', 'key.containertypeusr'),


### PR DESCRIPTION
When closing a document, cancel any in-flight builds happening for it.

rdar://127126348