### PR TITLE
Switch Windows search path options to std::string

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -372,10 +372,10 @@ private:
                            FrameworkSearchPaths.size() - 1);
   }
 
-  std::optional<StringRef> WinSDKRoot = std::nullopt;
-  std::optional<StringRef> WinSDKVersion = std::nullopt;
-  std::optional<StringRef> VCToolsRoot = std::nullopt;
-  std::optional<StringRef> VCToolsVersion = std::nullopt;
+  std::optional<std::string> WinSDKRoot = std::nullopt;
+  std::optional<std::string> WinSDKVersion = std::nullopt;
+  std::optional<std::string> VCToolsRoot = std::nullopt;
+  std::optional<std::string> VCToolsVersion = std::nullopt;
 
 public:
   StringRef getSDKPath() const { return SDKPath; }


### PR DESCRIPTION
A CompilerInvocation object may outlive the input argument list, so we need to copy these argument strings to avoid a use-after-free. This issue was causing sourcekit-lsp to crash whenever these flags showed up in the `compile_commands.json` used to initialize sourcekit-lsp.

Fixes apple/sourcekit-lsp#1167

cc @compnerd 