### PR TITLE
[sil-opt] Improvements to mąkę sil-opt behave like swift-frontend around language versions + some small other fixes

### DIFF
--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -78,7 +78,29 @@ enum class EnforceExclusivityMode {
   DynamicOnly,
   None,
 };
+
+enum class SILOptStrictConcurrency {
+  None = 0,
+  Complete,
+  Targeted,
+  Minimal,
+};
+
 } // end anonymous namespace
+
+std::optional<StrictConcurrency>
+convertSILOptToRawStrictConcurrencyLevel(SILOptStrictConcurrency level) {
+  switch (level) {
+  case SILOptStrictConcurrency::None:
+    return {};
+  case SILOptStrictConcurrency::Complete:
+    return StrictConcurrency::Complete;
+  case SILOptStrictConcurrency::Targeted:
+    return StrictConcurrency::Targeted;
+  case SILOptStrictConcurrency::Minimal:
+    return StrictConcurrency::Minimal;
+  }
+}
 
 namespace llvm {
 
@@ -489,15 +511,19 @@ struct SILOptOptions {
       cl::value_desc("format"), cl::init("yaml"));
 
   // Strict Concurrency
-  llvm::cl::opt<StrictConcurrency> StrictConcurrencyLevel =
-      llvm::cl::opt<StrictConcurrency>(
+  llvm::cl::opt<SILOptStrictConcurrency> StrictConcurrencyLevel =
+      llvm::cl::opt<SILOptStrictConcurrency>(
           "strict-concurrency", cl::desc("strict concurrency level"),
-          llvm::cl::values(clEnumValN(StrictConcurrency::Complete, "complete",
-                                      "Enable complete strict concurrency"),
-                           clEnumValN(StrictConcurrency::Targeted, "targeted",
-                                      "Enable targeted strict concurrency"),
-                           clEnumValN(StrictConcurrency::Minimal, "minimal",
-                                      "Enable minimal strict concurrency")));
+          llvm::cl::init(SILOptStrictConcurrency::None),
+          llvm::cl::values(
+              clEnumValN(SILOptStrictConcurrency::Complete, "complete",
+                         "Enable complete strict concurrency"),
+              clEnumValN(SILOptStrictConcurrency::Targeted, "targeted",
+                         "Enable targeted strict concurrency"),
+              clEnumValN(SILOptStrictConcurrency::Minimal, "minimal",
+                         "Enable minimal strict concurrency"),
+              clEnumValN(SILOptStrictConcurrency::None, "disabled",
+                         "Strict concurrency disabled")));
 
   llvm::cl::opt<bool>
       EnableCxxInterop = llvm::cl::opt<bool>("enable-experimental-cxx-interop",
@@ -693,15 +719,26 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
       options.BypassResilienceChecks;
   Invocation.getDiagnosticOptions().PrintDiagnosticNames =
       options.DebugDiagnosticNames;
+
   for (auto &featureName : options.UpcomingFeatures) {
-    if (auto feature = getUpcomingFeature(featureName)) {
-      Invocation.getLangOptions().enableFeature(*feature);
-    } else {
+    auto feature = getUpcomingFeature(featureName);
+    if (!feature) {
       llvm::errs() << "error: unknown upcoming feature "
                    << QuotedString(featureName) << "\n";
       exit(-1);
     }
+
+    if (auto firstVersion = getFeatureLanguageVersion(*feature)) {
+      if (Invocation.getLangOptions().isSwiftVersionAtLeast(*firstVersion)) {
+        llvm::errs() << "error: upcoming feature " << QuotedString(featureName)
+                     << " is already enabled as of Swift version "
+                     << *firstVersion << '\n';
+        exit(-1);
+      }
+    }
+    Invocation.getLangOptions().enableFeature(*feature);
   }
+
   for (auto &featureName : options.ExperimentalFeatures) {
     if (auto feature = getExperimentalFeature(featureName)) {
       Invocation.getLangOptions().enableFeature(*feature);
@@ -735,13 +772,26 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
 
   Invocation.getLangOptions().UnavailableDeclOptimizationMode =
       options.UnavailableDeclOptimization;
-  if (options.StrictConcurrencyLevel.hasArgStr()) {
+
+  // Enable strict concurrency if we have the feature specified or if it was
+  // specified via a command line option to sil-opt.
+  if (Invocation.getLangOptions().hasFeature(Feature::StrictConcurrency)) {
     Invocation.getLangOptions().StrictConcurrencyLevel =
-        options.StrictConcurrencyLevel;
-    if (options.StrictConcurrencyLevel == StrictConcurrency::Complete &&
-        !options.DisableRegionBasedIsolationWithStrictConcurrency) {
-      Invocation.getLangOptions().enableFeature(Feature::RegionBasedIsolation);
-    }
+        StrictConcurrency::Complete;
+  } else if (auto level = convertSILOptToRawStrictConcurrencyLevel(
+                 options.StrictConcurrencyLevel)) {
+    // If strict concurrency was enabled from the cmdline so the feature flag as
+    // well.
+    if (*level == StrictConcurrency::Complete)
+      Invocation.getLangOptions().enableFeature(Feature::StrictConcurrency);
+    Invocation.getLangOptions().StrictConcurrencyLevel = *level;
+  }
+
+  // If we have strict concurrency set as a feature and were told to turn off
+  // region based isolation... do so now.
+  if (Invocation.getLangOptions().hasFeature(Feature::StrictConcurrency) &&
+      !options.DisableRegionBasedIsolationWithStrictConcurrency) {
+    Invocation.getLangOptions().enableFeature(Feature::RegionBasedIsolation);
   }
 
   Invocation.getDiagnosticOptions().VerifyMode =

--- a/test/sil-opt/swift-version.sil
+++ b/test/sil-opt/swift-version.sil
@@ -1,0 +1,28 @@
+// RUN: %target-sil-opt -transfer-non-sendable -strict-concurrency=complete -swift-version 5 %s -verify -verify-additional-prefix complete-
+// RUN: %target-sil-opt -transfer-non-sendable -strict-concurrency=complete -swift-version 6 %s -verify -verify-additional-prefix tns-
+
+// READ THIS: This test takes advantage of the semantics of concurrency to
+// validate that sil-opt can properly set the swift-version flag in a way that
+// the rest of the compiler can understand. Please do not add actual concurrency
+// code to this test and always keep it simple if additional code needs to be
+// added since we aren't actually trying to test concurrency here!
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+
+import Swift
+import _Concurrency
+
+class NonSendableKlass {}
+
+sil @transfer_to_main : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+
+sil [ossa] @test : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %1 = function_ref  @transfer_to_main : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %1(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // expected-complete-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context; later accesses to value could race; this is an error in the Swift 6 language mode}}
+  // expected-tns-error @-2 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context; later accesses to value could race}}
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/sil-opt/swift-version.sil
+++ b/test/sil-opt/swift-version.sil
@@ -1,5 +1,5 @@
 // RUN: %target-sil-opt -transfer-non-sendable -strict-concurrency=complete -swift-version 5 %s -verify -verify-additional-prefix complete-
-// RUN: %target-sil-opt -transfer-non-sendable -strict-concurrency=complete -swift-version 6 %s -verify -verify-additional-prefix tns-
+// RUN: %target-sil-opt -transfer-non-sendable -swift-version 6 %s -verify -verify-additional-prefix tns-
 
 // READ THIS: This test takes advantage of the semantics of concurrency to
 // validate that sil-opt can properly set the swift-version flag in a way that

--- a/test/sil-opt/upcoming-feature.sil
+++ b/test/sil-opt/upcoming-feature.sil
@@ -1,0 +1,6 @@
+// RUN: not %target-sil-opt %s -enable-upcoming-feature RegionBasedIsolation -swift-version 6 2>&1 | %FileCheck %s
+
+// READ THIS: This test makes sure that we error if an upcoming feature is
+// enabled in a language mode where it is enabled by default.
+
+// CHECK: error: upcoming feature "RegionBasedIsolation" is already enabled as of Swift version 6


### PR DESCRIPTION
Specifically:

1. The first commit adds support for setting the swift-version when running sil-opt. I also added support for verify-additional-prefixes so that I could test easily that sil-opt was properly setting swift-version without having to have multiple files. That is just goodness.
2. I changed how we handled strict concurrency to ensure that if swift 6 is specified that it is enabled by default. By doing this I also ensures that upcoming features (as already happens with swift-frontend) cause the compiler to abort if they would be enabled by default given the selected swift-version.