### PR TITLE
6.0🍒[Observation] Optimize cancellation path to avoid excessive copies 

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -163,12 +163,10 @@ public struct ObservationRegistrar: Sendable {
     internal mutating func cancel(_ id: Int) {
       if let observation = observations.removeValue(forKey: id) {
         for keyPath in observation.properties {
-          if var ids = lookups[keyPath] {
-            ids.remove(id)
-            if ids.count == 0 {
-              lookups.removeValue(forKey: keyPath)
-            } else {
-              lookups[keyPath] = ids
+          if let index = lookups.index(forKey: keyPath) {
+            lookups.values[index].remove(id)
+            if lookups.values[index].isEmpty {
+              lookups.remove(at: index)
             }
           }
         }


### PR DESCRIPTION
Explanation: The existing code could potentially mis-optimize and create copies of the set for the cancellation tokens. This mutates it in-place to avoid those copies.

Radar: rdar://127018986

Scope: Only applies to the cancellation path inside of the Observation library

Risk: low - there are no functional changes in how the compiler is built

Testing: unit tests cover this particular case

Reviewed By: @glessard  in https://github.com/apple/swift/pull/73288