### PR TITLE
[Test] Reenable SIL unit tests on windows.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -197,10 +197,6 @@ private func functionTestThunk(
   let invocation = castToInvocation(fromOpaquePointer: erasedInvocation)
   let context = FunctionPassContext(_bridged: BridgedPassContext(invocation: passInvocation.invocation))
   invocation(function.function, arguments.native, context)
-#if !os(Windows)
-  // TODO: https://github.com/apple/swift/issues/73252
-  fflush(stdout)
-#endif
 }
 
 /// Bitcast a thin test closure to void *.

--- a/lib/SIL/Utils/Test.cpp
+++ b/lib/SIL/Utils/Test.cpp
@@ -105,6 +105,7 @@ void FunctionTest::run(SILFunction &function, Arguments &arguments,
     auto *fn = invocation.get<NativeSwiftInvocation>();
     Registry::get().getFunctionTestThunk()(fn, {&function}, {&arguments},
                                            {getSwiftPassInvocation()});
+    fflush(stdout);
   }
   this->pass = nullptr;
   this->function = nullptr;

--- a/test/SILOptimizer/argument_conventions.sil
+++ b/test/SILOptimizer/argument_conventions.sil
@@ -5,9 +5,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// https://github.com/apple/swift/issues/73252
-// UNSUPPORTED: OS=windows-msvc
-
 import Builtin
 
 class C {}

--- a/test/SILOptimizer/borrow_introducer_unit.sil
+++ b/test/SILOptimizer/borrow_introducer_unit.sil
@@ -2,9 +2,6 @@
 //
 // REQUIRES: swift_in_compiler
 
-// https://github.com/apple/swift/issues/73252
-// UNSUPPORTED: OS=windows-msvc
-
 sil_stage raw
 
 import Builtin

--- a/test/SILOptimizer/enclosing_def_unit.sil
+++ b/test/SILOptimizer/enclosing_def_unit.sil
@@ -2,9 +2,6 @@
 //
 // REQUIRES: swift_in_compiler
 
-// https://github.com/apple/swift/issues/73252
-// UNSUPPORTED: OS=windows-msvc
-
 sil_stage raw
 
 import Builtin

--- a/test/SILOptimizer/forwarding_utils.sil
+++ b/test/SILOptimizer/forwarding_utils.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// https://github.com/apple/swift/issues/73252
-// UNSUPPORTED: OS=windows-msvc
-
 sil_stage raw
 
 import Builtin

--- a/test/SILOptimizer/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence_util.sil
@@ -7,9 +7,6 @@
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
-// https://github.com/apple/swift/issues/73252
-// UNSUPPORTED: OS=windows-msvc
-
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/opaque_values_unit.sil
+++ b/test/SILOptimizer/opaque_values_unit.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// https://github.com/apple/swift/issues/73252
-// UNSUPPORTED: OS=windows-msvc
-
 import Builtin
 
 class C {}

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -6,9 +6,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// https://github.com/apple/swift/issues/73252
-// UNSUPPORTED: OS=windows-msvc
-
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/test_specification_parsing.sil
+++ b/test/SILOptimizer/test_specification_parsing.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// https://github.com/apple/swift/issues/73252
-// UNSUPPORTED: OS=windows-msvc
-
 sil_stage raw
 
 import Builtin


### PR DESCRIPTION
Use `fflush(stdout)` from C++.

Issue 73252.
