### PR TITLE
swift-inspect: Explicitly reference String.init(cString:)

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
@@ -97,7 +97,7 @@ extension SwiftReflectionContextRef {
   }
 
   internal func name(allocation tag: swift_metadata_allocation_tag_t) -> String?  {
-    return swift_reflection_metadataAllocationTagName(self, tag).map(String.init)
+    return swift_reflection_metadataAllocationTagName(self, tag).map(String.init(cString:))
   }
 
   internal func isContiguousArray(_ array: swift_reflection_ptr_t) -> Bool {


### PR DESCRIPTION
This was briefly failing to build because of an ambiguous initializer while making other changes, it's better to be explicit with method names anyway.

rdar://127548384