### PR TITLE
Relax @retroactive check to allow same-package declarations

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -185,7 +185,14 @@ usesDefaultDefinition(AssociatedTypeDecl *requirement) const {
 bool ProtocolConformance::isRetroactive() const {
   auto extensionModule = getDeclContext()->getParentModule();
   auto protocolModule = getProtocol()->getParentModule();
-  if (extensionModule->isSameModuleLookingThroughOverlays(protocolModule)) {
+  
+  auto isSameRetroactiveContext = 
+    [](ModuleDecl *moduleA, ModuleDecl *moduleB) -> bool {
+      return moduleA->isSameModuleLookingThroughOverlays(moduleB)) ||
+        moduleA->inSamePackage(moduleB));
+    };
+  
+  if (isSameRetroactiveContext(extensionModule, protocolModule)) {
     return false;
   }
 
@@ -193,8 +200,7 @@ bool ProtocolConformance::isRetroactive() const {
       ConformingType->getNominalOrBoundGenericNominal();
   if (conformingTypeDecl) {
     auto conformingTypeModule = conformingTypeDecl->getParentModule();
-    if (extensionModule->
-        isSameModuleLookingThroughOverlays(conformingTypeModule)) {
+    if (isSameRetroactiveContext(extensionModule, conformingTypeModule)) {
       return false;
     }
   }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -188,8 +188,8 @@ bool ProtocolConformance::isRetroactive() const {
   
   auto isSameRetroactiveContext = 
     [](ModuleDecl *moduleA, ModuleDecl *moduleB) -> bool {
-      return moduleA->isSameModuleLookingThroughOverlays(moduleB)) ||
-        moduleA->inSamePackage(moduleB));
+      return moduleA->isSameModuleLookingThroughOverlays(moduleB) ||
+        moduleA->inSamePackage(moduleB);
     };
   
   if (isSameRetroactiveContext(extensionModule, protocolModule)) {

--- a/test/Sema/extension_retroactive_conformances_package.swift
+++ b/test/Sema/extension_retroactive_conformances_package.swift
@@ -1,8 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -swift-version 5 %t/OtherLibrary.swift -package-name Library -emit-module -module-name OtherLibrary -package-name Library -o %t
-// RUN: %target-swift-frontend -typecheck %t/Library.swift -module-name Library -package-name Library -verify -swift-version 5 -import-underlying-module -I %t
-// RUN: %target-swift-frontend -typecheck %t/Client.swift -module-name Client -package-name Library -verify -swift-version 5 -I %t
+
+// RUN: %target-swift-frontend -swift-version 5 %t/Library.swift -emit-module -module-name Library -o %t -package-name Library 
+// RUN: %target-swift-frontend -swift-version 5 %t/OtherLibrary.swift -emit-module -module-name OtherLibrary -o %t -package-name Library
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -module-name Client -verify -swift-version 5 -I %t -package-name Library 
 
 //--- Library.swift
 
@@ -12,6 +13,7 @@ package class PackageLibraryClass {}
 package protocol PackageLibraryProtocol {}
 
 //--- OtherLibrary.swift
+
 public class OtherLibraryClass {}
 public protocol OtherLibraryProtocol {}
 package class PackageOtherLibraryClass {}
@@ -19,8 +21,8 @@ package protocol PackageOtherLibraryProtocol {}
 
 //--- Client.swift
 
-// package import Library
-// package import OtherLibrary
+package import Library
+package import OtherLibrary
 
 // These are all fine because all 3 of these modules are in the same package.
 

--- a/test/Sema/extension_retroactive_conformances_package.swift
+++ b/test/Sema/extension_retroactive_conformances_package.swift
@@ -6,23 +6,36 @@
 
 //--- Library.swift
 
-public class LibraryClass {
-}
-
-public protocol LibraryProtocol {
-}
+public class LibraryClass {}
+public protocol LibraryProtocol {}
+package class PackageLibraryClass {}
+package protocol PackageLibraryProtocol {}
 
 //--- OtherLibrary.swift
 public class OtherLibraryClass {}
-public class OtherLibraryProtocol {}
+public protocol OtherLibraryProtocol {}
+package class PackageOtherLibraryClass {}
+package protocol PackageOtherLibraryProtocol {}
 
 //--- Client.swift
 
-import Library
-import OtherLibrary
+// package import Library
+// package import OtherLibrary
 
-// These are all fine because all 3 of these libraries are in the same package.
+// These are all fine because all 3 of these modules are in the same package.
 
 extension LibraryClass: LibraryProtocol {}
 extension OtherLibraryClass: LibraryProtocol {}
 extension LibraryClass: OtherLibraryProtocol {}
+
+extension PackageLibraryClass: LibraryProtocol {}
+extension PackageOtherLibraryClass: LibraryProtocol {}
+extension PackageLibraryClass: OtherLibraryProtocol {}
+
+extension LibraryClass: PackageLibraryProtocol {}
+extension OtherLibraryClass: PackageLibraryProtocol {}
+extension LibraryClass: PackageOtherLibraryProtocol {}
+
+extension PackageLibraryClass: PackageLibraryProtocol {}
+extension PackageOtherLibraryClass: PackageLibraryProtocol {}
+extension PackageLibraryClass: PackageOtherLibraryProtocol {}

--- a/test/Sema/extension_retroactive_conformances_package.swift
+++ b/test/Sema/extension_retroactive_conformances_package.swift
@@ -21,8 +21,8 @@ package protocol PackageOtherLibraryProtocol {}
 
 //--- Client.swift
 
-package import Library
-package import OtherLibrary
+public import Library
+public import OtherLibrary
 
 // These are all fine because all 3 of these modules are in the same package.
 

--- a/test/Sema/extension_retroactive_conformances_package.swift
+++ b/test/Sema/extension_retroactive_conformances_package.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -swift-version 5 %t/OtherLibrary.swift -package-name Library -emit-module -module-name OtherLibrary -package-name Library -o %t
+// RUN: %target-swift-frontend -typecheck %t/Library.swift -module-name Library -package-name Library -verify -swift-version 5 -import-underlying-module -I %t
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -module-name Client -package-name Library -verify -swift-version 5 -I %t
+
+//--- Library.swift
+
+public class LibraryClass {
+}
+
+public protocol LibraryProtocol {
+}
+
+//--- OtherLibrary.swift
+public class OtherLibraryClass {}
+public class OtherLibraryProtocol {}
+
+//--- Client.swift
+
+import Library
+import OtherLibrary
+
+// These are all fine because all 3 of these libraries are in the same package.
+
+extension LibraryClass: LibraryProtocol {}
+extension OtherLibraryClass: LibraryProtocol {}
+extension LibraryClass: OtherLibraryProtocol {}


### PR DESCRIPTION
<!-- What's in this pull request? -->

This relaxes the @retroactive check to allow conformances as long as either the type or the protocol is declared in the same package as the extension.

Resolves rdar://127738893