### PR TITLE
[6.0][stdlib] ManagedBuffer: Fix misapplied linkage names for legacy entry points

### DIFF
--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -170,7 +170,7 @@ extension ManagedBuffer where Element: ~Copyable {
 
 extension ManagedBuffer {
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss13ManagedBufferC25withUnsafeMutablePointersyqd__qd__SpyxG_Spyq_GtKXEKlF")
+  @_silgen_name("$ss13ManagedBufferC32withUnsafeMutablePointerToHeaderyqd__qd__SpyxGKXEKlF")
   @usableFromInline
   internal final func __legacy_withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
@@ -179,7 +179,7 @@ extension ManagedBuffer {
   }
 
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss13ManagedBufferC32withUnsafeMutablePointerToHeaderyqd__qd__SpyxGKXEKlF")
+  @_silgen_name("$ss13ManagedBufferC34withUnsafeMutablePointerToElementsyqd__qd__Spyq_GKXEKlF")
   @usableFromInline
   internal final func __legacy_withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
@@ -188,7 +188,7 @@ extension ManagedBuffer {
   }
 
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss13ManagedBufferC34withUnsafeMutablePointerToElementsyqd__qd__Spyq_GKXEKlF")
+  @_silgen_name("$ss13ManagedBufferC25withUnsafeMutablePointersyqd__qd__SpyxG_Spyq_GtKXEKlF")
   @usableFromInline
   internal final func __legacy_withUnsafeMutablePointers<R>(
     _ body: (


### PR DESCRIPTION
- **Explanation:** Resolves a terrible copy-paste error in https://github.com/apple/swift/pull/73079 that resulted in legacy ABI entry points getting misdirected to the wrong implementations, causing immediate crashes.
- **Scope:** `ManagedBuffer`, specifically usages of it in binaries built with Swift standard libraries predating the PR above.
- **Issue:** rdar://127016847
- **Original PR:** https://github.com/apple/swift/pull/73400
- **Risk:** Low.
- **Testing:** Experimental verification that existing binaries no longer crash with this change.
- **Reviewer:** @Azoy 
