### PR TITLE
[test][Linux] Improve Gold/LLD detection for function_sections.swift

### DIFF
--- a/test/LinkerSections/function_sections.swift
+++ b/test/LinkerSections/function_sections.swift
@@ -1,8 +1,9 @@
 // REQUIRES: OS=linux-gnu || OS=freebsd
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -function-sections -emit-module -emit-library -static -parse-stdlib %S/Inputs/FunctionSections.swift
-// RUN: %target-build-swift -Xlinker -v -Xlinker --gc-sections -Xlinker -Map=%t/../../FunctionSections.map -I%t/../.. -L%t/../.. -lFunctionSections %S/Inputs/FunctionSectionsUse.swift 2>&1 | sed 's/.*\(gold\|LLD\).*/\1/g' | tr "[:lower:]" "[:upper:]" > %t/../../Linker.txt
-// RUN: %FileCheck --check-prefix $(cat %t/../../Linker.txt) %s < %t/../../FunctionSections.map
+// RUN: %target-build-swift -Xfrontend -function-sections -emit-module -emit-library -static -parse-stdlib %S/Inputs/FunctionSections.swift -o %t/libFunctionSections.a
+// RUN: %target-build-swift -Xlinker --gc-sections -Xlinker -Map=%t/FunctionSections.map -I%t -L%t -lFunctionSections %S/Inputs/FunctionSectionsUse.swift
+// RUN: if head -1 %t/FunctionSections.map | grep "Archive members"; then  %FileCheck --check-prefix GOLD %s < %t/FunctionSections.map ; fi
+// RUN: if head -1 %t/FunctionSections.map | grep "VMA"; then %FileCheck --check-prefix LLD %s < %t/FunctionSections.map ; fi
 
 // GOLD: Discarded input sections
 // GOLD: .text.$s16FunctionSections5func2yyF


### PR DESCRIPTION
In #72061 the test was modified because LLD and Gold linker map formats are different, so they need different CHECKs. The original method in PR #72061 presents problems when the output is not exactly only one line.

These changes use the first line of the linker map file to decide if the Gold or the LLD linker map checks should be used, since the format differs in both for the first line.

This way of checking works in my Linux machine when using the default linker, when forcing Gold with `-use-ld=gold` and when forcing LLD with `-use-ld=lld`.

Additionally, the temporary directory is used for the outputs, or the non-temporary directory static archive `libFunctionSections.a` will get more and more temporary objects added to it as one runs the test suite (`clang` invokes `ar` as `ar crs`, which will "replace" the objects, but since `clang` is using a temporary object, the object names always have different suffixes, so nothing gets replaced).

