### PR TITLE
[6.0][Sema] Non-exhaustive switch statements are always an error in Swift 6.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7031,10 +7031,9 @@ WARNING(redundant_particular_literal_case,none,
 NOTE(redundant_particular_literal_case_here,none,
      "first occurrence of identical literal pattern is here", ())
 
-WARNING(non_exhaustive_switch_warn,none, "switch must be exhaustive", ())
-WARNING(non_exhaustive_switch_unknown_only,none,
-        "switch covers known cases, but %0 may have additional unknown values"
-        "%select{|, possibly added in future versions}1", (Type, bool))
+ERROR(non_exhaustive_switch_unknown_only,none,
+      "switch covers known cases, but %0 may have additional unknown values"
+      "%select{|, possibly added in future versions}1", (Type, bool))
 
 ERROR(override_nsobject_hashvalue_error,none,
       "'NSObject.hashValue' is not overridable; "

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -194,6 +194,7 @@ UPCOMING_FEATURE(InferSendableFromCaptures, 418, 6)
 UPCOMING_FEATURE(ImplicitOpenExistentials, 352, 6)
 UPCOMING_FEATURE(RegionBasedIsolation, 414, 6)
 UPCOMING_FEATURE(DynamicActorIsolation, 423, 6)
+UPCOMING_FEATURE(NonfrozenEnumExhaustivity, 192, 6)
 
 // Swift 7
 UPCOMING_FEATURE(ExistentialAny, 335, 7)

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -454,10 +454,6 @@ namespace swift {
     /// Diagnose uses of NSCoding with classes that have unstable mangled names.
     bool EnableNSKeyedArchiverDiagnostics = true;
 
-    /// Diagnose switches over non-frozen enums that do not have catch-all
-    /// cases.
-    bool EnableNonFrozenEnumExhaustivityDiagnostics = false;
-
     /// Regex for the passes that should report passed and missed optimizations.
     ///
     /// These are shared_ptrs so that this class remains copyable.

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -635,6 +635,8 @@ static bool usesFeatureTransferringArgsAndResults(Decl *decl) {
 
 UNINTERESTING_FEATURE(DynamicActorIsolation)
 
+UNINTERESTING_FEATURE(NonfrozenEnumExhaustivity)
+
 UNINTERESTING_FEATURE(BorrowingSwitch)
 
 UNINTERESTING_FEATURE(ClosureIsolation)

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1084,10 +1084,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                    OPT_disable_nskeyedarchiver_diagnostics,
                    Opts.EnableNSKeyedArchiverDiagnostics);
 
-  Opts.EnableNonFrozenEnumExhaustivityDiagnostics =
-    Args.hasFlag(OPT_enable_nonfrozen_enum_exhaustivity_diagnostics,
-                 OPT_disable_nonfrozen_enum_exhaustivity_diagnostics,
-                 Opts.isSwiftVersionAtLeast(5));
+  if (Args.hasFlag(OPT_enable_nonfrozen_enum_exhaustivity_diagnostics,
+                   OPT_disable_nonfrozen_enum_exhaustivity_diagnostics,
+                   Opts.isSwiftVersionAtLeast(5))) {
+    Opts.enableFeature(Feature::NonfrozenEnumExhaustivity);
+  }
 
   if (Arg *A = Args.getLastArg(OPT_Rpass_EQ))
     Opts.OptimizationRemarkPassedPattern =

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1157,7 +1157,7 @@ namespace {
       case DowngradeToWarning::ForUnknownCase: {
         if (Context.LangOpts.DebuggerSupport ||
             Context.LangOpts.Playground ||
-            !Context.LangOpts.EnableNonFrozenEnumExhaustivityDiagnostics) {
+            !Context.LangOpts.hasFeature(Feature::NonfrozenEnumExhaustivity)) {
           // Don't require covering unknown cases in the debugger or in
           // playgrounds.
           return;
@@ -1259,7 +1259,7 @@ namespace {
               // will later decompose the space into cases.
               continue;
             }
-            if (!Context.LangOpts.EnableNonFrozenEnumExhaustivityDiagnostics)
+            if (!Context.LangOpts.hasFeature(Feature::NonfrozenEnumExhaustivity))
               continue;
 
             // This can occur if the switch is empty and the subject type is an

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1128,13 +1128,13 @@ namespace {
       // Decide whether we want an error or a warning.
       std::optional<decltype(diag::non_exhaustive_switch)> mainDiagType =
           diag::non_exhaustive_switch;
+      bool downgrade = false;
       if (unknownCase) {
         switch (defaultReason) {
         case RequiresDefault::EmptySwitchBody:
           llvm_unreachable("there's an @unknown case; the body can't be empty");
         case RequiresDefault::No:
-          if (!uncovered.isEmpty())
-            mainDiagType = diag::non_exhaustive_switch_warn;
+          downgrade = !uncovered.isEmpty();
           break;
         case RequiresDefault::UncoveredSwitch:
         case RequiresDefault::SpaceTooLarge: {
@@ -1170,7 +1170,8 @@ namespace {
               theEnum->getParentModule()->isSystemModule();
         }
         DE.diagnose(startLoc, diag::non_exhaustive_switch_unknown_only,
-                    subjectType, shouldIncludeFutureVersionComment);
+                    subjectType, shouldIncludeFutureVersionComment)
+          .warnUntilSwiftVersion(6);
         mainDiagType = std::nullopt;
       }
         break;
@@ -1187,7 +1188,8 @@ namespace {
         return;
       case RequiresDefault::UncoveredSwitch: {
         OS << tok::kw_default << ":\n" << placeholder << "\n";
-        DE.diagnose(startLoc, mainDiagType.value());
+        DE.diagnose(startLoc, mainDiagType.value())
+          .warnUntilSwiftVersionIf(downgrade, 6);
         DE.diagnose(startLoc, diag::missing_several_cases, /*default*/true)
           .fixItInsert(insertLoc, buffer.str());
       }
@@ -1205,8 +1207,10 @@ namespace {
       if (uncovered.isEmpty()) return;
 
       // Check if we still have to emit the main diagnostic.
-      if (mainDiagType.has_value())
-        DE.diagnose(startLoc, mainDiagType.value());
+      if (mainDiagType.has_value()) {
+        DE.diagnose(startLoc, mainDiagType.value())
+          .warnUntilSwiftVersionIf(downgrade, 6);
+      }
 
       // Add notes to explain what's missing.
       auto processUncoveredSpaces =

--- a/test/ClangImporter/enum-exhaustivity-system.swift
+++ b/test/ClangImporter/enum-exhaustivity-system.swift
@@ -1,9 +1,13 @@
-// RUN: %target-swift-frontend -typecheck %s -Xcc -isystem -Xcc %S/Inputs/custom-modules -verify -enable-nonfrozen-enum-exhaustivity-diagnostics
+// RUN: %target-swift-frontend -typecheck %s -Xcc -isystem -Xcc %S/Inputs/custom-modules -verify -swift-version 5 -verify-additional-prefix swift5-
+// RUN: %target-swift-frontend -typecheck %s -Xcc -isystem -Xcc %S/Inputs/custom-modules -verify -swift-version 6 -verify-additional-prefix swift6-
 
 import EnumExhaustivity
 
 func test(_ value: RegularEnum, _ exhaustiveValue: ExhaustiveEnum) {
-  switch value { // expected-warning {{switch covers known cases, but 'RegularEnum' may have additional unknown values, possibly added in future versions}} expected-note {{handle unknown values using "@unknown default"}}
+  switch value {
+  // expected-swift5-warning@-1 {{switch covers known cases, but 'RegularEnum' may have additional unknown values, possibly added in future versions}}
+  // expected-swift6-error@-2 {{switch covers known cases, but 'RegularEnum' may have additional unknown values, possibly added in future versions}}
+  // expected-note@-3 {{handle unknown values using "@unknown default"}}
   case .A: break
   case .B: break
   }
@@ -29,7 +33,11 @@ func testAttributes(
   case .A, .B: break
   }
 
-  switch retetb { // expected-warning {{switch covers known cases, but 'RegularEnumTurnedExhaustiveThenBackViaAPINotes' may have additional unknown values, possibly added in future versions}} expected-note {{handle unknown values using "@unknown default"}}
+  switch retetb {
+  // expected-swift5-warning@-1 {{switch covers known cases, but 'RegularEnumTurnedExhaustiveThenBackViaAPINotes' may have additional unknown values, possibly added in future versions}}
+  // expected-swift6-error@-2 {{switch covers known cases, but 'RegularEnumTurnedExhaustiveThenBackViaAPINotes' may have additional unknown values, possibly added in future versions}}
+  // expected-note@-3 {{handle unknown values using "@unknown default"}}
+
   case .A, .B: break
   }
 

--- a/test/Compatibility/exhaustive_switch_swift_6.swift
+++ b/test/Compatibility/exhaustive_switch_swift_6.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-library-evolution
+
+enum OverlyLargeSpaceEnum {
+  case case0
+  case case1
+  case case2
+  case case3
+  case case4
+  case case5
+  case case6
+  case case7
+  case case8
+  case case9
+  case case10
+  case case11
+}
+
+func testSwitch() -> Bool {
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.case11, _)'}}
+  case (.case0, _): return true
+  case (.case1, _): return true
+  case (.case2, _): return true
+  case (.case3, _): return true
+  case (.case4, _): return true
+  case (.case5, _): return true
+  case (.case6, _): return true
+  case (.case7, _): return true
+  case (.case8, _): return true
+  case (.case9, _): return true
+  case (.case10, _): return true
+  @unknown default: return false
+  }
+}

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution %S/Inputs/exhaustive_switch_testable_helper.swift -emit-module -o %t
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -I %t
 // RUN: %target-typecheck-verify-swift -swift-version 4 -enable-library-evolution -enable-nonfrozen-enum-exhaustivity-diagnostics -I %t
+// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-library-evolution -enable-upcoming-feature NonfrozenEnumExhaustivity -I %t
 
 import exhaustive_switch_testable_helper
 


### PR DESCRIPTION
* **Explanation**: As described in https://forums.swift.org/t/amendment-se-0192-handling-future-enum-cases/68321, the Language Steering Group amended SE-0192 to make non-exhaustive switch statements over non-frozen enums errors in the Swift 6 language mode. These diagnostics have been staged in as warnings in Swift 5 mode for several releases; this change makes those warnings errors in Swift 6 mode, and adds a new `NonfrozenEnumExhaustivity` upcoming feature flag to subsume the bespoke `-enable-nonfrozen-enum-exhaustivity-diagnostics` which enables the diagnostics as warnings in the Swift 4 and 4.2 language modes.
* **Scope**: Only impacts non-exhaustive switch statements over non-frozen enums in the Swift 6 language mode.
* **Risk**: Low; only impacts the Swift 6 language mode.
* **Testing**: Added new tests.
* **Main branch PR**: https://github.com/apple/swift/pull/73472