### PR TITLE
[6.0][SourceKit] Don't use SourceEntitityWalker for placeholder expansion

### DIFF
--- a/test/SourceKit/CodeExpand/code-expand-no-typecheck.swift
+++ b/test/SourceKit/CodeExpand/code-expand-no-typecheck.swift
@@ -1,0 +1,17 @@
+// RUN: %sourcekitd-test -req=expand-placeholder %s | %FileCheck %s
+
+// FIXME: Make it acccept '-debug-forbid-typecheck-prefix' and ensure no typecheck happens.'
+
+protocol MyProto {}
+
+enum MyEnum: Hashable, MyProto {
+  case foo
+  case bar
+}
+
+func test(array: [MyEnum]) -> [NyEnum] {
+  array.filter(<#T##isIncluded: (MyEnum) throws -> Bool##(MyEnum) throws -> Bool#>)
+// CHECK: array.filter { <#MyEnum#> in 
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+}


### PR DESCRIPTION
cherry-pick https://github.com/apple/swift/pull/73394 into release/6.0

* **Explanation**: Placeholder expansion should be a syntactic operation, but `SourceEntityWalker` can invoke type checking operations, which causes unexpected behaviors including crashes. Instead use `ASTWalker`.
* **Scope**: SourceKit placeholder expansion
* **Risk**: Low. There was no reason to use `SourceEntityWalker`, using `ASTWalker` for similar operation is well tested
* **Testing**: Added a regression test case
* **Issue**: rdar://121360941
* **Reviewer**: Hamish Knight (@hamishknight) Alex Hoppen (@ahoppen)