### PR TITLE
NCGenerics: fix partial backdeployment support

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6735,7 +6735,7 @@ ERROR(availability_isolated_any_only_version_newer, none,
       "%0 %1 or newer",
       (StringRef, llvm::VersionTuple))
 
-ERROR(availability_noncopyable_generics_only_version_newer, none,
+WARNING(availability_noncopyable_generics_only_version_newer, none,
       "runtime support for '~' suppressions on generic parameters is only available in "
       "%0 %1 or newer",
       (StringRef, llvm::VersionTuple))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6735,6 +6735,11 @@ ERROR(availability_isolated_any_only_version_newer, none,
       "%0 %1 or newer",
       (StringRef, llvm::VersionTuple))
 
+ERROR(availability_noncopyable_generics_only_version_newer, none,
+      "runtime support for '~' suppressions on generic parameters is only available in "
+      "%0 %1 or newer",
+      (StringRef, llvm::VersionTuple))
+
 ERROR(availability_variadic_type_only_version_newer, none,
       "parameter packs in generic types are only available in %0 %1 or newer",
       (StringRef, llvm::VersionTuple))

--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -71,6 +71,8 @@ FEATURE(SwiftExceptionPersonality,                      (6, 0))
 // Metadata support for @isolated(any) function types
 FEATURE(IsolatedAny,                                    (6, 0))
 
+FEATURE(NoncopyableGenerics,                            (6, 0))
+
 FEATURE(TaskExecutor,                                   FUTURE)
 FEATURE(Differentiation,                                FUTURE)
 FEATURE(InitRawStructMetadata,                          FUTURE)

--- a/include/swift/Sema/CheckAvailability.h
+++ b/include/swift/Sema/CheckAvailability.h
@@ -1,0 +1,27 @@
+//===--- CheckAvailability.h - CheckAvailability ----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SEMA_CHECKAVAILABILITY_H
+#define SWIFT_SEMA_CHECKAVAILABILITY_H
+
+namespace swift {
+class NominalOrBoundGenericNominalType;
+
+/// NoncopyableGenerics, which is the generics system for inverses, does not
+/// always require the runtime metadata that is only availabile in Swift 6.
+///
+/// \returns true if the given type needs the newer runtime.
+bool requiresNoncopyableGenericsAvailabilityCheck(
+    NominalOrBoundGenericNominalType *type);
+}
+
+#endif //SWIFT_SEMA_CheckAVAILABILITY_H

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -372,6 +372,7 @@ getTypeRefByFunction(IRGenModule &IGM,
             Address(bindingsBufPtr, IGM.Int8Ty, IGM.getPointerAlignment()),
             MetadataState::Complete, subs);
 
+        substT = substT.getReferenceStorageReferent(); // FIXME: shot in the dark here
         auto ret = IGF.emitTypeMetadataRef(substT);
         IGF.Builder.CreateRet(ret);
       }

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -226,6 +226,20 @@ getRuntimeVersionThatSupportsDemanglingType(CanType type) {
       // involving them.
     }
 
+    // Any nominal type that has an inverse requirement in its generic signature
+    // uses NoncopyableGenerics. Since inverses are mangled into symbols,
+    // a Swift 6.0+ runtime is needed to demangle them.
+    if (auto nominalTy = dyn_cast<NominalOrBoundGenericNominalType>(t)) {
+      auto *nom = nominalTy->getDecl();
+      if (auto sig = nom->getGenericSignature()) {
+        SmallVector<InverseRequirement, 2> inverses;
+        SmallVector<Requirement, 2> reqs;
+        sig->getRequirementsWithInverses(reqs, inverses);
+        if (!inverses.empty())
+          return addRequirement(Swift_6_0);
+      }
+    }
+
     return false;
   });
 

--- a/test/Backdeploy/Noncopyable/mangling.swift
+++ b/test/Backdeploy/Noncopyable/mangling.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+// RUN: %swift-frontend %s -swift-version 6 -module-name main -emit-ir -o %t/new.ir
+// RUN: %FileCheck %s --check-prefix=NEW < %t/new.ir
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx10.15 -module-name main -emit-ir -o %t/old.ir
+// RUN: %FileCheck %s --check-prefix=OLD < %t/old.ir
+
+// Check that we add extra type metadata accessors for types with generic
+// parameters that have an inverse. These are used instead of using demangling
+// cache variables since old runtimes cannot synthesize type metadata based on
+// the new mangling.
+
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 %s -o %t/test_mangling
+// RUN: %target-run %t/test_mangling | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+
+
+// This type's generic parameter is noncopyable, so older runtimes can't
+// demangle the type's name to build the metadata.
+struct Foo<T: ~Copyable>: ~Copyable {
+  mutating func bar() { print("Foo.bar") }
+}
+
+func test() {
+  var foo = Foo<Int>()
+  foo.bar()
+}
+test()
+// CHECK: Foo.bar
+
+// NEW: define hidden swiftcc void @"$s4main4testyyF"()
+// NEW-NOT: %swift.metadata_response
+// NEW: call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s4main3FooVySiGMD")
+// NEW-NOT: %swift.metadata_response
+// NEW: }
+
+// OLD: define hidden swiftcc void @"$s4main4testyyF"()
+// OLD-NOT: __swift_instantiateConcreteTypeFromMangledName
+// OLD: call swiftcc %swift.metadata_response @"$s4main3FooVySiGMa"(i64 0)
+// OLD-NOT: __swift_instantiateConcreteTypeFromMangledName
+// OLD: }
+
+
+// This type does not need a Swift 6.0 runtime, despite being noncopyable,
+// because it doesn't have a noncopyable generic parameter.
+struct JustNoncopyable<T>: ~Copyable {
+  mutating func bar() { print("JustNoncopyable.bar") }
+}
+
+func testNonGeneric() {
+    var ng = JustNoncopyable<Int>()
+    ng.bar()
+}
+testNonGeneric()
+
+// CHECK: JustNoncopyable.bar
+
+// NEW: define hidden swiftcc void @"$s4main14testNonGenericyyF"()
+// NEW-NOT: %swift.metadata_response
+// NEW: call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s4main15JustNoncopyableVySiGMD")
+// NEW-NOT: %swift.metadata_response
+// NEW: }
+
+// OLD: define hidden swiftcc void @"$s4main14testNonGenericyyF"()
+// OLD-NOT: %swift.metadata_response
+// OLD: call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s4main15JustNoncopyableVySiGMD")
+// OLD-NOT: %swift.metadata_response
+// OLD: }


### PR DESCRIPTION
When the type substitution is concrete, we can obtain metadata on older runtimes for the type with a noncopyable generic parameter. We just have to avoid the demangling strategy.

resolves rdar://126239335
