### PR TITLE
Revert "Revert "[Dependency Scanning] Use a standalone `DependencyScanningFilesystem`on the scanner, sharing a common `status` cache from Clang's dependency service cache""

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -886,11 +886,6 @@ class SwiftDependencyScanningService {
   /// File prefix mapper.
   std::unique_ptr<llvm::TreePathPrefixMapper> Mapper;
 
-  /// The global file system cache.
-  std::optional<
-      clang::tooling::dependencies::DependencyScanningFilesystemSharedCache>
-      SharedFilesystemCache;
-
   /// A map from a String representing the target triple of a scanner invocation
   /// to the corresponding cached dependencies discovered so far when using this
   /// triple.
@@ -918,19 +913,6 @@ public:
   SwiftDependencyScanningService &
   operator=(const SwiftDependencyScanningService &) = delete;
   virtual ~SwiftDependencyScanningService() {}
-
-  /// Query the service's filesystem cache
-  clang::tooling::dependencies::DependencyScanningFilesystemSharedCache &getSharedCache() {
-    assert(SharedFilesystemCache && "Expected a shared cache");
-    return *SharedFilesystemCache;
-  }
-
-  /// Query the service's filesystem cache
-  clang::tooling::dependencies::DependencyScanningFilesystemSharedCache &
-  getSharedFilesystemCache() {
-    assert(SharedFilesystemCache && "Expected a shared cache");
-    return *SharedFilesystemCache;
-  }
 
   bool usingCachingFS() const { return !UseClangIncludeTree && (bool)CacheFS; }
   llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> getCachingFS() const { return CacheFS; }

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -427,7 +427,6 @@ SwiftDependencyScanningService::SwiftDependencyScanningService() {
       /* CAS (llvm::cas::ObjectStore) */ nullptr,
       /* Cache (llvm::cas::ActionCache) */ nullptr,
       /* SharedFS */ nullptr);
-  SharedFilesystemCache.emplace();
 }
 
 bool

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -153,6 +153,17 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
   auto ClangModuleCachePath = getModuleCachePathFromClang(
       ScanASTContext.getClangModuleLoader()->getClangInstance());
   auto &FEOpts = ScanCompilerInvocation.getFrontendOptions();
+
+  // Configure the filesystem to use the same shared `stat` cache as the Clang
+  // worker uses.
+  if (!globalScanningService.CacheFS) {
+    auto DepFS = llvm::makeIntrusiveRefCnt<
+        clang::tooling::dependencies::DependencyScanningWorkerFilesystem>(
+        globalScanningService.ClangScanningService->getSharedCache(),
+        ScanASTContext.SourceMgr.getFileSystem());
+    ScanASTContext.SourceMgr.setFileSystem(std::move(DepFS));
+  }
+
   ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
   ScanningASTDelegate = std::make_unique<InterfaceSubContextDelegateImpl>(
       ScanASTContext.SourceMgr, &ScanASTContext.Diags,


### PR DESCRIPTION
Reverts apple/swift#73234