### PR TITLE
IRGen: memcpy instead of the outlined copy with take

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -3283,7 +3283,10 @@ namespace {
                             bool zeroizeIfSensitive) const override {
       if (!ElementsAreABIAccessible) {
         emitInitializeWithTakeCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasParameterizedExistential()) {
+      } else if (isOutlined || T.hasParameterizedExistential() ||
+                 (getPayloadTypeInfo().isFixedSize() && // can use memcpy
+                  getPayloadTypeInfo().
+                  isBitwiseTakable(ResilienceExpansion::Maximal))) {
         emitIndirectInitialize(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsInitialization, IsTake);

--- a/test/IRGen/copy_addr_lowering.sil
+++ b/test/IRGen/copy_addr_lowering.sil
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -module-name A -Xllvm -sil-disable-pass=LowerAggregateInstr -emit-ir %s | %FileCheck %s
+sil_stage lowered
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct S {
+    var s: ArraySlice<UInt8>
+    var i: ArraySlice<UInt8>.Index
+}
+
+
+// CHECK: define{{.*}} swiftcc void @copy_test(
+// CHECK-NOT:  call ptr @"$s1A1SVSgWOb"(
+// CHECK: memcpy
+// CHECK:  ret void
+
+sil @copy_test : $@convention(thin) (@in Optional<S>) -> @out Optional<S> {
+bb0(%0 : $*Optional<S>, %1 : $*Optional<S>):
+  copy_addr [take] %1 to [init] %0 : $*Optional<S>
+  %5 = tuple ()
+  return %5 : $()
+}


### PR DESCRIPTION
The outlined copy with take would instantiate metadata to call the value witness table's copy function.

rdar://126751753