### PR TITLE
[6.0] Consistently mark `borrowing` and `consuming` parameters for move-only checking when captured.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1150,8 +1150,12 @@ namespace {
       // See if we have a noncopyable address from a project_box or global.
       if (Value.getType().isAddress() && Value.getType().isMoveOnly()) {
         SILValue addr = Value.getValue();
-        auto box = dyn_cast<ProjectBoxInst>(addr);
-        if (box || isa<GlobalAddrInst>(addr) || IsLazyInitializedGlobal) {
+        auto boxProject = addr;
+        if (auto m = dyn_cast<CopyableToMoveOnlyWrapperAddrInst>(boxProject)) {
+          boxProject = m->getOperand();
+        }
+        auto box = dyn_cast<ProjectBoxInst>(boxProject);
+        if (box || isa<GlobalAddrInst>(boxProject) || IsLazyInitializedGlobal) {
           if (Enforcement)
             addr = enterAccessScope(SGF, loc, base, addr, getTypeData(),
                                     getAccessKind(), *Enforcement,

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1054,6 +1054,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
                                  uint16_t ArgNo) {
 
   auto *VD = cast<VarDecl>(capture.getDecl());
+  
   SILLocation Loc(VD);
   Loc.markAsPrologue();
 
@@ -1082,6 +1083,30 @@ static void emitCaptureArguments(SILGenFunction &SGF,
   auto &lowering = SGF.getTypeLowering(getVarTypeInCaptureContext());
   SILType ty = lowering.getLoweredType();
 
+  bool isNoImplicitCopy;
+  
+  if (ty.isTrivial(SGF.F) || ty.isMoveOnly()) {
+    isNoImplicitCopy = false;
+  } else if (VD->isNoImplicitCopy()) {
+    isNoImplicitCopy = true;
+  } else if (auto pd = dyn_cast<ParamDecl>(VD)) {
+    switch (pd->getSpecifier()) {
+    case ParamSpecifier::Borrowing:
+    case ParamSpecifier::Consuming:
+      isNoImplicitCopy = true;
+      break;
+    case ParamSpecifier::ImplicitlyCopyableConsuming:
+    case ParamSpecifier::Default:
+    case ParamSpecifier::InOut:
+    case ParamSpecifier::LegacyOwned:
+    case ParamSpecifier::LegacyShared:
+      isNoImplicitCopy = false;
+      break;
+    }
+  } else {
+    isNoImplicitCopy = false;
+  }
+    
   SILValue arg;
   SILFunctionArgument *box = nullptr;
 
@@ -1116,6 +1141,10 @@ static void emitCaptureArguments(SILGenFunction &SGF,
       addr->finishInitialization(SGF);
       val = addr->getManagedAddress();
     }
+    
+    if (isNoImplicitCopy && !val.getType().isMoveOnly()) {
+      val = SGF.B.createGuaranteedCopyableToMoveOnlyWrapperValue(VD, val);
+    }
 
     // If this constant is a move only type, we need to add no_consume_or_assign checking to
     // ensure that we do not consume this captured value in the function. This
@@ -1149,6 +1178,9 @@ static void emitCaptureArguments(SILGenFunction &SGF,
         SILType::getPrimitiveObjectType(boxTy), VD);
     box->setClosureCapture(true);
     arg = SGF.B.createProjectBox(VD, box, 0);
+    if (isNoImplicitCopy && !arg->getType().isMoveOnly()) {
+      arg = SGF.B.createCopyableToMoveOnlyWrapperAddr(VD, arg);
+    }
     break;
   }
   case CaptureKind::StorageAddress:
@@ -1169,6 +1201,33 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     auto *fArg = SGF.F.begin()->createFunctionArgument(ty, VD);
     fArg->setClosureCapture(true);
     arg = SILValue(fArg);
+    
+    if (isNoImplicitCopy && !arg->getType().isMoveOnly()) {
+      switch (argConv) {
+      case SILArgumentConvention::Indirect_Inout:
+      case SILArgumentConvention::Indirect_InoutAliasable:
+      case SILArgumentConvention::Indirect_In:
+      case SILArgumentConvention::Indirect_In_Guaranteed:
+      case SILArgumentConvention::Pack_Inout:
+      case SILArgumentConvention::Pack_Owned:
+      case SILArgumentConvention::Pack_Guaranteed:
+        arg = SGF.B.createCopyableToMoveOnlyWrapperAddr(VD, arg);
+        break;
+        
+      case SILArgumentConvention::Direct_Owned:
+        arg = SGF.B.createOwnedCopyableToMoveOnlyWrapperValue(VD, arg);
+        break;
+      
+      case SILArgumentConvention::Direct_Guaranteed:
+        arg = SGF.B.createGuaranteedCopyableToMoveOnlyWrapperValue(VD, arg);
+        break;
+      
+      case SILArgumentConvention::Direct_Unowned:
+      case SILArgumentConvention::Indirect_Out:
+      case SILArgumentConvention::Pack_Out:
+        llvm_unreachable("should be impossible");
+      }
+    }
 
     // If we have an inout noncopyable parameter, insert a consumable and
     // assignable.
@@ -1177,7 +1236,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     // in SIL since it is illegal to capture an inout value in an escaping
     // closure. The later code knows how to handle that we have the
     // mark_unresolved_non_copyable_value here.
-    if (isInOut && ty.isMoveOnly(/*orWrapped=*/false)) {
+    if (isInOut && arg->getType().isMoveOnly()) {
       arg = SGF.B.createMarkUnresolvedNonCopyableValueInst(
           Loc, arg,
           MarkUnresolvedNonCopyableValueInst::CheckKind::

--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -707,9 +707,11 @@ SourceAccess AccessEnforcementSelection::getSourceAccess(SILValue address) {
   if (auto *mmci = dyn_cast<MarkUnresolvedNonCopyableValueInst>(address))
     return getSourceAccess(mmci->getOperand());
 
-  // Recurse through moveonlywrapper_to_copyable_addr.
+  // Recur through moveonlywrapper_to_copyable_addr or vice versa.
   if (auto *m = dyn_cast<MoveOnlyWrapperToCopyableAddrInst>(address))
     return getSourceAccess(m->getOperand());
+  if (auto *c = dyn_cast<CopyableToMoveOnlyWrapperAddrInst>(address))
+    return getSourceAccess(c->getOperand());
 
   // Recurse through drop_deinit.
   if (auto *ddi = dyn_cast<DropDeinitInst>(address))

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -417,6 +417,11 @@ static bool visitScopeEndsRequiringInit(
     llvm_unreachable("invalid check!?");
   }
 
+  // Look through wrappers.
+  if (auto m = dyn_cast<CopyableToMoveOnlyWrapperAddrInst>(operand)) {
+    operand = m->getOperand();
+  }
+
   // Check for inout types of arguments that are marked with consumable and
   // assignable.
   if (auto *fArg = dyn_cast<SILFunctionArgument>(operand)) {
@@ -1006,6 +1011,7 @@ void UseState::initializeLiveness(
   // Then check if our markedValue is from an argument that is in,
   // in_guaranteed, inout, or inout_aliasable, consider the marked address to be
   // the initialization point.
+  bool beginsInitialized = false;
   {
     SILValue operand = address->getOperand();
     if (auto *c = dyn_cast<CopyableToMoveOnlyWrapperAddrInst>(operand))
@@ -1024,8 +1030,7 @@ void UseState::initializeLiveness(
                "an init... adding mark_unresolved_non_copyable_value as "
                "init!\n");
         // We cheat here slightly and use our address's operand.
-        recordInitUse(address, address, liveness.getTopLevelSpan());
-        liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
+        beginsInitialized = true;
         break;
       case swift::SILArgumentConvention::Indirect_Out:
         llvm_unreachable("Should never have out addresses here");
@@ -1038,6 +1043,22 @@ void UseState::initializeLiveness(
       case swift::SILArgumentConvention::Pack_Out:
         llvm_unreachable("Working with addresses");
       }
+    }
+  }
+
+  // A read or write access always begins on an initialized value.
+  if (auto access = dyn_cast<BeginAccessInst>(address->getOperand())) {
+    switch (access->getAccessKind()) {
+    case SILAccessKind::Deinit:
+    case SILAccessKind::Read:
+    case SILAccessKind::Modify:
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Found move only arg closure box use... "
+                    "adding mark_unresolved_non_copyable_value as init!\n");
+      beginsInitialized = true;
+      break;
+    case SILAccessKind::Init:
+      break;
     }
   }
 
@@ -1056,16 +1077,14 @@ void UseState::initializeLiveness(
         LLVM_DEBUG(llvm::dbgs()
                    << "Found move only arg closure box use... "
                       "adding mark_unresolved_non_copyable_value as init!\n");
-        recordInitUse(address, address, liveness.getTopLevelSpan());
-        liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
+        beginsInitialized = true;
       }
     } else if (auto *box = dyn_cast<AllocBoxInst>(
                    lookThroughOwnershipInsts(projectBox->getOperand()))) {
       LLVM_DEBUG(llvm::dbgs()
                  << "Found move only var allocbox use... "
                     "adding mark_unresolved_non_copyable_value as init!\n");
-      recordInitUse(address, address, liveness.getTopLevelSpan());
-      liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
+      beginsInitialized = true;
     }
   }
 
@@ -1076,8 +1095,7 @@ void UseState::initializeLiveness(
     LLVM_DEBUG(llvm::dbgs()
                << "Found ref_element_addr use... "
                   "adding mark_unresolved_non_copyable_value as init!\n");
-    recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
+    beginsInitialized = true;
   }
 
   // Check if our address is from a global_addr. In such a case, we treat the
@@ -1087,8 +1105,7 @@ void UseState::initializeLiveness(
     LLVM_DEBUG(llvm::dbgs()
                << "Found global_addr use... "
                   "adding mark_unresolved_non_copyable_value as init!\n");
-    recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
+    beginsInitialized = true;
   }
 
   if (auto *ptai = dyn_cast<PointerToAddressInst>(
@@ -1097,24 +1114,21 @@ void UseState::initializeLiveness(
     LLVM_DEBUG(llvm::dbgs()
                << "Found pointer to address use... "
                   "adding mark_unresolved_non_copyable_value as init!\n");
-    recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
+    beginsInitialized = true;
   }
   
   if (auto *bai = dyn_cast_or_null<BeginApplyInst>(
         stripAccessMarkers(address->getOperand())->getDefiningInstruction())) {
     LLVM_DEBUG(llvm::dbgs()
                << "Adding accessor coroutine begin_apply as init!\n");
-    recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
+    beginsInitialized = true;
   }
   
   if (auto *eai = dyn_cast<UncheckedTakeEnumDataAddrInst>(
           stripAccessMarkers(address->getOperand()))) {
     LLVM_DEBUG(llvm::dbgs()
                << "Adding enum projection as init!\n");
-    recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
+    beginsInitialized = true;
   }
 
   // Assume a strict check of a temporary or formal access is initialized
@@ -1124,32 +1138,33 @@ void UseState::initializeLiveness(
       asi && address->isStrict()) {
     LLVM_DEBUG(llvm::dbgs()
                << "Adding strict-marked alloc_stack as init!\n");
-    recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
+    beginsInitialized = true;
   }
 
   // Assume a strict-checked value initialized before the check.
   if (address->isStrict()) {
     LLVM_DEBUG(llvm::dbgs()
                << "Adding strict marker as init!\n");
-    recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
+    beginsInitialized = true;
   }
 
   // Assume a value whose deinit has been dropped has been initialized.
   if (auto *ddi = dyn_cast<DropDeinitInst>(address->getOperand())) {
     LLVM_DEBUG(llvm::dbgs()
                << "Adding copyable_to_move_only_wrapper as init!\n");
-    recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
+    beginsInitialized = true;
   }
 
   // Assume a value wrapped in a MoveOnlyWrapper is initialized.
   if (auto *m2c = dyn_cast<CopyableToMoveOnlyWrapperAddrInst>(address->getOperand())) {
     LLVM_DEBUG(llvm::dbgs()
                << "Adding copyable_to_move_only_wrapper as init!\n");
+    beginsInitialized = true;
+  }
+  
+  if (beginsInitialized) {
     recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());    
+    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
   }
 
   // Now that we have finished initialization of defs, change our multi-maps

--- a/test/SILOptimizer/moveonly_copyable_wrapper_capture.swift
+++ b/test/SILOptimizer/moveonly_copyable_wrapper_capture.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+class Class {}
+//struct Class : ~Copyable {}
+
+func consume(_: consuming Class) {}
+func nonescapingClosure(_ body: () -> ()) {
+    body()
+}
+
+func testNonescapingCaptureConsuming(x: consuming Class) { // expected-error{{}}
+    nonescapingClosure { consume(x) } // expected-note{{consumed here}}
+}
+
+// TODO: `defer` should be allowed to consume local bindings
+func testDeferCaptureConsuming(x: consuming Class) { // expected-error{{}}
+    defer { consume(x) } // expected-note{{consumed here}}
+    do {}
+}
+
+func testLocalFunctionCaptureConsuming(x: consuming Class) {
+    func local() {
+        consume(x) // expected-error{{cannot be consumed when captured by an escaping closure}}
+    }
+}
+
+func testNonescapingCaptureBorrowing(x: borrowing Class) { // expected-error{{}}
+    nonescapingClosure { consume(x) } // expected-note{{consumed here}}
+}
+
+func testDeferCaptureBorrowing(x: borrowing Class) { // expected-error{{}}
+    defer { consume(x) } // expected-note{{consumed here}}
+    do {}
+}
+
+func testLocalFunctionCaptureBorrowing(x: borrowing Class) { // expected-error{{borrowed and cannot be consumed}}
+    func local() {
+        consume(x) // expected-note{{consumed here}}
+    }
+}

--- a/test/SILOptimizer/noimplicitcopy.swift
+++ b/test/SILOptimizer/noimplicitcopy.swift
@@ -1977,11 +1977,11 @@ public func closureClassUseAfterConsumeArg(_ argX: Klass) {
 }
 
 public func closureCaptureClassUseAfterConsume(_ x: Klass) {
-    @_noImplicitCopy let x2 = x
+    @_noImplicitCopy let x2 = x // expected-error{{}}
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note{{consumed here}}
+        print(x2) // expected-note{{consumed here}}
     }
     f()
 }
@@ -1989,9 +1989,9 @@ public func closureCaptureClassUseAfterConsume(_ x: Klass) {
 public func closureCaptureClassUseAfterConsumeError(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     let f = { // expected-note {{consumed here}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classUseMoveOnlyWithoutEscaping(copy x2)
+        classConsume(copy x2)
+        print(copy x2)
     }
     f()
     let x3 = x2 // expected-note {{consumed again here}}
@@ -2002,8 +2002,8 @@ public func closureCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) 
     // expected-error @-1 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     let f = { // expected-note {{closure capturing 'x2' here}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(copy x2)
+        print(copy x2)
     }
     f()
 }
@@ -2011,8 +2011,8 @@ public func closureCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) 
 public func closureCaptureClassOwnedArgUseAfterConsume(@_noImplicitCopy _ x2: __owned Klass) {
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(copy x2)
+        print(copy x2)
     }
     f()
 }
@@ -2020,8 +2020,8 @@ public func closureCaptureClassOwnedArgUseAfterConsume(@_noImplicitCopy _ x2: __
 public func closureCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     let f = { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(copy x2)
+        print(copy x2)
     }
     f()
     let x3 = x2 // expected-note {{consumed again here}}
@@ -2032,8 +2032,8 @@ public func deferCaptureClassUseAfterConsume(_ x: Klass) {
     @_noImplicitCopy let x2 = x
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(copy x2)
+        print(copy x2)
     }
     print(x)
 }
@@ -2042,8 +2042,8 @@ public func deferCaptureClassUseAfterConsume2(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     defer { // expected-note {{used here}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(copy x2)
+        print(copy x2)
     }
     let x3 = x2 // expected-note {{consumed here}}
     let _ = x3
@@ -2053,8 +2053,8 @@ public func deferCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) {
     classUseMoveOnlyWithoutEscaping(x2)
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(copy x2)
+        print(copy x2)
     }
     print("foo")
 }
@@ -2062,8 +2062,8 @@ public func deferCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) {
 public func deferCaptureClassOwnedArgUseAfterConsume(@_noImplicitCopy _ x2: __owned Klass) {
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(copy x2)
+        print(copy x2)
     }
     print("foo")
 }
@@ -2071,8 +2071,8 @@ public func deferCaptureClassOwnedArgUseAfterConsume(@_noImplicitCopy _ x2: __ow
 public func deferCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' used after consume}}
     defer { // expected-note {{used here}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(copy x2)
+        print(copy x2)
     }
     print(x2) // expected-note {{consumed here}}
 }
@@ -2082,8 +2082,8 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: Klass) {
     let f = {
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(copy x2)
+            print(copy x2)
         }
         print("foo")
     }
@@ -2093,11 +2093,11 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: Klass) {
 public func closureAndDeferCaptureClassUseAfterConsume2(_ x: Klass) {
     @_noImplicitCopy let x2 = x
     let f = {
-        classConsume(x2)
+        classConsume(copy x2)
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(copy x2)
+            print(copy x2)
         }
         print("foo")
     }
@@ -2107,11 +2107,11 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: Klass) {
 public func closureAndDeferCaptureClassUseAfterConsume3(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     let f = { // expected-note {{consumed here}}
-        classConsume(x2)
+        classConsume(copy x2)
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(copy x2)
+            print(copy x2)
         }
         print("foo")
     }
@@ -2124,8 +2124,8 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2:
     let f = { // expected-note {{closure capturing 'x2' here}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(copy x2)
+            print(copy x2)
         }
         print("foo")
     }
@@ -2136,8 +2136,8 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(@_noImplicitCopy 
     let f = {
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(copy x2)
+            print(copy x2)
         }
         print("foo")
     }
@@ -2148,8 +2148,8 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy
     let f = { // expected-note {{consumed here}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(copy x2)
+            print(copy x2)
         }
         print("foo")
     }
@@ -2158,12 +2158,13 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy
 }
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: Klass) {
-    @_noImplicitCopy let x2 = x
+    // TODO: why is `g` considered escaping?
+    @_noImplicitCopy let x2 = x // expected-error{{cannot be captured}}
     let f = {
-        let g = {
+        let g = { // expected-note{{capturing 'x2' here}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(copy x2)
+            print(copy x2)
         }
         g()
     }
@@ -2171,12 +2172,12 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: Klass) {
 }
 
 public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}} expected-error {{cannot be captured}}
     let f = { // expected-note {{consumed here}}
-        let g = {
+        let g = { // expected-note{{capturing 'x2' here}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(copy x2)
+            print(copy x2)
         }
         g()
     }
@@ -2185,37 +2186,37 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) {
 }
 
 
-public func closureAndClosureCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) {
+public func closureAndClosureCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) { // expected-error{{cannot be captured by an escaping closure}}
     // expected-error @-1 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     let f = { // expected-note {{closure capturing 'x2' here}}
-        let g = {
+        let g = { // expected-note{{capturing 'x2' here}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(copy x2)
+            print(copy x2)
         }
         g()
     }
     f()
 }
 
-public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(@_noImplicitCopy _ x2: __owned Klass) {
+public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(@_noImplicitCopy _ x2: __owned Klass) { // expected-error{{cannot be captured by an escaping closure}}
     let f = {
-        let g = {
+        let g = { // expected-note{{closure capturing 'x2' here}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(copy x2)
+            print(copy x2)
         }
         g()
     }
     f()
 }
 
-public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
+public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}} expected-error{{cannot be captured}}
     let f = { // expected-note {{consumed here}}
-        let g = {
+        let g = { // expected-note{{capturing 'x2' here}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(copy x2)
+            print(copy x2)
         }
         g()
     }

--- a/test/SILOptimizer/noimplicitcopy_borrowing_parameters.swift
+++ b/test/SILOptimizer/noimplicitcopy_borrowing_parameters.swift
@@ -399,7 +399,7 @@ struct LoadableSelfTest {
         // expected-error @-1 {{'self' cannot be captured by an escaping closure since it is a borrowed parameter}}
         var f: () -> () = {}
         f = { // expected-note {{closure capturing 'self' here}}
-            let _ = self
+            let _ = copy self
         }
         f()
     }
@@ -477,7 +477,7 @@ struct AddressOnlySelfTest<T> {
         // TODO: Capture.
         var f: () -> () = {}
         f = { // expected-note {{consumed here}}
-            let _ = self
+            let _ = copy self
         }
         f()
     }

--- a/test/SILOptimizer/noimplicitcopy_consuming_parameters.swift
+++ b/test/SILOptimizer/noimplicitcopy_consuming_parameters.swift
@@ -146,7 +146,7 @@ func testLoadableConsumingCallMethodSelfMutating(_ x: consuming NonTrivialStruct
 func testLoadableConsumingEscapingClosure(_ x: consuming NonTrivialStruct) {
     var f: () -> () = {}
     f = {
-        _ = x
+        _ = x // expected-error{{noncopyable 'x' cannot be consumed when captured by an escaping closure}}
     }
     _ = f
 }
@@ -155,7 +155,7 @@ func testLoadableConsumingEscapingClosure2(_ x: consuming NonTrivialStruct) {
     _ = x // expected-error {{noncopyable 'x' cannot be consumed when captured by an escaping closure}}
     var f: () -> () = {}
     f = {
-        _ = x
+        _ = x // expected-error{{noncopyable 'x' cannot be consumed when captured by an escaping closure}}
     }
     _ = f
 }
@@ -163,25 +163,26 @@ func testLoadableConsumingEscapingClosure2(_ x: consuming NonTrivialStruct) {
 func testLoadableConsumingEscapingClosure3(_ x: consuming NonTrivialStruct) {
     var f: () -> () = {}
     f = {
-        _ = x
+        _ = x // expected-error{{noncopyable 'x' cannot be consumed when captured by an escaping closure}}
     }
     _ = f
     _ = x // expected-error {{noncopyable 'x' cannot be consumed when captured by an escaping closure}}
 }
 
-func testLoadableConsumingNonEscapingClosure(_ x: consuming NonTrivialStruct) {
+func testLoadableConsumingNonEscapingClosure(_ x: consuming NonTrivialStruct) { // expected-error{{}}
     func useNonEscaping(_ f: () -> ()) {}
     useNonEscaping {
-        _ = x
+        _ = x // expected-note{{consumed here}}
     }
 }
 
 func testLoadableConsumingNonEscapingClosure2(_ x: consuming NonTrivialStruct) {
     // expected-error @-1 {{'x' used after consume}}
+    // expected-error @-2 {{}}
     let _ = x // expected-note {{consumed here}}
     func useNonEscaping(_ f: () -> ()) {}
     useNonEscaping { // expected-note {{used here}}
-        _ = x
+        _ = x // expected-note {{consumed here}}
     }
 }
 
@@ -439,7 +440,7 @@ func testAddressOnlyConsumingCallMethodSelfConsuming<T : P>(_ x: consuming Gener
 func testAddressOnlyConsumingEscapingClosure<T : P>(_ x: consuming GenericNonTrivialStruct<T>) {
     var f: () -> () = {}
     f = {
-        _ = x
+        _ = copy x
     }
     _ = f
 }
@@ -448,7 +449,7 @@ func testAddressOnlyConsumingEscapingClosure2<T : P>(_ x: consuming GenericNonTr
     let _ = x // expected-error {{noncopyable 'x' cannot be consumed when captured by an escaping closure}}
     var f: () -> () = {}
     f = {
-        _ = x
+        _ = copy x
     }
     _ = f
 }
@@ -456,7 +457,7 @@ func testAddressOnlyConsumingEscapingClosure2<T : P>(_ x: consuming GenericNonTr
 func testAddressOnlyConsumingEscapingClosure3<T : P>(_ x: consuming GenericNonTrivialStruct<T>) {
     var f: () -> () = {}
     f = {
-        _ = x
+        _ = copy x
     }
     _ = f
     let _ = x // expected-error {{noncopyable 'x' cannot be consumed when captured by an escaping closure}}
@@ -465,7 +466,7 @@ func testAddressOnlyConsumingEscapingClosure3<T : P>(_ x: consuming GenericNonTr
 func testAddressOnlyConsumingNonEscapingClosure<T : P>(_ x: consuming GenericNonTrivialStruct<T>) {
     func useNonEscaping(_ f: () -> ()) {}
     useNonEscaping {
-        _ = x
+        _ = copy x
     }
 }
 
@@ -474,7 +475,7 @@ func testAddressOnlyConsumingNonEscapingClosure2<T : P>(_ x: consuming GenericNo
     let _ = x // expected-note {{consumed here}}
     func useNonEscaping(_ f: () -> ()) {}
     useNonEscaping { // expected-note {{used here}}
-        _ = x
+        _ = copy x
     }
 }
 
@@ -645,7 +646,7 @@ struct LoadableSelfTest {
     consuming func testCallEscapingClosure() {
         var f: () -> () = {}
         f = {
-            let _ = self
+            let _ = copy self
         }
         f()
     }
@@ -654,7 +655,7 @@ struct LoadableSelfTest {
         let _ = self // expected-error {{noncopyable 'self' cannot be consumed when captured by an escaping closure}}
         var f: () -> () = {}
         f = {
-            let _ = self
+            let _ = copy self
         }
         f()
     }
@@ -662,7 +663,7 @@ struct LoadableSelfTest {
     consuming func testCallEscapingClosure3() {
         var f: () -> () = {}
         f = {
-            let _ = self
+            let _ = copy self
         }
         f()
         let _ = self // expected-error {{noncopyable 'self' cannot be consumed when captured by an escaping closure}}
@@ -671,7 +672,7 @@ struct LoadableSelfTest {
     consuming func testCallNonEscapingClosure() {
         func f(_ x: () -> ()) {}
         f {
-            _ = self
+            _ = copy self
         }
     }
 
@@ -680,7 +681,7 @@ struct LoadableSelfTest {
         let _ = self // expected-note {{consumed here}}
         func f(_ x: () -> ()) {}
         f { // expected-note {{used here}}
-            _ = self
+            _ = copy self
         }
     }
 
@@ -689,7 +690,7 @@ struct LoadableSelfTest {
         self = LoadableSelfTest()
         func f(_ x: () -> ()) {}
         f {
-            _ = self
+            _ = copy self
         }
     }
 }
@@ -803,7 +804,7 @@ struct AddressOnlySelfTest<T> {
     consuming func testCallEscapingClosure() {
         var f: () -> () = {}
         f = {
-            let _ = self
+            let _ = copy self
         }
         f()
     }
@@ -812,7 +813,7 @@ struct AddressOnlySelfTest<T> {
         let _ = self // expected-error {{noncopyable 'self' cannot be consumed when captured by an escaping closure}}
         var f: () -> () = {}
         f = {
-            let _ = self
+            let _ = copy self
         }
         f()
     }
@@ -820,7 +821,7 @@ struct AddressOnlySelfTest<T> {
     consuming func testCallEscapingClosure3() {
         var f: () -> () = {}
         f = {
-            let _ = self
+            let _ = copy self
         }
         f()
         let _ = self // expected-error {{noncopyable 'self' cannot be consumed when captured by an escaping closure}}
@@ -829,11 +830,11 @@ struct AddressOnlySelfTest<T> {
     consuming func testCallEscapingClosure4() {
         var f: () -> () = {}
         f = {
-            let _ = self
+            let _ = copy self
         }
         f()
         f = {
-            let _ = self
+            let _ = copy self
         }
         let _ = self // expected-error {{noncopyable 'self' cannot be consumed when captured by an escaping closure}}
     }
@@ -841,7 +842,7 @@ struct AddressOnlySelfTest<T> {
     consuming func testCallNonEscapingClosure() {
         func f(_ x: () -> ()) {}
         f {
-            _ = self
+            _ = copy self
         }
     }
 
@@ -850,10 +851,10 @@ struct AddressOnlySelfTest<T> {
         let _ = self // expected-note {{consumed here}}
         func f(_ x: () -> ()) {}
         f { // expected-note {{used here}}
-            _ = self
+            _ = copy self
         }
         f {
-            _ = self
+            _ = copy self
         }
     }
 }


### PR DESCRIPTION
Explanation: Fixes a miscompile when a `borrowing` or `consuming` parameter is captured by a closure and incorrectly consumed or modified in the closure body, by diagnosing the error instead of letting it slip by.
Scope: Fixes a miscompile
Issue: rdar://127382105
Original PR: https://github.com/apple/swift/pull/73380
Risk: Medium-low. This may cause existing code to be rejected, but the existing code would be getting miscompiled with previous compilers.
Testing: Swift CI, test case from bug report
Reviewer: @kavon 