### PR TITLE
[6.0][Runtime] Mask out spare bits after copying for Error in CVW

### DIFF
--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -913,8 +913,8 @@ static void errorRetain(const Metadata *metadata, LayoutStringReader1 &reader,
   uintptr_t object = *(uintptr_t *)(src + _addrOffset);
   if (object & _swift_abi_ObjCReservedBitsMask)
     return;
-  object &= ~_swift_abi_SwiftSpareBitsMask;
   memcpy(dest + addrOffset, &object, sizeof(SwiftError*));
+  object &= ~_swift_abi_SwiftSpareBitsMask;
   addrOffset = _addrOffset + sizeof(SwiftError *);
   swift_errorRetain((SwiftError *)object);
 }

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -1180,6 +1180,30 @@ func testMultiPayloadError() {
 
 testMultiPayloadError()
 
+// Regression test for rdar://127379960
+func testMultiPayloadErrorKeepsTagIntact() {
+    let ptr = UnsafeMutablePointer<MultiPayloadError>.allocate(capacity: 1)
+
+    // initWithTake
+    do {
+        let x = MultiPayloadError.error2(0, MyError(x: SimpleClass(x: 23)))
+        testInit(ptr, to: x)
+    }
+
+    // CHECK: Got error2!
+    switch ptr.pointee {
+        case .error1: print("Get error1!")
+        case .error2: print("Got error2!")
+        case .empty: print("Got empty!")
+    }
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+    ptr.deallocate()
+}
+
+testMultiPayloadErrorKeepsTagIntact()
+
 func testCTypeAligned() {
     let ptr = UnsafeMutablePointer<CTypeAligned>.allocate(capacity: 1)
 


### PR DESCRIPTION
**Explanation**: When the spare bits of an Error objects are used to store tag bits, this caused the enum tag to be lost, which caused the wrong enum cases to be matched.
**Scope**: Only affects compact value witnesses
**Risk**: Low. Only affects CVW
**Testing**: Added test cases that observe the issue before the fix
**Issue**: rdar://127379960
**Reviewer**: @mikeash
**Main branch PR**: https://github.com/apple/swift/pull/73426
