### PR TITLE
[BitwiseCopyable] Avoid a condfail.

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -394,6 +394,9 @@ struct PrintOptions {
   /// Suppress printing of '~Proto' for suppressible, non-invertible protocols.
   bool SuppressConformanceSuppression = false;
 
+  /// Replace BitwiseCopyable with _BitwiseCopyable.
+  bool SuppressBitwiseCopyable = false;
+
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {
       DeclAttrKind::Transparent, DeclAttrKind::Effects,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -176,9 +176,9 @@ LANGUAGE_FEATURE(BuiltinCreateTask, 0, "Builtin.createTask and Builtin.createDis
 SUPPRESSIBLE_LANGUAGE_FEATURE(AssociatedTypeImplements, 0, "@_implements on associated types")
 LANGUAGE_FEATURE(BuiltinAddressOfRawLayout, 0, "Builtin.addressOfRawLayout")
 LANGUAGE_FEATURE(MoveOnlyPartialConsumption, 429, "Partial consumption of noncopyable values")
-/// Enable bitwise-copyable feature.
 LANGUAGE_FEATURE(BitwiseCopyable, 426, "BitwiseCopyable protocol")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ConformanceSuppression, 426, "Suppressible inferred conformances")
+SUPPRESSIBLE_LANGUAGE_FEATURE(BitwiseCopyable2, 426, "BitwiseCopyable feature")
 SUPPRESSIBLE_LANGUAGE_FEATURE(NoncopyableGenerics, 427, "Noncopyable generics")
 
 // Swift 6

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3154,6 +3154,15 @@ suppressingFeatureConformanceSuppression(PrintOptions &options,
   options.ExcludeAttrList.resize(originalExcludeAttrCount);
 }
 
+static void
+suppressingFeatureBitwiseCopyable2(PrintOptions &options,
+                                   llvm::function_ref<void()> action) {
+  unsigned originalExcludeAttrCount = options.ExcludeAttrList.size();
+  llvm::SaveAndRestore<bool> scope(options.SuppressBitwiseCopyable, true);
+  action();
+  options.ExcludeAttrList.resize(originalExcludeAttrCount);
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {
@@ -3436,6 +3445,14 @@ void PrintAST::visitOpaqueTypeDecl(OpaqueTypeDecl *decl) {
 }
 
 void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
+  auto name = decl->getName();
+  bool suppressingBitwiseCopyable =
+      Options.SuppressBitwiseCopyable &&
+      decl->getModuleContext()->isStdlibModule() &&
+      (decl->getNameStr() == "_BitwiseCopyable");
+  if (suppressingBitwiseCopyable) {
+    name = decl->getASTContext().getIdentifier("BitwiseCopyable");
+  }
   printDocumentationComment(decl);
   printAttributes(decl);
   printAccess(decl);
@@ -3443,10 +3460,14 @@ void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
   printContextIfNeeded(decl);
   recordDeclLoc(decl,
     [&]{
-      Printer.printName(decl->getName(), getTypeMemberPrintNameContext(decl));
+      Printer.printName(name, getTypeMemberPrintNameContext(decl));
     }, [&]{ // Signature
       printGenericDeclGenericParams(decl);
     });
+  if (suppressingBitwiseCopyable) {
+    Printer << " = Swift._BitwiseCopyable";
+    return;
+  }
   bool ShouldPrint = true;
   Type Ty = decl->getUnderlyingType();
 
@@ -3627,6 +3648,12 @@ void PrintAST::printPrimaryAssociatedTypes(ProtocolDecl *decl) {
 }
 
 void PrintAST::visitProtocolDecl(ProtocolDecl *decl) {
+  auto name = decl->getName();
+  if (Options.SuppressBitwiseCopyable &&
+      decl->getModuleContext()->isStdlibModule() &&
+      (decl->getNameStr() == "BitwiseCopyable")) {
+    name = decl->getASTContext().getIdentifier("_BitwiseCopyable");
+  }
   printDocumentationComment(decl);
   printAttributes(decl);
   printAccess(decl);
@@ -3640,7 +3667,7 @@ void PrintAST::visitProtocolDecl(ProtocolDecl *decl) {
     printContextIfNeeded(decl);
     recordDeclLoc(decl,
       [&]{
-        Printer.printName(decl->getName());
+        Printer.printName(name);
       });
 
     if (Options.PrintPrimaryAssociatedTypes) {

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -695,6 +695,19 @@ static bool usesFeatureConformanceSuppression(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureBitwiseCopyable2(Decl *decl) {
+  if (!decl->getModuleContext()->isStdlibModule()) {
+    return false;
+  }
+  if (auto *proto = dyn_cast<ProtocolDecl>(decl)) {
+    return proto->getNameStr() == "BitwiseCopyable";
+  }
+  if (auto *typealias = dyn_cast<TypeAliasDecl>(decl)) {
+    return typealias->getNameStr() == "_BitwiseCopyable";
+  }
+  return false;
+}
+
 static bool usesFeatureIsolatedAny(Decl *decl) {
   return usesTypeMatching(decl, [](Type type) {
     if (auto fnType = type->getAs<AnyFunctionType>()) {

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -174,6 +174,7 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 @_documentation(visibility: internal)
 @_marker public protocol Escapable {}
 
+#if $BitwiseCopyable2
 #if $NoncopyableGenerics && $NonescapableTypes
 @_marker public protocol BitwiseCopyable: ~Escapable { }
 #else
@@ -182,3 +183,11 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 
 @available(*, deprecated, message: "Use BitwiseCopyable")
 public typealias _BitwiseCopyable = BitwiseCopyable
+#else
+#if $NoncopyableGenerics && $NonescapableTypes
+@_marker public protocol _BitwiseCopyable: ~Escapable { }
+#else
+@_marker public protocol _BitwiseCopyable { }
+#endif
+public typealias BitwiseCopyable = _BitwiseCopyable
+#endif

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -180,5 +180,5 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 @_marker public protocol BitwiseCopyable { }
 #endif
 
-@available(*, unavailable)
-@_marker public protocol _BitwiseCopyable {}
+@available(*, deprecated, message: "Use BitwiseCopyable")
+public typealias _BitwiseCopyable = BitwiseCopyable

--- a/test/ModuleInterface/bitwise_copyable.swift
+++ b/test/ModuleInterface/bitwise_copyable.swift
@@ -9,3 +9,9 @@
 public struct S_Implicit_Noncopyable {}
 
 // CHECK-NOT: extension Test.S_Implicit_Noncopyable : Swift.BitwiseCopyable {}
+
+// CHECK:      public protocol BitwiseCopyable {
+// CHECK-NEXT: }
+// CHECK-NEXT: public typealias _BitwiseCopyable = Test.BitwiseCopyable
+public protocol BitwiseCopyable {}
+public typealias _BitwiseCopyable = BitwiseCopyable

--- a/test/ModuleInterface/bitwise_copyable_stdlib.swift
+++ b/test/ModuleInterface/bitwise_copyable_stdlib.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -parse-stdlib -module-name Swift
+// RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -parse-stdlib -module-name Swift
+
+// CHECK:      #if compiler(>=5.3) && $BitwiseCopyable2
+// CHECK-NEXT: public protocol BitwiseCopyable {
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: public protocol _BitwiseCopyable {
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+
+// CHECK:      #if compiler(>=5.3) && $BitwiseCopyable2
+// CHECK-NEXT: public typealias _BitwiseCopyable = Swift.BitwiseCopyable
+// CHECK-NEXT: #else
+// CHECK-NEXT: public typealias BitwiseCopyable = Swift._BitwiseCopyable
+// CHECK-NEXT: #endif
+public protocol BitwiseCopyable {}
+public typealias _BitwiseCopyable = BitwiseCopyable
+

--- a/test/Sema/bitwse_copyable_underscore.swift
+++ b/test/Sema/bitwse_copyable_underscore.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift                       \
+// RUN:     -disable-availability-checking                   \
+// RUN:     -debug-diagnostic-names
+
+struct S : _BitwiseCopyable {} // expected-warning {{'_BitwiseCopyable' is deprecated: Use BitwiseCopyable}}
+
+func f<T : _BitwiseCopyable>(_ t: T) {} // expected-warning {{'_BitwiseCopyable' is deprecated: Use BitwiseCopyable}}


### PR DESCRIPTION
The standard library defines
```
protocol BitwiseCopyable {}
typealias _BitwiseCopyable = BitwiseCopyable
```
For current compilers, `BitwiseCopyable` is a "known protocol".

For older compilers, it is not; instead `_BitwiseCopyable` is.  So print the following into the swiftinterface for those older compilers:
```
protocol _BitwiseCopyable {}
typealias BitwiseCopyable = _BitwiseCopyable
```

rdar://127755503