### PR TITLE
utils: enable curl websockets support when building with `build.ps1`

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1298,7 +1298,7 @@ function Build-CURL([Platform]$Platform, $Arch) {
       ENABLE_THREADED_RESOLVER = "NO";
       ENABLE_UNICODE = "YES";
       ENABLE_UNIX_SOCKETS = "NO";
-      ENABLE_WEBSOCKETS = "NO";
+      ENABLE_WEBSOCKETS = "YES";
       HAVE_POLL_FINE = "NO";
       USE_IDN2 = "NO";
       USE_MSH3 = "NO";


### PR DESCRIPTION
`FoundationNetwork` has WebSocket support implemented (https://github.com/apple/swift-corelibs-foundation/pull/4643), so we just have to enable it on curl side.