### PR TITLE
[6.0] Bring back TaskGroup.next() and ThrowingTaskGroup.next() as public API

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -574,10 +574,8 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     return try! await _taskGroupWaitNext(group: _group) // !-safe cannot throw, we're a non-throwing TaskGroup
   }
 
-  @usableFromInline
   @available(SwiftStdlib 5.1, *)
-  @_silgen_name("$sScG4nextxSgyYaF")
-  internal mutating func __abi_next() async -> ChildTaskResult? {
+  public mutating func next() async -> ChildTaskResult? {
     // try!-safe because this function only exists for Failure == Never,
     // and as such, it is impossible to spawn a throwing child task.
     return try! await _taskGroupWaitNext(group: _group) // !-safe cannot throw, we're a non-throwing TaskGroup
@@ -1035,10 +1033,8 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     return try await _taskGroupWaitNext(group: _group)
   }
 
-  @usableFromInline
   @available(SwiftStdlib 5.1, *)
-  @_silgen_name("$sScg4nextxSgyYaKF")
-  internal mutating func __abi_next() async throws -> ChildTaskResult? {
+  public mutating func next() async throws -> ChildTaskResult? {
     return try await _taskGroupWaitNext(group: _group)
   }
 

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -575,6 +575,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   }
 
   @available(SwiftStdlib 5.1, *)
+  @_disfavoredOverload
   public mutating func next() async -> ChildTaskResult? {
     // try!-safe because this function only exists for Failure == Never,
     // and as such, it is impossible to spawn a throwing child task.
@@ -1034,6 +1035,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   }
 
   @available(SwiftStdlib 5.1, *)
+  @_disfavoredOverload
   public mutating func next() async throws -> ChildTaskResult? {
     return try await _taskGroupWaitNext(group: _group)
   }

--- a/test/Concurrency/async_task_groups_as_sequence.swift
+++ b/test/Concurrency/async_task_groups_as_sequence.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+// REQUIRES: libdispatch
+
+@available(SwiftStdlib 5.1, *)
+@rethrows
+protocol TGP: AsyncSequence, AsyncIteratorProtocol { }
+
+@available(SwiftStdlib 5.1, *)
+extension TaskGroup: TGP { }
+// expected-warning@-1{{extension declares a conformance of imported type 'TaskGroup' to imported protocol 'AsyncIteratorProtocol'}}
+// expected-note@-2{{add '@retroactive' to silence this warning}}
+
+@available(SwiftStdlib 5.1, *)
+extension ThrowingTaskGroup: TGP { }
+// expected-warning@-1{{extension declares a conformance of imported type 'ThrowingTaskGroup' to imported protocol 'AsyncIteratorProtocol'}}
+// expected-note@-2{{add '@retroactive' to silence this warning}}

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -112,14 +112,6 @@ Func TaskLocal.withValue(_:operation:file:line:) has parameter 1 type change fro
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 2 type change from Swift.String to (any _Concurrency.Actor)?
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 3 type change from Swift.UInt to Swift.String
 
-// The method is actually still there: '__abi_next' silgen_name("$sScG4nextxSgyYaF")
-Func TaskGroup.next() has been renamed to Func next(isolation:)
-Func TaskGroup.next() has mangled name changing from 'Swift.TaskGroup.next() async -> Swift.Optional<A>' to 'Swift.TaskGroup.next(isolation: isolated Swift.Optional<Swift.Actor>) async -> Swift.Optional<A>'
-
-// The method is actually still there: '__abi_next' silgen_name("$sScg4nextxSgyYaKF")
-Func ThrowingTaskGroup.next() has been renamed to Func next(isolation:)
-Func ThrowingTaskGroup.next() has mangled name changing from 'Swift.ThrowingTaskGroup.next() async throws -> Swift.Optional<A>' to 'Swift.ThrowingTaskGroup.next(isolation: isolated Swift.Optional<Swift.Actor>) async throws -> Swift.Optional<A>'
-
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 
 


### PR DESCRIPTION
Explanation: A change to introducing `next(isolation:)` entry points into `(Throwing)TaskGroup` also removed the API for `next()`, relying on a default argument to maintain source compatibility for calls to the API. However, this broke protocol conformances that depend on the exact signature of `next()`, so this pull request brings those APIs back as "disfavored" overloads.
**Original PR**: https://github.com/apple/swift/pull/73425
**Risk**: Low. Adds back APIs whose removal caused a source incompatibility.
**Radar/issue**: rdar://127499568
**Reviewed by**: @hborla 
**Testing**: New tests.