### PR TITLE
[region-isolation] Some diagnostic tweaks

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -953,10 +953,10 @@ ERROR(regionbasedisolation_unknown_pattern, none,
 //
 
 ERROR(regionbasedisolation_transfer_yields_race_no_isolation, none,
-      "transferring value of non-Sendable type %0; later accesses could race",
+      "sending value of non-Sendable type %0; later accesses could race",
       (Type))
 ERROR(regionbasedisolation_transfer_yields_race_with_isolation, none,
-      "transferring value of non-Sendable type %0 from %1 context to %2 context; later accesses could race",
+      "sending value of non-Sendable type %0 from %1 context to %2 context; later accesses could race",
       (Type, ActorIsolation, ActorIsolation))
 ERROR(regionbasedisolation_isolated_capture_yields_race, none,
       "%1 closure captures value of non-Sendable type %0 from %2 context; later accesses to value could race",
@@ -965,7 +965,7 @@ ERROR(regionbasedisolation_transfer_yields_race_stronglytransferred_binding, non
       "value of non-Sendable type %0 accessed after being transferred; later accesses could race",
       (Type))
 ERROR(regionbasedisolation_arg_transferred, none,
-      "%0 value of type %1 transferred to %2 context; later accesses to value could race",
+      "sending %0 value of type %1 to %2 context; later accesses to value could race",
       (StringRef, Type, ActorIsolation))
 ERROR(regionbasedisolation_arg_passed_to_strongly_transferred_param, none,
       "%0 value of type %1 passed as a strongly transferred parameter; later accesses could race",
@@ -979,14 +979,14 @@ NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
 //
 
 ERROR(regionbasedisolation_named_transfer_yields_race, none,
-      "transferring %0 may cause a data race",
+      "sending %0 may cause a data race",
       (Identifier))
 
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
-     "transferring %1 %0 to %2 callee could cause races in between callee %2 and local %3 uses",
+     "sending %1 %0 to %2 callee could cause races in between callee %2 and local %3 uses",
      (Identifier, StringRef, ActorIsolation, ActorIsolation))
 NOTE(regionbasedisolation_named_transfer_non_transferrable, none,
-      "transferring %1 %0 to %2 callee could cause races between %2 and %1 uses",
+      "sending %1 %0 to %2 callee could cause races between %2 and %1 uses",
       (Identifier, StringRef, ActorIsolation))
 NOTE(regionbasedisolation_named_transfer_into_transferring_param, none,
      "%0 %1 is passed as a transferring parameter; Uses in callee may race with later %0 uses",
@@ -1003,7 +1003,7 @@ NOTE(regionbasedisolation_named_isolated_closure_yields_race, none,
 
 // Misc Error.
 ERROR(regionbasedisolation_task_or_actor_isolated_transferred, none,
-      "task or actor isolated value cannot be transferred", ())
+      "task or actor isolated value cannot be sent", ())
 
 // TODO: print the name of the nominal type
 ERROR(deinit_not_visible, none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -943,7 +943,7 @@ NOTE(sil_referencebinding_inout_binding_here, none,
 //===----------------------------------------------------------------------===//
 
 NOTE(regionbasedisolation_maybe_race, none,
-     "use here could race", ())
+     "risks concurrent access", ())
 ERROR(regionbasedisolation_unknown_pattern, none,
       "pattern that the region based isolation checker does not understand how to check. Please file a bug",
       ())
@@ -979,7 +979,7 @@ NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
 //
 
 ERROR(regionbasedisolation_named_transfer_yields_race, none,
-      "sending %0 may cause a data race",
+      "sending %0 risks causing data races",
       (Identifier))
 
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -983,29 +983,29 @@ ERROR(regionbasedisolation_named_transfer_yields_race, none,
       (Identifier))
 
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
-     "sending %1 %0 to %2 callee risks causing data races between %2 and local %3 uses",
+     "sending %1%0 to %2 callee risks causing data races between %2 and local %3 uses",
      (Identifier, StringRef, ActorIsolation, ActorIsolation))
 NOTE(regionbasedisolation_named_info_transfer_yields_race_callee, none,
-     "sending %1 %0 to %2 %3 %4 risks causing data races between %2 and local %5 uses",
+     "sending %1%0 to %2 %3 %4 risks causing data races between %2 and local %5 uses",
      (Identifier, StringRef, ActorIsolation, DescriptiveDeclKind, DeclName, ActorIsolation))
 
 NOTE(regionbasedisolation_named_transfer_non_transferrable, none,
-      "sending %1 %0 to %2 callee risks causing data races between %2 and %1 uses",
-      (Identifier, StringRef, ActorIsolation))
+      "sending %1%0 to %2 callee risks causing data races between %2 and %3 uses",
+      (Identifier, StringRef, ActorIsolation, StringRef))
 NOTE(regionbasedisolation_named_transfer_non_transferrable_callee, none,
-      "sending %1 %0 to %2 %3 %4 risks causing data races between %2 and %1 uses",
-      (Identifier, StringRef, ActorIsolation, DescriptiveDeclKind, DeclName))
+      "sending %1%0 to %2 %3 %4 risks causing data races between %2 and %5 uses",
+      (Identifier, StringRef, ActorIsolation, DescriptiveDeclKind, DeclName, StringRef))
 NOTE(regionbasedisolation_named_transfer_into_transferring_param, none,
-     "%0 %1 is passed as a transferring parameter; Uses in callee may race with later %0 uses",
+     "%0%1 is passed as a transferring parameter; Uses in callee may race with later %0uses",
      (StringRef, Identifier))
 NOTE(regionbasedisolation_named_notransfer_transfer_into_result, none,
-     "%0 %1 cannot be a transferring result. %0 uses may race with caller uses",
-     (StringRef, Identifier))
+     "%0%1 cannot be a transferring result. %2 uses may race with caller uses",
+     (StringRef, Identifier, StringRef))
 NOTE(regionbasedisolation_named_stronglytransferred_binding, none,
       "%0 used after being passed as a transferring parameter; Later uses could race",
       (Identifier))
 NOTE(regionbasedisolation_named_isolated_closure_yields_race, none,
-      "%0 %1 is captured by a %2 closure. %2 uses in closure may race against later %3 uses",
+      "%0%1 is captured by a %2 closure. %2 uses in closure may race against later %3 uses",
       (StringRef, Identifier, ActorIsolation, ActorIsolation))
 
 // Misc Error.

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -983,11 +983,18 @@ ERROR(regionbasedisolation_named_transfer_yields_race, none,
       (Identifier))
 
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
-     "sending %1 %0 to %2 callee could cause races in between callee %2 and local %3 uses",
+     "sending %1 %0 to %2 callee risks causing data races between %2 and local %3 uses",
      (Identifier, StringRef, ActorIsolation, ActorIsolation))
+NOTE(regionbasedisolation_named_info_transfer_yields_race_callee, none,
+     "sending %1 %0 to %2 %3 %4 risks causing data races between %2 and local %5 uses",
+     (Identifier, StringRef, ActorIsolation, DescriptiveDeclKind, DeclName, ActorIsolation))
+
 NOTE(regionbasedisolation_named_transfer_non_transferrable, none,
-      "sending %1 %0 to %2 callee could cause races between %2 and %1 uses",
+      "sending %1 %0 to %2 callee risks causing data races between %2 and %1 uses",
       (Identifier, StringRef, ActorIsolation))
+NOTE(regionbasedisolation_named_transfer_non_transferrable_callee, none,
+      "sending %1 %0 to %2 %3 %4 risks causing data races between %2 and %1 uses",
+      (Identifier, StringRef, ActorIsolation, DescriptiveDeclKind, DeclName))
 NOTE(regionbasedisolation_named_transfer_into_transferring_param, none,
      "%0 %1 is passed as a transferring parameter; Uses in callee may race with later %0 uses",
      (StringRef, Identifier))

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -41,8 +41,6 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Debug.h"
 
-#pragma clang optimize off
-
 using namespace swift;
 using namespace swift::PartitionPrimitives;
 using namespace swift::PatternMatch;

--- a/test/ClangImporter/transferring.swift
+++ b/test/ClangImporter/transferring.swift
@@ -27,14 +27,14 @@ func funcTestTransferringResult() async {
   // Just to show that without the transferring param, we generate diagnostics.
   let x2 = NonSendableCStruct()
   let y2 = returnUserDefinedFromGlobalFunction(x2)
-  await transferToMain(x2) // expected-error {{sending 'x2' may cause a data race}}
+  await transferToMain(x2) // expected-error {{sending 'x2' risks causing data races}}
   // expected-note @-1 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  useValue(y2) // expected-note {{use here could race}}
+  useValue(y2) // expected-note {{risks concurrent access}}
 }
 
 func funcTestTransferringArg() async {
   let x = NonSendableCStruct()
-  transferUserDefinedIntoGlobalFunction(x) // expected-error {{sending 'x' may cause a data race}}
+  transferUserDefinedIntoGlobalFunction(x) // expected-error {{sending 'x' risks causing data races}}
   // expected-note @-1 {{'x' used after being passed as a transferring parameter}}
-  useValue(x) // expected-note {{use here could race}}
+  useValue(x) // expected-note {{risks concurrent access}}
 }

--- a/test/ClangImporter/transferring.swift
+++ b/test/ClangImporter/transferring.swift
@@ -27,14 +27,14 @@ func funcTestTransferringResult() async {
   // Just to show that without the transferring param, we generate diagnostics.
   let x2 = NonSendableCStruct()
   let y2 = returnUserDefinedFromGlobalFunction(x2)
-  await transferToMain(x2) // expected-error {{transferring 'x2' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(x2) // expected-error {{sending 'x2' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(y2) // expected-note {{use here could race}}
 }
 
 func funcTestTransferringArg() async {
   let x = NonSendableCStruct()
-  transferUserDefinedIntoGlobalFunction(x) // expected-error {{transferring 'x' may cause a data race}}
+  transferUserDefinedIntoGlobalFunction(x) // expected-error {{sending 'x' may cause a data race}}
   // expected-note @-1 {{'x' used after being passed as a transferring parameter}}
   useValue(x) // expected-note {{use here could race}}
 }

--- a/test/ClangImporter/transferring.swift
+++ b/test/ClangImporter/transferring.swift
@@ -28,7 +28,7 @@ func funcTestTransferringResult() async {
   let x2 = NonSendableCStruct()
   let y2 = returnUserDefinedFromGlobalFunction(x2)
   await transferToMain(x2) // expected-error {{sending 'x2' risks causing data races}}
-  // expected-note @-1 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x2' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(y2) // expected-note {{risks concurrent access}}
 }
 

--- a/test/ClangImporter/transferring_objc.swift
+++ b/test/ClangImporter/transferring_objc.swift
@@ -25,7 +25,7 @@ func methodTestTransferringResult() async {
 func methodTestTransferringArg() async {
   let x = MyType()
   let s = NSObject()
-  let _ = x.getResultWithTransferringArgument(s)  // expected-error {{transferring 's' may cause a data race}}
+  let _ = x.getResultWithTransferringArgument(s)  // expected-error {{sending 's' may cause a data race}}
   // expected-note @-1 {{'s' used after being passed as a transferring parameter; Later uses could race}}
   useValue(s) // expected-note {{use here could race}}
 }
@@ -45,14 +45,14 @@ func funcTestTransferringResult() async {
   // Just to show that without the transferring param, we generate diagnostics.
   let x2 = NSObject()
   let y2 = returnNSObjectFromGlobalFunction(x2)
-  await transferToMain(x2) // expected-error {{transferring 'x2' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(x2) // expected-error {{sending 'x2' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(y2) // expected-note {{use here could race}}
 }
 
 func funcTestTransferringArg() async {
   let x = NSObject()
-  transferNSObjectToGlobalFunction(x) // expected-error {{transferring 'x' may cause a data race}}
+  transferNSObjectToGlobalFunction(x) // expected-error {{sending 'x' may cause a data race}}
   // expected-note @-1 {{'x' used after being passed as a transferring parameter; Later uses could race}}
   useValue(x) // expected-note {{use here could race}}
 }

--- a/test/ClangImporter/transferring_objc.swift
+++ b/test/ClangImporter/transferring_objc.swift
@@ -46,7 +46,7 @@ func funcTestTransferringResult() async {
   let x2 = NSObject()
   let y2 = returnNSObjectFromGlobalFunction(x2)
   await transferToMain(x2) // expected-error {{sending 'x2' risks causing data races}}
-  // expected-note @-1 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x2' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(y2) // expected-note {{risks concurrent access}}
 }
 

--- a/test/ClangImporter/transferring_objc.swift
+++ b/test/ClangImporter/transferring_objc.swift
@@ -25,9 +25,9 @@ func methodTestTransferringResult() async {
 func methodTestTransferringArg() async {
   let x = MyType()
   let s = NSObject()
-  let _ = x.getResultWithTransferringArgument(s)  // expected-error {{sending 's' may cause a data race}}
+  let _ = x.getResultWithTransferringArgument(s)  // expected-error {{sending 's' risks causing data races}}
   // expected-note @-1 {{'s' used after being passed as a transferring parameter; Later uses could race}}
-  useValue(s) // expected-note {{use here could race}}
+  useValue(s) // expected-note {{risks concurrent access}}
 }
 
 // Make sure we just ignore the swift_attr if it is applied to something like a
@@ -45,14 +45,14 @@ func funcTestTransferringResult() async {
   // Just to show that without the transferring param, we generate diagnostics.
   let x2 = NSObject()
   let y2 = returnNSObjectFromGlobalFunction(x2)
-  await transferToMain(x2) // expected-error {{sending 'x2' may cause a data race}}
+  await transferToMain(x2) // expected-error {{sending 'x2' risks causing data races}}
   // expected-note @-1 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  useValue(y2) // expected-note {{use here could race}}
+  useValue(y2) // expected-note {{risks concurrent access}}
 }
 
 func funcTestTransferringArg() async {
   let x = NSObject()
-  transferNSObjectToGlobalFunction(x) // expected-error {{sending 'x' may cause a data race}}
+  transferNSObjectToGlobalFunction(x) // expected-error {{sending 'x' risks causing data races}}
   // expected-note @-1 {{'x' used after being passed as a transferring parameter; Later uses could race}}
-  useValue(x) // expected-note {{use here could race}}
+  useValue(x) // expected-note {{risks concurrent access}}
 }

--- a/test/Concurrency/async_task_locals_basic_warnings_bug_isolation.swift
+++ b/test/Concurrency/async_task_locals_basic_warnings_bug_isolation.swift
@@ -18,7 +18,7 @@ actor Test {
                      _ body: (consuming NonSendableValue, isolated (any Actor)?) -> Void) async {
     Self.$local.withValue(12) {
       // Unexpected errors here:
-      //  error: unexpected warning produced: transferring 'body' may cause a data race; this is an error in the Swift 6 language mode
+      //  error: unexpected warning produced: transferring 'body' risks causing data races; this is an error in the Swift 6 language mode
       //  error: unexpected note produced: actor-isolated 'body' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses
       body(NonSendableValue(), isolation)
     }

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -40,7 +40,7 @@ class NotSendable {
   MyActor.ns = ns
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{sending 'ns' may cause a data race}}
+    // expected-region-isolation-warning @+3 {{sending 'ns' risks causing data races}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
@@ -62,7 +62,7 @@ class NotSendable {
   ns.stash()
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{sending 'ns' may cause a data race}}
+    // expected-region-isolation-warning @+3 {{sending 'ns' risks causing data races}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
@@ -83,7 +83,7 @@ class NotSendable {
   let ns = NotSendable()
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{sending 'ns' may cause a data race}}
+    // expected-region-isolation-warning @+3 {{sending 'ns' risks causing data races}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -40,7 +40,7 @@ class NotSendable {
   MyActor.ns = ns
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a data race}}
+    // expected-region-isolation-warning @+3 {{sending 'ns' may cause a data race}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
@@ -62,7 +62,7 @@ class NotSendable {
   ns.stash()
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a data race}}
+    // expected-region-isolation-warning @+3 {{sending 'ns' may cause a data race}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
@@ -83,7 +83,7 @@ class NotSendable {
   let ns = NotSendable()
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a data race}}
+    // expected-region-isolation-warning @+3 {{sending 'ns' may cause a data race}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns

--- a/test/Concurrency/issue-57376.swift
+++ b/test/Concurrency/issue-57376.swift
@@ -34,7 +34,7 @@ func testAsyncSequence1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws whe
 
 func testAsyncSequenceTypedPattern<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{54-54=, Sendable}}
   // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{54-54=, Sendable}}
-  async let result: Int = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
+  async let result: Int = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be sent}}
   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
   // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
   let _ = try! await result
@@ -42,14 +42,14 @@ func testAsyncSequenceTypedPattern<Seq: AsyncSequence>(_ seq: Seq) async throws 
 
 func testAsyncSequenceTypedPattern1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{55-55=, Sendable}}
   // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{55-55=, Sendable}}
-  async let _: Int = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
+  async let _: Int = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be sent}}
   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
   // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{42-42=, Sendable}}
   // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{42-42=, Sendable}}
-  async let result = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
+  async let result = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be sent}}
   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
   // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
   let _ = try! await result
@@ -57,14 +57,14 @@ func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.El
 
 func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{43-43=, Sendable}}
   // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{43-43=, Sendable}}
-  async let _ = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
+  async let _ = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be sent}}
   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
   // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func testAsyncSequence3<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
   // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
-  async let result = seq // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
+  async let result = seq // expected-transferring-tns-warning {{task or actor isolated value cannot be sent}}
   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
   // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
   let _ = await result
@@ -72,7 +72,7 @@ func testAsyncSequence3<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, 
 
 func testAsyncSequence4<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
   // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
-  async let _ = seq // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
+  async let _ = seq // expected-transferring-tns-warning {{task or actor isolated value cannot be sent}}
   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
   // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -97,7 +97,7 @@ public actor MyActor: MyProto {
   func g(ns1: NS1) async {
     await nonisolatedAsyncFunc1(ns1) // expected-targeted-and-complete-warning{{passing argument of non-sendable type 'NS1' outside of actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{sending 'ns1' may cause a data race}}
-    // expected-tns-note @-2 {{sending actor-isolated 'ns1' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
+    // expected-tns-note @-2 {{sending actor-isolated 'ns1' to nonisolated global function 'nonisolatedAsyncFunc1' risks causing data races between nonisolated and actor-isolated uses}}
     _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable type 'NS1' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary}}
   }
 }
@@ -254,12 +254,12 @@ final class NonSendable {
     await update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
     // expected-tns-warning @-2 {{sending 'self' may cause a data race}}
-    // expected-tns-note @-3 {{sending task-isolated 'self' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+    // expected-tns-note @-3 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
 
     await self.update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
     // expected-tns-warning @-2 {{sending 'self' may cause a data race}}
-    // expected-tns-note @-3 {{sending task-isolated 'self' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+    // expected-tns-note @-3 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
 
     _ = await x
     // expected-warning@-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
@@ -278,7 +278,7 @@ func testNonSendableBaseArg() async {
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 't' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 't' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending disconnected 't' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   _ = await t.x
   // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
@@ -298,13 +298,13 @@ func callNonisolatedAsyncClosure(
   await g(ns)
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'ns' may cause a data race}}
-  // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated callee risks causing data races between nonisolated and main actor-isolated uses}}
 
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'ns' may cause a data race}}
-  // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated callee risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -96,7 +96,7 @@ public actor MyActor: MyProto {
 
   func g(ns1: NS1) async {
     await nonisolatedAsyncFunc1(ns1) // expected-targeted-and-complete-warning{{passing argument of non-sendable type 'NS1' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{sending 'ns1' may cause a data race}}
+    // expected-tns-warning @-1 {{sending 'ns1' risks causing data races}}
     // expected-tns-note @-2 {{sending actor-isolated 'ns1' to nonisolated global function 'nonisolatedAsyncFunc1' risks causing data races between nonisolated and actor-isolated uses}}
     _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable type 'NS1' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary}}
   }
@@ -253,12 +253,12 @@ final class NonSendable {
   func call() async {
     await update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{sending 'self' may cause a data race}}
+    // expected-tns-warning @-2 {{sending 'self' risks causing data races}}
     // expected-tns-note @-3 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
 
     await self.update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{sending 'self' may cause a data race}}
+    // expected-tns-warning @-2 {{sending 'self' risks causing data races}}
     // expected-tns-note @-3 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
 
     _ = await x
@@ -277,12 +277,12 @@ func testNonSendableBaseArg() async {
   let t = NonSendable()
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{sending 't' may cause a data race}}
+  // expected-tns-warning @-2 {{sending 't' risks causing data races}}
   // expected-tns-note @-3 {{sending 't' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   _ = await t.x
   // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
-  // expected-tns-note@-2 {{use here could race}}
+  // expected-tns-note@-2 {{risks concurrent access}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -297,13 +297,13 @@ func callNonisolatedAsyncClosure(
 ) async {
   await g(ns)
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{sending 'ns' may cause a data race}}
+  // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated callee risks causing data races between nonisolated and main actor-isolated uses}}
 
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{sending 'ns' may cause a data race}}
+  // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated callee risks causing data races between nonisolated and main actor-isolated uses}}
 }
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -278,7 +278,7 @@ func testNonSendableBaseArg() async {
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 't' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 't' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending 't' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   _ = await t.x
   // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -96,8 +96,8 @@ public actor MyActor: MyProto {
 
   func g(ns1: NS1) async {
     await nonisolatedAsyncFunc1(ns1) // expected-targeted-and-complete-warning{{passing argument of non-sendable type 'NS1' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'ns1' may cause a data race}}
-    // expected-tns-note @-2 {{transferring actor-isolated 'ns1' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
+    // expected-tns-warning @-1 {{sending 'ns1' may cause a data race}}
+    // expected-tns-note @-2 {{sending actor-isolated 'ns1' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
     _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable type 'NS1' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary}}
   }
 }
@@ -253,13 +253,13 @@ final class NonSendable {
   func call() async {
     await update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{transferring 'self' may cause a data race}}
-    // expected-tns-note @-3 {{transferring task-isolated 'self' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'self' may cause a data race}}
+    // expected-tns-note @-3 {{sending task-isolated 'self' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 
     await self.update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{transferring 'self' may cause a data race}}
-    // expected-tns-note @-3 {{transferring task-isolated 'self' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'self' may cause a data race}}
+    // expected-tns-note @-3 {{sending task-isolated 'self' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 
     _ = await x
     // expected-warning@-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
@@ -277,8 +277,8 @@ func testNonSendableBaseArg() async {
   let t = NonSendable()
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 't' may cause a data race}}
-  // expected-tns-note @-3 {{transferring disconnected 't' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-2 {{sending 't' may cause a data race}}
+  // expected-tns-note @-3 {{sending disconnected 't' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   _ = await t.x
   // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
@@ -297,14 +297,14 @@ func callNonisolatedAsyncClosure(
 ) async {
   await g(ns)
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 'ns' may cause a data race}}
-  // expected-tns-note @-3 {{transferring main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-tns-warning @-2 {{sending 'ns' may cause a data race}}
+  // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 'ns' may cause a data race}}
-  // expected-tns-note @-3 {{transferring main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-tns-warning @-2 {{sending 'ns' may cause a data race}}
+  // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -160,7 +160,7 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
   %useIndirect = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %useIndirect<NonSendableKlass>(%1) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   destroy_addr %1 : $*NonSendableKlass
   dealloc_stack %1 : $*NonSendableKlass
@@ -226,7 +226,7 @@ bb0(%0 : @guaranteed $NonSendableStruct):
   debug_value %0 : $NonSendableStruct, var, name "myname"
   %2 = struct_extract %0 : $NonSendableStruct, #NonSendableStruct.ns
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.ns' may cause a data race}}
+  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.ns' risks causing data races}}
   // expected-note @-1 {{task-isolated 'myname.ns' cannot be a transferring result. task-isolated uses may race with caller uses}}
 }
 
@@ -235,7 +235,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedStruct):
   debug_value %0 : $MainActorIsolatedStruct, var, name "myname"
   %2 = struct_extract %0 : $MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.ns' may cause a data race}}
+  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.ns' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'myname.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -244,7 +244,7 @@ bb0(%0 : $*MainActorIsolatedStruct):
   debug_value %0 : $*MainActorIsolatedStruct, var, name "myname"
   %2 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
   %3 = load [copy] %2 : $*NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.ns' may cause a data race}}
+  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.ns' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'myname.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -253,7 +253,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedEnum):
   debug_value %0 : $MainActorIsolatedEnum, var, name "myname"
   %2 = unchecked_enum_data %0 : $MainActorIsolatedEnum, #MainActorIsolatedEnum.second!enumelt
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.second' may cause a data race}}
+  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.second' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'myname.second' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -262,7 +262,7 @@ bb0(%0 : $*MainActorIsolatedEnum):
   debug_value %0 : $*MainActorIsolatedEnum, var, name "myname"
   %2 = unchecked_take_enum_data_addr %0 : $*MainActorIsolatedEnum, #MainActorIsolatedEnum.second!enumelt
   %3 = load [take] %2 : $*NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.second' may cause a data race}}
+  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.second' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'myname.second' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -281,7 +281,7 @@ bb2(%1 : @guaranteed $NonSendableKlass):
   br bb3(%3 : $FakeOptional<NonSendableKlass>)
 
 bb3(%4 : @owned $FakeOptional<NonSendableKlass>):
-  return %4 : $FakeOptional<NonSendableKlass> // expected-warning {{sending 'myname.some' may cause a data race}}
+  return %4 : $FakeOptional<NonSendableKlass> // expected-warning {{sending 'myname.some' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'myname.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -112,7 +112,7 @@ bb0(%0 : $*{ var NonSendableKlass }):
 
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending task-isolated value of type 'NonSendableKlass' to global actor '<null>'-isolated context}}
   destroy_value %1 : ${ var NonSendableKlass }
 
   %9999 = tuple ()
@@ -157,7 +157,7 @@ bb0:
 
   %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%1) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
   %useIndirect = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %useIndirect<NonSendableKlass>(%1) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   // expected-note @-1 {{use here could race}}
@@ -226,7 +226,7 @@ bb0(%0 : @guaranteed $NonSendableStruct):
   debug_value %0 : $NonSendableStruct, var, name "myname"
   %2 = struct_extract %0 : $NonSendableStruct, #NonSendableStruct.ns
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a data race}}
+  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.ns' may cause a data race}}
   // expected-note @-1 {{task-isolated 'myname.ns' cannot be a transferring result. task-isolated uses may race with caller uses}}
 }
 
@@ -235,7 +235,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedStruct):
   debug_value %0 : $MainActorIsolatedStruct, var, name "myname"
   %2 = struct_extract %0 : $MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a data race}}
+  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.ns' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'myname.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -244,7 +244,7 @@ bb0(%0 : $*MainActorIsolatedStruct):
   debug_value %0 : $*MainActorIsolatedStruct, var, name "myname"
   %2 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
   %3 = load [copy] %2 : $*NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a data race}}
+  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.ns' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'myname.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -253,7 +253,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedEnum):
   debug_value %0 : $MainActorIsolatedEnum, var, name "myname"
   %2 = unchecked_enum_data %0 : $MainActorIsolatedEnum, #MainActorIsolatedEnum.second!enumelt
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.second' may cause a data race}}
+  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.second' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'myname.second' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -262,7 +262,7 @@ bb0(%0 : $*MainActorIsolatedEnum):
   debug_value %0 : $*MainActorIsolatedEnum, var, name "myname"
   %2 = unchecked_take_enum_data_addr %0 : $*MainActorIsolatedEnum, #MainActorIsolatedEnum.second!enumelt
   %3 = load [take] %2 : $*NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.second' may cause a data race}}
+  return %3 : $NonSendableKlass // expected-warning {{sending 'myname.second' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'myname.second' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -281,7 +281,7 @@ bb2(%1 : @guaranteed $NonSendableKlass):
   br bb3(%3 : $FakeOptional<NonSendableKlass>)
 
 bb3(%4 : @owned $FakeOptional<NonSendableKlass>):
-  return %4 : $FakeOptional<NonSendableKlass> // expected-warning {{transferring 'myname.some' may cause a data race}}
+  return %4 : $FakeOptional<NonSendableKlass> // expected-warning {{sending 'myname.some' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'myname.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -292,7 +292,7 @@ bb0(%0 : @guaranteed $MyActor):
   %3 = class_method %0 : $MyActor, #MyActor.klass!getter : (isolated MyActor) -> () -> NonSendableKlass, $@convention(method) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
   %4 = apply %3(%0) : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
   %5 = class_method %4 : $NonSendableKlass, #NonSendableKlass.asyncCall : (NonSendableKlass) -> () async -> (), $@convention(method) @async (@guaranteed NonSendableKlass) -> ()
-  %6 = apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %5(%4) : $@convention(method) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{'self'-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
+  %6 = apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %5(%4) : $@convention(method) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending 'self'-isolated value of type 'NonSendableKlass' to actor-isolated context; later accesses to value could race}}
   destroy_value %4 : $NonSendableKlass
   hop_to_executor %0 : $MyActor
   %9 = tuple ()
@@ -313,7 +313,7 @@ bb0(%0 : @guaranteed $MyActor):
   %11 = alloc_stack $NonSendableKlass
   %12 = store_borrow %6 to %11 : $*NonSendableKlass
   %13 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %14 = apply [caller_isolation=actor_instance] [callee_isolation=global_actor] %13<NonSendableKlass>(%12) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{'self'-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
+  %14 = apply [caller_isolation=actor_instance] [callee_isolation=global_actor] %13<NonSendableKlass>(%12) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending 'self'-isolated value of type 'NonSendableKlass' to global actor '<null>'-isolated context}}
   end_borrow %12 : $*NonSendableKlass
   dealloc_stack %11 : $*NonSendableKlass
   hop_to_executor %0 : $MyActor

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -136,7 +136,7 @@ func closureInOut(_ a: MyActor) async {
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
   // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
 
   if await booleanFlag {
     // This is not an actual use since we are passing values to the same
@@ -162,7 +162,7 @@ func closureInOutDifferentActor(_ a: MyActor, _ a2: MyActor) async {
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
   // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
 
   // We only emit a warning on the first use we see, so make sure we do both
   // the use and the closure.
@@ -186,13 +186,13 @@ func closureInOut2(_ a: MyActor) async {
   var closure = {}
 
   await a.useKlass(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure = { useInOut(&contents) } // expected-tns-note {{use here could race}}
 
   await a.useKlass(ns1) // expected-tns-warning {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure() // expected-tns-note {{use here could race}}
@@ -214,7 +214,7 @@ func closureNonInOut(_ a: MyActor) async {
   closure = { useValue(contents) }
 
   await a.useKlass(ns1) // expected-tns-warning {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure() // expected-tns-note {{use here could race}}
@@ -338,7 +338,7 @@ extension MyActor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{sending disconnected 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
+    // expected-tns-note @-3 {{sending 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
 
     if await booleanFlag {
       closure = {
@@ -554,7 +554,7 @@ extension MyActor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{sending disconnected 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
+    // expected-tns-note @-3 {{sending 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
 
     // But this will error since we race.
     closure() // expected-tns-note {{use here could race}}
@@ -623,7 +623,7 @@ func singleFieldVarMergeTest() async {
   useValue(box.k)
 
   await transferToMain(box) // expected-tns-warning {{sending 'box' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'box' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'box' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
   
 
@@ -638,7 +638,7 @@ func multipleFieldVarMergeTest1() async {
 
   // This transfers the entire region.
   await transferToMain(box.k1) // expected-tns-warning {{sending 'box.k1' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'box.k1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'box.k1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   
 
@@ -679,7 +679,7 @@ func multipleFieldTupleMergeTest1() async {
 
   // This transfers the entire region.
   await transferToMain(box.0) // expected-tns-warning {{sending 'box.0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'box.0' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'box.0' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // So even if we reassign over k1, since we did a merge, this should error.
@@ -732,7 +732,7 @@ class ClassFieldTests { // expected-complete-note 6{{}}
 func letSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -741,7 +741,7 @@ func letSendableTrivialClassFieldTest() async {
 func letSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
 
   _ = test.letSendableNonTrivial
@@ -751,7 +751,7 @@ func letSendableNonTrivialClassFieldTest() async {
 func letNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -760,7 +760,7 @@ func letNonSendableNonTrivialClassFieldTest() async {
 func varSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -769,7 +769,7 @@ func varSendableTrivialClassFieldTest() async {
 func varSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{use here could race}}
   useValue(test)
@@ -778,7 +778,7 @@ func varSendableNonTrivialClassFieldTest() async {
 func varNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -800,7 +800,7 @@ final class FinalClassFieldTests { // expected-complete-note 6 {{}}
 func letSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -809,7 +809,7 @@ func letSendableTrivialFinalClassFieldTest() async {
 func letSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -818,7 +818,7 @@ func letSendableNonTrivialFinalClassFieldTest() async {
 func letNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -827,7 +827,7 @@ func letNonSendableNonTrivialFinalClassFieldTest() async {
 func varSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -836,7 +836,7 @@ func varSendableTrivialFinalClassFieldTest() async {
 func varSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{use here could race}}
   useValue(test)
@@ -845,7 +845,7 @@ func varSendableNonTrivialFinalClassFieldTest() async {
 func varNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -867,7 +867,7 @@ struct StructFieldTests { // expected-complete-note 31 {{}}
 func letSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -876,7 +876,7 @@ func letSendableTrivialLetStructFieldTest() async {
 func letSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -885,7 +885,7 @@ func letSendableNonTrivialLetStructFieldTest() async {
 func letNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -896,7 +896,7 @@ func letSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -906,7 +906,7 @@ func letSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -916,7 +916,7 @@ func letNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -936,7 +936,7 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
   }
   _ = cls2
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial
   _ = z
@@ -948,7 +948,7 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
 func varSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -957,7 +957,7 @@ func varSendableTrivialLetStructFieldTest() async {
 func varSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -966,7 +966,7 @@ func varSendableNonTrivialLetStructFieldTest() async {
 func varNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -977,7 +977,7 @@ func varSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -987,7 +987,7 @@ func varSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -997,7 +997,7 @@ func varNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -1013,7 +1013,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
   }
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -1028,7 +1028,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
   }
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -1043,7 +1043,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
   }
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
@@ -1059,7 +1059,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
   }
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -1075,7 +1075,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
   }
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -1091,7 +1091,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
   }
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
@@ -1106,7 +1106,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
   }
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
@@ -1121,7 +1121,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
   }
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
@@ -1136,7 +1136,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
   }
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
@@ -1154,7 +1154,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
     _ = cls
   } else {
     await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
     test.varSendableNonTrivial = SendableKlass()
@@ -1175,7 +1175,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
     _ = cls
 
     await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1197,7 +1197,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
     _ = cls
   } else {
     await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1217,7 +1217,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
     // the error on test below. This is still correct though, just not as
     // good... that is QoI though.
     await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
     // This is treated as a use since test is in box form and is mutable. So we
@@ -1246,7 +1246,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
   // compiler explain the regions well.
   for _ in 0..<1024 {
     await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
     test = StructFieldTests()
@@ -1270,11 +1270,11 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
     }
     _ = cls
     await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
     await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1291,7 +1291,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
 
   if await booleanFlag {
     await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
     cls = {
@@ -1299,7 +1299,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
     }
     _ = cls
     await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1314,7 +1314,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
 func varSendableTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.0
   useValue(z)
@@ -1324,7 +1324,7 @@ func varSendableTrivialLetTupleFieldTest() async {
 func varSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.1 // expected-tns-note {{use here could race}}
   useValue(z)
@@ -1334,7 +1334,7 @@ func varSendableNonTrivialLetTupleFieldTest() async {
 func varNonSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2 // expected-tns-note {{use here could race}}
   useValue(z)
@@ -1345,7 +1345,7 @@ func varSendableTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.0
   useValue(test) // expected-tns-note {{use here could race}}
@@ -1355,7 +1355,7 @@ func varSendableTrivialVarTupleFieldTest2() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test.2) // expected-tns-warning {{sending 'test.2' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test.2' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test.2' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   _ = test.0
   useValue(test) // expected-tns-note {{use here could race}}
@@ -1365,7 +1365,7 @@ func varSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.1
   useValue(test) // expected-tns-note {{use here could race}}
@@ -1375,7 +1375,7 @@ func varNonSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2 // expected-tns-note {{use here could race}}
   useValue(z)
@@ -1391,11 +1391,11 @@ func controlFlowTest1() async {
 
   if await booleanFlag {
     await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   } else {
     await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -1415,7 +1415,7 @@ func controlFlowTest2() async {
 
   for _ in 0..<1024 {
     await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
@@ -1573,7 +1573,7 @@ func testGetActorName() async {
   let a = MyActor()
   let x = NonSendableKlass()
   await a.useKlass(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -84,15 +84,15 @@ class TwoFieldKlassClassBox {
 extension MyActor {
   func warningIfCallingGetter() async {
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'self.klass' may cause a data race}}
-    // expected-tns-note @-2 {{transferring 'self'-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and 'self'-isolated uses}}
+    // expected-tns-warning @-1 {{sending 'self.klass' may cause a data race}}
+    // expected-tns-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and 'self'-isolated uses}}
   }
 
   func warningIfCallingAsyncOnFinalField() async {
     // Since we are calling finalKlass directly, we emit a warning here.
     await self.finalKlass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'self.finalKlass' may cause a data race}}
-    // expected-tns-note @-2 {{transferring 'self'-isolated 'self.finalKlass' to nonisolated callee could cause races between nonisolated and 'self'-isolated uses}}
+    // expected-tns-warning @-1 {{sending 'self.finalKlass' may cause a data race}}
+    // expected-tns-note @-2 {{sending 'self'-isolated 'self.finalKlass' to nonisolated callee could cause races between nonisolated and 'self'-isolated uses}}
   }
 
   // We do not warn on this since we warn in the caller of our getter instead.
@@ -105,8 +105,8 @@ extension FinalActor {
   func warningIfCallingAsyncOnFinalField() async {
     // Since our whole class is final, we emit the error directly here.
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'self.klass' may cause a data race}}
-    // expected-tns-note @-2 {{transferring 'self'-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and 'self'-isolated uses}}
+    // expected-tns-warning @-1 {{sending 'self.klass' may cause a data race}}
+    // expected-tns-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and 'self'-isolated uses}}
   }
 }
 
@@ -135,8 +135,8 @@ func closureInOut(_ a: MyActor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
-  // expected-tns-warning @-2 {{transferring 'ns0' may cause a data race}}
-  // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
+  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
 
   if await booleanFlag {
     // This is not an actual use since we are passing values to the same
@@ -161,8 +161,8 @@ func closureInOutDifferentActor(_ a: MyActor, _ a2: MyActor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
-  // expected-tns-warning @-2 {{transferring 'ns0' may cause a data race}}
-  // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
+  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
 
   // We only emit a warning on the first use we see, so make sure we do both
   // the use and the closure.
@@ -185,14 +185,14 @@ func closureInOut2(_ a: MyActor) async {
 
   var closure = {}
 
-  await a.useKlass(ns0) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.useKlass(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure = { useInOut(&contents) } // expected-tns-note {{use here could race}}
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.useKlass(ns1) // expected-tns-warning {{sending 'ns1' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure() // expected-tns-note {{use here could race}}
@@ -213,8 +213,8 @@ func closureNonInOut(_ a: MyActor) async {
 
   closure = { useValue(contents) }
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.useKlass(ns1) // expected-tns-warning {{sending 'ns1' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure() // expected-tns-note {{use here could race}}
@@ -245,8 +245,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfAndTransferThroughTuple() async {
@@ -256,7 +256,7 @@ extension MyActor {
     let x = (1, closure)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type '(Int, () -> ())' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{'self'-isolated value of type '(Int, () -> ())' transferred to main actor-isolated context}}
+    // expected-tns-warning @-2 {{sending 'self'-isolated value of type '(Int, () -> ())' to main actor-isolated context}}
   }
 
   func simpleClosureCaptureSelfAndTransferThroughTupleBackwards() async {
@@ -265,7 +265,7 @@ extension MyActor {
     }
 
     let x = (closure, 1)
-    await transferToMain(x) // expected-tns-warning {{'self'-isolated value of type '(() -> (), Int)' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{sending 'self'-isolated value of type '(() -> (), Int)' to main actor-isolated context}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '(() -> (), Int)' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -276,8 +276,8 @@ extension MyActor {
     }
     let x: Any? = (1, closure)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-2 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
+    // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfAndTransferThroughOptionalBackwards() async {
@@ -289,8 +289,8 @@ extension MyActor {
     // store it all as once.
     let x: Any? = (closure, 1)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-2 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
+    // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfWithReinit() async {
@@ -301,8 +301,8 @@ extension MyActor {
     // Error here.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
 
     closure = {}
 
@@ -327,8 +327,8 @@ extension MyActor {
     // Error here.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfWithReinit3() async {
@@ -337,8 +337,8 @@ extension MyActor {
     // We get a transfer after use error.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring disconnected 'closure' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending disconnected 'closure' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
 
     if await booleanFlag {
       closure = {
@@ -349,8 +349,8 @@ extension MyActor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-note @-2 {{use here could race}}
-    // expected-tns-warning @-3 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-4 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-3 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-4 {{sending 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   // In this case, we reinit along both paths, but only one has an actor derived
@@ -372,8 +372,8 @@ extension MyActor {
 
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   #if TYPECHECKER_ONLY
@@ -401,8 +401,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfThroughTuple2() async {
@@ -412,8 +412,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfThroughOptional() async {
@@ -423,8 +423,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 }
 
@@ -512,8 +512,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   // Make sure that we properly propagate actor derived from klass into field's
@@ -525,8 +525,8 @@ extension MyActor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 }
 
@@ -539,8 +539,8 @@ extension MyActor {
     // This should error.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
 
     // This doesnt since we re-assign
     closure = {}
@@ -553,8 +553,8 @@ extension MyActor {
     // But this transfer should.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring disconnected 'closure' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
+    // expected-tns-warning @-2 {{sending 'closure' may cause a data race}}
+    // expected-tns-note @-3 {{sending disconnected 'closure' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
 
     // But this will error since we race.
     closure() // expected-tns-note {{use here could race}}
@@ -577,8 +577,8 @@ func testConversionsAndSendable(a: MyActor, f: @Sendable () -> Void, f2: () -> V
   // Show that we error if we are not sendable.
   await a.useNonSendableFunction(f2) // expected-complete-warning {{passing argument of non-sendable type '() -> Void' into actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{transferring 'f2' may cause a data race}}
-  // expected-tns-note @-3 {{transferring task-isolated 'f2' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+  // expected-tns-warning @-2 {{sending 'f2' may cause a data race}}
+  // expected-tns-note @-3 {{sending task-isolated 'f2' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
 }
 
 func testSendableClosureCapturesNonSendable(a: MyActor) {
@@ -622,8 +622,8 @@ func singleFieldVarMergeTest() async {
   useValue(box)
   useValue(box.k)
 
-  await transferToMain(box) // expected-tns-warning {{transferring 'box' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'box' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(box) // expected-tns-warning {{sending 'box' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'box' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
   
 
@@ -637,8 +637,8 @@ func multipleFieldVarMergeTest1() async {
   box = TwoFieldKlassBox()
 
   // This transfers the entire region.
-  await transferToMain(box.k1) // expected-tns-warning {{transferring 'box.k1' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'box.k1' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(box.k1) // expected-tns-warning {{sending 'box.k1' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'box.k1' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   
 
@@ -678,8 +678,8 @@ func multipleFieldTupleMergeTest1() async {
   box = (NonSendableKlass(), NonSendableKlass())
 
   // This transfers the entire region.
-  await transferToMain(box.0) // expected-tns-warning {{transferring 'box.0' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'box.0' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(box.0) // expected-tns-warning {{sending 'box.0' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'box.0' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // So even if we reassign over k1, since we did a merge, this should error.
@@ -731,8 +731,8 @@ class ClassFieldTests { // expected-complete-note 6{{}}
 
 func letSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -740,8 +740,8 @@ func letSendableTrivialClassFieldTest() async {
 
 func letSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
 
   _ = test.letSendableNonTrivial
@@ -750,8 +750,8 @@ func letSendableNonTrivialClassFieldTest() async {
 
 func letNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -759,8 +759,8 @@ func letNonSendableNonTrivialClassFieldTest() async {
 
 func varSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -768,8 +768,8 @@ func varSendableTrivialClassFieldTest() async {
 
 func varSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{use here could race}}
   useValue(test)
@@ -777,8 +777,8 @@ func varSendableNonTrivialClassFieldTest() async {
 
 func varNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -799,8 +799,8 @@ final class FinalClassFieldTests { // expected-complete-note 6 {{}}
 
 func letSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -808,8 +808,8 @@ func letSendableTrivialFinalClassFieldTest() async {
 
 func letSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -817,8 +817,8 @@ func letSendableNonTrivialFinalClassFieldTest() async {
 
 func letNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -826,8 +826,8 @@ func letNonSendableNonTrivialFinalClassFieldTest() async {
 
 func varSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -835,8 +835,8 @@ func varSendableTrivialFinalClassFieldTest() async {
 
 func varSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{use here could race}}
   useValue(test)
@@ -844,8 +844,8 @@ func varSendableNonTrivialFinalClassFieldTest() async {
 
 func varNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
@@ -866,8 +866,8 @@ struct StructFieldTests { // expected-complete-note 31 {{}}
 
 func letSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -875,8 +875,8 @@ func letSendableTrivialLetStructFieldTest() async {
 
 func letSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -884,8 +884,8 @@ func letSendableNonTrivialLetStructFieldTest() async {
 
 func letNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -895,8 +895,8 @@ func letNonSendableNonTrivialLetStructFieldTest() async {
 func letSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -905,8 +905,8 @@ func letSendableTrivialVarStructFieldTest() async {
 func letSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -915,8 +915,8 @@ func letSendableNonTrivialVarStructFieldTest() async {
 func letNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -935,8 +935,8 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
     print(test)
   }
   _ = cls2
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial
   _ = z
@@ -947,8 +947,8 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
 
 func varSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -956,8 +956,8 @@ func varSendableTrivialLetStructFieldTest() async {
 
 func varSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -965,8 +965,8 @@ func varSendableNonTrivialLetStructFieldTest() async {
 
 func varNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -976,8 +976,8 @@ func varNonSendableNonTrivialLetStructFieldTest() async {
 func varSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -986,8 +986,8 @@ func varSendableTrivialVarStructFieldTest() async {
 func varSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
   useValue(test) // expected-tns-note {{use here could race}}
@@ -996,8 +996,8 @@ func varSendableNonTrivialVarStructFieldTest() async {
 func varNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -1012,8 +1012,8 @@ func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -1027,8 +1027,8 @@ func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -1042,8 +1042,8 @@ func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
@@ -1058,8 +1058,8 @@ func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -1074,8 +1074,8 @@ func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
@@ -1090,8 +1090,8 @@ func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
@@ -1105,8 +1105,8 @@ func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
     test.varSendableNonTrivial = SendableKlass()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
@@ -1120,8 +1120,8 @@ func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
     useInOut(&test)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
@@ -1135,8 +1135,8 @@ func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
     useInOut(&test.varSendableNonTrivial)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
@@ -1153,8 +1153,8 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
     test.varSendableNonTrivial = SendableKlass()
@@ -1174,8 +1174,8 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
     }
     _ = cls
 
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1196,8 +1196,8 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1216,8 +1216,8 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
     // loop carry use and an error due to multiple params. Then we could emit
     // the error on test below. This is still correct though, just not as
     // good... that is QoI though.
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
     // This is treated as a use since test is in box form and is mutable. So we
@@ -1245,8 +1245,8 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
   // this. This is a case where we are going to need to be able to have the
   // compiler explain the regions well.
   for _ in 0..<1024 {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
     test = StructFieldTests()
@@ -1269,12 +1269,12 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1290,16 +1290,16 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
   var cls = {}
 
   if await booleanFlag {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
     cls = {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1313,8 +1313,8 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
 
 func varSendableTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.0
   useValue(z)
@@ -1323,8 +1323,8 @@ func varSendableTrivialLetTupleFieldTest() async {
 
 func varSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.1 // expected-tns-note {{use here could race}}
   useValue(z)
@@ -1333,8 +1333,8 @@ func varSendableNonTrivialLetTupleFieldTest() async {
 
 func varNonSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2 // expected-tns-note {{use here could race}}
   useValue(z)
@@ -1344,8 +1344,8 @@ func varNonSendableNonTrivialLetTupleFieldTest() async {
 func varSendableTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.0
   useValue(test) // expected-tns-note {{use here could race}}
@@ -1354,8 +1354,8 @@ func varSendableTrivialVarTupleFieldTest() async {
 func varSendableTrivialVarTupleFieldTest2() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test.2) // expected-tns-warning {{transferring 'test.2' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test.2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test.2) // expected-tns-warning {{sending 'test.2' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test.2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   _ = test.0
   useValue(test) // expected-tns-note {{use here could race}}
@@ -1364,8 +1364,8 @@ func varSendableTrivialVarTupleFieldTest2() async {
 func varSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.1
   useValue(test) // expected-tns-note {{use here could race}}
@@ -1374,8 +1374,8 @@ func varSendableNonTrivialVarTupleFieldTest() async {
 func varNonSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(test) // expected-tns-warning {{sending 'test' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2 // expected-tns-note {{use here could race}}
   useValue(z)
@@ -1390,12 +1390,12 @@ func controlFlowTest1() async {
   let x = NonSendableKlass()
 
   if await booleanFlag {
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -1414,8 +1414,8 @@ func controlFlowTest2() async {
   var x = NonSendableKlass()
 
   for _ in 0..<1024 {
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+    await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
@@ -1439,24 +1439,24 @@ actor ActorWithSetter {
   func test1() async {
     let x = NonSendableKlass()
     self.field = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}    
   }
 
@@ -1476,8 +1476,8 @@ actor ActorWithSetter {
   func classBox() async {
     let x = NonSendableKlass()
     self.classBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
@@ -1492,24 +1492,24 @@ final actor FinalActorWithSetter {
   func test1() async {
     let x = NonSendableKlass()
     self.field = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -1529,15 +1529,15 @@ final actor FinalActorWithSetter {
   func classBox() async {
     let x = NonSendableKlass()
     self.classBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
 
 func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let _ = { @MainActor in
-    let _ = x // expected-tns-warning {{transferring 'x' may cause a data race}}
+    let _ = x // expected-tns-warning {{sending 'x' may cause a data race}}
     // expected-tns-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }
@@ -1551,8 +1551,8 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let a = MainActorIsolatedKlass()
   var c = NonSendableKlass()
   for _ in 0..<1024 {
-    await useValueAsync(c) // expected-tns-warning {{transferring 'c' may cause a data race}}
-    // expected-tns-note @-1 {{transferring main actor-isolated 'c' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+    await useValueAsync(c) // expected-tns-warning {{sending 'c' may cause a data race}}
+    // expected-tns-note @-1 {{sending main actor-isolated 'c' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' outside of main actor-isolated context may introduce data races}}
     c = a.klass
   }
@@ -1562,8 +1562,8 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let a = MainActorIsolatedKlass()
   var c = NonSendableKlass()
   for _ in 0..<1024 {
-    await useValueAsync(c) // expected-tns-warning {{transferring 'c' may cause a data race}}
-    // expected-tns-note @-1 {{transferring main actor-isolated 'c' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+    await useValueAsync(c) // expected-tns-warning {{sending 'c' may cause a data race}}
+    // expected-tns-note @-1 {{sending main actor-isolated 'c' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' outside of main actor-isolated context may introduce data races}}
     c = a.klassLet
   }
@@ -1572,24 +1572,24 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
 func testGetActorName() async {
   let a = MyActor()
   let x = NonSendableKlass()
-  await a.useKlass(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.useKlass(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
 }
 
 extension MyActor {
   func testCallBangIsolatedMethod(other: MyActor) async {
-    await klass.asyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{transferring 'self.klass' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'self.klass' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
+    await klass.asyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
 
 extension FinalActor {
   func testCallBangIsolatedMethod(other: MyActor) async {
-    await klass.asyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{transferring 'self.klass' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'self.klass' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
+    await klass.asyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
@@ -1601,16 +1601,16 @@ extension NonSendableKlass {
 
 extension MyActor {
   func testCallBangIsolatedDirectMethod(other: MyActor) async {
-    await klass.directAsyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{transferring 'self.klass' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'self.klass' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
+    await klass.directAsyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
 
 extension FinalActor {
   func testCallBangIsolatedDirectMethod(other: MyActor) async {
-    await klass.directAsyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{transferring 'self.klass' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'self.klass' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
+    await klass.directAsyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -65,27 +65,27 @@ struct TwoFieldKlassBox { // expected-complete-note 24{{}}
 
 func asyncLet_Let_ActorIsolated_Simple1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_Simple2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   let _ = await y
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
 }
 
 func asyncLet_Let_ActorIsolated_Simple3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -98,36 +98,36 @@ func asyncLet_Let_ActorIsolated_Simple3() async {
   if await booleanFlag {
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{use here could race}}
+    useValue(x) // expected-tns-note {{risks concurrent access}}
   }
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
 }
 
 func asyncLet_Let_ActorIsolated_Simple4() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
-    useValue(x) // expected-tns-note {{use here could race}}
+    useValue(x) // expected-tns-note {{risks concurrent access}}
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{use here could race}}
+    useValue(x) // expected-tns-note {{risks concurrent access}}
   }
 }
 
 func asyncLet_Let_ActorIsolated_Simple5() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
     let _ = await y
-    useValue(x) // expected-tns-note {{use here could race}}
+    useValue(x) // expected-tns-note {{risks concurrent access}}
   } else {
-    useValue(x) // expected-tns-note {{use here could race}}
+    useValue(x) // expected-tns-note {{risks concurrent access}}
   }
 }
 
@@ -135,31 +135,31 @@ func asyncLet_Let_ActorIsolated_Simple5() async {
 // async let rather than the base class.
 func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x.field) // expected-tns-note {{use here could race}}
+  useValue(x.field) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x.field2) // expected-tns-note {{use here could race}}
+  useValue(x.field2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -167,41 +167,41 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x.k1) // expected-tns-note {{use here could race}}
+  useValue(x.k1) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x.k2) // expected-tns-note {{use here could race}}
+  useValue(x.k2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x.k1.field) // expected-tns-note {{use here could race}}
+  useValue(x.k1.field) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -209,45 +209,45 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.1) // expected-tns-note {{use here could race}}
+  useValue(x.1) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.1.k2) // expected-tns-note {{use here could race}}
+  useValue(x.1.k2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.0.k2.field) // expected-tns-note {{use here could race}}
+  useValue(x.0.k2.field) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -255,34 +255,34 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr1() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
+  // expected-tns-warning @-2 {{sending 'x2' risks causing data races}}
   // expected-tns-note @-3 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await y
-  useValue(x2) // expected-tns-note {{use here could race}}
+  useValue(x2) // expected-tns-note {{risks concurrent access}}
 }
 
 func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
+  // expected-tns-warning @-2 {{sending 'x2' risks causing data races}}
   // expected-tns-note @-3 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x2) // expected-tns-note {{use here could race}}
+  useValue(x2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
 }
 
 // Make sure we emit separate errors for x and x2.
@@ -290,9 +290,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
+  // expected-tns-warning @-2 {{sending 'x2' risks causing data races}}
   // expected-tns-note @-3 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -301,8 +301,8 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
 
   // We only error on the first value captured if multiple values are captured
   // since we track a single partial_apply as a transfer instruction.
-  useValue(x) // expected-tns-note {{use here could race}}
-  useValue(x2) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
+  useValue(x2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -311,9 +311,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
 func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-note @-2:67 {{use here could race}}
+  // expected-tns-note @-2:67 {{risks concurrent access}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -327,9 +327,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{sending 'x' may cause a data race}}
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-note @-2:53 {{use here could race}}
+  // expected-tns-note @-2:53 {{risks concurrent access}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -360,7 +360,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{sending 'x2' may cause a data race}}
+  // expected-tns-warning @-1 {{sending 'x2' risks causing data races}}
   // expected-tns-note @-2 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -368,7 +368,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
-  useValue(x2) // expected-tns-note {{use here could race}}
+  useValue(x2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
   let _ = await z
 }
@@ -378,9 +378,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
   // expected-tns-note @-2 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
+  // expected-tns-warning @-3 {{sending 'x2' risks causing data races}}
   // expected-tns-note @-4 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}  
   // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -389,8 +389,8 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
 
   let _ = await y
   let _ = await z
-  useValue(x) // expected-tns-note {{use here could race}}
-  useValue(x2) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
+  useValue(x2) // expected-tns-note {{risks concurrent access}}
 }
 
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
@@ -398,9 +398,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
   // expected-tns-note @-2 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
+  // expected-tns-warning @-3 {{sending 'x2' risks causing data races}}
   // expected-tns-note @-4 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -408,9 +408,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
   // expected-complete-warning @-8 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let _ = await y
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await z
-  useValue(x2) // expected-tns-note {{use here could race}}
+  useValue(x2) // expected-tns-note {{risks concurrent access}}
 }
 
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
@@ -418,9 +418,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
   // expected-tns-note @-2 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
+  // expected-tns-warning @-3 {{sending 'x2' risks causing data races}}
   // expected-tns-note @-4 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // expected-complete-warning @-6 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -429,8 +429,8 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
   // expected-complete-warning @-9 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let _ = await y
-  useValue(x) // expected-tns-note {{use here could race}}
-  useValue(x2) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
+  useValue(x2) // expected-tns-note {{risks concurrent access}}
   let _ = await z
 }
 
@@ -443,7 +443,7 @@ func asyncLet_Let_NonIsolated_Simple1() async {
   async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -469,9 +469,9 @@ func asyncLet_Let_NonIsolated_Simple3() async {
   if await booleanFlag {
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{use here could race}}
+    useValue(x) // expected-tns-note {{risks concurrent access}}
   }
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
 }
 
 func asyncLet_Let_NonIsolated_Simple4() async {
@@ -480,10 +480,10 @@ func asyncLet_Let_NonIsolated_Simple4() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   if await booleanFlag {
-    useValue(x) // expected-tns-note {{use here could race}}
+    useValue(x) // expected-tns-note {{risks concurrent access}}
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{use here could race}}
+    useValue(x) // expected-tns-note {{risks concurrent access}}
   }
 }
 
@@ -496,7 +496,7 @@ func asyncLet_Let_NonIsolated_Simple5() async {
     let _ = await y
     useValue(x)
   } else {
-    useValue(x) // expected-tns-note {{use here could race}}
+    useValue(x) // expected-tns-note {{risks concurrent access}}
   }
 }
 
@@ -507,7 +507,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass1() async {
   async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -516,7 +516,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass2() async {
   async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
-  useValue(x.field) // expected-tns-note {{use here could race}}
+  useValue(x.field) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -525,7 +525,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass3() async {
   async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
-  useValue(x.field2) // expected-tns-note {{use here could race}}
+  useValue(x.field2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -536,7 +536,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct1() async {
   async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -545,7 +545,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct2() async {
   async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
-  useValue(x.k1) // expected-tns-note {{use here could race}}
+  useValue(x.k1) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -554,7 +554,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct3() async {
   async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
-  useValue(x.k2) // expected-tns-note {{use here could race}}
+  useValue(x.k2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -563,7 +563,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct4() async {
   async let y = transferToNonIsolatedInt(x.k2.field2) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
-  useValue(x.k1.field) // expected-tns-note {{use here could race}}
+  useValue(x.k1.field) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -575,7 +575,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple1() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -584,7 +584,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple2() async {
   async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.1) // expected-tns-note {{use here could race}}
+  useValue(x.1) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -594,7 +594,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple3() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
 
-  useValue(x.1.k2) // expected-tns-note {{use here could race}}
+  useValue(x.1.k2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -603,7 +603,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple4() async {
   async let y = transferToNonIsolatedInt(x.1.k1.field2) // expected-tns-warning {{sending value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.0.k2.field) // expected-tns-note {{use here could race}}
+  useValue(x.0.k2.field) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -614,7 +614,7 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr1() async {
   async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await y
   useValue(x2)
 }
@@ -626,7 +626,7 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr2() async {
   async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  useValue(x2) // expected-tns-note {{use here could race}}
+  useValue(x2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
   useValue(x)
 }
@@ -644,8 +644,8 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr3() async {
 
   // We only error on the first value captured if multiple values are captured
   // since we track a single partial_apply as a transfer instruction.
-  useValue(x) // expected-tns-note {{use here could race}}
-  useValue(x2) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
+  useValue(x2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 }
 
@@ -666,7 +666,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
   async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x)) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
-  // expected-tns-note @-1:60 {{use here could race}}
+  // expected-tns-note @-1:60 {{risks concurrent access}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -698,7 +698,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet3() async {
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
-  useValue(x2) // expected-tns-note {{use here could race}}
+  useValue(x2) // expected-tns-note {{risks concurrent access}}
   let _ = await y
   let _ = await z
 }
@@ -743,7 +743,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet6() async {
 
   let _ = await y
   useValue(x)
-  useValue(x2) // expected-tns-note {{use here could race}}
+  useValue(x2) // expected-tns-note {{risks concurrent access}}
   let _ = await z
 }
 
@@ -755,7 +755,7 @@ func asyncLet_Let_NormalUse_Simple1() async {
   let x = NonSendableKlass()
   async let y = x // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x) // expected-tns-note {{risks concurrent access}}
   let _ = await y
 
 }
@@ -775,8 +775,8 @@ func asyncLetWithoutCapture() async {
   async let x: NonSendableKlass = await returnValueFromMain()
   // expected-warning @-1 {{non-sendable type 'NonSendableKlass' returned by implicitly asynchronous call to main actor-isolated function cannot cross actor boundary}}
   let y = await x
-  await transferToMain(y) // expected-tns-warning {{sending 'y' may cause a data race}}
+  await transferToMain(y) // expected-tns-warning {{sending 'y' risks causing data races}}
   // expected-tns-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(y) // expected-tns-note {{use here could race}}
+  useValue(y) // expected-tns-note {{risks concurrent access}}
 }

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -66,7 +66,7 @@ struct TwoFieldKlassBox { // expected-complete-note 24{{}}
 func asyncLet_Let_ActorIsolated_Simple1() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
@@ -76,7 +76,7 @@ func asyncLet_Let_ActorIsolated_Simple1() async {
 func asyncLet_Let_ActorIsolated_Simple2() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   let _ = await y
@@ -86,7 +86,7 @@ func asyncLet_Let_ActorIsolated_Simple2() async {
 func asyncLet_Let_ActorIsolated_Simple3() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
@@ -106,7 +106,7 @@ func asyncLet_Let_ActorIsolated_Simple3() async {
 func asyncLet_Let_ActorIsolated_Simple4() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
@@ -120,7 +120,7 @@ func asyncLet_Let_ActorIsolated_Simple4() async {
 func asyncLet_Let_ActorIsolated_Simple5() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
@@ -136,7 +136,7 @@ func asyncLet_Let_ActorIsolated_Simple5() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
@@ -146,7 +146,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.field) // expected-tns-note {{use here could race}}
@@ -156,7 +156,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.field2) // expected-tns-note {{use here could race}}
@@ -168,7 +168,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
@@ -178,7 +178,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x.k1) // expected-tns-note {{use here could race}}
@@ -188,7 +188,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x.k2) // expected-tns-note {{use here could race}}
@@ -198,7 +198,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.k1.field) // expected-tns-note {{use here could race}}
@@ -210,7 +210,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -221,7 +221,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -232,7 +232,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -243,7 +243,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -256,9 +256,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr1() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -273,9 +273,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -291,9 +291,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -312,7 +312,7 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
   let x = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-note @-2:67 {{use here could race}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -328,7 +328,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-note @-2:53 {{use here could race}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -361,7 +361,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-tns-warning @-1 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-2 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -379,9 +379,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}  
+  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}  
   // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-7 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -399,9 +399,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-7 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -419,9 +419,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // expected-complete-warning @-6 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -776,7 +776,7 @@ func asyncLetWithoutCapture() async {
   // expected-warning @-1 {{non-sendable type 'NonSendableKlass' returned by implicitly asynchronous call to main actor-isolated function cannot cross actor boundary}}
   let y = await x
   await transferToMain(y) // expected-tns-warning {{sending 'y' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(y) // expected-tns-note {{use here could race}}
 }

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -66,7 +66,7 @@ struct TwoFieldKlassBox { // expected-complete-note 24{{}}
 func asyncLet_Let_ActorIsolated_Simple1() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
@@ -76,7 +76,7 @@ func asyncLet_Let_ActorIsolated_Simple1() async {
 func asyncLet_Let_ActorIsolated_Simple2() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   let _ = await y
@@ -86,7 +86,7 @@ func asyncLet_Let_ActorIsolated_Simple2() async {
 func asyncLet_Let_ActorIsolated_Simple3() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
@@ -106,7 +106,7 @@ func asyncLet_Let_ActorIsolated_Simple3() async {
 func asyncLet_Let_ActorIsolated_Simple4() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
@@ -120,7 +120,7 @@ func asyncLet_Let_ActorIsolated_Simple4() async {
 func asyncLet_Let_ActorIsolated_Simple5() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
@@ -136,7 +136,7 @@ func asyncLet_Let_ActorIsolated_Simple5() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
@@ -146,7 +146,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.field) // expected-tns-note {{use here could race}}
@@ -156,7 +156,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.field2) // expected-tns-note {{use here could race}}
@@ -168,7 +168,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
@@ -178,7 +178,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x.k1) // expected-tns-note {{use here could race}}
@@ -188,7 +188,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x.k2) // expected-tns-note {{use here could race}}
@@ -198,7 +198,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.k1.field) // expected-tns-note {{use here could race}}
@@ -210,7 +210,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -221,7 +221,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -232,7 +232,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -243,7 +243,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -256,9 +256,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr1() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -273,9 +273,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -291,9 +291,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -312,7 +312,7 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
   let x = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-note @-2:67 {{use here could race}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -328,7 +328,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-note @-2:53 {{use here could race}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -361,7 +361,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-tns-warning @-1 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-2 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -379,9 +379,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}  
+  // expected-tns-note @-4 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}  
   // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-7 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -399,9 +399,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-4 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-7 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -419,9 +419,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2 {{sending 'x' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
-  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-4 {{sending 'x2' to main actor-isolated callee risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // expected-complete-warning @-6 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -776,7 +776,7 @@ func asyncLetWithoutCapture() async {
   // expected-warning @-1 {{non-sendable type 'NonSendableKlass' returned by implicitly asynchronous call to main actor-isolated function cannot cross actor boundary}}
   let y = await x
   await transferToMain(y) // expected-tns-warning {{sending 'y' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(y) // expected-tns-note {{use here could race}}
 }

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -65,8 +65,8 @@ struct TwoFieldKlassBox { // expected-complete-note 24{{}}
 
 func asyncLet_Let_ActorIsolated_Simple1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
@@ -75,8 +75,8 @@ func asyncLet_Let_ActorIsolated_Simple1() async {
 
 func asyncLet_Let_ActorIsolated_Simple2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   let _ = await y
@@ -85,8 +85,8 @@ func asyncLet_Let_ActorIsolated_Simple2() async {
 
 func asyncLet_Let_ActorIsolated_Simple3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
@@ -105,8 +105,8 @@ func asyncLet_Let_ActorIsolated_Simple3() async {
 
 func asyncLet_Let_ActorIsolated_Simple4() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
@@ -119,8 +119,8 @@ func asyncLet_Let_ActorIsolated_Simple4() async {
 
 func asyncLet_Let_ActorIsolated_Simple5() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
@@ -135,8 +135,8 @@ func asyncLet_Let_ActorIsolated_Simple5() async {
 // async let rather than the base class.
 func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
@@ -145,8 +145,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.field) // expected-tns-note {{use here could race}}
@@ -155,8 +155,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.field2) // expected-tns-note {{use here could race}}
@@ -167,8 +167,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
@@ -177,8 +177,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x.k1) // expected-tns-note {{use here could race}}
@@ -187,8 +187,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x.k2) // expected-tns-note {{use here could race}}
@@ -197,8 +197,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.k1.field) // expected-tns-note {{use here could race}}
@@ -209,8 +209,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -220,8 +220,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -231,8 +231,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -242,8 +242,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -255,10 +255,10 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr1() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{transferring 'x2' may cause a data race}}
-  // expected-tns-note @-3 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
+  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -272,10 +272,10 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{transferring 'x2' may cause a data race}}
-  // expected-tns-note @-3 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
+  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -290,10 +290,10 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{transferring 'x2' may cause a data race}}
-  // expected-tns-note @-3 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-2 {{sending 'x2' may cause a data race}}
+  // expected-tns-note @-3 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -311,8 +311,8 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
 func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-tns-note @-2:67 {{use here could race}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -327,8 +327,8 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-tns-note @-2:53 {{use here could race}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -360,8 +360,8 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{transferring 'x2' may cause a data race}}
-  // expected-tns-note @-2 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-1 {{sending 'x2' may cause a data race}}
+  // expected-tns-note @-2 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -378,10 +378,10 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-2 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{transferring 'x2' may cause a data race}}
-  // expected-tns-note @-4 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}  
+  // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
+  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}  
   // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-7 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -398,10 +398,10 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-2 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{transferring 'x2' may cause a data race}}
-  // expected-tns-note @-4 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
+  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-7 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -418,10 +418,10 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-2 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{transferring 'x2' may cause a data race}}
-  // expected-tns-note @-4 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-tns-note @-2 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-3 {{sending 'x2' may cause a data race}}
+  // expected-tns-note @-4 {{sending disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   // expected-complete-warning @-6 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -440,7 +440,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
 
 func asyncLet_Let_NonIsolated_Simple1() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x) // expected-tns-note {{use here could race}}
@@ -458,7 +458,7 @@ func asyncLet_Let_NonIsolated_Simple2() async {
 
 func asyncLet_Let_NonIsolated_Simple3() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   // TODO: We shouldn't emit the 2nd error here given the current implementation
@@ -476,7 +476,7 @@ func asyncLet_Let_NonIsolated_Simple3() async {
 
 func asyncLet_Let_NonIsolated_Simple4() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   if await booleanFlag {
@@ -489,7 +489,7 @@ func asyncLet_Let_NonIsolated_Simple4() async {
 
 func asyncLet_Let_NonIsolated_Simple5() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   if await booleanFlag {
@@ -504,7 +504,7 @@ func asyncLet_Let_NonIsolated_Simple5() async {
 // async let rather than the base class.
 func asyncLet_Let_NonIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x) // expected-tns-note {{use here could race}}
@@ -513,7 +513,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass1() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x.field) // expected-tns-note {{use here could race}}
@@ -522,7 +522,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass2() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x.field2) // expected-tns-note {{use here could race}}
@@ -533,7 +533,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass3() async {
 // async let rather than the base struct.
 func asyncLet_Let_NonIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x) // expected-tns-note {{use here could race}}
@@ -542,7 +542,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct1() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x.k1) // expected-tns-note {{use here could race}}
@@ -551,7 +551,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct2() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x.k2) // expected-tns-note {{use here could race}}
@@ -560,7 +560,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct3() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k2.field2) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x.k2.field2) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x.k1.field) // expected-tns-note {{use here could race}}
@@ -571,7 +571,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct4() async {
 // async let rather than the base struct.
 func asyncLet_Let_NonIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -581,7 +581,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple1() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   useValue(x.1) // expected-tns-note {{use here could race}}
@@ -590,7 +590,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple2() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
 
@@ -600,7 +600,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple3() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.1.k1.field2) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
+  async let y = transferToNonIsolatedInt(x.1.k1.field2) // expected-tns-warning {{sending value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   useValue(x.0.k2.field) // expected-tns-note {{use here could race}}
@@ -611,7 +611,7 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr1() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   useValue(x) // expected-tns-note {{use here could race}}
@@ -623,7 +623,7 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr2() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   useValue(x2) // expected-tns-note {{use here could race}}
@@ -636,8 +636,8 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  // expected-tns-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -665,7 +665,7 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr4() async {
 func asyncLet_Let_NonIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x)) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-tns-note @-1:60 {{use here could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -693,7 +693,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet3() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
-  // expected-tns-warning @-1:60 {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  // expected-tns-warning @-1:60 {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -736,7 +736,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet6() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  // expected-tns-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -753,7 +753,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet6() async {
 
 func asyncLet_Let_NormalUse_Simple1() async {
   let x = NonSendableKlass()
-  async let y = x // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  async let y = x // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
@@ -775,8 +775,8 @@ func asyncLetWithoutCapture() async {
   async let x: NonSendableKlass = await returnValueFromMain()
   // expected-warning @-1 {{non-sendable type 'NonSendableKlass' returned by implicitly asynchronous call to main actor-isolated function cannot cross actor boundary}}
   let y = await x
-  await transferToMain(y) // expected-tns-warning {{transferring 'y' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(y) // expected-tns-warning {{sending 'y' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(y) // expected-tns-note {{use here could race}}
 }

--- a/test/Concurrency/transfernonsendable_cfg.sil
+++ b/test/Concurrency/transfernonsendable_cfg.sil
@@ -47,7 +47,7 @@ bb3:
   // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %useKlass = function_ref @useKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %useKlass(%klass) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
   destroy_value %klass : $NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()

--- a/test/Concurrency/transfernonsendable_cfg.sil
+++ b/test/Concurrency/transfernonsendable_cfg.sil
@@ -44,7 +44,7 @@ bb2:
 bb3:
   %transferKlass = function_ref @transferKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferKlass(%klass) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %useKlass = function_ref @useKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %useKlass(%klass) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   // expected-note @-1 {{use here could race}}

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -79,13 +79,13 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
   let x = firstList
 
   await transferToMainActor(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainActor' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedList<Int>' into main actor-isolated context may introduce data races}}
 
   let y = secondList.listHead!.next!
 
   await transferToMainActor(y) // expected-tns-warning {{sending 'y' may cause a data race}}
-  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'y' to main actor-isolated global function 'transferToMainActor' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
 
@@ -97,7 +97,7 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
   }
 
   await transferToMainActor(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainActor' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
 
@@ -152,7 +152,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   x.x = firstList
 
   await transferToNonIsolated(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to nonisolated callee could cause races between nonisolated and global actor 'CustomActor'-isolated uses}}
+  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to nonisolated global function 'transferToNonIsolated' risks causing data races between nonisolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
   useValue(x)
@@ -176,7 +176,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   x.1 = firstList
 
   await transferToNonIsolated(x) // expected-tns-warning {{sending 'x' may cause a data race}}
-  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to nonisolated callee could cause races between nonisolated and global actor 'CustomActor'-isolated uses}}
+  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to nonisolated global function 'transferToNonIsolated' risks causing data races between nonisolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
@@ -260,7 +260,7 @@ struct Clock {
   let erased: () -> Void = closure
 
   await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
-  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -269,7 +269,7 @@ struct Clock {
   let erased: () -> Void = mainActorFunction
 
   await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
-  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -278,7 +278,7 @@ struct Clock {
   let erased: (T) -> Void = useValueMainActor
 
   await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
-  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(T) -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -292,7 +292,7 @@ struct Clock {
   let erased: () -> Void = t.foo
 
   await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
-  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -306,7 +306,7 @@ struct Clock {
   let erased: () -> Void = t.foo
 
   await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
-  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -317,7 +317,7 @@ struct Clock {
   }
   // Regions: [{(closure), @MainActor}]
   await transferToCustomActor(closure) // expected-tns-warning {{sending 'closure' may cause a data race}}
-  // expected-tns-note @-1 {{sending main actor-isolated 'closure' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'closure' to global actor 'CustomActor'-isolated global function 'transferToCustomActor' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -327,7 +327,7 @@ struct Clock {
     mainActorFunction()
   }
   await transferToCustomActor(closure) // expected-tns-warning {{sending 'closure' may cause a data race}}
-  // expected-tns-note @-1 {{sending main actor-isolated 'closure' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'closure' to global actor 'CustomActor'-isolated global function 'transferToCustomActor' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -78,13 +78,13 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
 @CustomActor func useCustomActor1() async {
   let x = firstList
 
-  await transferToMainActor(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  await transferToMainActor(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainActor' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedList<Int>' into main actor-isolated context may introduce data races}}
 
   let y = secondList.listHead!.next!
 
-  await transferToMainActor(y) // expected-tns-warning {{sending 'y' may cause a data race}}
+  await transferToMainActor(y) // expected-tns-warning {{sending 'y' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'y' to main actor-isolated global function 'transferToMainActor' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
@@ -96,7 +96,7 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
     x = secondList.listHead!.next!
   }
 
-  await transferToMainActor(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  await transferToMainActor(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainActor' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
@@ -151,7 +151,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = StructContainingValue()
   x.x = firstList
 
-  await transferToNonIsolated(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  await transferToNonIsolated(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to nonisolated global function 'transferToNonIsolated' risks causing data races between nonisolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
@@ -175,7 +175,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
 
   x.1 = firstList
 
-  await transferToNonIsolated(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  await transferToNonIsolated(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to nonisolated global function 'transferToNonIsolated' risks causing data races between nonisolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
@@ -209,7 +209,7 @@ struct Clock {
   let _ = { @MainActor in
     // TODO: The type checker seems to think that the isolation here is
     // nonisolated instead of custom actor isolated.
-    print(ns) // expected-tns-warning {{sending 'ns' may cause a data race}}
+    print(ns) // expected-tns-warning {{sending 'ns' risks causing data races}}
     // expected-tns-note @-1 {{global actor 'CustomActor'-isolated 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     // expected-complete-warning @-2 {{capture of 'ns' with non-sendable type 'NonSendableKlass' in an isolated closure}}
   }
@@ -259,7 +259,7 @@ struct Clock {
 
   let erased: () -> Void = closure
 
-  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
+  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -268,7 +268,7 @@ struct Clock {
 @MainActor func synchronousActorIsolatedFunctionError() async {
   let erased: () -> Void = mainActorFunction
 
-  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
+  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -277,7 +277,7 @@ struct Clock {
 @MainActor func synchronousActorIsolatedGenericFunctionError<T>(_ t: T) async {
   let erased: (T) -> Void = useValueMainActor
 
-  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
+  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(T) -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -291,7 +291,7 @@ struct Clock {
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
+  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -305,7 +305,7 @@ struct Clock {
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
+  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -316,7 +316,7 @@ struct Clock {
     print(mainActorIsolatedGlobal)
   }
   // Regions: [{(closure), @MainActor}]
-  await transferToCustomActor(closure) // expected-tns-warning {{sending 'closure' may cause a data race}}
+  await transferToCustomActor(closure) // expected-tns-warning {{sending 'closure' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'closure' to global actor 'CustomActor'-isolated global function 'transferToCustomActor' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -326,7 +326,7 @@ struct Clock {
   let closure = {
     mainActorFunction()
   }
-  await transferToCustomActor(closure) // expected-tns-warning {{sending 'closure' may cause a data race}}
+  await transferToCustomActor(closure) // expected-tns-warning {{sending 'closure' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'closure' to global actor 'CustomActor'-isolated global function 'transferToCustomActor' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -78,14 +78,14 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
 @CustomActor func useCustomActor1() async {
   let x = firstList
 
-  await transferToMainActor(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  await transferToMainActor(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedList<Int>' into main actor-isolated context may introduce data races}}
 
   let y = secondList.listHead!.next!
 
-  await transferToMainActor(y) // expected-tns-warning {{transferring 'y' may cause a data race}}
-  // expected-tns-note @-1 {{transferring global actor 'CustomActor'-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  await transferToMainActor(y) // expected-tns-warning {{sending 'y' may cause a data race}}
+  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
 
@@ -96,8 +96,8 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
     x = secondList.listHead!.next!
   }
 
-  await transferToMainActor(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  await transferToMainActor(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
 
@@ -151,8 +151,8 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = StructContainingValue()
   x.x = firstList
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to nonisolated callee could cause races between nonisolated and global actor 'CustomActor'-isolated uses}}
+  await transferToNonIsolated(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to nonisolated callee could cause races between nonisolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
   useValue(x)
@@ -175,8 +175,8 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
 
   x.1 = firstList
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-  // expected-tns-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to nonisolated callee could cause races between nonisolated and global actor 'CustomActor'-isolated uses}}
+  await transferToNonIsolated(x) // expected-tns-warning {{sending 'x' may cause a data race}}
+  // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to nonisolated callee could cause races between nonisolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
@@ -196,7 +196,7 @@ struct Clock {
 // We used to crash when inferring the type for the diagnostic below.
 @MainActor func testIndirectParametersHandledCorrectly() async {
   let c = Clock()
-  let _: Int = await c.measure { // expected-tns-warning {{main actor-isolated value of type '() async -> Int' transferred to nonisolated context}}
+  let _: Int = await c.measure { // expected-tns-warning {{sending main actor-isolated value of type '() async -> Int' to nonisolated context}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() async -> Int' outside of main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     try! await c.sleep()
@@ -209,7 +209,7 @@ struct Clock {
   let _ = { @MainActor in
     // TODO: The type checker seems to think that the isolation here is
     // nonisolated instead of custom actor isolated.
-    print(ns) // expected-tns-warning {{transferring 'ns' may cause a data race}}
+    print(ns) // expected-tns-warning {{sending 'ns' may cause a data race}}
     // expected-tns-note @-1 {{global actor 'CustomActor'-isolated 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     // expected-complete-warning @-2 {{capture of 'ns' with non-sendable type 'NonSendableKlass' in an isolated closure}}
   }
@@ -259,8 +259,8 @@ struct Clock {
 
   let erased: () -> Void = closure
 
-  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a data race}}
-  // expected-tns-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -268,8 +268,8 @@ struct Clock {
 @MainActor func synchronousActorIsolatedFunctionError() async {
   let erased: () -> Void = mainActorFunction
 
-  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a data race}}
-  // expected-tns-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -277,8 +277,8 @@ struct Clock {
 @MainActor func synchronousActorIsolatedGenericFunctionError<T>(_ t: T) async {
   let erased: (T) -> Void = useValueMainActor
 
-  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a data race}}
-  // expected-tns-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(T) -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -291,8 +291,8 @@ struct Clock {
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a data race}}
-  // expected-tns-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -305,8 +305,8 @@ struct Clock {
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a data race}}
-  // expected-tns-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-tns-warning {{sending 'erased' may cause a data race}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -316,8 +316,8 @@ struct Clock {
     print(mainActorIsolatedGlobal)
   }
   // Regions: [{(closure), @MainActor}]
-  await transferToCustomActor(closure) // expected-tns-warning {{transferring 'closure' may cause a data race}}
-  // expected-tns-note @-1 {{transferring main actor-isolated 'closure' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+  await transferToCustomActor(closure) // expected-tns-warning {{sending 'closure' may cause a data race}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'closure' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -326,8 +326,8 @@ struct Clock {
   let closure = {
     mainActorFunction()
   }
-  await transferToCustomActor(closure) // expected-tns-warning {{transferring 'closure' may cause a data race}}
-  // expected-tns-note @-1 {{transferring main actor-isolated 'closure' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+  await transferToCustomActor(closure) // expected-tns-warning {{sending 'closure' may cause a data race}}
+  // expected-tns-note @-1 {{sending main actor-isolated 'closure' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }

--- a/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
@@ -101,7 +101,7 @@ extension NonSendableGlobalActorIsolatedStruct {
 
   mutating func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{transferring 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   mutating func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -166,7 +166,7 @@ extension NonSendableGlobalActorIsolatedEnum {
       return nil
     }
     return x
-  } // expected-error {{transferring 'x.some' may cause a data race}}
+  } // expected-error {{sending 'x.some' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'x.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -181,7 +181,7 @@ extension NonSendableGlobalActorIsolatedKlass {
 
   func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{transferring 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -214,7 +214,7 @@ extension FinalNonSendableGlobalActorIsolatedKlass {
 
   func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{transferring 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -247,7 +247,7 @@ extension GlobalActorIsolatedProtocol {
 
   mutating func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{transferring 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   mutating func test4() -> (any GlobalActorIsolatedProtocol)? {

--- a/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
@@ -101,7 +101,7 @@ extension NonSendableGlobalActorIsolatedStruct {
 
   mutating func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{sending 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   mutating func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -166,7 +166,7 @@ extension NonSendableGlobalActorIsolatedEnum {
       return nil
     }
     return x
-  } // expected-error {{sending 'x.some' may cause a data race}}
+  } // expected-error {{sending 'x.some' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'x.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -181,7 +181,7 @@ extension NonSendableGlobalActorIsolatedKlass {
 
   func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{sending 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -214,7 +214,7 @@ extension FinalNonSendableGlobalActorIsolatedKlass {
 
   func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{sending 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -247,7 +247,7 @@ extension GlobalActorIsolatedProtocol {
 
   mutating func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{sending 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   mutating func test4() -> (any GlobalActorIsolatedProtocol)? {

--- a/test/Concurrency/transfernonsendable_global_actor_serialization.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_serialization.swift
@@ -16,5 +16,5 @@ func useValueAsync<T>(_ t: T) async {}
   let erased: () -> Void = mainActorFunction
 
   await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
-  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_global_actor_serialization.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_serialization.swift
@@ -15,6 +15,6 @@ func useValueAsync<T>(_ t: T) async {}
 @MainActor func synchronousActorIsolatedFunctionError() async {
   let erased: () -> Void = mainActorFunction
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
-  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_global_actor_serialization.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_serialization.swift
@@ -15,6 +15,6 @@ func useValueAsync<T>(_ t: T) async {}
 @MainActor func synchronousActorIsolatedFunctionError() async {
   let erased: () -> Void = mainActorFunction
 
-  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_global_actor_swift6.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_swift6.swift
@@ -45,21 +45,21 @@ var booleanFlag: Bool { false }
   let erased: () -> Void = closure
 
   await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
-  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedFunctionError() async {
   let erased: () -> Void = mainActorFunction
 
   await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
-  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedGenericFunctionError<T>(_ t: T) async {
   let erased: (T) -> Void = useValueMainActor
 
   await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
-  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedClassMethodError() async {
@@ -71,7 +71,7 @@ var booleanFlag: Bool { false }
   let erased: () -> Void = t.foo
 
   await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
-  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedFinalClassMethodError() async {
@@ -83,5 +83,5 @@ var booleanFlag: Bool { false }
   let erased: () -> Void = t.foo
 
   await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
-  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_global_actor_swift6.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_swift6.swift
@@ -44,22 +44,22 @@ var booleanFlag: Bool { false }
 
   let erased: () -> Void = closure
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
-  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedFunctionError() async {
   let erased: () -> Void = mainActorFunction
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
-  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedGenericFunctionError<T>(_ t: T) async {
   let erased: (T) -> Void = useValueMainActor
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
-  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedClassMethodError() async {
@@ -70,8 +70,8 @@ var booleanFlag: Bool { false }
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
-  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedFinalClassMethodError() async {
@@ -82,6 +82,6 @@ var booleanFlag: Bool { false }
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
-  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_global_actor_swift6.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_swift6.swift
@@ -44,21 +44,21 @@ var booleanFlag: Bool { false }
 
   let erased: () -> Void = closure
 
-  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedFunctionError() async {
   let erased: () -> Void = mainActorFunction
 
-  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedGenericFunctionError<T>(_ t: T) async {
   let erased: (T) -> Void = useValueMainActor
 
-  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
@@ -70,7 +70,7 @@ var booleanFlag: Bool { false }
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
@@ -82,6 +82,6 @@ var booleanFlag: Bool { false }
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-error {{sending 'erased' may cause a data race}}
+  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -33,7 +33,7 @@ actor ActorWithSynchronousNonIsolatedInit {
 
     // TODO: This should say actor isolated.
     let _ = { @MainActor in
-      print(newK) // expected-error {{sending 'newK' may cause a data race}}
+      print(newK) // expected-error {{sending 'newK' risks causing data races}}
       // expected-note @-1 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -45,7 +45,7 @@ actor ActorWithSynchronousNonIsolatedInit {
 
     let _ = { @MainActor in
       // TODO: Second part should say later 'self'-isolated uses
-      print(newK) // expected-error {{sending 'newK' may cause a data race}}
+      print(newK) // expected-error {{sending 'newK' risks causing data races}}
       // expected-note @-1 {{'self'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -56,19 +56,19 @@ actor ActorWithSynchronousNonIsolatedInit {
 func initActorWithSyncNonIsolatedInit() {
   let k = NonSendableKlass()
   // TODO: This should say actor isolated.
-  _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
   // expected-note @-1 {{sending 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
-  let _ = { @MainActor in // expected-note {{use here could race}}
+  let _ = { @MainActor in // expected-note {{risks concurrent access}}
     print(k)
   }
 }
 
 func initActorWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
   // TODO: This should say actor isolated.
-  _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and task-isolated uses}}
   let _ = { @MainActor in
-    print(k) // expected-error {{sending 'k' may cause a data race}}
+    print(k) // expected-error {{sending 'k' risks causing data races}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }
@@ -76,7 +76,7 @@ func initActorWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
 actor ActorWithAsyncIsolatedInit {
   init(_ newK: NonSendableKlass) async {
     let _ = { @MainActor in
-      print(newK) // expected-error {{sending 'newK' may cause a data race}}
+      print(newK) // expected-error {{sending 'newK' risks causing data races}}
       // expected-note @-1 {{actor-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -85,19 +85,19 @@ actor ActorWithAsyncIsolatedInit {
 func initActorWithAsyncIsolatedInit() async {
   let k = NonSendableKlass()
   // TODO: This should say actor isolated.
-  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
   // expected-note @-1 {{sending 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
-  let _ = { @MainActor in // expected-note {{use here could race}}
+  let _ = { @MainActor in // expected-note {{risks concurrent access}}
     print(k)
   }
 }
 
 func initActorWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
   // TODO: This should say actor isolated.
-  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and task-isolated uses}}
   let _ = { @MainActor in
-    print(k) // expected-error {{sending 'k' may cause a data race}}
+    print(k) // expected-error {{sending 'k' risks causing data races}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }
@@ -114,7 +114,7 @@ class ClassWithSynchronousNonIsolatedInit {
     helper(newK)
 
     let _ = { @MainActor in
-      print(newK) // expected-error {{sending 'newK' may cause a data race}}
+      print(newK) // expected-error {{sending 'newK' risks causing data races}}
       // expected-note @-1 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -133,7 +133,7 @@ func initClassWithSyncNonIsolatedInit() {
 func initClassWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
   _ = ClassWithSynchronousNonIsolatedInit(k)
   let _ = { @MainActor in
-    print(k) // expected-error {{sending 'k' may cause a data race}}
+    print(k) // expected-error {{sending 'k' risks causing data races}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }
@@ -142,7 +142,7 @@ func initClassWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
 class ClassWithAsyncIsolatedInit {
   init(_ newK: NonSendableKlass) async {
     let _ = { @MainActor in
-      print(newK) // expected-error {{sending 'newK' may cause a data race}}
+      print(newK) // expected-error {{sending 'newK' risks causing data races}}
       // expected-note @-1 {{global actor 'CustomActor'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -153,18 +153,18 @@ func initClassWithAsyncIsolatedInit() async {
   // TODO: Might make sense to emit a more specific error here since the closure
   // is MainActor isolated. The actual capture is initially not isolated to
   // MainActor.
-  _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
   // expected-note @-1 {{sending 'k' to global actor 'CustomActor'-isolated initializer 'init(_:)' risks causing data races between global actor 'CustomActor'-isolated and local nonisolated uses}}
-  let _ = { @MainActor in // expected-note {{use here could race}}
+  let _ = { @MainActor in // expected-note {{risks concurrent access}}
     print(k)
   }
 }
 
 func initClassWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
-  _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'k' to global actor 'CustomActor'-isolated initializer 'init(_:)' risks causing data races between global actor 'CustomActor'-isolated and task-isolated uses}}
   let _ = { @MainActor in
-    print(k) // expected-error {{sending 'k' may cause a data race}}
+    print(k) // expected-error {{sending 'k' risks causing data races}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -57,7 +57,7 @@ func initActorWithSyncNonIsolatedInit() {
   let k = NonSendableKlass()
   // TODO: This should say actor isolated.
   _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'k' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     print(k)
   }
@@ -66,7 +66,7 @@ func initActorWithSyncNonIsolatedInit() {
 func initActorWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
   // TODO: This should say actor isolated.
   _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'k' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and task-isolated uses}}
   let _ = { @MainActor in
     print(k) // expected-error {{sending 'k' may cause a data race}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
@@ -86,7 +86,7 @@ func initActorWithAsyncIsolatedInit() async {
   let k = NonSendableKlass()
   // TODO: This should say actor isolated.
   _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'k' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     print(k)
   }
@@ -95,7 +95,7 @@ func initActorWithAsyncIsolatedInit() async {
 func initActorWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
   // TODO: This should say actor isolated.
   _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'k' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and task-isolated uses}}
   let _ = { @MainActor in
     print(k) // expected-error {{sending 'k' may cause a data race}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
@@ -154,7 +154,7 @@ func initClassWithAsyncIsolatedInit() async {
   // is MainActor isolated. The actual capture is initially not isolated to
   // MainActor.
   _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'k' to global actor 'CustomActor'-isolated callee could cause races in between callee global actor 'CustomActor'-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'k' to global actor 'CustomActor'-isolated initializer 'init(_:)' risks causing data races between global actor 'CustomActor'-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     print(k)
   }
@@ -162,7 +162,7 @@ func initClassWithAsyncIsolatedInit() async {
 
 func initClassWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
   _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'k' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'k' to global actor 'CustomActor'-isolated initializer 'init(_:)' risks causing data races between global actor 'CustomActor'-isolated and task-isolated uses}}
   let _ = { @MainActor in
     print(k) // expected-error {{sending 'k' may cause a data race}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -57,7 +57,7 @@ func initActorWithSyncNonIsolatedInit() {
   let k = NonSendableKlass()
   // TODO: This should say actor isolated.
   _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     print(k)
   }
@@ -86,7 +86,7 @@ func initActorWithAsyncIsolatedInit() async {
   let k = NonSendableKlass()
   // TODO: This should say actor isolated.
   _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     print(k)
   }
@@ -154,7 +154,7 @@ func initClassWithAsyncIsolatedInit() async {
   // is MainActor isolated. The actual capture is initially not isolated to
   // MainActor.
   _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'k' to global actor 'CustomActor'-isolated initializer 'init(_:)' risks causing data races between global actor 'CustomActor'-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'k' to global actor 'CustomActor'-isolated initializer 'init(_:)' risks causing data races between global actor 'CustomActor'-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     print(k)
   }

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -33,7 +33,7 @@ actor ActorWithSynchronousNonIsolatedInit {
 
     // TODO: This should say actor isolated.
     let _ = { @MainActor in
-      print(newK) // expected-error {{transferring 'newK' may cause a data race}}
+      print(newK) // expected-error {{sending 'newK' may cause a data race}}
       // expected-note @-1 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -45,7 +45,7 @@ actor ActorWithSynchronousNonIsolatedInit {
 
     let _ = { @MainActor in
       // TODO: Second part should say later 'self'-isolated uses
-      print(newK) // expected-error {{transferring 'newK' may cause a data race}}
+      print(newK) // expected-error {{sending 'newK' may cause a data race}}
       // expected-note @-1 {{'self'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -56,8 +56,8 @@ actor ActorWithSynchronousNonIsolatedInit {
 func initActorWithSyncNonIsolatedInit() {
   let k = NonSendableKlass()
   // TODO: This should say actor isolated.
-  _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'k' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'k' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     print(k)
   }
@@ -65,10 +65,10 @@ func initActorWithSyncNonIsolatedInit() {
 
 func initActorWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
   // TODO: This should say actor isolated.
-  _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'k' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+  _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'k' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
   let _ = { @MainActor in
-    print(k) // expected-error {{transferring 'k' may cause a data race}}
+    print(k) // expected-error {{sending 'k' may cause a data race}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }
@@ -76,7 +76,7 @@ func initActorWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
 actor ActorWithAsyncIsolatedInit {
   init(_ newK: NonSendableKlass) async {
     let _ = { @MainActor in
-      print(newK) // expected-error {{transferring 'newK' may cause a data race}}
+      print(newK) // expected-error {{sending 'newK' may cause a data race}}
       // expected-note @-1 {{actor-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -85,8 +85,8 @@ actor ActorWithAsyncIsolatedInit {
 func initActorWithAsyncIsolatedInit() async {
   let k = NonSendableKlass()
   // TODO: This should say actor isolated.
-  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'k' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'k' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     print(k)
   }
@@ -94,10 +94,10 @@ func initActorWithAsyncIsolatedInit() async {
 
 func initActorWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
   // TODO: This should say actor isolated.
-  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'k' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'k' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
   let _ = { @MainActor in
-    print(k) // expected-error {{transferring 'k' may cause a data race}}
+    print(k) // expected-error {{sending 'k' may cause a data race}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }
@@ -114,7 +114,7 @@ class ClassWithSynchronousNonIsolatedInit {
     helper(newK)
 
     let _ = { @MainActor in
-      print(newK) // expected-error {{transferring 'newK' may cause a data race}}
+      print(newK) // expected-error {{sending 'newK' may cause a data race}}
       // expected-note @-1 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -133,7 +133,7 @@ func initClassWithSyncNonIsolatedInit() {
 func initClassWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
   _ = ClassWithSynchronousNonIsolatedInit(k)
   let _ = { @MainActor in
-    print(k) // expected-error {{transferring 'k' may cause a data race}}
+    print(k) // expected-error {{sending 'k' may cause a data race}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }
@@ -142,7 +142,7 @@ func initClassWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
 class ClassWithAsyncIsolatedInit {
   init(_ newK: NonSendableKlass) async {
     let _ = { @MainActor in
-      print(newK) // expected-error {{transferring 'newK' may cause a data race}}
+      print(newK) // expected-error {{sending 'newK' may cause a data race}}
       // expected-note @-1 {{global actor 'CustomActor'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -153,18 +153,18 @@ func initClassWithAsyncIsolatedInit() async {
   // TODO: Might make sense to emit a more specific error here since the closure
   // is MainActor isolated. The actual capture is initially not isolated to
   // MainActor.
-  _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'k' to global actor 'CustomActor'-isolated callee could cause races in between callee global actor 'CustomActor'-isolated and local nonisolated uses}}
+  _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'k' to global actor 'CustomActor'-isolated callee could cause races in between callee global actor 'CustomActor'-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     print(k)
   }
 }
 
 func initClassWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
-  _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'k' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and task-isolated uses}}
+  _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{sending 'k' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'k' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and task-isolated uses}}
   let _ = { @MainActor in
-    print(k) // expected-error {{transferring 'k' may cause a data race}}
+    print(k) // expected-error {{sending 'k' may cause a data race}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -94,7 +94,7 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
   destroy_value %1 : $NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
@@ -110,7 +110,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   yield %3 : $*NonSendableKlass, resume bb1, unwind bb2
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
 bb1:
   end_borrow %3 : $*NonSendableKlass
@@ -137,7 +137,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<FakeOptional<NonSendableKlass>>(%2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   // expected-warning @-1 {{sending value of non-Sendable type 'FakeOptional<NonSendableKlass>' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   switch_enum_addr %2 : $*FakeOptional<NonSendableKlass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
 bb1:
   destroy_addr %2 : $*FakeOptional<NonSendableKlass>
@@ -164,7 +164,7 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
   destroy_value %1a : $NonSendableKlass
   destroy_value %1 : $NonSendableKlass
   %9999 = tuple ()
@@ -181,7 +181,7 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1a) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
   destroy_value %1a : $NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
@@ -200,7 +200,7 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableMoveOnlyStruct' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %5 = function_ref @useMoveOnlyStructIndirectly : $@convention(thin) (@in_guaranteed NonSendableMoveOnlyStruct) -> ()
   apply %5(%unresolved) : $@convention(thin) (@in_guaranteed NonSendableMoveOnlyStruct) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
   destroy_value %box : ${ var NonSendableMoveOnlyStruct }
   %9999 = tuple ()
   return %9999 : $()
@@ -220,7 +220,7 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%project) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
   destroy_value %binding : ${ var NonSendableKlass }
   %9999 = tuple ()
   return %9999 : $()
@@ -242,7 +242,7 @@ bb0:
   %0bb = begin_borrow %0a : $@moveOnly NonSendableKlass
   %0d = moveonlywrapper_to_copyable [guaranteed] %0bb : $@moveOnly NonSendableKlass
   apply %3(%0d) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
   end_borrow %0bb : $@moveOnly NonSendableKlass
   destroy_value %0a : $@moveOnly NonSendableKlass
   %9999 = tuple ()
@@ -265,7 +265,7 @@ bb0:
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%unwrappedProject) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   end_borrow %bb : ${ var @moveOnly NonSendableKlass }
   destroy_value %box : ${ var @moveOnly NonSendableKlass }
@@ -299,7 +299,7 @@ bb0:
   %p2 = project_box %bb2 : ${ var NonSendableKlass }, 0
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%p2) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
   end_borrow %bb2 : ${ var NonSendableKlass }
 
   destroy_value %pa : $@callee_owned () -> ()
@@ -367,7 +367,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   fix_lifetime %1 : $NonSendableKlass
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
   destroy_value %1 : $NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
@@ -387,7 +387,7 @@ bb0:
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   destroy_addr %3 : $*NonSendableKlass
   dealloc_stack %3 : $*NonSendableKlass
@@ -428,7 +428,7 @@ bb0:
 
   // But we have an error here since we store through the value.c
   apply %useNonSendableKlass(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   end_borrow %1a : $NonSendableKlass
   destroy_value %0 : $NonSendableKlass
@@ -455,7 +455,7 @@ sil [ossa] @mark_dependence_test_base_has_a_require : $@convention(thin) @async 
 
   // But we have an error here since we store through the value.c
   apply %useNonSendableKlass(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   end_borrow %1a : $NonSendableKlass
   destroy_value %0 : $NonSendableKlass
@@ -475,7 +475,7 @@ sil [ossa] @mark_dependence_test_base_is_a_require : $@convention(thin) @async (
 
   %1a = begin_borrow %1 : $NonSendableKlass
   %2 = mark_dependence %1a : $NonSendableKlass on %0 : $NonSendableKlass
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   end_borrow %1a : $NonSendableKlass
   destroy_value %0 : $NonSendableKlass
@@ -581,9 +581,9 @@ bb0(%0 : $Builtin.RawPointer):
 
   %useRawPointer = function_ref @useRawPointer : $@convention(thin) (Builtin.RawPointer) -> ()
   apply %useRawPointer(%3a) : $@convention(thin) (Builtin.RawPointer) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
   apply %useRawPointer(%5a) : $@convention(thin) (Builtin.RawPointer) -> ()
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   destroy_value %4 : $SendableKlass
   destroy_value %6 : $SendableKlass
@@ -607,7 +607,7 @@ bb0:
 
   // Test that this is viewed as a use of %construct
   %3 = raw_pointer_to_ref %3a : $Builtin.RawPointer to $SendableKlass
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   destroy_value %value : $NonSendableKlass
   %9999 = tuple ()
@@ -626,7 +626,7 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   destroy_value %value : $NonSendableKlass
   %9999 = tuple ()
@@ -652,8 +652,8 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
-  // expected-note @-1 {{use here could race}}
-  // expected-note @-2 {{use here could race}}  
+  // expected-note @-1 {{risks concurrent access}}
+  // expected-note @-2 {{risks concurrent access}}  
 
   destroy_value %value : $SendableKlass
   %9999 = tuple ()
@@ -670,7 +670,7 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %word = unchecked_trivial_bit_cast %value : $NonSendableKlass to $Builtin.Word
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   destroy_value %value : $NonSendableKlass
   %9999 = tuple ()
@@ -704,7 +704,7 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   destroy_value %value : $NonSendableKlass
   %9999 = tuple ()
@@ -728,8 +728,8 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
-  // expected-note @-1 {{use here could race}}
-  // expected-note @-2 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
+  // expected-note @-2 {{risks concurrent access}}
 
   destroy_value %value : $SendableKlass
   %9999 = tuple ()
@@ -746,7 +746,7 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %word = unchecked_bitwise_cast %value : $NonSendableKlass to $Builtin.Word
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   destroy_value %value : $NonSendableKlass
   %9999 = tuple ()
@@ -781,7 +781,7 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   end_borrow %valueB : $NonSendableKlass
   destroy_value %value : $NonSendableKlass
@@ -807,8 +807,8 @@ bb0:
   // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
-  // expected-note @-1 {{use here could race}}
-  // expected-note @-2 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
+  // expected-note @-2 {{risks concurrent access}}
 
   end_borrow %valueB : $SendableKlass
   destroy_value %value : $SendableKlass
@@ -827,7 +827,7 @@ bb0:
 
   %valueB = begin_borrow %value : $NonSendableKlass
   %word = unchecked_value_cast %valueB : $NonSendableKlass to $Builtin.Word
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
   end_borrow %valueB : $NonSendableKlass
 
   destroy_value %value : $NonSendableKlass
@@ -897,7 +897,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %value2 = unchecked_ref_cast %value : $NonSendableKlass to $Builtin.BridgeObject
-  %1 = classify_bridge_object %value2 : $Builtin.BridgeObject // expected-note {{use here could race}}
+  %1 = classify_bridge_object %value2 : $Builtin.BridgeObject // expected-note {{risks concurrent access}}
   destroy_value %value2 : $Builtin.BridgeObject
 
   %9999 = tuple ()
@@ -913,7 +913,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %value2 = unchecked_ref_cast %value : $NonSendableKlass to $Builtin.BridgeObject
-  %1 = bridge_object_to_word %value2 : $Builtin.BridgeObject to $Builtin.Word // expected-note {{use here could race}}
+  %1 = bridge_object_to_word %value2 : $Builtin.BridgeObject to $Builtin.Word // expected-note {{risks concurrent access}}
   destroy_value %value2 : $Builtin.BridgeObject
 
   %9999 = tuple ()
@@ -940,7 +940,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   destroy_value %value : $NonSendableKlass
-  %1 = is_unique %a : $*NonSendableKlass // expected-note {{use here could race}}
+  %1 = is_unique %a : $*NonSendableKlass // expected-note {{risks concurrent access}}
   destroy_addr %a : $*NonSendableKlass
   dealloc_stack %a : $*NonSendableKlass
 
@@ -962,7 +962,7 @@ bb0:
 
   %s = struct_element_addr %a : $*NonSendableStruct, #NonSendableStruct.ns
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f2<NonSendableKlass>(%s) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  apply %f2<NonSendableKlass>(%s) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{risks concurrent access}}
 
   destroy_addr %a : $*NonSendableStruct
   dealloc_stack %a : $*NonSendableStruct
@@ -988,7 +988,7 @@ bb0:
 
   %s = tuple_element_addr %a : $*(NonSendableKlass, NonSendableKlass), 0
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f2<NonSendableKlass>(%s) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  apply %f2<NonSendableKlass>(%s) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{risks concurrent access}}
 
   destroy_addr %a : $*(NonSendableKlass, NonSendableKlass)
   dealloc_stack %a : $*(NonSendableKlass, NonSendableKlass)
@@ -1046,7 +1046,7 @@ bb0:
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %2 = begin_borrow %1 : $NonSendableKlass
-  %3 = ref_tail_addr %2 : $NonSendableKlass, $*SendableKlass // expected-note {{use here could race}}
+  %3 = ref_tail_addr %2 : $NonSendableKlass, $*SendableKlass // expected-note {{risks concurrent access}}
 
   // Since our type is Sendable, we shouldn't see errors here.
   %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -1082,14 +1082,14 @@ bb0:
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %2 = begin_borrow %1 : $NonSendableKlass
-  %3 = ref_tail_addr [immutable] %2 : $NonSendableKlass, $*NonSendableKlass // expected-note {{use here could race}}
+  %3 = ref_tail_addr [immutable] %2 : $NonSendableKlass, $*NonSendableKlass // expected-note {{risks concurrent access}}
 
   // Since this is as assign, we should be able to get a separate error on the ref_tail_addr
   %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{risks concurrent access}}
 
   end_borrow %2 : $NonSendableKlass
   destroy_value %1 : $NonSendableKlass
@@ -1104,14 +1104,14 @@ bb0:
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %2 = begin_borrow %1 : $NonSendableKlass
-  %3 = ref_tail_addr %2 : $NonSendableKlass, $*NonSendableKlass // expected-note {{use here could race}}
+  %3 = ref_tail_addr %2 : $NonSendableKlass, $*NonSendableKlass // expected-note {{risks concurrent access}}
 
   // Since this is as assign, we should be able to get a separate error on the ref_tail_addr
   %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{risks concurrent access}}
 
   end_borrow %2 : $NonSendableKlass
   destroy_value %1 : $NonSendableKlass
@@ -1131,7 +1131,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{risks concurrent access}}
 
   end_borrow %2 : $KlassContainingKlasses
 
@@ -1152,7 +1152,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{risks concurrent access}}
 
   end_borrow %2 : $KlassContainingKlasses
 
@@ -1172,7 +1172,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor]  %f(%1) : $@convention(thin) @async (@guaranteed KlassContainingKlasses) -> () // expected-warning {{sending value of non-Sendable type 'KlassContainingKlasses' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %2 = begin_borrow %1 : $KlassContainingKlasses
-  %3 = ref_element_addr %2 : $KlassContainingKlasses, #KlassContainingKlasses.sMutable // expected-note {{use here could race}}
+  %3 = ref_element_addr %2 : $KlassContainingKlasses, #KlassContainingKlasses.sMutable // expected-note {{risks concurrent access}}
   end_borrow %2 : $KlassContainingKlasses
 
   destroy_value %1 : $KlassContainingKlasses
@@ -1217,7 +1217,7 @@ bb0:
   %3a = copy_value %1 : $NonSendableKlass
   (%uniq2, %3) = begin_cow_mutation %3a : $NonSendableKlass
   %f3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  apply %f3(%3) : $@convention(thin) (@guaranteed NonSendableKlass) -> () // expected-note {{use here could race}}
+  apply %f3(%3) : $@convention(thin) (@guaranteed NonSendableKlass) -> () // expected-note {{risks concurrent access}}
   destroy_value %3 : $NonSendableKlass
 
   destroy_value %1 : $NonSendableKlass
@@ -1238,11 +1238,11 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%a) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
   // This is a copy_addr [take] [init] + cast.
-  unchecked_ref_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{use here could race}}
+  unchecked_ref_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{risks concurrent access}}
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
   %use = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %use<NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  apply %use<NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{risks concurrent access}}
 
   destroy_addr %b : $*NonSendableKlass
   dealloc_stack %b : $*NonSendableKlass
@@ -1265,11 +1265,11 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%a) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
   // This is a copy_addr [take] [init] + cast.
-  unconditional_checked_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{use here could race}}
+  unconditional_checked_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{risks concurrent access}}
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
   %use = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %use<NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  apply %use<NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{risks concurrent access}}
 
   destroy_addr %b : $*NonSendableKlass
   dealloc_stack %b : $*NonSendableKlass
@@ -1291,12 +1291,12 @@ bb0:
 
 
   %b = alloc_stack $@sil_unowned NonSendableKlass
-  store_unowned %aValue to [init] %b : $*@sil_unowned NonSendableKlass // expected-note {{use here could race}}
+  store_unowned %aValue to [init] %b : $*@sil_unowned NonSendableKlass // expected-note {{risks concurrent access}}
   destroy_value %aValue : $NonSendableKlass
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
     %use = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %use<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  apply %use<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{risks concurrent access}}
 
   destroy_addr %b : $*@sil_unowned NonSendableKlass
   destroy_addr %a : $*NonSendableKlass
@@ -1326,7 +1326,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   destroy_value %value : $NonSendableKlass
-  mark_function_escape %a : $*NonSendableKlass // expected-note {{use here could race}}
+  mark_function_escape %a : $*NonSendableKlass // expected-note {{risks concurrent access}}
   destroy_addr %a : $*NonSendableKlass
   dealloc_stack %a : $*NonSendableKlass
 
@@ -1345,7 +1345,7 @@ bb0:
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  unmanaged_retain_value %value : $NonSendableKlass // expected-note {{use here could race}}
+  unmanaged_retain_value %value : $NonSendableKlass // expected-note {{risks concurrent access}}
   destroy_value %value : $NonSendableKlass
   destroy_addr %a : $*NonSendableKlass
   dealloc_stack %a : $*NonSendableKlass
@@ -1365,7 +1365,7 @@ bb0:
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  unmanaged_release_value %value : $NonSendableKlass // expected-note {{use here could race}}
+  unmanaged_release_value %value : $NonSendableKlass // expected-note {{risks concurrent access}}
   destroy_value %value : $NonSendableKlass
   destroy_addr %a : $*NonSendableKlass
   dealloc_stack %a : $*NonSendableKlass
@@ -1385,7 +1385,7 @@ bb0:
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  unmanaged_autorelease_value %value : $NonSendableKlass // expected-note {{use here could race}}
+  unmanaged_autorelease_value %value : $NonSendableKlass // expected-note {{risks concurrent access}}
   destroy_value %value : $NonSendableKlass
   destroy_addr %a : $*NonSendableKlass
   dealloc_stack %a : $*NonSendableKlass
@@ -1407,7 +1407,7 @@ bb0:
   %2 = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (Builtin.RawPointer) -> () // expected-warning {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %4 = integer_literal $Builtin.Word, 1
-  %5 = bind_memory %1 : $Builtin.RawPointer, %4 : $Builtin.Word to $NonSendableKlass // expected-note {{use here could race}}
+  %5 = bind_memory %1 : $Builtin.RawPointer, %4 : $Builtin.Word to $NonSendableKlass // expected-note {{risks concurrent access}}
   %9999 = tuple ()
   return %9999 : $()
 }
@@ -1419,7 +1419,7 @@ bb0:
   %2 = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (Builtin.RawPointer) -> () // expected-warning {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %4 = integer_literal $Builtin.Word, 1
-  %5 = rebind_memory %1 : $Builtin.RawPointer to %4 : $Builtin.Word // expected-note {{use here could race}}
+  %5 = rebind_memory %1 : $Builtin.RawPointer to %4 : $Builtin.Word // expected-note {{risks concurrent access}}
   %9999 = tuple ()
   return %9999 : $()
 }
@@ -1438,7 +1438,7 @@ bb0:
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  %addr2 = pack_element_get %index of %pack : $*Pack{NonSendableKlass, repeat each T} as $*NonSendableKlass // expected-note {{use here could race}}
+  %addr2 = pack_element_get %index of %pack : $*Pack{NonSendableKlass, repeat each T} as $*NonSendableKlass // expected-note {{risks concurrent access}}
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %f2<NonSendableKlass>(%addr2) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 
@@ -1469,7 +1469,7 @@ bb0:
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr0) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  %addr2 = pack_element_get %index1 of %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T} as $*SendableKlass // expected-note {{use here could race}}
+  %addr2 = pack_element_get %index1 of %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T} as $*SendableKlass // expected-note {{risks concurrent access}}
   dealloc_pack %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T}
 
   %9999 = tuple ()
@@ -1493,12 +1493,12 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   pack_element_set %addr : $*NonSendableKlass into %index of %pack2 : $*Pack{NonSendableKlass, repeat each T}
-  // expected-note @-1 {{use here could race}}
+  // expected-note @-1 {{risks concurrent access}}
 
   // Now transfer %addr and use it.
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f2<NonSendableKlass>(%addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  apply %f2<NonSendableKlass>(%addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{risks concurrent access}}
 
   dealloc_pack %pack2 : $*Pack{NonSendableKlass, repeat each T}
   dealloc_pack %pack : $*Pack{NonSendableKlass, repeat each T}
@@ -1527,7 +1527,7 @@ bb0:
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  pack_element_set %alloc : $*SendableKlass into %index1 of %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T} // expected-note {{use here could race}}
+  pack_element_set %alloc : $*SendableKlass into %index1 of %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T} // expected-note {{risks concurrent access}}
 
   dealloc_pack %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T}
   destroy_addr %alloc : $*SendableKlass
@@ -1550,7 +1550,7 @@ bb0(%index : $Builtin.Word):
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1>(%elt) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'τ_1_0' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  %elt2 = tuple_pack_element_addr %pi of %tuple : $*(NonSendableKlass, T, T, Int) as $*@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1 // expected-note {{use here could race}}
+  %elt2 = tuple_pack_element_addr %pi of %tuple : $*(NonSendableKlass, T, T, Int) as $*@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1 // expected-note {{risks concurrent access}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1>(%elt2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 
   dealloc_stack %tuple : $*(NonSendableKlass, T, T, Int)
@@ -1586,7 +1586,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %9 = alloc_stack $Builtin.UnsafeValueBuffer
-  begin_unpaired_access [read] [dynamic] [no_nested_conflict] %a : $*NonSendableKlass, %9 : $*Builtin.UnsafeValueBuffer // expected-note {{use here could race}}
+  begin_unpaired_access [read] [dynamic] [no_nested_conflict] %a : $*NonSendableKlass, %9 : $*Builtin.UnsafeValueBuffer // expected-note {{risks concurrent access}}
   destroy_value %value : $NonSendableKlass
   dealloc_stack %9 : $*Builtin.UnsafeValueBuffer
   destroy_addr %a : $*NonSendableKlass
@@ -1630,7 +1630,7 @@ bb0:
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
-  %b = load_unowned [take] %a : $*@sil_unowned NonSendableKlass // expected-note {{use here could race}}
+  %b = load_unowned [take] %a : $*@sil_unowned NonSendableKlass // expected-note {{risks concurrent access}}
   destroy_value %b : $NonSendableKlass
   destroy_value %value : $NonSendableKlass
   dealloc_stack %a : $*@sil_unowned NonSendableKlass
@@ -1651,7 +1651,7 @@ bb0:
   %v2 = unmanaged_to_ref %v : $@sil_unmanaged NonSendableKlass to $ NonSendableKlass
   %v3 = ref_to_unmanaged %v2 : $NonSendableKlass to $@sil_unmanaged NonSendableKlass
   %useFunc = function_ref @useUnmanagedNonSendableKlass : $@convention(thin) (@guaranteed @sil_unmanaged NonSendableKlass) -> ()
-  apply %useFunc(%v3) : $@convention(thin) (@guaranteed @sil_unmanaged NonSendableKlass) -> () // expected-note {{use here could race}}
+  apply %useFunc(%v3) : $@convention(thin) (@guaranteed @sil_unmanaged NonSendableKlass) -> () // expected-note {{risks concurrent access}}
   end_borrow %borrowedValue : $NonSendableKlass
   destroy_value %value : $NonSendableKlass
 
@@ -1673,7 +1673,7 @@ bb0(%arg : $Builtin.Word):
 
   %b = ref_to_bridge_object %value : $NonSendableKlass, %arg : $Builtin.Word
   %bridgeUse = function_ref @use_bridge_object : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> ()
-  apply %bridgeUse(%b) : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> () // expected-note {{use here could race}}
+  apply %bridgeUse(%b) : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> () // expected-note {{risks concurrent access}}
   destroy_value %b : $Builtin.BridgeObject
   %9999 = tuple ()
   return %9999 : $()
@@ -1760,7 +1760,7 @@ bb0:
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
-  %value2 = move_value [var_decl] %value : $NonSendableKlass // expected-note {{use here could race}}
+  %value2 = move_value [var_decl] %value : $NonSendableKlass // expected-note {{risks concurrent access}}
   destroy_value %value2 : $NonSendableKlass
 
   %9999 = tuple ()
@@ -1791,7 +1791,7 @@ bb0:
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
-  %value2 = begin_borrow [var_decl] %value : $NonSendableKlass // expected-note {{use here could race}}
+  %value2 = begin_borrow [var_decl] %value : $NonSendableKlass // expected-note {{risks concurrent access}}
   end_borrow %value2 : $NonSendableKlass
   destroy_value %value : $NonSendableKlass
 

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -91,7 +91,7 @@ bb0:
   %1 = apply %0() : $@convention(thin) () -> @owned NonSendableKlass
   %2 = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   // expected-note @-1 {{use here could race}}
@@ -108,7 +108,7 @@ bb0:
   %3 = store_borrow %1 to %2 : $*NonSendableKlass
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   yield %3 : $*NonSendableKlass, resume bb1, unwind bb2
   // expected-note @-1 {{use here could race}}
 
@@ -135,7 +135,7 @@ bb0:
   store %1a to [init] %2 : $*FakeOptional<NonSendableKlass>
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<FakeOptional<NonSendableKlass>>(%2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'FakeOptional<NonSendableKlass>' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'FakeOptional<NonSendableKlass>' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   switch_enum_addr %2 : $*FakeOptional<NonSendableKlass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
   // expected-note @-1 {{use here could race}}
 
@@ -161,7 +161,7 @@ bb0:
   %2 = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   %1a = explicit_copy_value %1 : $NonSendableKlass
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1a) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   // expected-note @-1 {{use here could race}}
@@ -178,7 +178,7 @@ bb0:
   %2 = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   %1a = move_value %1 : $NonSendableKlass
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1a) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1a) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   // expected-note @-1 {{use here could race}}
@@ -197,7 +197,7 @@ bb0:
   store %1 to [init] %unresolved : $*NonSendableMoveOnlyStruct
   %4 = function_ref @transferMoveOnlyStructIndirectly : $@convention(thin) @async (@in_guaranteed NonSendableMoveOnlyStruct) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4(%unresolved) : $@convention(thin) @async (@in_guaranteed NonSendableMoveOnlyStruct) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableMoveOnlyStruct' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableMoveOnlyStruct' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %5 = function_ref @useMoveOnlyStructIndirectly : $@convention(thin) (@in_guaranteed NonSendableMoveOnlyStruct) -> ()
   apply %5(%unresolved) : $@convention(thin) (@in_guaranteed NonSendableMoveOnlyStruct) -> ()
   // expected-note @-1 {{use here could race}}
@@ -217,7 +217,7 @@ bb0:
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%project) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%project) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   // expected-note @-1 {{use here could race}}
@@ -236,7 +236,7 @@ bb0:
   %0b = begin_borrow %0a : $@moveOnly NonSendableKlass
   %0c = moveonlywrapper_to_copyable [guaranteed] %0b : $@moveOnly NonSendableKlass
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%0c) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   end_borrow %0b : $@moveOnly NonSendableKlass
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   %0bb = begin_borrow %0a : $@moveOnly NonSendableKlass
@@ -261,7 +261,7 @@ bb0:
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%unwrappedProject) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%unwrappedProject) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -294,7 +294,7 @@ bb0:
   %pa = partial_apply %f2(%copiedUnwrappedBox) : $@convention(thin) (@guaranteed { var NonSendableKlass }) -> ()
   %4 = function_ref @transfer_partial_apply : $@convention(thin) @async (@guaranteed @callee_owned () -> ()) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4(%pa) : $@convention(thin) @async (@guaranteed @callee_owned () -> ()) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type '@callee_owned () -> ()' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type '@callee_owned () -> ()' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %bb2 = begin_borrow %unwrappedBox : ${ var NonSendableKlass }
   %p2 = project_box %bb2 : ${ var NonSendableKlass }, 0
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -318,7 +318,7 @@ bb0(%0 : @owned $NonSendableStruct):
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableStruct>(%2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{task-isolated value of type 'NonSendableStruct' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending task-isolated value of type 'NonSendableStruct' to global actor '<null>'-isolated context}}
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableStruct>(%2) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -336,7 +336,7 @@ bb0(%0 : $*NonSendableStruct):
   %2 = moveonlywrapper_to_copyable_addr %1 : $*@moveOnly NonSendableStruct
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableStruct>(%2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{task-isolated value of type 'NonSendableStruct' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending task-isolated value of type 'NonSendableStruct' to global actor '<null>'-isolated context}}
   %9999 = tuple ()
   return %9999 : $()
 }
@@ -348,7 +348,7 @@ bb0(%0 : @owned $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for 
   store %0 to [init] %blockAddr : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<() -> ()>(%blockAddr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{task-isolated value of type '@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending task-isolated value of type '@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>' to global actor '<null>'-isolated context}}
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<() -> ()>(%blockAddr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -365,7 +365,7 @@ bb0:
   %1 = apply %0() : $@convention(thin) () -> @owned NonSendableKlass
   %2 = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   fix_lifetime %1 : $NonSendableKlass
   // expected-note @-1 {{use here could race}}
   destroy_value %1 : $NonSendableKlass
@@ -383,7 +383,7 @@ bb0:
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -401,7 +401,7 @@ bb0(%0 : $*NonSendableKlass):
   mark_unresolved_move_addr %0 to %1 : $*NonSendableKlass
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%1) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending task-isolated value of type 'NonSendableKlass' to global actor '<null>'-isolated context}}
   destroy_addr %0 : $*NonSendableKlass
   destroy_addr %1 : $*NonSendableKlass
   dealloc_stack %1 : $*NonSendableKlass
@@ -420,7 +420,7 @@ bb0:
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%2) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   // No error here since just a requires on the first.
   %useNonSendableKlass = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
@@ -447,7 +447,7 @@ sil [ossa] @mark_dependence_test_base_has_a_require : $@convention(thin) @async 
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%2) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   // No error here since just a requires on the first.
   %useNonSendableKlass = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
@@ -471,7 +471,7 @@ sil [ossa] @mark_dependence_test_base_is_a_require : $@convention(thin) @async (
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %1a = begin_borrow %1 : $NonSendableKlass
   %2 = mark_dependence %1a : $NonSendableKlass on %0 : $NonSendableKlass
@@ -537,9 +537,9 @@ bb0(%0 : $Builtin.RawPointer):
   // Should error on both since the raw pointer is from an argument.
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%4) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending task-isolated value of type 'NonSendableKlass' to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%6) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending task-isolated value of type 'NonSendableKlass' to global actor '<null>'-isolated context}}
 
   destroy_value %4 : $NonSendableKlass
   destroy_value %6 : $NonSendableKlass
@@ -571,13 +571,13 @@ bb0(%0 : $Builtin.RawPointer):
   // But if we transfer the raw pointers and use them later we get separate errors.
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%0) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{task-isolated value of type 'Builtin.RawPointer' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending task-isolated value of type 'Builtin.RawPointer' to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%2) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{task-isolated value of type 'Builtin.RawPointer' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending task-isolated value of type 'Builtin.RawPointer' to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%3a) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%5a) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context}}
 
   %useRawPointer = function_ref @useRawPointer : $@convention(thin) (Builtin.RawPointer) -> ()
   apply %useRawPointer(%3a) : $@convention(thin) (Builtin.RawPointer) -> ()
@@ -603,7 +603,7 @@ bb0:
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   // Test that this is viewed as a use of %construct
   %3 = raw_pointer_to_ref %3a : $Builtin.RawPointer to $SendableKlass
@@ -623,7 +623,7 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
   // expected-note @-1 {{use here could race}}
@@ -642,14 +642,14 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $SendableKlass
 
   // This is not considered a bad use of the raw pointer since this is
   // transferring to the same isolation domain.
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
   // expected-note @-1 {{use here could race}}
@@ -667,7 +667,7 @@ bb0:
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %word = unchecked_trivial_bit_cast %value : $NonSendableKlass to $Builtin.Word
   // expected-note @-1 {{use here could race}}
@@ -701,7 +701,7 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
   // expected-note @-1 {{use here could race}}
@@ -720,12 +720,12 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $SendableKlass
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
   // expected-note @-1 {{use here could race}}
@@ -743,7 +743,7 @@ bb0:
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %word = unchecked_bitwise_cast %value : $NonSendableKlass to $Builtin.Word
   // expected-note @-1 {{use here could race}}
@@ -778,7 +778,7 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
   // expected-note @-1 {{use here could race}}
@@ -799,12 +799,12 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $SendableKlass
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
   // expected-note @-1 {{use here could race}}
@@ -823,7 +823,7 @@ bb0:
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %valueB = begin_borrow %value : $NonSendableKlass
   %word = unchecked_value_cast %valueB : $NonSendableKlass to $Builtin.Word
@@ -894,7 +894,7 @@ bb0:
   %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %value2 = unchecked_ref_cast %value : $NonSendableKlass to $Builtin.BridgeObject
   %1 = classify_bridge_object %value2 : $Builtin.BridgeObject // expected-note {{use here could race}}
@@ -910,7 +910,7 @@ bb0:
   %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %value2 = unchecked_ref_cast %value : $NonSendableKlass to $Builtin.BridgeObject
   %1 = bridge_object_to_word %value2 : $Builtin.BridgeObject to $Builtin.Word // expected-note {{use here could race}}
@@ -937,7 +937,7 @@ bb0:
   store %valueCopy to [init] %a : $*NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   destroy_value %value : $NonSendableKlass
   %1 = is_unique %a : $*NonSendableKlass // expected-note {{use here could race}}
@@ -958,7 +958,7 @@ bb0:
   store %1_copy to [init] %a : $*NonSendableStruct
 
   %f = function_ref @transferStruct : $@convention(thin) @async (@guaranteed NonSendableStruct) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableStruct) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableStruct' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableStruct) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableStruct' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %s = struct_element_addr %a : $*NonSendableStruct, #NonSendableStruct.ns
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -984,7 +984,7 @@ bb0:
   store %tup to [init] %a : $*(NonSendableKlass, NonSendableKlass)
 
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %s = tuple_element_addr %a : $*(NonSendableKlass, NonSendableKlass), 0
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -1044,7 +1044,7 @@ bb0:
   %0 = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
   %1 = apply %0() : $@convention(thin) () -> @owned NonSendableKlass
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %2 = begin_borrow %1 : $NonSendableKlass
   %3 = ref_tail_addr %2 : $NonSendableKlass, $*SendableKlass // expected-note {{use here could race}}
 
@@ -1080,13 +1080,13 @@ bb0:
   %0 = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
   %1 = apply %0() : $@convention(thin) () -> @owned NonSendableKlass
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %2 = begin_borrow %1 : $NonSendableKlass
   %3 = ref_tail_addr [immutable] %2 : $NonSendableKlass, $*NonSendableKlass // expected-note {{use here could race}}
 
   // Since this is as assign, we should be able to get a separate error on the ref_tail_addr
   %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
@@ -1102,13 +1102,13 @@ bb0:
   %0 = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
   %1 = apply %0() : $@convention(thin) () -> @owned NonSendableKlass
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %2 = begin_borrow %1 : $NonSendableKlass
   %3 = ref_tail_addr %2 : $NonSendableKlass, $*NonSendableKlass // expected-note {{use here could race}}
 
   // Since this is as assign, we should be able to get a separate error on the ref_tail_addr
   %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
@@ -1128,7 +1128,7 @@ bb0:
   %3 = ref_element_addr %2 : $KlassContainingKlasses, #KlassContainingKlasses.nsMutable
 
   %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
@@ -1149,7 +1149,7 @@ bb0:
   %3 = ref_element_addr %2 : $KlassContainingKlasses, #KlassContainingKlasses.nsImmutable
 
   %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
@@ -1169,7 +1169,7 @@ bb0:
   %f = function_ref @transferKlassContainingKlasses : $@convention(thin) @async (@guaranteed KlassContainingKlasses) -> ()
   // TODO: Improve diagnostic to make it clear that the reason we are failing is
   // that we could race on a write to the ref_element_addr.
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor]  %f(%1) : $@convention(thin) @async (@guaranteed KlassContainingKlasses) -> () // expected-warning {{transferring value of non-Sendable type 'KlassContainingKlasses' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor]  %f(%1) : $@convention(thin) @async (@guaranteed KlassContainingKlasses) -> () // expected-warning {{sending value of non-Sendable type 'KlassContainingKlasses' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %2 = begin_borrow %1 : $KlassContainingKlasses
   %3 = ref_element_addr %2 : $KlassContainingKlasses, #KlassContainingKlasses.sMutable // expected-note {{use here could race}}
@@ -1211,7 +1211,7 @@ bb0:
   %2a = copy_value %1 : $NonSendableKlass
   (%uniq, %2) = begin_cow_mutation %2a : $NonSendableKlass
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   destroy_value %2 : $NonSendableKlass
 
   %3a = copy_value %1 : $NonSendableKlass
@@ -1235,12 +1235,12 @@ bb0:
   apply %initIndirect<NonSendableKlass>(%a) : $@convention(thin) <T> () -> @out T
 
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%a) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%a) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
   // This is a copy_addr [take] [init] + cast.
   unchecked_ref_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{use here could race}}
 
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
   %use = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %use<NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
@@ -1262,12 +1262,12 @@ bb0:
   apply %initIndirect<NonSendableKlass>(%a) : $@convention(thin) <T> () -> @out T
 
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%a) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%a) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
   // This is a copy_addr [take] [init] + cast.
   unconditional_checked_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{use here could race}}
 
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
   %use = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %use<NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
@@ -1287,14 +1287,14 @@ bb0:
 
   %aValue = load [copy] %a : $*NonSendableKlass
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%a) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%a) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
 
   %b = alloc_stack $@sil_unowned NonSendableKlass
   store_unowned %aValue to [init] %b : $*@sil_unowned NonSendableKlass // expected-note {{use here could race}}
   destroy_value %aValue : $NonSendableKlass
 
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
     %use = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %use<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
@@ -1323,7 +1323,7 @@ bb0:
   store %valueCopy to [init] %a : $*NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   destroy_value %value : $NonSendableKlass
   mark_function_escape %a : $*NonSendableKlass // expected-note {{use here could race}}
@@ -1343,7 +1343,7 @@ bb0:
   store %valueCopy to [init] %a : $*NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   unmanaged_retain_value %value : $NonSendableKlass // expected-note {{use here could race}}
   destroy_value %value : $NonSendableKlass
@@ -1363,7 +1363,7 @@ bb0:
   store %valueCopy to [init] %a : $*NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   unmanaged_release_value %value : $NonSendableKlass // expected-note {{use here could race}}
   destroy_value %value : $NonSendableKlass
@@ -1383,7 +1383,7 @@ bb0:
   store %valueCopy to [init] %a : $*NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   unmanaged_autorelease_value %value : $NonSendableKlass // expected-note {{use here could race}}
   destroy_value %value : $NonSendableKlass
@@ -1405,7 +1405,7 @@ bb0:
   %0 = function_ref @initRawPointer : $@convention(thin) () -> Builtin.RawPointer
   %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
   %2 = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (Builtin.RawPointer) -> () // expected-warning {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (Builtin.RawPointer) -> () // expected-warning {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %4 = integer_literal $Builtin.Word, 1
   %5 = bind_memory %1 : $Builtin.RawPointer, %4 : $Builtin.Word to $NonSendableKlass // expected-note {{use here could race}}
   %9999 = tuple ()
@@ -1417,7 +1417,7 @@ bb0:
   %0 = function_ref @initRawPointer : $@convention(thin) () -> Builtin.RawPointer
   %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
   %2 = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (Builtin.RawPointer) -> () // expected-warning {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (Builtin.RawPointer) -> () // expected-warning {{sending value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %4 = integer_literal $Builtin.Word, 1
   %5 = rebind_memory %1 : $Builtin.RawPointer to %4 : $Builtin.Word // expected-note {{use here could race}}
   %9999 = tuple ()
@@ -1436,7 +1436,7 @@ bb0:
   %addr = pack_element_get %index of %pack : $*Pack{NonSendableKlass, repeat each T} as $*NonSendableKlass
   store %0 to [init] %addr : $*NonSendableKlass
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %addr2 = pack_element_get %index of %pack : $*Pack{NonSendableKlass, repeat each T} as $*NonSendableKlass // expected-note {{use here could race}}
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -1467,7 +1467,7 @@ bb0:
   store %0 to [init] %addr1 : $*SendableKlass
 
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr0) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr0) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %addr2 = pack_element_get %index1 of %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T} as $*SendableKlass // expected-note {{use here could race}}
   dealloc_pack %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T}
@@ -1490,13 +1490,13 @@ bb0:
   %addr = pack_element_get %index of %pack : $*Pack{NonSendableKlass, repeat each T} as $*NonSendableKlass
   store %0 to [init] %addr : $*NonSendableKlass
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   pack_element_set %addr : $*NonSendableKlass into %index of %pack2 : $*Pack{NonSendableKlass, repeat each T}
   // expected-note @-1 {{use here could race}}
 
   // Now transfer %addr and use it.
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %f2<NonSendableKlass>(%addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
@@ -1525,7 +1525,7 @@ bb0:
   store %ns to [init] %addr : $*NonSendableKlass
 
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   pack_element_set %alloc : $*SendableKlass into %index1 of %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T} // expected-note {{use here could race}}
 
@@ -1548,7 +1548,7 @@ bb0(%index : $Builtin.Word):
   open_pack_element %pi of <each U_1> at <Pack{NonSendableKlass, T, T, Int}>, shape $U_1, uuid "31FF306C-BF88-11ED-A03F-ACDE48001122"
   %elt = tuple_pack_element_addr %pi of %tuple : $*(NonSendableKlass, T, T, Int) as $*@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1>(%elt) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'τ_1_0' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1>(%elt) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'τ_1_0' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %elt2 = tuple_pack_element_addr %pi of %tuple : $*(NonSendableKlass, T, T, Int) as $*@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1 // expected-note {{use here could race}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1>(%elt2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -1583,7 +1583,7 @@ bb0:
   store %valueCopy to [init] %a : $*NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %9 = alloc_stack $Builtin.UnsafeValueBuffer
   begin_unpaired_access [read] [dynamic] [no_nested_conflict] %a : $*NonSendableKlass, %9 : $*Builtin.UnsafeValueBuffer // expected-note {{use here could race}}
@@ -1628,7 +1628,7 @@ bb0:
   store_unowned %value to [init] %a : $*@sil_unowned NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
   %b = load_unowned [take] %a : $*@sil_unowned NonSendableKlass // expected-note {{use here could race}}
   destroy_value %b : $NonSendableKlass
@@ -1644,7 +1644,7 @@ bb0:
   %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
   %borrowedValue = begin_borrow %value : $NonSendableKlass
   %v = ref_to_unmanaged %borrowedValue : $NonSendableKlass to $@sil_unmanaged NonSendableKlass
@@ -1669,7 +1669,7 @@ bb0(%arg : $Builtin.Word):
   %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %b = ref_to_bridge_object %value : $NonSendableKlass, %arg : $Builtin.Word
   %bridgeUse = function_ref @use_bridge_object : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> ()
@@ -1758,7 +1758,7 @@ bb0:
   %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
   %value2 = move_value [var_decl] %value : $NonSendableKlass // expected-note {{use here could race}}
   destroy_value %value2 : $NonSendableKlass
@@ -1789,7 +1789,7 @@ bb0:
   %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
   %value2 = begin_borrow [var_decl] %value : $NonSendableKlass // expected-note {{use here could race}}
   end_borrow %value2 : $NonSendableKlass

--- a/test/Concurrency/transfernonsendable_instruction_matching_differentiability.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_differentiability.sil
@@ -84,7 +84,7 @@ bb0:
   %0 = apply %init() : $@convention(thin) () -> @owned @differentiable(_linear) @callee_guaranteed (Float) -> Float
 
   %transfer = function_ref @transferLinearFunction : $@async @convention(thin) (@guaranteed @differentiable(_linear) @callee_guaranteed (Float) -> Float) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transfer(%0) : $@async @convention(thin) (@guaranteed @differentiable(_linear) @callee_guaranteed (Float) -> Float) -> () // expected-warning {{transferring value of non-Sendable type '@differentiable(_linear) @callee_guaranteed (Float) -> Float' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transfer(%0) : $@async @convention(thin) (@guaranteed @differentiable(_linear) @callee_guaranteed (Float) -> Float) -> () // expected-warning {{sending value of non-Sendable type '@differentiable(_linear) @callee_guaranteed (Float) -> Float' from nonisolated context to global actor '<null>'-isolated context}}
 
   // No error since this is just look through.
   %1 = begin_borrow %0 : $@differentiable(_linear) @callee_guaranteed (Float) -> Float
@@ -104,7 +104,7 @@ bb0:
   %0 = apply %init() : $@convention(thin) () -> @owned @differentiable(reverse) @callee_guaranteed (Float) -> Float
 
   %transfer = function_ref @transferDifferentiableFunction : $@async @convention(thin) (@guaranteed @differentiable(reverse) @callee_guaranteed (Float) -> Float) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transfer(%0) : $@async @convention(thin) (@guaranteed @differentiable(reverse) @callee_guaranteed (Float) -> Float) -> () // expected-warning {{transferring value of non-Sendable type '@differentiable(reverse) @callee_guaranteed (Float) -> Float' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transfer(%0) : $@async @convention(thin) (@guaranteed @differentiable(reverse) @callee_guaranteed (Float) -> Float) -> () // expected-warning {{sending value of non-Sendable type '@differentiable(reverse) @callee_guaranteed (Float) -> Float' from nonisolated context to global actor '<null>'-isolated context}}
 
   // No error since this is just look through.
   %1 = begin_borrow %0 : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
@@ -124,7 +124,7 @@ bb0:
   %1 = apply %0() : $@convention(thin) () -> @owned @callee_guaranteed (Float) -> Float
 
   %transfer = function_ref @transferFunction : $@async @convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transfer(%1) : $@async @convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-warning {{transferring value of non-Sendable type '@callee_guaranteed (Float) -> Float' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transfer(%1) : $@async @convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-warning {{sending value of non-Sendable type '@callee_guaranteed (Float) -> Float' from nonisolated context to global actor '<null>'-isolated context}}
 
   %2 = begin_borrow %1 : $@callee_guaranteed (Float) -> Float
   %3 = linear_function [parameters 0] %2 : $@callee_guaranteed (Float) -> Float // expected-note {{use here could race}}
@@ -145,7 +145,7 @@ bb0:
   %1 = apply %0() : $@convention(thin) () -> @owned @callee_guaranteed (Float) -> Float
 
   %transfer = function_ref @transferFunction : $@async @convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transfer(%1) : $@async @convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-warning {{transferring value of non-Sendable type '@callee_guaranteed (Float) -> Float' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transfer(%1) : $@async @convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-warning {{sending value of non-Sendable type '@callee_guaranteed (Float) -> Float' from nonisolated context to global actor '<null>'-isolated context}}
 
   %derivative = function_ref @derivative : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
   %vjp = function_ref @vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)

--- a/test/Concurrency/transfernonsendable_instruction_matching_differentiability.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_differentiability.sil
@@ -90,7 +90,7 @@ bb0:
   %1 = begin_borrow %0 : $@differentiable(_linear) @callee_guaranteed (Float) -> Float
   %2 = linear_function_extract [original] %1 : $@differentiable(_linear) @callee_guaranteed (Float) -> Float
   %f = function_ref @useFunction : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> ()
-  apply %f(%2) : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-note {{use here could race}}
+  apply %f(%2) : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-note {{risks concurrent access}}
   end_borrow %1 : $@differentiable(_linear) @callee_guaranteed (Float) -> Float
   destroy_value %0 : $@differentiable(_linear) @callee_guaranteed (Float) -> Float
 
@@ -110,7 +110,7 @@ bb0:
   %1 = begin_borrow %0 : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
   %2 = differentiable_function_extract [original] %1 : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
   %f = function_ref @useFunction : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> ()
-  apply %f(%2) : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-note {{use here could race}}
+  apply %f(%2) : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-note {{risks concurrent access}}
   end_borrow %1 : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
   destroy_value %0 : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
 
@@ -127,7 +127,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transfer(%1) : $@async @convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-warning {{sending value of non-Sendable type '@callee_guaranteed (Float) -> Float' from nonisolated context to global actor '<null>'-isolated context}}
 
   %2 = begin_borrow %1 : $@callee_guaranteed (Float) -> Float
-  %3 = linear_function [parameters 0] %2 : $@callee_guaranteed (Float) -> Float // expected-note {{use here could race}}
+  %3 = linear_function [parameters 0] %2 : $@callee_guaranteed (Float) -> Float // expected-note {{risks concurrent access}}
 
   end_borrow %2 : $@callee_guaranteed (Float) -> Float
   destroy_value %1 : $@callee_guaranteed (Float) -> Float
@@ -150,7 +150,7 @@ bb0:
   %derivative = function_ref @derivative : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
   %vjp = function_ref @vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
   %2 = begin_borrow %1 : $@callee_guaranteed (Float) -> Float
-  %3 = differentiable_function [parameters 0] [results 0] %2 : $@callee_guaranteed (Float) -> Float with_derivative {%derivative : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)} // expected-note {{use here could race}}
+  %3 = differentiable_function [parameters 0] [results 0] %2 : $@callee_guaranteed (Float) -> Float with_derivative {%derivative : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)} // expected-note {{risks concurrent access}}
 
   end_borrow %2 : $@callee_guaranteed (Float) -> Float
   destroy_value %1 : $@callee_guaranteed (Float) -> Float

--- a/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
@@ -104,7 +104,7 @@ bb0:
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("00000000-0000-0000-0000-000000000000") U_1>(%elt) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'τ_1_0' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  %elt2 = tuple_pack_extract %index of %1 : $(repeat each T) as $@pack_element("00000000-0000-0000-0000-000000000000") U_1 // expected-note {{use here could race}}
+  %elt2 = tuple_pack_extract %index of %1 : $(repeat each T) as $@pack_element("00000000-0000-0000-0000-000000000000") U_1 // expected-note {{risks concurrent access}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("00000000-0000-0000-0000-000000000000") U_1>(%elt) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 
   end_borrow %1 : $(repeat each T)
@@ -124,7 +124,7 @@ bb0:
   %b = begin_borrow %p : $P
   %v = open_existential_value %b : $P to $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", P) Self
   %w = witness_method $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", P) Self, #P.doSomething, %v : $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
-  apply %w<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", P) Self>(%v) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  apply %w<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", P) Self>(%v) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> () // expected-note {{risks concurrent access}}
   end_borrow %b : $P
   destroy_value %p : $P
 
@@ -144,7 +144,7 @@ bb0:
 
   %w = weak_copy_value %pBorrowed : $Optional<PAnyObject>
   %weakFunc = function_ref @usePAnyObjectWeak : $@convention(thin) (@guaranteed @sil_weak Optional<PAnyObject>) -> ()
-  apply %weakFunc(%w) : $@convention(thin) (@guaranteed @sil_weak Optional<PAnyObject>) -> () // expected-note {{use here could race}}
+  apply %weakFunc(%w) : $@convention(thin) (@guaranteed @sil_weak Optional<PAnyObject>) -> () // expected-note {{risks concurrent access}}
   destroy_value %w : $@sil_weak Optional<PAnyObject>
 
   end_borrow %pBorrowed : $Optional<PAnyObject>
@@ -167,7 +167,7 @@ bb0:
   %w = weak_copy_value %pBorrowed : $Optional<PAnyObject>
   %s = strong_copy_weak_value %w : $@sil_weak Optional<PAnyObject>
   %weakFunc = function_ref @usePAnyObject : $@convention(thin) (@guaranteed Optional<PAnyObject>) -> ()
-  apply %weakFunc(%s) : $@convention(thin) (@guaranteed Optional<PAnyObject>) -> () // expected-note {{use here could race}}
+  apply %weakFunc(%s) : $@convention(thin) (@guaranteed Optional<PAnyObject>) -> () // expected-note {{risks concurrent access}}
   destroy_value %s : $Optional<PAnyObject>
   destroy_value %w : $@sil_weak Optional<PAnyObject>
 
@@ -189,7 +189,7 @@ bb0:
 
   %i = init_existential_value %1 : $NonSendableKlass, $NonSendableKlass, $P
   %f2 = function_ref @useP : $@convention(thin) (@in_guaranteed P) -> ()
-  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> () // expected-note {{use here could race}}
+  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> () // expected-note {{risks concurrent access}}
   destroy_value %i : $P
 
   %9999 = tuple ()

--- a/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
@@ -81,7 +81,7 @@ bb0(%owned_value : @owned $T):
   %unowned_value = unowned_copy_value %owned_value : $T
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<@sil_unowned T>(%unowned_value) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{task-isolated value of type 'T' transferred to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<@sil_unowned T>(%unowned_value) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending task-isolated value of type 'T' to global actor '<null>'-isolated context}}
 
   destroy_value %unowned_value : $@sil_unowned T
   //destroy_value %value : $T
@@ -102,7 +102,7 @@ bb0:
   open_pack_element %index of <each U_1> at <Pack{repeat each T}>, shape $U_1, uuid "00000000-0000-0000-0000-000000000000"
   %elt = tuple_pack_extract %index of %1 : $(repeat each T) as $@pack_element("00000000-0000-0000-0000-000000000000") U_1
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("00000000-0000-0000-0000-000000000000") U_1>(%elt) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'τ_1_0' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("00000000-0000-0000-0000-000000000000") U_1>(%elt) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{sending value of non-Sendable type 'τ_1_0' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %elt2 = tuple_pack_extract %index of %1 : $(repeat each T) as $@pack_element("00000000-0000-0000-0000-000000000000") U_1 // expected-note {{use here could race}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("00000000-0000-0000-0000-000000000000") U_1>(%elt) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -119,7 +119,7 @@ bb0:
   %p = apply %f() : $@convention(thin) () -> @owned P
 
   %transferP = function_ref @transferP : $@async @convention(thin) (@guaranteed P) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferP(%p) : $@async @convention(thin) (@guaranteed P) -> () // expected-warning {{transferring value of non-Sendable type 'any P' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferP(%p) : $@async @convention(thin) (@guaranteed P) -> () // expected-warning {{sending value of non-Sendable type 'any P' from nonisolated context to global actor '<null>'-isolated context}}
 
   %b = begin_borrow %p : $P
   %v = open_existential_value %b : $P to $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", P) Self
@@ -140,7 +140,7 @@ bb0:
   %pBorrowed = begin_borrow %p : $Optional<PAnyObject>
   %pExt = unchecked_enum_data %pBorrowed : $Optional<PAnyObject>, #Optional.some!enumelt
   %transferP = function_ref @transferPAnyObject : $@async @convention(thin) (@guaranteed PAnyObject) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferP(%pExt) : $@async @convention(thin) (@guaranteed PAnyObject) -> () // expected-warning {{transferring value of non-Sendable type 'any PAnyObject' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferP(%pExt) : $@async @convention(thin) (@guaranteed PAnyObject) -> () // expected-warning {{sending value of non-Sendable type 'any PAnyObject' from nonisolated context to global actor '<null>'-isolated context}}
 
   %w = weak_copy_value %pBorrowed : $Optional<PAnyObject>
   %weakFunc = function_ref @usePAnyObjectWeak : $@convention(thin) (@guaranteed @sil_weak Optional<PAnyObject>) -> ()
@@ -162,7 +162,7 @@ bb0:
   %pBorrowed = begin_borrow %p : $Optional<PAnyObject>
   %pExt = unchecked_enum_data %pBorrowed : $Optional<PAnyObject>, #Optional.some!enumelt
   %transferP = function_ref @transferPAnyObject : $@async @convention(thin) (@guaranteed PAnyObject) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferP(%pExt) : $@async @convention(thin) (@guaranteed PAnyObject) -> () // expected-warning {{transferring value of non-Sendable type 'any PAnyObject' from nonisolated context to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferP(%pExt) : $@async @convention(thin) (@guaranteed PAnyObject) -> () // expected-warning {{sending value of non-Sendable type 'any PAnyObject' from nonisolated context to global actor '<null>'-isolated context}}
 
   %w = weak_copy_value %pBorrowed : $Optional<PAnyObject>
   %s = strong_copy_weak_value %w : $@sil_weak Optional<PAnyObject>
@@ -185,7 +185,7 @@ bb0:
 
   %2 = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %i = init_existential_value %1 : $NonSendableKlass, $NonSendableKlass, $P
   %f2 = function_ref @useP : $@convention(thin) (@in_guaranteed P) -> ()

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -69,7 +69,7 @@ actor ProtectsNonSendable {
     // This is not safe since we use l later.
     self.assumeIsolated { isolatedSelf in
       isolatedSelf.ns = l // expected-warning {{sending 'l' may cause a data race}}
-      // expected-note @-1 {{disconnected 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
 
     useValue(l) // expected-note {{use here could race}}
@@ -87,7 +87,7 @@ func normalFunc_testLocal_2() {
   let x = NonSendableKlass()
   let _ = { @MainActor in
     useValue(x) // expected-warning {{sending 'x' may cause a data race}}
-    // expected-note @-1 {{disconnected 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x) // expected-note {{use here could race}}
 }
@@ -99,7 +99,7 @@ func normalFunc_testLocal_2() {
 func transferBeforeCaptureErrors() async {
   let x = NonSendableKlass()
   await transferToCustom(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     useValue(x)
   }

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -40,7 +40,7 @@ actor ProtectsNonSendable {
     // TODO: This is wrong, we should get an error saying that nsArg is task
     // isolated since this is nonisolated.
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = nsArg // expected-warning {{transferring 'nsArg' may cause a data race}}
+      isolatedSelf.ns = nsArg // expected-warning {{sending 'nsArg' may cause a data race}}
       // expected-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -49,7 +49,7 @@ actor ProtectsNonSendable {
     let l = NonSendableKlass()
     doSomething(l, nsArg)
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = l // expected-warning {{transferring 'l' may cause a data race}}
+      isolatedSelf.ns = l // expected-warning {{sending 'l' may cause a data race}}
       // expected-note @-1 {{task-isolated 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -68,7 +68,7 @@ actor ProtectsNonSendable {
 
     // This is not safe since we use l later.
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = l // expected-warning {{transferring 'l' may cause a data race}}
+      isolatedSelf.ns = l // expected-warning {{sending 'l' may cause a data race}}
       // expected-note @-1 {{disconnected 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
 
@@ -86,7 +86,7 @@ func normalFunc_testLocal_1() {
 func normalFunc_testLocal_2() {
   let x = NonSendableKlass()
   let _ = { @MainActor in
-    useValue(x) // expected-warning {{transferring 'x' may cause a data race}}
+    useValue(x) // expected-warning {{sending 'x' may cause a data race}}
     // expected-note @-1 {{disconnected 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x) // expected-note {{use here could race}}
@@ -98,8 +98,8 @@ func normalFunc_testLocal_2() {
 // diagnostic.
 func transferBeforeCaptureErrors() async {
   let x = NonSendableKlass()
-  await transferToCustom(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x' to global actor 'CustomActor'-isolated callee could cause races in between callee global actor 'CustomActor'-isolated and local nonisolated uses}}
+  await transferToCustom(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x' to global actor 'CustomActor'-isolated callee could cause races in between callee global actor 'CustomActor'-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     useValue(x)
   }

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -99,7 +99,7 @@ func normalFunc_testLocal_2() {
 func transferBeforeCaptureErrors() async {
   let x = NonSendableKlass()
   await transferToCustom(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to global actor 'CustomActor'-isolated callee could cause races in between callee global actor 'CustomActor'-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     useValue(x)
   }

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -40,7 +40,7 @@ actor ProtectsNonSendable {
     // TODO: This is wrong, we should get an error saying that nsArg is task
     // isolated since this is nonisolated.
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = nsArg // expected-warning {{sending 'nsArg' may cause a data race}}
+      isolatedSelf.ns = nsArg // expected-warning {{sending 'nsArg' risks causing data races}}
       // expected-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -49,7 +49,7 @@ actor ProtectsNonSendable {
     let l = NonSendableKlass()
     doSomething(l, nsArg)
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = l // expected-warning {{sending 'l' may cause a data race}}
+      isolatedSelf.ns = l // expected-warning {{sending 'l' risks causing data races}}
       // expected-note @-1 {{task-isolated 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -68,11 +68,11 @@ actor ProtectsNonSendable {
 
     // This is not safe since we use l later.
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = l // expected-warning {{sending 'l' may cause a data race}}
+      isolatedSelf.ns = l // expected-warning {{sending 'l' risks causing data races}}
       // expected-note @-1 {{'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
 
-    useValue(l) // expected-note {{use here could race}}
+    useValue(l) // expected-note {{risks concurrent access}}
   }
 }
 
@@ -86,10 +86,10 @@ func normalFunc_testLocal_1() {
 func normalFunc_testLocal_2() {
   let x = NonSendableKlass()
   let _ = { @MainActor in
-    useValue(x) // expected-warning {{sending 'x' may cause a data race}}
+    useValue(x) // expected-warning {{sending 'x' risks causing data races}}
     // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
-  useValue(x) // expected-note {{use here could race}}
+  useValue(x) // expected-note {{risks concurrent access}}
 }
 
 // We error here since we are performing a double transfer.
@@ -98,9 +98,9 @@ func normalFunc_testLocal_2() {
 // diagnostic.
 func transferBeforeCaptureErrors() async {
   let x = NonSendableKlass()
-  await transferToCustom(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and local nonisolated uses}}
-  let _ = { @MainActor in // expected-note {{use here could race}}
+  let _ = { @MainActor in // expected-note {{risks concurrent access}}
     useValue(x)
   }
 }

--- a/test/Concurrency/transfernonsendable_ownership.swift
+++ b/test/Concurrency/transfernonsendable_ownership.swift
@@ -34,74 +34,74 @@ struct CustomActor {
 /////////////////
 
 func testConsuming(_ x: consuming Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testConsumingError(_ x: consuming Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
   print(x)
 }
 
 @CustomActor func testConsumingErrorGlobalActor(_ x: consuming Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   print(x)
 }
 
 func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected-error {{'x' consumed more than once}}
-  await consumeTransferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  await consumeTransferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
   // expected-note @-2 {{consumed here}}
   print(x)
   // expected-note @-1 {{consumed again here}}
 }
 
 @CustomActor func testConsumingUseAfterConsumeErrorGlobalActor(_ x: consuming Klass) async { // expected-error {{'x' consumed more than once}}
-  await consumeTransferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  await consumeTransferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-note @-2 {{consumed here}}
   print(x)
   // expected-note @-1 {{consumed again here}}
 }
 
 func testBorrowing(_ x: borrowing Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testBorrowingError(_ x: borrowing Klass) async { // expected-error {{'x' is borrowed and cannot be consumed}}
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
   print(x) // expected-note {{consumed here}}
 }
 
 @CustomActor func testBorrowingErrorGlobalActor(_ x: borrowing Klass) async { // expected-error {{'x' is borrowed and cannot be consumed}}
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   print(x) // expected-note {{consumed here}}
 }
 
 func testInOut(_ x: inout Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testInOutError(_ x: inout Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee}}
   print(x)
 }
 
 @CustomActor func testInOutErrorMainActor(_ x: inout Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee}}
   print(x)
 }
 
 @CustomActor func testInOutErrorMainActor2(_ x: inout Klass) async { // expected-error {{'x' used after consume}}
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee}}
   _ = consume x // expected-note {{consumed here}}
 } // expected-note {{used here}}

--- a/test/Concurrency/transfernonsendable_ownership.swift
+++ b/test/Concurrency/transfernonsendable_ownership.swift
@@ -34,24 +34,24 @@ struct CustomActor {
 /////////////////
 
 func testConsuming(_ x: consuming Klass) async {
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testConsumingError(_ x: consuming Klass) async {
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   print(x)
 }
 
 @CustomActor func testConsumingErrorGlobalActor(_ x: consuming Klass) async {
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   print(x)
 }
 
 func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected-error {{'x' consumed more than once}}
-  await consumeTransferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await consumeTransferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'consumeTransferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-note @-2 {{consumed here}}
   print(x)
@@ -59,7 +59,7 @@ func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected
 }
 
 @CustomActor func testConsumingUseAfterConsumeErrorGlobalActor(_ x: consuming Klass) async { // expected-error {{'x' consumed more than once}}
-  await consumeTransferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await consumeTransferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'consumeTransferToMain' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-note @-2 {{consumed here}}
   print(x)
@@ -67,41 +67,41 @@ func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected
 }
 
 func testBorrowing(_ x: borrowing Klass) async {
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testBorrowingError(_ x: borrowing Klass) async { // expected-error {{'x' is borrowed and cannot be consumed}}
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   print(x) // expected-note {{consumed here}}
 }
 
 @CustomActor func testBorrowingErrorGlobalActor(_ x: borrowing Klass) async { // expected-error {{'x' is borrowed and cannot be consumed}}
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   print(x) // expected-note {{consumed here}}
 }
 
 func testInOut(_ x: inout Klass) async {
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testInOutError(_ x: inout Klass) async {
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   print(x)
 }
 
 @CustomActor func testInOutErrorMainActor(_ x: inout Klass) async {
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMain'}}
   print(x)
 }
 
 @CustomActor func testInOutErrorMainActor2(_ x: inout Klass) async { // expected-error {{'x' used after consume}}
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMain'}}
   _ = consume x // expected-note {{consumed here}}
 } // expected-note {{used here}}

--- a/test/Concurrency/transfernonsendable_ownership.swift
+++ b/test/Concurrency/transfernonsendable_ownership.swift
@@ -35,24 +35,24 @@ struct CustomActor {
 
 func testConsuming(_ x: consuming Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testConsumingError(_ x: consuming Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   print(x)
 }
 
 @CustomActor func testConsumingErrorGlobalActor(_ x: consuming Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   print(x)
 }
 
 func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected-error {{'x' consumed more than once}}
   await consumeTransferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'consumeTransferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-note @-2 {{consumed here}}
   print(x)
   // expected-note @-1 {{consumed again here}}
@@ -60,7 +60,7 @@ func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected
 
 @CustomActor func testConsumingUseAfterConsumeErrorGlobalActor(_ x: consuming Klass) async { // expected-error {{'x' consumed more than once}}
   await consumeTransferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'consumeTransferToMain' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-note @-2 {{consumed here}}
   print(x)
   // expected-note @-1 {{consumed again here}}
@@ -68,40 +68,40 @@ func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected
 
 func testBorrowing(_ x: borrowing Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testBorrowingError(_ x: borrowing Klass) async { // expected-error {{'x' is borrowed and cannot be consumed}}
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   print(x) // expected-note {{consumed here}}
 }
 
 @CustomActor func testBorrowingErrorGlobalActor(_ x: borrowing Klass) async { // expected-error {{'x' is borrowed and cannot be consumed}}
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   print(x) // expected-note {{consumed here}}
 }
 
 func testInOut(_ x: inout Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testInOutError(_ x: inout Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   print(x)
 }
 
 @CustomActor func testInOutErrorMainActor(_ x: inout Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee}}
+  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMain'}}
   print(x)
 }
 
 @CustomActor func testInOutErrorMainActor2(_ x: inout Klass) async { // expected-error {{'x' used after consume}}
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated callee}}
+  // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMain'}}
   _ = consume x // expected-note {{consumed here}}
 } // expected-note {{used here}}

--- a/test/Concurrency/transfernonsendable_preconcurrency.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency.swift
@@ -64,9 +64,9 @@ func testPreconcurrencyExplicitlyNonSendable() async {
   await transferToMain(x)
   // expected-swift-5-no-tns-warning @-1 {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
   // expected-swift-5-warning @-2 {{sending 'x' may cause a data race}}
-  // expected-swift-5-note @-3 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-swift-5-note @-3 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-swift-6-warning @-4 {{sending 'x' may cause a data race}}
-  // expected-swift-6-note @-5 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-note @-5 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x)
   // expected-swift-5-note @-1 {{use here could race}}
   // expected-swift-6-note @-2 {{use here could race}}
@@ -78,8 +78,8 @@ func testNormal() async {
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
   // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
   // expected-swift-6-error @-2 {{sending 'x' may cause a data race}}
-  // expected-swift-5-note @-3 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-swift-6-note @-4 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-swift-5-note @-3 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-note @-4 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-swift-5-note {{use here could race}}
   // expected-swift-6-note @-1 {{use here could race}}
 }
@@ -92,9 +92,9 @@ func testOnlyErrorOnExactValue() async {
   await transferToMain(y)
   // expected-swift-5-no-tns-warning @-1 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
   // expected-swift-5-warning @-2 {{sending 'y' may cause a data race}}
-  // expected-swift-5-note @-3 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-swift-5-note @-3 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-swift-6-error @-4 {{sending 'y' may cause a data race}}
-  // expected-swift-6-note @-5 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-note @-5 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x)
   // expected-swift-5-note @-1 {{use here could race}}
   // expected-swift-6-note @-2 {{use here could race}}

--- a/test/Concurrency/transfernonsendable_preconcurrency.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency.swift
@@ -63,10 +63,10 @@ func testPreconcurrencyExplicitlyNonSendable() async {
   let x = PreCUncheckedExplicitlyNonSendableKlass()
   await transferToMain(x)
   // expected-swift-5-no-tns-warning @-1 {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-2 {{transferring 'x' may cause a data race}}
-  // expected-swift-5-note @-3 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-swift-6-warning @-4 {{transferring 'x' may cause a data race}}
-  // expected-swift-6-note @-5 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-5-warning @-2 {{sending 'x' may cause a data race}}
+  // expected-swift-5-note @-3 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-warning @-4 {{sending 'x' may cause a data race}}
+  // expected-swift-6-note @-5 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(x)
   // expected-swift-5-note @-1 {{use here could race}}
   // expected-swift-6-note @-2 {{use here could race}}
@@ -76,10 +76,10 @@ func testPreconcurrencyExplicitlyNonSendable() async {
 func testNormal() async {
   let x = PostCUncheckedNonSendableKlass()
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
-  // expected-swift-6-error @-2 {{transferring 'x' may cause a data race}}
-  // expected-swift-5-note @-3 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-swift-6-note @-4 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-6-error @-2 {{sending 'x' may cause a data race}}
+  // expected-swift-5-note @-3 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-note @-4 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-swift-5-note {{use here could race}}
   // expected-swift-6-note @-1 {{use here could race}}
 }
@@ -91,10 +91,10 @@ func testOnlyErrorOnExactValue() async {
   // though we use x later.
   await transferToMain(y)
   // expected-swift-5-no-tns-warning @-1 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-2 {{transferring 'y' may cause a data race}}
-  // expected-swift-5-note @-3 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-swift-6-error @-4 {{transferring 'y' may cause a data race}}
-  // expected-swift-6-note @-5 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-5-warning @-2 {{sending 'y' may cause a data race}}
+  // expected-swift-5-note @-3 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-error @-4 {{sending 'y' may cause a data race}}
+  // expected-swift-6-note @-5 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(x)
   // expected-swift-5-note @-1 {{use here could race}}
   // expected-swift-6-note @-2 {{use here could race}}
@@ -118,36 +118,36 @@ func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
 
 func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
-  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
-  // expected-swift-6-warning @-3 {{transferring 'x' may cause a data race}}
-  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-warning @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
-  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
-  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
-  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
-  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
-  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
-  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type '(PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)' (aka '(ExplicitlyNonSendableKlass, ExplicitlyNonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
-  // expected-swift-5-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
-  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
-  // expected-swift-6-note @-4 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 

--- a/test/Concurrency/transfernonsendable_preconcurrency.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency.swift
@@ -64,9 +64,9 @@ func testPreconcurrencyExplicitlyNonSendable() async {
   await transferToMain(x)
   // expected-swift-5-no-tns-warning @-1 {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
   // expected-swift-5-warning @-2 {{sending 'x' may cause a data race}}
-  // expected-swift-5-note @-3 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-5-note @-3 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-swift-6-warning @-4 {{sending 'x' may cause a data race}}
-  // expected-swift-6-note @-5 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-note @-5 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x)
   // expected-swift-5-note @-1 {{use here could race}}
   // expected-swift-6-note @-2 {{use here could race}}
@@ -78,8 +78,8 @@ func testNormal() async {
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
   // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
   // expected-swift-6-error @-2 {{sending 'x' may cause a data race}}
-  // expected-swift-5-note @-3 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-swift-6-note @-4 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-5-note @-3 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-note @-4 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-swift-5-note {{use here could race}}
   // expected-swift-6-note @-1 {{use here could race}}
 }
@@ -92,9 +92,9 @@ func testOnlyErrorOnExactValue() async {
   await transferToMain(y)
   // expected-swift-5-no-tns-warning @-1 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
   // expected-swift-5-warning @-2 {{sending 'y' may cause a data race}}
-  // expected-swift-5-note @-3 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-5-note @-3 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-swift-6-error @-4 {{sending 'y' may cause a data race}}
-  // expected-swift-6-note @-5 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-note @-5 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x)
   // expected-swift-5-note @-1 {{use here could race}}
   // expected-swift-6-note @-2 {{use here could race}}
@@ -119,35 +119,35 @@ func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
 func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
   // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-swift-6-warning @-3 {{sending 'x' may cause a data race}}
-  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
   // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
-  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
   // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
-  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type '(PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)' (aka '(ExplicitlyNonSendableKlass, ExplicitlyNonSendableKlass)') into main actor-isolated context may introduce data races}}
   // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
-  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 

--- a/test/Concurrency/transfernonsendable_preconcurrency.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency.swift
@@ -63,25 +63,25 @@ func testPreconcurrencyExplicitlyNonSendable() async {
   let x = PreCUncheckedExplicitlyNonSendableKlass()
   await transferToMain(x)
   // expected-swift-5-no-tns-warning @-1 {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-2 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-2 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-3 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-swift-6-warning @-4 {{sending 'x' may cause a data race}}
+  // expected-swift-6-warning @-4 {{sending 'x' risks causing data races}}
   // expected-swift-6-note @-5 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x)
-  // expected-swift-5-note @-1 {{use here could race}}
-  // expected-swift-6-note @-2 {{use here could race}}
+  // expected-swift-5-note @-1 {{risks concurrent access}}
+  // expected-swift-6-note @-2 {{risks concurrent access}}
 }
 
 // In swift 5 this is a warning and in swift 6 this is an error.
 func testNormal() async {
   let x = PostCUncheckedNonSendableKlass()
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-swift-6-error @-2 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
+  // expected-swift-6-error @-2 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-3 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-swift-6-note @-4 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  useValue(x) // expected-swift-5-note {{use here could race}}
-  // expected-swift-6-note @-1 {{use here could race}}
+  useValue(x) // expected-swift-5-note {{risks concurrent access}}
+  // expected-swift-6-note @-1 {{risks concurrent access}}
 }
 
 func testOnlyErrorOnExactValue() async {
@@ -91,13 +91,13 @@ func testOnlyErrorOnExactValue() async {
   // though we use x later.
   await transferToMain(y)
   // expected-swift-5-no-tns-warning @-1 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-2 {{sending 'y' may cause a data race}}
+  // expected-swift-5-warning @-2 {{sending 'y' risks causing data races}}
   // expected-swift-5-note @-3 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-swift-6-error @-4 {{sending 'y' may cause a data race}}
+  // expected-swift-6-error @-4 {{sending 'y' risks causing data races}}
   // expected-swift-6-note @-5 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x)
-  // expected-swift-5-note @-1 {{use here could race}}
-  // expected-swift-6-note @-2 {{use here could race}}
+  // expected-swift-5-note @-1 {{risks concurrent access}}
+  // expected-swift-6-note @-2 {{risks concurrent access}}
 }
 
 func testNoErrorIfUseInSameRegionLater() async {
@@ -118,35 +118,35 @@ func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
 
 func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-swift-6-warning @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-warning @-3 {{sending 'x' risks causing data races}}
   // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-error @-3 {{sending 'x' risks causing data races}}
   // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-error @-3 {{sending 'x' risks causing data races}}
   // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
   await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type '(PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)' (aka '(ExplicitlyNonSendableKlass, ExplicitlyNonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-error @-3 {{sending 'x' risks causing data races}}
   // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 

--- a/test/Concurrency/transfernonsendable_preconcurrency_transferring.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency_transferring.swift
@@ -62,9 +62,9 @@ func testPreconcurrencyExplicitlyNonSendable() async {
   let x = PreCUncheckedExplicitlyNonSendableKlass()
   transferArg(x)
 
-  // expected-swift-5-warning @-2 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-warning @-2 {{sending 'x' may cause a data race}}
   // expected-swift-5-note @-3 {{'x' used after being passed as a transferring parameter; Later uses could race}}
-  // expected-swift-6-warning @-4 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-warning @-4 {{sending 'x' may cause a data race}}
   // expected-swift-6-note @-5 {{'x' used after being passed as a transferring parameter; Later uses could race}}
   useValue(x)
   // expected-swift-5-note @-1 {{use here could race}}
@@ -75,8 +75,8 @@ func testPreconcurrencyExplicitlyNonSendable() async {
 func testNormal() async {
   let x = PostCUncheckedNonSendableKlass()
   transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
-  // expected-swift-6-error @-2 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-6-error @-2 {{sending 'x' may cause a data race}}
   // expected-swift-5-note @-3 {{'x' used after being passed as a transferring parameter; Later uses could race}}
   // expected-swift-6-note @-4 {{'x' used after being passed as a transferring parameter; Later uses could race}}
   useValue(x) // expected-swift-5-note {{use here could race}}
@@ -90,9 +90,9 @@ func testOnlyErrorOnExactValue() async {
   // though we use x later.
   transferArg(y)
   // expected-swift-5-no-tns-warning @-1 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-2 {{transferring 'y' may cause a data race}}
+  // expected-swift-5-warning @-2 {{sending 'y' may cause a data race}}
   // expected-swift-5-note @-3 {{'y' used after being passed as a transferring parameter; Later uses could race}}
-  // expected-swift-6-error @-4 {{transferring 'y' may cause a data race}}
+  // expected-swift-6-error @-4 {{sending 'y' may cause a data race}}
   // expected-swift-6-note @-5 {{'y' used after being passed as a transferring parameter; Later uses could race}}
   useValue(x)
   // expected-swift-5-note @-1 {{use here could race}}
@@ -117,35 +117,35 @@ func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
 
 func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
   transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
   // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
-  // expected-swift-6-warning @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-warning @-3 {{sending 'x' may cause a data race}}
   // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
 func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
   transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
   // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
-  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
   // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)) async {
   transferArg(x) // expected-swift-5-no-tns-warning 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
   // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
-  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
   // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
   transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type '(PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)' (aka '(ExplicitlyNonSendableKlass, ExplicitlyNonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{transferring 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
   // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
-  // expected-swift-6-error @-3 {{transferring 'x' may cause a data race}}
+  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
   // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 

--- a/test/Concurrency/transfernonsendable_preconcurrency_transferring.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency_transferring.swift
@@ -62,25 +62,25 @@ func testPreconcurrencyExplicitlyNonSendable() async {
   let x = PreCUncheckedExplicitlyNonSendableKlass()
   transferArg(x)
 
-  // expected-swift-5-warning @-2 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-2 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-3 {{'x' used after being passed as a transferring parameter; Later uses could race}}
-  // expected-swift-6-warning @-4 {{sending 'x' may cause a data race}}
+  // expected-swift-6-warning @-4 {{sending 'x' risks causing data races}}
   // expected-swift-6-note @-5 {{'x' used after being passed as a transferring parameter; Later uses could race}}
   useValue(x)
-  // expected-swift-5-note @-1 {{use here could race}}
-  // expected-swift-6-note @-2 {{use here could race}}
+  // expected-swift-5-note @-1 {{risks concurrent access}}
+  // expected-swift-6-note @-2 {{risks concurrent access}}
 }
 
 // In swift 5 this is a warning and in swift 6 this is an error.
 func testNormal() async {
   let x = PostCUncheckedNonSendableKlass()
   transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
-  // expected-swift-6-error @-2 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
+  // expected-swift-6-error @-2 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-3 {{'x' used after being passed as a transferring parameter; Later uses could race}}
   // expected-swift-6-note @-4 {{'x' used after being passed as a transferring parameter; Later uses could race}}
-  useValue(x) // expected-swift-5-note {{use here could race}}
-  // expected-swift-6-note @-1 {{use here could race}}
+  useValue(x) // expected-swift-5-note {{risks concurrent access}}
+  // expected-swift-6-note @-1 {{risks concurrent access}}
 }
 
 func testOnlyErrorOnExactValue() async {
@@ -90,13 +90,13 @@ func testOnlyErrorOnExactValue() async {
   // though we use x later.
   transferArg(y)
   // expected-swift-5-no-tns-warning @-1 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-2 {{sending 'y' may cause a data race}}
+  // expected-swift-5-warning @-2 {{sending 'y' risks causing data races}}
   // expected-swift-5-note @-3 {{'y' used after being passed as a transferring parameter; Later uses could race}}
-  // expected-swift-6-error @-4 {{sending 'y' may cause a data race}}
+  // expected-swift-6-error @-4 {{sending 'y' risks causing data races}}
   // expected-swift-6-note @-5 {{'y' used after being passed as a transferring parameter; Later uses could race}}
   useValue(x)
-  // expected-swift-5-note @-1 {{use here could race}}
-  // expected-swift-6-note @-2 {{use here could race}}
+  // expected-swift-5-note @-1 {{risks concurrent access}}
+  // expected-swift-6-note @-2 {{risks concurrent access}}
 }
 
 func testNoErrorIfUseInSameRegionLater() async {
@@ -117,35 +117,35 @@ func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
 
 func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
   transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
-  // expected-swift-6-warning @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-warning @-3 {{sending 'x' risks causing data races}}
   // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
 func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
   transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
-  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-error @-3 {{sending 'x' risks causing data races}}
   // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)) async {
   transferArg(x) // expected-swift-5-no-tns-warning 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
-  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-error @-3 {{sending 'x' risks causing data races}}
   // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
   transferArg(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type '(PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)' (aka '(ExplicitlyNonSendableKlass, ExplicitlyNonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-1 {{sending 'x' may cause a data race}}
+  // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
-  // expected-swift-6-error @-3 {{sending 'x' may cause a data race}}
+  // expected-swift-6-error @-3 {{sending 'x' risks causing data races}}
   // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -58,12 +58,12 @@ func test_isolation_crossing_sensitivity(a : A) async {
   foo_noniso(ns0);
 
   // This call consumes ns1
-  await a.foo(ns1); // expected-tns-warning {{sending 'ns1' may cause a data race}}
+  await a.foo(ns1); // expected-tns-warning {{sending 'ns1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   print(ns0);
-  print(ns1); // expected-tns-note {{use here could race}}
+  print(ns1); // expected-tns-note {{risks concurrent access}}
 }
 
 func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
@@ -76,7 +76,7 @@ func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
   await a.foo(ns_let); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   // Not safe to consume an arg.
-  await a.foo(ns_arg); // expected-tns-warning {{sending 'ns_arg' may cause a data race}}
+  await a.foo(ns_arg); // expected-tns-warning {{sending 'ns_arg' risks causing data races}}
   // expected-tns-note @-1 {{sending task-isolated 'ns_arg' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and task-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -107,7 +107,7 @@ func test_closure_capture(a : A) async {
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
-  print(ns0) // expected-tns-note {{use here could race}}
+  print(ns0) // expected-tns-note {{risks concurrent access}}
   print(ns1)
   print(ns2)
   print(ns3)
@@ -119,7 +119,7 @@ func test_closure_capture(a : A) async {
 
   // This only touches ns1/ns2 so we get an error on ns1 since it is first.
   print(ns0)
-  print(ns1) // expected-tns-note {{use here could race}}
+  print(ns1) // expected-tns-note {{risks concurrent access}}
   print(ns2)
   print(ns3)
 
@@ -132,7 +132,7 @@ func test_closure_capture(a : A) async {
   print(ns0)
   print(ns1)
   print(ns2)
-  print(ns3) // expected-tns-note {{use here could race}}
+  print(ns3) // expected-tns-note {{risks concurrent access}}
 }
 
 func test_regions(a : A, b : Bool) async {
@@ -155,68 +155,68 @@ func test_regions(a : A, b : Bool) async {
   // check for each of the above pairs that consuming half of it consumes the other half
 
   if (b) {
-    await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' may cause a data race}}
+    await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns0_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if (b) {
-      print(ns0_0) // expected-tns-note {{use here could race}}
+      print(ns0_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns0_1) // expected-tns-note {{use here could race}}
+      print(ns0_1) // expected-tns-note {{risks concurrent access}}
     }
   } else {
-    await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' may cause a data race}}
+    await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns0_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns0_0) // expected-tns-note {{use here could race}}
+      print(ns0_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns0_1) // expected-tns-note {{use here could race}}
+      print(ns0_1) // expected-tns-note {{risks concurrent access}}
     }
   }
 
   if (b) {
-    await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' may cause a data race}}
+    await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns1_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns1_0) // expected-tns-note {{use here could race}}
+      print(ns1_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns1_1) // expected-tns-note {{use here could race}}
+      print(ns1_1) // expected-tns-note {{risks concurrent access}}
     }
   } else {
-    await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' may cause a data race}}
+    await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns1_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns1_0) // expected-tns-note {{use here could race}}
+      print(ns1_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns1_1) // expected-tns-note {{use here could race}}
+      print(ns1_1) // expected-tns-note {{risks concurrent access}}
     }
   }
 
   if (b) {
-    await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' may cause a data race}}
+    await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns2_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns2_0) // expected-tns-note {{use here could race}}
+      print(ns2_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns2_1) // expected-tns-note {{use here could race}}
+      print(ns2_1) // expected-tns-note {{risks concurrent access}}
     }
   } else {
-    await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' may cause a data race}}
+    await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns2_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns2_0) // expected-tns-note {{use here could race}}
+      print(ns2_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns2_1) // expected-tns-note {{use here could race}}
+      print(ns2_1) // expected-tns-note {{risks concurrent access}}
     }
   }
 }
@@ -260,134 +260,134 @@ func test_indirect_regions(a : A, b : Bool) async {
   // now check for each pair that consuming half of it consumed the other half
 
   if (b) {
-    await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' may cause a data race}}
+    await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns0_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns0_0) // expected-tns-note {{use here could race}}
+      print(ns0_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns0_1) // expected-tns-note {{use here could race}}
+      print(ns0_1) // expected-tns-note {{risks concurrent access}}
     }
   } else {
-    await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' may cause a data race}}
+    await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns0_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns0_0) // expected-tns-note {{use here could race}}
+      print(ns0_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns0_1) // expected-tns-note {{use here could race}}
+      print(ns0_1) // expected-tns-note {{risks concurrent access}}
     }
   }
 
   if (b) {
-    await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' may cause a data race}}
+    await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns1_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns1_0) // expected-tns-note {{use here could race}}
+      print(ns1_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns1_1) // expected-tns-note {{use here could race}}
+      print(ns1_1) // expected-tns-note {{risks concurrent access}}
     }
   } else {
-    await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' may cause a data race}}
+    await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns1_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns1_0) // expected-tns-note {{use here could race}}
+      print(ns1_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns1_1) // expected-tns-note {{use here could race}}
+      print(ns1_1) // expected-tns-note {{risks concurrent access}}
     }
   }
 
   if (b) {
-    await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' may cause a data race}}
+    await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns2_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns2_0) // expected-tns-note {{use here could race}}
+      print(ns2_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns2_1) // expected-tns-note {{use here could race}}
+      print(ns2_1) // expected-tns-note {{risks concurrent access}}
     }
   } else {
-    await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' may cause a data race}}
+    await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns2_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns2_0) // expected-tns-note {{use here could race}}
+      print(ns2_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns2_1) // expected-tns-note {{use here could race}}
+      print(ns2_1) // expected-tns-note {{risks concurrent access}}
     }
   }
 
   if (b) {
-    await a.foo(ns3_0) // expected-tns-warning {{sending 'ns3_0' may cause a data race}}
+    await a.foo(ns3_0) // expected-tns-warning {{sending 'ns3_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns3_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns3_0) // expected-tns-note {{use here could race}}
+      print(ns3_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns3_1) // expected-tns-note {{use here could race}}
+      print(ns3_1) // expected-tns-note {{risks concurrent access}}
     }
   } else {
-    await a.foo(ns3_1) // expected-tns-warning {{sending 'ns3_1' may cause a data race}}
+    await a.foo(ns3_1) // expected-tns-warning {{sending 'ns3_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns3_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns3_0) // expected-tns-note {{use here could race}}
+      print(ns3_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns3_1) // expected-tns-note {{use here could race}}
+      print(ns3_1) // expected-tns-note {{risks concurrent access}}
     }
   }
 
   if (b) {
-    await a.foo(ns4_0) // expected-tns-warning {{sending 'ns4_0' may cause a data race}}
+    await a.foo(ns4_0) // expected-tns-warning {{sending 'ns4_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns4_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns4_0) // expected-tns-note {{use here could race}}
+      print(ns4_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns4_1) // expected-tns-note {{use here could race}}
+      print(ns4_1) // expected-tns-note {{risks concurrent access}}
     }
   } else {
-    await a.foo(ns4_1) // expected-tns-warning {{sending 'ns4_1' may cause a data race}}
+    await a.foo(ns4_1) // expected-tns-warning {{sending 'ns4_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns4_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns4_0) // expected-tns-note {{use here could race}}
+      print(ns4_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns4_1) // expected-tns-note {{use here could race}}
+      print(ns4_1) // expected-tns-note {{risks concurrent access}}
     }
   }
 
   if (b) {
-    await a.foo(ns5_0) // expected-tns-warning {{sending 'ns5_0' may cause a data race}}
+    await a.foo(ns5_0) // expected-tns-warning {{sending 'ns5_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns5_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns5_0) // expected-tns-note {{use here could race}}
+      print(ns5_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns5_1) // expected-tns-note {{use here could race}}
+      print(ns5_1) // expected-tns-note {{risks concurrent access}}
     }
   } else {
-    await a.foo(ns5_1) // expected-tns-warning {{sending 'ns5_1' may cause a data race}}
+    await a.foo(ns5_1) // expected-tns-warning {{sending 'ns5_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns5_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
     if b {
-      print(ns5_0) // expected-tns-note {{use here could race}}
+      print(ns5_0) // expected-tns-note {{risks concurrent access}}
     } else {
-      print(ns5_1) // expected-tns-note {{use here could race}}
+      print(ns5_1) // expected-tns-note {{risks concurrent access}}
     }
   }
 }
@@ -404,7 +404,7 @@ class C_NonSendable {
     foo_noniso(captures_self)
 
     // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
-    await a.foo(captures_self) // expected-tns-warning {{sending 'captures_self' may cause a data race}}
+    await a.foo(captures_self) // expected-tns-warning {{sending 'captures_self' risks causing data races}}
     // expected-tns-note @-1 {{sending task-isolated 'captures_self' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and task-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -441,7 +441,7 @@ actor A_Sendable {
     // actor and is non-Sendable. For now, we ban this since we do not
     // support the ability to dynamically invoke the synchronous closure on
     // the specific actor.
-    await a.foo(captures_self) // expected-tns-warning {{sending 'captures_self' may cause a data race}}
+    await a.foo(captures_self) // expected-tns-warning {{sending 'captures_self' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'captures_self' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -452,9 +452,9 @@ func basic_loopiness(a : A, b : Bool) async {
   let ns = NonSendable()
 
   while (b) {
-    await a.foo(ns) // expected-tns-warning {{sending 'ns' may cause a data race}}
+    await a.foo(ns) // expected-tns-warning {{sending 'ns' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-tns-note @-2 {{use here could race}}
+    // expected-tns-note @-2 {{risks concurrent access}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   }
 }
@@ -470,10 +470,10 @@ func basic_loopiness_unsafe(a : A, b : Bool) async {
     (ns0, ns1, ns2, ns3) = (ns1, ns2, ns3, ns0)
   }
 
-  await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+  await a.foo(ns0) // expected-tns-warning {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo(ns3) // expected-tns-note {{use here could race}}
+  await a.foo(ns3) // expected-tns-note {{risks concurrent access}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
@@ -535,10 +535,10 @@ func test_class_assign_merges(a : A, b : Bool) async {
   box.contents = ns0
   box.contents = ns1
 
-  await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+  await a.foo(ns0) // expected-tns-warning {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo(ns1) // expected-tns-note {{use here could race}}
+  await a.foo(ns1) // expected-tns-note {{risks concurrent access}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
@@ -572,10 +572,10 @@ func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
   contents = ns0
   contents = ns1
 
-  await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+  await a.foo(ns0) // expected-tns-warning {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo(ns1) // expected-tns-note {{use here could race}}
+  await a.foo(ns1) // expected-tns-note {{risks concurrent access}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
@@ -590,74 +590,74 @@ func test_tuple_formation(a : A, i : Int) async {
 
   switch (i) {
   case 0:
-    await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+    await a.foo(ns0) // expected-tns-warning {{sending 'ns0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
-      foo_noniso(ns0); // expected-tns-note {{use here could race}}
+      foo_noniso(ns0); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns1); // expected-tns-note {{use here could race}}
+      foo_noniso(ns1); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns2); // expected-tns-note {{use here could race}}
+      foo_noniso(ns2); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns3); // expected-tns-note {{use here could race}}
+      foo_noniso(ns3); // expected-tns-note {{risks concurrent access}}
     } else if bool {
       foo_noniso(ns4);
     } else if bool {
-      foo_noniso(ns012); // expected-tns-note {{use here could race}}
+      foo_noniso(ns012); // expected-tns-note {{risks concurrent access}}
     } else {
-      foo_noniso(ns13); // expected-tns-note {{use here could race}}
+      foo_noniso(ns13); // expected-tns-note {{risks concurrent access}}
     }
   case 1:
-    await a.foo(ns1) // expected-tns-warning {{sending 'ns1' may cause a data race}}
+    await a.foo(ns1) // expected-tns-warning {{sending 'ns1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
-      foo_noniso(ns0); // expected-tns-note {{use here could race}}
+      foo_noniso(ns0); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns1); // expected-tns-note {{use here could race}}
+      foo_noniso(ns1); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns2); // expected-tns-note {{use here could race}}
+      foo_noniso(ns2); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns3); // expected-tns-note {{use here could race}}
+      foo_noniso(ns3); // expected-tns-note {{risks concurrent access}}
     } else if bool {
       foo_noniso(ns4);
     } else if bool {
-      foo_noniso(ns012); // expected-tns-note {{use here could race}}
+      foo_noniso(ns012); // expected-tns-note {{risks concurrent access}}
     } else {
-      foo_noniso(ns13); // expected-tns-note {{use here could race}}
+      foo_noniso(ns13); // expected-tns-note {{risks concurrent access}}
     }
   case 2:
-    await a.foo(ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
+    await a.foo(ns2) // expected-tns-warning {{sending 'ns2' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns2' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
-      foo_noniso(ns0); // expected-tns-note {{use here could race}}
+      foo_noniso(ns0); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns1); // expected-tns-note {{use here could race}}
+      foo_noniso(ns1); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns2); // expected-tns-note {{use here could race}}
+      foo_noniso(ns2); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns3); // expected-tns-note {{use here could race}}
+      foo_noniso(ns3); // expected-tns-note {{risks concurrent access}}
     } else if bool {
       foo_noniso(ns4);
     } else if bool {
-      foo_noniso(ns012); // expected-tns-note {{use here could race}}
+      foo_noniso(ns012); // expected-tns-note {{risks concurrent access}}
     } else {
-      foo_noniso(ns13); // expected-tns-note {{use here could race}}
+      foo_noniso(ns13); // expected-tns-note {{risks concurrent access}}
     }
   case 3:
-    await a.foo(ns4) // expected-tns-warning {{sending 'ns4' may cause a data race}}
+    await a.foo(ns4) // expected-tns-warning {{sending 'ns4' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns4' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     foo_noniso(ns0);
     foo_noniso(ns1);
     foo_noniso(ns2);
-    foo_noniso(ns4); // expected-tns-note {{use here could race}}
+    foo_noniso(ns4); // expected-tns-note {{risks concurrent access}}
     foo_noniso(ns012);
     foo_noniso(ns13);
   case 4:
@@ -666,38 +666,38 @@ func test_tuple_formation(a : A, i : Int) async {
     // expected-complete-warning @-2 3{{passing argument of non-sendable type '(NonSendable, NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
     if bool {
-      foo_noniso(ns0); // expected-tns-note {{use here could race}}
+      foo_noniso(ns0); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns1); // expected-tns-note {{use here could race}}
+      foo_noniso(ns1); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns2); // expected-tns-note {{use here could race}}
+      foo_noniso(ns2); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns3); // expected-tns-note {{use here could race}}
+      foo_noniso(ns3); // expected-tns-note {{risks concurrent access}}
     } else if bool {
       foo_noniso(ns4);
     } else if bool {
-      foo_noniso(ns012); // expected-tns-note {{use here could race}}
+      foo_noniso(ns012); // expected-tns-note {{risks concurrent access}}
     } else {
-      foo_noniso(ns13); // expected-tns-note {{use here could race}}
+      foo_noniso(ns13); // expected-tns-note {{risks concurrent access}}
     }
   default:
     await a.foo(ns13) // expected-tns-warning {{sending value of non-Sendable type '(NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 2{{passing argument of non-sendable type '(NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
     if bool {
-      foo_noniso(ns0); // expected-tns-note {{use here could race}}
+      foo_noniso(ns0); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns1); // expected-tns-note {{use here could race}}
+      foo_noniso(ns1); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns2); // expected-tns-note {{use here could race}}
+      foo_noniso(ns2); // expected-tns-note {{risks concurrent access}}
     } else if bool {
-      foo_noniso(ns3); // expected-tns-note {{use here could race}}
+      foo_noniso(ns3); // expected-tns-note {{risks concurrent access}}
     } else if bool {
       foo_noniso(ns4);
     } else if bool {
-      foo_noniso(ns012); // expected-tns-note {{use here could race}}
+      foo_noniso(ns012); // expected-tns-note {{risks concurrent access}}
     } else  {
-      foo_noniso(ns13); // expected-tns-note {{use here could race}}
+      foo_noniso(ns13); // expected-tns-note {{risks concurrent access}}
     }
   }
 }
@@ -723,16 +723,16 @@ func one_consume_many_require(a : A) async {
 
   await a.foo_multi(ns0, ns1, ns2);
   // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
+  // expected-tns-warning @-2 {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-4 {{sending 'ns1' may cause a data race}}
+  // expected-tns-warning @-4 {{sending 'ns1' risks causing data races}}
   // expected-tns-note @-5 {{sending 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-6 {{sending 'ns2' may cause a data race}}
+  // expected-tns-warning @-6 {{sending 'ns2' risks causing data races}}
   // expected-tns-note @-7 {{sending 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
 
-  foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
-  foo_noniso_multi(ns3, ns1, ns4); // expected-tns-note {{use here could race}}
-  foo_noniso_multi(ns4, ns3, ns2); // expected-tns-note {{use here could race}}
+  foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{risks concurrent access}}
+  foo_noniso_multi(ns3, ns1, ns4); // expected-tns-note {{risks concurrent access}}
+  foo_noniso_multi(ns4, ns3, ns2); // expected-tns-note {{risks concurrent access}}
 }
 
 func one_consume_one_require(a : A) async {
@@ -742,14 +742,14 @@ func one_consume_one_require(a : A) async {
 
   await a.foo_multi(ns0, ns1, ns2);
   // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
+  // expected-tns-warning @-2 {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-4 {{sending 'ns1' may cause a data race}}
+  // expected-tns-warning @-4 {{sending 'ns1' risks causing data races}}
   // expected-tns-note @-5 {{sending 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-6 {{sending 'ns2' may cause a data race}}
+  // expected-tns-warning @-6 {{sending 'ns2' risks causing data races}}
   // expected-tns-note @-7 {{sending 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
 
-  foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
+  foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{risks concurrent access}}
 }
 
 func many_consume_one_require(a : A) async {
@@ -760,16 +760,16 @@ func many_consume_one_require(a : A) async {
   let ns4 = NonSendable();
   let ns5 = NonSendable();
 
-  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' may cause a data race}}
+  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
+  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{use here could race}}
+  foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{risks concurrent access}}
 }
 
 func many_consume_many_require(a : A) async {
@@ -782,19 +782,19 @@ func many_consume_many_require(a : A) async {
   let ns6 = NonSendable();
   let ns7 = NonSendable();
 
-  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' may cause a data race}}
+  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
+  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-  foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{use here could race}}
-  foo_noniso_multi(ns6, ns1, ns7); // expected-tns-note {{use here could race}}
-  foo_noniso_multi(ns7, ns6, ns2); // expected-tns-note {{use here could race}}
+  foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{risks concurrent access}}
+  foo_noniso_multi(ns6, ns1, ns7); // expected-tns-note {{risks concurrent access}}
+  foo_noniso_multi(ns7, ns6, ns2); // expected-tns-note {{risks concurrent access}}
 }
 
 
@@ -823,11 +823,11 @@ func one_consume_many_require_varag(a : A) async {
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
   if bool {
-    foo_noniso_vararg(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
+    foo_noniso_vararg(ns0, ns3, ns4); // expected-tns-note {{risks concurrent access}}
   } else if bool {
-    foo_noniso_vararg(ns3, ns1, ns4); // expected-tns-note {{use here could race}}
+    foo_noniso_vararg(ns3, ns1, ns4); // expected-tns-note {{risks concurrent access}}
   } else {
-    foo_noniso_vararg(ns4, ns3, ns2); // expected-tns-note {{use here could race}}
+    foo_noniso_vararg(ns4, ns3, ns2); // expected-tns-note {{risks concurrent access}}
   }
 }
 
@@ -840,7 +840,7 @@ func one_consume_one_require_vararg(a : A) async {
   // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-  foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 1{{use here could race}}
+  foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 1{{risks concurrent access}}
 }
 
 func many_consume_one_require_vararg(a : A) async {
@@ -861,7 +861,7 @@ func many_consume_one_require_vararg(a : A) async {
   // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-  foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
+  foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 3{{risks concurrent access}}
 }
 
 func many_consume_many_require_vararg(a : A) async {
@@ -885,11 +885,11 @@ func many_consume_many_require_vararg(a : A) async {
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
   if bool {
-    foo_noniso_vararg(ns0, ns6, ns7); // expected-tns-note {{use here could race}}
+    foo_noniso_vararg(ns0, ns6, ns7); // expected-tns-note {{risks concurrent access}}
   } else if bool {
-    foo_noniso_vararg(ns6, ns1, ns7);  // expected-tns-note {{use here could race}}
+    foo_noniso_vararg(ns6, ns1, ns7);  // expected-tns-note {{risks concurrent access}}
   } else {
-    foo_noniso_vararg(ns7, ns6, ns2);  // expected-tns-note {{use here could race}}
+    foo_noniso_vararg(ns7, ns6, ns2);  // expected-tns-note {{risks concurrent access}}
   }
 }
 
@@ -929,10 +929,10 @@ func enum_test(a : A) async {
         foo_noniso(e4);
   }
 
-  await a.foo(e1); // expected-tns-warning {{sending 'e1' may cause a data race}}
+  await a.foo(e1); // expected-tns-warning {{sending 'e1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'e1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'E' into actor-isolated context may introduce data races}}
-  foo_noniso(e2); // expected-tns-note {{use here could race}}
-  foo_noniso(e3); // expected-tns-note {{use here could race}}
+  foo_noniso(e2); // expected-tns-note {{risks concurrent access}}
+  foo_noniso(e3); // expected-tns-note {{risks concurrent access}}
   foo_noniso(e4);
 }

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -58,8 +58,8 @@ func test_isolation_crossing_sensitivity(a : A) async {
   foo_noniso(ns0);
 
   // This call consumes ns1
-  await a.foo(ns1); // expected-tns-warning {{transferring 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.foo(ns1); // expected-tns-warning {{sending 'ns1' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   print(ns0);
@@ -76,8 +76,8 @@ func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
   await a.foo(ns_let); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   // Not safe to consume an arg.
-  await a.foo(ns_arg); // expected-tns-warning {{transferring 'ns_arg' may cause a data race}}
-  // expected-tns-note @-1 {{transferring task-isolated 'ns_arg' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+  await a.foo(ns_arg); // expected-tns-warning {{sending 'ns_arg' may cause a data race}}
+  // expected-tns-note @-1 {{sending task-isolated 'ns_arg' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   // Check for no duplicate warnings once self is "consumed"
@@ -103,7 +103,7 @@ func test_closure_capture(a : A) async {
   print(ns3)
 
   // this should consume ns0
-  await a.run_closure(captures0) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
+  await a.run_closure(captures0) // expected-tns-warning {{sending value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -113,7 +113,7 @@ func test_closure_capture(a : A) async {
   print(ns3)
 
   // this should consume ns1 and ns2
-  await a.run_closure(captures12) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
+  await a.run_closure(captures12) // expected-tns-warning {{sending value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -124,7 +124,7 @@ func test_closure_capture(a : A) async {
   print(ns3)
 
   // this should consume ns3
-  await a.run_closure(captures3indirect) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
+  await a.run_closure(captures3indirect) // expected-tns-warning {{sending value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -155,8 +155,8 @@ func test_regions(a : A, b : Bool) async {
   // check for each of the above pairs that consuming half of it consumes the other half
 
   if (b) {
-    await a.foo(ns0_0) // expected-tns-warning {{transferring 'ns0_0' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns0_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns0_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if (b) {
@@ -165,8 +165,8 @@ func test_regions(a : A, b : Bool) async {
       print(ns0_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns0_1) // expected-tns-warning {{transferring 'ns0_1' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns0_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns0_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -177,8 +177,8 @@ func test_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns1_0) // expected-tns-warning {{transferring 'ns1_0' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns1_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns1_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -187,8 +187,8 @@ func test_regions(a : A, b : Bool) async {
       print(ns1_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns1_1) // expected-tns-warning {{transferring 'ns1_1' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns1_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns1_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -199,8 +199,8 @@ func test_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns2_0) // expected-tns-warning {{transferring 'ns2_0' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns2_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns2_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -209,8 +209,8 @@ func test_regions(a : A, b : Bool) async {
       print(ns2_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns2_1) // expected-tns-warning {{transferring 'ns2_1' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns2_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns2_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -260,8 +260,8 @@ func test_indirect_regions(a : A, b : Bool) async {
   // now check for each pair that consuming half of it consumed the other half
 
   if (b) {
-    await a.foo(ns0_0) // expected-tns-warning {{transferring 'ns0_0' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns0_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns0_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -270,8 +270,8 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns0_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns0_1) // expected-tns-warning {{transferring 'ns0_1' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns0_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns0_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -282,8 +282,8 @@ func test_indirect_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns1_0) // expected-tns-warning {{transferring 'ns1_0' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns1_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns1_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -292,8 +292,8 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns1_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns1_1) // expected-tns-warning {{transferring 'ns1_1' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns1_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns1_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -304,8 +304,8 @@ func test_indirect_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns2_0) // expected-tns-warning {{transferring 'ns2_0' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns2_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns2_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -314,8 +314,8 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns2_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns2_1) // expected-tns-warning {{transferring 'ns2_1' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns2_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns2_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -326,8 +326,8 @@ func test_indirect_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns3_0) // expected-tns-warning {{transferring 'ns3_0' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns3_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns3_0) // expected-tns-warning {{sending 'ns3_0' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns3_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -336,8 +336,8 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns3_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns3_1) // expected-tns-warning {{transferring 'ns3_1' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns3_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns3_1) // expected-tns-warning {{sending 'ns3_1' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns3_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -348,8 +348,8 @@ func test_indirect_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns4_0) // expected-tns-warning {{transferring 'ns4_0' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns4_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns4_0) // expected-tns-warning {{sending 'ns4_0' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns4_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -358,8 +358,8 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns4_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns4_1) // expected-tns-warning {{transferring 'ns4_1' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns4_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns4_1) // expected-tns-warning {{sending 'ns4_1' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns4_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -370,8 +370,8 @@ func test_indirect_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns5_0) // expected-tns-warning {{transferring 'ns5_0' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns5_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns5_0) // expected-tns-warning {{sending 'ns5_0' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns5_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
     if b {
@@ -380,8 +380,8 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns5_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns5_1) // expected-tns-warning {{transferring 'ns5_1' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns5_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns5_1) // expected-tns-warning {{sending 'ns5_1' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns5_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
     if b {
@@ -404,8 +404,8 @@ class C_NonSendable {
     foo_noniso(captures_self)
 
     // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
-    await a.foo(captures_self) // expected-tns-warning {{transferring 'captures_self' may cause a data race}}
-    // expected-tns-note @-1 {{transferring task-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+    await a.foo(captures_self) // expected-tns-warning {{sending 'captures_self' may cause a data race}}
+    // expected-tns-note @-1 {{sending task-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -441,8 +441,8 @@ actor A_Sendable {
     // actor and is non-Sendable. For now, we ban this since we do not
     // support the ability to dynamically invoke the synchronous closure on
     // the specific actor.
-    await a.foo(captures_self) // expected-tns-warning {{transferring 'captures_self' may cause a data race}}
-    // expected-tns-note @-1 {{transferring 'self'-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
+    await a.foo(captures_self) // expected-tns-warning {{sending 'captures_self' may cause a data race}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -452,8 +452,8 @@ func basic_loopiness(a : A, b : Bool) async {
   let ns = NonSendable()
 
   while (b) {
-    await a.foo(ns) // expected-tns-warning {{transferring 'ns' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns) // expected-tns-warning {{sending 'ns' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   }
@@ -470,8 +470,8 @@ func basic_loopiness_unsafe(a : A, b : Bool) async {
     (ns0, ns1, ns2, ns3) = (ns1, ns2, ns3, ns0)
   }
 
-  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns3) // expected-tns-note {{use here could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -535,8 +535,8 @@ func test_class_assign_merges(a : A, b : Bool) async {
   box.contents = ns0
   box.contents = ns1
 
-  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1) // expected-tns-note {{use here could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -572,8 +572,8 @@ func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
   contents = ns0
   contents = ns1
 
-  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1) // expected-tns-note {{use here could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -590,8 +590,8 @@ func test_tuple_formation(a : A, i : Int) async {
 
   switch (i) {
   case 0:
-    await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -610,8 +610,8 @@ func test_tuple_formation(a : A, i : Int) async {
       foo_noniso(ns13); // expected-tns-note {{use here could race}}
     }
   case 1:
-    await a.foo(ns1) // expected-tns-warning {{transferring 'ns1' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns1) // expected-tns-warning {{sending 'ns1' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -630,8 +630,8 @@ func test_tuple_formation(a : A, i : Int) async {
       foo_noniso(ns13); // expected-tns-note {{use here could race}}
     }
   case 2:
-    await a.foo(ns2) // expected-tns-warning {{transferring 'ns2' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -650,8 +650,8 @@ func test_tuple_formation(a : A, i : Int) async {
       foo_noniso(ns13); // expected-tns-note {{use here could race}}
     }
   case 3:
-    await a.foo(ns4) // expected-tns-warning {{transferring 'ns4' may cause a data race}}
-    // expected-tns-note @-1 {{transferring disconnected 'ns4' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    await a.foo(ns4) // expected-tns-warning {{sending 'ns4' may cause a data race}}
+    // expected-tns-note @-1 {{sending disconnected 'ns4' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     foo_noniso(ns0);
@@ -661,7 +661,7 @@ func test_tuple_formation(a : A, i : Int) async {
     foo_noniso(ns012);
     foo_noniso(ns13);
   case 4:
-    await a.foo(ns012) // expected-tns-warning {{transferring value of non-Sendable type '(NonSendable, NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
+    await a.foo(ns012) // expected-tns-warning {{sending value of non-Sendable type '(NonSendable, NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
     // TODO: Interestingly with complete, we emit this error 3 times?!
     // expected-complete-warning @-2 3{{passing argument of non-sendable type '(NonSendable, NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
@@ -681,7 +681,7 @@ func test_tuple_formation(a : A, i : Int) async {
       foo_noniso(ns13); // expected-tns-note {{use here could race}}
     }
   default:
-    await a.foo(ns13) // expected-tns-warning {{transferring value of non-Sendable type '(NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
+    await a.foo(ns13) // expected-tns-warning {{sending value of non-Sendable type '(NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 2{{passing argument of non-sendable type '(NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -723,12 +723,12 @@ func one_consume_many_require(a : A) async {
 
   await a.foo_multi(ns0, ns1, ns2);
   // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 'ns0' may cause a data race}}
-  // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-4 {{transferring 'ns1' may cause a data race}}
-  // expected-tns-note @-5 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-6 {{transferring 'ns2' may cause a data race}}
-  // expected-tns-note @-7 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
+  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-4 {{sending 'ns1' may cause a data race}}
+  // expected-tns-note @-5 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-6 {{sending 'ns2' may cause a data race}}
+  // expected-tns-note @-7 {{sending disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
 
   foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
   foo_noniso_multi(ns3, ns1, ns4); // expected-tns-note {{use here could race}}
@@ -742,12 +742,12 @@ func one_consume_one_require(a : A) async {
 
   await a.foo_multi(ns0, ns1, ns2);
   // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 'ns0' may cause a data race}}
-  // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-4 {{transferring 'ns1' may cause a data race}}
-  // expected-tns-note @-5 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-6 {{transferring 'ns2' may cause a data race}}
-  // expected-tns-note @-7 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
+  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-4 {{sending 'ns1' may cause a data race}}
+  // expected-tns-note @-5 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-6 {{sending 'ns2' may cause a data race}}
+  // expected-tns-note @-7 {{sending disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
 
   foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
 }
@@ -760,14 +760,14 @@ func many_consume_one_require(a : A) async {
   let ns4 = NonSendable();
   let ns5 = NonSendable();
 
-  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{transferring 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{transferring 'ns2' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{use here could race}}
 }
@@ -782,14 +782,14 @@ func many_consume_many_require(a : A) async {
   let ns6 = NonSendable();
   let ns7 = NonSendable();
 
-  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{transferring 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{transferring 'ns2' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{use here could race}}
@@ -819,7 +819,7 @@ func one_consume_many_require_varag(a : A) async {
 
   //TODO: find a way to make the type used in the diagnostic more specific than the signature type
   await a.foo_vararg(ns0, ns1, ns2);
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
   if bool {
@@ -837,7 +837,7 @@ func one_consume_one_require_vararg(a : A) async {
   let ns2 = NonSendable();
 
   await a.foo_vararg(ns0, ns1, ns2);
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
   foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 1{{use here could race}}
@@ -852,13 +852,13 @@ func many_consume_one_require_vararg(a : A) async {
   let ns5 = NonSendable();
 
   await a.foo_vararg(ns0, ns3, ns3)
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
   await a.foo_vararg(ns4, ns1, ns4)
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
   await a.foo_vararg(ns5, ns5, ns2)
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
   foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
@@ -875,13 +875,13 @@ func many_consume_many_require_vararg(a : A) async {
   let ns7 = NonSendable();
 
   await a.foo_vararg(ns0, ns3, ns3)
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
   await a.foo_vararg(ns4, ns1, ns4)
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
   await a.foo_vararg(ns5, ns5, ns2)
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
   if bool {
@@ -919,7 +919,7 @@ func enum_test(a : A) async {
     case .E2:
       switch (e3) {
       case let .E3(ns3):
-        await a.foo(ns3.x); // expected-tns-warning {{transferring value of non-Sendable type 'Any' from nonisolated context to actor-isolated context; later accesses could race}}
+        await a.foo(ns3.x); // expected-tns-warning {{sending value of non-Sendable type 'Any' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
       default: ()
       }
@@ -929,8 +929,8 @@ func enum_test(a : A) async {
         foo_noniso(e4);
   }
 
-  await a.foo(e1); // expected-tns-warning {{transferring 'e1' may cause a data race}}
-  // expected-tns-note @-1 {{transferring disconnected 'e1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  await a.foo(e1); // expected-tns-warning {{sending 'e1' may cause a data race}}
+  // expected-tns-note @-1 {{sending disconnected 'e1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'E' into actor-isolated context may introduce data races}}
   foo_noniso(e2); // expected-tns-note {{use here could race}}
   foo_noniso(e3); // expected-tns-note {{use here could race}}

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -59,7 +59,7 @@ func test_isolation_crossing_sensitivity(a : A) async {
 
   // This call consumes ns1
   await a.foo(ns1); // expected-tns-warning {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   print(ns0);
@@ -156,7 +156,7 @@ func test_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns0_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns0_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if (b) {
@@ -166,7 +166,7 @@ func test_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns0_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns0_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -178,7 +178,7 @@ func test_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns1_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns1_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -188,7 +188,7 @@ func test_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns1_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns1_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -200,7 +200,7 @@ func test_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns2_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns2_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -210,7 +210,7 @@ func test_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns2_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns2_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -261,7 +261,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns0_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns0_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -271,7 +271,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns0_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns0_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -283,7 +283,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns1_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns1_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -293,7 +293,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns1_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns1_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -305,7 +305,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns2_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns2_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -315,7 +315,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns2_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns2_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -327,7 +327,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns3_0) // expected-tns-warning {{sending 'ns3_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns3_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns3_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -337,7 +337,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns3_1) // expected-tns-warning {{sending 'ns3_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns3_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns3_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -349,7 +349,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns4_0) // expected-tns-warning {{sending 'ns4_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns4_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns4_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -359,7 +359,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns4_1) // expected-tns-warning {{sending 'ns4_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns4_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns4_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -371,7 +371,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns5_0) // expected-tns-warning {{sending 'ns5_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns5_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns5_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
     if b {
@@ -381,7 +381,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns5_1) // expected-tns-warning {{sending 'ns5_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns5_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns5_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
     if b {
@@ -453,7 +453,7 @@ func basic_loopiness(a : A, b : Bool) async {
 
   while (b) {
     await a.foo(ns) // expected-tns-warning {{sending 'ns' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   }
@@ -471,7 +471,7 @@ func basic_loopiness_unsafe(a : A, b : Bool) async {
   }
 
   await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns3) // expected-tns-note {{use here could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -536,7 +536,7 @@ func test_class_assign_merges(a : A, b : Bool) async {
   box.contents = ns1
 
   await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1) // expected-tns-note {{use here could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -573,7 +573,7 @@ func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
   contents = ns1
 
   await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1) // expected-tns-note {{use here could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -591,7 +591,7 @@ func test_tuple_formation(a : A, i : Int) async {
   switch (i) {
   case 0:
     await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -611,7 +611,7 @@ func test_tuple_formation(a : A, i : Int) async {
     }
   case 1:
     await a.foo(ns1) // expected-tns-warning {{sending 'ns1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -631,7 +631,7 @@ func test_tuple_formation(a : A, i : Int) async {
     }
   case 2:
     await a.foo(ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns2' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -651,7 +651,7 @@ func test_tuple_formation(a : A, i : Int) async {
     }
   case 3:
     await a.foo(ns4) // expected-tns-warning {{sending 'ns4' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns4' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending 'ns4' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     foo_noniso(ns0);
@@ -724,11 +724,11 @@ func one_consume_many_require(a : A) async {
   await a.foo_multi(ns0, ns1, ns2);
   // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-4 {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-5 {{sending disconnected 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-5 {{sending 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-6 {{sending 'ns2' may cause a data race}}
-  // expected-tns-note @-7 {{sending disconnected 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-7 {{sending 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
 
   foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
   foo_noniso_multi(ns3, ns1, ns4); // expected-tns-note {{use here could race}}
@@ -743,11 +743,11 @@ func one_consume_one_require(a : A) async {
   await a.foo_multi(ns0, ns1, ns2);
   // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-4 {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-5 {{sending disconnected 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-5 {{sending 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-6 {{sending 'ns2' may cause a data race}}
-  // expected-tns-note @-7 {{sending disconnected 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-7 {{sending 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
 
   foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
 }
@@ -761,13 +761,13 @@ func many_consume_one_require(a : A) async {
   let ns5 = NonSendable();
 
   await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{use here could race}}
 }
@@ -783,13 +783,13 @@ func many_consume_many_require(a : A) async {
   let ns7 = NonSendable();
 
   await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{use here could race}}
@@ -930,7 +930,7 @@ func enum_test(a : A) async {
   }
 
   await a.foo(e1); // expected-tns-warning {{sending 'e1' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'e1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending 'e1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'E' into actor-isolated context may introduce data races}}
   foo_noniso(e2); // expected-tns-note {{use here could race}}
   foo_noniso(e3); // expected-tns-note {{use here could race}}

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -59,7 +59,7 @@ func test_isolation_crossing_sensitivity(a : A) async {
 
   // This call consumes ns1
   await a.foo(ns1); // expected-tns-warning {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   print(ns0);
@@ -77,7 +77,7 @@ func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
 
   // Not safe to consume an arg.
   await a.foo(ns_arg); // expected-tns-warning {{sending 'ns_arg' may cause a data race}}
-  // expected-tns-note @-1 {{sending task-isolated 'ns_arg' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+  // expected-tns-note @-1 {{sending task-isolated 'ns_arg' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and task-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   // Check for no duplicate warnings once self is "consumed"
@@ -156,7 +156,7 @@ func test_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns0_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns0_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if (b) {
@@ -166,7 +166,7 @@ func test_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns0_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns0_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -178,7 +178,7 @@ func test_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns1_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns1_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -188,7 +188,7 @@ func test_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns1_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns1_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -200,7 +200,7 @@ func test_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns2_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns2_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -210,7 +210,7 @@ func test_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns2_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns2_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -261,7 +261,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns0_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns0_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -271,7 +271,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns0_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns0_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -283,7 +283,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns1_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns1_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -293,7 +293,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns1_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns1_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -305,7 +305,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns2_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns2_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -315,7 +315,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns2_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns2_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -327,7 +327,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns3_0) // expected-tns-warning {{sending 'ns3_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns3_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns3_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -337,7 +337,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns3_1) // expected-tns-warning {{sending 'ns3_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns3_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns3_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -349,7 +349,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns4_0) // expected-tns-warning {{sending 'ns4_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns4_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns4_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -359,7 +359,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns4_1) // expected-tns-warning {{sending 'ns4_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns4_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns4_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
@@ -371,7 +371,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
   if (b) {
     await a.foo(ns5_0) // expected-tns-warning {{sending 'ns5_0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns5_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns5_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
     if b {
@@ -381,7 +381,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
   } else {
     await a.foo(ns5_1) // expected-tns-warning {{sending 'ns5_1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns5_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns5_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
     if b {
@@ -405,7 +405,7 @@ class C_NonSendable {
 
     // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
     await a.foo(captures_self) // expected-tns-warning {{sending 'captures_self' may cause a data race}}
-    // expected-tns-note @-1 {{sending task-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+    // expected-tns-note @-1 {{sending task-isolated 'captures_self' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and task-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -442,7 +442,7 @@ actor A_Sendable {
     // support the ability to dynamically invoke the synchronous closure on
     // the specific actor.
     await a.foo(captures_self) // expected-tns-warning {{sending 'captures_self' may cause a data race}}
-    // expected-tns-note @-1 {{sending 'self'-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
+    // expected-tns-note @-1 {{sending 'self'-isolated 'captures_self' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -453,7 +453,7 @@ func basic_loopiness(a : A, b : Bool) async {
 
   while (b) {
     await a.foo(ns) // expected-tns-warning {{sending 'ns' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   }
@@ -471,7 +471,7 @@ func basic_loopiness_unsafe(a : A, b : Bool) async {
   }
 
   await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns3) // expected-tns-note {{use here could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -536,7 +536,7 @@ func test_class_assign_merges(a : A, b : Bool) async {
   box.contents = ns1
 
   await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1) // expected-tns-note {{use here could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -573,7 +573,7 @@ func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
   contents = ns1
 
   await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1) // expected-tns-note {{use here could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -591,7 +591,7 @@ func test_tuple_formation(a : A, i : Int) async {
   switch (i) {
   case 0:
     await a.foo(ns0) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -611,7 +611,7 @@ func test_tuple_formation(a : A, i : Int) async {
     }
   case 1:
     await a.foo(ns1) // expected-tns-warning {{sending 'ns1' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -631,7 +631,7 @@ func test_tuple_formation(a : A, i : Int) async {
     }
   case 2:
     await a.foo(ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -651,7 +651,7 @@ func test_tuple_formation(a : A, i : Int) async {
     }
   case 3:
     await a.foo(ns4) // expected-tns-warning {{sending 'ns4' may cause a data race}}
-    // expected-tns-note @-1 {{sending disconnected 'ns4' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-1 {{sending disconnected 'ns4' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     foo_noniso(ns0);
@@ -724,11 +724,11 @@ func one_consume_many_require(a : A) async {
   await a.foo_multi(ns0, ns1, ns2);
   // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-4 {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-5 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-5 {{sending disconnected 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-6 {{sending 'ns2' may cause a data race}}
-  // expected-tns-note @-7 {{sending disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-7 {{sending disconnected 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
 
   foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
   foo_noniso_multi(ns3, ns1, ns4); // expected-tns-note {{use here could race}}
@@ -743,11 +743,11 @@ func one_consume_one_require(a : A) async {
   await a.foo_multi(ns0, ns1, ns2);
   // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-3 {{sending disconnected 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-4 {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-5 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-5 {{sending disconnected 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-6 {{sending 'ns2' may cause a data race}}
-  // expected-tns-note @-7 {{sending disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-7 {{sending disconnected 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
 
   foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
 }
@@ -761,13 +761,13 @@ func many_consume_one_require(a : A) async {
   let ns5 = NonSendable();
 
   await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{use here could race}}
 }
@@ -783,13 +783,13 @@ func many_consume_many_require(a : A) async {
   let ns7 = NonSendable();
 
   await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{use here could race}}
@@ -930,7 +930,7 @@ func enum_test(a : A) async {
   }
 
   await a.foo(e1); // expected-tns-warning {{sending 'e1' may cause a data race}}
-  // expected-tns-note @-1 {{sending disconnected 'e1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-1 {{sending disconnected 'e1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'E' into actor-isolated context may introduce data races}}
   foo_noniso(e2); // expected-tns-note {{use here could race}}
   foo_noniso(e3); // expected-tns-note {{use here could race}}

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -111,12 +111,12 @@ func testNonStrongTransferDoesntMerge() async {
 func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) async {
   await transferToMain(x)
   await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // TODO: We should not error on this since we are transferring to the same place.
   await transferToMain(x) // expected-note {{use here could race}}
@@ -124,7 +124,7 @@ func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y:
 
 func testTransferringParameter_cannotUseAfterTransfer(_ x: transferring Klass, _ y: Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-note {{use here could race}}
 }
 
@@ -134,18 +134,18 @@ actor MyActor {
   func canTransferWithTransferringMethodArg(_ x: transferring Klass, _ y: Klass) async {
     await transferToMain(x)
     await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
-    // expected-note @-1 {{sending actor-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-note @-1 {{sending actor-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and actor-isolated uses}}
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
     await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-    // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
+    // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
     await transferToMain(x) // expected-note {{use here could race}}
   }
 
   func getNormalErrorIfUseAfterTransfer(_ x: transferring Klass) async {
     await transferToMain(x)  // expected-warning {{sending 'x' may cause a data race}}
-    // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
+    // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
     useValue(x) // expected-note {{use here could race}}
   }
 
@@ -160,7 +160,7 @@ actor MyActor {
   func assignTransferringIntoActor2(_ x: transferring Klass) async {
     field = x
     await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 }
 
@@ -172,7 +172,7 @@ actor MyActor {
   globalKlass = x
   // TODO: This is incorrect! transferring should be independent of @MainActor.
   await transferToCustom(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+  // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
 
 @MainActor func canAssignTransferringIntoGlobalActor3(_ x: transferring Klass) async {
@@ -209,7 +209,7 @@ func canTransferAssigningIntoLocal2a(_ x: transferring Klass) async {
 func canTransferAssigningIntoLocal3(_ x: transferring Klass) async {
   let _ = x
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   let y = x // expected-note {{use here could race}}
   _ = y
 }
@@ -235,7 +235,7 @@ func assigningIsAMergeError(_ x: transferring Klass) async {
 
   // We can still transfer y since x is disconnected.
   await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
 }
@@ -256,7 +256,7 @@ func assigningIsAMergeAnyError(_ x: transferring Any) async {
   x = y
 
   await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
 }
@@ -282,7 +282,7 @@ func canTransferAfterAssignButUseIsError(_ x: transferring Any) async {
 
   // TODO: This should refer to the transferring parameter.
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
 }
@@ -312,7 +312,7 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) a
 
   // Transfer x
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // y is assigned into a field of x.
   x.first = y // expected-note {{use here could race}}
@@ -328,7 +328,7 @@ func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) 
 
   // Transfer x
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   x.first = y  // expected-note {{use here could race}}
 }
@@ -343,7 +343,7 @@ func doubleArgument() async {
 func testTransferSrc(_ x: transferring Klass) async {
   let y = Klass()
   await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   x = y // expected-note {{use here could race}}
 }
 
@@ -376,11 +376,11 @@ func testMergeWithTaskIsolated(_ x: transferring Klass, y: Klass) async {
   await transferToMain(x)
   x = y
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 @MainActor func testMergeWithActorIsolated(_ x: transferring Klass, y: Klass) async {
   x = y
   await transferToCustom(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+  // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -69,17 +69,17 @@ func twoTransferArg(_ x: transferring Klass, _ y: transferring Klass) {}
 
 func testSimpleTransferLet() {
   let k = Klass()
-  transferArg(k) // expected-warning {{sending 'k' may cause a data race}}
+  transferArg(k) // expected-warning {{sending 'k' risks causing data races}}
   // expected-note @-1 {{'k' used after being passed as a transferring parameter}}
-  useValue(k) // expected-note {{use here could race}}
+  useValue(k) // expected-note {{risks concurrent access}}
 }
 
 func testSimpleTransferVar() {
   var k = Klass()
   k = Klass()
-  transferArg(k) // expected-warning {{sending 'k' may cause a data race}}
+  transferArg(k) // expected-warning {{sending 'k' risks causing data races}}
   // expected-note @-1 {{'k' used after being passed as a transferring parameter}}
-  useValue(k) // expected-note {{use here could race}}
+  useValue(k) // expected-note {{risks concurrent access}}
 }
 
 func testSimpleTransferUseOfOtherParamNoError() {
@@ -110,22 +110,22 @@ func testNonStrongTransferDoesntMerge() async {
 
 func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) async {
   await transferToMain(x)
-  await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // TODO: We should not error on this since we are transferring to the same place.
-  await transferToMain(x) // expected-note {{use here could race}}
+  await transferToMain(x) // expected-note {{risks concurrent access}}
 }
 
 func testTransferringParameter_cannotUseAfterTransfer(_ x: transferring Klass, _ y: Klass) async {
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  useValue(x) // expected-note {{use here could race}}
+  useValue(x) // expected-note {{risks concurrent access}}
 }
 
 actor MyActor {
@@ -133,20 +133,20 @@ actor MyActor {
 
   func canTransferWithTransferringMethodArg(_ x: transferring Klass, _ y: Klass) async {
     await transferToMain(x)
-    await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
+    await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
     // expected-note @-1 {{sending actor-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and actor-isolated uses}}
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
-    await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
     // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
-    await transferToMain(x) // expected-note {{use here could race}}
+    await transferToMain(x) // expected-note {{risks concurrent access}}
   }
 
   func getNormalErrorIfUseAfterTransfer(_ x: transferring Klass) async {
-    await transferToMain(x)  // expected-warning {{sending 'x' may cause a data race}}
+    await transferToMain(x)  // expected-warning {{sending 'x' risks causing data races}}
     // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
-    useValue(x) // expected-note {{use here could race}}
+    useValue(x) // expected-note {{risks concurrent access}}
   }
 
   // After assigning into the actor, we can still use x in the actor as long as
@@ -159,7 +159,7 @@ actor MyActor {
   // Once we assign into the actor, we cannot transfer further.
   func assignTransferringIntoActor2(_ x: transferring Klass) async {
     field = x
-    await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+    await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
     // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 }
@@ -171,7 +171,7 @@ actor MyActor {
 @MainActor func canAssignTransferringIntoGlobalActor2(_ x: transferring Klass) async {
   globalKlass = x
   // TODO: This is incorrect! transferring should be independent of @MainActor.
-  await transferToCustom(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
 
@@ -208,9 +208,9 @@ func canTransferAssigningIntoLocal2a(_ x: transferring Klass) async {
 
 func canTransferAssigningIntoLocal3(_ x: transferring Klass) async {
   let _ = x
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  let y = x // expected-note {{use here could race}}
+  let y = x // expected-note {{risks concurrent access}}
   _ = y
 }
 
@@ -234,10 +234,10 @@ func assigningIsAMergeError(_ x: transferring Klass) async {
   x = y
 
   // We can still transfer y since x is disconnected.
-  await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
-  useValue(x) // expected-note {{use here could race}}
+  useValue(x) // expected-note {{risks concurrent access}}
 }
 
 func assigningIsAMergeAny(_ x: transferring Any) async {
@@ -255,10 +255,10 @@ func assigningIsAMergeAnyError(_ x: transferring Any) async {
 
   x = y
 
-  await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
-  useValue(x) // expected-note {{use here could race}}
+  useValue(x) // expected-note {{risks concurrent access}}
 }
 
 func canTransferAfterAssign(_ x: transferring Any) async {
@@ -281,10 +281,10 @@ func canTransferAfterAssignButUseIsError(_ x: transferring Any) async {
   x = y
 
   // TODO: This should refer to the transferring parameter.
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
-  useValue(x) // expected-note {{use here could race}}
+  useValue(x) // expected-note {{risks concurrent access}}
 }
 
 func assignToEntireValueEliminatesEarlierTransfer(_ x: transferring Any) async {
@@ -311,11 +311,11 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) a
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // y is assigned into a field of x.
-  x.first = y // expected-note {{use here could race}}
+  x.first = y // expected-note {{risks concurrent access}}
 
   useValue(x)
 }
@@ -327,24 +327,24 @@ func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) 
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
-  x.first = y  // expected-note {{use here could race}}
+  x.first = y  // expected-note {{risks concurrent access}}
 }
 
 func doubleArgument() async {
   let x = Klass()
-  twoTransferArg(x, x) // expected-warning {{sending 'x' may cause a data race}}
+  twoTransferArg(x, x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{'x' used after being passed as a transferring parameter}}
-  // expected-note @-2 {{use here could race}}
+  // expected-note @-2 {{risks concurrent access}}
 }
 
 func testTransferSrc(_ x: transferring Klass) async {
   let y = Klass()
-  await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  x = y // expected-note {{use here could race}}
+  x = y // expected-note {{risks concurrent access}}
 }
 
 func testTransferOtherParam(_ x: transferring Klass, y: Klass) async {
@@ -358,7 +358,7 @@ func testTransferOtherParamTuple(_ x: transferring Klass, y: (Klass, Klass)) asy
 func taskIsolatedError(_ x: @escaping @MainActor () async -> ()) {
   func fakeInit(operation: transferring @escaping () async -> ()) {}
 
-  fakeInit(operation: x) // expected-warning {{sending 'x' may cause a data race}}
+  fakeInit(operation: x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
@@ -366,7 +366,7 @@ func taskIsolatedError(_ x: @escaping @MainActor () async -> ()) {
   func fakeInit(operation: transferring @escaping () async -> ()) {}
 
   // TODO: This needs to say actor-isolated.
-  fakeInit(operation: x) // expected-warning {{sending 'x' may cause a data race}}
+  fakeInit(operation: x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later main actor-isolated uses}}
 }
 
@@ -375,12 +375,12 @@ func taskIsolatedError(_ x: @escaping @MainActor () async -> ()) {
 func testMergeWithTaskIsolated(_ x: transferring Klass, y: Klass) async {
   await transferToMain(x)
   x = y
-  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 @MainActor func testMergeWithActorIsolated(_ x: transferring Klass, y: Klass) async {
   x = y
-  await transferToCustom(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -116,7 +116,7 @@ func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) 
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // TODO: We should not error on this since we are transferring to the same place.
   await transferToMain(x) // expected-note {{use here could race}}
@@ -124,7 +124,7 @@ func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y:
 
 func testTransferringParameter_cannotUseAfterTransfer(_ x: transferring Klass, _ y: Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-note {{use here could race}}
 }
 
@@ -139,13 +139,13 @@ actor MyActor {
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
     await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-    // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
     await transferToMain(x) // expected-note {{use here could race}}
   }
 
   func getNormalErrorIfUseAfterTransfer(_ x: transferring Klass) async {
     await transferToMain(x)  // expected-warning {{sending 'x' may cause a data race}}
-    // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
     useValue(x) // expected-note {{use here could race}}
   }
 
@@ -209,7 +209,7 @@ func canTransferAssigningIntoLocal2a(_ x: transferring Klass) async {
 func canTransferAssigningIntoLocal3(_ x: transferring Klass) async {
   let _ = x
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   let y = x // expected-note {{use here could race}}
   _ = y
 }
@@ -235,7 +235,7 @@ func assigningIsAMergeError(_ x: transferring Klass) async {
 
   // We can still transfer y since x is disconnected.
   await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
 }
@@ -256,7 +256,7 @@ func assigningIsAMergeAnyError(_ x: transferring Any) async {
   x = y
 
   await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
 }
@@ -282,7 +282,7 @@ func canTransferAfterAssignButUseIsError(_ x: transferring Any) async {
 
   // TODO: This should refer to the transferring parameter.
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
 }
@@ -312,7 +312,7 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) a
 
   // Transfer x
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // y is assigned into a field of x.
   x.first = y // expected-note {{use here could race}}
@@ -328,7 +328,7 @@ func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) 
 
   // Transfer x
   await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   x.first = y  // expected-note {{use here could race}}
 }
@@ -343,7 +343,7 @@ func doubleArgument() async {
 func testTransferSrc(_ x: transferring Klass) async {
   let y = Klass()
   await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   x = y // expected-note {{use here could race}}
 }
 

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -69,7 +69,7 @@ func twoTransferArg(_ x: transferring Klass, _ y: transferring Klass) {}
 
 func testSimpleTransferLet() {
   let k = Klass()
-  transferArg(k) // expected-warning {{transferring 'k' may cause a data race}}
+  transferArg(k) // expected-warning {{sending 'k' may cause a data race}}
   // expected-note @-1 {{'k' used after being passed as a transferring parameter}}
   useValue(k) // expected-note {{use here could race}}
 }
@@ -77,7 +77,7 @@ func testSimpleTransferLet() {
 func testSimpleTransferVar() {
   var k = Klass()
   k = Klass()
-  transferArg(k) // expected-warning {{transferring 'k' may cause a data race}}
+  transferArg(k) // expected-warning {{sending 'k' may cause a data race}}
   // expected-note @-1 {{'k' used after being passed as a transferring parameter}}
   useValue(k) // expected-note {{use here could race}}
 }
@@ -110,21 +110,21 @@ func testNonStrongTransferDoesntMerge() async {
 
 func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) async {
   await transferToMain(x)
-  await transferToMain(y) // expected-warning {{transferring 'y' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   // TODO: We should not error on this since we are transferring to the same place.
   await transferToMain(x) // expected-note {{use here could race}}
 }
 
 func testTransferringParameter_cannotUseAfterTransfer(_ x: transferring Klass, _ y: Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-note {{use here could race}}
 }
 
@@ -133,19 +133,19 @@ actor MyActor {
 
   func canTransferWithTransferringMethodArg(_ x: transferring Klass, _ y: Klass) async {
     await transferToMain(x)
-    await transferToMain(y) // expected-warning {{transferring 'y' may cause a data race}}
-    // expected-note @-1 {{transferring actor-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
+    // expected-note @-1 {{sending actor-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
-    await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-    // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+    // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
     await transferToMain(x) // expected-note {{use here could race}}
   }
 
   func getNormalErrorIfUseAfterTransfer(_ x: transferring Klass) async {
-    await transferToMain(x)  // expected-warning {{transferring 'x' may cause a data race}}
-    // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
+    await transferToMain(x)  // expected-warning {{sending 'x' may cause a data race}}
+    // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
     useValue(x) // expected-note {{use here could race}}
   }
 
@@ -159,8 +159,8 @@ actor MyActor {
   // Once we assign into the actor, we cannot transfer further.
   func assignTransferringIntoActor2(_ x: transferring Klass) async {
     field = x
-    await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-    // expected-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 }
 
@@ -171,12 +171,12 @@ actor MyActor {
 @MainActor func canAssignTransferringIntoGlobalActor2(_ x: transferring Klass) async {
   globalKlass = x
   // TODO: This is incorrect! transferring should be independent of @MainActor.
-  await transferToCustom(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring main actor-isolated 'x' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+  await transferToCustom(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
 
 @MainActor func canAssignTransferringIntoGlobalActor3(_ x: transferring Klass) async {
-  await transferToCustom(globalKlass) // expected-warning {{main actor-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
+  await transferToCustom(globalKlass) // expected-warning {{sending main actor-isolated value of type 'Klass' to global actor 'CustomActor'-isolated context}}
 }
 
 func canTransferAssigningIntoLocal(_ x: transferring Klass) async {
@@ -208,8 +208,8 @@ func canTransferAssigningIntoLocal2a(_ x: transferring Klass) async {
 
 func canTransferAssigningIntoLocal3(_ x: transferring Klass) async {
   let _ = x
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   let y = x // expected-note {{use here could race}}
   _ = y
 }
@@ -234,8 +234,8 @@ func assigningIsAMergeError(_ x: transferring Klass) async {
   x = y
 
   // We can still transfer y since x is disconnected.
-  await transferToMain(y) // expected-warning {{transferring 'y' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
 }
@@ -255,8 +255,8 @@ func assigningIsAMergeAnyError(_ x: transferring Any) async {
 
   x = y
 
-  await transferToMain(y) // expected-warning {{transferring 'y' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
 }
@@ -281,8 +281,8 @@ func canTransferAfterAssignButUseIsError(_ x: transferring Any) async {
   x = y
 
   // TODO: This should refer to the transferring parameter.
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
 }
@@ -311,8 +311,8 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) a
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   // y is assigned into a field of x.
   x.first = y // expected-note {{use here could race}}
@@ -327,23 +327,23 @@ func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) 
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   x.first = y  // expected-note {{use here could race}}
 }
 
 func doubleArgument() async {
   let x = Klass()
-  twoTransferArg(x, x) // expected-warning {{transferring 'x' may cause a data race}}
+  twoTransferArg(x, x) // expected-warning {{sending 'x' may cause a data race}}
   // expected-note @-1 {{'x' used after being passed as a transferring parameter}}
   // expected-note @-2 {{use here could race}}
 }
 
 func testTransferSrc(_ x: transferring Klass) async {
   let y = Klass()
-  await transferToMain(y) // expected-warning {{transferring 'y' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(y) // expected-warning {{sending 'y' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   x = y // expected-note {{use here could race}}
 }
 
@@ -358,7 +358,7 @@ func testTransferOtherParamTuple(_ x: transferring Klass, y: (Klass, Klass)) asy
 func taskIsolatedError(_ x: @escaping @MainActor () async -> ()) {
   func fakeInit(operation: transferring @escaping () async -> ()) {}
 
-  fakeInit(operation: x) // expected-warning {{transferring 'x' may cause a data race}}
+  fakeInit(operation: x) // expected-warning {{sending 'x' may cause a data race}}
   // expected-note @-1 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
@@ -366,7 +366,7 @@ func taskIsolatedError(_ x: @escaping @MainActor () async -> ()) {
   func fakeInit(operation: transferring @escaping () async -> ()) {}
 
   // TODO: This needs to say actor-isolated.
-  fakeInit(operation: x) // expected-warning {{transferring 'x' may cause a data race}}
+  fakeInit(operation: x) // expected-warning {{sending 'x' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later main actor-isolated uses}}
 }
 
@@ -375,12 +375,12 @@ func taskIsolatedError(_ x: @escaping @MainActor () async -> ()) {
 func testMergeWithTaskIsolated(_ x: transferring Klass, y: Klass) async {
   await transferToMain(x)
   x = y
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  await transferToMain(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 @MainActor func testMergeWithActorIsolated(_ x: transferring Klass, y: Klass) async {
   x = y
-  await transferToCustom(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring main actor-isolated 'x' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+  await transferToCustom(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -85,10 +85,10 @@ func simpleTest() async {
 func simpleTest2() async {
   let x = NonSendableKlass()
   let y = transferResultWithArg(x)
-  await transferToMainDirect(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMainDirect(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(y)
-  useValue(x) // expected-note {{use here could race}}
+  useValue(x) // expected-note {{risks concurrent access}}
 }
 
 // Make sure that later errors with y can happen.
@@ -96,16 +96,16 @@ func simpleTest3() async {
   let x = NonSendableKlass()
   let y = transferResultWithArg(x)
   await transferToMainDirect(x)
-  await transferToMainDirect(y) // expected-warning {{sending 'y' may cause a data race}}
+  await transferToMainDirect(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-  useValue(y) // expected-note {{use here could race}}
+  useValue(y) // expected-note {{risks concurrent access}}
 }
 
 func transferResult() async -> transferring NonSendableKlass {
   let x = NonSendableKlass()
-  await transferToMainDirect(x) // expected-warning {{sending 'x' may cause a data race}}
+  await transferToMainDirect(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-  return x // expected-note {{use here could race}}
+  return x // expected-note {{risks concurrent access}}
 }
 
 func transferInAndOut(_ x: transferring NonSendableKlass) -> transferring NonSendableKlass {
@@ -114,13 +114,13 @@ func transferInAndOut(_ x: transferring NonSendableKlass) -> transferring NonSen
 
 
 func transferReturnArg(_ x: NonSendableKlass) -> transferring NonSendableKlass {
-  return x // expected-warning {{sending 'x' may cause a data race}}
+  return x // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{task-isolated 'x' cannot be a transferring result. task-isolated uses may race with caller uses}}
 }
 
 // TODO: This will be fixed once I represent @MainActor on func types.
 @MainActor func transferReturnArgMainActor(_ x: NonSendableKlass) -> transferring NonSendableKlass {
-  return x // expected-warning {{sending 'x' may cause a data race}}
+  return x // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'x' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -141,7 +141,7 @@ func useTransferredResult() async {
 
 extension MainActorIsolatedStruct {
   func testNonSendableErrorReturnWithTransfer() -> transferring NonSendableKlass {
-    return ns // expected-warning {{sending 'self.ns' may cause a data race}}
+    return ns // expected-warning {{sending 'self.ns' risks causing data races}}
     // expected-note @-1 {{main actor-isolated 'self.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
   }
   func testNonSendableErrorReturnNoTransfer() -> NonSendableKlass {
@@ -157,7 +157,7 @@ extension MainActorIsolatedEnum {
     case .second(let ns):
       return ns
     }
-  } // expected-warning {{sending 'ns.some' may cause a data race}}
+  } // expected-warning {{sending 'ns.some' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'ns.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func testSwitchReturnNoTransfer() -> NonSendableKlass? {
@@ -174,7 +174,7 @@ extension MainActorIsolatedEnum {
       return ns // TODO: The error below should be here.
     }
     return nil
-  } // expected-warning {{sending 'ns.some' may cause a data race}}
+  } // expected-warning {{sending 'ns.some' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'ns.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}} 
 
   func testIfLetReturnNoTransfer() -> NonSendableKlass? {

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -86,7 +86,7 @@ func simpleTest2() async {
   let x = NonSendableKlass()
   let y = transferResultWithArg(x)
   await transferToMainDirect(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(y)
   useValue(x) // expected-note {{use here could race}}
 }
@@ -97,14 +97,14 @@ func simpleTest3() async {
   let y = transferResultWithArg(x)
   await transferToMainDirect(x)
   await transferToMainDirect(y) // expected-warning {{sending 'y' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(y) // expected-note {{use here could race}}
 }
 
 func transferResult() async -> transferring NonSendableKlass {
   let x = NonSendableKlass()
   await transferToMainDirect(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   return x // expected-note {{use here could race}}
 }
 

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -86,7 +86,7 @@ func simpleTest2() async {
   let x = NonSendableKlass()
   let y = transferResultWithArg(x)
   await transferToMainDirect(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(y)
   useValue(x) // expected-note {{use here could race}}
 }
@@ -97,14 +97,14 @@ func simpleTest3() async {
   let y = transferResultWithArg(x)
   await transferToMainDirect(x)
   await transferToMainDirect(y) // expected-warning {{sending 'y' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(y) // expected-note {{use here could race}}
 }
 
 func transferResult() async -> transferring NonSendableKlass {
   let x = NonSendableKlass()
   await transferToMainDirect(x) // expected-warning {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
   return x // expected-note {{use here could race}}
 }
 

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -85,8 +85,8 @@ func simpleTest() async {
 func simpleTest2() async {
   let x = NonSendableKlass()
   let y = transferResultWithArg(x)
-  await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMainDirect(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(y)
   useValue(x) // expected-note {{use here could race}}
 }
@@ -96,15 +96,15 @@ func simpleTest3() async {
   let x = NonSendableKlass()
   let y = transferResultWithArg(x)
   await transferToMainDirect(x)
-  await transferToMainDirect(y) // expected-warning {{transferring 'y' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMainDirect(y) // expected-warning {{sending 'y' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(y) // expected-note {{use here could race}}
 }
 
 func transferResult() async -> transferring NonSendableKlass {
   let x = NonSendableKlass()
-  await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMainDirect(x) // expected-warning {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   return x // expected-note {{use here could race}}
 }
 
@@ -114,13 +114,13 @@ func transferInAndOut(_ x: transferring NonSendableKlass) -> transferring NonSen
 
 
 func transferReturnArg(_ x: NonSendableKlass) -> transferring NonSendableKlass {
-  return x // expected-warning {{transferring 'x' may cause a data race}}
+  return x // expected-warning {{sending 'x' may cause a data race}}
   // expected-note @-1 {{task-isolated 'x' cannot be a transferring result. task-isolated uses may race with caller uses}}
 }
 
 // TODO: This will be fixed once I represent @MainActor on func types.
 @MainActor func transferReturnArgMainActor(_ x: NonSendableKlass) -> transferring NonSendableKlass {
-  return x // expected-warning {{transferring 'x' may cause a data race}}
+  return x // expected-warning {{sending 'x' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'x' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -141,7 +141,7 @@ func useTransferredResult() async {
 
 extension MainActorIsolatedStruct {
   func testNonSendableErrorReturnWithTransfer() -> transferring NonSendableKlass {
-    return ns // expected-warning {{transferring 'self.ns' may cause a data race}}
+    return ns // expected-warning {{sending 'self.ns' may cause a data race}}
     // expected-note @-1 {{main actor-isolated 'self.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
   }
   func testNonSendableErrorReturnNoTransfer() -> NonSendableKlass {
@@ -157,7 +157,7 @@ extension MainActorIsolatedEnum {
     case .second(let ns):
       return ns
     }
-  } // expected-warning {{transferring 'ns.some' may cause a data race}}
+  } // expected-warning {{sending 'ns.some' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'ns.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func testSwitchReturnNoTransfer() -> NonSendableKlass? {
@@ -174,7 +174,7 @@ extension MainActorIsolatedEnum {
       return ns // TODO: The error below should be here.
     }
     return nil
-  } // expected-warning {{transferring 'ns.some' may cause a data race}}
+  } // expected-warning {{sending 'ns.some' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'ns.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}} 
 
   func testIfLetReturnNoTransfer() -> NonSendableKlass? {

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -19,10 +19,10 @@ actor Bar {
   }
   func bar() async {
     let ns = NonSendable()
-    _ = Bar(ns) // expected-warning {{transferring 'ns' may cause a data race}}
+    _ = Bar(ns) // expected-warning {{sending 'ns' may cause a data race}}
     // TODO: This needs to be:
     // disconnected 'ns' is transferred to actor-isolated callee. Later local uses could race with uses in callee.
-    // expected-note @-3 {{transferring disconnected 'ns' to actor-isolated callee could cause races in between callee actor-isolated and local actor-isolated uses}}
+    // expected-note @-3 {{sending disconnected 'ns' to actor-isolated callee could cause races in between callee actor-isolated and local actor-isolated uses}}
     ns.foo() // expected-note {{use here could race}}
   }
 }

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -19,10 +19,10 @@ actor Bar {
   }
   func bar() async {
     let ns = NonSendable()
-    _ = Bar(ns) // expected-warning {{sending 'ns' may cause a data race}}
+    _ = Bar(ns) // expected-warning {{sending 'ns' risks causing data races}}
     // TODO: This needs to be:
     // 'ns' is transferred to actor-isolated callee. Later local uses could race with uses in callee.
     // expected-note @-3 {{sending 'ns' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local actor-isolated uses}}
-    ns.foo() // expected-note {{use here could race}}
+    ns.foo() // expected-note {{risks concurrent access}}
   }
 }

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -21,8 +21,8 @@ actor Bar {
     let ns = NonSendable()
     _ = Bar(ns) // expected-warning {{sending 'ns' may cause a data race}}
     // TODO: This needs to be:
-    // disconnected 'ns' is transferred to actor-isolated callee. Later local uses could race with uses in callee.
-    // expected-note @-3 {{sending disconnected 'ns' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local actor-isolated uses}}
+    // 'ns' is transferred to actor-isolated callee. Later local uses could race with uses in callee.
+    // expected-note @-3 {{sending 'ns' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local actor-isolated uses}}
     ns.foo() // expected-note {{use here could race}}
   }
 }

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -22,7 +22,7 @@ actor Bar {
     _ = Bar(ns) // expected-warning {{sending 'ns' may cause a data race}}
     // TODO: This needs to be:
     // disconnected 'ns' is transferred to actor-isolated callee. Later local uses could race with uses in callee.
-    // expected-note @-3 {{sending disconnected 'ns' to actor-isolated callee could cause races in between callee actor-isolated and local actor-isolated uses}}
+    // expected-note @-3 {{sending disconnected 'ns' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local actor-isolated uses}}
     ns.foo() // expected-note {{use here could race}}
   }
 }

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -21,7 +21,7 @@ func transferValue<T>(_ t: transferring T) {}
 func testIsolationError() async {
   let x = NonSendableType()
   await transferToMain(x) // expected-error {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-note {{use here could race}}
 }
 
@@ -50,7 +50,7 @@ func testIsolationCrossingDueToCapture() async {
   let x = NonSendableType()
   let _ = { @MainActor in
     print(x) // expected-error {{sending 'x' may cause a data race}}
-    // expected-note @-1 {{disconnected 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x) // expected-note {{use here could race}}
 }

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -21,13 +21,13 @@ func transferValue<T>(_ t: transferring T) {}
 func testIsolationError() async {
   let x = NonSendableType()
   await transferToMain(x) // expected-error {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-note {{use here could race}}
 }
 
 func testTransferArgumentError(_ x: NonSendableType) async {
   await transferToMain(x) // expected-error {{sending 'x' may cause a data race}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testPassArgumentAsTransferringParameter(_ x: NonSendableType) async {

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -20,18 +20,18 @@ func transferValue<T>(_ t: transferring T) {}
 
 func testIsolationError() async {
   let x = NonSendableType()
-  await transferToMain(x) // expected-error {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-error {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  useValue(x) // expected-note {{use here could race}}
+  useValue(x) // expected-note {{risks concurrent access}}
 }
 
 func testTransferArgumentError(_ x: NonSendableType) async {
-  await transferToMain(x) // expected-error {{sending 'x' may cause a data race}}
+  await transferToMain(x) // expected-error {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
 func testPassArgumentAsTransferringParameter(_ x: NonSendableType) async {
-  transferValue(x) // expected-error {{sending 'x' may cause a data race}}
+  transferValue(x) // expected-error {{sending 'x' risks causing data races}}
   // expected-note @-1 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
@@ -49,15 +49,15 @@ func testAssigningParameterIntoTransferringParameter(_ x: transferring NonSendab
 func testIsolationCrossingDueToCapture() async {
   let x = NonSendableType()
   let _ = { @MainActor in
-    print(x) // expected-error {{sending 'x' may cause a data race}}
+    print(x) // expected-error {{sending 'x' risks causing data races}}
     // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
-  useValue(x) // expected-note {{use here could race}}
+  useValue(x) // expected-note {{risks concurrent access}}
 }
 
 func testIsolationCrossingDueToCaptureParameter(_ x: NonSendableType) async {
   let _ = { @MainActor in
-    print(x) // expected-error {{sending 'x' may cause a data race}}
+    print(x) // expected-error {{sending 'x' risks causing data races}}
     // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x)

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -20,18 +20,18 @@ func transferValue<T>(_ t: transferring T) {}
 
 func testIsolationError() async {
   let x = NonSendableType()
-  await transferToMain(x) // expected-error {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  await transferToMain(x) // expected-error {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-note {{use here could race}}
 }
 
 func testTransferArgumentError(_ x: NonSendableType) async {
-  await transferToMain(x) // expected-error {{transferring 'x' may cause a data race}}
-  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  await transferToMain(x) // expected-error {{sending 'x' may cause a data race}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testPassArgumentAsTransferringParameter(_ x: NonSendableType) async {
-  transferValue(x) // expected-error {{transferring 'x' may cause a data race}}
+  transferValue(x) // expected-error {{sending 'x' may cause a data race}}
   // expected-note @-1 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
@@ -49,7 +49,7 @@ func testAssigningParameterIntoTransferringParameter(_ x: transferring NonSendab
 func testIsolationCrossingDueToCapture() async {
   let x = NonSendableType()
   let _ = { @MainActor in
-    print(x) // expected-error {{transferring 'x' may cause a data race}}
+    print(x) // expected-error {{sending 'x' may cause a data race}}
     // expected-note @-1 {{disconnected 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x) // expected-note {{use here could race}}
@@ -57,7 +57,7 @@ func testIsolationCrossingDueToCapture() async {
 
 func testIsolationCrossingDueToCaptureParameter(_ x: NonSendableType) async {
   let _ = { @MainActor in
-    print(x) // expected-error {{transferring 'x' may cause a data race}}
+    print(x) // expected-error {{sending 'x' may cause a data race}}
     // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x)

--- a/test/Distributed/distributed_actor_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_transfernonsendable.swift
@@ -49,12 +49,12 @@ distributed actor MyDistributedActor {
 
   distributed func transferActorField() async {
     await transferToMain(x) // expected-error {{sending 'self.x' may cause a data race}}
-    // expected-note @-1 {{sending 'self'-isolated 'self.x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    // expected-note @-1 {{sending 'self'-isolated 'self.x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   distributed func transferActorIsolatedArg(_ x: NonSendableKlass) async {
     await transferToMain(x) // expected-error {{sending 'x' may cause a data race}}
-    // expected-note @-1 {{sending actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-note @-1 {{sending actor-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and actor-isolated uses}}
   }
 
   distributed func transferActorIsolatedArgIntoClosure(_ x: NonSendableKlass) async {

--- a/test/Distributed/distributed_actor_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_transfernonsendable.swift
@@ -33,7 +33,7 @@ distributed actor MyDistributedActor {
     actorSystem = system
     _ = { @MainActor in
       // TODO: This should error saying 'y' is actor isolated.
-      print(y) // expected-error {{transferring 'y' may cause a data race}}
+      print(y) // expected-error {{sending 'y' may cause a data race}}
       // expected-note @-1 {{task-isolated 'y' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -42,26 +42,26 @@ distributed actor MyDistributedActor {
     x = y2
     actorSystem = system
     _ = { @MainActor in
-      print(y2) // expected-error {{transferring 'y2' may cause a data race}}
+      print(y2) // expected-error {{sending 'y2' may cause a data race}}
       // expected-note @-1 {{'self'-isolated 'y2' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 
   distributed func transferActorField() async {
-    await transferToMain(x) // expected-error {{transferring 'self.x' may cause a data race}}
-    // expected-note @-1 {{transferring 'self'-isolated 'self.x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+    await transferToMain(x) // expected-error {{sending 'self.x' may cause a data race}}
+    // expected-note @-1 {{sending 'self'-isolated 'self.x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   distributed func transferActorIsolatedArg(_ x: NonSendableKlass) async {
-    await transferToMain(x) // expected-error {{transferring 'x' may cause a data race}}
-    // expected-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    await transferToMain(x) // expected-error {{sending 'x' may cause a data race}}
+    // expected-note @-1 {{sending actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
   distributed func transferActorIsolatedArgIntoClosure(_ x: NonSendableKlass) async {
     _ = { @MainActor in
       // TODO: In 2nd part of message should say actor-isolated instead of later
       // nonisolated uses in the case of a closure.
-      print(x) // expected-error {{transferring 'x' may cause a data race}}
+      print(x) // expected-error {{sending 'x' may cause a data race}}
       // expected-note @-1 {{actor-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }

--- a/test/Distributed/distributed_actor_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_transfernonsendable.swift
@@ -33,7 +33,7 @@ distributed actor MyDistributedActor {
     actorSystem = system
     _ = { @MainActor in
       // TODO: This should error saying 'y' is actor isolated.
-      print(y) // expected-error {{sending 'y' may cause a data race}}
+      print(y) // expected-error {{sending 'y' risks causing data races}}
       // expected-note @-1 {{task-isolated 'y' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -42,18 +42,18 @@ distributed actor MyDistributedActor {
     x = y2
     actorSystem = system
     _ = { @MainActor in
-      print(y2) // expected-error {{sending 'y2' may cause a data race}}
+      print(y2) // expected-error {{sending 'y2' risks causing data races}}
       // expected-note @-1 {{'self'-isolated 'y2' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 
   distributed func transferActorField() async {
-    await transferToMain(x) // expected-error {{sending 'self.x' may cause a data race}}
+    await transferToMain(x) // expected-error {{sending 'self.x' risks causing data races}}
     // expected-note @-1 {{sending 'self'-isolated 'self.x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   distributed func transferActorIsolatedArg(_ x: NonSendableKlass) async {
-    await transferToMain(x) // expected-error {{sending 'x' may cause a data race}}
+    await transferToMain(x) // expected-error {{sending 'x' risks causing data races}}
     // expected-note @-1 {{sending actor-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -61,7 +61,7 @@ distributed actor MyDistributedActor {
     _ = { @MainActor in
       // TODO: In 2nd part of message should say actor-isolated instead of later
       // nonisolated uses in the case of a closure.
-      print(x) // expected-error {{sending 'x' may cause a data race}}
+      print(x) // expected-error {{sending 'x' risks causing data races}}
       // expected-note @-1 {{actor-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }

--- a/test/sil-opt/swift-version.sil
+++ b/test/sil-opt/swift-version.sil
@@ -21,8 +21,8 @@ sil [ossa] @test : $@convention(thin) @async (@guaranteed NonSendableKlass) -> (
 bb0(%0 : @guaranteed $NonSendableKlass):
   %1 = function_ref  @transfer_to_main : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %1(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-complete-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context; later accesses to value could race; this is an error in the Swift 6 language mode}}
-  // expected-tns-error @-2 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context; later accesses to value could race}}
+  // expected-complete-warning @-1 {{}}
+  // expected-tns-error @-2 {{}}
   %9999 = tuple ()
   return %9999 : $()
 }


### PR DESCRIPTION
Just tweaking diagnostics a little bit to match terminology we are using else where.

Specifically:

1. uses here could race -> risks concurrent access.
2. transferring -> sending
3. use "risks" instead of could or possible.
4. Remove callee in favor of printing the actual descriptive decl kind and callee name.
5. Do not print disconnected if a region is disconnected. Keep printing if it is not disconnected though.

rdar://127580781