### PR TITLE
IRGen: Fix incorrect BitwiseCopyable conformance lookups

### DIFF
--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -414,7 +414,7 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
       IGM.getSwiftModule()->getASTContext().getProtocol(
           KnownProtocolKind::BitwiseCopyable);
   // The protocol won't be present in swiftinterfaces from older SDKs.
-  if (bitwiseCopyableProtocol && IGM.getSwiftModule()->lookupConformance(
+  if (bitwiseCopyableProtocol && IGM.getSwiftModule()->checkConformance(
                                      archetype, bitwiseCopyableProtocol)) {
     return BitwiseCopyableTypeInfo::create(storageType, abiAccessible);
   }

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -7303,17 +7303,19 @@ ResilientEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
                                                   SILType Type,
                                                   EnumDecl *theEnum,
                                                   llvm::StructType *enumTy) {
+  auto cp = !theEnum->canBeCopyable()
+    ? IsNotCopyable : IsCopyable;
   auto abiAccessible = IsABIAccessible_t(TC.IGM.isTypeABIAccessible(Type));
   auto *bitwiseCopyableProtocol =
       IGM.getSwiftModule()->getASTContext().getProtocol(
           KnownProtocolKind::BitwiseCopyable);
   if (bitwiseCopyableProtocol &&
-      IGM.getSwiftModule()->lookupConformance(
-          theEnum->getDeclaredInterfaceType(), bitwiseCopyableProtocol)) {
+      IGM.getSwiftModule()->checkConformance(Type.getASTType(),
+                                             bitwiseCopyableProtocol)) {
     return BitwiseCopyableTypeInfo::create(enumTy, abiAccessible);
   }
   return registerEnumTypeInfo(
-                       new ResilientEnumTypeInfo(*this, enumTy, Copyable,
+                       new ResilientEnumTypeInfo(*this, enumTy, cp,
                                                  abiAccessible));
 }
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1706,8 +1706,7 @@ const TypeInfo *TypeConverter::convertStructType(TypeBase *key, CanType type,
         IGM.getSwiftModule()->getASTContext().getProtocol(
             KnownProtocolKind::BitwiseCopyable);
     if (bitwiseCopyableProtocol &&
-        IGM.getSwiftModule()->lookupConformance(D->getDeclaredInterfaceType(),
-                                                bitwiseCopyableProtocol)) {
+        IGM.getSwiftModule()->checkConformance(type, bitwiseCopyableProtocol)) {
       return BitwiseCopyableTypeInfo::create(IGM.OpaqueTy, structAccessible);
     }
     return &getResilientStructTypeInfo(copyable, structAccessible);

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -523,7 +523,7 @@ const TypeInfo *TypeConverter::convertTupleType(TupleType *tuple) {
     auto *bitwiseCopyableProtocol =
         IGM.getSwiftModule()->getASTContext().getProtocol(
             KnownProtocolKind::BitwiseCopyable);
-    if (bitwiseCopyableProtocol && IGM.getSwiftModule()->lookupConformance(
+    if (bitwiseCopyableProtocol && IGM.getSwiftModule()->checkConformance(
                                        tuple, bitwiseCopyableProtocol)) {
       return BitwiseCopyableTypeInfo::create(IGM.OpaqueTy, IsABIAccessible);
     }

--- a/test/IRGen/variadic_generic_tuples.sil
+++ b/test/IRGen/variadic_generic_tuples.sil
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+// CHECK-LABEL: define{{.*}} swiftcc void @func1
+
+// CHECK: [[METADATA_PAIR:%.*]] = phi %swift.metadata_response
+// CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[METADATA_PAIR]], 0
+// CHECK: [[VWT_PTR:%.*]] = getelementptr inbounds ptr, ptr [[METADATA]], {{i32|i64}} -1
+// CHECK: [[VWT:%.*]] = load ptr, ptr [[VWT_PTR]]
+// CHECK: [[DESTROY_PTR:%.*]] = getelementptr inbounds ptr, ptr [[VWT]], i32 1
+// CHECK: [[DESTROY:%.*]] = load ptr, ptr [[DESTROY_PTR]]
+// CHECK: call void [[DESTROY]]({{.*}})
+// CHECK: ret void
+
+sil @func1 : $@convention(thin) <each V> (@in (repeat each V)) -> () {
+bb0(%0 : $*(repeat each V)):
+  destroy_addr %0 : $*(repeat each V)
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc void @func2
+// CHECK-NOT: call void %
+// CHECK: ret void
+
+sil @func2 : $@convention(thin) <each V where repeat each V : BitwiseCopyable> (@in (repeat each V)) -> () {
+bb0(%0 : $*(repeat each V)):
+  destroy_addr %0 : $*(repeat each V)
+  %ret = tuple ()
+  return %ret : $()
+}
+

--- a/test/Interpreter/Inputs/bitwise_copyable_other.swift
+++ b/test/Interpreter/Inputs/bitwise_copyable_other.swift
@@ -1,0 +1,13 @@
+public struct BitwiseStruct<T> {
+  var t: T
+
+  public init(t: T) { self.t = t }
+}
+
+extension BitwiseStruct: BitwiseCopyable where T: BitwiseCopyable {}
+
+public enum BitwiseEnum<T> {
+  case t(T)
+}
+
+extension BitwiseEnum: BitwiseCopyable where T: BitwiseCopyable {}

--- a/test/Interpreter/bitwise_copyable.swift
+++ b/test/Interpreter/bitwise_copyable.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(bitwise_copyable_other)) -enable-library-evolution %S/Inputs/bitwise_copyable_other.swift -emit-module -emit-module-path %t/bitwise_copyable_other.swiftmodule -module-name bitwise_copyable_other
+// RUN: %target-codesign %t/%target-library-name(bitwise_copyable_other)
+
+// RUN: %target-build-swift %s -lbitwise_copyable_other -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+
+// RUN: %target-run %t/main %t/%target-library-name(bitwise_copyable_other)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import bitwise_copyable_other
+
+var bitwise = TestSuite("BitwiseCopyable")
+
+bitwise.test("Conditional conformance with resilient struct") {
+  func callee(_: consuming BitwiseStruct<LifetimeTracked>) {}
+
+  for _ in 0..<10 {
+    callee(BitwiseStruct(t: LifetimeTracked(0)))
+  }
+}
+
+bitwise.test("Conditional conformance with resilient enum") {
+  func callee(_: consuming BitwiseEnum<LifetimeTracked>) {}
+
+  for _ in 0..<10 {
+    callee(BitwiseEnum.t(LifetimeTracked(0)))
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
Fixes the regression introduced by d1bd039ebdb716c2e7aeb5030441135c26355975.

rdar://126637139, rdar://126779977