### PR TITLE
[DebugInfo] Fix verifier crash for complex switch 

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -423,6 +423,9 @@ public:
 #else
     (void)skipVarDeclAssert;
 #endif
+    // Don't apply location overrides on variables.
+    if (Var && !Var->Loc)
+      Var->Loc = Loc;
     return insert(AllocStackInst::create(
         getSILDebugLocation(Loc, true), elementType, getFunction(),
         substituteAnonymousArgs(Name, Var, Loc), dynamic, isLexical,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2083,6 +2083,13 @@ public:
   /// VarDecl.
   void setIsFromVarDecl() { sharedUInt8().AllocStackInst.fromVarDecl = true; }
 
+  /// Return the SILLocation for the debug variable.
+  SILLocation getVarLoc() const {
+    if (hasAuxDebugLocation())
+      return *getTrailingObjects<SILLocation>();
+    return getLoc();
+  }
+
   /// Return the debug variable information attached to this instruction.
   std::optional<SILDebugVariable> getVarInfo() const {
     // If we used to have debug info attached but our debug info is now
@@ -5373,6 +5380,13 @@ public:
   /// Return the underlying variable declaration that this denotes,
   /// or null if we don't have one.
   VarDecl *getDecl() const;
+
+  /// Return the SILLocation for the debug variable.
+  SILLocation getVarLoc() const {
+    if (hasAuxDebugLocation())
+      return *getTrailingObjects<SILLocation>();
+    return getLoc();
+  }
 
   /// Return the debug variable information attached to this instruction.
   std::optional<SILDebugVariable> getVarInfo() const {

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -286,6 +286,9 @@ AllocStackInst *AllocStackInst::create(SILDebugLocation Loc,
 }
 
 VarDecl *AllocationInst::getDecl() const {
+  if (auto ASI = dyn_cast<AllocStackInst>(this)) {
+    return ASI->getVarLoc().getAsASTNode<VarDecl>();
+  }
   return getLoc().getAsASTNode<VarDecl>();
 }
 
@@ -505,7 +508,7 @@ bool DebugValueInst::exprStartsWithDeref() const {
 }
 
 VarDecl *DebugValueInst::getDecl() const {
-  return getLoc().getAsASTNode<VarDecl>();
+  return getVarLoc().getAsASTNode<VarDecl>();
 }
 
 VarDecl *SILDebugVariable::getDecl() const {

--- a/test/DebugInfo/case-match-vars.swift
+++ b/test/DebugInfo/case-match-vars.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -module-name a -parse-as-library -emit-ir -g %t/Seq.swift %t/A.swift | %FileCheck %s
+
+// This code used to trigger the verifier.
+// https://github.com/apple/swift/issues/73338
+
+// BEGIN Seq.swift
+struct A<Element: Equatable>: ExpressibleByArrayLiteral, Equatable {
+  var base: Element?
+  init(arrayLiteral elements: Element...) {}
+}
+struct B<Element: Equatable>: ExpressibleByArrayLiteral, Equatable {
+  var first: Element?
+  init(arrayLiteral elements: Element...) {}
+}
+
+// BEGIN A.swift
+enum E<T: P> {
+  case a(A<T.ID>)
+  case b(B<T.ID>)
+  case c
+
+  static func ==(lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case (.a([]), .c), (.c, .a([])),
+         (.b([]), .c), (.c, .b([])):
+      return true
+    default:
+      return false
+    }
+  }
+}
+public protocol P {
+  associatedtype ID: Equatable
+}
+
+// The [] expressions should be available in the debugger
+
+// CHECK: !DILocalVariable(name: "$_0", {{.+}} line: 9
+// CHECK: !DILocalVariable(name: "$_1", {{.+}} line: 9
+// CHECK: !DILocalVariable(name: "$_2", {{.+}} line: 8
+// CHECK: !DILocalVariable(name: "$_3", {{.+}} line: 8
+

--- a/test/DebugInfo/copyforward.sil
+++ b/test/DebugInfo/copyforward.sil
@@ -17,7 +17,7 @@ bb0(%0 : $*Optional<Element>, %1 : $*CollectionOfOne<Element>.Iterator):
   %3 = alloc_stack [lexical] [var_decl] $Optional<Element>, let, name "result", loc "backward.swift":67:9, scope 2
   %4 = struct_element_addr %1 : $*CollectionOfOne<Element>.Iterator, #CollectionOfOne.Iterator._elements, loc "backward.swift":67:18, scope 1
 
-  // CHECK: debug_value %{{[0-9]+}} : $*Optional<Element>, let, (name "result", loc "backward.swift":67:9, scope 2), expr op_deref, loc "backward.swift":67:18, scope 2
+  // CHECK: debug_value %{{[0-9]+}} : $*Optional<Element>, let, (name "result", loc "backward.swift":67:9), expr op_deref, loc "backward.swift":67:18, scope 2
 
   copy_addr %4 to [init] %3 : $*Optional<Element>, loc "backward.swift":67:18, scope 1
   %6 = alloc_stack $Optional<Element>, loc "backward.swift":68:17, scope 2

--- a/test/DebugInfo/debug_info_expression.sil
+++ b/test/DebugInfo/debug_info_expression.sil
@@ -25,7 +25,7 @@ bb0:
   %3 = struct_element_addr %2 : $*MyStruct, #MyStruct.x, loc "file.swift":9:17, scope 1
   // CHECK: %[[FIELD_X:.*]] = getelementptr {{.*}} %[[MY_STRUCT]]
   // CHECK-SIL: debug_value %{{[0-9]+}} : $*Builtin.Int64
-  // CHECK-SIL-SAME:        (name "my_struct", loc "file.swift":8:9, scope {{[0-9]+}})
+  // CHECK-SIL-SAME:        (name "my_struct", loc "file.swift":8:9)
   // CHECK-SIL-SAME:        type $MyStruct, expr op_deref:op_fragment:#MyStruct.x
   debug_value %3 : $*Builtin.Int64, var, (name "my_struct", loc "file.swift":8:9, scope 1), type $MyStruct, expr op_deref:op_fragment:#MyStruct.x, loc "file.swift":9:17, scope 1
 
@@ -51,7 +51,7 @@ bb0:
   // CHECK: %[[MY_STRUCT:.+]] = alloca %{{.*}}MyStruct
   // CHECK: llvm.dbg.declare(metadata ptr %[[MY_STRUCT]], metadata ![[VAR_DECL_MD:[0-9]+]]
   // CHECK-SIL: alloc_stack $Int, var
-  // CHECK-SIL-SAME:        (name "my_struct", loc "file.swift":15:9, scope {{[0-9]+}})
+  // CHECK-SIL-SAME:        (name "my_struct", loc "file.swift":15:9)
   // CHECK-SIL-SAME:        type $MyStruct, expr op_fragment:#MyStruct.x
   %field_x = alloc_stack $Int, var, (name "my_struct", loc "file.swift":15:9, scope 2), type $MyStruct, expr op_fragment:#MyStruct.x, loc "file.swift":16:17, scope 2
   // CHECK: %[[FIELD_X:.+]] = alloca %TSi

--- a/test/DebugInfo/sroa_mem2reg.sil
+++ b/test/DebugInfo/sroa_mem2reg.sil
@@ -57,8 +57,8 @@ bb0(%0 : $Int64, %1 : $Int64):
   // CHECK-MEM2REG: %[[FIELD_Y:[0-9]+]] = struct_extract %[[STRUCT]] : $MyStruct, #MyStruct.y, loc "sroa.swift":8:21
   store %1 to %15 : $*Int64, loc "sroa.swift":10:17, scope 2
   // Make sure the struct fields' SSA values are properly connected to the source variables via op_fragment
-  // CHECK-MEM2REG: debug_value %[[FIELD_X]] : $Int64, var, (name "my_struct", loc "sroa.swift":8:9, scope 2), type $*MyStruct, expr op_fragment:#MyStruct.x
-  // CHECK-MEM2REG: debug_value %[[FIELD_Y]] : $Int64, var, (name "my_struct", loc "sroa.swift":8:9, scope 2), type $*MyStruct, expr op_fragment:#MyStruct.y
+  // CHECK-MEM2REG: debug_value %[[FIELD_X]] : $Int64, var, (name "my_struct", loc "sroa.swift":8:9), type $*MyStruct, expr op_fragment:#MyStruct.x
+  // CHECK-MEM2REG: debug_value %[[FIELD_Y]] : $Int64, var, (name "my_struct", loc "sroa.swift":8:9), type $*MyStruct, expr op_fragment:#MyStruct.y
   // CHECK-IR: call void @llvm.dbg.value(metadata i64 %0
   // CHECK-IR-SAME:                      metadata ![[STRUCT_MD:[0-9]+]]
   // CHECK-IR-SAME:                      !DIExpression(DW_OP_LLVM_fragment, 0, 64)
@@ -66,8 +66,8 @@ bb0(%0 : $Int64, %1 : $Int64):
   // CHECK-IR-SAME:                      metadata ![[STRUCT_MD]]
   // CHECK-IR-SAME:                      !DIExpression(DW_OP_LLVM_fragment, 64, 64)
   // Make sure function arguments' SSA values are also properly connected to the source variables
-  // CHECK-MEM2REG: debug_value %0 : $Int64, var, (name "my_struct", loc "sroa.swift":8:9, scope 2), type $*MyStruct, expr op_fragment:#MyStruct.x
-  // CHECK-MEM2REG: debug_value %1 : $Int64, var, (name "my_struct", loc "sroa.swift":8:9, scope 2), type $*MyStruct, expr op_fragment:#MyStruct.y
+  // CHECK-MEM2REG: debug_value %0 : $Int64, var, (name "my_struct", loc "sroa.swift":8:9), type $*MyStruct, expr op_fragment:#MyStruct.x
+  // CHECK-MEM2REG: debug_value %1 : $Int64, var, (name "my_struct", loc "sroa.swift":8:9), type $*MyStruct, expr op_fragment:#MyStruct.y
   // CHECK-IR: call void @llvm.dbg.value(metadata i64 %0, metadata ![[ARG1_MD:[0-9]+]]
   // CHECK-IR: call void @llvm.dbg.value(metadata i64 %1, metadata ![[ARG2_MD:[0-9]+]]
   dealloc_stack %4 : $*MyStruct, loc "sroa.swift":8:9, scope 2

--- a/test/SILOptimizer/assemblyvision_remark/cast_remarks.swift
+++ b/test/SILOptimizer/assemblyvision_remark/cast_remarks.swift
@@ -35,14 +35,11 @@ public func forcedCast3<NS, T>(_ ns: NS) -> T {
 
 public func forcedCast4<NS, T>(_ ns: NS, _ ns2: NS) -> T {
   // Make sure the colon info is right so that the arrow is under the a.
-  //
-  // Today, we lose that x was assigned ns2. This is flow sensitive information
-  // that we might be able to recover. We still emit that a runtime cast
-  // occurred here, just don't say what the underlying value was.
   var x = ns
   x = ns2
   return x as! T  // expected-remark @:12 {{unconditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-9:44 {{of 'ns2'}}
+                  // expected-note @-5:44 {{of 'ns2'}}
+                  // expected-note @-4:7 {{of 'x'}}
 }
 
 public func condCast<NS, T>(_ ns: NS) -> T? {
@@ -73,14 +70,11 @@ public func condCast3<NS, T>(_ ns: NS) -> T? {
 
 public func condCast4<NS, T>(_ ns: NS, _ ns2: NS) -> T? {
   // Make sure the colon info is right so that the arrow is under the a.
-  //
-  // Today, we lose that x was assigned ns2. This is flow sensitive information
-  // that we might be able to recover. We still emit that a runtime cast
-  // occurred here, just don't say what the underlying value was.
   var x = ns
   x = ns2
   return x as? T  // expected-remark @:12 {{conditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-9:42 {{of 'ns2'}}
+                  // expected-note @-5:42 {{of 'ns2'}}
+                  // expected-note @-4:7 {{of 'x'}}
 }
 
 public func condCast5<NS, T>(_ ns: NS) -> T? {
@@ -252,6 +246,7 @@ public func forcedCast4(_ ns: Existential1, _ ns2: Existential1) -> Existential2
   x = ns2
   return x as! Existential2  // expected-remark @:12 {{unconditional runtime cast of value with type 'any Existential1' to 'any Existential2'}}
                              // expected-note @-5:47 {{of 'ns2'}}
+                             // expected-note @-4:7 {{of 'x'}}
 }
 
 public func condCast(_ ns: Existential1) -> Existential2? {
@@ -287,6 +282,7 @@ public func condCast4(_ ns: Existential1, _ ns2: Existential1) -> Existential2? 
   x = ns2
   return x as? Existential2 // expected-remark @:12 {{conditional runtime cast of value with type 'any Existential1' to 'any Existential2'}}
                             // expected-note @-5:45 {{of 'ns2'}}
+                            // expected-note @-4:7 {{of 'x'}}
 }
 
 public func condCast5(_ ns: Existential1) -> Existential2? {

--- a/test/SILOptimizer/assemblyvision_remark/cast_remarks_objc.swift
+++ b/test/SILOptimizer/assemblyvision_remark/cast_remarks_objc.swift
@@ -18,34 +18,27 @@ public func forcedCast<NS, T>(_ ns: NS) -> T {
 
 public func forcedCast2<NS, T>(_ ns: NS) -> T {
   // Make sure the colon info is right so that the arrow is under the a.
-  //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow.
   let x = ns
   return x as! T  // expected-remark @:12 {{unconditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-7:34 {{of 'ns'}}
+                  // expected-note @-4:34 {{of 'ns'}}
+                  // expected-note @-3:7 {{of 'x'}}
 }
 
 public func forcedCast3<NS, T>(_ ns: NS) -> T {
   // Make sure the colon info is right so that the arrow is under the a.
-  //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow.
   var x = ns // expected-warning {{variable 'x' was never mutated}}
   return x as! T  // expected-remark @:12 {{unconditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-7:34 {{of 'ns'}}
+                  // expected-note @-4:34 {{of 'ns'}}
+                  // expected-note @-3:7 {{of 'x'}}
 }
 
 public func forcedCast4<NS, T>(_ ns: NS, _ ns2: NS) -> T {
   // Make sure the colon info is right so that the arrow is under the a.
-  //
-  // Today, we lose that x was assigned ns2. This is flow sensitive information
-  // that we might be able to recover. We still emit that a runtime cast
-  // occurred here, just don't say what the underlying value was.
   var x = ns
   x = ns2
   return x as! T  // expected-remark @:12 {{unconditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-9:44 {{of 'ns2'}}
+                  // expected-note @-5:44 {{of 'ns2'}}
+                  // expected-note @-4:7 {{of 'x'}}
 }
 
 public func condCast<NS, T>(_ ns: NS) -> T? {
@@ -56,34 +49,27 @@ public func condCast<NS, T>(_ ns: NS) -> T? {
 
 public func condCast2<NS, T>(_ ns: NS) -> T? {
   // Make sure the colon info is right so that the arrow is under the a.
-  //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow.
   let x = ns
   return x as? T  // expected-remark @:12 {{conditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-7:32 {{of 'ns'}}
+                  // expected-note @-4:32 {{of 'ns'}}
+                  // expected-note @-3:7 {{of 'x'}}
 }
 
 public func condCast3<NS, T>(_ ns: NS) -> T? {
   // Make sure the colon info is right so that the arrow is under the a.
-  //
-  // Today, we seem to completely eliminate 'x' here in the debug info. TODO:
-  // Maybe we can recover this info somehow.
   var x = ns // expected-warning {{variable 'x' was never mutated}}
   return x as? T  // expected-remark @:12 {{conditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-7:32 {{of 'ns'}}
+                  // expected-note @-4:32 {{of 'ns'}}
+                  // expected-note @-3:7 {{of 'x'}}
 }
 
 public func condCast4<NS, T>(_ ns: NS, _ ns2: NS) -> T? {
   // Make sure the colon info is right so that the arrow is under the a.
-  //
-  // Today, we lose that x was assigned ns2. This is flow sensitive information
-  // that we might be able to recover. We still emit that a runtime cast
-  // occurred here, just don't say what the underlying value was.
   var x = ns
   x = ns2
   return x as? T  // expected-remark @:12 {{conditional runtime cast of value with type 'NS' to 'T'}}
-                  // expected-note @-9:42 {{of 'ns2'}}
+                  // expected-note @-5:42 {{of 'ns2'}}
+                  // expected-note @-4:7 {{of 'x'}}
 }
 
 public func condCast5<NS, T>(_ ns: NS) -> T? {

--- a/test/SILOptimizer/assemblyvision_remark/chacha.swift
+++ b/test/SILOptimizer/assemblyvision_remark/chacha.swift
@@ -43,9 +43,10 @@ public func run_ChaCha(_ N: Int) {
                             // expected-remark @-1:27 {{release of type '}}
   }
 } // expected-remark {{release of type '}}
-
+  // expected-note @-7 {{of 'plaintext}}
   // expected-remark @-2 {{release of type '}}
   // expected-note @-16 {{of 'nonce}}
   // expected-remark @-4 {{release of type '}}
   // expected-note @-19 {{of 'key}}
   // expected-remark @-6 {{release of type '}}
+  // expected-note @-18 {{of 'checkedtext}}


### PR DESCRIPTION
An alloc_stack, just like a debug_value, should ignore location overrides for their variable.

Additionally, for this to work correctly, we need to use the variable's location and not the instruction's location when generating anonymous variables in IRGen (which uses getDecl).

To implement this more easily, the variable's location is always set, and when there is no override, the duplicate location information is removed in AllocStackInst::create.

Fixes #73338
rdar://127348128