### PR TITLE
Build: EarlySwiftDriver: Use consistent Foundation/Dispatch

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
@@ -107,14 +107,6 @@ def run_build_script_helper(action, host_target, product, args):
     swiftc_path = os.path.abspath(product.toolchain.swiftc)
     toolchain_path = os.path.dirname(os.path.dirname(swiftc_path))
 
-    # Pass Dispatch directory down if we built it
-    dispatch_build_dir = os.path.join(
-        build_root, '%s-%s' % ('libdispatch', host_target))
-
-    # Pass Foundation directory down if we built it
-    foundation_build_dir = os.path.join(
-        build_root, '%s-%s' % ('foundation', host_target))
-
     # Pass the swift lit tests if we're testing and the Swift tests were built
     swift_build_dir = os.path.join(
         build_root, 'swift-{}'.format(host_target))
@@ -135,14 +127,6 @@ def run_build_script_helper(action, host_target, product, args):
         '--local_compiler_build'
     ]
 
-    if os.path.exists(dispatch_build_dir):
-        helper_cmd += [
-            '--dispatch-build-dir', dispatch_build_dir
-        ]
-    if os.path.exists(foundation_build_dir):
-        helper_cmd += [
-            '--foundation-build-dir', foundation_build_dir
-        ]
     if os.path.exists(lit_test_dir) and action == 'test':
         helper_cmd += [
             '--lit-test-dir', lit_test_dir


### PR DESCRIPTION
The early swift driver build would switch the Dispatch and Foundation build used while building between an initial clean build and an incremental rebuild. The early swift driver should consistently use the same Foundation and Dispatch for each build (the one from the SDK that's it's being built for).

This change tells the early swift driver stops build-script from telling the early driver build to use the Foundation and Dispatch that it built.