### PR TITLE
[ClangImporter] Import `extern "C"` declarations from the bridging header

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1686,11 +1686,24 @@ bool ClangImporter::Implementation::importHeader(
 
   // We can't do this as we're parsing because we may want to resolve naming
   // conflicts between the things we've parsed.
-  for (auto group : allParsedDecls)
-    for (auto *D : group)
-      if (auto named = dyn_cast<clang::NamedDecl>(D))
-        addEntryToLookupTable(*BridgingHeaderLookupTable, named,
+
+  std::function<void(clang::Decl *)> visit = [&](clang::Decl *decl) {
+    // Iterate into extern "C" {} type declarations.
+    if (auto linkageDecl = dyn_cast<clang::LinkageSpecDecl>(decl)) {
+      for (auto *decl : linkageDecl->noload_decls()) {
+        visit(decl);
+      }
+    }
+    if (auto named = dyn_cast<clang::NamedDecl>(decl)) {
+      addEntryToLookupTable(*BridgingHeaderLookupTable, named,
                               getNameImporter());
+    }
+  };
+  for (auto group : allParsedDecls) {
+    for (auto *D : group) {
+      visit(D);
+    }
+  }
 
   pp.EndSourceFile();
   bumpGeneration();

--- a/test/SourceKit/CodeComplete/complete_extern_c_from_bridging_header.swift
+++ b/test/SourceKit/CodeComplete/complete_extern_c_from_bridging_header.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+//--- Bridging-Header.h
+
+void func_from_bridging_header(void);
+
+extern "C"
+void extern_c_func_from_bridging_header(void);
+
+extern "C" {
+  extern "C" {
+    void nested_extern_c_func_from_bridging_header(void);
+  }
+}
+
+//--- test.swift
+
+// Passes
+// RUN: %sourcekitd-test -req=complete -pos 1:1 %t/test.swift -- %t/test.swift -import-bridging-header %t/Bridging-Header.h -cxx-interoperability-mode=default -pch-output-dir %t/pch-dir | %FileCheck %s
+// RUN: %sourcekitd-test -req=complete -pos 1:1 %t/test.swift -- %t/test.swift -import-bridging-header %t/Bridging-Header.h -cxx-interoperability-mode=default | %FileCheck %s
+// CHECK-DAG: func_from_bridging_header
+// CHECK-DAG: extern_c_func_from_bridging_header
+// CHECK-DAG: nested_extern_c_func_from_bridging_header


### PR DESCRIPTION
We do iterate into extern C declarations when building the Swift lookup table during PCH generation.

https://github.com/apple/swift/blob/0fad799f51f6c5408696379b1fe35cd10c131136/lib/ClangImporter/SwiftLookupTable.cpp#L2140-L2146

However, we don’t import `extern "C"` declarations while parsing the bridging header (eg. when no `-pch-output-dir` is specified during code completion). This caused us to miss functions annotated as `extern "C"` in code completion.

rdar://127512985
