### PR TITLE
[sending] Change CheckedContinuation.resume and Async{Throwing,}Stream.yield to use transferring parameters.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -445,7 +445,8 @@ protected:
   void appendRetroactiveConformances(SubstitutionMap subMap,
                                      GenericSignature sig);
   void appendImplFunctionType(SILFunctionType *fn, GenericSignature sig,
-                              const ValueDecl *forDecl = nullptr);
+                              const ValueDecl *forDecl = nullptr,
+                              bool isInRecursion = true);
   void appendOpaqueTypeArchetype(ArchetypeType *archetype,
                                  OpaqueTypeDecl *opaqueDecl,
                                  SubstitutionMap subs,
@@ -521,25 +522,29 @@ protected:
     FunctionMangling,
   };
 
-  void appendFunction(AnyFunctionType *fn, GenericSignature sig,
-                    FunctionManglingKind functionMangling = NoFunctionMangling,
-                    const ValueDecl *forDecl = nullptr);
+  void
+  appendFunction(AnyFunctionType *fn, GenericSignature sig,
+                 FunctionManglingKind functionMangling = NoFunctionMangling,
+                 const ValueDecl *forDecl = nullptr,
+                 bool isRecursedInto = true);
   void appendFunctionType(AnyFunctionType *fn, GenericSignature sig,
                           bool isAutoClosure = false,
-                          const ValueDecl *forDecl = nullptr);
+                          const ValueDecl *forDecl = nullptr,
+                          bool isRecursedInto = true);
   void appendClangType(AnyFunctionType *fn);
   template <typename FnType>
   void appendClangType(FnType *fn, llvm::raw_svector_ostream &os);
 
-  void appendFunctionSignature(AnyFunctionType *fn,
-                               GenericSignature sig,
+  void appendFunctionSignature(AnyFunctionType *fn, GenericSignature sig,
                                const ValueDecl *forDecl,
-                               FunctionManglingKind functionMangling);
+                               FunctionManglingKind functionMangling,
+                               bool isRecursedInto = true);
 
   void appendFunctionInputType(ArrayRef<AnyFunctionType::Param> params,
                                LifetimeDependenceInfo lifetimeDependenceInfo,
                                GenericSignature sig,
-                               const ValueDecl *forDecl = nullptr);
+                               const ValueDecl *forDecl = nullptr,
+                               bool isRecursedInto = true);
   void appendFunctionResultType(Type resultType,
                                 GenericSignature sig,
                                 const ValueDecl *forDecl = nullptr);

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -517,14 +517,14 @@ BUILTIN_SIL_OPERATION(ApplyDerivative, "applyDerivative", Special)
 /// applyTranspose
 BUILTIN_SIL_OPERATION(ApplyTranspose, "applyTranspose", Special)
 
-/// withUnsafeContinuation<T> : (Builtin.RawUnsafeContinuation -> ()) async -> T
+/// withUnsafeContinuation<T> : (Builtin.RawUnsafeContinuation -> ()) async -> sending T
 ///
 /// Unsafely capture the current continuation and pass it to the given
 /// function value. Returns a value of type T when the continuation is
 /// resumed.
 BUILTIN_SIL_OPERATION(WithUnsafeContinuation, "withUnsafeContinuation", Special)
 
-/// withUnsafeThrowingContinuation<T> : (Builtin.RawUnsafeContinuation -> ()) async throws -> T
+/// withUnsafeThrowingContinuation<T> : (Builtin.RawUnsafeContinuation -> ()) async throws -> sending T
 ///
 /// Unsafely capture the current continuation and pass it to the given
 /// function value. Returns a value of type T or throws an error when

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -196,6 +196,8 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(NoncopyableGenerics, 427, "Noncopyable generics")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ConformanceSuppression, 426, "Suppressible inferred conformances")
 SUPPRESSIBLE_LANGUAGE_FEATURE(BitwiseCopyable2, 426, "BitwiseCopyable feature")
 LANGUAGE_FEATURE(BodyMacros, 415, "Function body macros")
+LANGUAGE_FEATURE(TransferringArgsAndResults, 430, "Transferring args and results")
+SUPPRESSIBLE_LANGUAGE_FEATURE(SendingArgsAndResults, 430, "Sending arg and results")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
@@ -214,8 +216,6 @@ UPCOMING_FEATURE(DynamicActorIsolation, 423, 6)
 UPCOMING_FEATURE(NonfrozenEnumExhaustivity, 192, 6)
 UPCOMING_FEATURE(GlobalActorIsolatedTypesUsability, 0434, 6)
 UPCOMING_FEATURE(BorrowingSwitch, 432, 6)
-UPCOMING_FEATURE(TransferringArgsAndResults, 430, 6)
-SUPPRESSIBLE_UPCOMING_FEATURE(SendingArgsAndResults, 430, 6)
 
 // Swift 7
 UPCOMING_FEATURE(ExistentialAny, 335, 7)

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -470,6 +470,21 @@ public:
     llvm_unreachable("covered switch");
   }
 
+  /// Return the sil_isolated operand if we have one.
+  Operand *getIsolatedArgumentOperandOrNullPtr() {
+    switch (ApplySiteKind(Inst->getKind())) {
+    case ApplySiteKind::ApplyInst:
+      return cast<ApplyInst>(Inst)->getIsolatedArgumentOperandOrNullPtr();
+    case ApplySiteKind::BeginApplyInst:
+      return cast<BeginApplyInst>(Inst)->getIsolatedArgumentOperandOrNullPtr();
+    case ApplySiteKind::TryApplyInst:
+      return cast<TryApplyInst>(Inst)->getIsolatedArgumentOperandOrNullPtr();
+    case ApplySiteKind::PartialApplyInst:
+      llvm_unreachable("Unhandled case");
+    }
+    llvm_unreachable("covered switch");
+  }
+
   /// Return a list of applied arguments without self.
   OperandValueArrayRef getArgumentsWithoutSelf() const {
     switch (ApplySiteKind(Inst->getKind())) {

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2039,7 +2039,8 @@ getResultDifferentiability(SILResultInfo::Options options) {
 
 void ASTMangler::appendImplFunctionType(SILFunctionType *fn,
                                         GenericSignature outerGenericSig,
-                                        const ValueDecl *forDecl) {
+                                        const ValueDecl *forDecl,
+                                        bool isInRecursion) {
 
   llvm::SmallVector<char, 32> OpArgs;
 
@@ -2164,7 +2165,7 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn,
   }
 
   // Mangle if we have a transferring result.
-  if (fn->hasSendingResult())
+  if (isInRecursion && fn->hasSendingResult())
     OpArgs.push_back('T');
 
   // Mangle the results.
@@ -2947,7 +2948,7 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
 
 void ASTMangler::appendFunction(AnyFunctionType *fn, GenericSignature sig,
                                 FunctionManglingKind functionMangling,
-                                const ValueDecl *forDecl) {
+                                const ValueDecl *forDecl, bool isRecursedInto) {
   // Append parameter labels right before the signature/type.
   auto parameters = fn->getParams();
   auto firstLabel = std::find_if(
@@ -2967,15 +2968,16 @@ void ASTMangler::appendFunction(AnyFunctionType *fn, GenericSignature sig,
   }
 
   if (functionMangling != NoFunctionMangling) {
-    appendFunctionSignature(fn, sig, forDecl, functionMangling);
+    appendFunctionSignature(fn, sig, forDecl, functionMangling, isRecursedInto);
   } else {
-    appendFunctionType(fn, sig, /*autoclosure*/ false, forDecl);
+    appendFunctionType(fn, sig, /*autoclosure*/ false, forDecl, isRecursedInto);
   }
 }
 
 void ASTMangler::appendFunctionType(AnyFunctionType *fn, GenericSignature sig,
                                     bool isAutoClosure,
-                                    const ValueDecl *forDecl) {
+                                    const ValueDecl *forDecl,
+                                    bool isRecursedInto) {
   assert((DWARFMangling || fn->isCanonical()) &&
          "expecting canonical types when not mangling for the debugger");
 
@@ -3047,10 +3049,11 @@ void ASTMangler::appendClangType(AnyFunctionType *fn) {
 void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
                                          GenericSignature sig,
                                          const ValueDecl *forDecl,
-                                         FunctionManglingKind functionMangling) {
+                                         FunctionManglingKind functionMangling,
+                                         bool isRecursedInto) {
   appendFunctionResultType(fn->getResult(), sig, forDecl);
   appendFunctionInputType(fn->getParams(), fn->getLifetimeDependenceInfo(), sig,
-                          forDecl);
+                          forDecl, isRecursedInto);
   if (fn->isAsync())
     appendOperator("Ya");
   if (fn->isSendable())
@@ -3096,7 +3099,7 @@ void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
     break;
   }
 
-  if (fn->hasSendingResult()) {
+  if (isRecursedInto && fn->hasSendingResult()) {
     appendOperator("YT");
   }
 
@@ -3142,7 +3145,13 @@ getDefaultOwnership(const ValueDecl *forDecl) {
 
 static ParameterTypeFlags
 getParameterFlagsForMangling(ParameterTypeFlags flags,
-                             ParamSpecifier defaultSpecifier) {
+                             ParamSpecifier defaultSpecifier,
+                             bool isInRecursion = true) {
+  // If we have been recursed into, then remove sending from our flags.
+  if (!isInRecursion) {
+    flags = flags.withSending(false);
+  }
+
   switch (auto specifier = flags.getOwnershipSpecifier()) {
   // If no parameter specifier was provided, mangle as-is, because we are by
   // definition using the default convention.
@@ -3169,7 +3178,7 @@ getParameterFlagsForMangling(ParameterTypeFlags flags,
 void ASTMangler::appendFunctionInputType(
     ArrayRef<AnyFunctionType::Param> params,
     LifetimeDependenceInfo lifetimeDependenceInfo, GenericSignature sig,
-    const ValueDecl *forDecl) {
+    const ValueDecl *forDecl, bool isRecursedInto) {
   auto defaultSpecifier = getDefaultOwnership(forDecl);
   
   switch (params.size()) {
@@ -3192,7 +3201,7 @@ void ASTMangler::appendFunctionInputType(
       appendParameterTypeListElement(
           Identifier(), type,
           getParameterFlagsForMangling(param.getParameterFlags(),
-                                       defaultSpecifier),
+                                       defaultSpecifier, isRecursedInto),
           lifetimeDependenceInfo.getLifetimeDependenceOnParam(/*paramIndex*/ 0),
           sig, nullptr);
       break;
@@ -3214,7 +3223,7 @@ void ASTMangler::appendFunctionInputType(
       appendParameterTypeListElement(
           Identifier(), param.getPlainType(),
           getParameterFlagsForMangling(param.getParameterFlags(),
-                                       defaultSpecifier),
+                                       defaultSpecifier, isRecursedInto),
           lifetimeDependenceInfo.getLifetimeDependenceOnParam(paramIndex), sig,
           nullptr);
       appendListSeparator(isFirstParam);
@@ -3878,7 +3887,8 @@ void ASTMangler::appendDeclType(const ValueDecl *decl,
               : decl->getDeclContext()->getGenericSignatureOfContext());
 
   if (AnyFunctionType *FuncTy = type->getAs<AnyFunctionType>()) {
-    appendFunction(FuncTy, sig, functionMangling, decl);
+    appendFunction(FuncTy, sig, functionMangling, decl,
+                   false /*is recursed into*/);
   } else {
     appendType(type, sig, decl);
   }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2981,7 +2981,7 @@ void ASTMangler::appendFunctionType(AnyFunctionType *fn, GenericSignature sig,
   assert((DWARFMangling || fn->isCanonical()) &&
          "expecting canonical types when not mangling for the debugger");
 
-  appendFunctionSignature(fn, sig, forDecl, NoFunctionMangling);
+  appendFunctionSignature(fn, sig, forDecl, NoFunctionMangling, isRecursedInto);
 
   bool mangleClangType = fn->getASTContext().LangOpts.UseClangFunctionTypes &&
                          fn->hasNonDerivableClangType();

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1646,7 +1646,7 @@ static ValueDecl *getStartAsyncLet(ASTContext &ctx, Identifier id) {
   // a case want to thunk and not emit an error. So in such a case, we always
   // make this builtin take a sending result.
   bool hasSendingResult =
-      ctx.LangOpts.hasFeature(Feature::TransferringArgsAndResults);
+      ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation);
 
   // operation async function pointer: () async throws -> transferring T
   auto extInfo = ASTExtInfoBuilder()

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -422,13 +422,10 @@ enum class BuiltinThrowsKind : uint8_t {
 }
 
 /// Build a builtin function declaration.
-static FuncDecl *
-getBuiltinGenericFunction(Identifier Id,
-                          ArrayRef<AnyFunctionType::Param> ArgParamTypes,
-                          Type ResType,
-                          GenericParamList *GenericParams,
-                          GenericSignature Sig,
-                          bool Async, BuiltinThrowsKind Throws) {
+static FuncDecl *getBuiltinGenericFunction(
+    Identifier Id, ArrayRef<AnyFunctionType::Param> ArgParamTypes, Type ResType,
+    GenericParamList *GenericParams, GenericSignature Sig, bool Async,
+    BuiltinThrowsKind Throws, bool SendingResult) {
   assert(GenericParams && "Missing generic parameters");
   auto &Context = ResType->getASTContext();
 
@@ -460,6 +457,7 @@ getBuiltinGenericFunction(Identifier Id,
       Throws != BuiltinThrowsKind::None, /*thrownType=*/Type(),
       GenericParams, paramList, ResType, DC);
 
+  func->setSendingResult(SendingResult);
   func->setAccess(AccessLevel::Public);
   func->setGenericSignature(Sig);
   if (Throws == BuiltinThrowsKind::Rethrows)
@@ -681,6 +679,7 @@ namespace {
     Type InterfaceResult;
     bool Async = false;
     BuiltinThrowsKind Throws = BuiltinThrowsKind::None;
+    bool SendingResult = false;
 
     // Accumulate params and requirements here, so that we can call
     // `buildGenericSignature()` when `build()` is called.
@@ -745,16 +744,17 @@ namespace {
       Throws = BuiltinThrowsKind::Rethrows;
     }
 
+    void setSendingResult() { SendingResult = true; }
+
     FuncDecl *build(Identifier name) {
       auto GenericSig = buildGenericSignature(
           Context, GenericSignature(),
           std::move(genericParamTypes),
           std::move(addedRequirements),
           /*allowInverses=*/false);
-      return getBuiltinGenericFunction(name, InterfaceParams,
-                                       InterfaceResult,
-                                       TheGenericParamList, GenericSig,
-                                       Async, Throws);
+      return getBuiltinGenericFunction(name, InterfaceParams, InterfaceResult,
+                                       TheGenericParamList, GenericSig, Async,
+                                       Throws, SendingResult);
     }
 
     // Don't use these generator classes directly; call the make{...}
@@ -2073,6 +2073,7 @@ static ValueDecl *getWithUnsafeContinuation(ASTContext &ctx,
   builder.setAsync();
   if (throws)
     builder.setThrows();
+  builder.setSendingResult();
 
   return builder.build(id);
 }

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -576,17 +576,6 @@ struct SILOptOptions {
           "disable-region-based-isolation-with-strict-concurrency",
           llvm::cl::init(false));
 
-  llvm::cl::opt<bool>
-      DisableTransferringArgsAndResultsWithRegionBasedIsolation = llvm::cl::opt<
-          bool>(
-          "disable-transferring-args-and-results-with-region-based-isolation",
-          llvm::cl::init(false));
-
-  llvm::cl::opt<bool> DisableSendingArgsAndResultsWithRegionBasedIsolation =
-      llvm::cl::opt<bool>(
-          "disable-sending-args-and-results-with-region-based-isolation",
-          llvm::cl::init(false));
-
   llvm::cl::opt<std::string> SwiftVersionString = llvm::cl::opt<std::string>(
       "swift-version",
       llvm::cl::desc(
@@ -803,19 +792,6 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   if (Invocation.getLangOptions().hasFeature(Feature::StrictConcurrency) &&
       !options.DisableRegionBasedIsolationWithStrictConcurrency) {
     Invocation.getLangOptions().enableFeature(Feature::RegionBasedIsolation);
-  }
-
-  if (Invocation.getLangOptions().hasFeature(Feature::RegionBasedIsolation)) {
-    if (!options.DisableTransferringArgsAndResultsWithRegionBasedIsolation)
-      Invocation.getLangOptions().enableFeature(
-          Feature::TransferringArgsAndResults);
-    if (!options.DisableSendingArgsAndResultsWithRegionBasedIsolation)
-      Invocation.getLangOptions().enableFeature(Feature::SendingArgsAndResults);
-  }
-
-  if (Invocation.getLangOptions().hasFeature(
-          Feature::TransferringArgsAndResults)) {
-    Invocation.getLangOptions().enableFeature(Feature::SendingArgsAndResults);
   }
 
   Invocation.getDiagnosticOptions().VerifyMode =

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1112,34 +1112,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       Opts.enableFeature(Feature::RegionBasedIsolation);
   }
 
-  // Enable TransferringArgsAndResults/SendingArgsAndResults whenever
-  // RegionIsolation is enabled.
-  if (Opts.hasFeature(Feature::RegionBasedIsolation)) {
-    bool enableTransferringArgsAndResults = true;
-    bool enableSendingArgsAndResults = true;
-#ifndef NDEBUG
-    enableTransferringArgsAndResults = !Args.hasArg(
-        OPT_disable_transferring_args_and_results_with_region_isolation);
-    enableSendingArgsAndResults = !Args.hasArg(
-        OPT_disable_sending_args_and_results_with_region_isolation);
-#endif
-    if (enableTransferringArgsAndResults)
-      Opts.enableFeature(Feature::TransferringArgsAndResults);
-    if (enableSendingArgsAndResults)
-      Opts.enableFeature(Feature::SendingArgsAndResults);
-  }
-
-  // Enable SendingArgsAndResults whenever TransferringArgsAndResults is
-  // enabled.
-  //
-  // The reason that we are doing this is we want to phase out transferring in
-  // favor of sending and this ensures that if we output 'sending' instead of
-  // 'transferring' (for instance when emitting suppressed APIs), we know that
-  // the compiler will be able to handle sending as well.
-  if (Opts.hasFeature(Feature::TransferringArgsAndResults)) {
-    Opts.enableFeature(Feature::SendingArgsAndResults);
-  }
-
   Opts.WarnImplicitOverrides =
     Args.hasArg(OPT_warn_implicit_overrides);
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5464,14 +5464,9 @@ ParserStatus Parser::ParsedTypeAttributeList::slowParse(Parser &P) {
     // Perform an extra check for transferring. Since it is a specifier, we use
     // the actual parsing logic below.
     if (Tok.isContextualKeyword("transferring")) {
-      if (!P.Context.LangOpts.hasFeature(Feature::TransferringArgsAndResults)) {
-        P.diagnose(Tok, diag::requires_experimental_feature, Tok.getRawText(),
-                   false, getFeatureName(Feature::TransferringArgsAndResults));
-      } else {
-        // Now that we have sending, warn users to convert 'transferring' to
-        // 'sendable'.
-        P.diagnose(Tok, diag::transferring_is_now_sendable);
-      }
+      // Now that we have sending, warn users to convert 'transferring' to
+      // 'sendable'.
+      P.diagnose(Tok, diag::transferring_is_now_sendable);
 
       // Do not allow for transferring to be parsed after a specifier has been
       // parsed.

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -263,7 +263,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
           continue;
         }
 
-        if (Context.LangOpts.hasFeature(Feature::TransferringArgsAndResults) &&
+        if (Context.LangOpts.hasFeature(Feature::SendingArgsAndResults) &&
             Tok.isContextualKeyword("transferring")) {
           diagnose(Tok, diag::parameter_specifier_as_attr_disallowed, Tok.getText())
                     .warnUntilSwiftVersion(6);

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -171,7 +171,10 @@ SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc, bool asForeign,
     loc = ACE;
     kind = Kind::Func;
     if (ACE->getASTContext().LangOpts.hasFeature(
-            Feature::TransferringArgsAndResults)) {
+            Feature::RegionBasedIsolation)) {
+      assert(ACE->getASTContext().LangOpts.hasFeature(
+                 Feature::SendingArgsAndResults) &&
+             "Sending args and results should always be enabled");
       if (auto *autoClosure = dyn_cast<AutoClosureExpr>(ACE)) {
         isAsyncLetClosure =
             autoClosure->getThunkKind() == AutoClosureExpr::Kind::AsyncLet;

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -298,7 +298,8 @@ public:
   }
 
   SILResultInfo substInterface(SILResultInfo orig) {
-    return SILResultInfo(visit(orig.getInterfaceType()), orig.getConvention());
+    return SILResultInfo(visit(orig.getInterfaceType()), orig.getConvention(),
+                         orig.getOptions());
   }
 
   SILYieldInfo substInterface(SILYieldInfo orig) {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1970,6 +1970,13 @@ public:
         }
       }
     }
+
+    // Make sure that our subst and orig callee type agree on having sending
+    // results or not.
+    require(site.getOrigCalleeType()->hasSendingResult() ==
+                site.getSubstCalleeType()->hasSendingResult(),
+            "Callee's orig and subst callee type must have the same sending "
+            "result");
   }
 
   void checkApplyInst(ApplyInst *AI) {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1926,10 +1926,10 @@ public:
                                      isolationInfo);
     }
 
-    // If our result is transferring, then pass in empty as our results and then
-    // perform assign fresh.
+    // If our result is transferring, then pass in empty as our results, no
+    // override isolation, then perform assign fresh.
     ArrayRef<SILValue> empty;
-    translateSILMultiAssign(empty, nonTransferringParameters, isolationInfo);
+    translateSILMultiAssign(empty, nonTransferringParameters, {});
     for (SILValue result : applyResults) {
       if (auto value = tryToTrackValue(result)) {
         builder.addAssignFresh(value->getRepresentative().getValue());

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -47,6 +47,12 @@ using namespace swift::PartitionPrimitives;
 using namespace swift::PatternMatch;
 using namespace swift::regionanalysisimpl;
 
+static llvm::cl::opt<bool> AbortOnUnknownPatternMatchError(
+    "sil-region-isolation-assert-on-unknown-pattern",
+    llvm::cl::desc("Abort if SIL region isolation detects an unknown pattern. "
+                   "Intended only to be used when debugging the compiler!"),
+    llvm::cl::init(false), llvm::cl::Hidden);
+
 //===----------------------------------------------------------------------===//
 //                              MARK: Utilities
 //===----------------------------------------------------------------------===//
@@ -1191,6 +1197,10 @@ struct PartitionOpBuilder {
   }
 
   void addUnknownPatternError(SILValue value) {
+    if (AbortOnUnknownPatternMatchError) {
+      llvm::report_fatal_error(
+          "RegionIsolation: Aborting on unknown pattern match error");
+    }
     currentInstPartitionOps.emplace_back(
         PartitionOp::UnknownPatternError(lookupValueID(value), currentInst));
   }
@@ -1510,12 +1520,12 @@ private:
   std::optional<std::pair<TrackableValue, bool>>
   initializeTrackedValue(SILValue value, SILIsolationInfo info) const {
     auto trackedValuePair = valueMap.initializeTrackableValue(value, info);
-    if (trackedValuePair.first.isNonSendable()) {
-      assert(trackedValuePair.second);
-      return trackedValuePair;
-    }
-    assert(trackedValuePair.second);
-    return {};
+
+    // If we have a Sendable value return none.
+    if (!trackedValuePair.first.isNonSendable())
+      return {};
+
+    return trackedValuePair;
   }
 
   TrackableValue
@@ -1564,27 +1574,52 @@ public:
   /// Require all non-sendable sources, merge their regions, and assign the
   /// resulting region to all non-sendable targets, or assign non-sendable
   /// targets to a fresh region if there are no non-sendable sources.
+  ///
+  /// \arg isolationInfo An isolation info that can be specified as the true
+  /// base isolation of results. Otherwise, results are assumed to have a
+  /// element isolation of disconnected. NOTE: The results will still be in the
+  /// region of the non-Sendable arguments so at the region level they will have
+  /// the same value.
   template <typename TargetRange, typename SourceRange>
-  void translateSILMultiAssign(const TargetRange &resultValues,
-                               const SourceRange &sourceValues,
-                               SILIsolationInfo isolationInfo = {}) {
+  void
+  translateSILMultiAssign(const TargetRange &resultValues,
+                          const SourceRange &sourceValues,
+                          SILIsolationInfo resultIsolationInfoOverride = {}) {
     SmallVector<SILValue, 8> assignOperands;
     SmallVector<SILValue, 8> assignResults;
+
+    std::optional<SILDynamicMergedIsolationInfo> mergedInfo;
+    if (resultIsolationInfoOverride) {
+      mergedInfo = resultIsolationInfoOverride;
+    } else {
+      mergedInfo = SILIsolationInfo::getDisconnected(false);
+    }
 
     for (SILValue src : sourceValues) {
       if (auto value = tryToTrackValue(src)) {
         assignOperands.push_back(value->getRepresentative().getValue());
+        mergedInfo = mergedInfo->merge(value->getIsolationRegionInfo());
+
+        // If we fail to merge, then we have an incompatibility in between some
+        // of our arguments (consider isolated to different actors) or with the
+        // isolationInfo we specified. Emit an unknown patten error.
+        if (!mergedInfo) {
+          builder.addUnknownPatternError(src);
+          continue;
+        }
       }
     }
 
     for (SILValue result : resultValues) {
-      if (isolationInfo) {
+      // If we had isolation info explicitly passed in... use our
+      // mergedInfo. Otherwise, we want to infer.
+      if (resultIsolationInfoOverride) {
         // We only get back result if it is non-Sendable.
         if (auto nonSendableValue =
-                initializeTrackedValue(result, isolationInfo)) {
+                initializeTrackedValue(result, resultIsolationInfoOverride)) {
+          // If we did not insert, emit an unknown patten error.
           if (!nonSendableValue->second) {
             builder.addUnknownPatternError(result);
-            continue;
           }
           assignResults.push_back(
               nonSendableValue->first.getRepresentative().getValue());
@@ -1611,8 +1646,13 @@ public:
       // non-Sendable operands and we are supposed to mark value as actor
       // derived, introduce a fake element so we just propagate the actor
       // region.
-      if (assignOperands.size() && isolationInfo) {
-        builder.addActorIntroducingInst(assignOperands.back(), isolationInfo);
+      //
+      // NOTE: Here we check if we have mergedInfo rather than isolationInfo
+      // since we want to do this regardless of whether or not we passed in a
+      // specific isolation info unlike earlier when processing actual results.
+      if (assignOperands.size() && resultIsolationInfoOverride) {
+        builder.addActorIntroducingInst(assignOperands.back(),
+                                        resultIsolationInfoOverride);
       }
 
       return;
@@ -1818,8 +1858,7 @@ public:
 
     // If we do not have a special builtin, just do a multi-assign. Builtins do
     // not cross async boundaries.
-    return translateSILMultiAssign(bi->getResults(), bi->getOperandValues(),
-                                   {});
+    return translateSILMultiAssign(bi->getResults(), bi->getOperandValues());
   }
 
   void translateNonIsolationCrossingSILApply(FullApplySite fas) {
@@ -1864,11 +1903,16 @@ public:
       }
     }
 
-    // Add our callee to non-transferring parameters. This ensures that if it is
-    // actor isolated, that propagates into our results. This is especially
-    // important since our callee could be dynamically isolated and we cannot
-    // know that until we perform dataflow.
-    nonTransferringParameters.push_back(fas.getCallee());
+    // Require our callee operand if it is non-Sendable.
+    //
+    // DISCUSSION: Even though we do not include our callee operand in the same
+    // region as our operands/results, we still need to require that it is live
+    // at the point of application. Otherwise, we will not emit errors if the
+    // closure before this function application is already in the same region as
+    // a transferred value. In such a case, the function application must error.
+    if (auto value = tryToTrackValue(fas.getCallee())) {
+      builder.addRequire(value->getRepresentative().getValue());
+    }
 
     SmallVector<SILValue, 8> applyResults;
     getApplyResults(*fas, applyResults);
@@ -2769,18 +2813,14 @@ PartitionOpTranslator::visitAllocStackInst(AllocStackInst *asi) {
 
   // Ok at this point we know that our value is a non-Sendable temporary.
   auto isolationInfo = SILIsolationInfo::get(asi);
-  if (!bool(isolationInfo)) {
-    return TranslationSemantics::AssignFresh;
-  }
-
-  if (isolationInfo.isDisconnected()) {
+  if (!bool(isolationInfo) || isolationInfo.isDisconnected()) {
     return TranslationSemantics::AssignFresh;
   }
 
   // Ok, we can handle this and have a valid isolation. Initialize the value.
   auto v = initializeTrackedValue(asi, isolationInfo);
-  if (!v)
-    return TranslationSemantics::AssignFresh;
+  assert(v && "Only return none if we have a sendable value, but we checked "
+              "that earlier!");
 
   // If we already had a value for this alloc_stack (which we shouldn't
   // ever)... emit an unknown pattern error.
@@ -2789,7 +2829,9 @@ PartitionOpTranslator::visitAllocStackInst(AllocStackInst *asi) {
     return TranslationSemantics::Special;
   }
 
-  translateSILAssignFresh(v->first.getRepresentative().getValue());
+  // NOTE: To prevent an additional reinitialization by the canned AssignFresh
+  // code, we do our own assign fresh and return special.
+  builder.addAssignFresh(v->first.getRepresentative().getValue());
   return TranslationSemantics::Special;
 }
 

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -221,6 +221,15 @@ inferIsolationInfoForTempAllocStack(AllocStackInst *asi) {
 
   // Otherwise, lets see if we had a same block indirect result.
   if (state.sameBlockIndirectResultUses) {
+    // Check if this indirect result has a sending result. In such a case, we
+    // always return disconnected.
+    if (auto fas =
+            FullApplySite::isa(state.sameBlockIndirectResultUses->getUser())) {
+      if (fas.getSubstCalleeType()->hasSendingResult())
+        return SILIsolationInfo::getDisconnected(
+            false /*is unsafe non isolated*/);
+    }
+
     // If we do not have any writes in between the alloc stack and the
     // initializer, then we have a good target. Otherwise, we just return
     // AssignFresh.
@@ -338,6 +347,11 @@ inferIsolationInfoForTempAllocStack(AllocStackInst *asi) {
   // At this point, we know that we have a single indirect result use that
   // dominates all writes and other indirect result uses. We can say that our
   // alloc_stack temporary is that indirect result use's isolation.
+  if (auto fas = FullApplySite::isa(targetOperand->getUser())) {
+    if (fas.getSubstCalleeType()->hasSendingResult())
+      return SILIsolationInfo::getDisconnected(
+          false /*is unsafe non isolated*/);
+  }
   return SILIsolationInfo::get(targetOperand->getUser());
 }
 

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -348,21 +348,17 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
         return info;
     }
 
-    if (fas.hasSelfArgument()) {
-      auto &selfOp = fas.getSelfArgumentOperand();
-      CanType selfASTType = selfOp.get()->getType().getASTType();
+    if (auto *isolatedOp = fas.getIsolatedArgumentOperandOrNullPtr()) {
+      CanType selfASTType = isolatedOp->get()->getType().getASTType();
       selfASTType =
           selfASTType->lookThroughAllOptionalTypes()->getCanonicalType();
 
-      if (fas.getArgumentParameterInfo(selfOp).hasOption(
-              SILParameterInfo::Isolated)) {
-        if (auto *nomDecl = selfASTType->getAnyActor()) {
-          // TODO: We really should be doing this based off of an Operand. Then
-          // we would get the SILValue() for the first element. Today this can
-          // only mess up isolation history.
-          return SILIsolationInfo::getActorInstanceIsolated(
-              SILValue(), selfOp.get(), nomDecl);
-        }
+      if (auto *nomDecl = selfASTType->getAnyActor()) {
+        // TODO: We really should be doing this based off of an Operand. Then
+        // we would get the SILValue() for the first element. Today this can
+        // only mess up isolation history.
+        return SILIsolationInfo::getActorInstanceIsolated(
+            SILValue(), isolatedOp->get(), nomDecl);
       }
     }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9043,8 +9043,11 @@ static Expr *wrapAsyncLetInitializer(
   bool throws = TypeChecker::canThrow(cs.getASTContext(), initializer)
                   .has_value();
   bool hasSendingeResult = isSendingInitializer(initializer);
-  bool isSendable = !cs.getASTContext().LangOpts.hasFeature(
-      Feature::TransferringArgsAndResults);
+  bool isSendable =
+      !cs.getASTContext().LangOpts.hasFeature(Feature::RegionBasedIsolation);
+  assert((isSendable || cs.getASTContext().LangOpts.hasFeature(
+                            Feature::SendingArgsAndResults)) &&
+         "Region Isolation should imply SendingArgsAndResults");
   auto extInfo = ASTExtInfoBuilder()
                      .withAsync()
                      .withThrows(throws, /*FIXME:*/ Type())

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2541,9 +2541,13 @@ namespace {
           if (patternBindingDecl && patternBindingDecl->isAsyncLet()) {
             // Defer diagnosing checking of non-Sendable types that are passed
             // into async let to SIL level region based isolation if we have
-            // transferring and region based isolation enabled.
-            if (!ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation) ||
-                !ctx.LangOpts.hasFeature(Feature::TransferringArgsAndResults)) {
+            // region based isolation enabled.
+            //
+            // We purposely do not do this for SendingArgsAndResults since that
+            // just triggers the actual ability to represent
+            // 'sending'. RegionBasedIsolation is what determines if we get the
+            // differing semantics.
+            if (!ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation)) {
               diagnoseNonSendableTypes(
                   type, getDeclContext(),
                   /*inDerivedConformance*/Type(), capture.getLoc(),
@@ -3606,8 +3610,11 @@ namespace {
 
       // Check for sendability of the result type if we do not have a
       // transferring result.
-      if ((!ctx.LangOpts.hasFeature(Feature::TransferringArgsAndResults) ||
+      if ((!ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation) ||
            !fnType->hasSendingResult())) {
+        assert(ctx.LangOpts.hasFeature(Feature::SendingArgsAndResults) &&
+               "SendingArgsAndResults should be enabled if RegionIsolation is "
+               "enabled");
         // See if we are a autoclosure that has a direct callee that has the
         // same non-transferred type value returned. If so, do not emit an
         // error... we are going to emit an error on the call expr and do not

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -192,7 +192,7 @@ public struct AsyncStream<Element> {
     /// This can be called more than once and returns to the caller immediately
     /// without blocking for any awaiting consumption from the iteration.
     @discardableResult
-    public func yield(_ value: __owned Element) -> YieldResult {
+    public func yield(_ value: sending Element) -> YieldResult {
       storage.yield(value)
     }
 
@@ -422,11 +422,11 @@ extension AsyncStream.Continuation {
   /// blocking for any awaiting consumption from the iteration.
   @discardableResult
   public func yield(
-    with result: Result<Element, Never>
+    with result: __shared sending Result<Element, Never>
   ) -> YieldResult {
     switch result {
-      case .success(let val):
-        return storage.yield(val)
+    case .success(let val):
+      return storage.yield(val)
     }
   }
 
@@ -501,7 +501,7 @@ public struct AsyncStream<Element> {
     @discardableResult
     @available(SwiftStdlib 5.1, *)
     @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-    public func yield(_ value: __owned Element) -> YieldResult {
+    public func yield(_ value: sending Element) -> YieldResult {
       fatalError("Unavailable in task-to-thread concurrency model")
     }
     @available(SwiftStdlib 5.1, *)
@@ -571,7 +571,7 @@ extension AsyncStream.Continuation {
   @available(SwiftStdlib 5.1, *)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public func yield(
-    with result: Result<Element, Never>
+    with result: __shared sending Result<Element, Never>
   ) -> YieldResult {
     fatalError("Unavailable in task-to-thread concurrency model")
   }

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -214,7 +214,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     /// This can be called more than once and returns to the caller immediately
     /// without blocking for any awaiting consumption from the iteration.
     @discardableResult
-    public func yield(_ value: __owned Element) -> YieldResult {
+    public func yield(_ value: sending Element) -> YieldResult {
       storage.yield(value)
     }
 
@@ -463,7 +463,7 @@ extension AsyncThrowingStream.Continuation {
   /// blocking for any awaiting consumption from the iteration.
   @discardableResult
   public func yield(
-    with result: Result<Element, Failure>
+    with result: __shared sending Result<Element, Failure>
   ) -> YieldResult where Failure == Error {
     switch result {
     case .success(let val):
@@ -547,7 +547,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     @discardableResult
     @available(SwiftStdlib 5.1, *)
     @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-    public func yield(_ value: __owned Element) -> YieldResult {
+    public func yield(_ value: sending Element) -> YieldResult {
       fatalError("Unavailable in task-to-thread concurrency model")
     }
     @available(SwiftStdlib 5.1, *)
@@ -610,7 +610,7 @@ extension AsyncThrowingStream.Continuation {
   @available(SwiftStdlib 5.1, *)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public func yield(
-    with result: Result<Element, Failure>
+    with result: __shared sending Result<Element, Failure>
   ) -> YieldResult where Failure == Error {
     fatalError("Unavailable in task-to-thread concurrency model")
   }

--- a/test/ClangImporter/sending_objc.swift
+++ b/test/ClangImporter/sending_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -emit-sil -o /dev/null %s -parse-as-library -enable-experimental-feature TransferringArgsAndResults -verify -import-objc-header %S/Inputs/transferring.h
+// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -emit-sil -o /dev/null %s -parse-as-library -verify -import-objc-header %S/Inputs/transferring.h
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/ClangImporter/transferring.swift
+++ b/test/ClangImporter/transferring.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -emit-sil -o /dev/null %s -parse-as-library -enable-experimental-feature TransferringArgsAndResults -verify -import-objc-header %S/Inputs/transferring.h
+// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -emit-sil -o /dev/null %s -parse-as-library -verify -import-objc-header %S/Inputs/transferring.h
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/ClangImporter/transferring_objc.swift
+++ b/test/ClangImporter/transferring_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -emit-sil -o /dev/null %s -parse-as-library -enable-experimental-feature TransferringArgsAndResults -verify -import-objc-header %S/Inputs/transferring.h
+// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -emit-sil -o /dev/null %s -parse-as-library -verify -import-objc-header %S/Inputs/transferring.h
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/assumeIsolated.swift
+++ b/test/Concurrency/assumeIsolated.swift
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift -swift-version 5 %s -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -Xfrontend -verify
+// RUN: %target-build-swift -swift-version 5 %s -strict-concurrency=complete -Xfrontend -verify
 
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -1,7 +1,13 @@
+// First without any concurrency enabled.
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix without-transferring-
+
+// Then with targeted.
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix without-transferring-
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency -verify-additional-prefix without-transferring- -disable-transferring-args-and-results-with-region-based-isolation -disable-sending-args-and-results-with-region-based-isolation
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -disable-transferring-args-and-results-with-region-based-isolation -disable-sending-args-and-results-with-region-based-isolation -verify-additional-prefix without-transferring-
+
+// Then with strict concurrency without region isolation.
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency -verify-additional-prefix without-transferring-
+
+// Then strict-concurrency with everything.
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix tns-
 
 // REQUIRES: concurrency

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -7,8 +7,8 @@
 // Emit SIL with targeted concurrency.
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix without-transferring-
 
-// Emit SIL with strict concurrency + region based isolation but without transferring.
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns- -verify-additional-prefix without-transferring- -disable-transferring-args-and-results-with-region-based-isolation -disable-sending-args-and-results-with-region-based-isolation
+// Emit SIL with strict concurrency but without region based isolation
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns- -verify-additional-prefix without-transferring- -disable-region-based-isolation-with-strict-concurrency
 
 // Emit SIL with strict concurrency + region based isolation + transferring
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete  -verify-additional-prefix complete-tns-

--- a/test/Concurrency/issue-57376.swift
+++ b/test/Concurrency/issue-57376.swift
@@ -1,17 +1,5 @@
 // RUN: %target-swift-frontend -disable-availability-checking -strict-concurrency=targeted %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-and-complete-
-
-// NOTE: We test separately with region isolation and region isolation +
-// sending args and results since the semantics when sending args and
-// results are enabled is different since async let in such a case takes a
-// non-Sendable closure whose captures are transferred in while without it, we
-// leave the async let closure as sendable and use sema level checking.
-
-// No transferring.
-//
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete  -verify-additional-prefix tns- -verify-additional-prefix no-transferring-tns- -disable-transferring-args-and-results-with-region-based-isolation -disable-sending-args-and-results-with-region-based-isolation
-
-// With transferring.
-//
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete  -verify-additional-prefix tns- -verify-additional-prefix no-transferring-tns- -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix tns- -verify-additional-prefix transferring-tns-
 
 // REQUIRES: concurrency

--- a/test/Concurrency/sending_continuation.swift
+++ b/test/Concurrency/sending_continuation.swift
@@ -1,0 +1,105 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -verify %s -o /dev/null -parse-as-library
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+func useValue<T>(_ t: T) {}
+func useValueAsync<T>(_ t: T) async {}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+@MainActor
+func withCheckedContinuation_1() async -> NonSendableKlass {
+  await withCheckedContinuation { continuation in
+    continuation.resume(returning: NonSendableKlass())
+  }
+}
+
+@MainActor
+func withCheckedContinuation_2() async -> NonSendableKlass {
+  await withCheckedContinuation { continuation in
+    let x = NonSendableKlass()
+    continuation.resume(returning: x)
+    // expected-error @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{'x' used after being passed as a 'sending' parameter}}
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+}
+
+@MainActor
+func withCheckedContinuation_3() async {
+  // x is main actor isolated since withCheckedContinuation is #isolated.
+  let x = await withCheckedContinuation { continuation in
+    let x = NonSendableKlass()
+    continuation.resume(returning: x)
+    // expected-error @-1 {{sending 'x' risks causing data races}}
+    // expected-note @-2 {{'x' used after being passed as a 'sending' parameter}}
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+  await useValueAsync(x)
+  // expected-error @-1 {{sending 'x' risks causing data races}}
+  // expected-note @-2 {{sending main actor-isolated 'x' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+}
+
+@MainActor
+func withCheckedContinuation_4() async {
+  // x is main actor isolated since withCheckedContinuation is #isolated.
+  let y = NonSendableKlass()
+  let x = await withCheckedContinuation { continuation in
+    continuation.resume(returning: y)
+    // expected-error @-1 {{sending 'y' risks causing data races}}
+    // expected-note @-2 {{main actor-isolated 'y' is passed as a 'sending' parameter}}
+    useValue(y)
+  }
+  await useValueAsync(x)
+  // expected-error @-1 {{sending 'x' risks causing data races}}
+  // expected-note @-2 {{sending main actor-isolated 'x' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+}
+
+@MainActor func testAsyncStream() {
+  let (_, continuation) = AsyncStream.makeStream(of: NonSendableKlass.self)
+
+  continuation.yield(NonSendableKlass())
+  let x = NonSendableKlass()
+  continuation.yield(x) // expected-error {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{'x' used after being passed as a 'sending' parameter; Later uses could race}}
+  useValue(x) // expected-note {{access can happen concurrently}}
+}
+
+@MainActor func testAsyncStreamContinuation() {
+  let _ = AsyncStream(NonSendableKlass.self) { continuation in
+    continuation.yield(NonSendableKlass())
+    let x = NonSendableKlass()
+    continuation.yield(x) // expected-error {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{'x' used after being passed as a 'sending' parameter; Later uses could race}}
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+}
+
+@MainActor func testAsyncThrowingStream() {
+  let (_, continuation) = AsyncThrowingStream.makeStream(of: NonSendableKlass.self)
+
+  continuation.yield(NonSendableKlass())
+  let x = NonSendableKlass()
+  continuation.yield(x) // expected-error {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{'x' used after being passed as a 'sending' parameter; Later uses could race}}
+  useValue(x) // expected-note {{access can happen concurrently}}
+}
+
+@MainActor func testAsyncThrowingStreamContinuation() {
+  let _ = AsyncThrowingStream(NonSendableKlass.self) { continuation in
+    continuation.yield(NonSendableKlass())
+    let x = NonSendableKlass()
+    continuation.yield(x) // expected-error {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{'x' used after being passed as a 'sending' parameter; Later uses could race}}
+    useValue(x) // expected-note {{access can happen concurrently}}
+  }
+}

--- a/test/Concurrency/sending_mangling.swift
+++ b/test/Concurrency/sending_mangling.swift
@@ -82,3 +82,25 @@ extension SendingProtocol {
   // CHECK: sil hidden [ossa] @(extension in sending_mangling):sending_mangling.SendingProtocol.sendingArgWithFunctionSendingResult() -> (sending __owned sending_mangling.NonSendableKlass) -> () : $@convention(method) <Self where Self : SendingProtocol> (@in_guaranteed Self) -> @sil_sending @owned @callee_guaranteed (@sil_sending @owned NonSendableKlass) -> () {
   func sendingArgWithFunctionSendingResult() -> sending (sending NonSendableKlass) -> () { fatalError() }
 }
+
+// Make sure we only do not mangle in __shared if we are borrowed by default and
+// have sending.
+//
+// CHECK: sil hidden [ossa] @sending_mangling.sendingArgWithShared(sending_mangling.NonSendableKlass) -> () : $@convention(thin) (@sil_sending @guaranteed NonSendableKlass) -> () {
+func sendingArgWithShared(_ x: __shared sending NonSendableKlass) {}
+
+// CHECK: sil hidden [ossa] @sending_mangling.argWithShared(__shared sending_mangling.NonSendableKlass) -> () : $@convention(thin) (@guaranteed NonSendableKlass) -> () {
+func argWithShared(_ x: __shared NonSendableKlass) {}
+
+struct ConstructorSharedTest {
+  // Inits take their value at +1, so we need to mangle in shared even if we do
+  // not mangle in sending itself.
+  //
+  // CHECK: sil hidden [ossa] @sending_mangling.ConstructorSharedTest.init(__shared sending_mangling.NonSendableKlass) -> sending_mangling.ConstructorSharedTest : $@convention(method) (@sil_sending @guaranteed NonSendableKlass, @thin ConstructorSharedTest.Type) -> ConstructorSharedTest {
+  init(_ x: __shared sending NonSendableKlass) {}
+
+  // This is a func which takes its parameter at +0 so we should suppress both.
+  //
+  // CHECK: sil hidden [ossa] @sending_mangling.ConstructorSharedTest.functionSupressed(sending_mangling.NonSendableKlass) -> () : $@convention(method) (@sil_sending @guaranteed NonSendableKlass, ConstructorSharedTest) -> () {
+  func functionSupressed(_ x: __shared sending NonSendableKlass) {}
+}

--- a/test/Concurrency/sending_mangling.swift
+++ b/test/Concurrency/sending_mangling.swift
@@ -1,0 +1,84 @@
+// RUN: %target-swift-frontend %s -emit-silgen -swift-version 6 | swift-demangle | %FileCheck -check-prefix=CHECK %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+class NonSendableKlass {}
+
+struct S<T> {
+  var count: Int { 0 }
+}
+
+// CHECK: sil hidden [ossa] @sending_mangling.testRemoveFunctionArg(__owned sending_mangling.NonSendableKlass) -> () : $@convention(thin) (@sil_sending @owned NonSendableKlass) -> () {
+func testRemoveFunctionArg(_ x: sending NonSendableKlass) {}
+
+// CHECK: sil hidden [ossa] @sending_mangling.testNoRemoveFunctionArgSubTypeArg(__owned sending_mangling.S<(sending __owned sending_mangling.NonSendableKlass) -> ()>) -> () : $@convention(thin) (@sil_sending S<(sending NonSendableKlass) -> ()>) -> () {
+func testNoRemoveFunctionArgSubTypeArg(_ x: sending S<(sending NonSendableKlass) -> ()>) {}
+
+// CHECK: sil hidden [ossa] @sending_mangling.testNoRemoveFunctionArgSubTypeReturn(__owned sending_mangling.S<() -> sending sending_mangling.NonSendableKlass>) -> () : $@convention(thin) (@sil_sending S<() -> sending NonSendableKlass>) -> () {
+func testNoRemoveFunctionArgSubTypeReturn(_ x: sending S<() -> sending NonSendableKlass>) {}
+
+// CHECK: sil hidden [ossa] @sending_mangling.testRemoveFunctionResult() -> sending_mangling.NonSendableKlass : $@convention(thin) () -> @sil_sending @owned NonSendableKlass {
+func testRemoveFunctionResult() -> sending NonSendableKlass {
+}
+
+// CHECK: sil hidden [ossa] @sending_mangling.testNoRemoveFunctionResultSubTypeArg() -> sending_mangling.S<(sending __owned sending_mangling.NonSendableKlass) -> ()> : $@convention(thin) () -> @sil_sending S<(sending NonSendableKlass) -> ()> {
+func testNoRemoveFunctionResultSubTypeArg() -> sending S<(sending NonSendableKlass) -> ()> { fatalError() }
+
+// CHECK: sil hidden [ossa] @sending_mangling.testNoRemoveFunctionResultSubTypeResult() -> sending_mangling.S<() -> sending sending_mangling.NonSendableKlass> : $@convention(thin) () -> @sil_sending S<() -> sending NonSendableKlass> {
+func testNoRemoveFunctionResultSubTypeResult() -> sending S<() -> sending NonSendableKlass> { fatalError() }
+
+// We do not remove this since the sending is in the subtype of the result.
+// CHECK: sil hidden [ossa] @sending_mangling.testNoRemoveFunctionResultImmediateTypedFunctionWithArg() -> (sending __owned sending_mangling.NonSendableKlass) -> () : $@convention(thin) () -> @owned @callee_guaranteed (@sil_sending @owned NonSendableKlass) -> () {
+func testNoRemoveFunctionResultImmediateTypedFunctionWithArg() -> ((sending NonSendableKlass) -> ()) { fatalError() }
+
+// CHECK: sil hidden [ossa] @sending_mangling.testNoRemoveFunctionResultImmedateTypedFunctionWithResult() -> () -> sending sending_mangling.NonSendableKlass : $@convention(thin) () -> @owned @callee_guaranteed () -> @sil_sending @owned NonSendableKlass {
+func testNoRemoveFunctionResultImmedateTypedFunctionWithResult() -> (() -> sending NonSendableKlass) { fatalError() }
+
+struct MethodTest {
+  // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.testMethodRemoveFunctionArg(__owned sending_mangling.NonSendableKlass) -> () : $@convention(method) (@sil_sending @owned NonSendableKlass, MethodTest) -> () {
+  func testMethodRemoveFunctionArg(_ x: sending NonSendableKlass) {}
+  
+  // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.testNoRemoveFunctionArgSubTypeArg(__owned sending_mangling.S<(sending __owned sending_mangling.NonSendableKlass) -> ()>) -> () : $@convention(method) (@sil_sending S<(sending NonSendableKlass) -> ()>, MethodTest) -> () {
+  func testNoRemoveFunctionArgSubTypeArg(_ x: sending S<(sending NonSendableKlass) -> ()>) {}
+  
+  // DEMANGLE sil hidden [ossa] @sending_mangling.MethodTest.testNoRemoveFunctionArgSubTypeReturn(__owned sending_mangling.S<() -> sending sending_mangling.NonSendableKlass>) -> () : $@convention(method) (@sil_sending S<() -> sending NonSendableKlass>, MethodTest) -> () {
+  func testNoRemoveFunctionArgSubTypeReturn(_ x: sending S<() -> sending NonSendableKlass>) {}
+
+  // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.testMethodRemoveFunctionResult() -> sending_mangling.NonSendableKlass : $@convention(method) (MethodTest) -> @sil_sending @owned NonSendableKlass {
+  func testMethodRemoveFunctionResult() -> sending NonSendableKlass {
+  }
+
+  // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.testNoRemoveFunctionResultSubTypeArg() -> sending_mangling.S<(sending __owned sending_mangling.NonSendableKlass) -> ()> : $@convention(method) (MethodTest) -> @sil_sending S<(sending NonSendableKlass) -> ()> {
+  func testNoRemoveFunctionResultSubTypeArg() -> sending S<(sending NonSendableKlass) -> ()> { fatalError() }
+  
+  // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.testNoRemoveFunctionResultSubTypeResult() -> sending_mangling.S<() -> sending sending_mangling.NonSendableKlass> : $@convention(method) (MethodTest) -> @sil_sending S<() -> sending NonSendableKlass> {
+  func testNoRemoveFunctionResultSubTypeResult() -> sending S<() -> sending NonSendableKlass> { fatalError() }
+
+  // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.testNoRemoveFunctionResultImmediateTypedFunctionWithArg() -> (sending __owned sending_mangling.NonSendableKlass) -> () : $@convention(method) (MethodTest) -> @owned @callee_guaranteed (@sil_sending @owned NonSendableKlass) -> () {
+  func testNoRemoveFunctionResultImmediateTypedFunctionWithArg() -> ((sending NonSendableKlass) -> ()) { fatalError() }
+
+  // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.testNoRemoveFunctionResultImmedateTypedFunctionWithResult() -> () -> sending sending_mangling.NonSendableKlass : $@convention(method) (MethodTest) -> @owned @callee_guaranteed () -> @sil_sending @owned NonSendableKlass {
+  func testNoRemoveFunctionResultImmedateTypedFunctionWithResult() -> (() -> sending NonSendableKlass) { fatalError() }
+}
+
+protocol SendingProtocol {
+  func sendingArg(_ x: sending NonSendableKlass)
+  func sendingResult() -> sending NonSendableKlass
+  func sendingArgWithFunctionSendingArg(_ x: sending (sending NonSendableKlass) -> ())
+  func sendingArgWithFunctionSendingResult() -> sending (sending NonSendableKlass) -> ()
+}
+
+extension SendingProtocol {
+  // CHECK: sil hidden [ossa] @(extension in sending_mangling):sending_mangling.SendingProtocol.sendingArg(__owned sending_mangling.NonSendableKlass) -> () : $@convention(method) <Self where Self : SendingProtocol> (@sil_sending @owned NonSendableKlass, @in_guaranteed Self) -> () {
+  func sendingArg(_ x: sending NonSendableKlass) {}
+
+  // CHECK: sil hidden [ossa] @(extension in sending_mangling):sending_mangling.SendingProtocol.sendingResult() -> sending_mangling.NonSendableKlass : $@convention(method) <Self where Self : SendingProtocol> (@in_guaranteed Self) -> @sil_sending @owned NonSendableKlass {
+  func sendingResult() -> sending NonSendableKlass { fatalError() }
+
+  // CHECK: sil hidden [ossa] @(extension in sending_mangling):sending_mangling.SendingProtocol.sendingArgWithFunctionSendingArg(__owned (sending __owned sending_mangling.NonSendableKlass) -> ()) -> () : $@convention(method) <Self where Self : SendingProtocol> (@sil_sending @owned @noescape @callee_guaranteed (@sil_sending @owned NonSendableKlass) -> (), @in_guaranteed Self) -> () {
+  func sendingArgWithFunctionSendingArg(_ x: sending (sending NonSendableKlass) -> ()) {}
+
+  // CHECK: sil hidden [ossa] @(extension in sending_mangling):sending_mangling.SendingProtocol.sendingArgWithFunctionSendingResult() -> (sending __owned sending_mangling.NonSendableKlass) -> () : $@convention(method) <Self where Self : SendingProtocol> (@in_guaranteed Self) -> @sil_sending @owned @callee_guaranteed (@sil_sending @owned NonSendableKlass) -> () {
+  func sendingArgWithFunctionSendingResult() -> sending (sending NonSendableKlass) -> () { fatalError() }
+}

--- a/test/Concurrency/sending_mangling.swift
+++ b/test/Concurrency/sending_mangling.swift
@@ -36,6 +36,9 @@ func testNoRemoveFunctionResultImmediateTypedFunctionWithArg() -> ((sending NonS
 func testNoRemoveFunctionResultImmedateTypedFunctionWithResult() -> (() -> sending NonSendableKlass) { fatalError() }
 
 struct MethodTest {
+  // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.init(__owned sending_mangling.NonSendableKlass) -> sending_mangling.MethodTest : $@convention(method) (@sil_sending @owned NonSendableKlass, @thin MethodTest.Type) -> MethodTest {
+  init(_ x: sending NonSendableKlass) {}
+
   // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.testMethodRemoveFunctionArg(__owned sending_mangling.NonSendableKlass) -> () : $@convention(method) (@sil_sending @owned NonSendableKlass, MethodTest) -> () {
   func testMethodRemoveFunctionArg(_ x: sending NonSendableKlass) {}
   

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -transfer-non-sendable -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature TransferringArgsAndResults -strict-concurrency=complete %s -o /dev/null -verify
+// RUN: %target-sil-opt -transfer-non-sendable -strict-concurrency=complete %s -o /dev/null -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -375,3 +375,24 @@ bb0(%0 : @guaranteed $Self):
   return %9999 : $()
 }
 
+sil @closureForCheckedContinuation : $@convention(thin) <τ_0_0> (@in_guaranteed CheckedContinuation<τ_0_0, Never>) -> ()
+sil @withCheckedContinuation : $@convention(thin) @async <τ_0_0> (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @callee_guaranteed <τ_0_0> (@in_guaranteed CheckedContinuation<τ_0_0, Never>) -> ()) -> @sil_sending @out τ_0_0
+
+// We shouldn't emit any error here due to sil_sending.
+sil [ossa] @sending_result_from_callee : $@convention(thin) @async () -> () {
+bb0:
+  %0 = alloc_stack $NonSendableKlass
+  %1 = function_ref @closureForCheckedContinuation : $@convention(thin) <τ_0_0> (@in_guaranteed CheckedContinuation<τ_0_0, Never>) -> ()
+  %1a = thin_to_thick_function %1 : $@convention(thin) <τ_0_0> (@in_guaranteed CheckedContinuation<τ_0_0, Never>) -> ()  to $@noescape @callee_guaranteed <τ_0_0> (@in_guaranteed CheckedContinuation<τ_0_0, Never>) -> ()
+  %2 = enum $Optional<any Actor>, #Optional.none!enumelt
+  %3 = function_ref @withCheckedContinuation : $@convention(thin) @async <τ_0_0> (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @callee_guaranteed <τ_0_0> (@in_guaranteed CheckedContinuation<τ_0_0, Never>) -> ()) -> @sil_sending @out τ_0_0
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %3<NonSendableKlass>(%0, %2, %1a) : $@convention(thin) @async <τ_0_0> (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @callee_guaranteed <τ_0_0> (@in_guaranteed CheckedContinuation<τ_0_0, Never>) -> ()) -> @sil_sending @out τ_0_0
+
+  %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %f<NonSendableKlass>(%0) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+
+  destroy_addr %0 : $*NonSendableKlass
+  dealloc_stack %0 : $*NonSendableKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null -disable-region-based-isolation-with-strict-concurrency -enable-upcoming-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -verify %s -o /dev/null -parse-as-library -enable-experimental-feature TransferringArgsAndResults
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -verify %s -o /dev/null -parse-as-library
 
 // READ THIS: This test is testing specifically behavior around global actor
 // isolated types that are nonsendable. This is a bit of a corner case so we use

--- a/test/Concurrency/transfernonsendable_global_actor_sending.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_sending.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -verify %s -o /dev/null -parse-as-library
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -verify %s -o /dev/null -parse-as-library
 
 // README: Once we loosen the parser so that sending is rejected in Sema
 // instead of the parser, move into the normal

--- a/test/Concurrency/transfernonsendable_ownership.swift
+++ b/test/Concurrency/transfernonsendable_ownership.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-experimental-feature TransferringArgsAndResults %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -enable-upcoming-feature GlobalActorIsolatedTypesUsability %s -o /dev/null
 
 // This test validates the behavior of transfer non sendable around ownership
 // constructs like non copyable types, consuming/borrowing parameters, and inout

--- a/test/Concurrency/transfernonsendable_preconcurrency_sending.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency_sending.swift
@@ -7,10 +7,10 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/PreconcurrencyChecked.swiftmodule -module-name PreconcurrencyChecked %S/Inputs/transfernonsendable_preconcurrency_checked.swift -disable-availability-checking -swift-version 5 -strict-concurrency=complete
 
 // Test swift 5 with strict concurrency
-// RUN: %target-swift-frontend -swift-version 5 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-5- -parse-as-library -I %t -strict-concurrency=complete -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults
+// RUN: %target-swift-frontend -swift-version 5 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-5- -parse-as-library -I %t -strict-concurrency=complete -disable-availability-checking
 
 // Test swift 6
-// RUN: %target-swift-frontend -swift-version 6 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-6- -parse-as-library -I %t -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults
+// RUN: %target-swift-frontend -swift-version 6 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-6- -parse-as-library -I %t -disable-availability-checking
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_sending_params.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -parse-as-library -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -disable-availability-checking -strict-concurrency=complete -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_sending_results.swift
+++ b/test/Concurrency/transfernonsendable_sending_results.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -verify -enable-upcoming-feature RegionBasedIsolation %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_transferring_and_sending.swift
+++ b/test/Concurrency/transfernonsendable_transferring_and_sending.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -swift-version 6 -enable-experimental-feature TransferringArgsAndResults %s -verify
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 %s -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -swift-version 6 -enable-experimental-feature TransferringArgsAndResults
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -swift-version 6
 
 // REQUIRES: concurrency
 

--- a/test/Concurrency/transferring_conditional_suppression.swift
+++ b/test/Concurrency/transferring_conditional_suppression.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-upcoming-feature TransferringArgsAndResults -swift-version 5 -enable-library-evolution -module-name test -emit-module -o %t/test.swiftmodule -emit-module-interface-path - %s | %FileCheck %s
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -enable-library-evolution -module-name test -emit-module -o %t/test.swiftmodule -emit-module-interface-path - %s | %FileCheck %s
 
 public class NonSendableKlass {}
 

--- a/test/DebugInfo/sending_params_and_results.swift
+++ b/test/DebugInfo/sending_params_and_results.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-ir -g -o - -module-name test -strict-concurrency=complete -swift-version 5 -enable-upcoming-feature SendingArgsAndResults -disable-availability-checking %s | %FileCheck %s
+
+// Test that we can properly reconstruct sending from various tests when
+// emitting debug info. Only place examples in here that have already failed.
+
+public struct SendableStruct: Sendable {
+}
+
+// This verifies that we can properly type reconstruct:
+//
+//   $ss6ResultOy4test14SendableStructVs5Error_pGIeggT_D
+//
+// Which is:
+//
+//   @escaping @callee_guaranteed (@guaranteed sending Swift.Result<test.SendableStruct, Swift.Error>) -> ()
+//
+// CHECK: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$ss6ResultOy4test14SendableStructVs5Error_pGIeggT_D", flags: DIFlagFwdDecl, runtimeLang: DW_LANG_Swift)
+func testReconstructingEscapingClosureWithSendingParam() async throws -> SendableStruct {
+  func callSendableFunction(_ x: @Sendable () -> ()) {}
+
+  func helper(_ completion: @escaping (Result<SendableStruct, Swift.Error>) -> Void) {
+    fatalError()
+  }
+
+  return try await withCheckedThrowingContinuation { continuation in
+    callSendableFunction {
+      helper(continuation.resume(with:))
+    }
+  }
+}

--- a/test/Parse/parameter_specifier_before_param_name.swift
+++ b/test/Parse/parameter_specifier_before_param_name.swift
@@ -19,7 +19,6 @@ func foo(isolated x b: MyActor) {} // expected-warning {{'isolated' before a par
 
 func foo(_const x b: MyClass) {} // expected-warning {{'_const' before a parameter name is not allowed, place it before the parameter type instead; this is an error in the Swift 6 language mode}}
 
-// expected-error@+3 {{expected ',' separator}}
-// expected-error@+2 {{expected ':' following argument label and parameter name}}
 @available(SwiftStdlib 5.1, *)
-func foo(transferring x b: MyActor) {}
+func foo(transferring x b: MyActor) {} // expected-warning {{'transferring' before a parameter name is not allowed, place it before the parameter type instead}}
+// expected-warning @-1 {{'transferring' has been renamed to 'sending' and the 'transferring' spelling will be removed shortly}}

--- a/test/Parse/transferring.swift
+++ b/test/Parse/transferring.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -strict-concurrency=complete
 
 // REQUIRES: asserts
 

--- a/test/Runtime/demangleToMetadataTransferring.swift
+++ b/test/Runtime/demangleToMetadataTransferring.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -enable-experimental-feature TransferringArgsAndResults -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete  -Xfrontend -disable-availability-checking -parse-stdlib %s -module-name main -o %t/a.out
+// RUN: %target-build-swift -strict-concurrency=complete  -Xfrontend -disable-availability-checking -parse-stdlib %s -module-name main -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 

--- a/test/SIL/Parser/sending.sil
+++ b/test/SIL/Parser/sending.sil
@@ -1,4 +1,5 @@
-// RUN: %target-sil-opt -enable-upcoming-feature SendingArgsAndResults -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete %s | %target-sil-opt -enable-upcoming-feature SendingArgsAndResults -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete | %FileCheck %s
+// RUN: %target-sil-opt -strict-concurrency=complete %s | %target-sil-opt -strict-concurrency=complete | %FileCheck %s
+// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SIL/Parser/transferring.sil
+++ b/test/SIL/Parser/transferring.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-upcoming-feature TransferringArgsAndResults -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete %s | %target-sil-opt -enable-upcoming-feature TransferringArgsAndResults -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete | %FileCheck %s
+// RUN: %target-sil-opt -strict-concurrency=complete %s | %target-sil-opt -strict-concurrency=complete | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SIL/Serialization/sending.sil
+++ b/test/SIL/Serialization/sending.sil
@@ -1,9 +1,9 @@
 // First parse this and then emit a *.sib. Then read in the *.sib, then recreate
 
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt -enable-upcoming-feature TransferringArgsAndResults -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete %s -emit-sib -o %t/tmp.sib -module-name basic2
-// RUN: %target-sil-opt -enable-upcoming-feature TransferringArgsAndResults -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete %t/tmp.sib -o %t/tmp.2.sib -module-name basic2
-// RUN: %target-sil-opt -enable-upcoming-feature TransferringArgsAndResults -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete %t/tmp.2.sib -module-name basic2 -emit-sorted-sil | %FileCheck %s
+// RUN: %target-sil-opt -strict-concurrency=complete %s -emit-sib -o %t/tmp.sib -module-name basic2
+// RUN: %target-sil-opt -strict-concurrency=complete %t/tmp.sib -o %t/tmp.2.sib -module-name basic2
+// RUN: %target-sil-opt -strict-concurrency=complete %t/tmp.2.sib -module-name basic2 -emit-sorted-sil | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILGen/sending.swift
+++ b/test/SILGen/sending.swift
@@ -2,97 +2,111 @@
 
 class NonSendable {}
 
-// CHECK-LABEL: sil hidden [ossa] @$s7sending15returnsSendableSSyYTF : $@convention(thin) () -> @sil_sending @owned String {
+// CHECK-LABEL: sil hidden [ossa] @$s7sending15returnsSendableSSyF : $@convention(thin) () -> @sil_sending @owned String {
 func returnsSendable() -> sending String { fatalError() }
-// CHECK-LABEL: sil hidden [ossa] @$s7sending18returnsNonSendableAA0cD0CyYTF : $@convention(thin) () -> @sil_sending @owned NonSendable {
+
+// CHECK-LABEL: sil hidden [ossa] @$s7sending18returnsNonSendableAA0cD0CyF : $@convention(thin) () -> @sil_sending @owned NonSendable {
 func returnsNonSendable() -> sending NonSendable { fatalError() }
-// CHECK-LABEL: sil hidden [ossa] @$s7sending25genericReturnsNonSendablexyYTlF : $@convention(thin) <T> () -> @sil_sending @out T {
+
+// CHECK-LABEL: sil hidden [ossa] @$s7sending25genericReturnsNonSendablexylF : $@convention(thin) <T> () -> @sil_sending @out T {
 func genericReturnsNonSendable<T>() -> sending T { fatalError() }
 
 actor MyActor {
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending7MyActorC15returnsSendableSSyYTF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending7MyActorC15returnsSendableSSyF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @sil_sending @owned String {
   func returnsSendable() -> sending String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending7MyActorC18returnsNonSendableAA0eF0CyYTF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @sil_sending @owned NonSendable {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending7MyActorC18returnsNonSendableAA0eF0CyF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> sending NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending7MyActorC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@sil_isolated @guaranteed MyActor) -> @sil_sending @out T {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending7MyActorC25genericReturnsNonSendablexylF : $@convention(method) <T> (@sil_isolated @guaranteed MyActor) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> sending T { fatalError() }
 }
 
 struct Struct {
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV15returnsSendableSSyYTF : $@convention(method) (Struct) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV15returnsSendableSSyF : $@convention(method) (Struct) -> @sil_sending @owned String {
   func returnsSendable() -> sending String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV18returnsNonSendableAA0dE0CyYTF : $@convention(method) (Struct) -> @sil_sending @owned NonSendable {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV18returnsNonSendableAA0dE0CyF : $@convention(method) (Struct) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> sending NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (Struct) -> @sil_sending @out T {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV25genericReturnsNonSendablexylF : $@convention(method) <T> (Struct) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> sending T { fatalError() }
 }
 
 @MainActor
 struct MainActorStruct {
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending15MainActorStructV15returnsSendableSSyYTF : $@convention(method) (MainActorStruct) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending15MainActorStructV15returnsSendableSSyF : $@convention(method) (MainActorStruct) -> @sil_sending @owned String {
   func returnsSendable() -> sending String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending15MainActorStructV18returnsNonSendableAA0fG0CyYTF : $@convention(method) (MainActorStruct) -> @sil_sending @owned NonSendable {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending15MainActorStructV18returnsNonSendableAA0fG0CyF : $@convention(method) (MainActorStruct) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> sending NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending15MainActorStructV25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (MainActorStruct) -> @sil_sending @out T {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending15MainActorStructV25genericReturnsNonSendablexylF : $@convention(method) <T> (MainActorStruct) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> sending T { fatalError() }
 }
 
 class Class {
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending5ClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed Class) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending5ClassC15returnsSendableSSyF : $@convention(method) (@guaranteed Class) -> @sil_sending @owned String {
   func returnsSendable() -> sending String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending5ClassC18returnsNonSendableAA0dE0CyYTF : $@convention(method) (@guaranteed Class) -> @sil_sending @owned NonSendable {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending5ClassC18returnsNonSendableAA0dE0CyF : $@convention(method) (@guaranteed Class) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> sending NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending5ClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed Class) -> @sil_sending @out T {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending5ClassC25genericReturnsNonSendablexylF : $@convention(method) <T> (@guaranteed Class) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> sending T { fatalError() }
 }
 
 final class FinalClass {
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending10FinalClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed FinalClass) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending10FinalClassC15returnsSendableSSyF : $@convention(method) (@guaranteed FinalClass) -> @sil_sending @owned String {
   func returnsSendable() -> sending String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending10FinalClassC18returnsNonSendableAA0eF0CyYTF : $@convention(method) (@guaranteed FinalClass) -> @sil_sending @owned NonSendable {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending10FinalClassC18returnsNonSendableAA0eF0CyF : $@convention(method) (@guaranteed FinalClass) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> sending NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending10FinalClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed FinalClass) -> @sil_sending @out T {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending10FinalClassC25genericReturnsNonSendablexylF : $@convention(method) <T> (@guaranteed FinalClass) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> sending T { fatalError() }
 }
 
 @MainActor
 class MainActorClass {
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending14MainActorClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed MainActorClass) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending14MainActorClassC15returnsSendableSSyF : $@convention(method) (@guaranteed MainActorClass) -> @sil_sending @owned String {
   func returnsSendable() -> sending String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending14MainActorClassC18returnsNonSendableAA0fG0CyYTF : $@convention(method) (@guaranteed MainActorClass) -> @sil_sending @owned NonSendable {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending14MainActorClassC18returnsNonSendableAA0fG0CyF : $@convention(method) (@guaranteed MainActorClass) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> sending NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending14MainActorClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed MainActorClass) -> @sil_sending @out T {
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending14MainActorClassC25genericReturnsNonSendablexylF : $@convention(method) <T> (@guaranteed MainActorClass) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> sending T { fatalError() }
 }
 
 @MainActor
 final class FinalMainActorClass {
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending19FinalMainActorClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed FinalMainActorClass) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending19FinalMainActorClassC15returnsSendableSSyF : $@convention(method) (@guaranteed FinalMainActorClass) -> @sil_sending @owned String {
   func returnsSendable() -> sending String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending19FinalMainActorClassC18returnsNonSendableAA0gH0CyYTF : $@convention(method) (@guaranteed FinalMainActorClass) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending19FinalMainActorClassC18returnsNonSendableAA0gH0CyF : $@convention(method) (@guaranteed FinalMainActorClass) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> sending NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending19FinalMainActorClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed FinalMainActorClass) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending19FinalMainActorClassC25genericReturnsNonSendablexylF : $@convention(method) <T> (@guaranteed FinalMainActorClass) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> sending T { fatalError() }
 }
 
 enum Enum {
   case myCase
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending4EnumO15returnsSendableSSyYTF : $@convention(method) (Enum) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending4EnumO15returnsSendableSSyF : $@convention(method) (Enum) -> @sil_sending @owned String {
   func returnsSendable() -> sending String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending4EnumO18returnsNonSendableAA0dE0CyYTF : $@convention(method) (Enum) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending4EnumO18returnsNonSendableAA0dE0CyF : $@convention(method) (Enum) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> sending NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending4EnumO25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (Enum) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending4EnumO25genericReturnsNonSendablexylF : $@convention(method) <T> (Enum) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> sending T { fatalError() }
 }
 
 @MainActor
 enum MainActorEnum {
   case myCase
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending13MainActorEnumO15returnsSendableSSyYTF : $@convention(method) (MainActorEnum) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending13MainActorEnumO15returnsSendableSSyF : $@convention(method) (MainActorEnum) -> @sil_sending @owned String {
   func returnsSendable() -> sending String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending13MainActorEnumO18returnsNonSendableAA0fG0CyYTF : $@convention(method) (MainActorEnum) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending13MainActorEnumO18returnsNonSendableAA0fG0CyF : $@convention(method) (MainActorEnum) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> sending NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending13MainActorEnumO25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (MainActorEnum) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending13MainActorEnumO25genericReturnsNonSendablexylF : $@convention(method) <T> (MainActorEnum) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> sending T { fatalError() }
 }
 
@@ -103,19 +117,19 @@ protocol P {
 }
 
 extension P {
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending1PPAAE19protReturnsSendableSSyYTF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending1PPAAE19protReturnsSendableSSyF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @sil_sending @owned String {
   func protReturnsSendable() -> sending String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending1PPAAE22protReturnsNonSendableAA0dE0CyYTF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending1PPAAE22protReturnsNonSendableAA0dE0CyF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @sil_sending @owned NonSendable {
   func protReturnsNonSendable() -> sending NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending1PPAAE29protGenericReturnsNonSendableqd__yYTlF : $@convention(method) <Self where Self : P><T> (@in_guaranteed Self) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending1PPAAE29protGenericReturnsNonSendableqd__ylF : $@convention(method) <Self where Self : P><T> (@in_guaranteed Self) -> @sil_sending @out T {
   func protGenericReturnsNonSendable<T>() -> sending T { fatalError() }
 }
 
 extension Struct : P {
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV19protReturnsSendableSSyYTF : $@convention(method) (Struct) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV19protReturnsSendableSSyF : $@convention(method) (Struct) -> @sil_sending @owned String {
   func protReturnsSendable() -> sending String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV22protReturnsNonSendableAA0eF0CyYTF : $@convention(method) (Struct) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV22protReturnsNonSendableAA0eF0CyF : $@convention(method) (Struct) -> @sil_sending @owned NonSendable {
   func protReturnsNonSendable() -> sending NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV29protGenericReturnsNonSendablexyYTlF : $@convention(method) <T> (Struct) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s7sending6StructV29protGenericReturnsNonSendablexylF : $@convention(method) <T> (Struct) -> @sil_sending @out T {
   func protGenericReturnsNonSendable<T>() -> sending T { fatalError() }
 }

--- a/test/SILGen/transferring.swift
+++ b/test/SILGen/transferring.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults -strict-concurrency=complete %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -disable-availability-checking -strict-concurrency=complete %s | %FileCheck %s
 
 class NonSendable {}
 

--- a/test/SILGen/transferring.swift
+++ b/test/SILGen/transferring.swift
@@ -2,97 +2,97 @@
 
 class NonSendable {}
 
-// CHECK-LABEL: sil hidden [ossa] @$s12transferring15returnsSendableSSyYTF : $@convention(thin) () -> @sil_sending @owned String {
+// CHECK-LABEL: sil hidden [ossa] @$s12transferring15returnsSendableSSyF : $@convention(thin) () -> @sil_sending @owned String {
 func returnsSendable() -> transferring String { fatalError() }
-// CHECK-LABEL: sil hidden [ossa] @$s12transferring18returnsNonSendableAA0cD0CyYTF : $@convention(thin) () -> @sil_sending @owned NonSendable {
+// CHECK-LABEL: sil hidden [ossa] @$s12transferring18returnsNonSendableAA0cD0CyF : $@convention(thin) () -> @sil_sending @owned NonSendable {
 func returnsNonSendable() -> transferring NonSendable { fatalError() }
-// CHECK-LABEL: sil hidden [ossa] @$s12transferring25genericReturnsNonSendablexyYTlF : $@convention(thin) <T> () -> @sil_sending @out T {
+// CHECK-LABEL: sil hidden [ossa] @$s12transferring25genericReturnsNonSendablexylF : $@convention(thin) <T> () -> @sil_sending @out T {
 func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 
 actor MyActor {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC15returnsSendableSSyYTF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC15returnsSendableSSyF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @sil_sending @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC18returnsNonSendableAA0eF0CyYTF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC18returnsNonSendableAA0eF0CyF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@sil_isolated @guaranteed MyActor) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC25genericReturnsNonSendablexylF : $@convention(method) <T> (@sil_isolated @guaranteed MyActor) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 struct Struct {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV15returnsSendableSSyYTF : $@convention(method) (Struct) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV15returnsSendableSSyF : $@convention(method) (Struct) -> @sil_sending @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV18returnsNonSendableAA0dE0CyYTF : $@convention(method) (Struct) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV18returnsNonSendableAA0dE0CyF : $@convention(method) (Struct) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (Struct) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV25genericReturnsNonSendablexylF : $@convention(method) <T> (Struct) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 @MainActor
 struct MainActorStruct {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV15returnsSendableSSyYTF : $@convention(method) (MainActorStruct) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV15returnsSendableSSyF : $@convention(method) (MainActorStruct) -> @sil_sending @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV18returnsNonSendableAA0fG0CyYTF : $@convention(method) (MainActorStruct) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV18returnsNonSendableAA0fG0CyF : $@convention(method) (MainActorStruct) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (MainActorStruct) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV25genericReturnsNonSendablexylF : $@convention(method) <T> (MainActorStruct) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 class Class {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed Class) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC15returnsSendableSSyF : $@convention(method) (@guaranteed Class) -> @sil_sending @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC18returnsNonSendableAA0dE0CyYTF : $@convention(method) (@guaranteed Class) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC18returnsNonSendableAA0dE0CyF : $@convention(method) (@guaranteed Class) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed Class) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC25genericReturnsNonSendablexylF : $@convention(method) <T> (@guaranteed Class) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 final class FinalClass {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed FinalClass) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC15returnsSendableSSyF : $@convention(method) (@guaranteed FinalClass) -> @sil_sending @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC18returnsNonSendableAA0eF0CyYTF : $@convention(method) (@guaranteed FinalClass) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC18returnsNonSendableAA0eF0CyF : $@convention(method) (@guaranteed FinalClass) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed FinalClass) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC25genericReturnsNonSendablexylF : $@convention(method) <T> (@guaranteed FinalClass) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 @MainActor
 class MainActorClass {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed MainActorClass) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC15returnsSendableSSyF : $@convention(method) (@guaranteed MainActorClass) -> @sil_sending @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC18returnsNonSendableAA0fG0CyYTF : $@convention(method) (@guaranteed MainActorClass) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC18returnsNonSendableAA0fG0CyF : $@convention(method) (@guaranteed MainActorClass) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed MainActorClass) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC25genericReturnsNonSendablexylF : $@convention(method) <T> (@guaranteed MainActorClass) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 @MainActor
 final class FinalMainActorClass {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed FinalMainActorClass) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC15returnsSendableSSyF : $@convention(method) (@guaranteed FinalMainActorClass) -> @sil_sending @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC18returnsNonSendableAA0gH0CyYTF : $@convention(method) (@guaranteed FinalMainActorClass) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC18returnsNonSendableAA0gH0CyF : $@convention(method) (@guaranteed FinalMainActorClass) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed FinalMainActorClass) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC25genericReturnsNonSendablexylF : $@convention(method) <T> (@guaranteed FinalMainActorClass) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 enum Enum {
   case myCase
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO15returnsSendableSSyYTF : $@convention(method) (Enum) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO15returnsSendableSSyF : $@convention(method) (Enum) -> @sil_sending @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO18returnsNonSendableAA0dE0CyYTF : $@convention(method) (Enum) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO18returnsNonSendableAA0dE0CyF : $@convention(method) (Enum) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (Enum) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO25genericReturnsNonSendablexylF : $@convention(method) <T> (Enum) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 @MainActor
 enum MainActorEnum {
   case myCase
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO15returnsSendableSSyYTF : $@convention(method) (MainActorEnum) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO15returnsSendableSSyF : $@convention(method) (MainActorEnum) -> @sil_sending @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO18returnsNonSendableAA0fG0CyYTF : $@convention(method) (MainActorEnum) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO18returnsNonSendableAA0fG0CyF : $@convention(method) (MainActorEnum) -> @sil_sending @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (MainActorEnum) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO25genericReturnsNonSendablexylF : $@convention(method) <T> (MainActorEnum) -> @sil_sending @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
@@ -103,19 +103,19 @@ protocol P {
 }
 
 extension P {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE19protReturnsSendableSSyYTF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE19protReturnsSendableSSyF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @sil_sending @owned String {
   func protReturnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE22protReturnsNonSendableAA0dE0CyYTF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE22protReturnsNonSendableAA0dE0CyF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @sil_sending @owned NonSendable {
   func protReturnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE29protGenericReturnsNonSendableqd__yYTlF : $@convention(method) <Self where Self : P><T> (@in_guaranteed Self) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE29protGenericReturnsNonSendableqd__ylF : $@convention(method) <Self where Self : P><T> (@in_guaranteed Self) -> @sil_sending @out T {
   func protGenericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 extension Struct : P {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV19protReturnsSendableSSyYTF : $@convention(method) (Struct) -> @sil_sending @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV19protReturnsSendableSSyF : $@convention(method) (Struct) -> @sil_sending @owned String {
   func protReturnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV22protReturnsNonSendableAA0eF0CyYTF : $@convention(method) (Struct) -> @sil_sending @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV22protReturnsNonSendableAA0eF0CyF : $@convention(method) (Struct) -> @sil_sending @owned NonSendable {
   func protReturnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV29protGenericReturnsNonSendablexyYTlF : $@convention(method) <T> (Struct) -> @sil_sending @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV29protGenericReturnsNonSendablexylF : $@convention(method) <T> (Struct) -> @sil_sending @out T {
   func protGenericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }

--- a/test/Sema/transferring.swift
+++ b/test/Sema/transferring.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete
 
 // REQUIRES: asserts
 // REQUIRES: concurrency

--- a/test/Serialization/sending.swift
+++ b/test/Serialization/sending.swift
@@ -49,9 +49,8 @@ func main() {
   }
 }
 
-
-// CHECK: sil @$s17transferring_test0B12TransferringyS2SnYuYTF : $@convention(thin) (@sil_sending @owned String) -> @sil_sending @owned String
-// CHECK: sil @$s17transferring_test0B7SendingyS2SnYuYTF : $@convention(thin) (@sil_sending @owned String) -> @sil_sending @owned String
+// CHECK: sil @$s17transferring_test0B12TransferringyS2SnF : $@convention(thin) (@sil_sending @owned String) -> @sil_sending @owned String
+// CHECK: sil @$s17transferring_test0B7SendingyS2SnF : $@convention(thin) (@sil_sending @owned String) -> @sil_sending @owned String
 // CHECK: sil @$s17transferring_test0B16TransferringFuncyyySSnYuXEF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (@sil_sending @owned String) -> ()) -> ()
 // CHECK: sil @$s17transferring_test0B11SendingFuncyyySSnYuXEF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed (@sil_sending @owned String) -> ()) -> ()
 // CHECK: sil @$s17transferring_test0B22TransferringResultFuncyySSyYTXEF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @sil_sending @owned String) -> ()

--- a/test/Serialization/sending.swift
+++ b/test/Serialization/sending.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature TransferringArgsAndResults -module-name transferring_test -emit-module -o %t/transferring_test.swiftmodule %S/Inputs/sending.swift
-// RUN: %target-swift-frontend -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature TransferringArgsAndResults -module-name transferring -emit-sil -I %t %s | %FileCheck %s
-// RUN: %target-sil-opt -strict-concurrency=complete -module-name transferring_test -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature TransferringArgsAndResults %t/transferring_test.swiftmodule | %FileCheck -check-prefix=AST %s
+// RUN: %target-swift-frontend -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -module-name transferring_test -emit-module -o %t/transferring_test.swiftmodule %S/Inputs/sending.swift
+// RUN: %target-swift-frontend -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -module-name transferring -emit-sil -I %t %s | %FileCheck %s
+// RUN: %target-sil-opt -strict-concurrency=complete -module-name transferring_test -enable-upcoming-feature RegionBasedIsolation %t/transferring_test.swiftmodule | %FileCheck -check-prefix=AST %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -92,6 +92,11 @@ Func withCheckedContinuation(function:_:) has mangled name changing from '_Concu
 // AsyncStream.init(unfolding:onCancel:) uses @_silgen_name to preserve mangling after adding @preconcurrency.
 Constructor AsyncStream.init(unfolding:onCancel:) has mangled name changing from 'Swift.AsyncStream.init(unfolding: () async -> Swift.Optional<A>, onCancel: Swift.Optional<@Sendable () -> ()>) -> Swift.AsyncStream<A>' to 'Swift.AsyncStream.init(unfolding: () async -> Swift.Optional<A>, onCancel: Swift.Optional<() -> ()>) -> Swift.AsyncStream<A>'
 
+// We did not change the mangling, we did change from Default to Shared. Both
+// took their arg at +0, so there is no actual ABI difference.
+Func AsyncStream.Continuation.yield(with:) has parameter 0 changing from Default to Shared
+Func AsyncThrowingStream.Continuation.yield(with:) has parameter 0 changing from Default to Shared
+
 // SerialExecutor gained `enqueue(_: __owned Job)`, protocol requirements got default implementations
 Func SerialExecutor.enqueue(_:) has been added as a protocol requirement
 


### PR DESCRIPTION
[transferring] Change CheckedContinuation.resume and Async{Throwing,}Stream.yield to use transferring parameters.

Importantly, I used silgen_name to preserve the name since I have not yet
removed the mangling for transferring for named entities. This ensures that
this is an ABI neutral change until I make that other change.

rdar://120420024

