### PR TITLE
[Basic] Manually implement popcount when not available

### DIFF
--- a/include/swift/Basic/MathUtils.h
+++ b/include/swift/Basic/MathUtils.h
@@ -17,7 +17,9 @@
 #ifndef SWIFT_BASIC_MATH_UTILS_H
 #define SWIFT_BASIC_MATH_UTILS_H
 
+#include "Compiler.h"
 #include <cstddef>
+#include <cstdint>
 
 #if SWIFT_COMPILER_IS_MSVC
 #include <intrin.h>
@@ -38,11 +40,17 @@ static inline size_t roundUpToAlignMask(size_t size, size_t alignMask) {
 }
 
 static inline unsigned popcount(unsigned value) {
-#if SWIFT_COMPILER_IS_MSVC
+#if SWIFT_COMPILER_IS_MSVC && (defined(_M_IX86) || defined(_M_X64))
+  // The __popcnt intrinsic is only available when targetting x86{_64} with MSVC.
   return __popcnt(value);
-#else
-  // Assume we have a compiler with this intrinsic.
+#elif __has_builtin(__builtin_popcount)
   return __builtin_popcount(value);
+#else
+  // From llvm/ADT/bit.h which the runtime doesn't have access to (yet?)
+  uint32_t v = value;
+  v = v - ((v >> 1) & 0x55555555);
+  v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
+  return int(((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24);
 #endif
 }
 


### PR DESCRIPTION
MSVC doesn't provide the `__popcnt` intrinsic when targeting arm64 windows, so just manually implement popcount if neither intrinsic is available. Note, we can't include `llvm/ADT/bit.h` because this header doesn't exist for the runtime (yet?)