### PR TITLE
[RelatedIdents] Fix an assertion failure if two invalid declarations have the same base name

### DIFF
--- a/include/swift/Index/Index.h
+++ b/include/swift/Index/Index.h
@@ -25,6 +25,7 @@ namespace index {
 void indexDeclContext(DeclContext *DC, IndexDataConsumer &consumer);
 void indexSourceFile(SourceFile *SF, IndexDataConsumer &consumer);
 void indexModule(ModuleDecl *module, IndexDataConsumer &consumer);
+bool printDisplayName(const swift::ValueDecl *D, llvm::raw_ostream &OS);
 
 } // end namespace index
 } // end namespace swift

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -73,7 +73,7 @@ printArtificialName(const swift::AbstractStorageDecl *ASD, AccessorKind AK, llvm
   llvm_unreachable("Unhandled AccessorKind in switch.");
 }
 
-static bool printDisplayName(const swift::ValueDecl *D, llvm::raw_ostream &OS) {
+bool index::printDisplayName(const swift::ValueDecl *D, llvm::raw_ostream &OS) {
   if (!D->hasName() && !isa<ParamDecl>(D)) {
     auto *FD = dyn_cast<AccessorDecl>(D);
     if (!FD)

--- a/lib/Refactoring/LocalRename.cpp
+++ b/lib/Refactoring/LocalRename.cpp
@@ -194,21 +194,13 @@ swift::ide::getRenameInfo(ResolvedCursorInfoPtr cursorInfo) {
 }
 
 class RenameRangeCollector : public IndexDataConsumer {
-  StringRef usr;
+  const ValueDecl *declToRename;
   std::unique_ptr<StringScratchSpace> stringStorage;
   std::vector<RenameLoc> locations;
 
 public:
-  RenameRangeCollector(StringRef usr)
-      : usr(usr), stringStorage(new StringScratchSpace()) {}
-
-  RenameRangeCollector(const ValueDecl *D)
-      : stringStorage(new StringScratchSpace()) {
-    SmallString<64> SS;
-    llvm::raw_svector_ostream OS(SS);
-    printValueDeclUSR(D, OS);
-    usr = stringStorage->copyString(SS.str());
-  }
+  RenameRangeCollector(const ValueDecl *declToRename)
+      : declToRename(declToRename), stringStorage(new StringScratchSpace()) {}
 
   RenameRangeCollector(RenameRangeCollector &&collector) = default;
 
@@ -228,7 +220,7 @@ private:
   bool finishDependency(bool isClangModule) override { return true; }
 
   Action startSourceEntity(const IndexSymbol &symbol) override {
-    if (symbol.USR != usr) {
+    if (symbol.decl != declToRename) {
       return IndexDataConsumer::Continue;
     }
     auto loc = indexSymbolToRenameLoc(symbol);

--- a/test/SourceKit/RelatedIdents/two_invalid_decls_with_same_base_name.swift
+++ b/test/SourceKit/RelatedIdents/two_invalid_decls_with_same_base_name.swift
@@ -1,0 +1,6 @@
+struct Foo {
+  func bar(body: Invalid) {}
+
+// RUN: %sourcekitd-test -req=related-idents -pos=%(line + 1):8 %s -- %s
+  func bar(ignoreCase: Bool, body: Invalid) {}
+}


### PR DESCRIPTION
For example, the following declarations have the same USR with a single ERROR_TYPE parameter despite being distinct declarations.

```swift
func bar(body: Invalid) {}
func bar(ignoreCase: Bool, body: Invalid) {}
```

We originally intended to check the USR so that local rename behaves more like global rename, which also looks symbols up by USR. But the above example proves that assumption wrong.

rdar://126803702