### PR TITLE
[ScanDependencies] Get accurate macro dependency

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -244,6 +244,7 @@ static llvm::Error resolveExplicitModuleInputs(
     return E;
 
   std::vector<std::string> commandLine = resolvingDepInfo.getCommandline();
+  auto dependencyInfoCopy = resolvingDepInfo;
   for (const auto &depModuleID : dependencies) {
     const auto &depInfo = cache.findKnownDependency(depModuleID);
     switch (depModuleID.Kind) {
@@ -255,6 +256,14 @@ static llvm::Error resolveExplicitModuleInputs(
                        : interfaceDepDetails->moduleCacheKey;
       commandLine.push_back("-swift-module-file=" + depModuleID.ModuleName + "=" +
                             path);
+      // Add the exported macro from interface into current module.
+      llvm::for_each(
+          interfaceDepDetails->textualModuleDetails.macroDependencies,
+          [&](const auto &entry) {
+            dependencyInfoCopy.addMacroDependency(entry.first(),
+                                                  entry.second.LibraryPath,
+                                                  entry.second.ExecutablePath);
+          });
     } break;
     case swift::ModuleDependencyKind::SwiftBinary: {
       auto binaryDepDetails = depInfo.getAsSwiftBinaryModule();
@@ -319,7 +328,6 @@ static llvm::Error resolveExplicitModuleInputs(
   }
 
   // Update the dependency in the cache with the modified command-line.
-  auto dependencyInfoCopy = resolvingDepInfo;
   if (resolvingDepInfo.isSwiftInterfaceModule() ||
       resolvingDepInfo.isClangModule()) {
     if (service.hasPathMapping())
@@ -345,6 +353,10 @@ static llvm::Error resolveExplicitModuleInputs(
       llvm::for_each(
           sourceDep->auxiliaryFiles,
           [&tracker](const std::string &file) { tracker->trackFile(file); });
+      llvm::for_each(sourceDep->textualModuleDetails.macroDependencies,
+                     [&tracker](const auto &entry) {
+                       tracker->trackFile(entry.second.LibraryPath);
+                     });
       auto root = tracker->createTreeFromDependencies();
       if (!root)
         return root.takeError();

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -239,7 +239,7 @@ static llvm::Expected<CompilerPlugin *>
 initializePlugin(ASTContext &ctx, CompilerPlugin *plugin, StringRef libraryPath,
                  Identifier moduleName) {
   // Lock the plugin while initializing.
-  // Note that'executablePlugn' can be shared between multiple ASTContext.
+  // Note that 'executablePlugin' can be shared between multiple ASTContext.
   plugin->lock();
   SWIFT_DEFER { plugin->unlock(); };
 


### PR DESCRIPTION
Build an accurate macro dependency for swift caching. Specifically, do not include not used macro plugins into the dependency, which might cause false negatives for cache hits.

This also builds the foundation for future improvement when dependency scanning will determine the macro plugin to load and swift-frontend do not need to redo the work.

rdar://127116512