### PR TITLE
Extract common code for building opened existential and element signatures

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -197,6 +197,11 @@ public:
   /// array of the generic parameters for the innermost generic type.
   ArrayRef<GenericTypeParamType *> getInnermostGenericParams() const;
 
+  /// Returns the depth that a generic parameter at the next level of
+  /// nesting would have. This is zero for the empty signature,
+  /// and one plus the depth of the final generic parameter otherwise.
+  unsigned getNextDepth() const;
+
   /// Retrieve the requirements.
   ArrayRef<Requirement> getRequirements() const;
 
@@ -306,6 +311,9 @@ public:
     assert(Mem);
     return Mem;
   }
+
+  /// Returns the depth of the last generic parameter.
+  unsigned getMaxDepth() const;
 
   /// Transform the requirements into a form where implicit Copyable and
   /// Escapable conformances are omitted, and their absence is explicitly

--- a/include/swift/AST/LocalArchetypeRequirementCollector.h
+++ b/include/swift/AST/LocalArchetypeRequirementCollector.h
@@ -1,0 +1,68 @@
+//===--- LocalArchetypeRequirementCollector.h -------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file has utility code for extending a generic signature with opened
+// existentials and shape classes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_LOCAL_ARCHETYPE_REQUIREMENT_COLLECTOR_H
+#define SWIFT_AST_LOCAL_ARCHETYPE_REQUIREMENT_COLLECTOR_H
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/AST/Requirement.h"
+#include "swift/AST/Types.h"
+
+namespace swift {
+
+struct LocalArchetypeRequirementCollector {
+  const ASTContext &Context;
+  GenericSignature OuterSig;
+  unsigned Depth;
+
+  /// The lists of new parameters and requirements to add to the signature.
+  SmallVector<GenericTypeParamType *, 2> Params;
+  SmallVector<Requirement, 2> Requirements;
+
+  LocalArchetypeRequirementCollector(const ASTContext &ctx, GenericSignature sig);
+
+  void addOpenedExistential(Type constraint);
+  void addOpenedElement(CanGenericTypeParamType shapeClass);
+
+  GenericTypeParamType *addParameter();
+};
+
+struct MapLocalArchetypesOutOfContext {
+  GenericSignature baseGenericSig;
+  ArrayRef<GenericEnvironment *> capturedEnvs;
+
+  MapLocalArchetypesOutOfContext(GenericSignature baseGenericSig,
+                                 ArrayRef<GenericEnvironment *> capturedEnvs)
+      : baseGenericSig(baseGenericSig), capturedEnvs(capturedEnvs) {}
+
+  Type operator()(SubstitutableType *type) const;
+};
+
+GenericSignature buildGenericSignatureWithCapturedEnvironments(
+    ASTContext &ctx,
+    GenericSignature sig,
+    ArrayRef<GenericEnvironment *> capturedEnvs);
+
+SubstitutionMap buildSubstitutionMapWithCapturedEnvironments(
+    SubstitutionMap baseSubMap,
+    GenericSignature genericSigWithCaptures,
+    ArrayRef<GenericEnvironment *> capturedEnvs);
+
+}
+
+#endif // SWIFT_AST_LOCAL_ARCHETYPE_REQUIREMENT_COLLECTOR_H

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5884,11 +5884,8 @@ CanGenericSignature ASTContext::getSingleGenericParameterSignature() const {
 
 Type OpenedArchetypeType::getSelfInterfaceTypeFromContext(GenericSignature parentSig,
                                                           ASTContext &ctx) {
-  unsigned depth = 0;
-  if (!parentSig.getGenericParams().empty())
-    depth = parentSig.getGenericParams().back()->getDepth() + 1;
   return GenericTypeParamType::get(/*isParameterPack=*/ false,
-                                   /*depth=*/ depth, /*index=*/ 0,
+                                   parentSig.getNextDepth(), /*index=*/ 0,
                                    ctx);
 }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2748,7 +2748,7 @@ void ASTMangler::appendContextualInverses(const GenericTypeDecl *contextDecl,
   parts.params = std::nullopt;
 
   // The depth of parameters for this extension is +1 of the extended signature.
-  parts.initialParamDepth = sig.getGenericParams().back()->getDepth() + 1;
+  parts.initialParamDepth = sig.getNextDepth();
 
   appendModule(module, alternateModuleName);
   appendGenericSignatureParts(sig, parts);
@@ -3391,7 +3391,7 @@ void ASTMangler::gatherGenericSignatureParts(GenericSignature sig,
   } else {
     inverseReqs.clear();
   }
-  base.setDepth(canSig.getGenericParams().back()->getDepth());
+  base.setDepth(canSig->getMaxDepth());
 
   unsigned &initialParamDepth = parts.initialParamDepth;
   auto &genericParams = parts.params;
@@ -3412,7 +3412,7 @@ void ASTMangler::gatherGenericSignatureParts(GenericSignature sig,
 
   // The signature depth starts above the depth of the context signature.
   if (!contextSig.getGenericParams().empty()) {
-    initialParamDepth = contextSig.getGenericParams().back()->getDepth() + 1;
+    initialParamDepth = contextSig.getNextDepth();
   }
 
   // If both signatures have exactly the same requirements, ignoring
@@ -4760,11 +4760,10 @@ static std::optional<unsigned> getEnclosingTypeGenericDepth(const Decl *decl) {
   if (!typeDecl)
     return std::nullopt;
 
-  auto genericParams = typeDecl->getGenericParams();
-  if (!genericParams)
+  if (!typeDecl->isGeneric())
     return std::nullopt;
 
-  return genericParams->getParams().back()->getDepth();
+  return typeDecl->getGenericSignature()->getMaxDepth();
 }
 
 ASTMangler::BaseEntitySignature::BaseEntitySignature(const Decl *decl)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1807,10 +1807,7 @@ void PrintAST::printSingleDepthOfGenericSignature(
       auto *DC = Current->getInnermostDeclContext()->getInnermostTypeContext();
       M = DC->getParentModule();
       subMap = CurrentType->getContextSubstitutionMap(M, DC);
-      if (!subMap.empty()) {
-        typeContextDepth = subMap.getGenericSignature()
-            .getGenericParams().back()->getDepth() + 1;
-      }
+      typeContextDepth = subMap.getGenericSignature().getNextDepth();
     }
   }
 
@@ -7075,7 +7072,7 @@ public:
 
     // The element archetypes are at a depth one past the max depth
     // of the base signature.
-    unsigned elementDepth = params.back()->getDepth() + 1;
+    unsigned elementDepth = sig.getNextDepth();
 
     // Transform the archetype's interface type to be based on the
     // corresponding non-canonical type parameter.

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -62,6 +62,7 @@ add_swift_host_library(swiftAST STATIC
   InlinableText.cpp
   LayoutConstraint.cpp
   LifetimeDependence.cpp
+  LocalArchetypeRequirementCollector.cpp
   Module.cpp
   ModuleDependencies.cpp
   ModuleLoader.cpp

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -79,7 +79,7 @@ ArrayRef<GenericTypeParamType *>
 GenericSignatureImpl::getInnermostGenericParams() const {
   const auto params = getGenericParams();
 
-  const unsigned maxDepth = params.back()->getDepth();
+  const unsigned maxDepth = getMaxDepth();
   if (params.front()->getDepth() == maxDepth)
     return params;
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -95,6 +95,16 @@ GenericSignatureImpl::getInnermostGenericParams() const {
   return params.slice(sliceCount);
 }
 
+unsigned GenericSignatureImpl::getMaxDepth() const {
+  return getGenericParams().back()->getDepth();
+}
+
+unsigned GenericSignature::getNextDepth() const {
+  if (!getPointer())
+    return 0;
+  return getPointer()->getMaxDepth() + 1;
+}
+
 void GenericSignatureImpl::forEachParam(
     llvm::function_ref<void(GenericTypeParamType *, bool)> callback) const {
   // Figure out which generic parameters are concrete or same-typed to another

--- a/lib/AST/LocalArchetypeRequirementCollector.cpp
+++ b/lib/AST/LocalArchetypeRequirementCollector.cpp
@@ -1,0 +1,235 @@
+//===--- LocalArchetypeRequirementCollector.cpp ---------------------------===//1
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the LocalArchetypeRequirementCollector class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/LocalArchetypeRequirementCollector.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/AST/Requirement.h"
+#include "swift/AST/Types.h"
+
+using namespace swift;
+
+LocalArchetypeRequirementCollector::LocalArchetypeRequirementCollector(
+	const ASTContext &ctx, GenericSignature sig)
+    : Context(ctx), OuterSig(sig), Depth(sig.getNextDepth()) {}
+
+void LocalArchetypeRequirementCollector::addOpenedExistential(Type constraint) {
+  assert(constraint->isConstraintType() ||
+         constraint->getClassOrBoundGenericClass());
+  assert(OuterSig || !constraint->hasTypeParameter() &&
+         "Interface type here requires a parent signature");
+
+  auto param = addParameter();
+
+  Requirements.emplace_back(RequirementKind::Conformance, param, constraint);
+
+  ++Depth;
+}
+
+void LocalArchetypeRequirementCollector::addOpenedElement(
+        CanGenericTypeParamType shapeClass) {
+
+  size_t startingIndex = Params.size();
+
+  /// Add a parameter for each of the opened elements in this shape class.
+  SmallVector<GenericTypeParamType *, 2> packParams;
+  for (auto paramType : OuterSig.getGenericParams()) {
+    if (paramType->isParameterPack() &&
+        OuterSig->haveSameShape(paramType, shapeClass)) {
+      packParams.push_back(paramType);
+      addParameter();
+    }
+  }
+
+  assert(!packParams.empty());
+
+  // Clone the element requirements.
+
+  // Helper function: replace references to type parameter packs
+  // with one of the opened element type parameters we just created for this
+  // shape class.
+  auto rewriteElementType = [=](Type type) {
+    return type.transformTypeParameterPacks(
+      [&](SubstitutableType *t) -> std::optional<Type> {
+        auto *paramType = cast<GenericTypeParamType>(t);
+        for (unsigned packElementIndex : indices(packParams)) {
+          if (paramType == packParams[packElementIndex])
+            return Params[startingIndex + packElementIndex];
+        }
+
+        return std::nullopt;
+      });
+  };
+
+  // Clone the pack requirements that apply to this shape class.
+  for (auto req : OuterSig.getRequirements()) {
+    switch (req.getKind()) {
+    case RequirementKind::SameShape:
+      // These never involve element types.
+      break;
+    case RequirementKind::Conformance:
+    case RequirementKind::Superclass:
+    case RequirementKind::SameType: {
+      auto substFirstType = rewriteElementType(req.getFirstType());
+      auto substSecondType = rewriteElementType(req.getSecondType());
+      if (!substFirstType->isEqual(req.getFirstType()) ||
+          !substSecondType->isEqual(req.getSecondType())) {
+        Requirements.emplace_back(req.getKind(), substFirstType, substSecondType);
+      }
+      break;
+    }
+    case RequirementKind::Layout: {
+      auto substFirstType = rewriteElementType(req.getFirstType());
+      if (!substFirstType->isEqual(req.getFirstType())) {
+        Requirements.emplace_back(req.getKind(), substFirstType,
+                                  req.getLayoutConstraint());
+      }
+      break;
+    }
+    }
+  }
+
+  ++Depth;
+}
+
+GenericTypeParamType *LocalArchetypeRequirementCollector::addParameter() {
+  unsigned index = 0;
+  if (!Params.empty() &&
+      Params.back()->getDepth() == Depth) {
+    index = Params.back()->getIndex() + 1;
+  }
+
+  auto *param = GenericTypeParamType::get(/*pack*/ false, Depth,
+                                          index, Context);
+  Params.push_back(param);
+  return param;
+}
+
+GenericSignature swift::buildGenericSignatureWithCapturedEnvironments(
+    ASTContext &ctx,
+    GenericSignature sig,
+    ArrayRef<GenericEnvironment *> capturedEnvs) {
+  // Add new generic parameters to replace the local archetypes.
+  LocalArchetypeRequirementCollector collector(ctx, sig);
+
+  for (auto *genericEnv : capturedEnvs) {
+    switch (genericEnv->getKind()) {
+    case GenericEnvironment::Kind::Primary:
+    case GenericEnvironment::Kind::Opaque:
+      break;
+
+    case GenericEnvironment::Kind::OpenedExistential: {
+      auto constraint = genericEnv->getOpenedExistentialType();
+      if (auto existential = constraint->getAs<ExistentialType>())
+        constraint = existential->getConstraintType();
+      collector.addOpenedExistential(constraint);
+      continue;
+    }
+    case GenericEnvironment::Kind::OpenedElement: {
+      collector.addOpenedElement(
+          genericEnv->getOpenedElementShapeClass());
+      continue;
+    }
+    }
+
+    llvm_unreachable("Cannot happen");
+  }
+
+  return buildGenericSignature(ctx,
+                               collector.OuterSig,
+                               collector.Params,
+                               collector.Requirements,
+                               /*allowInverses=*/false);
+}
+
+Type MapLocalArchetypesOutOfContext::operator()(SubstitutableType *type) const {
+  auto *archetypeTy = cast<ArchetypeType>(type);
+
+  // Primary archetypes just map out of context.
+  if (isa<PrimaryArchetypeType>(archetypeTy) ||
+      isa<PackArchetypeType>(archetypeTy)) {
+    return archetypeTy->getInterfaceType();
+  }
+
+  assert(isa<LocalArchetypeType>(archetypeTy));
+
+  // Handle dependent member types recursively in the usual way.
+  if (!archetypeTy->isRoot())
+    return Type();
+
+  // Root local archetypes change depth.
+  auto *genericEnv = archetypeTy->getGenericEnvironment();
+  auto rootParam = archetypeTy->getInterfaceType()
+      ->castTo<GenericTypeParamType>();
+  assert(!rootParam->isParameterPack());
+  assert(rootParam->getDepth() == genericEnv->getGenericSignature()->getMaxDepth());
+
+  // The new depth is determined by counting how many captured environments
+  // precede this one.
+  unsigned depth = baseGenericSig.getNextDepth();
+  for (auto *capturedEnv : capturedEnvs) {
+    if (capturedEnv == genericEnv) {
+      return GenericTypeParamType::get(/*isParameterPack=*/false,
+                                       depth, rootParam->getIndex(),
+                                       rootParam->getASTContext());
+    }
+
+    ++depth;
+  }
+
+  llvm_unreachable("Fell off the end");
+}
+
+/// Given a substitution map for a call to a local function or closure, extend
+/// it to include all captured element archetypes; they become primary archetypes
+/// inside the body of the function.
+SubstitutionMap
+swift::buildSubstitutionMapWithCapturedEnvironments(
+    SubstitutionMap baseSubMap,
+    GenericSignature genericSigWithCaptures,
+    ArrayRef<GenericEnvironment *> capturedEnvs) {
+
+  if (capturedEnvs.empty()) {
+    assert((!baseSubMap && !genericSigWithCaptures) ||
+           baseSubMap.getGenericSignature()->isEqual(genericSigWithCaptures));
+    return baseSubMap;
+  }
+
+  unsigned baseDepth = genericSigWithCaptures.getNextDepth() - capturedEnvs.size();
+
+  return SubstitutionMap::get(
+    genericSigWithCaptures,
+    [&](SubstitutableType *type) -> Type {
+      auto param = cast<GenericTypeParamType>(type);
+      if (param->getDepth() >= baseDepth) {
+        assert(!param->isParameterPack());
+        unsigned envIndex = param->getDepth() - baseDepth;
+        assert(envIndex < capturedEnvs.size());
+        auto *capturedEnv = capturedEnvs[envIndex];
+        auto localInterfaceType = capturedEnv->getGenericSignature()
+            .getInnermostGenericParams()[param->getIndex()];
+        return capturedEnvs[envIndex]->mapTypeIntoContext(localInterfaceType);
+      }
+      return Type(type).subst(baseSubMap);
+    },
+    [&](CanType origType, Type substType,
+        ProtocolDecl *proto) -> ProtocolConformanceRef {
+      if (origType->getRootGenericParam()->getDepth() >= baseDepth)
+        return ProtocolConformanceRef(proto);
+      return baseSubMap.lookupConformance(origType, proto);
+    });
+}

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -77,13 +77,9 @@ RequirementEnvironment::RequirementEnvironment(
 
   // Calculate the depth at which the requirement's generic parameters
   // appear in the witness thunk signature.
-  unsigned depth = 0;
-  if (covariantSelf) {
+  unsigned depth = conformanceSig.getNextDepth();
+  if (covariantSelf)
     ++depth;
-  }
-  if (conformanceSig) {
-    depth += conformanceSig.getGenericParams().back()->getDepth() + 1;
-  }
 
   // Build a substitution map to replace the protocol's \c Self and the type
   // parameters of the requirement into a combined context that provides the

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -578,7 +578,7 @@ OverrideSubsInfo::OverrideSubsInfo(const NominalTypeDecl *baseNominal,
     DerivedParams(derivedParams) {
 
   if (auto baseNominalSig = baseNominal->getGenericSignature()) {
-    BaseDepth = baseNominalSig.getGenericParams().back()->getDepth() + 1;
+    BaseDepth = baseNominalSig.getNextDepth();
 
     auto *genericEnv = derivedNominal->getGenericEnvironment();
     auto derivedNominalTy = derivedNominal->getDeclaredInterfaceType();
@@ -602,7 +602,7 @@ OverrideSubsInfo::OverrideSubsInfo(const NominalTypeDecl *baseNominal,
   }
 
   if (auto derivedNominalSig = derivedNominal->getGenericSignature())
-    OrigDepth = derivedNominalSig.getGenericParams().back()->getDepth() + 1;
+    OrigDepth = derivedNominalSig.getNextDepth();
 }
 
 Type QueryOverrideSubs::operator()(SubstitutableType *type) const {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ForeignInfo.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/LocalArchetypeRequirementCollector.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ModuleLoader.h"
 #include "swift/AST/TypeCheckRequests.h"
@@ -2871,148 +2872,6 @@ CanSILFunctionType swift::getNativeSILFunctionType(
       substConstant, reqtSubs, witnessMethodConformance);
 }
 
-namespace {
-struct LocalArchetypeRequirementCollector {
-  const ASTContext &Context;
-  unsigned Depth;
-
-  /// The lists of new parameters and requirements to add to the signature.
-  SmallVector<GenericTypeParamType *, 2> Params;
-  SmallVector<Requirement, 2> Requirements;
-
-  /// The list of contextual types from the original function to use as
-  /// substitutions for the new parameters; parallel to Params.
-  SmallVector<Type, 4> ParamSubs;
-
-  /// A mapping of local archetypes to the corresponding type parameters
-  /// created for them.
-  llvm::DenseMap<CanType, Type> ParamsForLocalArchetypes;
-
-  /// The set of element environments we've processed.
-  llvm::SmallPtrSet<GenericEnvironment*, 4> ElementEnvs;
-
-  LocalArchetypeRequirementCollector(const ASTContext &ctx, unsigned depth)
-    : Context(ctx), Depth(depth) {}
-
-  void collect(CanLocalArchetypeType archetype) {
-    if (auto openedExistential = dyn_cast<OpenedArchetypeType>(archetype)) {
-      collect(openedExistential);
-    } else {
-      collect(cast<ElementArchetypeType>(archetype));
-    }
-  }
-
-  void collect(CanOpenedArchetypeType archetype) {
-    auto param = addParameter(archetype);
-
-    assert(archetype->isRoot());
-    auto constraint = archetype->getExistentialType();
-    if (auto existential = constraint->getAs<ExistentialType>())
-      constraint = existential->getConstraintType();
-
-    addRequirement(RequirementKind::Conformance, param, constraint);
-  }
-
-  void collect(CanElementArchetypeType archetype) {
-    size_t startingIndex = Params.size();
-
-    // Check whether we've already handled this environment.
-    // This can happen with opened-element environments because
-    // they can open multiple archetypes.
-    auto env = archetype->getGenericEnvironment();
-    if (!ElementEnvs.insert(env).second) return;
-
-    // Add a parameter for each of the opened elements in this environment.
-    auto sig = env->getGenericSignature();
-    auto elementParams = sig.getInnermostGenericParams();
-#ifndef NDEBUG
-    unsigned nextIndex = 0;
-#endif
-    for (auto elementParam : elementParams) {
-      assert(elementParam->getIndex() == nextIndex++);
-      auto elementArchetype = env->mapTypeIntoContext(elementParam);
-      addParameter(cast<LocalArchetypeType>(CanType(elementArchetype)));
-    }
-
-    // Clone the element requirements.
-
-    // The element parameters should all have the same depth, and their
-    // index values are dense and in order from 0..<N in that depth.
-    // We asserted that above, and we'll use it below to map them to
-    // their new parameters in Params.
-    auto elementDepth = elementParams.front()->getDepth();
-
-    // Helper function: does the given type refer to an opened element
-    // parameter from the opened element generic signature?
-    auto refersToElementType = [=](Type type) {
-      return type.findIf([&](Type t) {
-        if (auto *param = t->getAs<GenericTypeParamType>())
-          return (param->getDepth() == elementDepth);
-        return false;
-      });
-    };
-    // Helper function: replace references to opened element parameters
-    // with one of the type parameters we just created for this
-    // environment.
-    auto rewriteElementType = [=](Type type) {
-      return type.transformRec([&](Type t) -> std::optional<Type> {
-        if (auto *param = t->getAs<GenericTypeParamType>()) {
-          if (param->getDepth() == elementDepth)
-            return Type(Params[startingIndex + param->getIndex()]);
-        }
-        return std::nullopt;
-      });
-    };
-
-    for (auto req : sig.getRequirements()) {
-      switch (req.getKind()) {
-      case RequirementKind::SameShape:
-        // These never involve element types.
-        break;
-      case RequirementKind::Conformance:
-        if (refersToElementType(req.getFirstType())) {
-          addRequirement(RequirementKind::Conformance,
-                         rewriteElementType(req.getFirstType()),
-                         req.getSecondType());
-        }
-        break;
-      case RequirementKind::Superclass:
-      case RequirementKind::SameType:
-        if (refersToElementType(req.getFirstType()) ||
-            refersToElementType(req.getSecondType())) {
-          addRequirement(req.getKind(),
-                         rewriteElementType(req.getFirstType()),
-                         rewriteElementType(req.getSecondType()));
-        }
-        break;
-        break;
-      case RequirementKind::Layout:
-        if (refersToElementType(req.getFirstType())) {
-          addRequirement(RequirementKind::Layout,
-                         rewriteElementType(req.getFirstType()),
-                         req.getLayoutConstraint());
-        }
-        break;
-      }
-    }
-  }
-
-  GenericTypeParamType *addParameter(CanLocalArchetypeType localArchetype) {
-    auto *param = GenericTypeParamType::get(/*pack*/ false, Depth,
-                                            Params.size(), Context);
-    Params.push_back(param);
-    ParamSubs.push_back(localArchetype);
-    ParamsForLocalArchetypes.insert(std::make_pair(localArchetype, param));
-    return param;
-  }
-
-  template <class... Args>
-  void addRequirement(Args &&... args) {
-    Requirements.emplace_back(std::forward<Args>(args)...);
-  }
-};
-} // end anonymous namespace
-
 /// Build a generic signature and environment for a re-abstraction thunk.
 ///
 /// Most thunks share the generic environment with their original function.
@@ -3047,33 +2906,35 @@ buildThunkSignature(SILFunction *fn,
     return genericSig;
   }
 
-  // Add the existing generic signature.
-  unsigned depth = 0;
-  GenericSignature baseGenericSig;
-  if (auto genericSig =
-        fn->getLoweredFunctionType()->getInvocationGenericSignature()) {
-    baseGenericSig = genericSig;
-    depth = genericSig.getGenericParams().back()->getDepth() + 1;
-  }
+  // Get the existing generic signature.
+  auto baseGenericSig =
+      fn->getLoweredFunctionType()->getInvocationGenericSignature();
 
-  // Add new generic parameters to replace the local archetypes.
-  LocalArchetypeRequirementCollector collector(ctx, depth);
-
+  SmallVector<GenericEnvironment *, 2> capturedEnvs;
   for (auto archetype : localArchetypes) {
-    collector.collect(archetype);
+    auto *genericEnv = archetype->getGenericEnvironment();
+    if (std::find(capturedEnvs.begin(), capturedEnvs.end(), genericEnv)
+          == capturedEnvs.end()) {
+      capturedEnvs.push_back(genericEnv);
+    }
   }
 
-  auto genericSig = buildGenericSignature(ctx, baseGenericSig,
-                                          collector.Params,
-                                          collector.Requirements,
-                                          /*allowInverses=*/false);
+  auto genericSig = buildGenericSignatureWithCapturedEnvironments(
+      ctx, baseGenericSig, capturedEnvs);
+  LLVM_DEBUG(llvm::dbgs() << "Thunk generic signature: " << genericSig << "\n");
+
   genericEnv = genericSig.getGenericEnvironment();
+
+  MapLocalArchetypesOutOfContext mapOutOfContext(baseGenericSig, capturedEnvs);
 
   // Map the local archetypes to their new parameter types.
   for (auto localArchetype : localArchetypes) {
-    auto param =
-      collector.ParamsForLocalArchetypes.find(localArchetype)->second;
-    auto thunkArchetype = genericEnv->mapTypeIntoContext(param);
+    auto thunkInterfaceType = Type(localArchetype).subst(
+        mapOutOfContext,
+        MakeAbstractConformanceForGenericType(),
+        SubstFlags::PreservePackExpansionLevel);
+    auto thunkArchetype = genericEnv->mapTypeIntoContext(
+        thunkInterfaceType);
     contextLocalArchetypes.insert(std::make_pair(localArchetype,
                                                  thunkArchetype));
   }
@@ -3088,18 +2949,18 @@ buildThunkSignature(SILFunction *fn,
   }
 
   // Calculate substitutions to map interface types to the caller's archetypes.
+  interfaceSubs = buildSubstitutionMapWithCapturedEnvironments(
+      forwardingSubs, genericSig, capturedEnvs);
+  LLVM_DEBUG(llvm::dbgs() << "Thunk substitution map: " << interfaceSubs << "\n");
 
-  interfaceSubs = SubstitutionMap::get(
-    genericSig,
-    [&](SubstitutableType *type) -> Type {
-      if (auto param = dyn_cast<GenericTypeParamType>(type)) {
-        if (param->getDepth() == depth) {
-          return collector.ParamSubs[param->getIndex()];
-        }
-      }
-      return Type(type).subst(forwardingSubs);
-    },
-    MakeAbstractConformanceForGenericType());
+  for (auto pair : contextLocalArchetypes) {
+    auto substArchetype = Type(pair.second).subst(interfaceSubs);
+    if (!pair.first->isEqual(substArchetype)) {
+      llvm::errs() << "Expected: "; pair.first->dump(llvm::errs());
+      llvm::errs() << "Got: "; substArchetype->dump(llvm::errs());
+      abort();
+    }
+  }
 
   return genericSig.getCanonicalSignature();
 }

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -277,10 +277,7 @@ void ExistentialTransform::convertExistentialArgTypesToGenericArgTypes(
   params.append(FTy->getParameters().begin(), FTy->getParameters().end());
 
   /// Determine the existing generic parameter depth.
-  int Depth = 0;
-  if (OrigGenericSig != nullptr) {
-    Depth = OrigGenericSig.getGenericParams().back()->getDepth() + 1;
-  }
+  int Depth = OrigGenericSig.getNextDepth();
 
   /// Index of the Generic Parameter.
   int GPIdx = 0;
@@ -514,10 +511,7 @@ void ExistentialTransform::populateThunkBody() {
     }
   }
 
-  unsigned int OrigDepth = 0;
-  if (F->getLoweredFunctionType()->isPolymorphic()) {
-    OrigDepth = OrigCalleeGenericSig.getGenericParams().back()->getDepth() + 1;
-  }
+  unsigned int OrigDepth = OrigCalleeGenericSig.getNextDepth();
   SubstitutionMap OrigSubMap = F->getForwardingSubstitutionMap();
 
   /// Create substitutions for Apply instructions.

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -410,7 +410,7 @@ getSubstitutionsForCallee(SILModule &module, CanSILFunctionType baseCalleeType,
   unsigned baseDepth = 0;
   SubstitutionMap baseSubMap;
   if (auto baseClassSig = baseClassDecl->getGenericSignatureOfContext()) {
-    baseDepth = baseClassSig.getGenericParams().back()->getDepth() + 1;
+    baseDepth = baseClassSig.getNextDepth();
 
     // Compute the type of the base class, starting from the
     // derived class type and the type of the method's self
@@ -435,9 +435,7 @@ getSubstitutionsForCallee(SILModule &module, CanSILFunctionType baseCalleeType,
 
   // Add generic parameters from the method itself, ignoring any generic
   // parameters from the derived class.
-  unsigned origDepth = 0;
-  if (auto calleeClassSig = calleeClassDecl->getGenericSignatureOfContext())
-    origDepth = calleeClassSig.getGenericParams().back()->getDepth() + 1;
+  unsigned origDepth = calleeClassDecl->getGenericSignature().getNextDepth();
 
   auto baseCalleeSig = baseCalleeType->getInvocationGenericSignature();
 
@@ -927,10 +925,8 @@ getWitnessMethodSubstitutions(
   // substitutions for the concrete type's generic parameters.
   auto baseSubMap = conformance->getSubstitutionMap();
 
-  unsigned baseDepth = 0;
   auto *rootConformance = conformance->getRootConformance();
-  if (auto conformingTypeSig = rootConformance->getGenericSignature())
-    baseDepth = conformingTypeSig.getGenericParams().back()->getDepth() + 1;
+  unsigned baseDepth = rootConformance->getGenericSignature().getNextDepth();
 
   // witnessThunkSig begins with the optional class 'Self', followed by the
   // generic parameters of the concrete conforming type, followed by the

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1572,8 +1572,7 @@ shouldOpenExistentialCallArgument(ValueDecl *callee, unsigned paramIdx,
 
   auto genericSig = callee->getInnermostDeclContext()
       ->getGenericSignatureOfContext().getCanonicalSignature();
-  if (genericParam->getDepth() <
-          genericSig.getGenericParams().back()->getDepth())
+  if (genericParam->getDepth() < genericSig->getMaxDepth())
     return std::nullopt;
 
   // If the existential argument conforms to all of protocol requirements on

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -541,9 +541,7 @@ createDesignatedInitOverrideGenericParams(ASTContext &ctx,
   if (genericParams == nullptr)
     return nullptr;
 
-  unsigned depth = 0;
-  if (auto classSig = classDecl->getGenericSignature())
-    depth = classSig.getGenericParams().back()->getDepth() + 1;
+  unsigned depth = classDecl->getGenericSignature().getNextDepth();
 
   SmallVector<GenericTypeParamDecl *, 4> newParams;
   for (auto *param : genericParams->getParams()) {

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -215,7 +215,7 @@ static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
       module, VD->getDeclContext(), genericDecl->getGenericEnvironment());
 
   // The innermost generic parameters are mapped to error types.
-  unsigned innerDepth = genericSig.getGenericParams().back()->getDepth();
+  unsigned innerDepth = genericSig->getMaxDepth();
   if (!genericDecl->isGeneric())
     ++innerDepth;
 

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -713,8 +713,8 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
         if (!xGeneric)
           return false;
 
-        unsigned xDepth = xGeneric->getGenericParams().back()->getDepth();
-        unsigned yDepth = yGeneric->getGenericParams().back()->getDepth();
+        unsigned xDepth = xGeneric->getGenericSignature()->getMaxDepth();
+        unsigned yDepth = yGeneric->getGenericSignature()->getMaxDepth();
         return xDepth < yDepth;
       });
     }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -96,10 +96,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
   // types and their interface constraints.
   auto originatingDC = originatingDecl->getInnermostDeclContext();
   auto outerGenericSignature = originatingDC->getGenericSignatureOfContext();
-  unsigned opaqueSignatureDepth =
-      outerGenericSignature
-          ? outerGenericSignature.getGenericParams().back()->getDepth() + 1
-          : 0;
+  unsigned opaqueSignatureDepth = outerGenericSignature.getNextDepth();
 
   // Determine the context of the opaque type declaration we'll be creating.
   auto parentDC = originatingDecl->getDeclContext();

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -286,10 +286,7 @@ static void initDocGenericParams(const Decl *D, DocEntityInfo &Info,
         DC = D->getInnermostDeclContext()->getInnermostTypeContext();
       M = DC->getParentModule();
       SubMap = BaseType->getContextSubstitutionMap(M, DC);
-      if (!SubMap.empty()) {
-        TypeContextDepth = SubMap.getGenericSignature()
-            .getGenericParams().back()->getDepth() + 1;
-      }
+      TypeContextDepth = SubMap.getGenericSignature().getNextDepth();
     }
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/73348. Re-abstraction thunk emission had a utility for building a generic signature from several captured existential or element environments. Make this generally usable, since we need it for closures that capture element environments too.

I’m structuring these PRs to keep the refactoring separate from new code. The 6.0 cherry pick will not change existing logic, it will just add new code that only runs in the case that used to crash.