### PR TITLE
SILGen: Correct handling of subscripts with addressors.

### DIFF
--- a/test/SILGen/moveonly_subscript_addressor.swift
+++ b/test/SILGen/moveonly_subscript_addressor.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+struct Foo: ~Copyable {
+  let value: Int
+
+  @_silgen_name("load")
+  borrowing func load() -> Int
+}
+
+// CHECK-LABEL: sil {{.*}} @${{.*}}4load
+func load(b: UnsafeMutableBufferPointer<Foo>) -> Int {
+    // Ensure the borrowing invocation of `load` happens within the access to
+    // the pointed-at memory.
+    // CHECK: [[PTR:%.*]] = pointer_to_address
+    // CHECK: [[BEGIN:%.*]] = begin_access [read] [unsafe] [[PTR]]
+    // CHECK: [[FN:%.*]] = function_ref @load
+    // CHECK: apply [[FN]]
+    // CHECK: end_access [[BEGIN]]
+    return b[1].load()
+}


### PR DESCRIPTION
Remove improper special-case handling of subscripts in `findStorageReferenceExprForMoveOnly`. The correct thing to do for any storage decl ref of noncopyable type is to emit it as a borrow if it's implemented using storage, a read accessor, or an addressor. Fixes rdar://127335590.