### PR TITLE
[6.0][IRGen] Add missing blocklist check for some CVW cases

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1221,8 +1221,7 @@ static void addValueWitness(IRGenModule &IGM, ConstantStructBuilder &B,
   case ValueWitness::GetEnumTag: {
     assert(concreteType.getEnumOrBoundGenericEnum());
 
-    if (IGM.Context.LangOpts.hasFeature(Feature::LayoutStringValueWitnesses) &&
-        IGM.getOptions().EnableLayoutStringValueWitnesses) {
+    if (layoutStringsEnabled(IGM)) {
       auto ty = boundGenericCharacteristics
                     ? boundGenericCharacteristics->concreteType
                     : concreteType;
@@ -1244,8 +1243,7 @@ static void addValueWitness(IRGenModule &IGM, ConstantStructBuilder &B,
   }
   case ValueWitness::DestructiveInjectEnumTag: {
     assert(concreteType.getEnumOrBoundGenericEnum());
-    if (IGM.Context.LangOpts.hasFeature(Feature::LayoutStringValueWitnesses) &&
-        IGM.getOptions().EnableLayoutStringValueWitnesses) {
+    if (layoutStringsEnabled(IGM)) {
       auto ty = boundGenericCharacteristics
                     ? boundGenericCharacteristics->concreteType
                     : concreteType;

--- a/test/IRGen/layout_string_witnesses_block_list.swift
+++ b/test/IRGen/layout_string_witnesses_block_list.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-experimental-feature LayoutStringValueWitnesses -enable-layout-string-value-witnesses -emit-ir -module-name Foo %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-feature LayoutStringValueWitnesses -enable-experimental-feature LayoutStringValueWitnessesInstantiation -enable-layout-string-value-witnesses -enable-layout-string-value-witnesses-instantiation -emit-ir -module-name Foo %s | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir -module-name Foo %s | %FileCheck %s --check-prefix=CHECK-DISABLED
 
 // RUN: echo "---" > %t/blocklist.yml
@@ -20,4 +20,11 @@
 public struct Bar {
     let x: Int
     let y: AnyObject
+}
+
+// CHECK-BLOCKED-NOT: swift_enumFn_getEnumTag
+public enum Foo {
+    case a(AnyObject)
+    case b(Int, AnyObject)
+    case c
 }


### PR DESCRIPTION
**Explanation**: A blocklist check was missing before emitting CVW handlers for getEnumTag and destructiveInjectEnumTag, which could cause the CVW functions to be used when the feature was blocked via blocklist.
**Scope**: Only affects compact value witnesses
**Risk**: Low. Only affects CVW
**Testing**: Added test cases that observe the issue before the fix
**Issue**: rdar://127511568
**Reviewer**: @tshortli 
**Main branch PR**: https://github.com/apple/swift/pull/73465