### PR TITLE
[6.0] [DebugInfo] Fix PhiExpansion losing debug info

### DIFF
--- a/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
+++ b/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
@@ -439,6 +439,13 @@ bool PhiExpansionPass::optimizeArg(SILPhiArgument *initialArg) {
     }
   
     for (DebugValueInst *dvi : debugValueUsers) {
+      // Recreate the debug_value with a fragment.
+      SILBuilder B(dvi, dvi->getDebugScope());
+      SILDebugVariable var = *dvi->getVarInfo();
+      if (!var.Type)
+        var.Type = initialArg->getType();
+      var.DIExpr.append(SILDebugInfoExpression::createFragment(field));
+      B.createDebugValue(dvi->getLoc(), dvi->getOperand(), var);
       dvi->eraseFromParent();
     }
     for (StructExtractInst *sei : structExtractUsers) {

--- a/test/DebugInfo/phi-expansion.sil
+++ b/test/DebugInfo/phi-expansion.sil
@@ -1,0 +1,32 @@
+// RUN: %target-sil-opt %s -phi-expansion | %FileCheck %s
+
+sil_stage canonical
+
+import Swift
+
+struct Mystruct {
+  var i: Int
+  var j: Int
+}
+
+// CHECK-LABEL: sil @test_simple
+// CHECK:   br bb3(%{{[0-9]*}} : $Int)
+// CHECK: bb3(%[[PHI:[0-9]*]] : $Int):
+// CHECK:   debug_value %[[PHI]] : $Int, let, name "pos", type $Mystruct, expr op_fragment:#Mystruct.i
+// CHECK: } // end sil function 'test_simple'
+
+sil @test_simple : $@convention(thin) (Mystruct, Mystruct) -> Int {
+bb0(%0 : $Mystruct, %1 : $Mystruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0 : $Mystruct)
+
+bb2:
+  br bb3(%1 : $Mystruct)
+
+bb3(%5 : $Mystruct):
+  debug_value %5 : $Mystruct, let, name "pos"
+  %6 = struct_extract %5 : $Mystruct, #Mystruct.i
+  return %6 : $Int
+}


### PR DESCRIPTION
* **Explanation**: When replacing a struct with its field, it now emits a debug_value with a fragment, instead of dropping the debug_value.
* **Scope**: Salvages lost debug values in PhiExpansion
* **Original PR**: #73404
* **Risk**: Low, salvages dropped debug values in PhiExpansion only.
* **Testing**: A new test has been added
* **Issue**: None
* **Reviewer**:  @adrian-prantl 