### PR TITLE
Look through `@Sendable` conversions when considering C function pointer conversions.

### DIFF
--- a/test/SILGen/sendable_c_function_pointer_conversion.swift
+++ b/test/SILGen/sendable_c_function_pointer_conversion.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-emit-silgen -swift-version 5 -verify %s
+
+// In Swift 6 mode, we introduce an implicit `@Sendable` conversion on the
+// function value. Ensure that this doesn't impede C function pointer
+// conversion.
+// RUN: %target-swift-emit-silgen -swift-version 6 -verify %s
+
+public typealias PDCallbackFunction = @convention(c) (UnsafeMutableRawPointer?) -> Int32
+
+public enum System {
+  public static func setUpdateCallback(update: @escaping PDCallbackFunction, userdata: UnsafeMutableRawPointer?) {
+  }
+}
+
+@_cdecl("eventHandler")
+public func eventHandler(
+  pointer: UnsafeMutableRawPointer!
+) -> Int32 {
+  System.setUpdateCallback(update: update(pointer:), userdata: nil)
+  return 0
+}
+
+func update(pointer: UnsafeMutableRawPointer!) -> Int32 { 0 }


### PR DESCRIPTION
Adding (or removing) `@Sendable` doesn't add context, so it shouldn't prevent conversion to a C function pointer. Fix for rdar://127521718.