### PR TITLE
[unittests] Fix a stack use-after-scope

### DIFF
--- a/unittests/SourceKit/SwiftLang/CloseTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CloseTest.cpp
@@ -111,8 +111,7 @@ public:
 
   void getDiagnosticsAsync(
       const char *DocName, ArrayRef<const char *> CArgs,
-      llvm::function_ref<void(const RequestResult<DiagnosticsResult> &)>
-          callback) {
+      std::function<void(const RequestResult<DiagnosticsResult> &)> callback) {
     auto Args = makeArgs(DocName, CArgs);
     getLang().getDiagnostics(DocName, Args, /*VFSOpts*/ std::nullopt,
                              /*CancelToken*/ {}, callback);


### PR DESCRIPTION
We need to use a `std::function` here since it escapes the lifetime of the call.

rdar://127362231