### PR TITLE
[AST] Remove Builtin.copy.

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -537,14 +537,6 @@ BUILTIN_SIL_OPERATION(HopToActor, "hopToActor", None)
 /// Returns the number of items in a pack.
 BUILTIN_SIL_OPERATION(PackLength, "packLength", Special)
 
-/// TODO: Remove.  Only exists to avoid a reverse condfail.
-///       rdar://127516085 (Complete removal of Builtin.copy)
-///
-/// copy: <T>(T) -> T
-///
-/// Creates a copy of the source at the destination.
-BUILTIN_SIL_OPERATION(Copy, "copy", Special)
-
 // BUILTIN_RUNTIME_CALL - A call into a runtime function.
 // These functions accept a single argument of any type.
 #ifndef BUILTIN_RUNTIME_CALL

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -140,7 +140,6 @@ LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroupWithExecutor, 0, "Task create in t
 LANGUAGE_FEATURE(BuiltinCreateAsyncDiscardingTaskInGroup, 0, "Task create in discarding task group builtin, accounting for the Void return type")
 BASELINE_LANGUAGE_FEATURE(BuiltinCreateAsyncTaskWithExecutor, 0, "Task create builtin with extra executor preference")
 LANGUAGE_FEATURE(BuiltinCreateAsyncDiscardingTaskInGroupWithExecutor, 0, "Task create in discarding task group with extra executor preference")
-BASELINE_LANGUAGE_FEATURE(BuiltinCopy, 0, "Builtin.copy()")
 BASELINE_LANGUAGE_FEATURE(BuiltinStackAlloc, 0, "Builtin.stackAlloc")
 LANGUAGE_FEATURE(BuiltinUnprotectedStackAlloc, 0, "Builtin.unprotectedStackAlloc")
 LANGUAGE_FEATURE(BuiltinAllocVector, 0, "Builtin.allocVector")

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -901,14 +901,6 @@ static ValueDecl *getDestroyArrayOperation(ASTContext &ctx, Identifier id) {
                             _void);
 }
 
-static ValueDecl *getCopyOperation(ASTContext &ctx, Identifier id) {
-  return getBuiltinFunction(ctx, id, _thin,
-                            _generics(_unrestricted,
-                                      _conformsTo(_typeparam(0), _copyable),
-                                      _conformsTo(_typeparam(0), _escapable)),
-                            _parameters(_typeparam(0)), _typeparam(0));
-}
-
 static ValueDecl *getAssumeAlignment(ASTContext &ctx, Identifier id) {
   // This is always "(Builtin.RawPointer, Builtin.Word) -> Builtin.RawPointer"
   return getBuiltinFunction(ctx, id, _thin, _parameters(_rawPointer, _word),
@@ -2785,11 +2777,6 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
   case BuiltinValueKind::EndUnpairedAccess:
     if (!Types.empty()) return nullptr;
     return getEndUnpairedAccessOperation(Context, Id);
-
-  case BuiltinValueKind::Copy:
-    if (!Types.empty())
-      return nullptr;
-    return getCopyOperation(Context, Id);
 
   case BuiltinValueKind::AssumeAlignment:
     if (!Types.empty())

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -2027,23 +2027,6 @@ static ManagedValue emitBuiltinAddressOfRawLayout(SILGenFunction &SGF,
   return ManagedValue::forObjectRValueWithoutOwnership(bi);
 }
 
-/// TODO: Remove.  Only exists to avoid a reverse condfail.
-///       rdar://127516085 (Complete removal of Builtin.copy)
-static ManagedValue emitBuiltinCopy(SILGenFunction &SGF, SILLocation loc,
-                                    SubstitutionMap subs,
-                                    ArrayRef<ManagedValue> args, SGFContext C) {
-  // Builtin.copy has no uses in current/future swiftinterfaces.  It has a
-  // single use in old swiftinterfaces:
-  // func _copy<T>(_ t: T) -> T {
-  //   Builtin.copy(t)
-  // }
-  // It is sufficient to have the builtin pass the value through.  When the
-  // return is emitted, a copy will be made.
-  assert(args.size() == 1 && "not two arguments!?");
-  return ManagedValue::forOwnedAddressRValue(args[0].getValue(),
-                                             CleanupHandle::invalid());
-}
-
 std::optional<SpecializedEmitter>
 SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   // Only consider standalone declarations in the Builtin module.

--- a/test/stdlib/LifetimeManagement.swift
+++ b/test/stdlib/LifetimeManagement.swift
@@ -26,19 +26,3 @@ suite.test("move") {
 }
 
 runAllTests()
-
-// TODO: Remove.  Only exists to avoid a reverse condfail.
-//       rdar://127516085 (Complete removal of Builtin.copy)
-func _oldCopy<T>(_ value: T) -> T {
-  #if $BuiltinCopy
-    Builtin.copy(value)
-  #else
-    value
-  #endif
-}
-
-suite.test("_oldCopy") {
-  let k = Klass()
-  expectTrue(k === _oldCopy(k))
-}
-


### PR DESCRIPTION
A vestigial remnant of it was left behind after 06921cfe84d3a5025d296e0a462db8a9ad8ac413 in order to avoid a reverse condfail when building old swiftinterfaces that define

```swift
func _copy<T>(_ value: T) -> T {
  #if $BuiltinCopy
    Builtin.copy(value)
  #else
    value
  #endif
}
```

If the language feature is removed, though, such interfaces should again be buildable because the branch where the language feature isn't defined should be expanded.

rdar://127516085
