### PR TITLE
[cxx-interop] Do not crash when passing `Bool` as `const T&` parameter

### DIFF
--- a/lib/SIL/IR/Bridging.cpp
+++ b/lib/SIL/IR/Bridging.cpp
@@ -138,7 +138,7 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
   if (nativeBoolTy && t->isEqual(nativeBoolTy)) {
     // If we have a Clang type that was imported as Bool, it had better be
     // one of a small set of types.
-    if (clangTy) {
+    if (clangTy && clangTy->isBuiltinType()) {
       auto builtinTy = clangTy->castAs<clang::BuiltinType>();
       if (builtinTy->getKind() == clang::BuiltinType::Bool)
         return t;

--- a/test/Interop/Cxx/reference/Inputs/reference.h
+++ b/test/Interop/Cxx/reference/Inputs/reference.h
@@ -35,6 +35,8 @@ const ClassTemplate<T> &refToDependent() { return ClassTemplate<T>(); }
 void dontImportAtomicRef(_Atomic(int)&) { }
 
 void takeConstRef(const int &);
+inline bool takeConstRefBool(const bool &b) { return b; }
+inline void takeRefBool(bool &b) { b = true; }
 
 template<class T>
 T &refToTemplate(T &t) { return t; }

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -78,6 +78,17 @@ ReferenceTestSuite.test("pod-struct-const-lvalue-reference") {
   expectEqual(getStaticInt(), 78)
 }
 
+ReferenceTestSuite.test("const reference to bool") {
+  expectTrue(takeConstRefBool(true))
+  expectFalse(takeConstRefBool(false))
+}
+
+ReferenceTestSuite.test("reference to bool") {
+  var b = false
+  takeRefBool(&b)
+  expectTrue(b)
+}
+
 ReferenceTestSuite.test("reference to template") {
   var val: CInt = 53
   let ref = refToTemplate(&val)

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -72,8 +72,11 @@ template <class T> struct Dep { using TT = T; };
 template <class T> void useDependentType(typename Dep<T>::TT) {}
 
 template <class T> void lvalueReference(T &ref) { ref = 42; }
+template <class T> void lvalueReferenceZero(T &ref) { ref = 0; }
 
 template <class T> void constLvalueReference(const T &) {}
+
+template <class T> bool constLvalueReferenceToBool(const T &t) { return t; }
 
 template <class T> void forwardingReference(T &&) {}
 

--- a/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
+++ b/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
@@ -15,6 +15,11 @@ public func callIntegerTemplates() {
   hasDefaultedNonTypeTemplateParameter()
 }
 
+// CHECK: error: unexpected error produced: cannot pass immutable value as inout argument: literals are not mutable
+public func callLvalueRef() {
+  lvalueReference(true)
+}
+
 // Use protocol composition to create a type that we cannot (yet) turn into a clang::QualType.
 public protocol A { }
 public protocol B { }

--- a/test/Interop/Cxx/templates/function-template.swift
+++ b/test/Interop/Cxx/templates/function-template.swift
@@ -28,6 +28,17 @@ FunctionTemplateTestSuite.test("lvalueReference<T> where T == Int") {
   expectEqual(value, 42)
 }
 
+FunctionTemplateTestSuite.test("lvalueReferenceZero<T> where T == Bool") {
+  var value = true
+  lvalueReferenceZero(&value)
+  expectEqual(value, false)
+}
+
+FunctionTemplateTestSuite.test("constLvalueReferenceToBool<T> where T == Bool") {
+  expectTrue(constLvalueReferenceToBool(true))
+  expectFalse(constLvalueReferenceToBool(false))
+}
+
 // TODO: Generics, Any, and Protocols should be tested here but need to be
 // better supported in ClangTypeConverter first.
 


### PR DESCRIPTION
The type bridging logic assumed that if a value of type `Swift.Bool` is passed to a Clang function as an argument, then the type of the parameter must be a Clang built-in type (usually `_Bool`). This is not always correct. For instance, the type might be a templated const reference.

rdar://125508505