### PR TITLE
[🍒 5.10] CMake: ensure Swift host tools depend on HostCompatibilityLibs target

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -460,6 +460,17 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
 
     set(sdk_dir "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}/usr/lib/swift")
 
+    # HostCompatibilityLibs is defined as an interface library that
+    # does not generate any concrete build target
+    # (https://cmake.org/cmake/help/latest/command/add_library.html#interface-libraries)
+    # In order to specify a dependency to it using `add_dependencies`
+    # we need to manually "expand" its underlying targets
+    get_property(compatibility_libs
+      TARGET HostCompatibilityLibs
+      PROPERTY INTERFACE_LINK_LIBRARIES)
+    set(compatibility_libs_path
+      "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH}")
+
     # If we found a swift compiler and are going to use swift code in swift
     # host side tools but link with clang, add the appropriate -L paths so we
     # find all of the necessary swift libraries on Darwin.
@@ -498,8 +509,11 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       target_link_directories(${target} PRIVATE "${sdk_dir}")
 
       # A backup in case the toolchain doesn't have one of the compatibility libraries.
-      target_link_directories(${target} PRIVATE
-        "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+      # We are using on purpose `add_dependencies` instead of `target_link_libraries`,
+      # since we want to ensure the linker is pulling the matching archives
+      # only if needed
+      target_link_directories(${target} PRIVATE "${compatibility_libs_path}")
+      add_dependencies(${target} ${compatibility_libs})
 
       # Include the abi stable system stdlib in our rpath.
       set(swift_runtime_rpath "/usr/lib/swift")
@@ -511,8 +525,11 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       target_link_directories(${target} PRIVATE ${bs_lib_dir})
 
       # Required to pick up the built libswiftCompatibility<n>.a libraries
-      target_link_directories(${target} PRIVATE
-        "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+      # We are using on purpose `add_dependencies` instead of `target_link_libraries`,
+      # since we want to ensure the linker is pulling the matching archives
+      # only if needed
+      target_link_directories(${target} PRIVATE "${compatibility_libs_path}")
+      add_dependencies(${target} ${compatibility_libs})
 
       # At runtime link against the built swift libraries from the current
       # bootstrapping stage.


### PR DESCRIPTION
**Explanation**: explicitly add a dependency between Swift host tools and the compatibility libraries we just built -- we never noticed this was missing in the first place because in most configurations the latter are able to build before the former need them
**Radar**: rdar://126552386
**Scope**: CMake logic that builds the Swift part of the compiler and tools
**Risk**: low
* there are no functional changes in how the compiler is built
* in the worst case, we hit the same failure again because the added dependencies are not enough
**Testing**:

* CI testing -- in particular run compatibility suite and built toolchain

**Reviewed By**: @compnerd in https://github.com/apple/swift/pull/73065
