### PR TITLE
[6.0] Look through `@Sendable` conversions when considering C function pointer conversions.

### DIFF
--- a/test/SILGen/sendable_c_function_pointer_conversion.swift
+++ b/test/SILGen/sendable_c_function_pointer_conversion.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-emit-silgen -swift-version 5 -verify %s
+
+// In Swift 6 mode, we introduce an implicit `@Sendable` conversion on the
+// function value. Ensure that this doesn't impede C function pointer
+// conversion.
+// RUN: %target-swift-emit-silgen -swift-version 6 -verify %s
+
+public typealias PDCallbackFunction = @convention(c) (UnsafeMutableRawPointer?) -> Int32
+
+public enum System {
+  public static func setUpdateCallback(update: @escaping PDCallbackFunction, userdata: UnsafeMutableRawPointer?) {
+  }
+}
+
+@_cdecl("eventHandler")
+public func eventHandler(
+  pointer: UnsafeMutableRawPointer!
+) -> Int32 {
+  System.setUpdateCallback(update: update(pointer:), userdata: nil)
+  return 0
+}
+
+func update(pointer: UnsafeMutableRawPointer!) -> Int32 { 0 }


### PR DESCRIPTION
Explanation: Fixes an incorrect diagnostic when attempting to use a Swift function as a C function pointer in Swift 6 mode.
Scope: Fixes a bug that may impact source compatibility and C interoperability when transitioning to Swift 6 mode or strict concurrency checking.
Issue: rdar://127521718
Original PR: https://github.com/apple/swift/pull/73436
Risk: Low. This removes an incorrect error diagnostic in a fairly narrow situation.
Testing: Test case from bug report, Swift CI
Reviewer: TBD