### PR TITLE
Set toolchain clang linker to gold (Linux)

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -904,7 +904,9 @@ reconfigure
 
 # gcc version on amazon linux 2 is too old to configure and build tablegen.
 # Use the clang that we install in the path for macros
-llvm-cmake-options=-DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
+llvm-cmake-options=
+  -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
+  -DCLANG_DEFAULT_LINKER=gold
 
 [preset: buildbot_linux]
 mixin-preset=

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1653,6 +1653,8 @@ for host in "${ALL_HOSTS[@]}"; do
     else
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
+    export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
+    export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
 
     if [[ "${NATIVE_SWIFT_TOOLS_PATH}" ]] ; then
         SWIFTC_BIN="${NATIVE_SWIFT_TOOLS_PATH}/swiftc"
@@ -2720,6 +2722,8 @@ for host in "${ALL_HOSTS[@]}"; do
     else
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
+    export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
+    export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
 
     if [[ "${NATIVE_SWIFT_TOOLS_PATH}" ]] ; then
         SWIFTC_BIN="${NATIVE_SWIFT_TOOLS_PATH}/swiftc"
@@ -3066,6 +3070,20 @@ for host in "${ALL_HOSTS[@]}"; do
     if ! [[ $(should_execute_host_actions_for_phase ${host} install) ]]; then
         continue
     fi
+
+    # Have to set the clang path or the driver will try to link with the wrong
+    # clang
+    if [[ "${NATIVE_CLANG_TOOLS_PATH}" ]] ; then
+        CLANG_BIN="${NATIVE_CLANG_TOOLS_PATH}"
+        if [[ ! -f "${CLANG_BIN}/clang" ]] ; then
+            echo "error: clang does not exist at the specified native tools path: ${CLANG_BIN}/clang"
+            exit 1
+        fi
+    else
+        CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
+    fi
+    export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
+    export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
 
     # Set the build options for this host
     set_build_options_for_host $host


### PR DESCRIPTION
BFD doesn't work with Swift symbols. We get nasty errors like this:

```
error: link command failed with exit code 1 (use -v to see invocation)
/usr/bin/ld: ...wift/CMakeFiles/swiftDispatch.dir/Block.swift.o:
  relocation R_X86_64_PC32 against protected symbol
  `$s8Dispatch0A13WorkItemFlagsVSYAAMc' can not be used when making a
  shared object
/usr/bin/ld: final link failed: bad value
```

rdar://123061492