### PR TITLE
[cxx-interop] Do not crash when calling a subscript with unnamed parameter

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1692,7 +1692,16 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
                              : rawElementTy;
 
   auto &ctx = ImporterImpl.SwiftContext;
-  auto bodyParams = getterImpl->getParameters();
+
+  assert(getterImpl->getParameters()->size() == 1 &&
+         "subscript can only have 1 parameter");
+  auto bodyParam = ParamDecl::clone(ctx, getterImpl->getParameters()->get(0));
+  // If the subscript parameter is unnamed, give it a name to make sure SILGen
+  // creates a variable for it.
+  if (bodyParam->getName().empty())
+    bodyParam->setName(ctx.getIdentifier("__index"));
+
+  auto bodyParams = ParameterList::create(ctx, bodyParam);
   DeclName name(ctx, DeclBaseName::createSubscript(), bodyParams);
   auto dc = getterImpl->getDeclContext();
 

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -386,6 +386,16 @@ struct DerivedFromReadWriteIntArray : ReadWriteIntArray {};
 
 struct DerivedFromNonTrivialArrayByVal : NonTrivialArrayByVal {};
 
+struct SubscriptUnnamedParameter {
+  int operator[](int) const { return 123; }
+};
+
+struct SubscriptUnnamedParameterReadWrite {
+  int value = 0;
+  const int &operator[](int) const { return value; }
+  int &operator[](int) { return value; }
+};
+
 struct Iterator {
 private:
   int value = 123;

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -211,6 +211,13 @@
 // CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> NonTrivial
 // CHECK: }
 
+// CHECK: struct SubscriptUnnamedParameter {
+// CHECK:   subscript(__index: Int32) -> Int32 { get }
+// CHECK: }
+// CHECK: struct SubscriptUnnamedParameterReadWrite {
+// CHECK:   subscript(__index: Int32) -> Int32
+// CHECK: }
+
 // CHECK: struct Iterator {
 // CHECK:   var pointee: Int32 { mutating get set }
 // CHECK:   @available(*, unavailable, message: "use .pointee property")

--- a/test/Interop/Cxx/operators/member-inline-silgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-silgen.swift
@@ -171,6 +171,15 @@ public func index(_ arr: inout ConstPtrByVal, _ arg: Int32, _ val: Int32) -> Int
 // CHECK:   end_access [[SELFACCESS]] : $*ConstPtrByVal
 // CHECK: } // end sil function '$sSo13ConstPtrByValVySPys5Int32VGSgADcig
 
+public func subscriptUnnamed(_ unnamed: SubscriptUnnamedParameter, _ arg: Int32) -> Int32 { unnamed[arg] }
+// CHECK: sil shared [transparent] @$sSo25SubscriptUnnamedParameterVys5Int32VADcig : $@convention(method) (Int32, SubscriptUnnamedParameter) -> Int32 {
+// CHECK: bb0([[INDEX:%.*]] : $Int32, [[SELF:%.*]] : $SubscriptUnnamedParameter):
+// CHECK:   [[SELFACCESS:%.*]] = alloc_stack $SubscriptUnnamedParameter
+// CHECK:   [[OP:%.*]] = function_ref [[OPERATORNAME:@(_ZNK25SubscriptUnnamedParameterixEi|\?\?ASubscriptUnnamedParameter@@QEBAHH@Z)]] : $@convention(cxx_method) (Int32, @in_guaranteed SubscriptUnnamedParameter) -> Int32
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[INDEX]], [[SELFACCESS]]) : $@convention(cxx_method) (Int32, @in_guaranteed SubscriptUnnamedParameter) -> Int32
+// CHECK:   dealloc_stack [[SELFACCESS]]
+// CHECK: } // end sil function '$sSo25SubscriptUnnamedParameterVys5Int32VADcig'
+
 // CHECK: sil [clang ReadOnlyIntArray.__operatorSubscriptConst] [[READCLASSNAME]] : $@convention(cxx_method) (Int32, @in_guaranteed ReadOnlyIntArray) -> UnsafePointer<Int32>
 // CHECK: sil [clang ReadWriteIntArray.__operatorSubscript] [[READWRITECLASSNAME]] : $@convention(cxx_method) (Int32, @inout ReadWriteIntArray) -> UnsafeMutablePointer<Int32>
 // CHECK: sil [clang NonTrivialIntArrayByVal.__operatorSubscriptConst] [[READWRITECLASSNAMEBYVAL]] : $@convention(cxx_method) (Int32, @in_guaranteed NonTrivialIntArrayByVal) -> Int32

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -394,6 +394,22 @@ OperatorsTestSuite.test("SubscriptSetterConst") {
   setterConst[0] = 10
 }
 
+OperatorsTestSuite.test("SubscriptUnnamedParameter") {
+  let unnamed = SubscriptUnnamedParameter()
+  expectEqual(123, unnamed[0])
+  expectEqual(123, unnamed[321])
+}
+
+OperatorsTestSuite.test("SubscriptUnnamedParameterReadWrite") {
+  var unnamed = SubscriptUnnamedParameterReadWrite()
+  expectEqual(0, unnamed[0])
+  expectEqual(0, unnamed[321])
+
+  unnamed[456] = 456
+  expectEqual(456, unnamed[0])
+  expectEqual(456, unnamed[321])
+}
+
 OperatorsTestSuite.test("DerivedFromConstIteratorPrivatelyWithUsingDecl.pointee") {
   let stars = DerivedFromConstIteratorPrivatelyWithUsingDecl()
   let res = stars.pointee


### PR DESCRIPTION
This fixes a crash in SILGen when calling a C++ subscript that has an unnamed parameter from Swift.

The parameters from a C++ `operator[]` get carried over to the synthesized Swift subscript. If the Swift parameter has no name, there is no way to refer to it in SIL. However, the synthesized subscript accessor needs to pass this parameter to C++.

This change makes sure that we give a name to the Swift parameter if there isn't already a name on the C++ side.

rdar://83163841