### PR TITLE
[sil-opt] Hard exit(-1) instead of finishDiagProcessing when failing to setup a compiler invocation.

### DIFF
--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -864,7 +864,11 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   std::string InstanceSetupError;
   if (CI.setup(Invocation, InstanceSetupError)) {
     llvm::errs() << InstanceSetupError << '\n';
-    return finishDiagProcessing(1);
+    // Rather than finish Diag processing, exit -1 here to show we failed to
+    // setup here. The reason we do this is if the setup fails, we want to fail
+    // hard. We shouldn't be testing that we setup correctly with
+    // -verify/etc. We should be testing that later.
+    exit(-1);
   }
 
   CI.performSema();


### PR DESCRIPTION
[sil-opt] Hard exit(-1) instead of finishDiagProcessing when failing to setup a compiler invocation.

Running finishDiagProcessing and potentially silently exiting when -verify is set is the correct behavior for failures later in sil-opt when running Sema or when running SIL passes. This is incorrect behavior when just setting up the compiler instance since in such a case, we want to hard exit -1 since this means that a test has not properly setup the compiler instance itself. It is better to hard fail and have the test maintainer just update its command line arguments as appropriate.

