### PR TITLE
[opt] Devirtualize package class methods more aggressively.

### DIFF
--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -91,7 +91,8 @@ static bool isEffectivelyFinalMethod(FullApplySite applySite, CanType classType,
 
   auto *cmi = cast<MethodInst>(applySite.getCallee());
 
-  if (!calleesAreStaticallyKnowable(applySite.getModule(), cmi->getMember()))
+  if (!calleesAreStaticallyKnowable(applySite.getModule(), cmi->getMember()) &&
+      (!cd || cd->getFormalAccess() != AccessLevel::Package))
     return false;
 
   auto *method = cmi->getMember().getAbstractFunctionDecl();

--- a/test/SILOptimizer/Inputs/cross-module/default-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/default-module.swift
@@ -35,6 +35,14 @@ public final class ModuleKlass {
   }
 }
 
+package class PackageClass {
+  package func test() -> Int { 42 }
+}
+
+package class PackageClassDerived: PackageClass {
+  override package func test() -> Int { 0 }
+}
+
 public func moduleKlassMember() -> Int {
   let k = ModuleKlass()
   return k.i

--- a/test/SILOptimizer/package-cmo.swift
+++ b/test/SILOptimizer/package-cmo.swift
@@ -193,6 +193,22 @@ package func getPkgModuleKlassMemberTBD() -> Int {
   return ModuleTBD.pkgModuleKlassMember()
 }
 
+// CHECK-LABEL: sil package @$s4Main23callsPackageClassMethod1cSi6Module0cD0C_tF : $@convention(thin) (@guaranteed PackageClass) -> Int
+// CHECK-NOT:     class_method
+// CHECK-NOT:     apply
+// CHECK:         return
+public func callsPackageClassMethod(c: PackageClass) -> Int {
+  return c.test()
+}
+
+// CHECK-LABEL: sil package @$s4Main23callsPackageClassMethod1cSi6Module0cD7DerivedC_tF : $@convention(thin) (@guaranteed PackageClassDerived) -> Int
+// CHECK-NOT:     class_method
+// CHECK-NOT:     apply
+// CHECK:         return
+public func callsPackageClassMethod(c: PackageClassDerived) -> Int {
+  return c.test()
+}
+
 
 // CHECK-LABEL: sil [_semantics "optimize.no.crossmodule"] @$s9Submodule19incrementByOneNoCMOyS2iF : $@convention(thin) (Int) -> Int
 


### PR DESCRIPTION
Package class methods cannot be overridden outside of the module, so all callees should be statically knowable, and we can usually devirtualize them. 