### PR TITLE
Avoid using generic static members on Duration across module boundaries

### DIFF
--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -34,6 +34,21 @@ public struct ContinuousClock: Sendable {
   public init() { }
 }
 
+extension Duration {
+  internal init(_seconds s: Int64, nanoseconds n: Int64) {
+    let (secHi, secLo) = s.multipliedFullWidth(by: 1_000_000_000_000_000_000)
+    // _nanoseconds is in 0 ..< 1_000_000_000, so the conversion to UInt64
+    // and multiply cannot overflow. If you somehow trap here, it is because
+    // the underlying clock hook that produced the time value is implemented
+    // incorrectly on your platform, but because we trap we can't silently
+    // get bogus data.
+    let (low, carry) = secLo.addingReportingOverflow(UInt64(n) * 1_000_000_000)
+    let high = secHi &+ (carry ? 1 : 0)
+    _low = low
+    _high = high
+  }
+}
+
 @available(SwiftStdlib 5.7, *)
 extension Clock where Self == ContinuousClock {
   /// A clock that measures time that always increments but does not stop 
@@ -60,7 +75,7 @@ extension ContinuousClock: Clock {
       seconds: &seconds,
       nanoseconds: &nanoseconds,
       clock: _ClockID.continuous.rawValue)
-    return .seconds(seconds) + .nanoseconds(nanoseconds)
+    return Duration(_seconds: seconds, nanoseconds: nanoseconds)
   }
 
   /// The current continuous instant.
@@ -71,8 +86,9 @@ extension ContinuousClock: Clock {
       seconds: &seconds,
       nanoseconds: &nanoseconds,
       clock: _ClockID.continuous.rawValue)
-    return ContinuousClock.Instant(_value:
-      .seconds(seconds) + .nanoseconds(nanoseconds))
+    return Instant(
+      _value: Duration(_seconds: seconds, nanoseconds: nanoseconds)
+    )
   }
 
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -34,6 +34,7 @@ public struct ContinuousClock: Sendable {
   public init() { }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Duration {
   internal init(_seconds s: Int64, nanoseconds n: Int64) {
     let (secHi, secLo) = s.multipliedFullWidth(by: 1_000_000_000_000_000_000)

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -44,8 +44,7 @@ extension Duration {
     // get bogus data.
     let (low, carry) = secLo.addingReportingOverflow(UInt64(n) * 1_000_000_000)
     let high = secHi &+ (carry ? 1 : 0)
-    _low = low
-    _high = high
+    self.init(_high: high, low: low)
   }
 }
 

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -61,8 +61,9 @@ extension SuspendingClock: Clock {
       seconds: &seconds,
       nanoseconds: &nanoseconds,
       clock: _ClockID.suspending.rawValue)
-    return SuspendingClock.Instant(_value:
-      .seconds(seconds) + .nanoseconds(nanoseconds))
+    return Instant(
+      _value: Duration(_seconds: seconds, nanoseconds: nanoseconds)
+    )
   }
 
   /// The minimum non-zero resolution between any two calls to `now`.
@@ -74,7 +75,7 @@ extension SuspendingClock: Clock {
       seconds: &seconds,
       nanoseconds: &nanoseconds,
       clock: _ClockID.suspending.rawValue)
-    return .seconds(seconds) + .nanoseconds(nanoseconds)
+    return Duration(_seconds: seconds, nanoseconds: nanoseconds)
   }
 
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY


### PR DESCRIPTION
Because the clocks are implemented in Concurrency, but Duration is in the Swift module, these don't get specialized. Add a fully-concrete internal init in Concurrency to avoid the problem.