### PR TITLE
[6.0 cherry-pick][KeyPath] Fix regression in == on keypaths

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -237,12 +237,10 @@ extension AnyKeyPath: Hashable {
     if a === b {
       return true
     }
-    /*
     // Short-circuit differently-typed key paths
     if type(of: a) != type(of: b) {
       return false
     }
-    */
     return a.withBuffer {
       var aBuffer = $0
       return b.withBuffer {

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -327,6 +327,14 @@ keyPath.test("computed properties") {
   }
 }
 
+keyPath.test("equality") {
+  expectNotEqual(\Array<String>.isEmpty, \Substring.isEmpty)
+  expectNotEqual(\Array<String>.isEmpty, \Substring.isEmpty)
+  expectNotEqual(\Array<String>.isEmpty, \String.isEmpty)
+  expectNotEqual(\Array<String>.isEmpty, \Substring.last)
+  expectNotEqual(\Array<String>.isEmpty, \Array<Substring>.isEmpty)
+}
+
 class AB {
 }
 class ABC: AB, ABCProtocol {


### PR DESCRIPTION
* **Explanation**: A recent change in KeyPath implementation (https://github.com/apple/swift/pull/72472) that was done for Embedded Swift and was supposed to be an NFC for regular Swift accidentally commented out an important check inside the implementation of `==` in AnyKeyPath. This caused a regressions in the equality of keypaths and they were misreporting being equal in some cases when they're not supposed to. https://github.com/apple/swift/pull/73347
* **Scope**: Code that uses KeyPaths and specifically comparing them for equality.
* **Risk**: Low -- a removal of the accidental changes that reverts back to the implementation of `==` that has been in use for years.
* **Testing**: Added test case.
* **Issue**: rdar://127296261
* **Reviewer**: @Catfish-Man, @jckarter, @Azoy on https://github.com/apple/swift/pull/73347
