### PR TITLE
Revert "[6.0][CSBindings] Delay inference through OptionalObject if "object" is l-value capable"

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1692,26 +1692,6 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
 /// those types should be opened.
 void PotentialBindings::infer(Constraint *constraint) {
   switch (constraint->getKind()) {
-  case ConstraintKind::OptionalObject: {
-    // Inference through optional object is allowed if
-    // one of the types is resolved or "optional" type variable
-    // cannot be bound to l-value, otherwise there is a
-    // risk of binding "optional" to an optional type (inferred from
-    // the "object") and discovering an l-value binding for it later.
-    auto optionalType = constraint->getFirstType();
-
-    if (auto *optionalVar = optionalType->getAs<TypeVariableType>()) {
-      if (optionalVar->getImpl().canBindToLValue()) {
-        auto objectType =
-            constraint->getSecondType()->lookThroughAllOptionalTypes();
-        if (objectType->isTypeVariableOrMember())
-          return;
-      }
-    }
-
-    LLVM_FALLTHROUGH;
-  }
-
   case ConstraintKind::Bind:
   case ConstraintKind::Equal:
   case ConstraintKind::BindParam:
@@ -1721,6 +1701,7 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::Conversion:
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::OperatorArgumentConversion:
+  case ConstraintKind::OptionalObject:
   case ConstraintKind::UnresolvedMemberChainBase: {
     auto binding = inferFromRelational(constraint);
     if (!binding)

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1123,11 +1123,9 @@ func rdar17170728() {
   var j: Int?
   var k: Int? = 2
 
-  let _ = [i, j, k].reduce(0 as Int?) {  // expected-error {{missing argument label 'into:' in call}}
-    // expected-error@-1 {{cannot convert value of type 'Int?' to expected argument type '(inout @escaping (Bool, Bool) -> Bool?, Int?) throws -> ()'}}
+  let _ = [i, j, k].reduce(0 as Int?) {
     $0 && $1 ? $0! + $1! : ($0 ? $0! : ($1 ? $1! : nil))
-    // expected-error@-1 {{binary operator '+' cannot be applied to two 'Bool' operands}}
-    // expected-error@-2 4 {{cannot force unwrap value of non-optional type 'Bool'}}
+    // expected-error@-1 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
   }
 
   let _ = [i, j, k].reduce(0 as Int?) { // expected-error {{missing argument label 'into:' in call}}
@@ -1558,17 +1556,18 @@ func testNilCoalescingOperatorRemoveFix() {
   let _ = "" /* This is a comment */ ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{13-43=}}
 
   let _ = "" // This is a comment
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1560:13-1561:10=}}
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1558:13-1559:10=}}
 
   let _ = "" // This is a comment
     /*
      * The blank line below is part of the test case, do not delete it
      */
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1563:13-1567:10=}}
 
-  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-1570:9=}}
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1561:13-1566:10=}}
+
+  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-1569:9=}}
       "").isEmpty {}
 
   if ("" // This is a comment
-      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1572:9-1573:12=}}
+      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1571:9-1572:12=}}
 }

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -598,19 +598,3 @@ do {
   test(x!) // expected-error {{no exact matches in call to local function 'test'}}
   // expected-error@-1 {{cannot force unwrap value of non-optional type 'Double'}}
 }
-
-// Diagnose cases of invalid chaining when parameter is not optional based on context.
-do {
-  class Test {
-    var value: Int = 42
-  }
-
-  class Container {
-    let test: Test = Test()
-
-    func loop() {
-      [test].forEach { $0?.value = 42 }
-      // expected-error@-1 {{cannot use optional chaining on non-optional value of type 'Test'}}
-    }
-  }
-}


### PR DESCRIPTION
Reverts apple/swift#73105