### PR TITLE
[IRGen] Fix alignment for imported C types in CVW

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -1655,6 +1655,10 @@ AlignedGroupEntry::fixedAlignment(IRGenModule &IGM) const {
   if (_fixedAlignment.has_value())
     return *_fixedAlignment;
 
+  if (fixedTypeInfo) {
+    return *(_fixedAlignment = (*fixedTypeInfo)->getFixedAlignment());
+  }
+
   Alignment currentAlignment = Alignment(
     std::max((Alignment::int_type)1, minimumAlignment));
   for (auto *entry : entries) {

--- a/test/Interpreter/Inputs/CTypes/CTypes.h
+++ b/test/Interpreter/Inputs/CTypes/CTypes.h
@@ -1,9 +1,17 @@
 #ifndef SWIFT_TEST_CTYPES_H
 #define SWIFT_TEST_CTYPES_H
 
+#include <stdint.h>
+
 struct BigAlignment {
   _Alignas(16) float foo[4];
   char b;
 };
+
+#pragma pack(push, 4)
+struct UnderAligned {
+  int64_t bar;
+};
+#pragma pack(pop)
 
 #endif

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -49,6 +49,16 @@ public struct CTypeAligned {
     }
 }
 
+public struct CTypeUnderAligned {
+    let w: Int32 = 0
+    let x: UnderAligned? = UnderAligned()
+    let y: SimpleClass
+
+    public init(_ y: SimpleClass) {
+        self.y = y
+    }
+}
+
 public struct GenericStruct<T> {
     let x: Int = 0
     let y: T

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -1223,6 +1223,49 @@ func testCTypeAligned() {
 
 testCTypeAligned()
 
+func testCTypeUnderAligned() {
+    let ptr = UnsafeMutablePointer<CTypeUnderAligned>.allocate(capacity: 1)
+
+    // initWithCopy
+    do {
+        let x = CTypeUnderAligned(SimpleClass(x: 23))
+        testInit(ptr, to: x)
+    }
+
+    // assignWithTake
+    do {
+        let y = CTypeUnderAligned(SimpleClass(x: 1))
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // assignWithCopy
+    do {
+        var z = CTypeUnderAligned(SimpleClass(x: 5))
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssignCopy(ptr, from: &z)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // destroy
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testCTypeUnderAligned()
+
 #if os(macOS)
 func testObjc() {
     let ptr = UnsafeMutablePointer<ObjcWrapper>.allocate(capacity: 1)


### PR DESCRIPTION
rdar://127279770

When an imported C type is over or under aligned, we did not use the alignment of the type, but computed the maximum alignment of its components, causing alignment issues in compact value witnesses.
