### PR TITLE
Sema: Report references to missing imports from package extensions through typealiases

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3648,6 +3648,8 @@ ERROR(typealias_desugars_to_type_from_hidden_module,none,
       "as property wrapper here|"
       "as result builder here|"
       "in an extension with public or '@usableFromInline' members|"
+      "in an extension with conditional conformances|"
+      "in an extension with public, package, or '@usableFromInline' members|"
       "in an extension with conditional conformances}3 "
       "because %select{%4 has been imported as implementation-only|"
       "it is an SPI imported from %4|"


### PR DESCRIPTION
This diagnostic reports when an exported extension uses a typealias for which the underlying type points to a module that's not imported by the local file. This can break a swiftinterface as we print the underlying type instead of the typealias. Let's make sure it's properly reported for package extensions.