### PR TITLE
[Build] Pass in swift-syntax to SwiftPM

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1725,6 +1725,7 @@ function Build-PackageManager($Arch) {
       SwiftCollections_DIR = (Get-HostProjectCMakeModules Collections);
       SwiftASN1_DIR = (Get-HostProjectCMakeModules ASN1);
       SwiftCertificates_DIR = (Get-HostProjectCMakeModules Certificates);
+      SwiftSyntax_DIR = (Get-HostProjectCMakeModules Compilers);
       SQLite3_INCLUDE_DIR = "$LibraryRoot\sqlite-3.43.2\usr\include";
       SQLite3_LIBRARY = "$LibraryRoot\sqlite-3.43.2\usr\lib\SQLite3.lib";
     }


### PR DESCRIPTION
- **Explanation**: SwiftPM is using swift-syntax for its new manifest refactorings.
- **Scope**: Windows toolchain build
- **Risk**: Low, just adds another search path
- **Testing**: Checked that Swift still builds
- **Issue**: n/a
- **Reviewer**:   @bnbarham on https://github.com/apple/swift/pull/73267
