### PR TITLE
[SILGen]: Add test for parenthesized try expression

### DIFF
--- a/validation-test/SILGen/issue-73244.swift
+++ b/validation-test/SILGen/issue-73244.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-emit-silgen %s -verify
+
+// Check that SILGen does not crash because of a parenthesized try expression
+class Class {
+  var num: Int = 1
+
+  init() throws {}
+}
+_ = (try Class().num)


### PR DESCRIPTION
Changes Made

- Add test case for `SILGen` ensuring that the compiler does not crash with a parenthesized-try-expression

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #73244

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
