### PR TITLE
6.0: [BitwiseCopyable] Avoid a condfail. 

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -391,6 +391,9 @@ struct PrintOptions {
   /// Suppress printing of '~Proto' for suppressible, non-invertible protocols.
   bool SuppressConformanceSuppression = false;
 
+  /// Replace BitwiseCopyable with _BitwiseCopyable.
+  bool SuppressBitwiseCopyable = false;
+
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {
       DeclAttrKind::Transparent, DeclAttrKind::Effects,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -176,9 +176,9 @@ LANGUAGE_FEATURE(BuiltinStoreRaw, 0, "Builtin.storeRaw")
 LANGUAGE_FEATURE(BuiltinCreateTask, 0, "Builtin.createTask and Builtin.createDiscardingTask")
 SUPPRESSIBLE_LANGUAGE_FEATURE(AssociatedTypeImplements, 0, "@_implements on associated types")
 LANGUAGE_FEATURE(MoveOnlyPartialConsumption, 429, "Partial consumption of noncopyable values")
-/// Enable bitwise-copyable feature.
 LANGUAGE_FEATURE(BitwiseCopyable, 426, "BitwiseCopyable protocol")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ConformanceSuppression, 426, "Suppressible inferred conformances")
+SUPPRESSIBLE_LANGUAGE_FEATURE(BitwiseCopyable2, 426, "BitwiseCopyable feature")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -677,6 +677,19 @@ static bool usesFeatureConformanceSuppression(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureBitwiseCopyable2(Decl *decl) {
+  if (!decl->getModuleContext()->isStdlibModule()) {
+    return false;
+  }
+  if (auto *proto = dyn_cast<ProtocolDecl>(decl)) {
+    return proto->getNameStr() == "BitwiseCopyable";
+  }
+  if (auto *typealias = dyn_cast<TypeAliasDecl>(decl)) {
+    return typealias->getNameStr() == "_BitwiseCopyable";
+  }
+  return false;
+}
+
 static bool usesFeatureIsolatedAny(Decl *decl) {
   return usesTypeMatching(decl, [](Type type) {
     if (auto fnType = type->getAs<AnyFunctionType>()) {

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -174,6 +174,7 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 @_documentation(visibility: internal)
 @_marker public protocol Escapable {}
 
+#if $BitwiseCopyable2
 #if $NoncopyableGenerics && $NonescapableTypes
 @_marker public protocol BitwiseCopyable: ~Escapable { }
 #else
@@ -182,3 +183,11 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 
 @available(*, deprecated, message: "Use BitwiseCopyable")
 public typealias _BitwiseCopyable = BitwiseCopyable
+#else
+#if $NoncopyableGenerics && $NonescapableTypes
+@_marker public protocol _BitwiseCopyable: ~Escapable { }
+#else
+@_marker public protocol _BitwiseCopyable { }
+#endif
+public typealias BitwiseCopyable = _BitwiseCopyable
+#endif

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -180,5 +180,5 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 @_marker public protocol BitwiseCopyable { }
 #endif
 
-@available(*, unavailable)
-@_marker public protocol _BitwiseCopyable {}
+@available(*, deprecated, message: "Use BitwiseCopyable")
+public typealias _BitwiseCopyable = BitwiseCopyable

--- a/test/ModuleInterface/bitwise_copyable.swift
+++ b/test/ModuleInterface/bitwise_copyable.swift
@@ -9,3 +9,9 @@
 public struct S_Implicit_Noncopyable {}
 
 // CHECK-NOT: extension Test.S_Implicit_Noncopyable : Swift.BitwiseCopyable {}
+
+// CHECK:      public protocol BitwiseCopyable {
+// CHECK-NEXT: }
+// CHECK-NEXT: public typealias _BitwiseCopyable = Test.BitwiseCopyable
+public protocol BitwiseCopyable {}
+public typealias _BitwiseCopyable = BitwiseCopyable

--- a/test/ModuleInterface/bitwise_copyable_stdlib.swift
+++ b/test/ModuleInterface/bitwise_copyable_stdlib.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -parse-stdlib -module-name Swift
+// RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -parse-stdlib -module-name Swift
+
+// CHECK:      #if compiler(>=5.3) && $BitwiseCopyable2
+// CHECK-NEXT: public protocol BitwiseCopyable {
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: public protocol _BitwiseCopyable {
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+
+// CHECK:      #if compiler(>=5.3) && $BitwiseCopyable2
+// CHECK-NEXT: public typealias _BitwiseCopyable = Swift.BitwiseCopyable
+// CHECK-NEXT: #else
+// CHECK-NEXT: public typealias BitwiseCopyable = Swift._BitwiseCopyable
+// CHECK-NEXT: #endif
+public protocol BitwiseCopyable {}
+public typealias _BitwiseCopyable = BitwiseCopyable
+

--- a/test/Sema/bitwse_copyable_underscore.swift
+++ b/test/Sema/bitwse_copyable_underscore.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift                       \
+// RUN:     -disable-availability-checking                   \
+// RUN:     -debug-diagnostic-names
+
+struct S : _BitwiseCopyable {} // expected-warning {{'_BitwiseCopyable' is deprecated: Use BitwiseCopyable}}
+
+func f<T : _BitwiseCopyable>(_ t: T) {} // expected-warning {{'_BitwiseCopyable' is deprecated: Use BitwiseCopyable}}


### PR DESCRIPTION
**Explanation**: Fix a condfail related to BitwiseCopyable renaming.

Once the evolution proposal was accepted, the protocol was renamed from `_BitwiseCopyable` to `BitwiseCopyable`.  Old compilers still only "know about" `_BitwiseCopyable`, however--it is a "known protocol" for them.  They only permit suppression of `_BitwiseCopyable` and not `BitwiseCopyable`.  This is a problem for the new standard library's swiftinterface which includes several suppressions of `BitwiseCopyable`.

The solution is to keep defining the `_BitwiseCopyable` protocol in the standard library's swiftinterface as understood by older compilers while defining `BitwiseCopyable` to be a typealias for it.  Meanwhile, when current compilers read the same swiftinterface, they will see `BitwiseCopyable` to be defined as a protocol and `_BitwiseCopyable` to be a typealias for it.

**Scope**: Affects ASTPrinting of the BitwiseCopyable protocol and its deprecated typealias.
**Issue**: rdar://127755503
**Original PR**: https://github.com/apple/swift/pull/73516
**Risk**: Very low.  Only affects ASTPrinting of two declarations.
**Testing**: Added tests.
**Reviewer**: Allan Shortlidge ( @tshortli )
