### PR TITLE
6.0: [SILCombine] Handle indirect error in apply(convert_function).

### DIFF
--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -242,6 +242,24 @@ public:
     return 0;
   }
 
+  std::optional<SILResultInfo> getIndirectErrorResult() const {
+    if (!silConv.loweredAddresses)
+      return std::nullopt;
+    auto info = funcTy->getOptionalErrorResult();
+    if (!info)
+      return std::nullopt;
+    if (info->getConvention() != ResultConvention::Indirect)
+      return std::nullopt;
+    return info;
+  }
+
+  SILType getIndirectErrorResultType(TypeExpansionContext context) const {
+    auto result = getIndirectErrorResult();
+    if (!result)
+      return SILType();
+    return getSILType(*result, context);
+  }
+
   bool isArgumentIndexOfIndirectErrorResult(unsigned idx) {
     unsigned indirectResults = getNumIndirectSILResults();
     return idx >= indirectResults &&

--- a/include/swift/SIL/Test.h
+++ b/include/swift/SIL/Test.h
@@ -173,6 +173,8 @@ public:
   template <typename Analysis, typename Transform = SILFunctionTransform>
   Analysis *getAnalysis();
 
+  SILFunctionTransform *getPass();
+
   SwiftPassInvocation *getSwiftPassInvocation();
 
 //===----------------------------------------------------------------------===//
@@ -302,6 +304,8 @@ template <typename Analysis, typename Transform>
 Analysis *FunctionTest::getAnalysis() {
   return impl::getAnalysisFromTransform<Analysis, Transform>(pass);
 }
+
+inline SILFunctionTransform *FunctionTest::getPass() { return pass; }
 } // namespace test
 } // namespace swift
 

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -25,6 +25,7 @@
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILVisitor.h"
+#include "swift/SIL/Test.h"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Analysis/NonLocalAccessBlockAnalysis.h"
@@ -497,6 +498,29 @@ bool SILCombiner::doOneIteration(SILFunction &F, unsigned Iteration) {
   Worklist.resetChecked();
   return MadeChange;
 }
+
+namespace swift::test {
+// Arguments:
+// - instruction: the instruction to be canonicalized
+// Dumps:
+// - the function after the canonicalization is attempted
+static FunctionTest SILCombineCanonicalizeInstruction(
+    "sil_combine_instruction", [](auto &function, auto &arguments, auto &test) {
+      SILCombiner combiner(test.getPass(), false, false);
+      auto inst = arguments.takeInstruction();
+      combiner.Builder.setInsertionPoint(inst);
+      auto *result = combiner.visit(inst);
+      if (result) {
+        combiner.Worklist.replaceInstructionWithInstruction(inst, result
+#ifndef NDEBUG
+                                                            ,
+                                                            ""
+#endif
+        );
+      }
+      function.dump();
+    });
+} // end namespace swift::test
 
 bool SILCombiner::runOnFunction(SILFunction &F) {
   clear();

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -72,9 +72,11 @@ class SILCombiner :
   /// lifetimes in OSSA.
   NonLocalAccessBlockAnalysis *NLABA;
 
+public:
   /// Worklist containing all of the instructions primed for simplification.
   SmallSILInstructionWorklist<256> Worklist;
 
+private:
   /// Utility for dead code removal.
   InstructionDeleter deleter;
 
@@ -102,10 +104,12 @@ class SILCombiner :
   // The tracking list is used by `Builder` for newly added
   // instructions, which we will periodically move to our worklist.
   llvm::SmallVector<SILInstruction *, 64> TrackingList;
-  
+
+public:
   /// Builder used to insert instructions.
   SILBuilder Builder;
 
+private:
   SILOptFunctionBuilder FuncBuilder;
 
   /// Cast optimizer

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -157,6 +157,10 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
   auto context = AI.getFunction()->getTypeExpansionContext();
   auto oldOpRetTypes = substConventions.getIndirectSILResultTypes(context);
   auto newOpRetTypes = convertConventions.getIndirectSILResultTypes(context);
+  auto oldIndirectErrorResultType =
+      substConventions.getIndirectErrorResultType(context);
+  auto newIndirectErrorResultType =
+      convertConventions.getIndirectErrorResultType(context);
   auto oldOpParamTypes = substConventions.getParameterSILTypes(context);
   auto newOpParamTypes = convertConventions.getParameterSILTypes(context);
 
@@ -186,7 +190,13 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
        ++OpI, ++newRetI, ++oldRetI) {
     convertOp(Ops[OpI], *oldRetI, *newRetI);
   }
-  
+
+  if (oldIndirectErrorResultType) {
+    assert(newIndirectErrorResultType);
+    convertOp(Ops[OpI], oldIndirectErrorResultType, newIndirectErrorResultType);
+    ++OpI;
+  }
+
   auto newParamI = newOpParamTypes.begin();
   auto oldParamI = oldOpParamTypes.begin();
   for (auto e = newOpParamTypes.end(); newParamI != e;

--- a/test/SILOptimizer/sil_combine_apply_unit.sil
+++ b/test/SILOptimizer/sil_combine_apply_unit.sil
@@ -1,0 +1,34 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -test-runner | %FileCheck %s
+
+import Builtin
+
+struct Input {}
+struct Output {}
+enum Nunca {}
+
+sil @rdar127452206_callee : $@convention(thin) @Sendable @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_2, @error_indirect τ_0_1) for <Input, Nunca, Output>
+
+// CHECK-LABEL: sil @rdar127452206 : {{.*}} {
+// CHECK:       bb0([[INPUT:%[^,]+]] :
+// CHECK:         [[OUTPUT:%[^,]+]] = alloc_stack $Output
+// CHECK:         [[NUNCA:%[^,]+]] = alloc_stack $Nunca
+// CHECK:         [[OUTPUT_AS_OUTPUT:%[^,]+]] = unchecked_addr_cast [[OUTPUT]]
+// CHECK:         [[NUNCA_AS_NUNCA:%[^,]+]] = unchecked_addr_cast [[NUNCA]]
+// CHECK:         [[INPUT_AS_INPUT:%[^,]+]] = unchecked_addr_cast [[INPUT]]
+// CHECK:         apply [nothrow] {{%[^,]+}}([[OUTPUT_AS_OUTPUT]], [[NUNCA_AS_NUNCA]], [[INPUT_AS_INPUT]])
+// CHECK-LABEL: } // end sil function 'rdar127452206'
+sil @rdar127452206 : $@convention(thin) (@in Input) -> () {
+entry(%input : $*Input):
+  %output = alloc_stack $Output
+  %nunca = alloc_stack $Nunca
+  %callee = function_ref @rdar127452206_callee : $@convention(thin) @Sendable @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_2, @error_indirect τ_0_1) for <Input, Nunca, Output>
+  %convert = convert_function %callee : $@convention(thin) @Sendable @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_2, @error_indirect τ_0_1) for <Input, Nunca, Output> to $@convention(thin) @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_2, @error_indirect τ_0_1) for <Input, Nunca, Output> // user: %216
+  specify_test "sil_combine_instruction @instruction[4]"
+  apply [nothrow] %convert(%output, %nunca, %input) : $@convention(thin) @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_2, @error_indirect τ_0_1) for <Input, Nunca, Output>
+  dealloc_stack %nunca : $*Nunca
+  dealloc_stack %output : $*Output
+  %retval = tuple ()
+  return %retval : $()
+}
+
+


### PR DESCRIPTION
**Explanation**: Fix a compiler crash caused by misoptimizing certain applies.

Typed throws involves returning errors indirectly on throwing paths.  There is a simplification performed by SILCombine for `apply`s whose operand is a `convert_function`.  Among other things, it creates `unchecked_addr_cast`s of the indirect results and parameters.  It does this by iterating over all the operands of the `apply`.  In the case of a function with an `@indirect_error` result, that result appears in the operand list.  This simplification was not accounting for it, however.  So both incorrect casts and an invalid `apply` were created.

Here, this is fixed by iterating over the indirect error as well.

**Scope**: Affects code using typed throws such as via stdlib calls.
**Issue**:rdar://127468646
**Original PR**: https://github.com/apple/swift/pull/73408
**Risk**: Low.  Adds handling for indirect errors in a instruction simplification that already handles other indirect returns.
**Testing**: Added regression test.
**Reviewer**: Andrew Trick ( @atrick )
