### PR TITLE
[Concurrency] Fix too eager early return in checkIsolation mode detecting

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -53,6 +53,10 @@ SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableJobDispatchIntegration();
 // Concurrency library can call.
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations();
 
+// Wrapper around SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE that the
+// Concurrency library can call.
+SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverride();
+
 } // end namespace environment
 } // end namespace runtime
 } // end namespace swift

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -351,15 +351,16 @@ static void checkIsCurrentExecutorMode(void *context) {
 
   // Potentially, override the platform detected mode, primarily used in tests.
 #if SWIFT_STDLIB_HAS_ENVIRON
-  const char *modeStr = getenv("SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE");
-  if (!modeStr)
-    return;
-  
-  if (strcmp(modeStr, "nocrash") == 0) {
-    useLegacyMode = Legacy_NoCheckIsolated_NonCrashing;
-  } else if (strcmp(modeStr, "crash") == 0)  {
-    useLegacyMode = Default_UseCheckIsolated_AllowCrash;
-  } // else, just use the platform detected mode
+  if (const char *modeStr =
+          getenv("SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE")) {
+    if (modeStr && *modeStr) {
+      if (strcmp(modeStr, "nocrash") == 0) {
+        useLegacyMode = true;
+      } else if (strcmp(modeStr, "crash") == 0) {
+        useLegacyMode = false;
+      } // else, just use the platform detected mode
+    }
+  }
 #endif // SWIFT_STDLIB_HAS_ENVIRON
   isCurrentExecutorMode = useLegacyMode ? Legacy_NoCheckIsolated_NonCrashing
                                         : Default_UseCheckIsolated_AllowCrash;

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -30,6 +30,7 @@
 #include "swift/Runtime/Bincompat.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/DispatchShims.h"
+#include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Threading/Mutex.h"
 #include "swift/Threading/Once.h"
 #include "swift/Threading/Thread.h"
@@ -352,8 +353,8 @@ static void checkIsCurrentExecutorMode(void *context) {
   // Potentially, override the platform detected mode, primarily used in tests.
 #if SWIFT_STDLIB_HAS_ENVIRON
   if (const char *modeStr =
-          getenv("SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE")) {
-    if (modeStr && *modeStr) {
+          runtime::environment::concurrencyIsCurrentExecutorLegacyModeOverride()) {
+    if (modeStr) {
       if (strcmp(modeStr, "nocrash") == 0) {
         useLegacyMode = true;
       } else if (strcmp(modeStr, "crash") == 0) {

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -272,3 +272,7 @@ SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableJobDispatchIntegration() {
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations() {
   return runtime::environment::SWIFT_DEBUG_VALIDATE_UNCHECKED_CONTINUATIONS();
 }
+
+SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverride() {
+  return runtime::environment::SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE();
+}

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -112,4 +112,17 @@ VARIABLE(SWIFT_BACKTRACE, string, "",
          "crash catching and backtracing support in the runtime. "
          "See docs/Backtracing.rst in the Swift repository for details.")
 
+VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
+         "Allows for suppressing 'is current executor' equality check crashes. "
+         "As since Swift 6.0 checking for current executor equality, may crash "
+         "and will never return 'false' because we are calling into library "
+         "implemented SerialExecutor.checkIsolation which should crash if the "
+         "isolation is not the expected one. Some old code may rely on the "
+         "non-crashing behavior. This flag enables temporarily restoring the "
+         "legacy 'nocrash' behavior until adopting code has been adjusted.\n"
+         "\n"
+         "Legal values are: \n"
+         "  - nocrash (Legacy behavior)\n"
+         "  - crash (Swift 6.0+ behavior)")
+
 #undef VARIABLE

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -119,10 +119,9 @@ VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
          "implemented SerialExecutor.checkIsolation which should crash if the "
          "isolation is not the expected one. Some old code may rely on the "
          "non-crashing behavior. This flag enables temporarily restoring the "
-         "legacy 'nocrash' behavior until adopting code has been adjusted.\n"
-         "\n"
-         "Legal values are: \n"
-         "  - nocrash (Legacy behavior)\n"
-         "  - crash (Swift 6.0+ behavior)")
+         "legacy 'nocrash' behavior until adopting code has been adjusted. "
+         "Legal values are: "
+         " 'nocrash' (Legacy behavior), "
+         " 'crash' (Swift 6.0+ behavior)")
 
 #undef VARIABLE

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -567,3 +567,6 @@ Added: _swift_updatePureObjCClassMetadata
 
 // Runtime bincompat functions for Concurrency runtime to detect legacy mode
 Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks
+
+// Add add SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE
+Added: _concurrencyIsCurrentExecutorLegacyModeOverride

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -567,3 +567,6 @@ Added: _swift_updatePureObjCClassMetadata
 
 // Runtime bincompat functions for Concurrency runtime to detect legacy mode
 Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks
+
+// Add add SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE
+Added: _concurrencyIsCurrentExecutorLegacyModeOverride


### PR DESCRIPTION
Description: If we have the ability to check env variables, and there was no env variable set we aggressively bailed out of the function's logic, without setting the executor mode at all. This prevented the dynamic modes from working in real (non testing) scenarios.

Thanks to @mikeash for helping spot the silly mistake

Resolves rdar://127400013
