### PR TITLE
[MoveOnlyAddressChecker] Don't complete reborrows or their adjacent phis.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -3998,6 +3998,10 @@ bool MoveOnlyAddressChecker::completeLifetimes() {
   for (auto *block : postOrder->getPostOrder()) {
     for (SILInstruction &inst : reverse(*block)) {
       for (auto result : inst.getResults()) {
+        if (llvm::any_of(result->getUsers(),
+                         [](auto *user) { return isa<BranchInst>(user); })) {
+          continue;
+        }
         if (completion.completeOSSALifetime(result) ==
             LifetimeCompletion::WasCompleted) {
           changed = true;
@@ -4005,7 +4009,9 @@ bool MoveOnlyAddressChecker::completeLifetimes() {
       }
     }
     for (SILArgument *arg : block->getArguments()) {
-      assert(!arg->isReborrow() && "reborrows not legal at this SIL stage");
+      if (arg->isReborrow()) {
+        continue;
+      }
       if (completion.completeOSSALifetime(arg) ==
           LifetimeCompletion::WasCompleted) {
         changed = true;

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -871,3 +871,36 @@ exit:
   %retval = tuple ()
   return %retval : $()
 }
+
+// Test that we don't crash while attempting to complete reborrow lifetimes.
+sil [ossa] @closure_lifetime_fixup_output : $@convention(thin) (@owned NonTrivialStructPair) -> () {
+bb0(%pair : @owned $NonTrivialStructPair):
+  %none = enum $Optional<@callee_guaranteed () -> ()>, #Optional.none!enumelt
+  %none_borrow = begin_borrow %none : $Optional<@callee_guaranteed () -> ()>
+  %stack = alloc_stack $NonTrivialStructPair, let, name "job", argno 1
+  %addr = mark_unresolved_non_copyable_value [consumable_and_assignable] %stack : $*NonTrivialStructPair
+  store %pair to [init] %addr : $*NonTrivialStructPair
+  cond_br undef, bb1, bb3
+
+bb1:
+  end_borrow %none_borrow : $Optional<@callee_guaranteed () -> ()>
+  %closure = partial_apply [callee_guaranteed] undef() : $@convention(thin) () -> ()
+  %some = enum $Optional<@callee_guaranteed () -> ()>, #Optional.some!enumelt, %closure : $@callee_guaranteed () -> ()
+  %some_borrow = begin_borrow %some : $Optional<@callee_guaranteed () -> ()>
+  br bb2
+
+bb2:
+  br bb4(%some_borrow : $Optional<@callee_guaranteed () -> ()>, %some : $Optional<@callee_guaranteed () -> ()>)
+
+bb3:
+  br bb4(%none_borrow : $Optional<@callee_guaranteed () -> ()>, %none : $Optional<@callee_guaranteed () -> ()>)
+
+bb4(%reborrow : @reborrow @guaranteed $Optional<@callee_guaranteed () -> ()>, %maybe : @owned $Optional<@callee_guaranteed () -> ()>):
+  %borrow = borrowed %reborrow : $Optional<@callee_guaranteed () -> ()> from (%maybe : $Optional<@callee_guaranteed () -> ()>)
+  destroy_addr %addr : $*NonTrivialStructPair
+  dealloc_stack %stack : $*NonTrivialStructPair
+  end_borrow %borrow : $Optional<@callee_guaranteed () -> ()>
+  destroy_value %maybe : $Optional<@callee_guaranteed () -> ()>
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
After 874971c40d2b20c9c52b2b906516c96798023dd9, before running address checking, all lifetimes in the function are completed.  That doesn't quite work because lifetime completion expects not to encounter reborrows or their adjacent phis.

rdar://127312637
