### PR TITLE
NCGenerics: it's not experimental

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -179,6 +179,7 @@ LANGUAGE_FEATURE(MoveOnlyPartialConsumption, 429, "Partial consumption of noncop
 /// Enable bitwise-copyable feature.
 LANGUAGE_FEATURE(BitwiseCopyable, 426, "BitwiseCopyable protocol")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ConformanceSuppression, 426, "Suppressible inferred conformances")
+SUPPRESSIBLE_LANGUAGE_FEATURE(NoncopyableGenerics, 427, "Noncopyable generics")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
@@ -323,9 +324,6 @@ EXPERIMENTAL_FEATURE(Embedded, true)
 
 /// Enables importing the Volatile module
 EXPERIMENTAL_FEATURE(Volatile, true)
-
-/// Enables noncopyable generics
-SUPPRESSIBLE_EXPERIMENTAL_FEATURE(NoncopyableGenerics, true)
 
 // Alias for NoncopyableGenerics
 EXPERIMENTAL_FEATURE(NoncopyableGenerics2, true)

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5782,20 +5782,6 @@ cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext) {
   }
 
   if (auto var = dyn_cast<VarDecl>(decl)) {
-    auto oldContext = var->getDeclContext();
-    auto oldTypeDecl = oldContext->getSelfNominalTypeDecl();
-    // If the base type is non-copyable, and non-copyable generics are disabled,
-    // we cannot synthesize the accessor, because its implementation would use
-    // `UnsafePointer<BaseTy>`.
-    // We cannot use `ty->isNoncopyable()` here because that would create a
-    // cyclic dependency between ModuleQualifiedLookupRequest and
-    // LookupConformanceInModuleRequest, so we check for the presence of
-    // move-only attribute that is implicitly added to non-copyable C++ types by
-    // ClangImporter.
-    if (oldTypeDecl->getAttrs().hasAttribute<MoveOnlyAttr>() &&
-        !context.LangOpts.hasFeature(Feature::NoncopyableGenerics))
-      return nullptr;
-
     auto rawMemory = allocateMemoryForDecl<VarDecl>(var->getASTContext(),
                                                     sizeof(VarDecl), false);
     auto out =

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -509,26 +509,6 @@ namespace {
         return importFunctionPointerLikeType(*type, pointeeType);
       }
 
-      // If non-copyable generics are disabled, we cannot specify
-      // UnsafePointer<T> with a non-copyable type T.
-      // We cannot use `ty->isNoncopyable()` here because that would create a
-      // cyclic dependency between ModuleQualifiedLookupRequest and
-      // LookupConformanceInModuleRequest, so we check for the presence of
-      // move-only attribute that is implicitly added to non-copyable C++ types
-      // by ClangImporter.
-      if (pointeeType && pointeeType->getAnyNominal() &&
-          pointeeType->getAnyNominal()
-              ->getAttrs()
-              .hasAttribute<MoveOnlyAttr>() &&
-          !Impl.SwiftContext.LangOpts.hasFeature(
-              Feature::NoncopyableGenerics)) {
-        auto opaquePointerDecl = Impl.SwiftContext.getOpaquePointerDecl();
-        if (!opaquePointerDecl)
-          return Type();
-        return {opaquePointerDecl->getDeclaredInterfaceType(),
-                ImportHint::OtherPointer};
-      }
-
       PointerTypeKind pointerKind;
       if (quals.hasConst()) {
         pointerKind = PTK_UnsafePointer;

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -1,5 +1,4 @@
 // RUN: %target-sil-opt -transfer-non-sendable -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete %s -verify -o /dev/null
-// RUN: %target-sil-opt -enable-experimental-feature NoncopyableGenerics -transfer-non-sendable -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete %s -verify -o /dev/null
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Generics/copyable_and_self_conforming_protocols.swift
+++ b/test/Generics/copyable_and_self_conforming_protocols.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -enable-experimental-feature NonescapableTypes %s -verify
 
 // REQUIRES: objc_interop
 // REQUIRES: asserts

--- a/test/Generics/inverse_associatedtype_restriction.swift
+++ b/test/Generics/inverse_associatedtype_restriction.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:  -enable-experimental-feature NoncopyableGenerics \
 // RUN:  -enable-experimental-feature NonescapableTypes
 
 // The restriction is that we don't permit suppression requirements on

--- a/test/Generics/inverse_classes1.swift
+++ b/test/Generics/inverse_classes1.swift
@@ -1,7 +1,6 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:   -parse-stdlib -module-name Swift \
-// RUN:   -enable-experimental-feature MoveOnlyClasses \
-// RUN:   -enable-experimental-feature NoncopyableGenerics
+// RUN:   -enable-experimental-feature MoveOnlyClasses
 
 // NOTE: -parse-stdlib is a transitional workaround and should not be required.
 

--- a/test/Generics/inverse_classes2.swift
+++ b/test/Generics/inverse_classes2.swift
@@ -1,6 +1,5 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:   -parse-stdlib -module-name Swift \
-// RUN:   -enable-experimental-feature NoncopyableGenerics
+// RUN:   -parse-stdlib -module-name Swift
 
 // NOTE: -parse-stdlib is a transitional workaround and should not be required.
 

--- a/test/Generics/inverse_conditional_conformance_restriction.swift
+++ b/test/Generics/inverse_conditional_conformance_restriction.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature SuppressedAssociatedTypes
 

--- a/test/Generics/inverse_copyable_requirement.swift
+++ b/test/Generics/inverse_copyable_requirement.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
 
 // a concrete move-only type
 struct MO: ~Copyable {

--- a/test/Generics/inverse_copyable_requirement_errors.swift
+++ b/test/Generics/inverse_copyable_requirement_errors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift
 
 // a concrete move-only type
 struct MO: ~Copyable {

--- a/test/Generics/inverse_extension_signatures.swift
+++ b/test/Generics/inverse_extension_signatures.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -verify -typecheck %s -debug-generic-signatures \
 // RUN:   -debug-inverse-requirements 2>&1 | %FileCheck %s --implicit-check-not "error:"

--- a/test/Generics/inverse_extensions.swift
+++ b/test/Generics/inverse_extensions.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature SuppressedAssociatedTypes
 

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN: -enable-experimental-feature NoncopyableGenerics \
 // RUN: -enable-experimental-feature NonescapableTypes \
 // RUN: -enable-experimental-feature SuppressedAssociatedTypes
 

--- a/test/Generics/inverse_generics_stdlib.swift
+++ b/test/Generics/inverse_generics_stdlib.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -parse-stdlib -module-name Swift -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes
+// RUN: %target-typecheck-verify-swift -parse-stdlib -module-name Swift -enable-experimental-feature BuiltinModule -enable-experimental-feature NonescapableTypes
 
 
 

--- a/test/Generics/inverse_protocols.swift
+++ b/test/Generics/inverse_protocols.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift
 
 
 

--- a/test/Generics/inverse_protocols_errors.swift
+++ b/test/Generics/inverse_protocols_errors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift
 
 
 

--- a/test/Generics/inverse_rdar119950540.swift
+++ b/test/Generics/inverse_rdar119950540.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-silgen -enable-experimental-feature NoncopyableGenerics > /dev/null
+// RUN: %target-swift-frontend %s -emit-silgen > /dev/null
 
 
 

--- a/test/Generics/inverse_scoping.swift
+++ b/test/Generics/inverse_scoping.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes -enable-experimental-feature SuppressedAssociatedTypes
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NonescapableTypes -enable-experimental-feature SuppressedAssociatedTypes
 
 
 

--- a/test/Generics/inverse_signatures.swift
+++ b/test/Generics/inverse_signatures.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:   -verify -typecheck %s -debug-generic-signatures \

--- a/test/IRGen/existential_shape_metadata_noncopyable.swift
+++ b/test/IRGen/existential_shape_metadata_noncopyable.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend \
 // RUN:    -emit-ir %s -swift-version 5 \
 // RUN:   -disable-availability-checking \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:   -module-name existential_shape_metadata | %IRGenFileCheck %s
 

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -1,6 +1,5 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-ir -o - %s -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -parse-as-library \

--- a/test/IRGen/moveonly_enum_deinits.swift
+++ b/test/IRGen/moveonly_enum_deinits.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-irgen                             \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -disable-type-layout                             \
 // RUN:     %s                                               \
 // RUN: |                                                    \

--- a/test/IRGen/moveonly_value_functions.swift
+++ b/test/IRGen/moveonly_value_functions.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-irgen -O                          \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -disable-type-layout                             \
 // RUN:     %s                                               \
 // RUN: |                                                    \

--- a/test/IRGen/moveonly_value_functions_onone.swift
+++ b/test/IRGen/moveonly_value_functions_onone.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-irgen -Onone                      \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     %s                                               \
 // RUN: |                                                    \
 // RUN: %IRGenFileCheck %s

--- a/test/IRGen/noncopyable_field_descriptors.swift
+++ b/test/IRGen/noncopyable_field_descriptors.swift
@@ -1,6 +1,5 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-ir -o - %s -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -parse-as-library \
 // RUN:   -enable-library-evolution \

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=swift-6 -enable-experimental-feature NoncopyableGenerics %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
-// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=swift-6 %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
 
 import MoveOnlyCxxValueType
 

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=swift-6 -enable-experimental-feature NoncopyableGenerics %s -validate-tbd-against-ir=none | %FileCheck %s
-// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics %s -validate-tbd-against-ir=none | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=swift-6 %s -validate-tbd-against-ir=none | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s -validate-tbd-against-ir=none | %FileCheck %s
 
 import MoveOnlyCxxValueType
 

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-none)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O -Xfrontend -sil-verify-none)
 //
 // REQUIRES: executable_test
 // REQUIRES: GH_ISSUE_70246

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-module-interface.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-module-interface.swift
@@ -1,8 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnlyCxxValueType -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -source-filename=x | %FileCheck %s --check-prefix=CHECK-NO-NCG
-// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnlyCxxValueType -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -source-filename=x -enable-experimental-feature NoncopyableGenerics | %FileCheck %s --check-prefix=CHECK-NCG
-
-// CHECK-NO-NCG: func getNonCopyablePtr() -> OpaquePointer
-// CHECK-NO-NCG: func getNonCopyableDerivedPtr() -> OpaquePointer
+// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnlyCxxValueType -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -source-filename=x | %FileCheck %s --check-prefix=CHECK-NCG
 
 // CHECK-NCG: func getNonCopyablePtr() -> UnsafeMutablePointer<NonCopyable>
 // CHECK-NCG: func getNonCopyableDerivedPtr() -> UnsafeMutablePointer<NonCopyableDerived>

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9 -O)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
 
 // REQUIRES: executable_test
 
@@ -29,12 +27,10 @@ MoveOnlyCxxValueType.test("Test derived move only type member access") {
   var k = c.method(-3)
   expectEqual(k, -6)
   expectEqual(c.method(1), 2)
-#if HAS_NONCOPYABLE_GENERICS
   k = c.x
   expectEqual(k, 2)
   c.x = 11
   expectEqual(c.x, 11)
-#endif
   k = c.mutMethod(-13)
   expectEqual(k, -13)
 }
@@ -60,7 +56,6 @@ MoveOnlyCxxValueType.test("Test move only field access in holder") {
   expectEqual(c.x.x, 5)
 }
 
-#if HAS_NONCOPYABLE_GENERICS
 MoveOnlyCxxValueType.test("Test move only field access in derived holder") {
   var c = NonCopyableHolderDerivedDerived(-11)
   var k = borrowNC(c.x)
@@ -74,6 +69,5 @@ MoveOnlyCxxValueType.test("Test move only field access in derived holder") {
   c.x.mutMethod(5)
   expectEqual(c.x.x, 5)
 }
-#endif
 
 runAllTests()

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
@@ -1,11 +1,9 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9 -O)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
 //
 // REQUIRES: executable_test
 
@@ -92,7 +90,6 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderValueMutDeref pointee value") {
   expectEqual(k.x, k2.x)
 }
 
-#if HAS_NONCOPYABLE_GENERICS
 MoveOnlyCxxOperators.test("NonCopyableHolderConstDerefDerivedDerived pointee borrow") {
   let holder = NonCopyableHolderConstDerefDerivedDerived(11)
   var k = borrowNC(holder.pointee)
@@ -160,6 +157,5 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderValueMutDerefDerivedDerived poin
   var k2 = holder.pointee
   expectEqual(k.x, k2.x)
 }
-#endif
 
 runAllTests()

--- a/test/Interpreter/currying_generics.swift
+++ b/test/Interpreter/currying_generics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
-// RUN: %target-run-simple-swift -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/escapable_generics_casting.swift
+++ b/test/Interpreter/escapable_generics_casting.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NonescapableTypes) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NonescapableTypes) | %FileCheck %s
 
 // REQUIRES: executable_test, asserts
 

--- a/test/Interpreter/existential_member_accesses_self_assoctype.swift
+++ b/test/Interpreter/existential_member_accesses_self_assoctype.swift
@@ -1,5 +1,4 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-simple-swift -enable-experimental-feature NoncopyableGenerics
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interpreter/generic_casts.swift
+++ b/test/Interpreter/generic_casts.swift
@@ -7,8 +7,8 @@
 // RUN: %target-run %t/a.out | %FileCheck --check-prefix CHECK %s
 // RUN: %target-run %t/a.out.optimized | %FileCheck --check-prefix CHECK %s
 
-// RUN: %target-build-swift -enable-experimental-feature NoncopyableGenerics -Onone %s -o %t/a.out
-// RUN: %target-build-swift -enable-experimental-feature NoncopyableGenerics  -O %s -o %t/a.out.optimized
+// RUN: %target-build-swift -Onone %s -o %t/a.out
+// RUN: %target-build-swift -O %s -o %t/a.out.optimized
 // RUN: %target-codesign %t/a.out
 // RUN: %target-codesign %t/a.out.optimized
 //

--- a/test/Interpreter/generic_casts_objc.swift
+++ b/test/Interpreter/generic_casts_objc.swift
@@ -6,10 +6,10 @@
 // RUN: %target-codesign %t/a.out.optimized
 // RUN: %target-run %t/a.out.optimized | %FileCheck %s
 
-// RUN: %target-build-swift -enable-experimental-feature NoncopyableGenerics -Onone %s -o %t/a.out
+// RUN: %target-build-swift -Onone %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
-// RUN: %target-build-swift -enable-experimental-feature NoncopyableGenerics -O %s -o %t/a.out.optimized
+// RUN: %target-build-swift -O %s -o %t/a.out.optimized
 // RUN: %target-codesign %t/a.out.optimized
 // RUN: %target-run %t/a.out.optimized | %FileCheck %s
 

--- a/test/Interpreter/moveonly_address_maximize.swift
+++ b/test/Interpreter/moveonly_address_maximize.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all) | %FileCheck %s
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
 
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -Xfrontend -sil-verify-all) | %FileCheck %s
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-all) | %FileCheck %s
-
 // REQUIRES: executable_test
 
 struct S : ~Copyable {

--- a/test/Interpreter/moveonly_bufferview.swift
+++ b/test/Interpreter/moveonly_bufferview.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all) | %FileCheck %s
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
 
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -Xfrontend -sil-verify-all) | %FileCheck %s
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-all) | %FileCheck %s
-
 // REQUIRES: executable_test
 
 public struct BufferView<T>: ~Copyable {

--- a/test/Interpreter/moveonly_computed_property_in_class.swift
+++ b/test/Interpreter/moveonly_computed_property_in_class.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all)
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all)
 
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -Xfrontend -sil-verify-all)
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-all)
-
 // REQUIRES: executable_test
 @_moveOnly
 struct FileDescriptor {

--- a/test/Interpreter/moveonly_consuming_param.swift
+++ b/test/Interpreter/moveonly_consuming_param.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
 
-// RUN: %target-run-simple-swift -enable-experimental-feature NoncopyableGenerics  | %FileCheck %s
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-all) | %FileCheck %s
-
 // REQUIRES: executable_test
 
 @_moveOnly

--- a/test/Interpreter/moveonly_deinit_autoclosure.swift
+++ b/test/Interpreter/moveonly_deinit_autoclosure.swift
@@ -1,5 +1,4 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-simple-swift -enable-experimental-feature NoncopyableGenerics 
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/moveonly_discard.swift
+++ b/test/Interpreter/moveonly_discard.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-feature -Xfrontend MoveOnlyEnumDeinits -Xfrontend -sil-verify-all) | %FileCheck %s --implicit-check-not closing
 // RUN: %target-run-simple-swift(-O -Xfrontend -enable-experimental-feature -Xfrontend MoveOnlyEnumDeinits -Xfrontend -sil-verify-all) | %FileCheck %s --implicit-check-not closing
 
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -Xfrontend -enable-experimental-feature -Xfrontend MoveOnlyEnumDeinits -Xfrontend -sil-verify-all) | %FileCheck %s --implicit-check-not closing
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -enable-experimental-feature -Xfrontend MoveOnlyEnumDeinits -Xfrontend -sil-verify-all) | %FileCheck %s --implicit-check-not closing
-
 // REQUIRES: executable_test
 
 // NOTE: it's important that this test has the `--implicit-check-not closing` flag to catch double deinits!!

--- a/test/Interpreter/moveonly_escaping_capture_lifetimes.swift
+++ b/test/Interpreter/moveonly_escaping_capture_lifetimes.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
 
-// RUN: %target-run-simple-swift -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-all) | %FileCheck %s
-
 // REQUIRES: executable_test
 
 @_moveOnly

--- a/test/Interpreter/moveonly_escaping_definite_initialization.swift
+++ b/test/Interpreter/moveonly_escaping_definite_initialization.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
 
-// RUN: %target-run-simple-swift -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-all) | %FileCheck %s
-
 // REQUIRES: executable_test
 
 @_moveOnly

--- a/test/Interpreter/moveonly_field_in_class_reflection.swift
+++ b/test/Interpreter/moveonly_field_in_class_reflection.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-move-only)
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -Xfrontend -enable-experimental-move-only)
 
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -Xfrontend -enable-experimental-move-only)
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-all -Xfrontend -enable-experimental-move-only)
-
 // REQUIRES: executable_test
 
 // Verify that iterating through the fields of an object whose class has

--- a/test/Interpreter/moveonly_generics.swift
+++ b/test/Interpreter/moveonly_generics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics)
-// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics)
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all)
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all)
 
 // REQUIRES: executable_test
 // REQUIRES: asserts

--- a/test/Interpreter/moveonly_generics_associatedtype.swift
+++ b/test/Interpreter/moveonly_generics_associatedtype.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-emit-sil %s -DBAD_COPY -verify -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes) | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -DBAD_COPY -verify -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypes
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypes) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypes) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: asserts

--- a/test/Interpreter/moveonly_generics_casting.swift
+++ b/test/Interpreter/moveonly_generics_casting.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/moveonly_generics_casting_assoctypes.swift
+++ b/test/Interpreter/moveonly_generics_casting_assoctypes.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes)
-// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes)
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypes)
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature SuppressedAssociatedTypes)
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/moveonly_linkedlist.swift
+++ b/test/Interpreter/moveonly_linkedlist.swift
@@ -2,10 +2,6 @@
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all)
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -Xfrontend -enable-ossa-modules)
 
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -Xfrontend -sil-verify-all)
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-all)
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-all -Xfrontend -enable-ossa-modules)
-
 // REQUIRES: executable_test
 
 /// A class that we use as a box to store the memory for one of our linked list

--- a/test/Interpreter/moveonly_linkedlist_2_simple.swift
+++ b/test/Interpreter/moveonly_linkedlist_2_simple.swift
@@ -1,14 +1,13 @@
 // RUN: %target-swift-emit-irgen                             \
 // RUN:     -parse-as-library                                \
 // RUN:     -enable-builtin-module                           \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature BorrowingSwitch     \
 // RUN:     %s                                               \
 // RUN: |                                                    \
 // RUN: %FileCheck %s --check-prefix=CHECK-IR
-// RUN: %target-run-simple-swift(-parse-as-library -enable-builtin-module -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -Xfrontend -sil-verify-all) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -parse-as-library -enable-builtin-module -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -Xfrontend -sil-verify-all) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -parse-as-library -enable-builtin-module -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -Xfrontend -sil-verify-all -Xfrontend -enable-ossa-modules) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -enable-builtin-module -enable-experimental-feature BorrowingSwitch -Xfrontend -sil-verify-all) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -parse-as-library -enable-builtin-module -enable-experimental-feature BorrowingSwitch -Xfrontend -sil-verify-all) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -parse-as-library -enable-builtin-module -enable-experimental-feature BorrowingSwitch -Xfrontend -sil-verify-all -Xfrontend -enable-ossa-modules) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/moveonly_swiftskell.swift
+++ b/test/Interpreter/moveonly_swiftskell.swift
@@ -6,7 +6,6 @@
 // RUN:    -module-name Swiftskell \
 // RUN:    -parse-as-library \
 // RUN:    %S/../Inputs/Swiftskell.swift -c -o %t/Swiftskell.o \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature BorrowingSwitch
 

--- a/test/Interpreter/protocol_extensions.swift
+++ b/test/Interpreter/protocol_extensions.swift
@@ -1,5 +1,4 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-simple-swift -enable-experimental-feature NoncopyableGenerics
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/ModuleInterface/invertible_constraints.swift
+++ b/test/ModuleInterface/invertible_constraints.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test -enable-experimental-feature SuppressedAssociatedTypes
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
 // RUN: %FileCheck %s < %t.swiftinterface
 

--- a/test/ModuleInterface/invertible_protocols.swift
+++ b/test/ModuleInterface/invertible_protocols.swift
@@ -2,7 +2,6 @@
 // RUN:     -swift-version 5 \
 // RUN:     -enable-library-evolution \
 // RUN:     -emit-module -module-name Swift -parse-stdlib \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -o %t/Swift.swiftmodule \
 // RUN:     -emit-module-interface-path %t/Swift.swiftinterface
 

--- a/test/ModuleInterface/lifetime_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_dependence_test.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -o %t/lifetime_dependence.swiftmodule \
 // RUN:     -emit-module-interface-path %t/lifetime_dependence.swiftinterface \
@@ -15,12 +14,10 @@
 // See if we can compile a module through just the interface and typecheck using it.
 
 // RUN: %target-swift-frontend -compile-module-from-interface \
-// RUN:    -enable-experimental-feature NoncopyableGenerics \
 // RUN:    -enable-experimental-feature NonescapableTypes \
 // RUN:    %t/lifetime_dependence.swiftinterface -o %t/lifetime_dependence.swiftmodule
 
 // RUN: %target-swift-frontend -typecheck -I %t %s \
-// RUN:    -enable-experimental-feature NoncopyableGenerics \
 // RUN:    -enable-experimental-feature NonescapableTypes
 
 import lifetime_dependence

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -o %t/NoncopyableGenerics_Misc.swiftmodule \
@@ -9,7 +8,6 @@
 // RUN:     %S/Inputs/NoncopyableGenerics_Misc.swift
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -enable-experimental-feature BorrowingSwitch \
@@ -25,19 +23,16 @@
 // See if we can compile a module through just the interface and typecheck using it.
 
 // RUN: %target-swift-frontend -compile-module-from-interface \
-// RUN:    -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:    %t/NoncopyableGenerics_Misc.swiftinterface -o %t/NoncopyableGenerics_Misc.swiftmodule
 
 // RUN: %target-swift-frontend -compile-module-from-interface \
-// RUN:    -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:    %t/Swiftskell.swiftinterface -o %t/Swiftskell.swiftmodule
 
 // RUN: %target-swift-frontend -emit-silgen -I %t %s \
-// RUN:    -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:    -enable-experimental-feature NonescapableTypes \
 // RUN:    -o %t/final.silgen

--- a/test/Parse/explicit_lifetime_dependence_specifiers.swift
+++ b/test/Parse/explicit_lifetime_dependence_specifiers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics -enable-builtin-module
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -enable-builtin-module
 // REQUIRES: asserts
 
 import Builtin

--- a/test/Parse/inverse_escapable_feature.swift
+++ b/test/Parse/inverse_escapable_feature.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift
 
 
 

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature SuppressedAssociatedTypes
 
 protocol U {}
 

--- a/test/SIL/Parser/basic2_noncopyable_generics.sil
+++ b/test/SIL/Parser/basic2_noncopyable_generics.sil
@@ -1,15 +1,13 @@
 // RUN: %target-sil-opt                                      \
 // RUN:     %s                                               \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature NonescapableTypes   \
 // RUN: |                                                    \
 // RUN: %target-sil-opt                                      \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature NonescapableTypes   \
 // RUN: |                                                    \
 // RUN: %FileCheck %s
 
-// For -enable-experimental-feature NoncopyableGenerics/NonescapableTypes
+// For -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // TODO: Once NoncopyableGenerics/NonescapableTypes is no longer behind a feature flag, merge this into basic2.

--- a/test/SIL/Parser/lifetime_dependence.sil
+++ b/test/SIL/Parser/lifetime_dependence.sil
@@ -1,6 +1,5 @@
 // RUN: %target-sil-opt %s \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+// RUN:   -enable-experimental-feature NonescapableTypes | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -1,8 +1,7 @@
 // RUN: %target-swift-frontend %s \
 // RUN: -emit-sil  \
 // RUN: -enable-builtin-module \
-// RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+// RUN: -enable-experimental-feature NonescapableTypes | %FileCheck %s
 
 
 import Builtin

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s \
 // RUN: -emit-sil  -disable-availability-checking \
-// RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+// RUN: -enable-experimental-feature NonescapableTypes | %FileCheck %s
 // REQUIRES: asserts
 
 struct BufferView : ~Escapable {

--- a/test/SIL/lifetime_dependence_buffer_view_test.swift
+++ b/test/SIL/lifetime_dependence_buffer_view_test.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-sil \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -enable-experimental-feature NoncopyableGenerics
+// RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
-// RUN:   -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypes | %FileCheck %s
 
 
 protocol P {

--- a/test/SIL/type_lowering_unit.sil
+++ b/test/SIL/type_lowering_unit.sil
@@ -1,5 +1,5 @@
 // RUN: %target-sil-opt -test-runner \
-// RUN:   -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes \
+// RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   %s -o /dev/null 2>&1 | %FileCheck %s
 
 sil_stage raw

--- a/test/SILGen/bitwise_copyable_stdlib.swift
+++ b/test/SILGen/bitwise_copyable_stdlib.swift
@@ -1,4 +1,4 @@
-// R N: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DEMPTY -emit-sil -verify %s
+// R N: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -parse-stdlib -module-name Swift -DEMPTY -emit-sil -verify %s
 
 // RUN: %target-swift-frontend                               \
 // RUN:     -emit-sil                                        \
@@ -7,7 +7,6 @@
 // RUN:     -module-name Swift                               \
 // RUN:     -disable-availability-checking                   \
 // RUN:     -enable-experimental-feature BuiltinModule       \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature NonescapableTypes   \
 // RUN:     -enable-builtin-module
 

--- a/test/SILGen/borrowing_switch_return_binding_compat.swift
+++ b/test/SILGen/borrowing_switch_return_binding_compat.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -verify %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature BorrowingSwitch -verify %s
 func orElse<T: ~Copyable>(
     x: consuming T?,
     defaultValue: @autoclosure () throws -> T?

--- a/test/SILGen/borrowing_switch_return_on_all_paths.swift
+++ b/test/SILGen/borrowing_switch_return_on_all_paths.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -verify %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature BorrowingSwitch -verify %s
 
 struct Box<Wrapped: ~Copyable>: ~Copyable {
     var wrapped: Wrapped {

--- a/test/SILGen/mangling_inverse_generics.swift
+++ b/test/SILGen/mangling_inverse_generics.swift
@@ -1,6 +1,5 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-emit-silgen %s -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -parse-as-library \
 // RUN:   > %t/test.silgen

--- a/test/SILGen/mangling_inverse_generics_basic.swift
+++ b/test/SILGen/mangling_inverse_generics_basic.swift
@@ -1,6 +1,5 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-emit-silgen %s -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   > %t/test.silgen
 

--- a/test/SILGen/moveonly_basics.swift
+++ b/test/SILGen/moveonly_basics.swift
@@ -1,8 +1,4 @@
 // RUN: %target-swift-emit-silgen -module-name test %s | %FileCheck %s --enable-var-scope
-// RUN: %target-swift-emit-silgen -enable-experimental-feature NoncopyableGenerics -module-name test %s | %FileCheck %s --enable-var-scope
-
-// For -enable-experimental-feature NoncopyableGenerics
-
 
 class Retainable {}
 

--- a/test/SILGen/moveonly_consuming_switch.swift
+++ b/test/SILGen/moveonly_consuming_switch.swift
@@ -2,7 +2,6 @@
 // RUN:     -emit-silgen                                            \
 // RUN:     %s                                                      \
 // RUN:     -enable-experimental-feature BorrowingSwitch            \
-// RUN:     -enable-experimental-feature NoncopyableGenerics        \
 // RUN: | %FileCheck %s
 
 enum MaybeMaybeVoid<Wrapped: ~Copyable>: ~Copyable {

--- a/test/SILGen/moveonly_empty_conditionally_copyable.swift
+++ b/test/SILGen/moveonly_empty_conditionally_copyable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -emit-sil -verify -primary-file %s
+// RUN: %target-swift-frontend -emit-sil -verify -primary-file %s
 
 struct G<T: ~Copyable>: ~Copyable { }
 

--- a/test/SILGen/moveonly_optional_operations.swift
+++ b/test/SILGen/moveonly_optional_operations.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -verify %s
+// RUN: %target-swift-frontend -emit-sil -parse-stdlib -module-name Swift -verify %s
 
 @_marker protocol Copyable {}
 @_marker protocol Escapable {}

--- a/test/SILGen/moveonly_optional_operations_2.swift
+++ b/test/SILGen/moveonly_optional_operations_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -parse-stdlib -module-name Swift %s | %FileCheck %s
 
 @_marker protocol Copyable {}
 @_marker protocol Escapable {}

--- a/test/SILGen/typelowering_inverses.swift
+++ b/test/SILGen/typelowering_inverses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes -disable-availability-checking -module-name main %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NonescapableTypes -disable-availability-checking -module-name main %s | %FileCheck %s
 
 protocol NoCopyP: ~Copyable {}
 

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -1,5 +1,5 @@
 // RUN: %target-sil-opt -enable-sil-verify-all %s -capture-promotion \
-// RUN: -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics -module-name Swift \
+// RUN: -enable-experimental-feature NonescapableTypes -module-name Swift \
 // RUN: | %FileCheck %s
 
 // Check to make sure that the process of promoting closure captures results in

--- a/test/SILOptimizer/lifetime_dependence.sil
+++ b/test/SILOptimizer/lifetime_dependence.sil
@@ -2,8 +2,7 @@
 // RUN:   -o /dev/null \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name Swift \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -enable-experimental-feature NoncopyableGenerics
+// RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence_borrow.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
@@ -3,8 +3,7 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -enable-experimental-feature NoncopyableGenerics
+// RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence_closure.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence_diagnostics.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   2>&1 | %FileCheck %s
 

--- a/test/SILOptimizer/lifetime_dependence_generic.swift
+++ b/test/SILOptimizer/lifetime_dependence_generic.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:   -parse-stdlib -module-name Swift
 

--- a/test/SILOptimizer/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence_insertion.swift
@@ -2,7 +2,6 @@
 // RUN:   -Xllvm -sil-print-after=lifetime-dependence-insertion \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -o /dev/null 2>&1 | %FileCheck %s
 

--- a/test/SILOptimizer/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence_mutate.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_optional.swift
+++ b/test/SILOptimizer/lifetime_dependence_optional.swift
@@ -2,7 +2,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature BorrowingSwitch
 

--- a/test/SILOptimizer/lifetime_dependence_param.swift
+++ b/test/SILOptimizer/lifetime_dependence_param.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_param_fail.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   2>&1 | %FileCheck %s
 

--- a/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify \
-// RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -enable-experimental-feature NoncopyableGenerics
+// RUN: -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/lifetime_dependence_todo.swift
+++ b/test/SILOptimizer/lifetime_dependence_todo.swift
@@ -2,7 +2,6 @@
 // RUN:   -o /dev/null \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence_util.sil
@@ -1,6 +1,5 @@
 // RUN: %target-sil-opt -test-runner %s \
 // RUN:     -module-name Swift \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -o /dev/null 2>&1 | %FileCheck %s
 

--- a/test/SILOptimizer/moveonly_addresschecker_debuginfo.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_debuginfo.sil
@@ -1,6 +1,4 @@
 // RUN: %target-sil-opt -module-name moveonly_addresschecker -emit-verbose-sil -sil-move-only-checker -enable-sil-verify-all %s | %FileCheck %s
-// RUN: %target-sil-opt -enable-experimental-feature NoncopyableGenerics -module-name moveonly_addresschecker -emit-verbose-sil -sil-move-only-checker -enable-sil-verify-all %s | %FileCheck %s
-
 
 sil_stage raw
 

--- a/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
 
 // This test validates that we properly emit errors if we partially invalidate
 // through a type with a deinit.

--- a/test/SILOptimizer/moveonly_addresschecker_di_interactions.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_di_interactions.sil
@@ -1,5 +1,4 @@
 // RUN: %target-sil-opt -definite-init %s | %FileCheck %s
-// RUN: %target-sil-opt -enable-experimental-feature NoncopyableGenerics -definite-init %s | %FileCheck %s
 
 // Make sure that DI properly converts mark_unresolved_non_copyable_value
 // [assignable_but_not_consumable] -> mark_unresolved_non_copyable_value

--- a/test/SILOptimizer/moveonly_addresschecker_di_interactions.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_di_interactions.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy %s
-
 
 // This testStruct specifically testStructs how DI and the move checkers interact with each other
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -1,9 +1,6 @@
 // RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -verify
 // RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
 
-// RUN: %target-sil-opt -enable-experimental-feature NoncopyableGenerics -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -verify
-// RUN: %target-sil-opt -enable-experimental-feature NoncopyableGenerics -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
-
 // This file contains specific SIL test cases that we expect to emit
 // diagnostics. These are cases where we want to make it easy to validate
 // independent of potential changes in the frontend's emission that this

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -O -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil %s -O -sil-verify-all -verify -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -enable-experimental-feature NoImplicitCopy -sil-verify-all -verify -enable-library-evolution %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NoImplicitCopy -sil-verify-all -verify -enable-library-evolution %s
 
 // This test is used to validate that we properly handle library evolution code
 // until we can get all of the normal moveonly_addresschecker_diagnostics test

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
 
 struct Test: ~Copyable {
   public let baseAddress: UnsafeRawPointer

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial_reinit.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial_reinit.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
-// RUN: %target-swift-emit-sil  -enable-experimental-feature NoncopyableGenerics -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
 
 // Test diagnostics for partial-consumption without partial-reinitialization.
 

--- a/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -sil-verify-all -verify %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -sil-verify-all -verify %s
 
 
 class CopyableKlass {}

--- a/test/SILOptimizer/moveonly_addressors.swift
+++ b/test/SILOptimizer/moveonly_addressors.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DADDRESS_ONLY -emit-sil -verify %s
-// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DLOADABLE -emit-sil -verify %s
-// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DTRIVIAL -emit-sil -verify %s
-// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DEMPTY -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -parse-stdlib -module-name Swift -DADDRESS_ONLY -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -parse-stdlib -module-name Swift -DLOADABLE -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -parse-stdlib -module-name Swift -DTRIVIAL -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -parse-stdlib -module-name Swift -DEMPTY -emit-sil -verify %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/moveonly_borrowing_switch.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -verify -enable-experimental-feature BorrowingSwitch %s
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -emit-sil -verify -enable-experimental-feature BorrowingSwitch %s
 
 struct Payload: ~Copyable {
     var x: Int

--- a/test/SILOptimizer/moveonly_borrowing_switch_copyable_subpattern.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_copyable_subpattern.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -verify -enable-experimental-feature BorrowingSwitch %s
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -emit-sil -verify -enable-experimental-feature BorrowingSwitch %s
 
 struct Payload: ~Copyable {
     var x: Int

--- a/test/SILOptimizer/moveonly_borrowing_switch_load_borrow.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_load_borrow.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature BorrowingSwitch -emit-sil -verify %s
 
 struct Box<Wrapped: ~Copyable>: ~Copyable {
     init(_ element: consuming Wrapped) { }

--- a/test/SILOptimizer/moveonly_borrowing_switch_yield.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_yield.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -parse-as-library -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature BorrowingSwitch -parse-as-library -O -emit-sil -verify %s
 
 extension List {
     var peek: Element {

--- a/test/SILOptimizer/moveonly_builtins.swift
+++ b/test/SILOptimizer/moveonly_builtins.swift
@@ -1,10 +1,8 @@
 // RUN: %target-swift-frontend-typecheck -verify %s -DILLEGAL \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-builtin-module \
 // RUN:   -verify-additional-prefix illegal-
 
 // RUN: %target-swift-frontend -emit-sil -sil-verify-all -verify %s \
-// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-builtin-module
 
 import Builtin

--- a/test/SILOptimizer/moveonly_computed_property.swift
+++ b/test/SILOptimizer/moveonly_computed_property.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s > /dev/null
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -emit-sil -verify %s > /dev/null
 
 
 

--- a/test/SILOptimizer/moveonly_consuming_switch.swift
+++ b/test/SILOptimizer/moveonly_consuming_switch.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -verify %s
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BorrowingSwitch -verify %s
 
 // TODO: Remove this and just use the real `UnsafeMutablePointer` when
 // noncopyable type support has been upstreamed.

--- a/test/SILOptimizer/moveonly_discard.swift
+++ b/test/SILOptimizer/moveonly_discard.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyEnumDeinits %s
-// RUN: %target-swift-frontend  -enable-experimental-feature NoncopyableGenerics -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyEnumDeinits %s
 
 
 func posix_close(_ t: Int) {}

--- a/test/SILOptimizer/moveonly_generics_basic.swift
+++ b/test/SILOptimizer/moveonly_generics_basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-swift-frontend %s -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyPartialReinitialization
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/moveonly_generics_complex.swift
+++ b/test/SILOptimizer/moveonly_generics_complex.swift
@@ -2,7 +2,6 @@
 // RUN:     -emit-sil -verify                                       \
 // RUN:     %s                                                      \
 // RUN:     -enable-experimental-feature BuiltinModule              \
-// RUN:     -enable-experimental-feature NoncopyableGenerics        \
 // RUN:     -sil-verify-all
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/moveonly_partial_consumption_deinit.swift
+++ b/test/SILOptimizer/moveonly_partial_consumption_deinit.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-emit-sil \
 // RUN:     %s \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -sil-verify-all \
 // RUN:     -verify
 

--- a/test/SILOptimizer/moveonly_raw_layout.swift
+++ b/test/SILOptimizer/moveonly_raw_layout.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-frontend -enable-experimental-feature BuiltinModule -enable-experimental-feature RawLayout -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BuiltinModule -enable-experimental-feature RawLayout -emit-sil %s | %FileCheck %s
-
 
 import Builtin
 

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialReinitialization -sil-verify-all -verify %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature MoveOnlyPartialReinitialization -sil-verify-all -verify %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -sil-verify-all -verify %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -sil-verify-all -verify %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/noimplicitcopy.swift
+++ b/test/SILOptimizer/noimplicitcopy.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -sil-verify-all -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -sil-verify-all -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil
 
 import Swift
 

--- a/test/SILOptimizer/sil_combine_concrete_existential_noncopyable.swift
+++ b/test/SILOptimizer/sil_combine_concrete_existential_noncopyable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -O %s -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
 
 protocol P: ~Copyable {}
 

--- a/test/SILOptimizer/stdlib/Cell.swift
+++ b/test/SILOptimizer/stdlib/Cell.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -emit-sil -disable-availability-checking %s -enable-builtin-module -enable-experimental-feature RawLayout -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -disable-availability-checking %s -enable-builtin-module -enable-experimental-feature RawLayout | %FileCheck %s
 
 import Builtin
 

--- a/test/Sema/bitwise_copyable.swift
+++ b/test/Sema/bitwise_copyable.swift
@@ -1,7 +1,6 @@
 // RUN: %target-typecheck-verify-swift                       \
 // RUN:     -disable-availability-checking                   \
 // RUN:     -enable-experimental-feature NonescapableTypes   \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature Sensitive           \
 // RUN:     -enable-builtin-module                           \
 // RUN:     -debug-diagnostic-names

--- a/test/Sema/conditionally_copyable.swift
+++ b/test/Sema/conditionally_copyable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift
 
 struct G<T: ~Copyable>: ~Copyable {}
 

--- a/test/Sema/explicit_lifetime_dependence_specifiers1.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes
 // REQUIRES: asserts
 
 struct Container {

--- a/test/Sema/explicit_lifetime_dependence_specifiers2.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes
 // REQUIRES: asserts
 // REQUIRES: nonescapable_types
 

--- a/test/Sema/implicit_lifetime_dependence.swift
+++ b/test/Sema/implicit_lifetime_dependence.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NonescapableTypes
 // REQUIRES: asserts
 
 struct BufferView : ~Escapable, ~Copyable {

--- a/test/Sema/invertible_no_stdlib.swift
+++ b/test/Sema/invertible_no_stdlib.swift
@@ -1,6 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-builtin-module \
-// RUN:   -parse-stdlib -module-name Ghost \
-// RUN:   -enable-experimental-feature NoncopyableGenerics
+// RUN:   -parse-stdlib -module-name Ghost
 
 
 

--- a/test/Sema/move_expr_moveonly_partial_consumption.swift
+++ b/test/Sema/move_expr_moveonly_partial_consumption.swift
@@ -1,7 +1,6 @@
 // RUN: %target-typecheck-verify-swift                              \
 // RUN:     -disable-availability-checking                          \
 // RUN:     -enable-experimental-feature NoImplicitCopy             \
-// RUN:     -enable-experimental-feature NoncopyableGenerics        \
 // RUN:     -debug-diagnostic-names
 
 @_silgen_name("get")

--- a/test/Sema/moveonly_sendable_legacy.swift
+++ b/test/Sema/moveonly_sendable_legacy.swift
@@ -1,6 +1,5 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:   -parse-stdlib -module-name Swift \
-// RUN:   -enable-experimental-feature NoncopyableGenerics
+// RUN:   -parse-stdlib -module-name Swift
 
 @_marker protocol Copyable {}
 

--- a/test/Sema/suppressed_assoc_stdlib.swift
+++ b/test/Sema/suppressed_assoc_stdlib.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -parse-stdlib -module-name Swift -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift -parse-stdlib -module-name Swift
 
 public protocol Hello {
   associatedtype Req: ~Copyable

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -1,14 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_explicit_lifetime_dependence.swift \
 // RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -enable-experimental-feature NoncopyableGenerics \
 // RUN: -disable-lifetime-dependence-diagnostics
 
 // RUN: llvm-bcanalyzer %t/def_explicit_lifetime_dependence.swiftmodule 
 
 // RUN: %target-swift-frontend -module-name lifetime-dependence -emit-sil -I %t %s \
-// RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+// RUN: -enable-experimental-feature NonescapableTypes | %FileCheck %s
 
 import def_explicit_lifetime_dependence
 func testBasic() {

--- a/test/Serialization/implicit_lifetime_dependence.swift
+++ b/test/Serialization/implicit_lifetime_dependence.swift
@@ -1,14 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_implicit_lifetime_dependence.swift \
 // RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -enable-experimental-feature NoncopyableGenerics \
 // RUN: -disable-lifetime-dependence-diagnostics
 
 // RUN: llvm-bcanalyzer %t/def_implicit_lifetime_dependence.swiftmodule 
 
 // RUN: %target-swift-frontend -module-name lifetime-dependence -emit-sil -I %t %s \
-// RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+// RUN: -enable-experimental-feature NonescapableTypes | %FileCheck %s
 
 import def_implicit_lifetime_dependence
 

--- a/test/Serialization/noncopyable_generics.swift
+++ b/test/Serialization/noncopyable_generics.swift
@@ -1,17 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/ncgenerics.swift                      \
-// RUN:     -enable-experimental-feature NoncopyableGenerics                   \
 // RUN:     -enable-experimental-feature SuppressedAssociatedTypes             \
 // RUN:     -emit-module -module-name ncgenerics                               \
 // RUN:     -o %t
 
 // RUN: llvm-bcanalyzer %t/ncgenerics.swiftmodule | %FileCheck %s
 
-// *** Notice that we're checking when _not_ using NoncopyableGenerics! ***
 // RUN: %target-typecheck-verify-swift -I %t
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk)                  \
-// RUN:    -enable-experimental-feature NoncopyableGenerics                    \
 // RUN:     -enable-experimental-feature SuppressedAssociatedTypes             \
 // RUN:    -print-module -module-to-print=ncgenerics                           \
 // RUN:    -I %t -source-filename=%s                                           \

--- a/test/api-digester/compare-dump-abi-parsable-interface.swift
+++ b/test/api-digester/compare-dump-abi-parsable-interface.swift
@@ -6,7 +6,7 @@
 // RUN: %empty-directory(%t.module-cache)
 
 // RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.mod1/cake.swiftinterface %S/Inputs/cake_baseline/cake.swift -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -typecheck -emit-module-interface-path %t.mod2/cake.swiftinterface %S/Inputs/cake_current/cake.swift -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.mod2/cake.swiftinterface %S/Inputs/cake_current/cake.swift -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
 // RUN: %api-digester -diagnose-sdk -print-module -module cake -BI %t.mod1 -BI %S/Inputs/APINotesLeft -I %t.mod2 -I %S/Inputs/APINotesRight -sdk %clang-importer-sdk-path -bsdk %clang-importer-sdk-path -module-cache-path %t.module-cache -o %t.result -abi
 
 // RUN: %clang -E -P -x c %S/Outputs/Cake-abi.txt -o - | sed '/^\s*$/d' > %t.expected

--- a/test/api-digester/compare-dump-abi.swift
+++ b/test/api-digester/compare-dump-abi.swift
@@ -7,7 +7,7 @@
 // RUN: %empty-directory(%t.baseline/ABI)
 
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -emit-module-source-info -emit-module-source-info-path %t.mod1/cake.swiftsourceinfo 2> %t.compiler-diags
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -emit-module-source-info -emit-module-source-info-path %t.mod2/cake.swiftsourceinfo
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -emit-module-source-info -emit-module-source-info-path %t.mod2/cake.swiftsourceinfo
 // RUN: %api-digester -dump-sdk -module cake -output-dir %t.baseline -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft -abi
 // RUN: %api-digester -diagnose-sdk -print-module -baseline-dir %t.baseline -module cake -I %t.mod2 -I %S/Inputs/APINotesLeft -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -o %t.result
 // RUN: %clang -E -P -w -x c %S/Outputs/Cake-abi.txt -o - | sed '/^\s*$/d' > %t.abi.expected

--- a/test/api-digester/compare-dump-parsable-interface.swift
+++ b/test/api-digester/compare-dump-parsable-interface.swift
@@ -6,7 +6,7 @@
 // RUN: %empty-directory(%t.module-cache)
 
 // RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.mod1/cake.swiftinterface %S/Inputs/cake_baseline/cake.swift -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -typecheck -emit-module-interface-path %t.mod2/cake.swiftinterface %S/Inputs/cake_current/cake.swift -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.mod2/cake.swiftinterface %S/Inputs/cake_current/cake.swift -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
 // RUN: %api-digester -diagnose-sdk -print-module -module cake -BI %t.mod1 -BI %S/Inputs/APINotesLeft -I %t.mod2 -I %S/Inputs/APINotesRight -sdk %clang-importer-sdk-path -bsdk %clang-importer-sdk-path -module-cache-path %t.module-cache -o %t.result
 
 // RUN: %clang -E -P -x c %S/Outputs/Cake.txt -o - | sed '/^\s*$/d' > %t.expected

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -5,7 +5,7 @@
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name cake
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -module-name cake
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -module-name cake
 // RUN: %api-digester -dump-sdk -module cake -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft
 // RUN: %api-digester -dump-sdk -module cake -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod2 -I %S/Inputs/APINotesRight
 // RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result

--- a/test/attr/attr_nonEscapable.swift
+++ b/test/attr/attr_nonEscapable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 

--- a/test/stdlib/Noncopyables/MemoryLayout.swift
+++ b/test/stdlib/Noncopyables/MemoryLayout.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics) | %FileCheck %s
+// RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 
 struct A: ~Copyable {

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift -enable-upcoming-feature ExistentialAny
-// RUN: %target-typecheck-verify-swift -enable-upcoming-feature ExistentialAny -enable-experimental-feature NoncopyableGenerics
 
 protocol HasSelfRequirements {
   func foo(_ x: Self)

--- a/validation-test/IRGen/moveonly_partial_consumption_linked_list.swift
+++ b/validation-test/IRGen/moveonly_partial_consumption_linked_list.swift
@@ -2,7 +2,6 @@
 // RUN:     %s \
 // RUN:     -enable-builtin-module \
 // RUN:     -enable-experimental-feature BorrowingSwitch \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -sil-verify-all \
 // RUN:     -verify
 

--- a/validation-test/SILOptimizer/moveonly_partial_consumption_linked_list.swift
+++ b/validation-test/SILOptimizer/moveonly_partial_consumption_linked_list.swift
@@ -2,7 +2,6 @@
 // RUN:     %s \
 // RUN:     -enable-builtin-module \
 // RUN:     -enable-experimental-feature BorrowingSwitch \
-// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -sil-verify-all \
 // RUN:     -verify
 


### PR DESCRIPTION
This PR promotes the experimental feature to a full language feature. Also fixes a bug where you could use the feature without the right flags in the swiftinterface file for feature-guarded declarations (rdar://127701059)