### PR TITLE
[DebugInfo] Always emit unsubstituted generic types with size 0

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1134,11 +1134,13 @@ private:
   llvm::DICompositeType *createUnsubstitutedGenericStructOrClassType(
       DebugTypeInfo DbgTy, NominalTypeDecl *Decl, Type UnsubstitutedType,
       llvm::DIScope *Scope, llvm::DIFile *File, unsigned Line,
-      unsigned SizeInBits, unsigned AlignInBits, llvm::DINode::DIFlags Flags,
-      llvm::DIType *DerivedFrom, unsigned RuntimeLang, StringRef UniqueID) {
+      llvm::DINode::DIFlags Flags, llvm::DIType *DerivedFrom,
+      unsigned RuntimeLang, StringRef UniqueID) {
     // FIXME: ideally, we'd like to emit this type with no size and alignment at
     // all (instead of emitting them as 0). Fix this by changing DIBuilder to
     // allow for struct types that have optional size and alignment.
+    unsigned SizeInBits = 0;
+    unsigned AlignInBits = 0;
     StringRef Name = Decl->getName().str();
     auto FwdDecl = createStructForwardDecl(DbgTy, Decl, Scope, File, Line,
                                            SizeInBits, Flags, UniqueID, Name);
@@ -1163,7 +1165,7 @@ private:
         Scope, Name, File, Line, SizeInBits, AlignInBits, Flags, DerivedFrom,
         DBuilder.getOrCreateArray(Elements), RuntimeLang, nullptr, UniqueID);
     DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
-    return DITy;;
+    return DITy;
   }
 
   llvm::DIType *
@@ -1181,8 +1183,7 @@ private:
     std::string DeclTypeMangledName = Mangler.mangleTypeForDebugger(
         UnsubstitutedTy->mapTypeOutOfContext(), {});
     if (DeclTypeMangledName == MangledName) {
-      return createUnsubstitutedVariantType(DbgTy, Decl, MangledName,
-                                            SizeInBits, AlignInBits, Scope,
+      return createUnsubstitutedVariantType(DbgTy, Decl, MangledName, Scope,
                                             File, 0, Flags);
     }
     auto FwdDecl = llvm::TempDIType(DBuilder.createReplaceableCompositeType(
@@ -1241,9 +1242,8 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
       Mangler.mangleTypeForDebugger(UnsubstitutedTy->mapTypeOutOfContext(), {});
   if (DeclTypeMangledName == MangledName) {
     return createUnsubstitutedGenericStructOrClassType(
-        DbgTy, Decl, UnsubstitutedTy, Scope, File, Line, SizeInBits,
-        AlignInBits, Flags, nullptr, llvm::dwarf::DW_LANG_Swift,
-        DeclTypeMangledName);
+        DbgTy, Decl, UnsubstitutedTy, Scope, File, Line, Flags, nullptr,
+        llvm::dwarf::DW_LANG_Swift, DeclTypeMangledName);
   }
   // Force the creation of the unsubstituted type, don't create it
   // directly so it goes through all the caching/verification logic.
@@ -1408,7 +1408,6 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
   llvm::DICompositeType *
   createUnsubstitutedVariantType(DebugTypeInfo DbgTy, EnumDecl *Decl,
                                  StringRef MangledName,
-                                 unsigned SizeInBits, unsigned AlignInBits,
                                  llvm::DIScope *Scope, llvm::DIFile *File,
                                  unsigned Line, llvm::DINode::DIFlags Flags) {
     assert(!Decl->getRawType() &&
@@ -1417,6 +1416,8 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
     StringRef Name = Decl->getName().str();
     auto NumExtraInhabitants = DbgTy.getNumExtraInhabitants();
 
+    unsigned SizeInBits = 0;
+    unsigned AlignInBits = 0;
     // A variant part should actually be a child to a DW_TAG_structure_type
     // according to the DWARF spec.
     auto FwdDecl = llvm::TempDIType(DBuilder.createReplaceableCompositeType(
@@ -2091,7 +2092,7 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
       auto L = getFileAndLocation(Decl);
       unsigned FwdDeclLine = 0;
       if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes) {
-        if (EnumTy->isSpecialized())
+        if (EnumTy->isSpecialized() && !Decl->hasRawType())
           return createSpecializedEnumType(EnumTy, Decl, MangledName,
                                            SizeInBits, AlignInBits, Scope, File,
                                            FwdDeclLine, Flags);
@@ -2271,6 +2272,12 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
     unsigned CachedSizeInBits = getSizeInBits(CachedType);
     if ((SizeInBits && CachedSizeInBits != *SizeInBits) ||
         (!SizeInBits && CachedSizeInBits)) {
+      // In some situation a specialized type is emitted with size 0, even if the real 
+      // type has a size.
+      if (DbgTy.getType()->isSpecialized() && SizeInBits && *SizeInBits > 0 &&
+          CachedSizeInBits == 0)
+        return true;
+
       CachedType->dump();
       DbgTy.dump();
       llvm::errs() << "SizeInBits = " << SizeInBits << "\n";


### PR DESCRIPTION
Unsubstituted generic types shouldn't have a size, precisely because the generic parameters aren't substituted in. Always emit them with a size 0.

(cherry picked from commit 128d45237156274d198483a7b7bea76c3d3b01d8)

Explanation: When emitting debug information for unsubstituted generic types, the size of the type can't be known, since the generics haven't been substituted in yet. This patch fixes that by emitting them with a size of 0.
Scope: Affects debug info generation of generic types when compiling with `-gdwarf-types`, or for embedded Swift.
Risk: Low. Only affects debug info generation for generics in some situations.
Reviewer: @adrian-prantl 
Main branch PR: https://github.com/apple/swift/pull/72445