### PR TITLE
[Linux][Runtime][IRGen] Mark metadata sections as retained and support section GC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -975,6 +975,8 @@ endif()
 # Which default linker to use. Prefer LLVM_USE_LINKER if it set, otherwise use
 # our own defaults. This should only be possible in a unified (not stand alone)
 # build environment.
+include(GoldVersion)
+
 if(LLVM_USE_LINKER)
   set(SWIFT_USE_LINKER_default "${LLVM_USE_LINKER}")
 elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "ANDROID")
@@ -984,7 +986,17 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT CMAKE_HOST_SYSTEM_NAME STREQ
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   set(SWIFT_USE_LINKER_default "")
 else()
-  set(SWIFT_USE_LINKER_default "gold")
+  get_gold_version(gold_version)
+  if(NOT gold_version)
+    message(STATUS "GNU Gold not found; using lld instead")
+    set(SWIFT_USE_LINKER_default "lld")
+  elseif(gold_version VERSION_LESS "2.36")
+    message(STATUS "GNU Gold is too old (${gold_version}); using lld instead")
+    set(SWIFT_USE_LINKER_default "lld")
+  else()
+    message(STATUS "Using GNU Gold ${gold_version}")
+    set(SWIFT_USE_LINKER_default "gold")
+  endif()
 endif()
 set(SWIFT_USE_LINKER ${SWIFT_USE_LINKER_default} CACHE STRING
     "Build Swift with a non-default linker")

--- a/cmake/modules/GoldVersion.cmake
+++ b/cmake/modules/GoldVersion.cmake
@@ -1,0 +1,18 @@
+# Find the version of ld.gold, if installed.
+#
+# Versions prior to 2.36 break Swift programs because they won't coalesce
+# sections with different SHF_GNU_RETAIN flags.
+function(get_gold_version result_var_name)
+  find_program(gold_executable "ld.gold")
+  if(gold_executable)
+    execute_process(
+      COMMAND "${gold_executable}" "--version"
+      COMMAND "head" "-n" "1"
+      COMMAND "sed" "-e" "s/^.* (\\([^)]*\\)).*$/\\1/g;s/.* \\([0-9][0-9]*\\(\\.[0-9][0-9]*\\)*\\).*/\\1/g"
+      OUTPUT_VARIABLE gold_version
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set("${result_var_name}" "${gold_version}" PARENT_SCOPE)
+  else()
+    set("${result_var_name}" "" PARENT_SCOPE)
+  endif()
+endfunction()

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -616,7 +616,7 @@ public:
             std::string SecName(Start, StringSize);
             if (SecName != Name)
               continue;
-            if (Retained != !!(Hdr->sh_flags & llvm::ELF::SHF_GNU_RETAIN))
+            if (Retained != bool(Hdr->sh_flags & llvm::ELF::SHF_GNU_RETAIN))
               continue;
             RemoteAddress SecStart =
                 RemoteAddress(ImageStart.getAddressData() + Hdr->sh_addr);

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -214,17 +214,6 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
 #else
     Arguments.push_back(context.Args.MakeArgString("-fuse-ld=" + Linker));
 #endif
-    // Starting with lld 13, Swift stopped working with the lld --gc-sections
-    // implementation for ELF, unless -z nostart-stop-gc is also passed to lld:
-    //
-    // https://reviews.llvm.org/D96914
-    if (Linker == "lld" || (Linker.length() > 5 &&
-                            Linker.substr(Linker.length() - 6) == "ld.lld")) {
-      Arguments.push_back("-Xlinker");
-      Arguments.push_back("-z");
-      Arguments.push_back("-Xlinker");
-      Arguments.push_back("nostart-stop-gc");
-    }
   }
 
   // Configure the toolchain.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1030,15 +1030,6 @@ bool LinkInfo::isUsed(IRLinkage IRL) {
 ///
 /// This value must have a definition by the time the module is finalized.
 void IRGenModule::addUsedGlobal(llvm::GlobalValue *global) {
-
-  // As of reviews.llvm.org/D97448 "ELF: Create unique SHF_GNU_RETAIN sections
-  // for llvm.used global objects" LLVM creates separate sections for globals in
-  // llvm.used on ELF.  Therefore we use llvm.compiler.used on ELF instead.
-  if (TargetInfo.OutputObjectFormat == llvm::Triple::ELF) {
-    addCompilerUsedGlobal(global);
-    return;
-  }
-
   LLVMUsed.push_back(global);
 }
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -137,6 +137,9 @@ swift::getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx) {
 
   auto *Clang = static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
 
+  // Set UseInitArray appropriately.
+  TargetOpts.UseInitArray = Clang->getCodeGenOpts().UseInitArray;
+
   // WebAssembly doesn't support atomics yet, see
   // https://github.com/apple/swift/issues/54533 for more details.
   if (Clang->getTargetInfo().getTriple().isOSBinFormatWasm())

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1655,8 +1655,10 @@ void swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
     break;
   }
   }
+  IGM.addUsedGlobal(ASTSym);
   ASTSym->setSection(Section);
   ASTSym->setAlignment(llvm::MaybeAlign(serialization::SWIFTMODULE_ALIGNMENT));
+  IGM.finalize();
   ::performLLVM(Opts, Ctx.Diags, nullptr, nullptr, IGM.getModule(),
                 IGM.TargetMachine.get(),
                 OutputPath, Ctx.getOutputBackend(), Ctx.Stats);

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -36,32 +36,43 @@ static const void *__backtraceRef __attribute__((used))
 // by the linker.  Otherwise, we may end up with undefined symbol references as
 // the linker table section was never constructed.
 #if defined(__ELF__)
-# define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"a\"\n");
+# define DECLARE_EMPTY_METADATA_SECTION(name,attrs) __asm__("\t.section " #name ",\"" attrs "\"\n");
 #elif defined(__wasm__)
-# define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"R\",@\n");
+# define DECLARE_EMPTY_METADATA_SECTION(name,attrs) __asm__("\t.section " #name ",\"R\",@\n");
 #endif
 
-#define DECLARE_SWIFT_SECTION(name)                                                          \
-  DECLARE_EMPTY_METADATA_SECTION(name)                                                                \
-  __attribute__((__visibility__("hidden"),__aligned__(1))) extern const char __start_##name; \
-  __attribute__((__visibility__("hidden"),__aligned__(1))) extern const char __stop_##name;
+#define BOUNDS_VISIBILITY __attribute__((__visibility__("hidden"),__aligned__(1)))
+#define DECLARE_BOUNDS(name)                            \
+  BOUNDS_VISIBILITY extern const char __start_##name;   \
+  BOUNDS_VISIBILITY extern const char __stop_##name;
+
+#define DECLARE_SWIFT_SECTION(name)             \
+  DECLARE_EMPTY_METADATA_SECTION(name,"aR")     \
+  DECLARE_BOUNDS(name)
+
+// These may or may not be present, depending on compiler switches; it's
+// worth calling them out as a result.
+#define DECLARE_SWIFT_REFLECTION_SECTION(name)  \
+  DECLARE_SWIFT_SECTION(name)
 
 extern "C" {
 DECLARE_SWIFT_SECTION(swift5_protocols)
 DECLARE_SWIFT_SECTION(swift5_protocol_conformances)
 DECLARE_SWIFT_SECTION(swift5_type_metadata)
 
-DECLARE_SWIFT_SECTION(swift5_typeref)
-DECLARE_SWIFT_SECTION(swift5_reflstr)
-DECLARE_SWIFT_SECTION(swift5_fieldmd)
-DECLARE_SWIFT_SECTION(swift5_assocty)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_fieldmd)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_builtin)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_assocty)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_capture)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_reflstr)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_typeref)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_mpenum)
+
 DECLARE_SWIFT_SECTION(swift5_replace)
 DECLARE_SWIFT_SECTION(swift5_replac2)
-DECLARE_SWIFT_SECTION(swift5_builtin)
-DECLARE_SWIFT_SECTION(swift5_capture)
-DECLARE_SWIFT_SECTION(swift5_mpenum)
 DECLARE_SWIFT_SECTION(swift5_accessible_functions)
 DECLARE_SWIFT_SECTION(swift5_runtime_attributes)
+
 DECLARE_SWIFT_SECTION(swift5_tests)
 }
 

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -36,18 +36,20 @@ static const void *__backtraceRef __attribute__((used, retain))
 // by the linker.  Otherwise, we may end up with undefined symbol references as
 // the linker table section was never constructed.
 #if defined(__ELF__)
-# define DECLARE_EMPTY_METADATA_SECTION(name,attrs) __asm__("\t.section " #name ",\"" attrs "\"\n");
+# define DECLARE_EMPTY_METADATA_SECTION(name, attrs) __asm__("\t.section " #name ",\"" attrs "\"\n");
 #elif defined(__wasm__)
-# define DECLARE_EMPTY_METADATA_SECTION(name,attrs) __asm__("\t.section " #name ",\"R\",@\n");
+# define DECLARE_EMPTY_METADATA_SECTION(name, attrs) __asm__("\t.section " #name ",\"R\",@\n");
 #endif
 
-#define BOUNDS_VISIBILITY __attribute__((__visibility__("hidden"),__aligned__(1)))
+#define BOUNDS_VISIBILITY __attribute__((__visibility__("hidden"), \
+                                         __aligned__(1)))
+
 #define DECLARE_BOUNDS(name)                            \
   BOUNDS_VISIBILITY extern const char __start_##name;   \
   BOUNDS_VISIBILITY extern const char __stop_##name;
 
 #define DECLARE_SWIFT_SECTION(name)             \
-  DECLARE_EMPTY_METADATA_SECTION(name,"aR")     \
+  DECLARE_EMPTY_METADATA_SECTION(name, "aR")    \
   DECLARE_BOUNDS(name)
 
 // These may or may not be present, depending on compiler switches; it's

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -28,7 +28,7 @@ static constexpr const void *__dso_handle = nullptr;
 #if SWIFT_ENABLE_BACKTRACING
 // Drag in a symbol from the backtracer, to force the static linker to include
 // the code.
-static const void *__backtraceRef __attribute__((used))
+static const void *__backtraceRef __attribute__((used, retain))
   = (const void *)swift::runtime::backtrace::_swift_backtrace_isThunkFunction;
 #endif
 

--- a/test/Distributed/distributed_actor_accessor_section_elf.swift
+++ b/test/Distributed/distributed_actor_accessor_section_elf.swift
@@ -137,7 +137,7 @@ public distributed actor MyOtherActor {
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
 
-// CHECK:      @llvm.compiler.used = appending global [{{.*}} x ptr] [
+// CHECK:      @llvm.used = appending global [{{.*}} x ptr] [
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTEHF"
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTEHF"
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTEHF"

--- a/test/Driver/link-time-opt.swift
+++ b/test/Driver/link-time-opt.swift
@@ -14,7 +14,6 @@
 // CHECK-SIMPLE-THIN-linux-gnu: clang
 // CHECK-SIMPLE-THIN-linux-gnu-DAG: -flto=thin
 // CHECK-SIMPLE-THIN-linux-gnu-DAG: -fuse-ld=lld
-// CHECK-SIMPLE-THIN-linux-gnu-DAG: -Xlinker -z -Xlinker nostart-stop-gc
 // CHECK-SIMPLE-THIN-linux-gnu-DAG: [[BITCODEFILE]]
 // CHECK-SIMPLE-THIN-linux-gnu-NOT: swift-autolink-extract
 
@@ -36,7 +35,6 @@
 // CHECK-SIMPLE-FULL-linux-gnu: clang
 // CHECK-SIMPLE-FULL-linux-gnu-DAG: -flto=full
 // CHECK-SIMPLE-FULL-linux-gnu-DAG: -fuse-ld=lld
-// CHECK-SIMPLE-FULL-linux-gnu-DAG: -Xlinker -z -Xlinker nostart-stop-gc
 // CHECK-SIMPLE-FULL-linux-gnu-DAG: [[BITCODEFILE]]
 // CHECK-SIMPLE-FULL-linux-gnu-NOT: swift-autolink-extract
 

--- a/test/Driver/link-time-opt.swift
+++ b/test/Driver/link-time-opt.swift
@@ -1,3 +1,5 @@
+// UNSUPPORTED: linker_overridden
+
 // RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-thin -target x86_64-unknown-linux-gnu    | %FileCheck %s --check-prefix=CHECK-SIMPLE-THIN --check-prefix=CHECK-SIMPLE-THIN-linux-gnu
 // RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-thin -target x86_64-unknown-windows-msvc | %FileCheck %s --check-prefix=CHECK-SIMPLE-THIN --check-prefix=CHECK-SIMPLE-THIN-windows-msvc
 

--- a/test/Driver/static-archive.swift
+++ b/test/Driver/static-archive.swift
@@ -1,3 +1,5 @@
+// UNSUPPORTED: linker_overridden
+
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -module-name ARCHIVER -static 2>&1 | %FileCheck -check-prefix CHECK-MACOS %s
 
 // CHECK-MACOS: swift

--- a/test/IRGen/ELF-remove-autolink-section.swift
+++ b/test/IRGen/ELF-remove-autolink-section.swift
@@ -12,7 +12,7 @@
 
 print("Hi from Swift!")
 
-// ELF: @llvm.compiler.used = {{.*}}ptr @_swift1_autolink_entries
+// ELF: @llvm.used = {{.*}}ptr @_swift1_autolink_entries
 
 // SECTION: .swift1_autolink_entries
 // NOSECTION-NOT: .swift1_autolink_entries

--- a/test/IRGen/autolink_elf.swift
+++ b/test/IRGen/autolink_elf.swift
@@ -10,5 +10,4 @@ import Empty
 // as used.
 
 // CHECK-DAG: @_swift1_autolink_entries = private constant [26 x i8] c"-lswiftEmpty\00-lanotherLib\00", section ".swift1_autolink_entries",{{.*}} align 8
-// CHECK-DAG: @llvm.compiler.used = appending global [{{.*}} x ptr] [{{.*}}ptr @_swift1_autolink_entries{{.*}}], section "llvm.metadata"
-
+// CHECK-DAG: @llvm.used = appending global [{{.*}} x ptr] [{{.*}}ptr @_swift1_autolink_entries{{.*}}], section "llvm.metadata"

--- a/test/IRGen/objc_protocol_vars.sil
+++ b/test/IRGen/objc_protocol_vars.sil
@@ -27,6 +27,5 @@ import Foundation
 }
 
 // CHECK-macho: @llvm.used = appending global [{{.*}}] [{{.*}}, ptr @"\01l_OBJC_LABEL_PROTOCOL_$__TtP18objc_protocol_vars1T_", ptr @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP18objc_protocol_vars1T_", {{.*}}], {{.*}}
-// CHECK-elf: @llvm.compiler.used = appending global [{{.*}}] [{{.*}}, ptr @"\01l_OBJC_LABEL_PROTOCOL_$__TtP18objc_protocol_vars1T_", ptr @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP18objc_protocol_vars1T_", {{.*}}], {{.*}}
+// CHECK-elf: @llvm.used = appending global [{{.*}}] [{{.*}}, ptr @"\01l_OBJC_LABEL_PROTOCOL_$__TtP18objc_protocol_vars1T_", ptr @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP18objc_protocol_vars1T_", {{.*}}], {{.*}}
 // CHECK-coff: @llvm.used = appending global [{{.*}}] [{{.*}}, ptr @"\01l_OBJC_LABEL_PROTOCOL_$__TtP18objc_protocol_vars1T_", ptr @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP18objc_protocol_vars1T_", {{.*}}], {{.*}}
-

--- a/test/IRGen/section_asm.swift
+++ b/test/IRGen/section_asm.swift
@@ -1,27 +1,52 @@
-// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %S/section.swift -S -parse-as-library | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %S/section.swift -S -parse-as-library | %FileCheck --check-prefix CHECK%target-os-binfmt-elf %s
+
 // REQUIRES: swift_in_compiler
 // UNSUPPORTED: CPU=wasm32
 
-// CHECK: .section{{.*}}"__TEXT,__mysection","ax"
+// CHECK: .section{{.*}}__TEXT,__mysection
 // CHECK-NOT: .section
 // CHECK: $s7section3fooyyF:
 
-// CHECK: .section{{.*}}"__TEXT,__mysection","ax"
+// CHECK: .section{{.*}}__TEXT,__mysection
 // CHECK-NOT: .section
 // CHECK: $s7section8MyStructV3fooyyF:
 
-// CHECK: .section{{.*}}"__DATA,__mysection","aw"
+// CHECK: .section{{.*}}__DATA,__mysection
 // CHECK-NOT: .section
 // CHECK: $s7section2g0Sivp:
 // CHECK-NOT: .section
 // CHECK: $s7section2g1Si_Sitvp:
 // CHECK-NOT: .section
 // CHECK: $s7section2g2Sbvp:
-// CHECK: .section{{.*}}"__DATA,__mysection","awR"
+// CHECK-NOT: .section
 // CHECK: $s7section2g3Sbvp:
-// CHECK: .section{{.*}}"__DATA,__mysection","aw"
+// CHECK-NOT: .section
 // CHECK: $s7section2g4SpySiGSgvp:
 // CHECK-NOT: .section
 // CHECK: $s7section2g5SpySiGSgvp:
 // CHECK-NOT: .section
 // CHECK: $s7section8MyStructV7static0SivpZ:
+
+// CHECKELF: .section{{.*}}"__TEXT,__mysection","ax"
+// CHECKELF-NOT: .section
+// CHECKELF: $s7section3fooyyF:
+
+// CHECKELF: .section{{.*}}"__TEXT,__mysection","ax"
+// CHECKELF-NOT: .section
+// CHECKELF: $s7section8MyStructV3fooyyF:
+
+// CHECKELF: .section{{.*}}"__DATA,__mysection","aw"
+// CHECKELF-NOT: .section
+// CHECKELF: $s7section2g0Sivp:
+// CHECKELF-NOT: .section
+// CHECKELF: $s7section2g1Si_Sitvp:
+// CHECKELF-NOT: .section
+// CHECKELF: $s7section2g2Sbvp:
+// CHECKELF: .section{{.*}}"__DATA,__mysection","awR"
+// CHECKELF: $s7section2g3Sbvp:
+// CHECKELF: .section{{.*}}"__DATA,__mysection","aw"
+// CHECKELF: $s7section2g4SpySiGSgvp:
+// CHECKELF-NOT: .section
+// CHECKELF: $s7section2g5SpySiGSgvp:
+// CHECKELF-NOT: .section
+// CHECKELF: $s7section8MyStructV7static0SivpZ:

--- a/test/IRGen/section_asm.swift
+++ b/test/IRGen/section_asm.swift
@@ -2,24 +2,24 @@
 // REQUIRES: swift_in_compiler
 // UNSUPPORTED: CPU=wasm32
 
-// CHECK: .section{{.*}}__TEXT,__mysection
+// CHECK: .section{{.*}}"__TEXT,__mysection","ax"
 // CHECK-NOT: .section
 // CHECK: $s7section3fooyyF:
 
-// CHECK: .section{{.*}}__TEXT,__mysection
+// CHECK: .section{{.*}}"__TEXT,__mysection","ax"
 // CHECK-NOT: .section
 // CHECK: $s7section8MyStructV3fooyyF:
 
-// CHECK: .section{{.*}}__DATA,__mysection
+// CHECK: .section{{.*}}"__DATA,__mysection","aw"
 // CHECK-NOT: .section
 // CHECK: $s7section2g0Sivp:
 // CHECK-NOT: .section
 // CHECK: $s7section2g1Si_Sitvp:
 // CHECK-NOT: .section
 // CHECK: $s7section2g2Sbvp:
-// CHECK-NOT: .section
+// CHECK: .section{{.*}}"__DATA,__mysection","awR"
 // CHECK: $s7section2g3Sbvp:
-// CHECK-NOT: .section
+// CHECK: .section{{.*}}"__DATA,__mysection","aw"
 // CHECK: $s7section2g4SpySiGSgvp:
 // CHECK-NOT: .section
 // CHECK: $s7section2g5SpySiGSgvp:

--- a/test/IRGen/unused.sil
+++ b/test/IRGen/unused.sil
@@ -56,7 +56,7 @@ bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>
 // CHECK-elf: @"\01l_entry_point" = private constant { i32, i32 } { i32 trunc (i64 sub (i64 ptrtoint (ptr @main to i64), i64 ptrtoint (ptr @"\01l_entry_point" to i64)) to i32), i32 0 }, section "swift5_entry", align 4
 
 // CHECK-macho: @llvm.used = appending global [4 x ptr] [ptr @frieda, ptr @main, ptr @"\01l_entry_point", ptr @__swift_reflection_version], section "llvm.metadata"
-// CHECK-elf: @llvm.compiler.used = appending global [5 x ptr] [ptr @frieda, ptr @main, ptr @"\01l_entry_point", ptr @__swift_reflection_version, ptr @_swift1_autolink_entries], section "llvm.metadata"
+// CHECK-elf: @llvm.used = appending global [5 x ptr] [ptr @frieda, ptr @main, ptr @"\01l_entry_point", ptr @__swift_reflection_version, ptr @_swift1_autolink_entries], section "llvm.metadata"
 
 // CHECK: define linkonce_odr hidden swiftcc void @qux()
 // CHECK: define hidden swiftcc void @fred()

--- a/test/Interpreter/llvm_link_time_opt.swift
+++ b/test/Interpreter/llvm_link_time_opt.swift
@@ -10,6 +10,8 @@
 // loaded too late").
 // REQUIRES: no_asan
 
+// UNSUPPORTED: linker_overridden
+
 // RUN: %empty-directory(%t)
 // RUN: %use_just_built_liblto %target-swiftc_driver -emit-library -static -lto=llvm-full %lto_flags -emit-module %S/Inputs/lto/module1.swift -working-directory %t
 // RUN: %use_just_built_liblto %target-swiftc_driver -lto=llvm-full %lto_flags %s -I%t -L%t -lmodule1 -module-name main -o %t/main

--- a/test/LinkerSections/function_sections.swift
+++ b/test/LinkerSections/function_sections.swift
@@ -1,10 +1,13 @@
 // REQUIRES: OS=linux-gnu || OS=freebsd
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -function-sections -emit-module -emit-library -static -parse-stdlib %S/Inputs/FunctionSections.swift
-// RUN: %target-build-swift -Xlinker --gc-sections -Xlinker -Map=%t/../../FunctionSections.map -I%t/../.. -L%t/../.. -lFunctionSections %S/Inputs/FunctionSectionsUse.swift
-// RUN: %FileCheck %s < %t/../../FunctionSections.map
+// RUN: %target-build-swift -Xlinker -v -Xlinker --gc-sections -Xlinker -Map=%t/../../FunctionSections.map -I%t/../.. -L%t/../.. -lFunctionSections %S/Inputs/FunctionSectionsUse.swift 2>&1 | sed 's/.*\(gold\|LLD\).*/\1/g' | tr "[:lower:]" "[:upper:]" > %t/../../Linker.txt
+// RUN: %FileCheck --check-prefix $(cat %t/../../Linker.txt) %s < %t/../../FunctionSections.map
 
-// CHECK: Discarded input sections
-// CHECK: .text.$s16FunctionSections5func2yyF
-// CHECK: Memory map
-// CHECK: .text.$s16FunctionSections5func1yyF
+// GOLD: Discarded input sections
+// GOLD: .text.$s16FunctionSections5func2yyF
+// GOLD: Memory map
+// GOLD: .text.$s16FunctionSections5func1yyF
+
+// LLD: .text.$s16FunctionSections5func1yyF
+// LLD-NOT: .text.$s16FunctionSections5func2yyF

--- a/test/embedded/internalize-no-stdlib.swift
+++ b/test/embedded/internalize-no-stdlib.swift
@@ -26,7 +26,7 @@ public func main() {
 }
 
 // CHECK-ELF: @_swift1_autolink_entries =
-// CHECK-ELF: @llvm.compiler.used = appending global [1 x ptr] [ptr @_swift1_autolink_entries], section "llvm.metadata"
+// CHECK-ELF: @llvm.used = appending global [1 x ptr] [ptr @_swift1_autolink_entries], section "llvm.metadata"
 // CHECK-ELF-NOT: @llvm.used
 
 // CHECK-MACHO-NOT: @llvm.compiler.used

--- a/test/embedded/once.swift
+++ b/test/embedded/once.swift
@@ -6,6 +6,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu
+// UNSUPPORTED: linker_overridden
 
 // For LTO, the linker dlopen()'s the libLTO library, which is a scenario that
 // ASan cannot work in ("Interceptors are not working, AddressSanitizer is

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1027,6 +1027,46 @@ if run_os in (
              ):
   target_mandates_stable_abi = "TRUE"
   config.available_features.add('swift_only_stable_abi')
+
+if run_os in ('macosx', 'ios', 'maccatalyst', 'tvos', 'watchos', 'xros'):
+    target_os_family = 'DARWIN'
+    target_os_binfmt = 'MACH-O'
+elif run_os in ('windows-cygnus', 'windows-gnu', 'windows-msvc'):
+    target_os_family = 'WINDOWS'
+    target_os_binfmt = 'PE-COFF'
+elif run_os in ('linux-gnu', 'linux-gnueabihf', 'linux-android', 'linux-androideabi'):
+    target_os_family = 'LINUX'
+    target_os_binfmt = 'ELF'
+elif run_os in ('freebsd', 'openbsd'):
+    target_os_family = 'BSD'
+    target_os_binfmt = 'ELF'
+else:
+    target_os_family = 'UNKNOWN'
+    target_os_binfmt = 'UNKNOWN'
+
+config.available_features.add('OS_FAMILY={}'.format(target_os_family.lower()))
+config.available_features.add('OS_BINFMT={}'.format(target_os_binfmt.lower()))
+
+for family in ('DARWIN', 'WINDOWS', 'LINUX', 'BSD', 'UNKNOWN'):
+    if family == target_os_family:
+        subst = family
+    else:
+        subst = ""
+    config.substitutions.append(
+        ('%target-os-family-{}'.format(family.lower()), subst)
+    )
+config.substitutions.append(('%target-os-family', target_os_family))
+
+for binfmt in ('MACH-O', 'PE-COFF', 'ELF', 'UNKNOWN'):
+    if binfmt == target_os_binfmt:
+        subst = binfmt
+    else:
+        subst = ""
+    config.substitutions.append(
+        ('%target-os-binfmt-{}'.format(binfmt.lower()), subst)
+    )
+config.substitutions.append(('%target-os-binfmt', target_os_binfmt))
+
 config.substitutions.append(('%target-os-abi', target_os_abi))
 config.substitutions.append(('%target-os-is-maccatalyst', target_os_is_maccatalyst))
 config.substitutions.append(('%target-mandates-stable-abi',

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -542,6 +542,11 @@ config.swift_driver_test_options += os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', 
 config.swift_ide_test_test_options += os.environ.get('SWIFT_IDE_TEST_TEST_OPTIONS', '')
 config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
 
+# Check if we overrode the linker; if we do, set a feature to say that, which
+# lets us disable tests that rely on the driver choosing the linker.
+if re.search(r'(?:^|[ \t])-use-ld=[^ \t]*', config.swift_driver_test_options):
+    config.available_features.add('linker_overridden')
+
 config.clang_module_cache_path = make_path(config.swift_test_results_dir, "clang-module-cache")
 shutil.rmtree(config.clang_module_cache_path, ignore_errors=True)
 mcp_opt = "-module-cache-path %s" % shell_quote(config.clang_module_cache_path)

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -115,11 +115,14 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
       else()
         set(host_lib_dir "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
       endif()
+      set(host_lib_arch_dir "${host_lib_dir}/${SWIFT_HOST_VARIANT_ARCH}")
 
+      set(swiftrt "${host_lib_arch_dir}/swiftrt${CMAKE_C_OUTPUT_EXTENSION}")
       target_link_libraries(${target} PRIVATE ${swiftrt})
       target_link_libraries(${target} PRIVATE "swiftCore")
 
       target_link_directories(${target} PRIVATE ${host_lib_dir})
+      target_link_directories(${target} PRIVATE ${host_lib_arch_dir})
 
       file(RELATIVE_PATH relative_rtlib_path "${path}" "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
       list(APPEND RPATH_LIST "$ORIGIN/${relative_rtlib_path}")


### PR DESCRIPTION
We want to support section GC, and the `__start` and `__stop` symbols don't count as roots for that (at least, not by default). Additionally, while GNU `ld` and `lld` will coalesce retained and non-retained sections, `gold` refuses to do so (see https://sourceware.org/bugzilla/show_bug.cgi?id=31415), which trips up the reflection code because that only expects to find a single section.

Turn on the `SHF_GNU_RETAIN` flag in `swiftrt.o`, and remove the existing workarounds for both of the above.

Also fix generation of module objects to be section GC compatible by marking the `__Swift_AST` symbol as used and finalising the module in IRGen.

Additionally, it turns out that we weren't initialising the `llvm::TargetOptions` properly and in particular the `UseInitArray` setting was wrong; this is masked by code in `gold` that converts `.ctors` and `.dtors` sections into `.init_array` and `.fini_array` respectively, but `lld` does not do this, and since Glibc no longer calls functions in these sections, that means that when linked with `lld`, any constructors or destructors generated by the Swift compiler don't run. Fix by setting `UseInitArray`.

rdar://123504095