### PR TITLE
modulewrap: Disable ObjC interop by default on non-Darwin platforms

### DIFF
--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -48,6 +48,7 @@ private:
   llvm::Triple TargetTriple;
   std::vector<std::string> InputFilenames;
   bool UseSharedResourceFolder = true;
+  bool EnableObjCInterop = true;
 
 public:
   bool hasSingleInput() const { return InputFilenames.size() == 1; }
@@ -65,6 +66,7 @@ public:
   llvm::Triple &getTargetTriple() { return TargetTriple; }
 
   bool useSharedResourceFolder() { return UseSharedResourceFolder; }
+  bool enableObjCInterop() { return EnableObjCInterop; }
 
   int parseArgs(llvm::ArrayRef<const char *> Args, DiagnosticEngine &Diags) {
     using namespace options;
@@ -123,6 +125,9 @@ public:
         ParsedArgs.hasArg(OPT_static)) {
       UseSharedResourceFolder = false;
     }
+
+    EnableObjCInterop = ParsedArgs.hasFlag(OPT_enable_objc_interop,
+        OPT_disable_objc_interop, TargetTriple.isOSDarwin());
 
     return 0;
   }
@@ -184,6 +189,7 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   CASOptions CASOpts;
   LangOpts.Target = Invocation.getTargetTriple();
+  LangOpts.EnableObjCInterop = Invocation.enableObjCInterop();
   ASTContext &ASTCtx = *ASTContext::get(
       LangOpts, TypeCheckOpts, SILOpts, SearchPathOpts, ClangImporterOpts,
       SymbolGraphOpts, CASOpts, SrcMgr, Instance.getDiags(),


### PR DESCRIPTION
0a5653dbaf03c21e175d317a5344e446c64a4ef0 started to call `IGM.finalize()`, which leads the Clang instance to emit ObjC metadata sections when the ObjC interop is enabled. Emitting ObjC metadata sections is not well supported on non-Darwin platforms and causes crashes for WebAssembly and COFF object formats[^1].

modulewrap tool did not configure the ObjC interop option, so it always enabled the ObjC interop. This patch aligns the default ObjC interop value with other tools by disabling it on non-Darwin platforms.


This fixes https://ci.swift.org/job/oss-swift-pr-test-crosscompile-wasm-ubuntu-20_04/566/

[^1]: https://github.com/apple/llvm-project/blob/stable/20230725/clang/lib/CodeGen/CGObjCMac.cpp#L5068-L5074
