### PR TITLE
[cxx-interop][IRGen] Do not try to retain/release a null pointer

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -2668,7 +2668,8 @@ namespace {
         if (Refcounting == ReferenceCounting::Custom) {
           Explosion e;
           e.add(ptr);
-          getPayloadTypeInfo().as<ClassTypeInfo>().strongRetain(IGF, e, IGF.getDefaultAtomicity());
+          getPayloadTypeInfo().as<ClassTypeInfo>().strongCustomRetain(
+              IGF, e, /*needsNullCheck*/ true);
           return;
         }
 
@@ -2704,7 +2705,8 @@ namespace {
         if (Refcounting == ReferenceCounting::Custom) {
           Explosion e;
           e.add(ptr);
-          getPayloadTypeInfo().as<ClassTypeInfo>().strongRelease(IGF, e, IGF.getDefaultAtomicity());
+          getPayloadTypeInfo().as<ClassTypeInfo>().strongCustomRelease(
+              IGF, e, /*needsNullCheck*/ true);
           return;
         }
 

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -575,7 +575,8 @@ public:
   void emitBlockRelease(llvm::Value *value);
 
   void emitForeignReferenceTypeLifetimeOperation(ValueDecl *fn,
-                                                 llvm::Value *value);
+                                                 llvm::Value *value,
+                                                 bool needsNullCheck = false);
 
   // Routines for an unknown reference-counting style (meaning,
   // dynamically something compatible with either the ObjC or Swift styles).

--- a/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
@@ -27,7 +27,10 @@ __attribute__((swift_attr("release:LCRelease"))) LocalCount {
 
 }
 
-inline void LCRetain(NS::LocalCount *x) { x->value++; }
+inline void LCRetain(NS::LocalCount *x) {
+  x->value++;
+  finalLocalRefCount = x->value;
+}
 inline void LCRelease(NS::LocalCount *x) {
   x->value--;
   finalLocalRefCount = x->value;

--- a/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
@@ -46,6 +46,21 @@ __attribute__((swift_attr("release:GCRelease"))) GlobalCount {
 inline void GCRetain(GlobalCount *x) { globalCount++; }
 inline void GCRelease(GlobalCount *x) { globalCount--; }
 
+struct __attribute__((swift_attr("import_as_ref")))
+__attribute__((swift_attr("retain:GCRetainNullableInit")))
+__attribute__((swift_attr("release:GCReleaseNullableInit")))
+GlobalCountNullableInit {
+  static GlobalCountNullableInit *_Nullable create(bool wantNullptr) {
+    if (wantNullptr)
+      return nullptr;
+    return new (malloc(sizeof(GlobalCountNullableInit)))
+        GlobalCountNullableInit();
+  }
+};
+
+inline void GCRetainNullableInit(GlobalCountNullableInit *x) { globalCount++; }
+inline void GCReleaseNullableInit(GlobalCountNullableInit *x) { globalCount--; }
+
 SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #endif // TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_REFERENCE_COUNTED_H

--- a/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-emit-irgen %s -I %S/Inputs -cxx-interoperability-mode=default -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
+// XFAIL: OS=linux-android, OS=linux-androideabi
+
+import ReferenceCounted
+
+
+public func getLocalCount() -> NS.LocalCount {
+    let result = NS.LocalCount.create()
+    return result
+}
+
+// CHECK:      define {{.*}}swiftcc ptr @"$s4main13getLocalCountSo2NSO0cD0VyF"()
+// CHECK-NEXT: entry:
+// CHECK:        %0 = call ptr @{{_ZN2NS10LocalCount6createEv|"\?create\@LocalCount\@NS\@\@SAPEAU12\@XZ"}}()
+// CHECK-NEXT:   call void @{{_Z8LCRetainPN2NS10LocalCountE|"\?LCRetain\@\@YAXPEAULocalCount\@NS\@\@\@Z"}}(ptr %0)
+// CHECK:        ret ptr %0
+// CHECK-NEXT: }
+
+
+public func get42() -> Int32 {
+    let result = NS.LocalCount.create()
+    return result.returns42()
+}
+
+// CHECK:      define {{.*}}swiftcc i32 @"$s4main5get42s5Int32VyF"()
+// CHECK-NEXT: entry:
+// CHECK:        %0 = call ptr @{{_ZN2NS10LocalCount6createEv|"\?create\@LocalCount\@NS\@\@SAPEAU12\@XZ"}}()
+// CHECK-NEXT:   call void @{{_Z8LCRetainPN2NS10LocalCountE|"\?LCRetain\@\@YAXPEAULocalCount\@NS\@\@\@Z"}}(ptr %0)
+// CHECK:        %1 = call i32 @{{_ZN2NS10LocalCount9returns42Ev|"\?returns42\@LocalCount\@NS\@\@QEAAHXZ"}}
+// CHECK:        ret i32 %1
+// CHECK-NEXT: }
+
+
+public func getNullable(wantNullptr: Bool) -> GlobalCountNullableInit? {
+    let result = GlobalCountNullableInit.create(wantNullptr)
+    return result
+}
+
+// CHECK:      define {{.*}}swiftcc i64 @"$s4main11getNullable11wantNullptrSo011GlobalCountC4InitVSgSb_tF"(i1 %0)
+// CHECK-NEXT: entry:
+// CHECK:        %1 = call ptr @{{_ZN23GlobalCountNullableInit6createEb|"\?create\@GlobalCountNullableInit\@\@SAPEAU1\@_N\@Z"}}
+// CHECK-NEXT:   %2 = ptrtoint ptr %1 to i64
+// CHECK-NEXT:   %3 = inttoptr i64 %2 to ptr
+// CHECK-NEXT:   %4 = icmp ne ptr %3, null
+// CHECK-NEXT:   br i1 %4, label %lifetime.nonnull-value, label %lifetime.cont
+
+// CHECK:      lifetime.nonnull-value:
+// CHECK-NEXT:   call void @{{_Z20GCRetainNullableInitP23GlobalCountNullableInit|"\?GCRetainNullableInit\@\@YAXPEAUGlobalCountNullableInit\@\@\@Z"}}(ptr %3)
+// CHECK-NEXT:   br label %lifetime.cont
+
+// CHECK:      lifetime.cont:
+// CHECK:          ret i64 %2
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/foreign-reference/reference-counted.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted.swift
@@ -1,10 +1,8 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
 // TODO: This should work without ObjC interop in the future rdar://97497120
 // REQUIRES: objc_interop
-
-// REQUIRES: rdar97532642
 
 import StdlibUnittest
 import ReferenceCounted
@@ -17,7 +15,7 @@ public func blackHole<T>(_ _: T) {  }
 @inline(never)
 func localTest() {
     var x = NS.LocalCount.create()
-    expectEqual(x.value, 6) // This is 6 because of "var x" "x.value" * 2 and "(x, x, x)".
+    expectEqual(x.value, 8) // This is 8 because of "var x" "x.value" * 2, two method calls on x, and "(x, x, x)".
 
     expectEqual(x.returns42(), 42)
     expectEqual(x.constMethod(), 42)
@@ -35,7 +33,6 @@ ReferenceCountedTestSuite.test("Local") {
 var globalOptional: NS.LocalCount? = nil
 
 ReferenceCountedTestSuite.test("Global optional holding local ref count") {
-    expectEqual(finalLocalRefCount, 0)
     globalOptional = NS.LocalCount.create()
     expectEqual(finalLocalRefCount, 1)
 }


### PR DESCRIPTION
This teaches IRGen to only emit a lifetime operation (retain or release) for a C++ foreign reference type if the pointer is not `nullptr`.

Previously the compiler would in some cases emit a release call for `nullptr`, which breaks the assumption that the argument to a custom release function is `_Nonnull`. For instance:
```
var globalOptional: MyRefType? = nil
func foo() { globalOptional = MyRefType.create() }
```
When emitting IR for the assignment operation to `globalOptional`, the compiler would first emit code to retrieve the existing value of `globalOptional` and release it. If the value is `nil`, it does not need to be released.

This also re-enables a test that was disabled since 2022.

rdar://97532642