### PR TITLE
[6.0] Lost variables statistics + Fix -Onone

### DIFF
--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -302,6 +302,13 @@ with the proper attributes to ensure they'll be available in the debugger. In
 particular, if you see `SWIFT_DEBUG_DUMP` in a class declaration, that class
 has a `dump()` method you can call.
 
+### Pass statistics
+
+There are options to output a lot of different statistics, including about
+SIL passes. More information is available in
+[Compiler Performance](CompilerPerformance.md) for the unified statistics, and
+[Optimizer Counter Analysis](OptimizerCountersAnalysis.md) for pass counters.
+
 ## Debugging and Profiling on SIL level
 
 ### SIL source level profiling

--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -260,7 +260,7 @@ If one builds swift using ninja and wants to dump the SIL of the
 stdlib using some of the SIL dumping options from the previous
 section, one can use the following one-liner:
 
-    ninja -t commands | grep swiftc | grep Swift.o | grep " -c "
+    ninja -t commands | grep swiftc | grep 'Swift\.o'
 
 This should give one a single command line that one can use for
 Swift.o, perfect for applying the previous sections options to.

--- a/docs/HowToUpdateDebugInfo.md
+++ b/docs/HowToUpdateDebugInfo.md
@@ -255,7 +255,8 @@ debug_value %1 : $Int, var, name "pair", type $Pair, expr op_fragment:#Pair.a //
 
 ## Rules of thumb
 - Optimization passes may never drop a variable entirely. If a variable is
-  entirely optimized away, an `undef` debug value should still be kept.
+  entirely optimized away, an `undef` debug value should still be kept. The only
+  exception is an unreachable function or scope, which is entirely removed.
 - A `debug_value` must always describe a correct value for that source variable
   at that source location. If a value is only correct on some paths through that
   instruction, it must be replaced with `undef`. Debug info never speculates.
@@ -263,3 +264,9 @@ debug_value %1 : $Int, var, name "pair", type $Pair, expr op_fragment:#Pair.a //
   capture the effect of the deleted instruction in a debug expression, so the
   location can be preserved. You can also use an `InstructionDeleter` which will
   automatically call `salvageDebugInfo`.
+
+> [!Tip]
+> To detect when a pass drops a variable, you can use the
+> `-Xllvm -sil-stats-lost-variables` to print when a variable is lost by a pass.
+> More information about this option is available in
+> [Optimizer Counter Analysis](OptimizerCountersAnalysis.md)

--- a/docs/HowToUpdateDebugInfo.md
+++ b/docs/HowToUpdateDebugInfo.md
@@ -16,6 +16,11 @@ merge drop and copy locations, since all the same considerations apply. Helpers
 like `SILBuilderWithScope` make it easy to copy source locations when expanding
 SIL instructions.
 
+> [!Warning]
+> Don't use `SILBuilderWithScope` when replacing a single instruction of type
+> `AllocStackInst` or `DebugValueInst`. These meta instructions are skipped,
+> so the wrong scope will be inferred.
+
 ## Variables
 
 Each `debug_value` (and variable-carrying instruction) defines an update point
@@ -254,16 +259,34 @@ debug_value %1 : $Int, var, name "pair", type $Pair, expr op_fragment:#Pair.a //
 ```
 
 ## Rules of thumb
-- Optimization passes may never drop a variable entirely. If a variable is
-  entirely optimized away, an `undef` debug value should still be kept. The only
-  exception is an unreachable function or scope, which is entirely removed.
-- A `debug_value` must always describe a correct value for that source variable
-  at that source location. If a value is only correct on some paths through that
-  instruction, it must be replaced with `undef`. Debug info never speculates.
-- When a SIL instruction is deleted, call salvageDebugInfo(). It will try to
-  capture the effect of the deleted instruction in a debug expression, so the
-  location can be preserved. You can also use an `InstructionDeleter` which will
-  automatically call `salvageDebugInfo`.
+
+### Correctness
+A `debug_value` must always describe a correct value for that source variable
+at that source location. If a value is only correct on some paths through that
+instruction, it must be replaced with `undef`. Debug info never speculates.
+
+### Don't drop debug info
+
+Optimization passes may never drop a variable entirely. If a variable is
+entirely optimized away, an `undef` debug value should still be kept. The only
+exception is when the variable is in an unreachable function or scope, where it
+can be removed with the rest of the instructions.
+
+### Instruction Deletion
+
+When a SIL instruction is deleted, call `salvageDebugInfo`. It will try to
+capture the effect of the deleted instruction in a debug expression, so the
+location can be preserved.
+
+Alternatively, you can use an `InstructionDeleter`, which will automatically
+call `salvageDebugInfo`.
+
+If the debug info cannot be salvaged by `salvageDebugInfo`, and the pass has a
+special knowledge of the value, the pass can directly replace the debug value
+with the known value.
+
+If an instruction is being replaced by another, use `replaceAllUsesWith`. It
+will also update debug values to use the new instruction.
 
 > [!Tip]
 > To detect when a pass drops a variable, you can use the

--- a/docs/OptimizerCountersAnalysis.md
+++ b/docs/OptimizerCountersAnalysis.md
@@ -54,7 +54,8 @@ The following statistics can be recorded:
 
   * For SILFunctions: the number of SIL basic blocks for each SILFunction, the
     number of SIL instructions, the number of SILInstructions of a specific
-    kind (e.g. a number of alloc_ref instructions)
+    kind (e.g. a number of alloc_ref instructions), the number of debug
+    variables
 
   * For SILModules: the number of SIL basic blocks in the SILModule, the number
     of SIL instructions, the number of SILFunctions, the number of
@@ -117,6 +118,16 @@ can use a comma-separated list of instructions as a value of the option,
 e.g. `-Xllvm -sil-stats-only-instructions=alloc_ref,alloc_stack`. If you need to
 collect stats about all kinds of SIL instructions, you can use this syntax: 
 `-Xllvm -sil-stats-only-instructions=all`.
+
+### Debug variable level counters
+A different type of counter is the lost debug variables counter. It is enabled
+by using the `-Xllvm -sil-stats-lost-variables` command-line option. It only
+tracks statistics about lost variables in SILFunctions. It is not enabled by
+any other command-line option, but can be combined with the others. It is not
+compatible with thresholds, it always counts lost variables. Note that it does
+not track the number of debug variables: it counts the number of debug variables
+that were present, but aren't anymore. If a variable changes location or scope,
+which is not allowed, it will be counted as lost.
 
 ## Configuring which counters changes should be recorded
 
@@ -181,9 +192,9 @@ And for counter stats it looks like this:
   * `function_history` corresponds to the verbose mode of function
     counters collection, when changes to the SILFunction counters are logged 
     unconditionally, without any on-line filtering.
-* `CounterName` is typically one of `block`, `inst`, `function`, `memory`, 
-   or `inst_instruction_name` if you collect counters for specific kinds of SIL
-   instructions.
+* `CounterName` is typically one of `block`, `inst`, `function`, `memory`,
+   `lostvars`, or `inst_instruction_name` if you collect counters for specific
+   kinds of SIL instructions.
 * `Symbol` is e.g. the name of a function
 * `StageName` is the name of the current optimizer pipeline stage
 * `TransformName` is the name of the current optimizer transformation/pass
@@ -191,6 +202,14 @@ And for counter stats it looks like this:
 * `TransformPassNumber` is the optimizer pass number. It is useful if you 
    want to reproduce the result later using 
    `-Xllvm -sil-opt-pass-count -Xllvm TransformPassNumber`
+
+## Extract Lost Variables per Pass
+
+For lost variables, there is a script to output a CSV with only the amount of
+lost variables per pass. You can then easily open the resulting CSV in Numbers
+to make graphs.
+
+`utils/process-stats-lost-variables csv_file_with_counters > csv_aggregate`
 
 ## Storing the produced statistics into a database
 
@@ -345,4 +364,3 @@ from Counters C where C.counter = 'inst' and C.kind = 'module'
 group by Stage
 order by sum(C.Delta);
 ```
-

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -33,6 +33,7 @@
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
+#include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/StackNesting.h"
 #include "llvm/ADT/MapVector.h"
@@ -1777,7 +1778,7 @@ static void rewriteUsesOfSscalar(StructLoweringState &pass,
       createOutlinedCopyCall(copyBuilder, address, dest, pass);
       storeUser->eraseFromParent();
     } else if (auto *dbgInst = dyn_cast<DebugValueInst>(user)) {
-      SILBuilderWithScope dbgBuilder(dbgInst);
+      SILBuilder dbgBuilder(dbgInst, dbgInst->getDebugScope());
       // Rewrite the debug_value to point to the variable in the alloca.
       dbgBuilder.createDebugValueAddr(dbgInst->getLoc(), address,
                                       *dbgInst->getVarInfo());
@@ -2150,9 +2151,8 @@ static void rewriteFunction(StructLoweringState &pass,
       } else {
         assert(currOperand->getType().isAddress() &&
                "Expected an address type");
-        SILBuilderWithScope debugBuilder(instr);
         // SILBuilderWithScope skips over metainstructions.
-        debugBuilder.setCurrentDebugScope(instr->getDebugScope());
+        SILBuilder debugBuilder(instr, instr->getDebugScope());
         debugBuilder.createDebugValueAddr(instr->getLoc(), currOperand,
                                           *instr->getVarInfo());
         instr->getParent()->erase(instr);
@@ -3637,6 +3637,7 @@ protected:
 
     builder.createCopyAddr(load->getLoc(), load->getOperand(), addr, IsTake,
                            IsInitialization);
+    swift::salvageLoadDebugInfo(load);
     assignment.markForDeletion(load);
   }
 

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1475,9 +1475,8 @@ bool SILInstruction::mayTrap() const {
 }
 
 bool SILInstruction::isMetaInstruction() const {
-  // Every instruction that implements getVarInfo() should be in this list.
+  // Every instruction that doesn't generate code should be in this list.
   switch (getKind()) {
-  case SILInstructionKind::AllocBoxInst:
   case SILInstructionKind::AllocStackInst:
   case SILInstructionKind::DebugValueInst:
     return true;

--- a/test/DebugInfo/LoadableByAddress.sil
+++ b/test/DebugInfo/LoadableByAddress.sil
@@ -1,0 +1,49 @@
+// RUN: %target-sil-opt -loadable-address %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct X {
+  var x1 : Int
+  var x2 : Int
+  var x3 : Int
+  var x4: Int
+  var x5: Int
+  var x6: Int
+  var x7: Int
+  var x8: Int
+  var x9: Int
+  var x10: Int
+  var x11: Int
+  var x12: Int
+  var x13: Int
+  var x14: Int
+  var x15: Int
+  var x16: Int
+}
+
+
+// CHECK: sil @test1 : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:   %0 = alloc_stack $Optional<X>
+// CHECK:   %1 = alloc_stack $X
+// CHECK:   %2 = alloc_stack $X
+// CHECK:   %3 = alloc_stack $Optional<X>
+// CHECK:   debug_value %{{[0-9]+}} : $*X, let, name "temp"
+// CHECK: } // end sil function 'test1'
+
+sil @test1 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $X
+  %1 = alloc_stack $Optional<X>
+  %2 = load %0 : $*X
+  debug_value %2 : $X, let, name "temp"
+  %3 = enum $Optional<X>, #Optional.some!enumelt, %2 : $X
+  store %3 to %1 : $*Optional<X>
+  dealloc_stack %1 : $*Optional<X>
+  dealloc_stack %0 : $*X
+  %t = tuple ()
+  return %t : $()
+}

--- a/test/SILOptimizer/allocstack_hoisting_debuginfo.sil
+++ b/test/SILOptimizer/allocstack_hoisting_debuginfo.sil
@@ -98,13 +98,14 @@ bb4:
   return %9999 : $()
 }
 
-// This case we are not moving anything so we are leaving in the default
-// behavior which is not breaking blocks and not inserting debug_info.
+// This case we are not moving anything, so we don't add the
+// [moveable_value_debuginfo] flag, but we still want debug info for the
+// second alloc_stack!
 //
 // CHECK-LABEL: sil @hoist_generic_3 :
 // CHECK: bb0([[ARG:%.*]] : $*T,
 // CHECK-NEXT:   [[STACK:%.*]] = alloc_stack $T{{[ ]*}}, let, name "x"
-// CHECK-NOT:    debug_value
+// CHECK:        debug_value %{{.+}}, let, name "y"
 // CHECK: } // end sil function 'hoist_generic_3'
 sil @hoist_generic_3 : $@convention(thin) <T> (@in T, Builtin.Int1) -> () {
 bb0(%0 : $*T, %1: $Builtin.Int1):

--- a/utils/optimizer_counters_to_sql.py
+++ b/utils/optimizer_counters_to_sql.py
@@ -92,13 +92,13 @@ def addStatsFromInput(inputFile, db):
     for line in inputFile:
         # Read next line
         # Split into segments
-        segments = line.split(",")
+        segments = line.split(", ")
         if len(segments) < 6 or not (segments[0] in [
                 'module', 'function', 'function_history']):
             continue
         # Trim all values
-        segments = map(str.strip, segments)
-        if segments[0] == 'function_history':
+        segments = list(map(str.strip, segments))
+        if segments[0] == 'function_history' or segments[1] == 'lostvars':
             # Process history records
             delta = 0.0
             (kind, counter, stage, transform, passnum,
@@ -128,7 +128,7 @@ def processStatsFile(filename, dbname):
             filename,
             dbname))
     db = OptStatsDB(dbname)
-    with open(filename, "rb") as inputFile:
+    with open(filename, "r") as inputFile:
         addStatsFromInput(inputFile, db)
     db.finish()
 

--- a/utils/process-stats-lost-variables
+++ b/utils/process-stats-lost-variables
@@ -1,0 +1,24 @@
+#!/usr/bin/awk -f
+
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+BEGIN {
+  FS = ", "
+  OFS = ", "
+  print "Pass Name", "Lost Variables"
+}
+
+$1 == "function" && $2 == "lostvars" {
+  stats[$4] += $6
+}
+
+END {
+  for (i in stats)
+    print i, stats[i]
+}


### PR DESCRIPTION
* **Explanation**: This PR adds a compile flag to emit lost variables statistics, which is disabled by default. Additionally, it fixes lost variables at Onone in some later passes.
* **Scope**: Salvages lost debug values in some passes. Add optional statistics.
* **Original PR**: #73334 + #73387
* **Risk**: Low, adds an -Xllvm compile flag disabled by default, fix scope and missing variables in rare cases.
* **Testing**: New tests have been added, existing ones have been updated
* **Issue**: None
* **Reviewer**:  @adrian-prantl 