### PR TITLE
utils: use cmark gfm for the build when running the compiler

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1350,7 +1350,7 @@ function Build-ICU([Platform]$Platform, $Arch) {
 
 function Build-Runtime([Platform]$Platform, $Arch) {
   Isolate-EnvVars {
-    $env:Path = "$($HostArch.BinaryCache)\cmark-gfm-0.29.0.gfm.13\src;$(Get-PinnedToolchainRuntime);${env:Path}"
+    $env:Path = "$($BuildArch.BinaryCache)\cmark-gfm-0.29.0.gfm.13\src;$(Get-PinnedToolchainRuntime);${env:Path}"
 
     $CompilersBinaryCache = if ($IsCrossCompiling) {
       Get-BuildProjectBinaryCache Compilers


### PR DESCRIPTION
When using the just built compiler, we need to use the build CMark runtime as it is executing on the build. This used to work when host and build were guaranteed to be identical (i.e. no cross-compilation). This is now needed to support cross-compiling ARM64.