### PR TITLE
NCGenerics: add test for feature flag & force-enable all

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -47,6 +47,9 @@ LangOptions::LangOptions() {
 #endif
 
   // Note: Introduce default-on language options here.
+  Features.insert(Feature::NoncopyableGenerics);
+  Features.insert(Feature::BorrowingSwitch);
+  Features.insert(Feature::MoveOnlyPartialConsumption);
 
   // Enable any playground options that are enabled by default.
 #define PLAYGROUND_OPTION(OptionName, Description, DefaultOn, HighPerfOn) \

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5797,16 +5797,16 @@ cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext) {
   if (auto var = dyn_cast<VarDecl>(decl)) {
     auto oldContext = var->getDeclContext();
     auto oldTypeDecl = oldContext->getSelfNominalTypeDecl();
-    // If the base type is non-copyable, and non-copyable generics are disabled,
-    // we cannot synthesize the accessor, because its implementation would use
-    // `UnsafePointer<BaseTy>`.
+    // If the base type is non-copyable, we cannot synthesize the accessor,
+    // because its implementation would use `UnsafePointer<BaseTy>`, and that
+    // triggers a bug when building SwiftCompilerSources. (rdar://128013193)
+    //
     // We cannot use `ty->isNoncopyable()` here because that would create a
     // cyclic dependency between ModuleQualifiedLookupRequest and
     // LookupConformanceInModuleRequest, so we check for the presence of
     // move-only attribute that is implicitly added to non-copyable C++ types by
     // ClangImporter.
-    if (oldTypeDecl->getAttrs().hasAttribute<MoveOnlyAttr>() &&
-        !context.LangOpts.hasFeature(Feature::NoncopyableGenerics))
+    if (oldTypeDecl->getAttrs().hasAttribute<MoveOnlyAttr>())
       return nullptr;
 
     auto rawMemory = allocateMemoryForDecl<VarDecl>(var->getASTContext(),

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5795,6 +5795,20 @@ cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext) {
   }
 
   if (auto var = dyn_cast<VarDecl>(decl)) {
+    auto oldContext = var->getDeclContext();
+    auto oldTypeDecl = oldContext->getSelfNominalTypeDecl();
+    // If the base type is non-copyable, and non-copyable generics are disabled,
+    // we cannot synthesize the accessor, because its implementation would use
+    // `UnsafePointer<BaseTy>`.
+    // We cannot use `ty->isNoncopyable()` here because that would create a
+    // cyclic dependency between ModuleQualifiedLookupRequest and
+    // LookupConformanceInModuleRequest, so we check for the presence of
+    // move-only attribute that is implicitly added to non-copyable C++ types by
+    // ClangImporter.
+    if (oldTypeDecl->getAttrs().hasAttribute<MoveOnlyAttr>() &&
+        !context.LangOpts.hasFeature(Feature::NoncopyableGenerics))
+      return nullptr;
+
     auto rawMemory = allocateMemoryForDecl<VarDecl>(var->getASTContext(),
                                                     sizeof(VarDecl), false);
     auto out =

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -509,6 +509,26 @@ namespace {
         return importFunctionPointerLikeType(*type, pointeeType);
       }
 
+      // If non-copyable generics are disabled, we cannot specify
+      // UnsafePointer<T> with a non-copyable type T.
+      // We cannot use `ty->isNoncopyable()` here because that would create a
+      // cyclic dependency between ModuleQualifiedLookupRequest and
+      // LookupConformanceInModuleRequest, so we check for the presence of
+      // move-only attribute that is implicitly added to non-copyable C++ types
+      // by ClangImporter.
+      if (pointeeType && pointeeType->getAnyNominal() &&
+          pointeeType->getAnyNominal()
+              ->getAttrs()
+              .hasAttribute<MoveOnlyAttr>() &&
+          !Impl.SwiftContext.LangOpts.hasFeature(
+              Feature::NoncopyableGenerics)) {
+        auto opaquePointerDecl = Impl.SwiftContext.getOpaquePointerDecl();
+        if (!opaquePointerDecl)
+          return Type();
+        return {opaquePointerDecl->getDeclaredInterfaceType(),
+                ImportHint::OtherPointer};
+      }
+
       PointerTypeKind pointerKind;
       if (quals.hasConst()) {
         pointerKind = PTK_UnsafePointer;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -509,8 +509,10 @@ namespace {
         return importFunctionPointerLikeType(*type, pointeeType);
       }
 
-      // If non-copyable generics are disabled, we cannot specify
-      // UnsafePointer<T> with a non-copyable type T.
+      // We cannot specify UnsafePointer<T> with a non-copyable type T just yet,
+      // because it triggers a bug when building SwiftCompilerSources.
+      // (rdar://128013193)
+      //
       // We cannot use `ty->isNoncopyable()` here because that would create a
       // cyclic dependency between ModuleQualifiedLookupRequest and
       // LookupConformanceInModuleRequest, so we check for the presence of
@@ -519,9 +521,7 @@ namespace {
       if (pointeeType && pointeeType->getAnyNominal() &&
           pointeeType->getAnyNominal()
               ->getAttrs()
-              .hasAttribute<MoveOnlyAttr>() &&
-          !Impl.SwiftContext.LangOpts.hasFeature(
-              Feature::NoncopyableGenerics)) {
+              .hasAttribute<MoveOnlyAttr>()) {
         auto opaquePointerDecl = Impl.SwiftContext.getOpaquePointerDecl();
         if (!opaquePointerDecl)
           return Type();

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=swift-6 %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
 // RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
 
+// REQUIRES: rdar128013193
+
 import MoveOnlyCxxValueType
 
 func testGetX() -> CInt {

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=swift-6 %s -validate-tbd-against-ir=none | %FileCheck %s
 // RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s -validate-tbd-against-ir=none | %FileCheck %s
 
+// REQUIRES: rdar128013193
+
 import MoveOnlyCxxValueType
 
 func testGetX() -> CInt {

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-none)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O -Xfrontend -sil-verify-none)
 //
 // REQUIRES: executable_test
 // REQUIRES: GH_ISSUE_70246

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O -Xfrontend -sil-verify-none)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-none)
 //
 // REQUIRES: executable_test
 // REQUIRES: GH_ISSUE_70246

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-module-interface.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-module-interface.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnlyCxxValueType -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -source-filename=x | %FileCheck %s --check-prefix=CHECK-NO-NCG
-// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnlyCxxValueType -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -source-filename=x -enable-experimental-feature NoncopyableGenerics | %FileCheck %s --check-prefix=CHECK-NCG
+// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnlyCxxValueType -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -source-filename=x | %FileCheck %s --check-prefix=CHECK
 
-// CHECK-NO-NCG: func getNonCopyablePtr() -> OpaquePointer
-// CHECK-NO-NCG: func getNonCopyableDerivedPtr() -> OpaquePointer
+// CHECK: func getNonCopyablePtr() -> OpaquePointer
+// CHECK: func getNonCopyableDerivedPtr() -> OpaquePointer
 
-// CHECK-NCG: func getNonCopyablePtr() -> UnsafeMutablePointer<NonCopyable>
-// CHECK-NCG: func getNonCopyableDerivedPtr() -> UnsafeMutablePointer<NonCopyableDerived>
+// FIXME: would prefer to have this (rdar://128013193)
+// func getNonCopyablePtr() -> UnsafeMutablePointer<NonCopyable>
+// func getNonCopyableDerivedPtr() -> UnsafeMutablePointer<NonCopyableDerived>

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-module-interface.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-module-interface.swift
@@ -1,4 +1,8 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnlyCxxValueType -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -source-filename=x | %FileCheck %s --check-prefix=CHECK-NCG
+// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnlyCxxValueType -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -source-filename=x | %FileCheck %s --check-prefix=CHECK-NO-NCG
+// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnlyCxxValueType -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -source-filename=x -enable-experimental-feature NoncopyableGenerics | %FileCheck %s --check-prefix=CHECK-NCG
+
+// CHECK-NO-NCG: func getNonCopyablePtr() -> OpaquePointer
+// CHECK-NO-NCG: func getNonCopyableDerivedPtr() -> OpaquePointer
 
 // CHECK-NCG: func getNonCopyablePtr() -> UnsafeMutablePointer<NonCopyable>
 // CHECK-NCG: func getNonCopyableDerivedPtr() -> UnsafeMutablePointer<NonCopyableDerived>

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -1,6 +1,8 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9 -O)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
 
 // REQUIRES: executable_test
 
@@ -27,10 +29,12 @@ MoveOnlyCxxValueType.test("Test derived move only type member access") {
   var k = c.method(-3)
   expectEqual(k, -6)
   expectEqual(c.method(1), 2)
+#if HAS_NONCOPYABLE_GENERICS
   k = c.x
   expectEqual(k, 2)
   c.x = 11
   expectEqual(c.x, 11)
+#endif
   k = c.mutMethod(-13)
   expectEqual(k, -13)
 }
@@ -56,6 +60,7 @@ MoveOnlyCxxValueType.test("Test move only field access in holder") {
   expectEqual(c.x.x, 5)
 }
 
+#if HAS_NONCOPYABLE_GENERICS
 MoveOnlyCxxValueType.test("Test move only field access in derived holder") {
   var c = NonCopyableHolderDerivedDerived(-11)
   var k = borrowNC(c.x)
@@ -69,5 +74,6 @@ MoveOnlyCxxValueType.test("Test move only field access in derived holder") {
   c.x.mutMethod(5)
   expectEqual(c.x.x, 5)
 }
+#endif
 
 runAllTests()

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -1,8 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
+// -- FIXME: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -D HAS_RDAR_128013193)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9 -O)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
 
 // REQUIRES: executable_test
 
@@ -29,7 +28,7 @@ MoveOnlyCxxValueType.test("Test derived move only type member access") {
   var k = c.method(-3)
   expectEqual(k, -6)
   expectEqual(c.method(1), 2)
-#if HAS_NONCOPYABLE_GENERICS
+#if HAS_RDAR_128013193
   k = c.x
   expectEqual(k, 2)
   c.x = 11
@@ -60,7 +59,7 @@ MoveOnlyCxxValueType.test("Test move only field access in holder") {
   expectEqual(c.x.x, 5)
 }
 
-#if HAS_NONCOPYABLE_GENERICS
+#if HAS_RDAR_128013193
 MoveOnlyCxxValueType.test("Test move only field access in derived holder") {
   var c = NonCopyableHolderDerivedDerived(-11)
   var k = borrowNC(c.x)

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
@@ -1,9 +1,11 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9 -O)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
 //
 // REQUIRES: executable_test
 
@@ -90,6 +92,7 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderValueMutDeref pointee value") {
   expectEqual(k.x, k2.x)
 }
 
+#if HAS_NONCOPYABLE_GENERICS
 MoveOnlyCxxOperators.test("NonCopyableHolderConstDerefDerivedDerived pointee borrow") {
   let holder = NonCopyableHolderConstDerefDerivedDerived(11)
   var k = borrowNC(holder.pointee)
@@ -157,5 +160,6 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderValueMutDerefDerivedDerived poin
   var k2 = holder.pointee
   expectEqual(k.x, k2.x)
 }
+#endif
 
 runAllTests()

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
@@ -1,11 +1,11 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
+// -- FIXME: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -D HAS_RDAR_128013193)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9 -O)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O)
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O -enable-experimental-feature NoncopyableGenerics -D HAS_NONCOPYABLE_GENERICS)
+// -- FIXME: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O -D HAS_RDAR_128013193)
 //
 // REQUIRES: executable_test
 
@@ -92,7 +92,7 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderValueMutDeref pointee value") {
   expectEqual(k.x, k2.x)
 }
 
-#if HAS_NONCOPYABLE_GENERICS
+#if HAS_RDAR_128013193
 MoveOnlyCxxOperators.test("NonCopyableHolderConstDerefDerivedDerived pointee borrow") {
   let holder = NonCopyableHolderConstDerefDerivedDerived(11)
   var k = borrowNC(holder.pointee)

--- a/test/ModuleInterface/noncopyable_generics_feature_flag.swift
+++ b/test/ModuleInterface/noncopyable_generics_feature_flag.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %t/Library.swift -module-name Library
+// RUN: rm -f %t/Library.swiftmodule
+// RUN: %target-swift-frontend -I %t -typecheck -verify %t/test.swift
+
+
+//--- Library.swift
+
+public struct Hello<T: ~Copyable> {
+  public init() {}
+}
+
+//--- test.swift
+import Library
+
+struct NC: ~Copyable {}
+
+let x: Hello<NC> = .init()

--- a/test/Sema/moveonly_enum.swift
+++ b/test/Sema/moveonly_enum.swift
@@ -22,7 +22,7 @@ enum Foo3 {
 }
 
 func test_switch(x: consuming Foo3) {
-    switch x { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{12-12=consume }}
+    switch x { 
     default:
         break
     }
@@ -32,7 +32,7 @@ func test_switch(x: consuming Foo3) {
         break
     }
 
-    switch (x) { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{13-13=consume }}
+    switch (x) { 
     default:
         break
     }
@@ -43,7 +43,7 @@ func test_switch(x: consuming Foo3) {
     }
 
     let _: () -> () = {
-        switch x { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{16-16=consume }}
+        switch x { 
         default:
             break
         }
@@ -57,7 +57,7 @@ func test_switch(x: consuming Foo3) {
     }
 
     let _: () -> () = {
-        switch (x) { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{17-17=consume }}
+        switch (x) { 
         default:
             break
         }
@@ -72,9 +72,9 @@ func test_switch(x: consuming Foo3) {
 }
 
 func test_if_case(x: consuming Foo3) {
-    if case .bar(let y) = x { _ = y } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{27-27=consume }}
+    if case .bar(let y) = x { _ = y } 
 
-    guard case .bar(let y) = x else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{30-30=consume }}
+    guard case .bar(let y) = x else { return } 
     _ = y
 
     if case .bar(let z) = consume x { _ = z }
@@ -82,9 +82,9 @@ func test_if_case(x: consuming Foo3) {
     guard case .bar(let z) = consume x else { return }
     _ = z
 
-    if case .bar(let a) = (x) { _ = a } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{28-28=consume }}
+    if case .bar(let a) = (x) { _ = a } 
 
-    guard case .bar(let a) = (x) else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+    guard case .bar(let a) = (x) else { return } 
     _ = a
 
     if case .bar(let b) = (consume x) { _ = b }
@@ -93,11 +93,11 @@ func test_if_case(x: consuming Foo3) {
     _ = b
 
     let _: () -> () = {
-        if case .bar(let y) = x { _ = y } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+        if case .bar(let y) = x { _ = y } 
     }
 
     let _: () -> () = {
-        guard case .bar(let y) = x else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{34-34=consume }}
+        guard case .bar(let y) = x else { return } 
         _ = y
     }
 
@@ -111,11 +111,11 @@ func test_if_case(x: consuming Foo3) {
     }
 
     let _: () -> () = {
-        if case .bar(let a) = (x) { _ = a } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{32-32=consume }}
+        if case .bar(let a) = (x) { _ = a } 
     }
 
     let _: () -> () = {
-        guard case .bar(let a) = (x) else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{35-35=consume }}
+        guard case .bar(let a) = (x) else { return } 
         _ = a
     }
 
@@ -130,7 +130,7 @@ func test_if_case(x: consuming Foo3) {
 }
 
 func test_switch_b(x: __owned Foo3) {
-    switch x { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{12-12=consume }}
+    switch x { 
     default:
         break
     }
@@ -140,7 +140,7 @@ func test_switch_b(x: __owned Foo3) {
         break
     }
 
-    switch (x) { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{13-13=consume }}
+    switch (x) { 
     default:
         break
     }
@@ -151,7 +151,7 @@ func test_switch_b(x: __owned Foo3) {
     }
 
     let _: () -> () = {
-        switch x { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{16-16=consume }}
+        switch x { 
         default:
             break
         }
@@ -165,7 +165,7 @@ func test_switch_b(x: __owned Foo3) {
     }
 
     let _: () -> () = {
-        switch (x) { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{17-17=consume }}
+        switch (x) { 
         default:
             break
         }
@@ -180,9 +180,9 @@ func test_switch_b(x: __owned Foo3) {
 }
 
 func test_if_case_b(x: __owned Foo3) {
-    if case .bar(let y) = x { _ = y } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{27-27=consume }}
+    if case .bar(let y) = x { _ = y } 
 
-    guard case .bar(let y) = x else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{30-30=consume }}
+    guard case .bar(let y) = x else { return } 
     _ = y
 
     if case .bar(let z) = consume x { _ = z }
@@ -190,9 +190,9 @@ func test_if_case_b(x: __owned Foo3) {
     guard case .bar(let z) = consume x else { return }
     _ = z
 
-    if case .bar(let a) = (x) { _ = a } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{28-28=consume }}
+    if case .bar(let a) = (x) { _ = a } 
 
-    guard case .bar(let a) = (x) else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+    guard case .bar(let a) = (x) else { return } 
     _ = a
 
     if case .bar(let b) = (consume x) { _ = b }
@@ -201,11 +201,11 @@ func test_if_case_b(x: __owned Foo3) {
     _ = b
 
     let _: () -> () = {
-        if case .bar(let y) = x { _ = y } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+        if case .bar(let y) = x { _ = y } 
     }
 
     let _: () -> () = {
-        guard case .bar(let y) = x else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{34-34=consume }}
+        guard case .bar(let y) = x else { return } 
         _ = y
     }
 
@@ -219,11 +219,11 @@ func test_if_case_b(x: __owned Foo3) {
     }
 
     let _: () -> () = {
-        if case .bar(let a) = (x) { _ = a } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{32-32=consume }}
+        if case .bar(let a) = (x) { _ = a } 
     }
 
     let _: () -> () = {
-        guard case .bar(let a) = (x) else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{35-35=consume }}
+        guard case .bar(let a) = (x) else { return } 
         _ = a
     }
 


### PR DESCRIPTION
Ensure that when using noncopyable generics when building a module, the compiler can re-ingest it and will pick the part guarded by $NoncopyableGenerics.

verifies the concern in rdar://127701059