### PR TITLE
[Const extract] Remove duplicate hasAttachedPropertyWrapper check

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -427,11 +427,6 @@ extractTypePropertyInfo(VarDecl *propertyDecl) {
 
   if (const auto binding = propertyDecl->getParentPatternBinding()) {
     if (const auto originalInit = binding->getInit(0)) {
-      if (propertyDecl->hasAttachedPropertyWrapper()) {
-        return {propertyDecl, extractCompileTimeValue(originalInit),
-                propertyWrapperValues};
-      }
-
       return {propertyDecl, extractCompileTimeValue(originalInit),
               propertyWrapperValues};
     }


### PR DESCRIPTION
Removes a duplicate check of `if (propertyDecl->hasAttachedPropertyWrapper())` introduced in https://github.com/apple/swift/pull/73261

This return is the same regardless of the if statement.