### PR TITLE
[6.0][region-isolation] Upstreaming some fixes

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -692,6 +692,18 @@ autorelease in the callee.
   type behaves like a non-generic type, as if the substitutions were
   actually applied to the underlying function type.
 
+- SIL functions may optionally mark a function parameter as
+  ``@sil_isolated``. An ``@sil_isolated`` parameter must be one of:
+
+  - An actor or any actor type.
+  - A generic type that conforms to Actor or AnyActor.
+
+  and must be the actor instance that a function is isolated to. Importantly
+  this means that global actor isolated nominal types are never
+  ``@sil_isolated``. Only one parameter can ever be marked as ``@sil_isolated``
+  since a function cannot be isolated to multiple actors at the same time.
+
+
 Async Functions
 ```````````````
 

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -271,10 +271,7 @@ public:
   void printForDiagnostics(llvm::raw_ostream &os,
                            StringRef openingQuotationMark = "'") const;
 
-  SWIFT_DEBUG_DUMP {
-    print(llvm::dbgs());
-    llvm::dbgs() << '\n';
-  }
+  SWIFT_DEBUG_DUMPER(dump());
 
   // Defined out of line to prevent linker errors since libswiftBasic would
   // include this header exascerbating a layering violation where libswiftBasic

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -266,6 +266,8 @@ public:
 
   void print(llvm::raw_ostream &os) const;
 
+  void printForSIL(llvm::raw_ostream &os) const;
+
   void printForDiagnostics(llvm::raw_ostream &os,
                            StringRef openingQuotationMark = "'") const;
 

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -205,6 +205,8 @@ public:
     return getKind() == GlobalActor;
   }
 
+  bool isActorInstanceIsolated() const { return getKind() == ActorInstance; }
+
   bool isMainActor() const;
 
   bool isDistributedActor() const;
@@ -262,29 +264,7 @@ public:
                               state.parameterIndex);
   }
 
-  void print(llvm::raw_ostream &os) const {
-    switch (getKind()) {
-    case Unspecified:
-      os << "unspecified";
-      return;
-    case ActorInstance:
-      os << "actor_instance";
-      return;
-    case Nonisolated:
-      os << "nonisolated";
-      return;
-    case NonisolatedUnsafe:
-      os << "nonisolated_unsafe";
-      return;
-    case GlobalActor:
-      os << "global_actor";
-      return;
-    case Erased:
-      os << "erased";
-      return;
-    }
-    llvm_unreachable("Covered switch isn't covered?!");
-  }
+  void print(llvm::raw_ostream &os) const;
 
   void printForDiagnostics(llvm::raw_ostream &os,
                            StringRef openingQuotationMark = "'") const;

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -382,6 +382,9 @@ struct PrintOptions {
   /// Suppress 'isolated' and '#isolation' on isolated parameters with optional type.
   bool SuppressOptionalIsolatedParams = false;
 
+  /// Suppress 'transferring' on arguments and results.
+  bool SuppressTransferringArgsAndResults = false;
+
   /// Suppress Noncopyable generics.
   bool SuppressNoncopyableGenerics = false;
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -349,7 +349,7 @@ EXPERIMENTAL_FEATURE(FixedArrays, true)
 EXPERIMENTAL_FEATURE(GroupActorErrors, true)
 
 // Allow for the 'transferring' keyword to be applied to arguments and results.
-EXPERIMENTAL_FEATURE(TransferringArgsAndResults, true)
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(TransferringArgsAndResults, true)
 
 // Enable explicit isolation of closures.
 EXPERIMENTAL_FEATURE(ClosureIsolation, true)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -196,6 +196,7 @@ UPCOMING_FEATURE(ImplicitOpenExistentials, 352, 6)
 UPCOMING_FEATURE(RegionBasedIsolation, 414, 6)
 UPCOMING_FEATURE(DynamicActorIsolation, 423, 6)
 UPCOMING_FEATURE(NonfrozenEnumExhaustivity, 192, 6)
+UPCOMING_FEATURE(GlobalActorIsolatedTypesUsability, 0434, 6)
 UPCOMING_FEATURE(BorrowingSwitch, 432, 6)
 
 // Swift 7
@@ -371,9 +372,6 @@ EXPERIMENTAL_FEATURE(CImplementation, true)
 
 // Enable the stdlib @DebugDescription macro.
 EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(DebugDescriptionMacro, true)
-
-// Enable usability improvements for global-actor-isolated types.
-EXPERIMENTAL_FEATURE(GlobalActorIsolatedTypesUsability, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1539,6 +1539,17 @@ public:
     return getArguments().back();
   }
 
+  /// If we have an isolated argument, return that. Returns nullptr otherwise.
+  const SILArgument *maybeGetIsolatedArgument() const {
+    for (auto *arg : getArgumentsWithoutIndirectResults()) {
+      if (cast<SILFunctionArgument>(arg)->getKnownParameterInfo().hasOption(
+              SILParameterInfo::Isolated))
+        return arg;
+    }
+
+    return nullptr;
+  }
+
   const SILArgument *getDynamicSelfMetadata() const {
     assert(hasDynamicSelfMetadata() && "This method can only be called if the "
            "SILFunction has a self-metadata parameter");

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -305,7 +305,10 @@ public:
     os << "\n    Rep Value: " << getRepresentative();
   }
 
-  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
+  SWIFT_DEBUG_DUMP {
+    print(llvm::dbgs());
+    llvm::dbgs() << '\n';
+  }
 };
 
 class RegionAnalysis;

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -31,27 +31,6 @@ using TransferringOperandSetFactory = Partition::TransferringOperandSetFactory;
 using Element = PartitionPrimitives::Element;
 using Region = PartitionPrimitives::Region;
 
-/// Check if the passed in type is NonSendable.
-///
-/// NOTE: We special case RawPointer and NativeObject to ensure they are
-/// treated as non-Sendable and strict checking is applied to it.
-inline bool isNonSendableType(SILType type, SILFunction *fn) {
-  // Treat Builtin.NativeObject and Builtin.RawPointer as non-Sendable.
-  if (type.getASTType()->is<BuiltinNativeObjectType>() ||
-      type.getASTType()->is<BuiltinRawPointerType>()) {
-    return true;
-  }
-
-  // Treat Builtin.SILToken as Sendable. It cannot escape from the current
-  // function. We should change isSendable to hardwire this.
-  if (type.getASTType()->is<SILTokenType>()) {
-    return false;
-  }
-
-  // Otherwise, delegate to seeing if type conforms to the Sendable protocol.
-  return !type.isSendable(fn);
-}
-
 /// Return the ApplyIsolationCrossing for a specific \p inst if it
 /// exists. Returns std::nullopt otherwise.
 std::optional<ApplyIsolationCrossing>

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -192,7 +192,10 @@ private:
         actorInstance(ActorInstance::getForValue(actorInstance)) {
     assert((!actorInstance ||
             (actorIsolation.getKind() == ActorIsolation::ActorInstance &&
-             actorInstance->getType().isAnyActor())) &&
+             actorInstance->getType()
+                 .getASTType()
+                 ->lookThroughAllOptionalTypes()
+                 ->getAnyActor())) &&
            "actorInstance must be an actor if it is non-empty");
   }
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -640,22 +640,38 @@ UNINTERESTING_FEATURE(FixedArrays)
 UNINTERESTING_FEATURE(GroupActorErrors)
 
 static bool usesFeatureTransferringArgsAndResults(Decl *decl) {
-  if (auto *pd = dyn_cast<ParamDecl>(decl))
-    if (pd->isTransferring())
+  auto functionTypeUsesTransferring = [](Decl *decl) {
+    return usesTypeMatching(decl, [](Type type) {
+      auto fnType = type->getAs<AnyFunctionType>();
+      if (!fnType)
+        return false;
+
+      if (fnType->hasExtInfo() && fnType->hasTransferringResult())
+        return true;
+
+      return llvm::any_of(fnType->getParams(),
+                          [](AnyFunctionType::Param param) {
+                            return param.getParameterFlags().isTransferring();
+                          });
+    });
+  };
+
+  if (auto *pd = dyn_cast<ParamDecl>(decl)) {
+    if (pd->isTransferring()) {
       return true;
+    }
+
+    if (functionTypeUsesTransferring(pd))
+      return true;
+  }
 
   if (auto *fDecl = dyn_cast<FuncDecl>(decl)) {
-    auto fnTy = fDecl->getInterfaceType();
-    bool hasTransferring = false;
-    if (auto *ft = llvm::dyn_cast_if_present<FunctionType>(fnTy)) {
-      if (ft->hasExtInfo())
-        hasTransferring = ft->hasTransferringResult();
-    } else if (auto *ft =
-                   llvm::dyn_cast_if_present<GenericFunctionType>(fnTy)) {
-      if (ft->hasExtInfo())
-        hasTransferring = ft->hasTransferringResult();
-    }
-    if (hasTransferring)
+    // First check for param decl results.
+    if (llvm::any_of(fDecl->getParameters()->getArray(), [](ParamDecl *pd) {
+          return usesFeatureTransferringArgsAndResults(pd);
+        }))
+      return true;
+    if (functionTypeUsesTransferring(decl))
       return true;
   }
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1784,6 +1784,11 @@ void ActorIsolation::printForSIL(llvm::raw_ostream &os) const {
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
+void ActorIsolation::dump() const {
+  print(llvm::dbgs());
+  llvm::dbgs() << '\n';
+}
+
 void ActorIsolation::dumpForDiagnostics() const {
   printForDiagnostics(llvm::dbgs());
   llvm::dbgs() << '\n';

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1760,6 +1760,30 @@ void ActorIsolation::print(llvm::raw_ostream &os) const {
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
+void ActorIsolation::printForSIL(llvm::raw_ostream &os) const {
+  switch (getKind()) {
+  case Unspecified:
+    os << "unspecified";
+    return;
+  case ActorInstance:
+    os << "actor_instance";
+    return;
+  case Nonisolated:
+    os << "nonisolated";
+    return;
+  case NonisolatedUnsafe:
+    os << "nonisolated_unsafe";
+    return;
+  case GlobalActor:
+    os << "global_actor";
+    return;
+  case Erased:
+    os << "erased";
+    return;
+  }
+  llvm_unreachable("Covered switch isn't covered?!");
+}
+
 void ActorIsolation::dumpForDiagnostics() const {
   printForDiagnostics(llvm::dbgs());
   llvm::dbgs() << '\n';

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1733,6 +1733,33 @@ void ActorIsolation::printForDiagnostics(llvm::raw_ostream &os,
   }
 }
 
+void ActorIsolation::print(llvm::raw_ostream &os) const {
+  switch (getKind()) {
+  case Unspecified:
+    os << "unspecified";
+    return;
+  case ActorInstance:
+    os << "actor_instance";
+    if (auto *vd = getActorInstance()) {
+      os << ". name: '" << vd->getBaseIdentifier() << "'";
+    }
+    return;
+  case Nonisolated:
+    os << "nonisolated";
+    return;
+  case NonisolatedUnsafe:
+    os << "nonisolated_unsafe";
+    return;
+  case GlobalActor:
+    os << "global_actor. type: " << getGlobalActor();
+    return;
+  case Erased:
+    os << "erased";
+    return;
+  }
+  llvm_unreachable("Covered switch isn't covered?!");
+}
+
 void ActorIsolation::dumpForDiagnostics() const {
   printForDiagnostics(llvm::dbgs());
   llvm::dbgs() << '\n';

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3314,6 +3314,12 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     P.printDebugScopeRef(getDebugScope(), SM);
   }
   OS << '\n';
+
+  if (auto functionIsolation = getActorIsolation()) {
+    OS << "// Isolation: ";
+    functionIsolation.print(OS);
+    OS << '\n';
+  }
   printClangQualifiedNameCommentIfPresent(OS, getClangDecl());
 
   OS << "sil ";

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1550,11 +1550,17 @@ public:
       *this << "[noasync] ";
     if (auto isolationCrossing = AI->getIsolationCrossing()) {
       auto callerIsolation = isolationCrossing->getCallerIsolation();
-      if (callerIsolation != ActorIsolation::Unspecified)
-        *this << "[callee_isolation=" << callerIsolation << "] ";
+      if (callerIsolation != ActorIsolation::Unspecified) {
+        *this << "[callee_isolation=";
+        callerIsolation.printForSIL(PrintState.OS);
+        *this << "] ";
+      }
       auto calleeIsolation = isolationCrossing->getCalleeIsolation();
-      if (calleeIsolation != ActorIsolation::Unspecified)
-        *this << "[caller_isolation=" << calleeIsolation << "] ";
+      if (calleeIsolation != ActorIsolation::Unspecified) {
+        *this << "[caller_isolation=";
+        calleeIsolation.printForSIL(PrintState.OS);
+        *this << "] ";
+      }
     }
     visitApplyInstBase(AI);
   }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6577,6 +6577,13 @@ public:
                                     SILResultInfo::IsTransferring);
                               })),
             "transferring result means all results are transferring");
+
+    // We should only ever have a single sil_isolated parameter.
+    require(1 >= std::count_if(FTy->getParameters().begin(), FTy->getParameters().end(),
+                               [](const SILParameterInfo &parameterInfo) {
+                                 return parameterInfo.hasOption(SILParameterInfo::Isolated);
+                               }),
+            "Should only ever be isolated to a single parameter");
   }
 
   struct VerifyFlowSensitiveRulesDetails {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6578,36 +6578,6 @@ public:
                               })),
             "transferring result means all results are transferring");
 
-    // We should only ever have a single sil_isolated parameter.
-    bool foundIsolatedParameter = false;
-    for (const auto &parameterInfo : FTy->getParameters()) {
-      if (parameterInfo.hasOption(SILParameterInfo::Isolated)) {
-        auto argType = parameterInfo.getArgumentType(F.getModule(),
-                                                     FTy,
-                                                     F.getTypeExpansionContext());
-        if (argType->isOptional())
-          argType = argType->lookThroughAllOptionalTypes()->getCanonicalType();
-
-        auto genericSig = FTy->getInvocationGenericSignature();
-        auto &ctx = F.getASTContext();
-        auto *actorProtocol = ctx.getProtocol(KnownProtocolKind::Actor);
-        auto *anyActorProtocol = ctx.getProtocol(KnownProtocolKind::AnyActor);
-        bool genericTypeWithActorRequirement = llvm::any_of(
-            genericSig.getRequirements(), [&](const Requirement &other) {
-              if (other.getKind() != RequirementKind::Conformance)
-                return false;
-              if (other.getFirstType()->getCanonicalType() != argType)
-                return false;
-              auto *otherProtocol = other.getProtocolDecl();
-              return otherProtocol->inheritsFrom(actorProtocol) ||
-                     otherProtocol->inheritsFrom(anyActorProtocol);
-            });
-        require(argType->isAnyActorType() || genericTypeWithActorRequirement,
-                "Only any actor types can be isolated");
-        require(!foundIsolatedParameter, "Two isolated parameters");
-        foundIsolatedParameter = true;
-      }
-    }
     require(1 >= std::count_if(FTy->getParameters().begin(), FTy->getParameters().end(),
                                [](const SILParameterInfo &parameterInfo) {
                                  return parameterInfo.hasOption(SILParameterInfo::Isolated);
@@ -7015,11 +6985,37 @@ public:
     }
   }
 
+  void verifyParentFunctionSILFunctionType(CanSILFunctionType FTy) {
+    bool foundIsolatedParameter = false;
+    for (const auto &parameterInfo : FTy->getParameters()) {
+      if (parameterInfo.hasOption(SILParameterInfo::Isolated)) {
+           auto argType = parameterInfo.getArgumentType(F.getModule(),
+                                                     FTy,
+                                                     F.getTypeExpansionContext());
+
+        if (argType->isOptional())
+          argType = argType->lookThroughAllOptionalTypes()->getCanonicalType();
+
+        auto genericSig = FTy->getInvocationGenericSignature();
+        auto &ctx = F.getASTContext();
+        auto *actorProtocol = ctx.getProtocol(KnownProtocolKind::Actor);
+        auto *anyActorProtocol = ctx.getProtocol(KnownProtocolKind::AnyActor);
+        require(argType->isAnyActorType() ||
+                    genericSig->requiresProtocol(argType, actorProtocol) ||
+                    genericSig->requiresProtocol(argType, anyActorProtocol),
+                "Only any actor types can be isolated");
+        require(!foundIsolatedParameter, "Two isolated parameters");
+        foundIsolatedParameter = true;
+      }
+    }
+  }
+
   void visitSILFunction(SILFunction *F) {
     PrettyStackTraceSILFunction stackTrace("verifying", F);
 
     CanSILFunctionType FTy = F->getLoweredFunctionType();
     verifySILFunctionType(FTy);
+    verifyParentFunctionSILFunctionType(FTy);
 
     SILModule &mod = F->getModule();
     bool embedded = mod.getASTContext().LangOpts.hasFeature(Feature::Embedded);

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -156,48 +156,38 @@ struct UseDefChainVisitor
         isMerge = true;
         break;
       case ProjectionKind::Enum: {
-        // Enum is never a merge since it always has a single tuple field... but
-        // it can be actor isolated.
-        if (!bool(actorIsolation)) {
-          auto *uedi = cast<UncheckedTakeEnumDataAddrInst>(inst);
-          auto i = getActorIsolation(uedi->getEnumDecl());
-          // If our operand decl is actor isolated, then we want to stop looking
-          // through since it is Sendable.
-          if (i.isActorIsolated()) {
-            actorIsolation = i;
-            return SILValue();
-          }
-        }
+        auto op = cast<UncheckedTakeEnumDataAddrInst>(inst)->getOperand();
+
+        // See if our operand type is a sendable type. In such a case, we do not
+        // want to look through our operand.
+        if (!isNonSendableType(op->getType(), op->getFunction()))
+          return SILValue();
+
         break;
       }
       case ProjectionKind::Tuple: {
         // These are merges if we have multiple fields.
-        auto *tti = cast<TupleElementAddrInst>(inst);
+        auto op = cast<TupleElementAddrInst>(inst)->getOperand();
 
-        // See if our result type is a sendable type. In such a case, we do not
-        // want to look through the tuple_element_addr since we do not want to
-        // identify the sendable type with the non-sendable operand. These we
-        // are always going to ignore anyways since a sendable let/var field of
-        // a struct can always be used.
-        if (!isNonSendableType(tti->getType(), tti->getFunction()))
+        if (!isNonSendableType(op->getType(), op->getFunction()))
           return SILValue();
 
-        isMerge |= tti->getOperand()->getType().getNumTupleElements() > 1;
+        isMerge |= op->getType().getNumTupleElements() > 1;
         break;
       }
       case ProjectionKind::Struct:
-        auto *sea = cast<StructElementAddrInst>(inst);
+        auto op = cast<StructElementAddrInst>(inst)->getOperand();
 
         // See if our result type is a sendable type. In such a case, we do not
         // want to look through the struct_element_addr since we do not want to
         // identify the sendable type with the non-sendable operand. These we
         // are always going to ignore anyways since a sendable let/var field of
         // a struct can always be used.
-        if (!isNonSendableType(sea->getType(), sea->getFunction()))
+        if (!isNonSendableType(op->getType(), op->getFunction()))
           return SILValue();
 
         // These are merges if we have multiple fields.
-        isMerge |= sea->getOperand()->getType().getNumNominalFields() > 1;
+        isMerge |= op->getType().getNumNominalFields() > 1;
         break;
       }
     }
@@ -1446,6 +1436,8 @@ public:
         LLVM_DEBUG(llvm::dbgs() << "    %%" << state->getID() << ": ";
                    state->print(llvm::dbgs()); llvm::dbgs() << *arg);
         nonSendableJoinedIndices.push_back(state->getID());
+      } else {
+        LLVM_DEBUG(llvm::dbgs() << "    Sendable: " << *arg);
       }
     }
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -124,7 +124,8 @@ struct UseDefChainVisitor
     // If this is a type case, see if the result of the cast is sendable. In
     // such a case, we do not want to look through this cast.
     if (castType == AccessStorageCast::Type &&
-        !isNonSendableType(cast->getType(), cast->getFunction()))
+        !SILIsolationInfo::isNonSendableType(cast->getType(),
+                                             cast->getFunction()))
       return SILValue();
 
     // If we do not have an identity cast, mark this as a merge.
@@ -160,7 +161,8 @@ struct UseDefChainVisitor
 
         // See if our operand type is a sendable type. In such a case, we do not
         // want to look through our operand.
-        if (!isNonSendableType(op->getType(), op->getFunction()))
+        if (!SILIsolationInfo::isNonSendableType(op->getType(),
+                                                 op->getFunction()))
           return SILValue();
 
         break;
@@ -169,7 +171,8 @@ struct UseDefChainVisitor
         // These are merges if we have multiple fields.
         auto op = cast<TupleElementAddrInst>(inst)->getOperand();
 
-        if (!isNonSendableType(op->getType(), op->getFunction()))
+        if (!SILIsolationInfo::isNonSendableType(op->getType(),
+                                                 op->getFunction()))
           return SILValue();
 
         isMerge |= op->getType().getNumTupleElements() > 1;
@@ -183,7 +186,8 @@ struct UseDefChainVisitor
         // identify the sendable type with the non-sendable operand. These we
         // are always going to ignore anyways since a sendable let/var field of
         // a struct can always be used.
-        if (!isNonSendableType(op->getType(), op->getFunction()))
+        if (!SILIsolationInfo::isNonSendableType(op->getType(),
+                                                 op->getFunction()))
           return SILValue();
 
         // These are merges if we have multiple fields.
@@ -314,21 +318,23 @@ static SILValue getUnderlyingTrackedObjectValue(SILValue value) {
       // If we have a cast and our operand and result are non-Sendable, treat it
       // as a look through.
       if (isLookThroughIfOperandAndResultNonSendable(svi)) {
-        if (isNonSendableType(svi->getType(), fn) &&
-            isNonSendableType(svi->getOperand(0)->getType(), fn)) {
+        if (SILIsolationInfo::isNonSendableType(svi->getType(), fn) &&
+            SILIsolationInfo::isNonSendableType(svi->getOperand(0)->getType(),
+                                                fn)) {
           temp = svi->getOperand(0);
         }
       }
 
       if (isLookThroughIfResultNonSendable(svi)) {
-        if (isNonSendableType(svi->getType(), fn)) {
+        if (SILIsolationInfo::isNonSendableType(svi->getType(), fn)) {
           temp = svi->getOperand(0);
         }
       }
 
       if (isLookThroughIfOperandNonSendable(svi)) {
         // If our operand is a non-Sendable type, look through this instruction.
-        if (isNonSendableType(svi->getOperand(0)->getType(), fn)) {
+        if (SILIsolationInfo::isNonSendableType(svi->getOperand(0)->getType(),
+                                                fn)) {
           temp = svi->getOperand(0);
         }
       }
@@ -1464,7 +1470,7 @@ private:
   /// NOTE: We special case RawPointer and NativeObject to ensure they are
   /// treated as non-Sendable and strict checking is applied to it.
   bool isNonSendableType(SILType type) const {
-    return ::isNonSendableType(type, function);
+    return SILIsolationInfo::isNonSendableType(type, function);
   }
 
   TrackableValue
@@ -2221,7 +2227,8 @@ public:
     case TranslationSemantics::AssertingIfNonSendable:
       // Do not error if all of our operands are sendable.
       if (llvm::none_of(inst->getOperandValues(), [&](SILValue value) {
-            return ::isNonSendableType(value->getType(), inst->getFunction());
+            return ::SILIsolationInfo::isNonSendableType(value->getType(),
+                                                         inst->getFunction());
           }))
         return;
       llvm::errs() << "BadInst: " << *inst;
@@ -3241,11 +3248,18 @@ TrackableValue RegionAnalysisValueMap::getTrackableValue(
     // If we were able to find this was actor isolated from finding our
     // underlying object, use that. It is never wrong.
     if (info.actorIsolation) {
-      SILValue actorInstance =
-          info.value->getType().isAnyActor() ? info.value : SILValue();
-      iter.first->getSecond().mergeIsolationRegionInfo(
-          SILIsolationInfo::getActorIsolated(value, actorInstance,
-                                             *info.actorIsolation));
+      SILIsolationInfo isolation;
+      if (info.value->getType().isAnyActor()) {
+        isolation = SILIsolationInfo::getActorInstanceIsolated(
+            value, info.value, info.actorIsolation->getActor());
+      } else if (info.actorIsolation->isGlobalActor()) {
+        isolation = SILIsolationInfo::getGlobalActorIsolated(
+            value, info.actorIsolation->getGlobalActor());
+      }
+
+      if (isolation) {
+        iter.first->getSecond().mergeIsolationRegionInfo(isolation);
+      }
     }
 
     auto storage = AccessStorageWithBase::compute(value);
@@ -3277,7 +3291,7 @@ TrackableValue RegionAnalysisValueMap::getTrackableValue(
   }
 
   // Otherwise refer to the oracle. If we have a Sendable value, just return.
-  if (!isNonSendableType(value->getType(), fn)) {
+  if (!SILIsolationInfo::isNonSendableType(value->getType(), fn)) {
     iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
     return {iter.first->first, iter.first->second};
   }
@@ -3295,8 +3309,9 @@ TrackableValue RegionAnalysisValueMap::getTrackableValue(
     auto parentAddrInfo = getUnderlyingTrackedValue(svi);
     if (parentAddrInfo.actorIsolation) {
       iter.first->getSecond().mergeIsolationRegionInfo(
-          SILIsolationInfo::getActorIsolated(svi, parentAddrInfo.value,
-                                             *parentAddrInfo.actorIsolation));
+          SILIsolationInfo::getActorInstanceIsolated(
+              svi, parentAddrInfo.value,
+              parentAddrInfo.actorIsolation->getActor()));
     }
 
     auto storage = AccessStorageWithBase::compute(svi->getOperand(0));

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -188,17 +188,6 @@ struct UseDefChainVisitor
       case ProjectionKind::Struct:
         auto *sea = cast<StructElementAddrInst>(inst);
 
-        // See if our type is actor isolated.
-        if (!bool(actorIsolation)) {
-          auto i = getActorIsolation(sea->getStructDecl());
-          // If our parent type is actor isolated then we do not want to keep on
-          // walking up from use->def since the value is considered Sendable.
-          if (i.isActorIsolated()) {
-            actorIsolation = i;
-            return SILValue();
-          }
-        }
-
         // See if our result type is a sendable type. In such a case, we do not
         // want to look through the struct_element_addr since we do not want to
         // identify the sendable type with the non-sendable operand. These we

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -1466,8 +1466,8 @@ struct DiagnosticEvaluator final
     if (auto *svi =
             dyn_cast<SingleValueInstruction>(partitionOp.getSourceInst())) {
       if (isa<TupleElementAddrInst, StructElementAddrInst>(svi) &&
-          !regionanalysisimpl::isNonSendableType(svi->getType(),
-                                                 svi->getFunction())) {
+          !SILIsolationInfo::isNonSendableType(svi->getType(),
+                                               svi->getFunction())) {
         bool isCapture = operandState.isClosureCaptured;
         if (!isCapture) {
           return;

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -243,10 +243,21 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
                                               sei->getStructDecl());
   }
 
+  if (auto *seai = dyn_cast<StructElementAddrInst>(inst)) {
+    return SILIsolationInfo::getActorIsolated(seai, SILValue(),
+                                              seai->getStructDecl());
+  }
+
   // See if we have an unchecked_enum_data from a global actor isolated type.
   if (auto *uedi = dyn_cast<UncheckedEnumDataInst>(inst)) {
     return SILIsolationInfo::getActorIsolated(uedi, SILValue(),
                                               uedi->getEnumDecl());
+  }
+
+  // See if we have an unchecked_enum_data from a global actor isolated type.
+  if (auto *utedi = dyn_cast<UncheckedTakeEnumDataAddrInst>(inst)) {
+    return SILIsolationInfo::getActorIsolated(utedi, SILValue(),
+                                              utedi->getEnumDecl());
   }
 
   // Check if we have an unsafeMutableAddressor from a global actor, mark the

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -105,11 +105,8 @@ static DeclRefExpr *getDeclRefExprFromExpr(Expr *expr) {
 SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   if (auto fas = FullApplySite::isa(inst)) {
     if (auto crossing = fas.getIsolationCrossing()) {
-      if (crossing->getCalleeIsolation().isActorIsolated()) {
-        // SIL level, just let it through
-        return SILIsolationInfo::getActorIsolated(
-            SILValue(), SILValue(), crossing->getCalleeIsolation());
-      }
+      if (auto info = SILIsolationInfo::getWithIsolationCrossing(*crossing))
+        return info;
     }
 
     if (fas.hasSelfArgument()) {
@@ -118,8 +115,11 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
               SILParameterInfo::Isolated)) {
         if (auto *nomDecl =
                 self.get()->getType().getNominalOrBoundGenericNominal()) {
-          return SILIsolationInfo::getActorIsolated(SILValue(), self.get(),
-                                                    nomDecl);
+          // TODO: We really should be doing this based off of an Operand. Then
+          // we would get the SILValue() for the first element. Today this can
+          // only mess up isolation history.
+          return SILIsolationInfo::getActorInstanceIsolated(
+              SILValue(), self.get(), nomDecl);
         }
       }
     }
@@ -128,21 +128,44 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   if (auto *pai = dyn_cast<PartialApplyInst>(inst)) {
     if (auto *ace = pai->getLoc().getAsASTNode<AbstractClosureExpr>()) {
       auto actorIsolation = ace->getActorIsolation();
-      SILValue actorInstance;
-      if (actorIsolation.isActorIsolated()) {
-        if (actorIsolation.getKind() == ActorIsolation::ActorInstance) {
-          ApplySite as(pai);
-          for (auto &op : as.getArgumentOperands()) {
-            if (as.getArgumentParameterInfo(op).hasOption(
-                    SILParameterInfo::Isolated)) {
-              actorInstance = op.get();
-              break;
-            }
+
+      if (actorIsolation.isGlobalActor()) {
+        return SILIsolationInfo::getGlobalActorIsolated(
+            pai, actorIsolation.getGlobalActor());
+      }
+
+      if (actorIsolation.isActorInstanceIsolated()) {
+        ApplySite as(pai);
+        SILValue actorInstance;
+        for (auto &op : as.getArgumentOperands()) {
+          if (as.getArgumentParameterInfo(op).hasOption(
+                  SILParameterInfo::Isolated)) {
+            actorInstance = op.get();
+            break;
           }
         }
-        return SILIsolationInfo::getActorIsolated(pai, actorInstance,
-                                                  actorIsolation);
+
+        if (actorInstance) {
+          return SILIsolationInfo::getActorInstanceIsolated(
+              pai, actorInstance, actorIsolation.getActor());
+        }
+
+        // For now, if we do not have an actor instance, just create an actor
+        // instance isolated without an actor instance.
+        //
+        // If we do not have an actor instance, that means that we have a
+        // partial apply for which the isolated parameter was not closed over
+        // and is an actual argument that we pass in. This means that the
+        // partial apply is actually flow sensitive in terms of which specific
+        // actor instance we are isolated to.
+        //
+        // TODO: How do we want to resolve this.
+        return SILIsolationInfo::getPartialApplyActorInstanceIsolated(
+            pai, actorIsolation.getActor());
       }
+
+      assert(actorIsolation.getKind() != ActorIsolation::Erased &&
+             "Implement this!");
     }
   }
 
@@ -153,9 +176,16 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   if (auto *rei = dyn_cast<RefElementAddrInst>(inst)) {
     auto *nomDecl =
         rei->getOperand()->getType().getNominalOrBoundGenericNominal();
-    SILValue actorInstance =
-        nomDecl->isAnyActor() ? rei->getOperand() : SILValue();
-    return SILIsolationInfo::getActorIsolated(rei, actorInstance, nomDecl);
+
+    if (nomDecl->isAnyActor())
+      return SILIsolationInfo::getActorInstanceIsolated(rei, rei->getOperand(),
+                                                        nomDecl);
+
+    if (auto isolation = swift::getActorIsolation(nomDecl)) {
+      assert(isolation.isGlobalActor());
+      return SILIsolationInfo::getGlobalActorIsolated(
+          rei, isolation.getGlobalActor());
+    }
   }
 
   // Check if we have a global_addr inst.
@@ -164,7 +194,8 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       if (auto *globalDecl = global->getDecl()) {
         auto isolation = swift::getActorIsolation(globalDecl);
         if (isolation.isGlobalActor()) {
-          return SILIsolationInfo::getActorIsolated(ga, SILValue(), isolation);
+          return SILIsolationInfo::getGlobalActorIsolated(
+              ga, isolation.getGlobalActor());
         }
       }
     }
@@ -173,10 +204,24 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   // Treat function ref as either actor isolated or sendable.
   if (auto *fri = dyn_cast<FunctionRefInst>(inst)) {
     auto isolation = fri->getReferencedFunction()->getActorIsolation();
-    if (isolation.isActorIsolated() &&
-        (isolation.getKind() != ActorIsolation::ActorInstance ||
-         isolation.getActorInstanceParameter() == 0)) {
-      return SILIsolationInfo::getActorIsolated(fri, SILValue(), isolation);
+    if (isolation.isActorIsolated()) {
+      if (isolation.isGlobalActor()) {
+        return SILIsolationInfo::getGlobalActorIsolated(
+            fri, isolation.getGlobalActor());
+      }
+
+      // TODO: We need to be able to support flow sensitive actor instances like
+      // we do for partial apply. Until we do so, just store SILValue() for
+      // this. This could cause a problem if we can construct a function ref and
+      // invoke it with two different actor instances of the same type and pass
+      // in the same parameters to both. We should error and we would not with
+      // this impl since we could not distinguish the two.
+      if (isolation.getKind() == ActorIsolation::ActorInstance) {
+        return SILIsolationInfo::getFlowSensitiveActorIsolated(fri, isolation);
+      }
+
+      assert(isolation.getKind() != ActorIsolation::Erased &&
+             "Implement this!");
     }
 
     // Otherwise, lets look at the AST and see if our function ref is from an
@@ -185,18 +230,16 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       if (auto *funcType = autoclosure->getType()->getAs<AnyFunctionType>()) {
         if (funcType->hasGlobalActor()) {
           if (funcType->hasGlobalActor()) {
-            return SILIsolationInfo::getActorIsolated(
-                fri, SILValue(),
-                ActorIsolation::forGlobalActor(funcType->getGlobalActor()));
+            return SILIsolationInfo::getGlobalActorIsolated(
+                fri, funcType->getGlobalActor());
           }
         }
 
         if (auto *resultFType =
                 funcType->getResult()->getAs<AnyFunctionType>()) {
           if (resultFType->hasGlobalActor()) {
-            return SILIsolationInfo::getActorIsolated(
-                fri, SILValue(),
-                ActorIsolation::forGlobalActor(resultFType->getGlobalActor()));
+            return SILIsolationInfo::getGlobalActorIsolated(
+                fri, resultFType->getGlobalActor());
           }
         }
       }
@@ -214,10 +257,15 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
           if (isolation.isActorIsolated() &&
               (isolation.getKind() != ActorIsolation::ActorInstance ||
                isolation.getActorInstanceParameter() == 0)) {
-            auto actor = cmi->getOperand()->getType().isAnyActor()
-                             ? cmi->getOperand()
-                             : SILValue();
-            return SILIsolationInfo::getActorIsolated(cmi, actor, isolation);
+            if (cmi->getOperand()->getType().isAnyActor()) {
+              return SILIsolationInfo::getActorInstanceIsolated(
+                  cmi, cmi->getOperand(),
+                  cmi->getOperand()
+                      ->getType()
+                      .getNominalOrBoundGenericNominal());
+            }
+            return SILIsolationInfo::getGlobalActorIsolated(
+                cmi, isolation.getGlobalActor());
           }
         }
 
@@ -226,10 +274,15 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
             if (isolation.isActorIsolated() &&
                 (isolation.getKind() != ActorIsolation::ActorInstance ||
                  isolation.getActorInstanceParameter() == 0)) {
-              auto actor = cmi->getOperand()->getType().isAnyActor()
-                               ? cmi->getOperand()
-                               : SILValue();
-              return SILIsolationInfo::getActorIsolated(cmi, actor, isolation);
+              if (cmi->getOperand()->getType().isAnyActor()) {
+                return SILIsolationInfo::getActorInstanceIsolated(
+                    cmi, cmi->getOperand(),
+                    cmi->getOperand()
+                        ->getType()
+                        .getNominalOrBoundGenericNominal());
+              }
+              return SILIsolationInfo::getGlobalActorIsolated(
+                  cmi, isolation.getGlobalActor());
             }
           }
         }
@@ -239,25 +292,23 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
 
   // See if we have a struct_extract from a global actor isolated type.
   if (auto *sei = dyn_cast<StructExtractInst>(inst)) {
-    return SILIsolationInfo::getActorIsolated(sei, SILValue(),
-                                              sei->getStructDecl());
+    return SILIsolationInfo::getGlobalActorIsolated(sei, sei->getStructDecl());
   }
 
   if (auto *seai = dyn_cast<StructElementAddrInst>(inst)) {
-    return SILIsolationInfo::getActorIsolated(seai, SILValue(),
-                                              seai->getStructDecl());
+    return SILIsolationInfo::getGlobalActorIsolated(seai,
+                                                    seai->getStructDecl());
   }
 
   // See if we have an unchecked_enum_data from a global actor isolated type.
   if (auto *uedi = dyn_cast<UncheckedEnumDataInst>(inst)) {
-    return SILIsolationInfo::getActorIsolated(uedi, SILValue(),
-                                              uedi->getEnumDecl());
+    return SILIsolationInfo::getGlobalActorIsolated(uedi, uedi->getEnumDecl());
   }
 
   // See if we have an unchecked_enum_data from a global actor isolated type.
   if (auto *utedi = dyn_cast<UncheckedTakeEnumDataAddrInst>(inst)) {
-    return SILIsolationInfo::getActorIsolated(utedi, SILValue(),
-                                              utedi->getEnumDecl());
+    return SILIsolationInfo::getGlobalActorIsolated(utedi,
+                                                    utedi->getEnumDecl());
   }
 
   // Check if we have an unsafeMutableAddressor from a global actor, mark the
@@ -267,8 +318,8 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       if (calleeFunction->isGlobalInit()) {
         auto isolation = getGlobalActorInitIsolation(calleeFunction);
         if (isolation && isolation->isGlobalActor()) {
-          return SILIsolationInfo::getActorIsolated(applySite, SILValue(),
-                                                    *isolation);
+          return SILIsolationInfo::getGlobalActorIsolated(
+              applySite, isolation->getGlobalActor());
         }
       }
     }
@@ -324,13 +375,10 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   // of the actor.
   if (ApplyExpr *apply = inst->getLoc().getAsASTNode<ApplyExpr>()) {
     if (auto crossing = apply->getIsolationCrossing()) {
-      auto calleeIsolation = crossing->getCalleeIsolation();
-      if (calleeIsolation.isActorIsolated()) {
-        return SILIsolationInfo::getActorIsolated(
-            SILValue(), SILValue(), crossing->getCalleeIsolation());
-      }
+      if (auto info = SILIsolationInfo::getWithIsolationCrossing(*crossing))
+        return info;
 
-      if (calleeIsolation.isNonisolated()) {
+      if (crossing->getCalleeIsolation().isNonisolated()) {
         return SILIsolationInfo::getDisconnected();
       }
     }
@@ -340,13 +388,17 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
 }
 
 SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
+  // Return early if we do not have a non-Sendable type.
+  if (!SILIsolationInfo::isNonSendableType(arg->getType(), arg->getFunction()))
+    return {};
+
   // Handle a switch_enum from a global actor isolated type.
   if (auto *phiArg = dyn_cast<SILPhiArgument>(arg)) {
     if (auto *singleTerm = phiArg->getSingleTerminator()) {
       if (auto *swi = dyn_cast<SwitchEnumInst>(singleTerm)) {
         auto enumDecl =
             swi->getOperand()->getType().getEnumOrBoundGenericEnum();
-        return SILIsolationInfo::getActorIsolated(arg, SILValue(), enumDecl);
+        return SILIsolationInfo::getGlobalActorIsolated(arg, enumDecl);
       }
     }
     return SILIsolationInfo();
@@ -361,28 +413,41 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
        fArg->isTransferring()))
     return SILIsolationInfo::getDisconnected();
 
-  // If we have self and our function is actor isolated, all of our arguments
-  // should be marked as actor isolated.
-  if (auto *self = fArg->getFunction()->maybeGetSelfArgument()) {
+  // Before we do anything further, see if we have an isolated parameter. This
+  // handles isolated self and specifically marked isolated.
+  if (auto *isolatedArg = fArg->getFunction()->maybeGetIsolatedArgument()) {
     if (auto functionIsolation = fArg->getFunction()->getActorIsolation()) {
-      if (functionIsolation.isActorIsolated()) {
-        if (auto *nomDecl = self->getType().getNominalOrBoundGenericNominal()) {
-          return SILIsolationInfo::getActorIsolated(fArg, SILValue(), nomDecl);
-        }
+      assert(functionIsolation.isActorInstanceIsolated());
+      if (auto *nomDecl =
+              isolatedArg->getType().getNominalOrBoundGenericNominal()) {
+        return SILIsolationInfo::getActorInstanceIsolated(fArg, isolatedArg,
+                                                          nomDecl);
       }
     }
   }
 
-  if (auto *decl = fArg->getDecl()) {
-    auto isolation = swift::getActorIsolation(const_cast<ValueDecl *>(decl));
-    if (!bool(isolation)) {
-      if (auto *dc = decl->getDeclContext()) {
-        isolation = swift::getActorIsolationOfContext(dc);
+  // Otherwise, see if we have an allocator decl ref. If we do and we have an
+  // actor instance isolation, then we know that we are actively just calling
+  // the initializer. To just make region isolation work, treat this as
+  // disconnected so we can construct the actor value. Users cannot write
+  // allocator functions so we just need to worry about compiler generated
+  // code. In the case of a non-actor, we can only have an allocator that is
+  // global actor isolated, so we will never hit this code path.
+  if (auto declRef = fArg->getFunction()->getDeclRef()) {
+    if (declRef.kind == SILDeclRef::Kind::Allocator) {
+      if (fArg->getFunction()->getActorIsolation().isActorInstanceIsolated()) {
+        return SILIsolationInfo::getDisconnected();
       }
     }
+  }
 
-    if (isolation.isActorIsolated()) {
-      return SILIsolationInfo::getActorIsolated(fArg, SILValue(), isolation);
+  // Otherwise, if we do not have an isolated argument and are not in an
+  // alloactor, then we might be isolated via global isolation.
+  if (auto functionIsolation = fArg->getFunction()->getActorIsolation()) {
+    if (functionIsolation.isActorIsolated()) {
+      assert(functionIsolation.isGlobalActor());
+      return SILIsolationInfo::getGlobalActorIsolated(
+          fArg, functionIsolation.getGlobalActor());
     }
   }
 
@@ -534,6 +599,27 @@ void SILIsolationInfo::printForDiagnostics(llvm::raw_ostream &os) const {
     os << "task-isolated";
     return;
   }
+}
+
+// Check if the passed in type is NonSendable.
+//
+// NOTE: We special case RawPointer and NativeObject to ensure they are
+// treated as non-Sendable and strict checking is applied to it.
+bool SILIsolationInfo::isNonSendableType(SILType type, SILFunction *fn) {
+  // Treat Builtin.NativeObject and Builtin.RawPointer as non-Sendable.
+  if (type.getASTType()->is<BuiltinNativeObjectType>() ||
+      type.getASTType()->is<BuiltinRawPointerType>()) {
+    return true;
+  }
+
+  // Treat Builtin.SILToken as Sendable. It cannot escape from the current
+  // function. We should change isSendable to hardwire this.
+  if (type.getASTType()->is<SILTokenType>()) {
+    return false;
+  }
+
+  // Otherwise, delegate to seeing if type conforms to the Sendable protocol.
+  return !type.isSendable(fn);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -416,13 +416,10 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   // Before we do anything further, see if we have an isolated parameter. This
   // handles isolated self and specifically marked isolated.
   if (auto *isolatedArg = fArg->getFunction()->maybeGetIsolatedArgument()) {
-    if (auto functionIsolation = fArg->getFunction()->getActorIsolation()) {
-      assert(functionIsolation.isActorInstanceIsolated());
-      if (auto *nomDecl =
-              isolatedArg->getType().getNominalOrBoundGenericNominal()) {
-        return SILIsolationInfo::getActorInstanceIsolated(fArg, isolatedArg,
-                                                          nomDecl);
-      }
+    if (auto *nomDecl =
+        isolatedArg->getType().getNominalOrBoundGenericNominal()) {
+      return SILIsolationInfo::getActorInstanceIsolated(fArg, isolatedArg,
+                                                        nomDecl);
     }
   }
 

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -398,10 +398,26 @@ void SILIsolationInfo::print(llvm::raw_ostream &os) const {
     os << "disconnected";
     return;
   case Actor:
-    os << "actor";
+    if (SILValue instance = getActorInstance()) {
+      if (auto name = VariableNameInferrer::inferName(instance)) {
+        os << "'" << *name << "'-isolated\n";
+        os << "instance: " << *instance;
+        return;
+      }
+    }
+
+    if (getActorIsolation().getKind() == ActorIsolation::ActorInstance) {
+      if (auto *vd = getActorIsolation().getActorInstance()) {
+        os << "'" << vd->getBaseIdentifier() << "'-isolated";
+        return;
+      }
+    }
+
+    getActorIsolation().printForDiagnostics(os);
     return;
   case Task:
-    os << "task";
+    os << "task-isolated\n";
+    os << "instance: " << *getIsolatedValue();
     return;
   }
 }

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -113,8 +113,9 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       auto &self = fas.getSelfArgumentOperand();
       if (fas.getArgumentParameterInfo(self).hasOption(
               SILParameterInfo::Isolated)) {
+        CanType astType = self.get()->getType().getASTType();
         if (auto *nomDecl =
-                self.get()->getType().getNominalOrBoundGenericNominal()) {
+                astType->lookThroughAllOptionalTypes()->getAnyActor()) {
           // TODO: We really should be doing this based off of an Operand. Then
           // we would get the SILValue() for the first element. Today this can
           // only mess up isolation history.
@@ -416,8 +417,8 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   // Before we do anything further, see if we have an isolated parameter. This
   // handles isolated self and specifically marked isolated.
   if (auto *isolatedArg = fArg->getFunction()->maybeGetIsolatedArgument()) {
-    if (auto *nomDecl =
-        isolatedArg->getType().getNominalOrBoundGenericNominal()) {
+    auto astType = isolatedArg->getType().getASTType();
+    if (auto *nomDecl = astType->lookThroughAllOptionalTypes()->getAnyActor()) {
       return SILIsolationInfo::getActorInstanceIsolated(fArg, isolatedArg,
                                                         nomDecl);
     }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -2,8 +2,8 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature GlobalActorIsolatedTypesUsability %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature GlobalActorIsolatedTypesUsability %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature GlobalActorIsolatedTypesUsability %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature GlobalActorIsolatedTypesUsability %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 -emit-sil -o /dev/null -verify -enable-experimental-feature GlobalActorIsolatedTypesUsability %s
+// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 -emit-sil -o /dev/null -verify -enable-upcoming-feature GlobalActorIsolatedTypesUsability %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/derived_conformances_nonisolated.swift
+++ b/test/Concurrency/derived_conformances_nonisolated.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -812,26 +812,6 @@ func testActorWithInitAccessorInit() {
       print(a) // Ok (nonisolated)
     }
   }
-
-  class NonSendableKlass {
-    init(_ x: NonSendableKlass? = nil) {
-
-    }
-  }
-  
-  @available(SwiftStdlib 5.1, *)
-  actor NonSendableInit {
-    var first: NonSendableKlass
-    var second: NonSendableKlass? = nil {
-      @storageRestrictions(initializes: first)
-      init(initialValue)  {
-        first = initialValue!
-      }
-
-      get { fatalError() }
-      set { fatalError() }
-    }
-  }
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -812,6 +812,26 @@ func testActorWithInitAccessorInit() {
       print(a) // Ok (nonisolated)
     }
   }
+
+  class NonSendableKlass {
+    init(_ x: NonSendableKlass? = nil) {
+
+    }
+  }
+  
+  @available(SwiftStdlib 5.1, *)
+  actor NonSendableInit {
+    var first: NonSendableKlass
+    var second: NonSendableKlass? = nil {
+      @storageRestrictions(initializes: first)
+      init(initialValue)  {
+        first = initialValue!
+      }
+
+      get { fatalError() }
+      set { fatalError() }
+    }
+  }
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -strict-concurrency=complete %S/Inputs/other_global_actor_inference.swift -enable-experimental-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted- -enable-experimental-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix minimal-targeted- -enable-experimental-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns- -enable-experimental-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -verify-additional-prefix complete-tns- -enable-experimental-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -strict-concurrency=complete %S/Inputs/other_global_actor_inference.swift -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted- -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix minimal-targeted- -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns- -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -verify-additional-prefix complete-tns- -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -2,8 +2,7 @@
 
 // RUN: %target-swift-frontend -swift-version 6 -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -strict-concurrency=complete %S/Inputs/other_global_actor_inference.swift
 
-// RUN: %target-swift-frontend -swift-version 6 -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -enable-experimental-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -swift-version 6 -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -enable-experimental-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -swift-version 6 -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 

--- a/test/Concurrency/global_actor_sendable_fn_type_inference.swift
+++ b/test/Concurrency/global_actor_sendable_fn_type_inference.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -disable-availability-checking -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -disable-availability-checking -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -27,7 +27,7 @@ func testInAsync(x: X) async {
   let _: Int = unsafelySendableClosure // expected-error{{type '@Sendable (@Sendable () -> Void) -> ()'}}
   let _: Int = unsafelyMainActorClosure // expected-error{{type '@Sendable (@MainActor () -> Void) -> ()'}}
   let _: Int = unsafelyDoEverythingClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
-  let _: Int = x.unsafelyDoEverythingClosure // expected-error{{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  let _: Int = x.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = X.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (X) -> @Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
 
@@ -42,7 +42,7 @@ func testElsewhere(x: X) {
   let _: Int = unsafelySendableClosure // expected-error{{type '@Sendable (@Sendable () -> Void) -> ()'}}
   let _: Int = unsafelyMainActorClosure // expected-error{{type '@Sendable (@MainActor () -> Void) -> ()'}}
   let _: Int = unsafelyDoEverythingClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
-  let _: Int = x.unsafelyDoEverythingClosure // expected-error{{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  let _: Int = x.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = X.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (X) -> @Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -97,7 +97,7 @@ public actor MyActor: MyProto {
   func g(ns1: NS1) async {
     await nonisolatedAsyncFunc1(ns1) // expected-targeted-and-complete-warning{{passing argument of non-sendable type 'NS1' outside of actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{sending 'ns1' risks causing data races}}
-    // expected-tns-note @-2 {{sending actor-isolated 'ns1' to nonisolated global function 'nonisolatedAsyncFunc1' risks causing data races between nonisolated and actor-isolated uses}}
+    // expected-tns-note @-2 {{sending 'self'-isolated 'ns1' to nonisolated global function 'nonisolatedAsyncFunc1' risks causing data races between nonisolated and 'self'-isolated uses}}
     _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable type 'NS1' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary}}
   }
 }

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-upcoming-feature InferSendableFromCaptures -strict-concurrency=complete -enable-experimental-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature InferSendableFromCaptures -strict-concurrency=complete -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -15,10 +15,14 @@
 ////////////////////////
 
 /// Classes are always non-sendable, so this is non-sendable
-class NonSendableKlass { // expected-complete-note 46{{}}
+class NonSendableKlass { // expected-complete-note 48{{}}
   // expected-typechecker-only-note @-1 4{{}}
   // expected-tns-note @-2 2{{}}
   var field: NonSendableKlass? = nil
+
+  init() {}
+  init(_ x: NonSendableKlass) {
+  }
 
   func asyncCall() async {}
   func asyncCallWithIsolatedParameter(isolation: isolated (any Actor)? = #isolation) async {
@@ -626,7 +630,7 @@ func singleFieldVarMergeTest() async {
   await transferToMain(box) // expected-tns-warning {{sending 'box' risks causing data races}}
   // expected-tns-note @-1 {{sending 'box' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
-  
+
 
   // But if we use box.k here, we emit an error since we didn't reinitialize at
   // all.
@@ -641,7 +645,7 @@ func multipleFieldVarMergeTest1() async {
   await transferToMain(box.k1) // expected-tns-warning {{sending 'box.k1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'box.k1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  
+
 
   // So even if we reassign over k1, since we did a merge, this should error.
   box.k1 = NonSendableKlass() // expected-tns-note {{access can happen concurrently}}
@@ -727,7 +731,7 @@ class ClassFieldTests { // expected-complete-note 6{{}}
   let letNonSendableNonTrivial = NonSendableKlass()
   var varSendableTrivial = 0
   var varSendableNonTrivial = SendableKlass()
-  var varNonSendableNonTrivial = NonSendableKlass()  
+  var varNonSendableNonTrivial = NonSendableKlass()
 }
 
 func letSendableTrivialClassFieldTest() async {
@@ -795,7 +799,7 @@ final class FinalClassFieldTests { // expected-complete-note 6 {{}}
   let letNonSendableNonTrivial = NonSendableKlass()
   var varSendableTrivial = 0
   var varSendableNonTrivial = SendableKlass()
-  var varNonSendableNonTrivial = NonSendableKlass()  
+  var varNonSendableNonTrivial = NonSendableKlass()
 }
 
 func letSendableTrivialFinalClassFieldTest() async {
@@ -862,7 +866,7 @@ struct StructFieldTests { // expected-complete-note 31 {{}}
   let letNonSendableNonTrivial = NonSendableKlass()
   var varSendableTrivial = 0
   var varSendableNonTrivial = SendableKlass()
-  var varNonSendableNonTrivial = NonSendableKlass()  
+  var varNonSendableNonTrivial = NonSendableKlass()
 }
 
 func letSendableTrivialLetStructFieldTest() async {
@@ -1343,7 +1347,7 @@ func varNonSendableNonTrivialLetTupleFieldTest() async {
 }
 
 func varSendableTrivialVarTupleFieldTest() async {
-  var test = (0, SendableKlass(), NonSendableKlass()) 
+  var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -1353,7 +1357,7 @@ func varSendableTrivialVarTupleFieldTest() async {
 }
 
 func varSendableTrivialVarTupleFieldTest2() async {
-  var test = (0, SendableKlass(), NonSendableKlass()) 
+  var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test.2) // expected-tns-warning {{sending 'test.2' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test.2' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -1363,7 +1367,7 @@ func varSendableTrivialVarTupleFieldTest2() async {
 }
 
 func varSendableNonTrivialVarTupleFieldTest() async {
-  var test = (0, SendableKlass(), NonSendableKlass()) 
+  var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -1373,7 +1377,7 @@ func varSendableNonTrivialVarTupleFieldTest() async {
 }
 
 func varNonSendableNonTrivialVarTupleFieldTest() async {
-  var test = (0, SendableKlass(), NonSendableKlass()) 
+  var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -1458,7 +1462,7 @@ actor ActorWithSetter {
     self.twoFieldBoxInTuple.1.k1 = x
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}    
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   // This triggers a crash in SILGen with tns enabled.
@@ -1645,4 +1649,52 @@ extension MyActor {
       // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     }
   }
+}
+
+func initAccessorTests() {
+  @available(SwiftStdlib 5.1, *)
+  actor NonisolatedAccessors {
+    nonisolated var a: Int = 0 {
+      init {
+      }
+
+      get { 0 }
+      set {}
+    }
+
+    init(value: Int) {
+      let escapingSelf: (NonisolatedAccessors) -> Void = { _ in }
+
+      // a is initialized here via default value
+
+      escapingSelf(self)
+
+      self.a = value // Ok (nonisolated)
+      print(a) // Ok (nonisolated)
+    }
+  }
+
+  @available(SwiftStdlib 5.1, *)
+  actor NonSendableInit {
+    var first: NonSendableKlass
+    var second: NonSendableKlass? = nil {
+      @storageRestrictions(initializes: first)
+      init(initialValue)  {
+        first = initialValue!
+      }
+
+      get { fatalError() }
+      set { fatalError() }
+    }
+  }
+}
+
+func differentInstanceTest(_ a: MyActor, _ b: MyActor) async {
+  let x = NonSendableKlass()
+  await a.useKlass(x)
+  // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
+  // expected-tns-note @-2 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+  await b.useKlass(x) // expected-tns-note {{access can happen concurrently}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -596,7 +596,7 @@ func testSendableClosureCapturesNonSendable(a: MyActor) {
 func testSendableClosureCapturesNonSendable2(a: FinalMainActorIsolatedKlass) {
   let klass = NonSendableKlass()
   let _ = { @Sendable @MainActor in
-    a.klass = klass // expected-warning {{capture of 'klass' with non-sendable type 'NonSendableKlass' in a `@Sendable` closure}}
+    a.klass = klass // expected-complete-warning {{capture of 'klass' with non-sendable type 'NonSendableKlass' in a `@Sendable` closure}}
   }
 }
 
@@ -1710,4 +1710,14 @@ func associatedTypeTestBasic2<T: AssociatedTypeTestProtocol>(_: T, iso: isolated
   await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'iso'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'iso'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+}
+
+func sendableGlobalActorIsolated() {
+  let x = NonSendableKlass()
+  let _ = { @Sendable @MainActor in
+    print(x) // expected-tns-warning {{sending 'x' risks causing data races}}
+    // expected-tns-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in a `@Sendable` closure}}
+  }
+  print(x) // expected-tns-note {{access can happen concurrently}}
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -15,7 +15,7 @@
 ////////////////////////
 
 /// Classes are always non-sendable, so this is non-sendable
-class NonSendableKlass { // expected-complete-note 48{{}}
+class NonSendableKlass { // expected-complete-note 49{{}}
   // expected-typechecker-only-note @-1 4{{}}
   // expected-tns-note @-2 2{{}}
   var field: NonSendableKlass? = nil
@@ -1697,4 +1697,17 @@ func differentInstanceTest(_ a: MyActor, _ b: MyActor) async {
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   await b.useKlass(x) // expected-tns-note {{access can happen concurrently}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+}
+
+protocol AssociatedTypeTestProtocol {
+  associatedtype A: Actor
+}
+
+func associatedTypeTestBasic<T: AssociatedTypeTestProtocol>(_: T, _: isolated T.A) {
+}
+
+func associatedTypeTestBasic2<T: AssociatedTypeTestProtocol>(_: T, iso: isolated T.A, x: NonSendableKlass) async {
+  await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'iso'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'iso'-isolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null -disable-region-based-isolation-with-strict-concurrency
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null -disable-region-based-isolation-with-strict-concurrency -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_crashers_objc.swift
+++ b/test/Concurrency/transfernonsendable_crashers_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -disable-availability-checking %s -o /dev/null -import-objc-header %S/Inputs/transfernonsendable_crashers_objc.h
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -disable-availability-checking %s -o /dev/null -import-objc-header %S/Inputs/transfernonsendable_crashers_objc.h -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: objc_interop
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_defer_and_typecheck_only.swift
+++ b/test/Concurrency/transfernonsendable_defer_and_typecheck_only.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null -parse-as-library -disable-region-based-isolation-with-strict-concurrency
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null -parse-as-library
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null -parse-as-library -disable-region-based-isolation-with-strict-concurrency -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -211,7 +211,7 @@ struct Clock {
     // nonisolated instead of custom actor isolated.
     print(ns) // expected-tns-warning {{sending 'ns' risks causing data races}}
     // expected-tns-note @-1 {{global actor 'CustomActor'-isolated 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
-    // expected-complete-warning @-2 {{capture of 'ns' with non-sendable type 'NonSendableKlass' in an isolated closure}}
+    // expected-complete-warning @-2 {{capture of 'ns' with non-sendable type 'NonSendableKlass' in a `@Sendable` closure}}
   }
 
   useValue(ns)

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -30,6 +30,31 @@ var booleanFlag: Bool { false }
 @MainActor var mainActorIsolatedGlobal = NonSendableKlass()
 @CustomActor var customActorIsolatedGlobal = NonSendableKlass()
 
+@MainActor
+class NonSendableGlobalActorIsolatedKlass {}
+
+@available(*, unavailable)
+extension NonSendableGlobalActorIsolatedKlass: Sendable {}
+
+@MainActor
+struct NonSendableGlobalActorIsolatedStruct {
+  var k = NonSendableKlass()
+}
+
+@available(*, unavailable)
+extension NonSendableGlobalActorIsolatedStruct: Sendable {}
+
+@MainActor
+enum NonSendableGlobalActorIsolatedEnum {
+  case first
+  case second(NonSendableKlass)
+  case third(SendableKlass)
+}
+
+@available(*, unavailable)
+extension NonSendableGlobalActorIsolatedEnum: Sendable {}
+
+
 /////////////////
 // MARK: Tests //
 /////////////////

--- a/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
@@ -1,0 +1,270 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -verify %s -o /dev/null -parse-as-library -enable-experimental-feature TransferringArgsAndResults
+
+// READ THIS: This test is testing specifically behavior around global actor
+// isolated types that are nonsendable. This is a bit of a corner case so we use
+// a separate test case from the main global actor test case.
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+final class SendableKlass : Sendable {}
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+func transferToNonIsolated<T>(_ t: T) async {}
+@MainActor func transferToMainActor<T>(_ t: T) async {}
+@CustomActor func transferToCustomActor<T>(_ t: T) async {}
+func useValue<T>(_ t: T) {}
+func useValueAsync<T>(_ t: T) async {}
+@MainActor func useValueMainActor<T>(_ t: T) {}
+@MainActor func mainActorFunction() {}
+
+var booleanFlag: Bool { false }
+@MainActor var mainActorIsolatedGlobal = NonSendableKlass()
+@CustomActor var customActorIsolatedGlobal = NonSendableKlass()
+
+@MainActor
+class NonSendableGlobalActorIsolatedKlass {
+  var k = NonSendableKlass()
+  var p: (any GlobalActorIsolatedProtocol)? = nil
+  var p2: OtherProtocol? = nil
+}
+
+@available(*, unavailable)
+extension NonSendableGlobalActorIsolatedKlass: Sendable {}
+
+@MainActor
+final class FinalNonSendableGlobalActorIsolatedKlass {
+  var k = NonSendableKlass()
+  var p: (any GlobalActorIsolatedProtocol)? = nil
+  var p2: OtherProtocol? = nil
+}
+
+@available(*, unavailable)
+extension FinalNonSendableGlobalActorIsolatedKlass: Sendable {}
+
+
+@MainActor
+struct NonSendableGlobalActorIsolatedStruct {
+  var k = NonSendableKlass()
+  var p: (any GlobalActorIsolatedProtocol)? = nil
+  var p2: OtherProtocol? = nil
+}
+
+@available(*, unavailable)
+extension NonSendableGlobalActorIsolatedStruct: Sendable {}
+
+@MainActor protocol GlobalActorIsolatedProtocol {
+  var k: NonSendableKlass { get }
+  var p: GlobalActorIsolatedProtocol { get }
+  var p2: OtherProtocol { get }
+}
+
+protocol OtherProtocol {
+  var k: NonSendableKlass { get }
+}
+
+@MainActor
+enum NonSendableGlobalActorIsolatedEnum {
+  case first
+  case second(NonSendableKlass)
+  case third(SendableKlass)
+  case fourth(GlobalActorIsolatedProtocol)
+  case fifth(OtherProtocol)
+}
+
+@available(*, unavailable)
+extension NonSendableGlobalActorIsolatedEnum: Sendable {}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+extension NonSendableGlobalActorIsolatedStruct {
+  mutating func test() {
+    _ = self.k
+  }
+
+  mutating func test2() -> NonSendableKlass {
+    self.k
+  }
+
+  mutating func test3() -> transferring NonSendableKlass {
+    self.k
+  } // expected-error {{transferring 'self.k' may cause a data race}}
+  // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
+
+  mutating func test4() -> (any GlobalActorIsolatedProtocol)? {
+    self.p
+  }
+
+  // TODO: Should error here.
+  mutating func test5() -> transferring (any GlobalActorIsolatedProtocol)? {
+    self.p
+  }
+
+  mutating func test6() -> (any OtherProtocol)? {
+    self.p2
+  }
+
+  // TODO: Should error here.
+  mutating func test7() -> transferring (any OtherProtocol)? {
+    self.p2
+  }
+}
+
+extension NonSendableGlobalActorIsolatedEnum {
+  mutating func test() {
+    if case let .fourth(x) = self {
+      print(x)
+    }
+    switch self {
+    case .first:
+      break
+    case .second(let x):
+      print(x)
+      break
+    case .third(let x):
+      print(x)
+      break
+    case .fourth(let x):
+      print(x)
+      break
+    case .fifth(let x):
+      print(x)
+      break
+    }
+  }
+
+  mutating func test2() -> (any GlobalActorIsolatedProtocol)? {
+    guard case let .fourth(x) = self else {
+      return nil
+    }
+    return x
+  }
+
+  // TODO: This should error.
+  mutating func test3() -> transferring (any GlobalActorIsolatedProtocol)? {
+    guard case let .fourth(x) = self else {
+      return nil
+    }
+    return x
+  }
+
+  mutating func test3() -> transferring NonSendableKlass? {
+    guard case let .second(x) = self else {
+      return nil
+    }
+    return x
+  } // expected-error {{transferring 'x.some' may cause a data race}}
+  // expected-note @-1 {{main actor-isolated 'x.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
+}
+
+extension NonSendableGlobalActorIsolatedKlass {
+  func test() {
+    _ = self.k
+  }
+
+  func test2() -> NonSendableKlass {
+    self.k
+  }
+
+  func test3() -> transferring NonSendableKlass {
+    self.k
+  } // expected-error {{transferring 'self.k' may cause a data race}}
+  // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
+
+  func test4() -> (any GlobalActorIsolatedProtocol)? {
+    self.p
+  }
+
+  // TODO: Should error here.
+  func test5() -> transferring (any GlobalActorIsolatedProtocol)? {
+    self.p
+  }
+
+  func test6() -> (any OtherProtocol)? {
+    self.p2
+  }
+
+  // TODO: Should error here.
+  func test7() -> transferring (any OtherProtocol)? {
+    self.p2
+  }
+}
+
+extension FinalNonSendableGlobalActorIsolatedKlass {
+  func test() {
+    _ = self.k
+  }
+
+  func test2() -> NonSendableKlass {
+    self.k
+  }
+
+  func test3() -> transferring NonSendableKlass {
+    self.k
+  } // expected-error {{transferring 'self.k' may cause a data race}}
+  // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
+
+  func test4() -> (any GlobalActorIsolatedProtocol)? {
+    self.p
+  }
+
+  // TODO: Should error here.
+  func test5() -> transferring (any GlobalActorIsolatedProtocol)? {
+    self.p
+  }
+
+  func test6() -> (any OtherProtocol)? {
+    self.p2
+  }
+
+  // TODO: Should error here.
+  func test7() -> transferring (any OtherProtocol)? {
+    self.p2
+  }
+}
+
+extension GlobalActorIsolatedProtocol {
+  mutating func test() {
+    _ = self.k
+  }
+
+  mutating func test2() -> NonSendableKlass {
+    self.k
+  }
+
+  mutating func test3() -> transferring NonSendableKlass {
+    self.k
+  } // expected-error {{transferring 'self.k' may cause a data race}}
+  // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
+
+  mutating func test4() -> (any GlobalActorIsolatedProtocol)? {
+    self.p
+  }
+
+  // TODO: Should error here.
+  mutating func test5() -> transferring (any GlobalActorIsolatedProtocol)? {
+    self.p
+  }
+
+  mutating func test6() -> (any OtherProtocol)? {
+    self.p2
+  }
+
+  // TODO: Should error here.
+  mutating func test7() -> transferring (any OtherProtocol)? {
+    self.p2
+  }
+}

--- a/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
@@ -101,7 +101,7 @@ extension NonSendableGlobalActorIsolatedStruct {
 
   mutating func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{transferring 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   mutating func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -166,7 +166,7 @@ extension NonSendableGlobalActorIsolatedEnum {
       return nil
     }
     return x
-  } // expected-error {{transferring 'x.some' may cause a data race}}
+  } // expected-error {{sending 'x.some' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'x.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -181,7 +181,7 @@ extension NonSendableGlobalActorIsolatedKlass {
 
   func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{transferring 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -214,7 +214,7 @@ extension FinalNonSendableGlobalActorIsolatedKlass {
 
   func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{transferring 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -247,7 +247,7 @@ extension GlobalActorIsolatedProtocol {
 
   mutating func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{transferring 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   mutating func test4() -> (any GlobalActorIsolatedProtocol)? {

--- a/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
@@ -101,7 +101,7 @@ extension NonSendableGlobalActorIsolatedStruct {
 
   mutating func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{sending 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   mutating func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -166,7 +166,7 @@ extension NonSendableGlobalActorIsolatedEnum {
       return nil
     }
     return x
-  } // expected-error {{sending 'x.some' may cause a data race}}
+  } // expected-error {{sending 'x.some' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'x.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -181,7 +181,7 @@ extension NonSendableGlobalActorIsolatedKlass {
 
   func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{sending 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -214,7 +214,7 @@ extension FinalNonSendableGlobalActorIsolatedKlass {
 
   func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{sending 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func test4() -> (any GlobalActorIsolatedProtocol)? {
@@ -247,7 +247,7 @@ extension GlobalActorIsolatedProtocol {
 
   mutating func test3() -> transferring NonSendableKlass {
     self.k
-  } // expected-error {{sending 'self.k' may cause a data race}}
+  } // expected-error {{sending 'self.k' risks causing data races}}
   // expected-note @-1 {{main actor-isolated 'self.k' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   mutating func test4() -> (any GlobalActorIsolatedProtocol)? {

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -75,9 +75,10 @@ func initActorWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
 
 actor ActorWithAsyncIsolatedInit {
   init(_ newK: NonSendableKlass) async {
+    // TODO: This should say actor isolated.
     let _ = { @MainActor in
       print(newK) // expected-error {{sending 'newK' risks causing data races}}
-      // expected-note @-1 {{actor-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'self'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 }

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -27,6 +27,8 @@ func useValue<T>(_ t: T) {}
 @MainActor func transferToMain<T>(_ t: T) {}
 @CustomActor func transferToCustom<T>(_ t: T) {}
 
+var boolValue: Bool { false }
+
 /////////////////
 // MARK: Tests //
 /////////////////
@@ -37,12 +39,19 @@ actor ProtectsNonSendable {
   var ns: NonSendableKlass = .init()
 
   nonisolated func testParameter(_ nsArg: NonSendableKlass) async {
-    // TODO: This is wrong, we should get an error saying that nsArg is task
-    // isolated since this is nonisolated.
     self.assumeIsolated { isolatedSelf in
       isolatedSelf.ns = nsArg // expected-warning {{sending 'nsArg' risks causing data races}}
       // expected-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
+  }
+
+  nonisolated func testParameterOutOfLine2(_ nsArg: NonSendableKlass) async {
+    let closure: (isolated ProtectsNonSendable) -> () = { isolatedSelf in
+      isolatedSelf.ns = nsArg // expected-warning {{sending 'nsArg' risks causing data races}}
+      // expected-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+    self.assumeIsolated(closure)
+    self.assumeIsolated(closure)
   }
 
   nonisolated func testParameterMergedIntoLocal(_ nsArg: NonSendableKlass) async {
@@ -103,4 +112,58 @@ func transferBeforeCaptureErrors() async {
   let _ = { @MainActor in // expected-note {{access can happen concurrently}}
     useValue(x)
   }
+}
+
+// TODO: This should have an error. We aren't disambiguating the actors.
+func testDifferentIsolationFromSameClassKindPartialApply() async {
+  let p1 = ProtectsNonSendable()
+  let p2 = ProtectsNonSendable()
+
+  let x = NonSendableKlass()
+
+  let closure: (isolated ProtectsNonSendable) -> () = { isolatedSelf in
+    print(x)
+  }
+
+  await closure(p1)
+  await closure(p2)
+}
+
+// TODO: This should have an error. We aren't disambiguating the actors.
+func testDifferentIsolationFromSameClassKindPartialApplyFlowSensitive() async {
+  let p1 = ProtectsNonSendable()
+  let p2 = ProtectsNonSendable()
+
+  let x = NonSendableKlass()
+
+  let closure: (isolated ProtectsNonSendable) -> () = { isolatedSelf in
+    print(x)
+  }
+
+  if await boolValue {
+    await closure(p1)
+    await closure(p1)
+  } else {
+    await closure(p2)
+    await closure(p2)
+  }
+}
+
+// TODO: This should have an error. We aren't disambiguating the actors.
+func testDifferentIsolationFromSameClassKindPartialApplyFlowSensitive2() async {
+  let p1 = ProtectsNonSendable()
+  let p2 = ProtectsNonSendable()
+
+  let x = NonSendableKlass()
+
+  let closure: (isolated ProtectsNonSendable) -> () = { isolatedSelf in
+    print(x)
+  }
+
+  if await boolValue {
+    await closure(p1)
+  } else {
+    await closure(p2)
+  }
+  await closure(p2)
 }

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -disable-availability-checking -verify %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_nonisolated.swift
+++ b/test/Concurrency/transfernonsendable_nonisolated.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_ownership.swift
+++ b/test/Concurrency/transfernonsendable_ownership.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-experimental-feature TransferringArgsAndResults %s -o /dev/null
 
 // This test validates the behavior of transfer non sendable around ownership
 // constructs like non copyable types, consuming/borrowing parameters, and inout

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix complete- %s -disable-region-based-isolation-with-strict-concurrency
-// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix tns- %s
+// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix complete- %s -disable-region-based-isolation-with-strict-concurrency -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix tns- %s -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -parse-as-library -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -verify %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -134,7 +134,7 @@ actor MyActor {
   func canTransferWithTransferringMethodArg(_ x: transferring Klass, _ y: Klass) async {
     await transferToMain(x)
     await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
-    // expected-note @-1 {{sending actor-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and actor-isolated uses}}
+    // expected-note @-1 {{sending 'self'-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -384,3 +384,20 @@ func testMergeWithTaskIsolated(_ x: transferring Klass, y: Klass) async {
   await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
+
+
+@available(SwiftStdlib 5.1, *)
+actor NonSendableInit {
+  var first: Klass
+  var second: Klass? = nil {
+    @storageRestrictions(initializes: first)
+    init(initialValue)  {
+      transferArg(initialValue!) // expected-warning {{sending 'initialValue' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated 'initialValue' is passed as a transferring parameter}}
+      first = initialValue!
+    }
+
+    get { fatalError() }
+    set { fatalError() }
+  }
+}

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -verify -enable-upcoming-feature RegionBasedIsolation %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -verify -enable-upcoming-feature RegionBasedIsolation %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -disable-availability-checking -verify  %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -disable-availability-checking -verify  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transferring_conditional_suppression.swift
+++ b/test/Concurrency/transferring_conditional_suppression.swift
@@ -1,0 +1,92 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -module-name test -emit-module -o %t/test.swiftmodule -emit-module-interface-path -  -enable-experimental-feature TransferringArgsAndResults %s | %FileCheck %s
+
+public class NonSendableKlass {}
+
+// CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+// CHECK-NEXT: public func transferArgTest(_ x: transferring test.NonSendableKlass)
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func transferArgTest(_ x: test.NonSendableKlass)
+// CHECK-NEXT: #endif
+public func transferArgTest(_ x: transferring NonSendableKlass) {}
+
+// CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+// CHECK-NEXT: public func transferResultTest() -> transferring test.NonSendableKlass
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func transferResultTest() -> test.NonSendableKlass
+// CHECK-NEXT: #endif
+public func transferResultTest() -> transferring NonSendableKlass { fatalError() }
+
+// CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+// CHECK-NEXT: public func transferArgAndResultTest(_ x: test.NonSendableKlass, _ y: transferring test.NonSendableKlass, _ z: test.NonSendableKlass) -> transferring test.NonSendableKlass
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func transferArgAndResultTest(_ x: test.NonSendableKlass, _ y: test.NonSendableKlass, _ z: test.NonSendableKlass) -> test.NonSendableKlass
+// CHECK-NEXT: #endif
+public func transferArgAndResultTest(_ x: NonSendableKlass, _ y: transferring NonSendableKlass, _ z: NonSendableKlass) -> transferring NonSendableKlass { fatalError() }
+
+// CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+// CHECK-NEXT: public func argEmbeddedInType(_ fn: (transferring test.NonSendableKlass) -> ())
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func argEmbeddedInType(_ fn: (test.NonSendableKlass) -> ())
+// CHECK-NEXT: #endif
+public func argEmbeddedInType(_ fn: (transferring NonSendableKlass) -> ()) {}
+
+// CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+// CHECK-NEXT: public func resultEmbeddedInType(_ fn: () -> transferring test.NonSendableKlass)
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func resultEmbeddedInType(_ fn: () -> test.NonSendableKlass)
+// CHECK-NEXT: #endif
+public func resultEmbeddedInType(_ fn: () -> transferring NonSendableKlass) {}
+
+// CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+// CHECK-NEXT: public func argAndResultEmbeddedInType(_ fn: (test.NonSendableKlass, transferring test.NonSendableKlass, test.NonSendableKlass) -> transferring test.NonSendableKlass)
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func argAndResultEmbeddedInType(_ fn: (test.NonSendableKlass, test.NonSendableKlass, test.NonSendableKlass) -> test.NonSendableKlass)
+// CHECK-NEXT: #endif
+public func argAndResultEmbeddedInType(_ fn: (NonSendableKlass, transferring NonSendableKlass, NonSendableKlass) -> transferring NonSendableKlass) {}
+
+public class TestInKlass {
+  // CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+  // CHECK-NEXT: public func testKlassArg(_ x: transferring test.NonSendableKlass)
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: public func testKlassArg(_ x: test.NonSendableKlass)
+  // CHECK-NEXT: #endif
+  public func testKlassArg(_ x: transferring NonSendableKlass) { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+  // CHECK-NEXT: public func testKlassResult() -> transferring test.NonSendableKlass
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: public func testKlassResult() -> test.NonSendableKlass
+  // CHECK-NEXT: #endif
+  public func testKlassResult() -> transferring NonSendableKlass { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: transferring test.NonSendableKlass, z: test.NonSendableKlass) -> transferring test.NonSendableKlass
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: test.NonSendableKlass, z: test.NonSendableKlass) -> test.NonSendableKlass
+  // CHECK-NEXT: #endif
+  public func testKlassArgAndResult(_ x: NonSendableKlass, _ y: transferring NonSendableKlass, z: NonSendableKlass) -> transferring NonSendableKlass { fatalError() }
+}
+
+public struct TestInStruct {
+  // CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+  // CHECK-NEXT: public func testKlassArg(_ x: transferring test.NonSendableKlass)
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: public func testKlassArg(_ x: test.NonSendableKlass)
+  // CHECK-NEXT: #endif
+  public func testKlassArg(_ x: transferring NonSendableKlass) { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+  // CHECK-NEXT: public func testKlassResult() -> transferring test.NonSendableKlass
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: public func testKlassResult() -> test.NonSendableKlass
+  // CHECK-NEXT: #endif
+  public func testKlassResult() -> transferring NonSendableKlass { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $TransferringArgsAndResults
+  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: transferring test.NonSendableKlass, z: test.NonSendableKlass) -> transferring test.NonSendableKlass
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: test.NonSendableKlass, z: test.NonSendableKlass) -> test.NonSendableKlass
+  // CHECK-NEXT: #endif
+  public func testKlassArgAndResult(_ x: NonSendableKlass, _ y: transferring NonSendableKlass, z: NonSendableKlass) -> transferring NonSendableKlass { fatalError() }
+}

--- a/test/Distributed/distributed_actor_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_transfernonsendable.swift
@@ -66,3 +66,19 @@ distributed actor MyDistributedActor {
     }
   }
 }
+
+/////////////////////////////////
+// MARK: Associated Type Tests //
+/////////////////////////////////
+
+protocol AssociatedTypeTestProtocol {
+  associatedtype A: DistributedActor
+}
+
+func associatedTypeTestBasic<T: AssociatedTypeTestProtocol>(_: T, _: isolated T.A) {
+}
+
+func associatedTypeTestBasic2<T: AssociatedTypeTestProtocol>(_: T, iso: isolated T.A, x: NonSendableKlass) async {
+  await transferToMain(x) // expected-error {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'iso'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'iso'-isolated uses}}
+}

--- a/test/Distributed/distributed_actor_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_transfernonsendable.swift
@@ -54,7 +54,7 @@ distributed actor MyDistributedActor {
 
   distributed func transferActorIsolatedArg(_ x: NonSendableKlass) async {
     await transferToMain(x) // expected-error {{sending 'x' risks causing data races}}
-    // expected-note @-1 {{sending actor-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and actor-isolated uses}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   distributed func transferActorIsolatedArgIntoClosure(_ x: NonSendableKlass) async {
@@ -62,7 +62,7 @@ distributed actor MyDistributedActor {
       // TODO: In 2nd part of message should say actor-isolated instead of later
       // nonisolated uses in the case of a closure.
       print(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{actor-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'self'-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 }

--- a/test/SIL/Serialization/isolated_parameters.sil
+++ b/test/SIL/Serialization/isolated_parameters.sil
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name borrow
-// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name borrow
-// RUN: %target-sil-opt %t/tmp.2.sib -module-name borrow -emit-sorted-sil | %FileCheck %s
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name _Concurrency
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name _Concurrency
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name _Concurrency -emit-sorted-sil | %FileCheck %s
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
@@ -13,6 +13,7 @@ import Swift
 import SwiftShims
 
 // NOTE: In SIL we do not save/print out imports, so we cannot import _Concurrency here!
+
 public protocol AnyActor: AnyObject, Sendable {}
 public protocol Actor : AnyActor {}
 

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -488,6 +488,7 @@ func testNoescape() {
 // Despite being a noescape closure, this needs to capture 'a' by-box so it can
 // be passed to the capturing closure.closure
 // CHECK: closure #1 () -> () in functions.testNoescape() -> ()
+// CHECK-NEXT: Isolation: nonisolated
 // CHECK-NEXT: sil private [ossa] @$s9functions12testNoescapeyyFyyXEfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 
 
@@ -508,7 +509,9 @@ func testNoescape2() {
 // CHECK-LABEL: sil hidden [ossa] @$s9functions13testNoescape2yyF : $@convention(thin) () -> () {
 
 // CHECK: // closure #1 () -> () in functions.testNoescape2() -> ()
+// CHECK-NEXT: Isolation: nonisolated
 // CHECK-NEXT: sil private [ossa] @$s9functions13testNoescape2yyFyyXEfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 
 // CHECK: // closure #1 () -> () in closure #1 () -> () in functions.testNoescape2() -> ()
+// CHECK-NEXT: Isolation: nonisolated
 // CHECK-NEXT: sil private [ossa] @$s9functions13testNoescape2yyFyyXEfU_yycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {


### PR DESCRIPTION
Explanation: This contains a series of fixes from main into release/6.0.

- 99fee4eea291b3a4f7559cecc63283cc48242c9c. This commit enables GlobalActorIsolatedTypesUsability as an upcoming feature for swift 6 and updates tests.
- bf6905d1c75c80e06d79ffe7b86a63a2b1b81831. This commit allows for Sendable global actor isolated closures to use transferred non-Sendable parameters. Beyond being the correct modeling, enabling GlobalActorIsolatedTypesUsability caused this to show up a lot more, so we fixed it.
- a415084783b5a73668d691ce181d71297d1792a4. In this commit, I made it so that we properly compute the isolation of generic typed things that were constrained to actor or any actor. Before, we were bailing early and going down the wrong path.
- 8b3d645dae3f9da4894efbd57ec265830dd41583. This added a SILVerifier check that proved that SILFunction's only ever have a single sil_isolated parameter and that said parameter conforms to AnyActor.
- d7a1a01eb125b5b856214f8d741e5a2e6c61ce6f. This is part of the work enabling 8b3d645dae3f9da4894efbd57ec265830dd41583.
- 8304ceb596f56a98dbb6f30744cd770da6c28729 This is part of the work enabling 8b3d645dae3f9da4894efbd57ec265830dd41583.
- edb2dae87004ef1d4025276f8e072737523955fb. This is part of the work enabling 8b3d645dae3f9da4894efbd57ec265830dd41583.
- cee9d0f71437ee5289a171fdad526d30e74f1602. This is part of the work enabling 8b3d645dae3f9da4894efbd57ec265830dd41583.
- 12963933817dc4216aab132f425d37c7dbc3f134. This is part of the work enabling 8b3d645dae3f9da4894efbd57ec265830dd41583.
- 541f702848483bc656c9a2e8fd22c21971d5e52b. This just updated some tests since we are now printing out the isolation of SIL functions if SILGen provides it.
- 61f955c51c457ae2bb06e8ebd23827d2acb509b9. I discovered while doing some other experiments that we were not handling init accessors correctly. The problem was that init accessors are isolated to self, but are not passed self. So I had to create a special way of representing that a function can be self isolated but we don't have self in the internal machinery of the infrastructure.
- 41609ffdf26fac678e9ddc7089e87c55162fbcad. In this change, I made it so that we inferred isolation from isolated parameters correctly.
- e2413440e3d7a9de12d4a8a6f51fdeb93f83536e. This was a gardening update in preparation for 41609ffdf26fac678e9ddc7089e87c55162fbcad.
- de2963c87b4b379c6e48356acc19d7168ab89764. This was fixing a test that merge conflicted on 6.0 since I haven't yet cherry-picked a specific async let change.
- d6e8a9e57f003cfe3b02d9bdc68127ba5c9b8b07.  This makes it so that we properly produce suppressing diagnostics for transferring.
- f576462580a6626088d5f335291a2d04ae8db053. This ensures that we treat actor isolated non-Sendable enums correctly.
- 6a0a19029089f90cd55b78edd146ffe7291dbf42. This ensures that we treat actor isolated non-Sendable structs correctly.

Radars:

- rdar://118244451.
- rdar://125200006.
- rdar://128021548.
- rdar://127844737
- rdar://127295657
- rdar://126780823
- rdar://127006035.

Original PRs:

- #73304
- #73355
- #73556
- #73602
- #73605

Risk: Low. Just affects region isolation.
Testing: Added tests to the test suite.
Reviewer: N/A