### PR TITLE
stdlib: Add `security.h` to the WinSDK module

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -316,6 +316,7 @@ module WinSDK [system] {
 
   module Security {
     header "../shared/sddl.h"
+    header "../shared/security.h"
 
     module AuthZ {
       header "AuthZ.h"
@@ -337,6 +338,8 @@ module WinSDK [system] {
 
       link "Crypt32.Lib"
     }
+
+    link "Secur32.Lib"
   }
 
   module Shell {


### PR DESCRIPTION
This is required for getting access to the System Services extensions. The change was motivated by the work to support swift-foundation on Windows.