### PR TITLE
[Lexer] Fix an assertion failure when invoking code completion inside a single-quoted string literal

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1832,6 +1832,12 @@ void Lexer::diagnoseSingleQuoteStringLiteral(const char *TokStart,
       OutputPtr = Ptr;
       // Escape double quotes.
       replacement.append("\\\"");
+    } else if (Ptr[-1] == 0) {
+      // The string literal might contain a null byte if the code completion
+      // position is inside the string literal. Don't include the null byte in
+      // the replacement string.
+      replacement.append(OutputPtr, Ptr - 1);
+      OutputPtr = Ptr;
     }
   }
   assert(Ptr == TokEnd && Ptr[-1] == '\'');

--- a/test/SourceKit/CodeComplete/complete_in_single_quoted_string_literal.swift
+++ b/test/SourceKit/CodeComplete/complete_in_single_quoted_string_literal.swift
@@ -1,0 +1,4 @@
+fileprivate enum BundleComponent {
+  // RUN: %sourcekitd-test -req=complete -pos=%(line + 1):25 %s -- %s
+  case swiftVersions = 's'
+}


### PR DESCRIPTION
* **Explanation**: When performing code completion inside a single-quoted string literal, we were trying to generate a Fix-It to change the string literal to double quotes. This Fix-It accidentally contained the null byte that signified the code completion location, resulting in an assertion failure. Exclude the null byte from the Fix-It to resolve the assertion failure.
* **Scope**: Completion inside single-quoted string literals
* **Risk**: Fairly low, we are just skipping over null bytes in Fix-Its
* **Testing**: Added a regression test
* **Issue**: rdar://126924962
* **Reviewer**:  @rintaro on https://github.com/apple/swift/pull/73467