### PR TITLE
[SourceKit] Don't use SourceEntitityWalker for placeholder expansion

### DIFF
--- a/test/SourceKit/CodeExpand/code-expand-no-typecheck.swift
+++ b/test/SourceKit/CodeExpand/code-expand-no-typecheck.swift
@@ -1,0 +1,17 @@
+// RUN: %sourcekitd-test -req=expand-placeholder %s | %FileCheck %s
+
+// FIXME: Make it acccept '-debug-forbid-typecheck-prefix' and ensure no typecheck happens.'
+
+protocol MyProto {}
+
+enum MyEnum: Hashable, MyProto {
+  case foo
+  case bar
+}
+
+func test(array: [MyEnum]) -> [NyEnum] {
+  array.filter(<#T##isIncluded: (MyEnum) throws -> Bool##(MyEnum) throws -> Bool#>)
+// CHECK: array.filter { <#MyEnum#> in 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+}


### PR DESCRIPTION
Placeholder expansion should be a syntactic operation, but `SourceEntityWalker` can invoke type checking operations, which causes unexpected bahaviors including crashes.

rdar://121360941`
