### PR TITLE
[6.0][Concurrency] Use EnvVars utilities for SWIFT_IS_CURRENT_EXECUTOR_LEG…

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -53,6 +53,10 @@ SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableJobDispatchIntegration();
 // Concurrency library can call.
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations();
 
+// Wrapper around SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE that the
+// Concurrency library can call.
+SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverride();
+
 } // end namespace environment
 } // end namespace runtime
 } // end namespace swift

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -30,6 +30,7 @@
 #include "swift/Runtime/Bincompat.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/DispatchShims.h"
+#include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Threading/Mutex.h"
 #include "swift/Threading/Once.h"
 #include "swift/Threading/Thread.h"
@@ -352,8 +353,8 @@ static void checkIsCurrentExecutorMode(void *context) {
   // Potentially, override the platform detected mode, primarily used in tests.
 #if SWIFT_STDLIB_HAS_ENVIRON
   if (const char *modeStr =
-          getenv("SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE")) {
-    if (modeStr && *modeStr) {
+          runtime::environment::concurrencyIsCurrentExecutorLegacyModeOverride()) {
+    if (modeStr) {
       if (strcmp(modeStr, "nocrash") == 0) {
         useLegacyMode = true;
       } else if (strcmp(modeStr, "crash") == 0) {

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -272,3 +272,7 @@ SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableJobDispatchIntegration() {
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations() {
   return runtime::environment::SWIFT_DEBUG_VALIDATE_UNCHECKED_CONTINUATIONS();
 }
+
+SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverride() {
+  return runtime::environment::SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE();
+}

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -119,4 +119,17 @@ VARIABLE(SWIFT_BACKTRACE, string, "",
          "crash catching and backtracing support in the runtime. "
          "See docs/Backtracing.rst in the Swift repository for details.")
 
+VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
+         "Allows for suppressing 'is current executor' equality check crashes. "
+         "As since Swift 6.0 checking for current executor equality, may crash "
+         "and will never return 'false' because we are calling into library "
+         "implemented SerialExecutor.checkIsolation which should crash if the "
+         "isolation is not the expected one. Some old code may rely on the "
+         "non-crashing behavior. This flag enables temporarily restoring the "
+         "legacy 'nocrash' behavior until adopting code has been adjusted.\n"
+         "\n"
+         "Legal values are: \n"
+         "  - nocrash (Legacy behavior)\n"
+         "  - crash (Swift 6.0+ behavior)")
+
 #undef VARIABLE

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -126,10 +126,9 @@ VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
          "implemented SerialExecutor.checkIsolation which should crash if the "
          "isolation is not the expected one. Some old code may rely on the "
          "non-crashing behavior. This flag enables temporarily restoring the "
-         "legacy 'nocrash' behavior until adopting code has been adjusted.\n"
-         "\n"
-         "Legal values are: \n"
-         "  - nocrash (Legacy behavior)\n"
-         "  - crash (Swift 6.0+ behavior)")
+         "legacy 'nocrash' behavior until adopting code has been adjusted. "
+         "Legal values are: "
+         " 'nocrash' (Legacy behavior), "
+         " 'crash' (Swift 6.0+ behavior)")
 
 #undef VARIABLE

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -565,3 +565,6 @@ Added: __swift_enableSwizzlingOfAllocationAndRefCountingFunctions_forInstruments
 
 // Runtime bincompat functions for Concurrency runtime to detect legacy mode
 Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks
+
+// Add add SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE
+Added: _concurrencyIsCurrentExecutorLegacyModeOverride

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -565,3 +565,6 @@ Added: __swift_enableSwizzlingOfAllocationAndRefCountingFunctions_forInstruments
 
 // Runtime bincompat functions for Concurrency runtime to detect legacy mode
 Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks
+
+// Add add SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE
+Added: _concurrencyIsCurrentExecutorLegacyModeOverride


### PR DESCRIPTION
**Description**: Minor follow up to https://github.com/apple/swift/pull/73496 this is a more efficient and will show up in help way of introducing the env variable. We only use it in testing, but nevertheless it can be useful to document to override the behavior for verification purposes.
**Scope/Impact**: No behavior change, just documenting the option better.
**Risk:** Low, no behavioral change 
**Testing**: CI testing
**Reviewed by**: @mikeash 

**Original PR:** https://github.com/apple/swift/pull/73495
**Radar:** rdar://127400013