### PR TITLE
[cxx-interop] Fixes for tests for foreign reference types

### DIFF
--- a/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
@@ -36,7 +36,7 @@ public func getNullable(wantNullptr: Bool) -> GlobalCountNullableInit? {
     return result
 }
 
-// CHECK:      define {{.*}}swiftcc i64 @"$s4main11getNullable11wantNullptrSo011GlobalCountC4InitVSgSb_tF"(i1 %0)
+// CHECK:      define {{.*}}swiftcc i{{.*}} @"$s4main11getNullable11wantNullptrSo011GlobalCountC4InitVSgSb_tF"(i1 %0)
 // CHECK-NEXT: entry:
 // CHECK:        %1 = call ptr @{{_ZN23GlobalCountNullableInit6createEb|"\?create\@GlobalCountNullableInit\@\@SAPEAU1\@_N\@Z"}}
 // CHECK-NEXT:   %2 = ptrtoint ptr %1 to i64

--- a/test/Interop/Cxx/foreign-reference/reference-counted.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -Xfrontend -disable-availability-checking -Onone -D NO_OPTIMIZATIONS)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -Xfrontend -disable-availability-checking -O)
 //
 // REQUIRES: executable_test
 // TODO: This should work without ObjC interop in the future rdar://97497120
@@ -15,13 +16,17 @@ public func blackHole<T>(_ _: T) {  }
 @inline(never)
 func localTest() {
     var x = NS.LocalCount.create()
+#if NO_OPTIMIZATIONS
     expectEqual(x.value, 8) // This is 8 because of "var x" "x.value" * 2, two method calls on x, and "(x, x, x)".
+#endif
 
     expectEqual(x.returns42(), 42)
     expectEqual(x.constMethod(), 42)
 
     let t = (x, x, x)
+#if NO_OPTIMIZATIONS
     expectEqual(x.value, 5)
+#endif
 }
 
 ReferenceCountedTestSuite.test("Local") {
@@ -41,14 +46,18 @@ ReferenceCountedTestSuite.test("Global optional holding local ref count") {
 func globalTest1() {
     var x = GlobalCount.create()
     let t = (x, x, x)
+#if NO_OPTIMIZATIONS
     expectEqual(globalCount, 4)
+#endif
     blackHole(t)
 }
 
 @inline(never)
 func globalTest2() {
     var x = GlobalCount.create()
+#if NO_OPTIMIZATIONS
     expectEqual(globalCount, 1)
+#endif
 }
 
 ReferenceCountedTestSuite.test("Global") {


### PR DESCRIPTION
This fixes two tests that started failing in post-commit CI.

rdar://127795392
rdar://127795755