### PR TITLE
stdlib: fix android build

### DIFF
--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -49,6 +49,11 @@
 #include <psapi.h>
 #endif
 
+#ifdef __linux__
+// Needed for 'readlink'.
+#include <unistd.h>
+#endif
+
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
the readlink addition in f4bf278 (https://github.com/apple/swift/commit/f4bf27852fe3e6c7278d6d5a2870a4507084fcd8) was introduced without a corresponding include.
