### PR TITLE
[6.0][Concurrency] Fix too eager early return in checkIsolation mode detecting

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -351,15 +351,16 @@ static void checkIsCurrentExecutorMode(void *context) {
 
   // Potentially, override the platform detected mode, primarily used in tests.
 #if SWIFT_STDLIB_HAS_ENVIRON
-  const char *modeStr = getenv("SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE");
-  if (!modeStr)
-    return;
-  
-  if (strcmp(modeStr, "nocrash") == 0) {
-    useLegacyMode = Legacy_NoCheckIsolated_NonCrashing;
-  } else if (strcmp(modeStr, "crash") == 0)  {
-    useLegacyMode = Default_UseCheckIsolated_AllowCrash;
-  } // else, just use the platform detected mode
+  if (const char *modeStr =
+          getenv("SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE")) {
+    if (modeStr && *modeStr) {
+      if (strcmp(modeStr, "nocrash") == 0) {
+        useLegacyMode = true;
+      } else if (strcmp(modeStr, "crash") == 0) {
+        useLegacyMode = false;
+      } // else, just use the platform detected mode
+    }
+  }
 #endif // SWIFT_STDLIB_HAS_ENVIRON
   isCurrentExecutorMode = useLegacyMode ? Legacy_NoCheckIsolated_NonCrashing
                                         : Default_UseCheckIsolated_AllowCrash;


### PR DESCRIPTION
**Description**: If we have the ability to check env variables, and there was no env variable set we aggressively bailed out of the function's logic, without setting the executor mode at all. This prevented the dynamic modes from working in real (non testing) scenarios.

**Scope/Impact**: Existing projects, compiled against old SDK would still trigger the new runtime check without this fix. This can break existing applications when user upgrades to new OS, and the application wasn't re-built/tested using the new stricter behavior.
**Risk:** Low, small change in handling null value
**Testing**: CI testing
**Reviewed by**: @mikeash 

**Original PR:** https://github.com/apple/swift/pull/73495/
**Radar:** rdar://127400013