### PR TITLE
6.0: [MoveOnlyAddressChecker] Don't complete reborrows or their adjacent phis.

### DIFF
--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -871,3 +871,35 @@ exit:
   %retval = tuple ()
   return %retval : $()
 }
+
+// Test that we don't crash while attempting to complete reborrow lifetimes.
+sil [ossa] @closure_lifetime_fixup_output : $@convention(thin) (@owned NonTrivialStructPair) -> () {
+bb0(%pair : @owned $NonTrivialStructPair):
+  %none = enum $Optional<@callee_guaranteed () -> ()>, #Optional.none!enumelt
+  %none_borrow = begin_borrow %none : $Optional<@callee_guaranteed () -> ()>
+  %stack = alloc_stack $NonTrivialStructPair, let, name "job", argno 1
+  %addr = mark_unresolved_non_copyable_value [consumable_and_assignable] %stack : $*NonTrivialStructPair
+  store %pair to [init] %addr : $*NonTrivialStructPair
+  cond_br undef, bb1, bb3
+
+bb1:
+  end_borrow %none_borrow : $Optional<@callee_guaranteed () -> ()>
+  %closure = partial_apply [callee_guaranteed] undef() : $@convention(thin) () -> ()
+  %some = enum $Optional<@callee_guaranteed () -> ()>, #Optional.some!enumelt, %closure : $@callee_guaranteed () -> ()
+  %some_borrow = begin_borrow %some : $Optional<@callee_guaranteed () -> ()>
+  br bb2
+
+bb2:
+  br bb4(%some_borrow : $Optional<@callee_guaranteed () -> ()>, %some : $Optional<@callee_guaranteed () -> ()>)
+
+bb3:
+  br bb4(%none_borrow : $Optional<@callee_guaranteed () -> ()>, %none : $Optional<@callee_guaranteed () -> ()>)
+
+bb4(%reborrow : @reborrow @guaranteed $Optional<@callee_guaranteed () -> ()>, %maybe : @owned $Optional<@callee_guaranteed () -> ()>):
+  destroy_addr %addr : $*NonTrivialStructPair
+  dealloc_stack %stack : $*NonTrivialStructPair
+  end_borrow %reborrow : $Optional<@callee_guaranteed () -> ()>
+  destroy_value %maybe : $Optional<@callee_guaranteed () -> ()>
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
**Explanation**: Fix a compiler crash caused by completing certain lifetimes during move checking.

Move-only checking relies on the completeness of lifetimes of interest.  Way back in https://github.com/apple/swift/pull/68381 , a change was made to run lifetime completion in functions continaing move-only _values_; only values obviously derived from the value being checked had their lifetimes completed.  Much more recently, in 874971c40d2b20c9c52b2b906516c96798023dd9, an analogous change was made to complete lifetimes in functions containing move-only _addresses_; in the recent patch, though, rather than trying to find all the values that could be derived from the address being checked, all lifetimes in the function were completed.  This doesn't quite work, though, because lifetime completion doesn't know how to deal with reborrows--it's intended to be run in a SIL prior to reborrows existing.

Here, the lifetimes that are completed in functions with move-only addresses are trimmed back to exclude values whose lifetimes depend on reborrows.

**Scope**: Affects noncopyable code.
**Issue**: rdar://127312637
**Original PR**: https://github.com/apple/swift/pull/73358
**Risk**: Low.  Decreases the cases in which a SIL transformation is run.
**Testing**: Added regression test.
**Reviewer**: Andrew Trick ( @atrick )

