### PR TITLE
Support generating loadable types in serialized function when package-cmo is enabled.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -779,11 +779,7 @@ public:
     return getLoweredFunctionType()->getRepresentation();
   }
 
-  ResilienceExpansion getResilienceExpansion() const {
-    return (isSerialized()
-            ? ResilienceExpansion::Minimal
-            : ResilienceExpansion::Maximal);
-  }
+  ResilienceExpansion getResilienceExpansion() const;
 
   // Returns the type expansion context to be used inside this function.
   TypeExpansionContext getTypeExpansionContext() const {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -158,22 +158,9 @@ namespace {
 template <typename DeclType>
 bool checkResilience(DeclType *D, ModuleDecl *M,
                      ResilienceExpansion expansion) {
-  auto refDeclModule = D->getModuleContext();
   // Explicitly bypassed for debugging with `bypass-resilience-checks`
-  if (refDeclModule->getBypassResilience())
+  if (D->getModuleContext()->getBypassResilience())
     return false;
-
-  // If package serialization is enabled with `experimental-package-cmo`,
-  // decls can be serialized in a resiliently built module. In such case,
-  // a direct access should be allowed.
-  auto packageSerialized = expansion == ResilienceExpansion::Minimal &&
-                           refDeclModule->isResilient() &&
-                           refDeclModule->allowNonResilientAccess() &&
-                           refDeclModule->serializePackageEnabled() &&
-                           refDeclModule->inSamePackage(M);
-  if (packageSerialized)
-    return false;
-
   return D->isResilient(M, expansion);
 }
 


### PR DESCRIPTION
To support generating loadable types in a serialized function, return maximal resilience expansion in SILFunction::getResilienceExpansion() if package serialization is enabled for modules built resiliently. 
This allows aggregate types to be generated as loadable SIL types which otherwise are address-only
in a serialized function. During type lowering, opaque flag setting is also skipped if package serialization 
is enabled.

Resolves rdar://127400743