### PR TITLE
[KeyPath] Fix regression in == on keypaths

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -237,12 +237,10 @@ extension AnyKeyPath: Hashable {
     if a === b {
       return true
     }
-    /*
     // Short-circuit differently-typed key paths
     if type(of: a) != type(of: b) {
       return false
     }
-    */
     return a.withBuffer {
       var aBuffer = $0
       return b.withBuffer {

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -327,6 +327,14 @@ keyPath.test("computed properties") {
   }
 }
 
+keyPath.test("equality") {
+  expectNotEqual(\Array<String>.isEmpty, \Substring.isEmpty)
+  expectNotEqual(\Array<String>.isEmpty, \Substring.isEmpty)
+  expectNotEqual(\Array<String>.isEmpty, \String.isEmpty)
+  expectNotEqual(\Array<String>.isEmpty, \Substring.last)
+  expectNotEqual(\Array<String>.isEmpty, \Array<Substring>.isEmpty)
+}
+
 class AB {
 }
 class ABC: AB, ABCProtocol {


### PR DESCRIPTION
The change in https://github.com/apple/swift/pull/72472 accidentally commented out an important check inside the implementation of `==` in AnyKeyPath. This breaks equality of keypaths and they now misreport being equal in some cases when they're not supposed to. The added testcase reproduces the problem.

rdar://127296261
