### PR TITLE
[Test] Update `verify-fixits.swift` after upstream FileCheck change

### DIFF
--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -5,10 +5,10 @@
 func labeledFunc(aa: Int, bb: Int) {}
 
 func testNoneMarkerCheck() {
-  // CHECK: [[@LINE+1]]:87: error: A second {{{{}}none}} was found. It may only appear once in an expectation.
+  // CHECK: [[@LINE+1]]:87: error: A second {{\{\{}}none}} was found. It may only appear once in an expectation.
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{none}} {{none}}
 
-  // CHECK: [[@LINE+1]]:134: error: {{{{}}none}} must be at the end.
+  // CHECK: [[@LINE+1]]:134: error: {{\{\{}}none}} must be at the end.
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{none}} {{23-26=bb}}
 }
 
@@ -173,27 +173,27 @@ func test1Fixits() {
 
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}}
 
-  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}}
 
-  // CHECK: [[@LINE+1]]:134: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  // CHECK: [[@LINE+1]]:134: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{15-18=xx}}
 
-  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}} {{15-18=aa}}
 
-  // CHECK: [[@LINE+1]]:121: error: expected no fix-its; actual fix-it seen: {{{{}}15-18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected no fix-its; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{none}}
 
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
 
-  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}} {{none}}
 
-  // CHECK: [[@LINE+1]]:134: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  // CHECK: [[@LINE+1]]:134: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=aa}} {{15-18=xx}} {{none}}
 
-  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}} {{15-18=aa}} {{none}}
 
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
@@ -215,13 +215,13 @@ func test1Fixits() {
   labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{216:15-+1:18=bb}}
               bbx: 1)
 
-  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{61:15-18=aa}}
-  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{-1:15-18=aa}}
-  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{+0:15--1:18=aa}}
-  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{61:15-+1:18=aa}}
 }
 
@@ -232,7 +232,7 @@ func testDefaultedLineNumbers() {
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
   unlabeledFunc(aa: // expected-error {{extraneous argument label 'aa:' in call}} {{+0:17-+1:5=}}
     1)
-  // CHECK: [[@LINE+1]]:83: error: expected fix-it not seen; actual fix-it seen: {{{{}}17-[[@LINE+2]]:5=}}
+  // CHECK: [[@LINE+1]]:83: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}17-[[@LINE+2]]:5=}}
   unlabeledFunc(aa: // expected-error {{extraneous argument label 'aa:' in call}} {{+0:17-5=}}
     1)
 
@@ -240,7 +240,7 @@ func testDefaultedLineNumbers() {
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
   labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{+1:15-+1:18=bb}}
               bbx: 1)
-  // CHECK: [[@LINE+1]]:113: error: expected fix-it not seen; actual fix-it seen: {{{{}}[[@LINE+2]]:15-18=bb}}
+  // CHECK: [[@LINE+1]]:113: error: expected fix-it not seen; actual fix-it seen: {{\{\{}}[[@LINE+2]]:15-18=bb}}
   labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{15-+1:18=bb}}
               bbx: 1)
 }
@@ -250,22 +250,22 @@ func test2Fixits() {
 
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}}
 
-  // CHECK: [[@LINE+1]]:124: error: expected fix-it not seen; actual fix-its seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
+  // CHECK: [[@LINE+1]]:124: error: expected fix-it not seen; actual fix-its seen: {{\{\{}}15-18=aa}} {{\{\{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=xx}}
 
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}}
 
-  // CHECK: [[@LINE+1]]:137: error: expected fix-it not seen; actual fix-its seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
+  // CHECK: [[@LINE+1]]:137: error: expected fix-it not seen; actual fix-its seen: {{\{\{}}15-18=aa}} {{\{\{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=xx}}
 
-  // CHECK: [[@LINE+1]]:124: error: expected no fix-its; actual fix-its seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
+  // CHECK: [[@LINE+1]]:124: error: expected no fix-its; actual fix-its seen: {{\{\{}}15-18=aa}} {{\{\{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{none}}
 
-  // CHECK: [[@LINE+1]]:137: error: unexpected fix-it seen; actual fix-its seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
+  // CHECK: [[@LINE+1]]:137: error: unexpected fix-it seen; actual fix-its seen: {{\{\{}}15-18=aa}} {{\{\{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{none}}
 
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=bb}} {{none}}
 
-  // CHECK: [[@LINE+1]]:137: error: expected fix-it not seen; actual fix-its seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
+  // CHECK: [[@LINE+1]]:137: error: expected fix-it not seen; actual fix-its seen: {{\{\{}}15-18=aa}} {{\{\{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=xx}} {{none}}
 }


### PR DESCRIPTION
a3eeef82da8be7f2cfa6dc7bed0fe4c11d585180 modified FileCheck such that `{{{{}}` now has to be `{{\{\{}}`.