### PR TITLE
Fix up for CountAttributedType and TypeCoupledDeclRefInfo handlers

### DIFF
--- a/include/swift/ClangImporter/SwiftAbstractBasicReader.h
+++ b/include/swift/ClangImporter/SwiftAbstractBasicReader.h
@@ -99,11 +99,6 @@ public:
   T *readDeclAs() {
     return asImpl().template readDeclAs<T>();
   }
-
-  clang::TypeCoupledDeclRefInfo readTypeCoupledDeclRefInfo() {
-    return clang::TypeCoupledDeclRefInfo(
-        asImpl().template readDeclAs<clang::ValueDecl>(), asImpl().readBool());
-  }
 };
 
 }

--- a/include/swift/ClangImporter/SwiftAbstractBasicWriter.h
+++ b/include/swift/ClangImporter/SwiftAbstractBasicWriter.h
@@ -99,11 +99,6 @@ public:
     // hit any of its attributes.
     llvm::report_fatal_error("Should never hit BTFTypeTagAttr serialization");
   }
-
-  void writeTypeCoupledDeclRefInfo(clang::TypeCoupledDeclRefInfo info) {
-    asImpl().writeDeclRef(info.getDecl());
-    asImpl().writeBool(info.isDeref());
-  }
 };
 
 }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -443,6 +443,17 @@ namespace {
       return Type();
     }
 
+    ImportResult VisitCountAttributedType(
+        const clang::CountAttributedType *type) {
+      // CountAttributedType is a clang type representing a pointer with
+      // a "counted_by" type attribute. For now, we don't import these
+      // into Swift.
+      // In the future we could do something more clever (such as trying to
+      // import as an Array where possible) or less clever (such as importing
+      // as the desugared, underlying pointer type).
+      return Type();
+    }
+
     ImportResult VisitMemberPointerType(const clang::MemberPointerType *type) {
       return Type();
     }
@@ -1286,10 +1297,6 @@ namespace {
     }
 
     ImportResult VisitPackIndexingType(const clang::PackIndexingType *type) {
-      return Type();
-    }
-
-    ImportResult VisitCountAttributedType(const clang::CountAttributedType *type) {
       return Type();
     }
   };

--- a/lib/ClangImporter/Serializability.cpp
+++ b/lib/ClangImporter/Serializability.cpp
@@ -317,6 +317,18 @@ namespace {
     }
 
     void writeAttr(const clang::Attr *attr) {}
+
+    // CountAttributedType is a clang type representing a pointer with
+    // a "counted_by" type attribute and DynamicRangePointerType
+    // is representing a "__ended_by" type attribute.
+    // TypeCoupledDeclRefInfo is used to hold information of a declaration
+    // referenced from an expression argument of "__counted_by(expr)" or
+    // "__ended_by(expr)".
+    // Leave it non-serializable for now as we currently don't import
+    // these types into Swift.
+    void writeTypeCoupledDeclRefInfo(clang::TypeCoupledDeclRefInfo info) {
+      llvm_unreachable("TypeCoupledDeclRefInfo shouldn't be reached from swift");
+    }
   };
 }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -7990,6 +7990,18 @@ public:
 
     return attr;
   }
+
+  // CountAttributedType is a clang type representing a pointer with
+  // a "counted_by" type attribute and DynamicRangePointerType is
+  // representing a "__ended_by" type attribute.
+  // TypeCoupledDeclRefInfo is used to hold information of a declaration
+  // referenced from an expression argument of "__counted_by(expr)" or
+  // "__ended_by(expr)".
+  // Nothing to be done for now as we currently don't import
+  // these types into Swift.
+  clang::TypeCoupledDeclRefInfo readTypeCoupledDeclRefInfo() {
+    llvm_unreachable("TypeCoupledDeclRefInfo shouldn't be reached from swift");
+  }
 };
 
 } // end anonymous namespace

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5965,6 +5965,18 @@ public:
     writeBool(swiftAttr->isPackExpansion());
     writeUInt64(S.addUniquedStringRef(swiftAttr->getAttribute()));
   }
+
+  // CountAttributedType is a clang type representing a pointer with
+  // a "counted_by" type attribute and DynamicRangePointerType is
+  // representing a "__ended_by" type attribute.
+  // TypeCoupledDeclRefInfo is used to hold information of a declaration
+  // referenced from an expression argument of "__counted_by(expr)" or
+  // "__ended_by(expr)".
+  // Nothing to be done for now as we currently don't import
+  // these types into Swift.
+  void writeTypeCoupledDeclRefInfo(clang::TypeCoupledDeclRefInfo info) {
+    llvm_unreachable("TypeCoupledDeclRefInfo shouldn't be reached from swift");
+  }
 };
 
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

CountAttributedType and TypeCoupledDeclRefInfo are new Clang type and type metadata created for types with the 'counted_by' attribute, which shouldn't be accessible from Swift right now. Hence, making them unreachable.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
