### PR TITLE
[6.0] Support closures that capture opened pack element types

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -657,7 +657,8 @@ protected:
   void appendClosureEntity(const AbstractClosureExpr *closure);
 
   void appendClosureComponents(Type Ty, unsigned discriminator, bool isImplicit,
-                               const DeclContext *parentContext);
+                               const DeclContext *parentContext,
+                               ArrayRef<GenericEnvironment *> capturedEnvs);
 
   void appendDefaultArgumentEntity(const DeclContext *ctx, unsigned index);
 

--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -43,6 +43,7 @@ class ValueDecl;
 class FuncDecl;
 class OpaqueValueExpr;
 class VarDecl;
+class GenericEnvironment;
 
 /// CapturedValue includes both the declaration being captured, along with flags
 /// that indicate how it is captured.
@@ -140,19 +141,27 @@ class DynamicSelfType;
 /// Stores information about captured variables.
 class CaptureInfo {
   class CaptureInfoStorage final
-      : public llvm::TrailingObjects<CaptureInfoStorage, CapturedValue> {
+      : public llvm::TrailingObjects<CaptureInfoStorage,
+                                     CapturedValue,
+                                     GenericEnvironment *> {
 
     DynamicSelfType *DynamicSelf;
     OpaqueValueExpr *OpaqueValue;
-    unsigned Count;
-  public:
-    explicit CaptureInfoStorage(unsigned count, DynamicSelfType *dynamicSelf,
-                                OpaqueValueExpr *opaqueValue)
-      : DynamicSelf(dynamicSelf), OpaqueValue(opaqueValue), Count(count) { }
+    unsigned NumCapturedValues;
+    unsigned NumGenericEnvironments;
 
-    ArrayRef<CapturedValue> getCaptures() const {
-      return llvm::ArrayRef(this->getTrailingObjects<CapturedValue>(), Count);
-    }
+  public:
+    explicit CaptureInfoStorage(DynamicSelfType *dynamicSelf,
+                                OpaqueValueExpr *opaqueValue,
+                                unsigned numCapturedValues,
+                                unsigned numGenericEnvironments)
+      : DynamicSelf(dynamicSelf), OpaqueValue(opaqueValue),
+        NumCapturedValues(numCapturedValues),
+        NumGenericEnvironments(numGenericEnvironments) { }
+
+    ArrayRef<CapturedValue> getCaptures() const;
+
+    ArrayRef<GenericEnvironment *> getGenericEnvironments() const;
 
     DynamicSelfType *getDynamicSelfType() const {
       return DynamicSelf;
@@ -160,6 +169,10 @@ class CaptureInfo {
 
     OpaqueValueExpr *getOpaqueValue() const {
       return OpaqueValue;
+    }
+
+    unsigned numTrailingObjects(OverloadToken<CapturedValue>) const {
+      return NumCapturedValues;
     }
   };
 
@@ -173,9 +186,11 @@ class CaptureInfo {
 public:
   /// The default-constructed CaptureInfo is "not yet computed".
   CaptureInfo() = default;
-  CaptureInfo(ASTContext &ctx, ArrayRef<CapturedValue> captures,
+  CaptureInfo(ASTContext &ctx,
+              ArrayRef<CapturedValue> captures,
               DynamicSelfType *dynamicSelf, OpaqueValueExpr *opaqueValue,
-              bool genericParamCaptures);
+              bool genericParamCaptures,
+              ArrayRef<GenericEnvironment *> genericEnv=ArrayRef<GenericEnvironment*>());
 
   /// A CaptureInfo representing no captures at all.
   static CaptureInfo empty();
@@ -189,6 +204,7 @@ public:
            !hasDynamicSelfCapture() && !hasOpaqueValueCapture();
   }
 
+  /// Returns all captured values and opaque expressions.
   ArrayRef<CapturedValue> getCaptures() const {
     // FIXME: Ideally, everywhere that synthesizes a function should include
     // its capture info.
@@ -206,7 +222,14 @@ public:
   /// \returns true if getLocalCaptures() will return a non-empty list.
   bool hasLocalCaptures() const;
 
-  /// \returns true if the function captures any generic type parameters.
+  /// Returns all captured pack element environments.
+  ArrayRef<GenericEnvironment *> getGenericEnvironments() const {
+    assert(hasBeenComputed());
+    return StorageAndFlags.getPointer()->getGenericEnvironments();
+  }
+
+  /// \returns true if the function captures the primary generic environment
+  /// from its innermost declaration context.
   bool hasGenericParamCaptures() const {
     // FIXME: Ideally, everywhere that synthesizes a function should include
     // its capture info.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6053,10 +6053,6 @@ enum class PropertyWrapperSynthesizedPropertyKind {
 class VarDecl : public AbstractStorageDecl {
   friend class NamingPatternRequest;
   NamedPattern *NamingPattern = nullptr;
-  /// When the variable is declared in context of a for-in loop over the elements of 
-  /// a parameter pack, this is the opened element environment of the pack expansion
-  /// to use as the variable's context generic environment.
-  GenericEnvironment *OpenedElementEnvironment = nullptr;
 
 public:
   enum class Introducer : uint8_t {
@@ -6194,13 +6190,6 @@ public:
 
   NamedPattern *getNamingPattern() const;
   void setNamingPattern(NamedPattern *Pat);
-
-  GenericEnvironment *getOpenedElementEnvironment() const {
-    return OpenedElementEnvironment;
-  }
-  void setOpenedElementEnvironment(GenericEnvironment *Env) {
-    OpenedElementEnvironment = Env;
-  }
 
   /// If this is a VarDecl that does not belong to a CaseLabelItem's pattern,
   /// return this. Otherwise, this VarDecl must belong to a CaseStmt's

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -197,6 +197,11 @@ public:
   /// array of the generic parameters for the innermost generic type.
   ArrayRef<GenericTypeParamType *> getInnermostGenericParams() const;
 
+  /// Returns the depth that a generic parameter at the next level of
+  /// nesting would have. This is zero for the empty signature,
+  /// and one plus the depth of the final generic parameter otherwise.
+  unsigned getNextDepth() const;
+
   /// Retrieve the requirements.
   ArrayRef<Requirement> getRequirements() const;
 
@@ -306,6 +311,9 @@ public:
     assert(Mem);
     return Mem;
   }
+
+  /// Returns the depth of the last generic parameter.
+  unsigned getMaxDepth() const;
 
   /// Transform the requirements into a form where implicit Copyable and
   /// Escapable conformances are omitted, and their absence is explicitly

--- a/include/swift/AST/LocalArchetypeRequirementCollector.h
+++ b/include/swift/AST/LocalArchetypeRequirementCollector.h
@@ -1,0 +1,79 @@
+//===--- LocalArchetypeRequirementCollector.h -------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file has utility code for extending a generic signature with opened
+// existentials and shape classes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_LOCAL_ARCHETYPE_REQUIREMENT_COLLECTOR_H
+#define SWIFT_AST_LOCAL_ARCHETYPE_REQUIREMENT_COLLECTOR_H
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/AST/Requirement.h"
+#include "swift/AST/Types.h"
+
+namespace swift {
+
+struct LocalArchetypeRequirementCollector {
+  const ASTContext &Context;
+  GenericSignature OuterSig;
+  unsigned Depth;
+
+  /// The lists of new parameters and requirements to add to the signature.
+  SmallVector<GenericTypeParamType *, 2> Params;
+  SmallVector<Requirement, 2> Requirements;
+
+  LocalArchetypeRequirementCollector(const ASTContext &ctx, GenericSignature sig);
+
+  void addOpenedExistential(Type constraint);
+  void addOpenedElement(CanGenericTypeParamType shapeClass);
+
+  GenericTypeParamType *addParameter();
+};
+
+struct MapLocalArchetypesOutOfContext {
+  GenericSignature baseGenericSig;
+  ArrayRef<GenericEnvironment *> capturedEnvs;
+
+  MapLocalArchetypesOutOfContext(GenericSignature baseGenericSig,
+                                 ArrayRef<GenericEnvironment *> capturedEnvs)
+      : baseGenericSig(baseGenericSig), capturedEnvs(capturedEnvs) {}
+
+  Type operator()(SubstitutableType *type) const;
+};
+
+struct MapIntoLocalArchetypeContext {
+  GenericEnvironment *baseGenericEnv;
+  ArrayRef<GenericEnvironment *> capturedEnvs;
+
+  MapIntoLocalArchetypeContext(GenericEnvironment *baseGenericEnv,
+                               ArrayRef<GenericEnvironment *> capturedEnvs)
+      : baseGenericEnv(baseGenericEnv), capturedEnvs(capturedEnvs) {}
+
+  Type operator()(SubstitutableType *type) const;
+};
+
+GenericSignature buildGenericSignatureWithCapturedEnvironments(
+    ASTContext &ctx,
+    GenericSignature sig,
+    ArrayRef<GenericEnvironment *> capturedEnvs);
+
+SubstitutionMap buildSubstitutionMapWithCapturedEnvironments(
+    SubstitutionMap baseSubMap,
+    GenericSignature genericSigWithCaptures,
+    ArrayRef<GenericEnvironment *> capturedEnvs);
+
+}
+
+#endif // SWIFT_AST_LOCAL_ARCHETYPE_REQUIREMENT_COLLECTOR_H

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -128,10 +128,9 @@ public:
     /// This type expression contains a TypeVariableType.
     HasTypeVariable      = 0x01,
 
-    /// This type expression contains a context-dependent archetype, either a
-    /// \c PrimaryArchetypeType, \c OpenedArchetypeType,
-    /// \c ElementArchetypeType, or \c PackArchetype.
-    HasArchetype         = 0x02,
+    /// This type expression contains a PrimaryArchetypeType
+    /// or PackArchetypeType.
+    HasPrimaryArchetype  = 0x02,
 
     /// This type expression contains a GenericTypeParamType.
     HasTypeParameter     = 0x04,
@@ -171,7 +170,7 @@ public:
     /// This type contains a parameterized existential type \c any P<T>.
     HasParameterizedExistential = 0x2000,
 
-    /// This type contains an ElementArchetype.
+    /// This type contains an ElementArchetypeType.
     HasElementArchetype = 0x4000,
 
     /// Whether the type is allocated in the constraint solver arena. This can
@@ -183,7 +182,7 @@ public:
     /// Contains a PackType.
     HasPack = 0x10000,
 
-    /// Contains a PackArchetypeType.
+    /// Contains a PackArchetypeType. Also implies HasPrimaryArchetype.
     HasPackArchetype = 0x20000,
 
     Last_Property = HasPackArchetype
@@ -205,9 +204,10 @@ public:
   /// variable?
   bool hasTypeVariable() const { return Bits & HasTypeVariable; }
 
-  /// Does a type with these properties structurally contain a
-  /// context-dependent archetype (that is, a Primary- or OpenedArchetype)?
-  bool hasArchetype() const { return Bits & HasArchetype; }
+  /// Does a type with these properties structurally contain a primary
+  /// or pack archetype? These are the archetypes instantiated from a
+  /// primary generic environment.
+  bool hasPrimaryArchetype() const { return Bits & HasPrimaryArchetype; }
 
   /// Does a type with these properties structurally contain an
   /// archetype from an opaque type declaration?
@@ -696,9 +696,23 @@ public:
     return getRecursiveProperties().hasPlaceholder();
   }
 
-  /// Determine whether the type involves a context-dependent archetype.
+  /// Determine whether the type involves a PrimaryArchetypeType *or* a
+  /// PackArchetypeType. These are the archetypes instantiated from a
+  /// primary generic environment.
+  bool hasPrimaryArchetype() const {
+    return getRecursiveProperties().hasPrimaryArchetype();
+  }
+
+  /// Whether the type contains a PackArchetypeType.
+  bool hasPackArchetype() const {
+    return getRecursiveProperties().hasPackArchetype();
+  }
+
+  /// Determine whether the type involves a primary, pack or local archetype.
+  ///
+  /// FIXME: Replace all remaining callers with a more precise check.
   bool hasArchetype() const {
-    return getRecursiveProperties().hasArchetype();
+    return hasPrimaryArchetype() || hasLocalArchetype();
   }
   
   /// Determine whether the type involves an opened existential archetype.
@@ -725,11 +739,6 @@ public:
   /// Whether the type contains a PackType.
   bool hasPack() const {
     return getRecursiveProperties().hasPack();
-  }
-
-  /// Whether the type contains a PackArchetypeType.
-  bool hasPackArchetype() const {
-    return getRecursiveProperties().hasPackArchetype();
   }
 
   /// Whether the type has any flavor of pack.

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -237,6 +237,9 @@ private:
   /// The context archetypes of the function.
   GenericEnvironment *GenericEnv = nullptr;
 
+  /// Captured local generic environments.
+  ArrayRef<GenericEnvironment *> CapturedEnvs;
+
   /// The information about specialization.
   /// Only set if this function is a specialization of another function.
   const GenericSpecializationInformation *SpecializationInfo = nullptr;
@@ -1276,8 +1279,22 @@ public:
   GenericEnvironment *getGenericEnvironment() const {
     return GenericEnv;
   }
-  void setGenericEnvironment(GenericEnvironment *env) {
+
+  /// Return any captured local generic environments, currently used for pack
+  /// element environments only. After SILGen, these are rewritten into
+  /// primary archetypes.
+  ArrayRef<GenericEnvironment *> getCapturedEnvironments() const {
+    return CapturedEnvs;
+  }
+
+  void setGenericEnvironment(GenericEnvironment *env);
+
+  void setGenericEnvironment(GenericEnvironment *env,
+                             ArrayRef<GenericEnvironment *> capturedEnvs,
+                             SubstitutionMap forwardingSubs) {
     GenericEnv = env;
+    CapturedEnvs = capturedEnvs;
+    ForwardingSubMap = forwardingSubs;
   }
 
   /// Retrieve the generic signature from the generic environment of this
@@ -1306,9 +1323,30 @@ public:
   /// responsibility of the caller.
   void eraseAllBlocks();
 
-  /// Return the identity substitutions necessary to forward this call if it is
-  /// generic.
-  SubstitutionMap getForwardingSubstitutionMap();
+  /// A substitution map that sends the generic parameters of the invocation
+  /// generic signature to some combination of primar and local archetypes.
+  ///
+  /// CAUTION: If this is a SILFunction that captures pack element environments,
+  /// then at SILGen time, this is not actually the forwarding substitution map
+  /// of the SILFunction's generic environment. This is because:
+  ///
+  /// 1) The SILFunction's generic signature includes extra generic parameters,
+  ///    to model captured pack elements;
+  /// 2) The SILFunction's generic environment is the AST generic environment,
+  ///    so it's based on the original generic signature;
+  /// 3) SILGen uses this AST generic environment together with local archetypes
+  ///    for lowering SIL instructions.
+  ///
+  /// Therefore, the SILFunction's forwarding substitution map takes the extended
+  /// generic signature (1). It maps the original generic parameters to the
+  /// archetypes of (2), and the extended generic parameters to the local archetypes
+  /// of (3).
+  ///
+  /// After SILGen, all archetypes are re-instantiated inside the SIL function,
+  /// and the forwarding substitution map and generic environment then align.
+  SubstitutionMap getForwardingSubstitutionMap() const {
+    return ForwardingSubMap;
+  }
 
   /// Returns true if this SILFunction must be a defer statement.
   ///

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -477,6 +477,11 @@ public:
   /// This should only be the case during parsing or deserialization.
   bool hasUnresolvedLocalArchetypeDefinitions();
 
+  /// If we added any instructions that reference unresolved local archetypes
+  /// and then deleted those instructions without resolving those archetypes,
+  /// we must reclaim those unresolved local archetypes.
+  void reclaimUnresolvedLocalArchetypeDefinitions();
+
   /// Get a unique index for a struct or class field in layout order.
   ///
   /// Precondition: \p decl must be a non-resilient struct or class.

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -461,13 +461,19 @@ public:
   }
 
   /// Returns true if the referenced type is expressed in terms of one
-  /// or more opened existential types.
+  /// or more opened existential archetypes.
   bool hasOpenedExistential() const {
     return getASTType()->hasOpenedExistential();
   }
 
   TypeTraitResult canBeClass() const {
     return getASTType()->canBeClass();
+  }
+
+  /// Returns true if the referenced type is expressed in terms of one
+  /// or more element archetypes.
+  bool hasElementArchetype() const {
+    return getASTType()->hasElementArchetype();
   }
 
   /// Returns true if the referenced type is expressed in terms of one
@@ -557,8 +563,13 @@ public:
     return false;
   }
 
-  /// True if the type involves any archetypes.
+  /// True if the type involves any primary or local archetypes.
   bool hasArchetype() const { return getASTType()->hasArchetype(); }
+
+  /// True if the type involves any primary archetypes.
+  bool hasPrimaryArchetype() const {
+    return getASTType()->hasPrimaryArchetype();
+  }
 
   /// True if the type involves any opaque archetypes.
   bool hasOpaqueArchetype() const {

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -1076,6 +1076,13 @@ public:
   /// Get the generic environment for a constant.
   GenericEnvironment *getConstantGenericEnvironment(SILDeclRef constant);
 
+  /// Get the generic environment for SILGen to use. The substitution map
+  /// sends the generic parameters of the function's interface type into
+  /// archetypes, which will either be primary archetypes from this
+  /// environment, or local archetypes captured by this function.
+  std::tuple<GenericEnvironment *, ArrayRef<GenericEnvironment *>, SubstitutionMap>
+  getForwardingSubstitutionsForLowering(SILDeclRef constant);
+
   /// Returns the SIL type of a constant reference.
   SILType getConstantType(TypeExpansionContext context, SILDeclRef constant) {
     return getConstantInfo(context, constant).getSILType();

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -1073,6 +1073,12 @@ public:
   GenericSignatureWithCapturedEnvironments
   getGenericSignatureWithCapturedEnvironments(SILDeclRef constant);
 
+  /// Get the substitution map for calling a constant.
+  SubstitutionMap
+  getSubstitutionMapWithCapturedEnvironments(SILDeclRef constant,
+                                             const CaptureInfo &captureInfo,
+                                             SubstitutionMap subs);
+
   /// Get the generic environment for a constant.
   GenericEnvironment *getConstantGenericEnvironment(SILDeclRef constant);
 

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -704,6 +704,28 @@ struct FunctionTypeInfo {
   CanSILFunctionType ExpectedLoweredType;
 };
 
+/// Return type of getGenericSignatureWithCapturedEnvironments().
+struct GenericSignatureWithCapturedEnvironments {
+  GenericSignature baseGenericSig;
+  GenericSignature genericSig;
+  ArrayRef<GenericEnvironment *> capturedEnvs;
+
+  explicit GenericSignatureWithCapturedEnvironments() {}
+
+  explicit GenericSignatureWithCapturedEnvironments(
+      GenericSignature baseGenericSig)
+    : baseGenericSig(baseGenericSig),
+      genericSig(baseGenericSig) {}
+
+  GenericSignatureWithCapturedEnvironments(
+      GenericSignature baseGenericSig,
+      GenericSignature genericSig,
+      ArrayRef<GenericEnvironment *> capturedEnvs)
+    : baseGenericSig(baseGenericSig),
+      genericSig(genericSig),
+      capturedEnvs(capturedEnvs) {}
+};
+
 /// TypeConverter - helper class for creating and managing TypeLowerings.
 class TypeConverter {
   friend class TypeLowering;
@@ -1047,8 +1069,9 @@ public:
   const SILConstantInfo &getConstantInfo(TypeExpansionContext context,
                                          SILDeclRef constant);
 
-  /// Get the generic environment for a constant.
-  GenericSignature getConstantGenericSignature(SILDeclRef constant);
+  /// Get the generic signature for a constant.
+  GenericSignatureWithCapturedEnvironments
+  getGenericSignatureWithCapturedEnvironments(SILDeclRef constant);
 
   /// Get the generic environment for a constant.
   GenericEnvironment *getConstantGenericEnvironment(SILDeclRef constant);

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -61,6 +61,7 @@ add_swift_host_library(swiftAST STATIC
   IndexSubset.cpp
   InlinableText.cpp
   LayoutConstraint.cpp
+  LocalArchetypeRequirementCollector.cpp
   Module.cpp
   ModuleDependencies.cpp
   ModuleLoader.cpp

--- a/lib/AST/CaptureInfo.cpp
+++ b/lib/AST/CaptureInfo.cpp
@@ -13,9 +13,20 @@
 #include "swift/AST/CaptureInfo.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
+
+ArrayRef<CapturedValue>
+CaptureInfo::CaptureInfoStorage::getCaptures() const {
+  return llvm::ArrayRef(this->getTrailingObjects<CapturedValue>(), NumCapturedValues);
+}
+
+ArrayRef<GenericEnvironment *>
+CaptureInfo::CaptureInfoStorage::getGenericEnvironments() const {
+  return llvm::ArrayRef(this->getTrailingObjects<GenericEnvironment *>(), NumGenericEnvironments);
+}
 
 //===----------------------------------------------------------------------===//
 //                             MARK: CaptureInfo
@@ -24,36 +35,50 @@ using namespace swift;
 CaptureInfo::CaptureInfo(ASTContext &ctx, ArrayRef<CapturedValue> captures,
                          DynamicSelfType *dynamicSelf,
                          OpaqueValueExpr *opaqueValue,
-                         bool genericParamCaptures) {
+                         bool genericParamCaptures,
+                         ArrayRef<GenericEnvironment *> genericEnv) {
   static_assert(IsTriviallyDestructible<CapturedValue>::value,
                 "Capture info is alloc'd on the ASTContext and not destroyed");
   static_assert(IsTriviallyDestructible<CaptureInfo::CaptureInfoStorage>::value,
                 "Capture info is alloc'd on the ASTContext and not destroyed");
 
+  // This is the only kind of local generic environment we can capture right now.
+#ifndef NDEBUG
+  for (auto *env : genericEnv) {
+    assert(env->getKind() == GenericEnvironment::Kind::OpenedElement);
+  }
+#endif
+
   OptionSet<Flags> flags;
   if (genericParamCaptures)
     flags |= Flags::HasGenericParamCaptures;
 
-  if (captures.empty() && !dynamicSelf && !opaqueValue) {
+  if (captures.empty() && genericEnv.empty() && !dynamicSelf && !opaqueValue) {
     *this = CaptureInfo::empty();
     StorageAndFlags.setInt(flags);
     return;
   }
 
   size_t storageToAlloc =
-      CaptureInfoStorage::totalSizeToAlloc<CapturedValue>(captures.size());
+      CaptureInfoStorage::totalSizeToAlloc<CapturedValue,
+                                           GenericEnvironment *>(captures.size(),
+                                                                 genericEnv.size());
   void *storageBuf = ctx.Allocate(storageToAlloc, alignof(CaptureInfoStorage));
-  auto *storage = new (storageBuf) CaptureInfoStorage(captures.size(),
-                                                      dynamicSelf,
-                                                      opaqueValue);
+  auto *storage = new (storageBuf) CaptureInfoStorage(dynamicSelf,
+                                                      opaqueValue,
+                                                      captures.size(),
+                                                      genericEnv.size());
   StorageAndFlags.setPointerAndInt(storage, flags);
   std::uninitialized_copy(captures.begin(), captures.end(),
                           storage->getTrailingObjects<CapturedValue>());
+  std::uninitialized_copy(genericEnv.begin(), genericEnv.end(),
+                          storage->getTrailingObjects<GenericEnvironment *>());
 }
 
 CaptureInfo CaptureInfo::empty() {
-  static const CaptureInfoStorage empty{0, /*dynamicSelf*/nullptr,
-                                        /*opaqueValue*/nullptr};
+  static const CaptureInfoStorage empty{/*dynamicSelf*/nullptr,
+                                        /*opaqueValue*/nullptr,
+                                        0, 0};
   CaptureInfo result;
   result.StorageAndFlags.setPointer(&empty);
   return result;
@@ -136,6 +161,13 @@ void CaptureInfo::print(raw_ostream &OS) const {
                  OS << "<noescape>";
              },
              [&] { OS << ", "; });
+
+  interleave(getGenericEnvironments(),
+             [&](GenericEnvironment *genericEnv) {
+               OS << " shape_class=";
+               OS << genericEnv->getOpenedElementShapeClass();
+             },
+             [&] { OS << ","; });
   OS << ')';
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8180,7 +8180,7 @@ Type VarDecl::getPropertyWrapperInitValueInterfaceType() const {
     return Type();
 
   Type valueInterfaceTy = initInfo.getWrappedValuePlaceholder()->getType();
-  if (valueInterfaceTy->hasArchetype())
+  if (valueInterfaceTy->hasPrimaryArchetype())
     valueInterfaceTy = valueInterfaceTy->mapTypeOutOfContext();
 
   return valueInterfaceTy;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7286,12 +7286,6 @@ VarDecl::VarDecl(DeclKind kind, bool isStatic, VarDecl::Introducer introducer,
 }
 
 Type VarDecl::getTypeInContext() const {
-  // If the variable is declared in context of a for-in loop over the elements
-  // of a parameter pack, its interface type must be mapped into context using
-  // the opened element environment of the pack expansion.
-  if (auto *env = getOpenedElementEnvironment())
-    return GenericEnvironment::mapTypeIntoContext(env, getInterfaceType());
-
   return getDeclContext()->mapTypeIntoContext(getInterfaceType());
 }
 

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -404,12 +404,11 @@ GenericEnvironment::maybeApplyOuterContextSubstitutions(Type type) const {
 
 Type GenericEnvironment::mapTypeIntoContext(GenericEnvironment *env,
                                             Type type) {
-  assert((!type->hasArchetype() || type->hasLocalArchetype()) &&
-         "already have a contextual type");
-  assert((env || !type->hasTypeParameter()) &&
-         "no generic environment provided for type with type parameters");
+  assert(!type->hasPrimaryArchetype() && "already have a contextual type");
 
   if (!env) {
+    assert(!type->hasTypeParameter() &&
+           "no generic environment provided for type with type parameters");
     return type;
   }
 
@@ -632,8 +631,7 @@ Type QueryInterfaceTypeSubstitutions::operator()(SubstitutableType *type) const{
 Type GenericEnvironment::mapTypeIntoContext(
                                 Type type,
                                 LookupConformanceFn lookupConformance) const {
-  assert((!type->hasArchetype() || type->hasLocalArchetype()) &&
-         "already have a contextual type");
+  assert(!type->hasPrimaryArchetype() && "already have a contextual type");
 
   Type result = type.subst(QueryInterfaceTypeSubstitutions(this),
                            lookupConformance,
@@ -668,7 +666,7 @@ GenericEnvironment::mapContextualPackTypeIntoElementContext(Type type) const {
   assert(getKind() == Kind::OpenedElement);
   assert(!type->hasTypeParameter() && "expected contextual type");
 
-  if (!type->hasArchetype()) return type;
+  if (!type->hasPackArchetype()) return type;
 
   auto sig = getGenericSignature();
   auto shapeClass = getOpenedElementShapeClass();
@@ -698,9 +696,9 @@ GenericEnvironment::mapContextualPackTypeIntoElementContext(CanType type) const 
 Type
 GenericEnvironment::mapPackTypeIntoElementContext(Type type) const {
   assert(getKind() == Kind::OpenedElement);
-  assert(!type->hasArchetype());
+  assert(!type->hasPackArchetype());
 
-  if (!type->hasTypeParameter()) return type;
+  if (!type->hasParameterPack()) return type;
 
   // Get a contextual type in the original generic environment, not the
   // substituted one, which is what mapContextualPackTypeIntoElementContext()

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -416,15 +416,12 @@ Type GenericEnvironment::mapTypeIntoContext(GenericEnvironment *env,
 }
 
 Type MapTypeOutOfContext::operator()(SubstitutableType *type) const {
-  auto archetype = cast<ArchetypeType>(type);
-  if (isa<OpaqueTypeArchetypeType>(archetype->getRoot()))
-    return Type();
+  if (isa<PrimaryArchetypeType>(type) ||
+      isa<PackArchetypeType>(type)) {
+    return cast<ArchetypeType>(type)->getInterfaceType();
+  }
 
-  // Leave opened archetypes alone; they're handled contextually.
-  if (isa<OpenedArchetypeType>(archetype))
-    return Type(type);
-
-  return archetype->getInterfaceType();
+  return type;
 }
 
 Type TypeBase::mapTypeOutOfContext() {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -95,6 +95,16 @@ GenericSignatureImpl::getInnermostGenericParams() const {
   return params.slice(sliceCount);
 }
 
+unsigned GenericSignatureImpl::getMaxDepth() const {
+  return getGenericParams().back()->getDepth();
+}
+
+unsigned GenericSignature::getNextDepth() const {
+  if (!getPointer())
+    return 0;
+  return getPointer()->getMaxDepth() + 1;
+}
+
 void GenericSignatureImpl::forEachParam(
     llvm::function_ref<void(GenericTypeParamType *, bool)> callback) const {
   // Figure out which generic parameters are concrete or same-typed to another

--- a/lib/AST/LocalArchetypeRequirementCollector.cpp
+++ b/lib/AST/LocalArchetypeRequirementCollector.cpp
@@ -1,0 +1,250 @@
+//===--- LocalArchetypeRequirementCollector.cpp ---------------------------===//1
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the LocalArchetypeRequirementCollector class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/LocalArchetypeRequirementCollector.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/AST/Requirement.h"
+#include "swift/AST/Types.h"
+
+using namespace swift;
+
+LocalArchetypeRequirementCollector::LocalArchetypeRequirementCollector(
+	const ASTContext &ctx, GenericSignature sig)
+    : Context(ctx), OuterSig(sig), Depth(sig.getNextDepth()) {}
+
+void LocalArchetypeRequirementCollector::addOpenedExistential(Type constraint) {
+  assert(constraint->isConstraintType() ||
+         constraint->getClassOrBoundGenericClass());
+  assert(OuterSig || !constraint->hasTypeParameter() &&
+         "Interface type here requires a parent signature");
+
+  auto param = addParameter();
+
+  Requirements.emplace_back(RequirementKind::Conformance, param, constraint);
+
+  ++Depth;
+}
+
+void LocalArchetypeRequirementCollector::addOpenedElement(
+        CanGenericTypeParamType shapeClass) {
+
+  size_t startingIndex = Params.size();
+
+  /// Add a parameter for each of the opened elements in this shape class.
+  SmallVector<GenericTypeParamType *, 2> packParams;
+  for (auto paramType : OuterSig.getGenericParams()) {
+    if (paramType->isParameterPack() &&
+        OuterSig->haveSameShape(paramType, shapeClass)) {
+      packParams.push_back(paramType);
+      addParameter();
+    }
+  }
+
+  assert(!packParams.empty());
+
+  // Clone the element requirements.
+
+  // Helper function: replace references to type parameter packs
+  // with one of the opened element type parameters we just created for this
+  // shape class.
+  auto rewriteElementType = [=](Type type) {
+    return type.transformTypeParameterPacks(
+      [&](SubstitutableType *t) -> std::optional<Type> {
+        auto *paramType = cast<GenericTypeParamType>(t);
+        for (unsigned packElementIndex : indices(packParams)) {
+          if (paramType == packParams[packElementIndex])
+            return Params[startingIndex + packElementIndex];
+        }
+
+        return std::nullopt;
+      });
+  };
+
+  // Clone the pack requirements that apply to this shape class.
+  for (auto req : OuterSig.getRequirements()) {
+    switch (req.getKind()) {
+    case RequirementKind::SameShape:
+      // These never involve element types.
+      break;
+    case RequirementKind::Conformance:
+    case RequirementKind::Superclass:
+    case RequirementKind::SameType: {
+      auto substFirstType = rewriteElementType(req.getFirstType());
+      auto substSecondType = rewriteElementType(req.getSecondType());
+      if (!substFirstType->isEqual(req.getFirstType()) ||
+          !substSecondType->isEqual(req.getSecondType())) {
+        Requirements.emplace_back(req.getKind(), substFirstType, substSecondType);
+      }
+      break;
+    }
+    case RequirementKind::Layout: {
+      auto substFirstType = rewriteElementType(req.getFirstType());
+      if (!substFirstType->isEqual(req.getFirstType())) {
+        Requirements.emplace_back(req.getKind(), substFirstType,
+                                  req.getLayoutConstraint());
+      }
+      break;
+    }
+    }
+  }
+
+  ++Depth;
+}
+
+GenericTypeParamType *LocalArchetypeRequirementCollector::addParameter() {
+  unsigned index = 0;
+  if (!Params.empty() &&
+      Params.back()->getDepth() == Depth) {
+    index = Params.back()->getIndex() + 1;
+  }
+
+  auto *param = GenericTypeParamType::get(/*pack*/ false, Depth,
+                                          index, Context);
+  Params.push_back(param);
+  return param;
+}
+
+GenericSignature swift::buildGenericSignatureWithCapturedEnvironments(
+    ASTContext &ctx,
+    GenericSignature sig,
+    ArrayRef<GenericEnvironment *> capturedEnvs) {
+  // Add new generic parameters to replace the local archetypes.
+  LocalArchetypeRequirementCollector collector(ctx, sig);
+
+  for (auto *genericEnv : capturedEnvs) {
+    switch (genericEnv->getKind()) {
+    case GenericEnvironment::Kind::Primary:
+    case GenericEnvironment::Kind::Opaque:
+      break;
+
+    case GenericEnvironment::Kind::OpenedExistential: {
+      auto constraint = genericEnv->getOpenedExistentialType();
+      if (auto existential = constraint->getAs<ExistentialType>())
+        constraint = existential->getConstraintType();
+      collector.addOpenedExistential(constraint);
+      continue;
+    }
+    case GenericEnvironment::Kind::OpenedElement: {
+      collector.addOpenedElement(
+          genericEnv->getOpenedElementShapeClass());
+      continue;
+    }
+    }
+
+    llvm_unreachable("Cannot happen");
+  }
+
+  return buildGenericSignature(ctx,
+                               collector.OuterSig,
+                               collector.Params,
+                               collector.Requirements,
+                               /*allowInverses=*/false);
+}
+
+Type MapLocalArchetypesOutOfContext::operator()(SubstitutableType *type) const {
+  auto *archetypeTy = cast<ArchetypeType>(type);
+
+  // Primary archetypes just map out of context.
+  if (isa<PrimaryArchetypeType>(archetypeTy) ||
+      isa<PackArchetypeType>(archetypeTy)) {
+    return archetypeTy->getInterfaceType();
+  }
+
+  assert(isa<LocalArchetypeType>(archetypeTy));
+
+  // Handle dependent member types recursively in the usual way.
+  if (!archetypeTy->isRoot())
+    return Type();
+
+  // Root local archetypes change depth.
+  auto *genericEnv = archetypeTy->getGenericEnvironment();
+  auto rootParam = archetypeTy->getInterfaceType()
+      ->castTo<GenericTypeParamType>();
+  assert(!rootParam->isParameterPack());
+  assert(rootParam->getDepth() == genericEnv->getGenericSignature()->getMaxDepth());
+
+  // The new depth is determined by counting how many captured environments
+  // precede this one.
+  unsigned depth = baseGenericSig.getNextDepth();
+  for (auto *capturedEnv : capturedEnvs) {
+    if (capturedEnv == genericEnv) {
+      return GenericTypeParamType::get(/*isParameterPack=*/false,
+                                       depth, rootParam->getIndex(),
+                                       rootParam->getASTContext());
+    }
+
+    ++depth;
+  }
+
+  llvm_unreachable("Fell off the end");
+}
+
+static Type mapIntoLocalContext(GenericTypeParamType *param, unsigned baseDepth,
+                                ArrayRef<GenericEnvironment *> capturedEnvs) {
+  assert(!param->isParameterPack());
+  unsigned envIndex = param->getDepth() - baseDepth;
+  assert(envIndex < capturedEnvs.size());
+  auto *capturedEnv = capturedEnvs[envIndex];
+  auto localInterfaceType = capturedEnv->getGenericSignature()
+      .getInnermostGenericParams()[param->getIndex()];
+  assert(localInterfaceType->getIndex() == param->getIndex());
+  return capturedEnvs[envIndex]->mapTypeIntoContext(localInterfaceType);
+}
+
+Type MapIntoLocalArchetypeContext::operator()(SubstitutableType *type) const {
+  unsigned baseDepth = baseGenericEnv->getGenericSignature().getNextDepth();
+
+  auto param = cast<GenericTypeParamType>(type);
+  if (param->getDepth() >= baseDepth)
+    return mapIntoLocalContext(param, baseDepth, capturedEnvs);
+
+  return baseGenericEnv->mapTypeIntoContext(param);
+}
+
+/// Given a substitution map for a call to a local function or closure, extend
+/// it to include all captured element archetypes; they become primary archetypes
+/// inside the body of the function.
+SubstitutionMap
+swift::buildSubstitutionMapWithCapturedEnvironments(
+    SubstitutionMap baseSubMap,
+    GenericSignature genericSigWithCaptures,
+    ArrayRef<GenericEnvironment *> capturedEnvs) {
+
+  if (capturedEnvs.empty()) {
+    assert((!baseSubMap && !genericSigWithCaptures) ||
+           baseSubMap.getGenericSignature()->isEqual(genericSigWithCaptures));
+    return baseSubMap;
+  }
+
+  unsigned baseDepth = genericSigWithCaptures.getNextDepth() - capturedEnvs.size();
+
+  return SubstitutionMap::get(
+    genericSigWithCaptures,
+    [&](SubstitutableType *type) -> Type {
+      auto param = cast<GenericTypeParamType>(type);
+      if (param->getDepth() >= baseDepth)
+        return mapIntoLocalContext(param, baseDepth, capturedEnvs);
+      return Type(type).subst(baseSubMap);
+    },
+    [&](CanType origType, Type substType,
+        ProtocolDecl *proto) -> ProtocolConformanceRef {
+      if (origType->getRootGenericParam()->getDepth() >= baseDepth)
+        return ProtocolConformanceRef(proto);
+      return baseSubMap.lookupConformance(origType, proto);
+    });
+}

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3454,7 +3454,7 @@ PrimaryArchetypeType::PrimaryArchetypeType(const ASTContext &Ctx,
                                      ArrayRef<ProtocolDecl *> ConformsTo,
                                      Type Superclass, LayoutConstraint Layout)
   : ArchetypeType(TypeKind::PrimaryArchetype, Ctx,
-                  RecursiveTypeProperties::HasArchetype,
+                  RecursiveTypeProperties::HasPrimaryArchetype,
                   InterfaceType, ConformsTo, Superclass, Layout, GenericEnv)
 {
   assert(!InterfaceType->isParameterPack());
@@ -3518,8 +3518,7 @@ OpenedArchetypeType::OpenedArchetypeType(
     LayoutConstraint layout)
   : LocalArchetypeType(TypeKind::OpenedArchetype,
                        interfaceType->getASTContext(),
-                       RecursiveTypeProperties::HasArchetype
-                         | RecursiveTypeProperties::HasOpenedExistential,
+                       RecursiveTypeProperties::HasOpenedExistential,
                        interfaceType, conformsTo, superclass, layout,
                        environment)
 {
@@ -3535,8 +3534,8 @@ PackArchetypeType::PackArchetypeType(
     ArrayRef<ProtocolDecl *> ConformsTo, Type Superclass,
     LayoutConstraint Layout, PackShape Shape)
     : ArchetypeType(TypeKind::PackArchetype, Ctx,
-                    RecursiveTypeProperties::HasArchetype |
-                        RecursiveTypeProperties::HasPackArchetype,
+                    RecursiveTypeProperties::HasPrimaryArchetype |
+                    RecursiveTypeProperties::HasPackArchetype,
                     InterfaceType, ConformsTo, Superclass, Layout, GenericEnv) {
   assert(InterfaceType->isParameterPack());
   *getTrailingObjects<PackShape>() = Shape;
@@ -3586,7 +3585,6 @@ ElementArchetypeType::ElementArchetypeType(
     ArrayRef<ProtocolDecl *> ConformsTo, Type Superclass,
     LayoutConstraint Layout)
     : LocalArchetypeType(TypeKind::ElementArchetype, Ctx,
-                         RecursiveTypeProperties::HasArchetype |
                          RecursiveTypeProperties::HasElementArchetype,
                          InterfaceType,
                          ConformsTo, Superclass, Layout, GenericEnv) {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1074,7 +1074,9 @@ void InterfaceTypeRequest::cacheResult(Type type) const {
   if (type) {
     assert(!type->hasTypeVariable() && "Type variable in interface type");
     assert(!type->is<InOutType>() && "Interface type must be materializable");
-    assert(!type->hasArchetype() && "Archetype in interface type");
+    assert(!type->hasPrimaryArchetype() && "Archetype in interface type");
+    assert(decl->getDeclContext()->isLocalContext() || !type->hasLocalArchetype() &&
+           "Local archetype in interface type of non-local declaration");
   }
   decl->TypeAndAccess.setPointer(type);
 }

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -244,7 +244,6 @@ void SILFunction::init(
          "function type has open type parameters");
 
   this->LoweredType = LoweredType;
-  this->GenericEnv = genericEnv;
   this->SpecializationInfo = nullptr;
   this->EntryCount = entryCount;
   this->Availability = AvailabilityContext::alwaysAvailable();
@@ -280,6 +279,7 @@ void SILFunction::init(
   assert(!Transparent || !IsDynamicReplaceable);
   validateSubclassScope(classSubclassScope, isThunk, nullptr);
   setDebugScope(DebugScope);
+  setGenericEnvironment(genericEnv);
 }
 
 SILFunction::~SILFunction() {
@@ -993,14 +993,10 @@ void SILFunction::eraseAllBlocks() {
   BlockList.clear();
 }
 
-SubstitutionMap SILFunction::getForwardingSubstitutionMap() {
-  if (ForwardingSubMap)
-    return ForwardingSubMap;
-
-  if (auto *env = getGenericEnvironment())
-    ForwardingSubMap = env->getForwardingSubstitutionMap();
-
-  return ForwardingSubMap;
+void SILFunction::setGenericEnvironment(GenericEnvironment *env) {
+  setGenericEnvironment(env, ArrayRef<GenericEnvironment *>(),
+                        env ? env->getForwardingSubstitutionMap()
+                            : SubstitutionMap());
 }
 
 bool SILFunction::shouldVerifyOwnership() const {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2834,7 +2834,7 @@ CanSILFunctionType swift::getNativeSILFunctionType(
 }
 
 namespace {
-struct LocalArchetypeRequirementCollector {
+struct OldLocalArchetypeRequirementCollector {
   const ASTContext &Context;
   unsigned Depth;
 
@@ -2853,7 +2853,7 @@ struct LocalArchetypeRequirementCollector {
   /// The set of element environments we've processed.
   llvm::SmallPtrSet<GenericEnvironment*, 4> ElementEnvs;
 
-  LocalArchetypeRequirementCollector(const ASTContext &ctx, unsigned depth)
+  OldLocalArchetypeRequirementCollector(const ASTContext &ctx, unsigned depth)
     : Context(ctx), Depth(depth) {}
 
   void collect(CanLocalArchetypeType archetype) {
@@ -3023,7 +3023,7 @@ buildThunkSignature(SILFunction *fn,
   }
 
   // Add new generic parameters to replace the local archetypes.
-  LocalArchetypeRequirementCollector collector(ctx, depth);
+  OldLocalArchetypeRequirementCollector collector(ctx, depth);
 
   for (auto archetype : localArchetypes) {
     collector.collect(archetype);

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4162,6 +4162,9 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
   // that IRGen can pass dynamic 'Self' metadata.
   std::optional<CapturedValue> selfCapture;
 
+  // Captured pack element environments.
+  llvm::SetVector<GenericEnvironment *> genericEnv;
+
   bool capturesGenericParams = false;
   DynamicSelfType *capturesDynamicSelf = nullptr;
   OpaqueValueExpr *capturesOpaqueValue = nullptr;
@@ -4179,6 +4182,13 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
       capturesDynamicSelf = captureInfo.getDynamicSelfType();
     if (captureInfo.hasOpaqueValueCapture())
       capturesOpaqueValue = captureInfo.getOpaqueValue();
+
+    // Any set of mutually-recursive local functions will capture the same
+    // element environments, because we can't "cross" a pack expansion
+    // expression.
+    for (auto *env : captureInfo.getGenericEnvironments()) {
+      genericEnv.insert(env);
+    }
 
     SmallVector<CapturedValue, 4> localCaptures;
     captureInfo.getLocalCaptures(localCaptures);
@@ -4397,8 +4407,9 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
   }
 
   // Cache the uniqued set of transitive captures.
-  CaptureInfo info{Context, resultingCaptures, capturesDynamicSelf,
-                   capturesOpaqueValue, capturesGenericParams};
+  CaptureInfo info(Context, resultingCaptures,
+                   capturesDynamicSelf, capturesOpaqueValue,
+                   capturesGenericParams, genericEnv.getArrayRef());
   auto inserted = LoweredCaptures.insert({fn, info});
   assert(inserted.second && "already in map?!");
   (void)inserted;

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4088,6 +4088,21 @@ TypeConverter::getGenericSignatureWithCapturedEnvironments(SILDeclRef c) {
   llvm_unreachable("Unhandled SILDeclRefKind in switch.");
 }
 
+SubstitutionMap
+TypeConverter::getSubstitutionMapWithCapturedEnvironments(
+    SILDeclRef constant, const CaptureInfo &captureInfo,
+    SubstitutionMap subs) {
+  auto sig = getGenericSignatureWithCapturedEnvironments(constant);
+  if (!sig.genericSig) {
+    assert(!sig.baseGenericSig);
+    assert(sig.capturedEnvs.empty());
+    return SubstitutionMap();
+  }
+
+  return buildSubstitutionMapWithCapturedEnvironments(
+      subs, sig.genericSig, sig.capturedEnvs);
+}
+
 GenericEnvironment *
 TypeConverter::getConstantGenericEnvironment(SILDeclRef c) {
   return getGenericSignatureWithCapturedEnvironments(c)

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -22,7 +22,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/GenericEnvironment.h"
-#include "swift/AST/LazyResolver.h"
+#include "swift/AST/LocalArchetypeRequirementCollector.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"
@@ -3634,20 +3634,37 @@ const TypeLowering *TypeConverter::getTypeLoweringForExpansion(
   return nullptr;
 }
 
-static GenericSignature 
-getEffectiveGenericSignature(DeclContext *dc,
-                             CaptureInfo captureInfo) {
-  if (dc->getParent()->isLocalContext() &&
-      !captureInfo.hasGenericParamCaptures())
-    return nullptr;
+static GenericSignatureWithCapturedEnvironments
+getGenericSignatureWithCapturedEnvironments(DeclContext *dc,
+                                            CaptureInfo captureInfo) {
+  auto capturedEnvs = captureInfo.getGenericEnvironments();
 
-  return dc->getGenericSignatureOfContext();
+  // A closure or local function does not need a generic signature if it
+  // doesn't capture the primary generic environment or any pack element
+  // environments from the outer scope.
+  if (dc->getParent()->isLocalContext() &&
+      capturedEnvs.empty() &&
+      !captureInfo.hasGenericParamCaptures())
+    return GenericSignatureWithCapturedEnvironments();
+
+  auto genericSig = dc->getGenericSignatureOfContext();
+  if (capturedEnvs.empty())
+    return GenericSignatureWithCapturedEnvironments(genericSig);
+
+  // Build a new generic signature where all captured element archetypes
+  // are represented by new generic parameters.
+  auto newSig = buildGenericSignatureWithCapturedEnvironments(
+      dc->getASTContext(), genericSig, capturedEnvs);
+
+  LLVM_DEBUG(llvm::dbgs() << "-- effective generic signature: " << newSig << "\n");
+  return GenericSignatureWithCapturedEnvironments(genericSig, newSig, capturedEnvs);
 }
 
-static GenericSignature 
-getEffectiveGenericSignature(AnyFunctionRef fn,
-                             CaptureInfo captureInfo) {
-  return getEffectiveGenericSignature(fn.getAsDeclContext(), captureInfo);
+static GenericSignatureWithCapturedEnvironments
+getGenericSignatureWithCapturedEnvironments(AnyFunctionRef fn,
+                                            CaptureInfo captureInfo) {
+  return getGenericSignatureWithCapturedEnvironments(
+      fn.getAsDeclContext(), captureInfo);
 }
 
 static CanGenericSignature
@@ -3704,7 +3721,7 @@ static CanAnyFunctionType getDefaultArgGeneratorInterfaceType(
   canResultTy = removeNoEscape(canResultTy);
 
   // Get the generic signature from the surrounding context.
-  auto sig = TC.getConstantGenericSignature(c);
+  auto sig = TC.getGenericSignatureWithCapturedEnvironments(c).genericSig;
 
   // FIXME: Verify ExtInfo state is correct, not working by accident.
   CanAnyFunctionType::ExtInfo info;
@@ -3757,7 +3774,8 @@ static CanAnyFunctionType getPropertyWrapperBackingInitializerInterfaceType(
     inputType = interfaceType->getCanonicalType();
   }
 
-  GenericSignature sig = TC.getConstantGenericSignature(c);
+  GenericSignature sig = TC.getGenericSignatureWithCapturedEnvironments(c)
+      .genericSig;
 
   AnyFunctionType::Param param(
       inputType, Identifier(),
@@ -3839,7 +3857,16 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
 
   // Capture generic parameters from the enclosing context if necessary.
   auto closure = *constant.getAnyFunctionRef();
-  auto genericSig = getEffectiveGenericSignature(closure, captureInfo);
+  auto sig = getGenericSignatureWithCapturedEnvironments(closure, captureInfo);
+
+  if (funcType->hasArchetype()) {
+    assert(isa<FunctionType>(funcType));
+    auto substType = Type(funcType).subst(
+        MapLocalArchetypesOutOfContext(sig.baseGenericSig, sig.capturedEnvs),
+        MakeAbstractConformanceForGenericType(),
+        SubstFlags::PreservePackExpansionLevel);
+    funcType = cast<FunctionType>(substType->getCanonicalType());
+  }
 
   auto innerExtInfo =
       AnyFunctionType::ExtInfoBuilder(FunctionType::Representation::Thin,
@@ -3853,7 +3880,7 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
           .build();
 
   return CanAnyFunctionType::get(
-      getCanonicalSignatureOrNull(genericSig),
+      getCanonicalSignatureOrNull(sig.genericSig),
       funcType.getParams(), funcType.getResult(),
       innerExtInfo);
 }
@@ -3939,12 +3966,9 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
   case SILDeclRef::Kind::Func: {
     CanAnyFunctionType funcTy;
     if (auto *ACE = c.loc.dyn_cast<AbstractClosureExpr *>()) {
-      // FIXME: Closures could have an interface type computed by Sema.
-      funcTy = cast<AnyFunctionType>(
-        ACE->getType()->mapTypeOutOfContext()->getCanonicalType());
+      funcTy = cast<AnyFunctionType>(ACE->getType()->getCanonicalType());
     } else {
-      funcTy = cast<AnyFunctionType>(
-        vd->getInterfaceType()->getCanonicalType());
+      funcTy = cast<AnyFunctionType>(vd->getInterfaceType()->getCanonicalType());
     }
     return getFunctionInterfaceTypeWithCaptures(*this, funcTy, c);
   }
@@ -4007,10 +4031,10 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
   llvm_unreachable("Unhandled SILDeclRefKind in switch.");
 }
 
-GenericSignature 
-TypeConverter::getConstantGenericSignature(SILDeclRef c) {
+GenericSignatureWithCapturedEnvironments
+TypeConverter::getGenericSignatureWithCapturedEnvironments(SILDeclRef c) {
   auto *vd = c.loc.dyn_cast<ValueDecl *>();
-  
+
   /// Get the function generic params, including outer params.
   switch (c.kind) {
   case SILDeclRef::Kind::Func:
@@ -4019,16 +4043,17 @@ TypeConverter::getConstantGenericSignature(SILDeclRef c) {
   case SILDeclRef::Kind::Destroyer:
   case SILDeclRef::Kind::Deallocator: {
     auto captureInfo = getLoweredLocalCaptures(c);
-    return getEffectiveGenericSignature(
+    return ::getGenericSignatureWithCapturedEnvironments(
       *c.getAnyFunctionRef(), captureInfo);
   }
   case SILDeclRef::Kind::IVarInitializer:
   case SILDeclRef::Kind::IVarDestroyer:
-    return cast<ClassDecl>(vd)->getGenericSignature();
+    return GenericSignatureWithCapturedEnvironments(
+        cast<ClassDecl>(vd)->getGenericSignature());
   case SILDeclRef::Kind::DefaultArgGenerator: {
     // Use the generic environment of the original function.
     auto captureInfo = getLoweredLocalCaptures(c);
-    return getEffectiveGenericSignature(
+    return ::getGenericSignatureWithCapturedEnvironments(
       vd->getInnermostDeclContext(), captureInfo);
   }
   case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
@@ -4045,17 +4070,19 @@ TypeConverter::getConstantGenericSignature(SILDeclRef c) {
       } else {
         enclosingDecl = SILDeclRef(cast<AbstractFunctionDecl>(dc));
       }
-      return getConstantGenericSignature(enclosingDecl);
+      return getGenericSignatureWithCapturedEnvironments(enclosingDecl);
     }
-    return dc->getGenericSignatureOfContext();
+    return GenericSignatureWithCapturedEnvironments(
+        dc->getGenericSignatureOfContext());
   }
   case SILDeclRef::Kind::EnumElement:
   case SILDeclRef::Kind::GlobalAccessor:
   case SILDeclRef::Kind::StoredPropertyInitializer:
-    return vd->getDeclContext()->getGenericSignatureOfContext();
+    return GenericSignatureWithCapturedEnvironments(
+        vd->getDeclContext()->getGenericSignatureOfContext());
   case SILDeclRef::Kind::EntryPoint:
   case SILDeclRef::Kind::AsyncEntryPoint:
-    llvm_unreachable("Doesn't have generic signature");
+    return GenericSignatureWithCapturedEnvironments();
   }
 
   llvm_unreachable("Unhandled SILDeclRefKind in switch.");
@@ -4063,7 +4090,8 @@ TypeConverter::getConstantGenericSignature(SILDeclRef c) {
 
 GenericEnvironment *
 TypeConverter::getConstantGenericEnvironment(SILDeclRef c) {
-  return getConstantGenericSignature(c).getGenericEnvironment();
+  return getGenericSignatureWithCapturedEnvironments(c)
+      .genericSig.getGenericEnvironment();
 }
 
 SILType TypeConverter::getSubstitutedStorageType(TypeExpansionContext context,

--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -28,6 +28,7 @@ add_swift_host_library(swiftSILGen STATIC
   SILGenFunction.cpp
   SILGenGlobalVariable.cpp
   SILGenLazyConformance.cpp
+  SILGenLocalArchetype.cpp
   SILGenLValue.cpp
   SILGenPack.cpp
   SILGenPattern.cpp

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1223,8 +1223,11 @@ void SILGenModule::preEmitFunction(SILDeclRef constant, SILFunction *F,
                                    SILLocation Loc) {
   assert(F->empty() && "already emitted function?!");
 
-  if (F->getLoweredFunctionType()->isPolymorphic())
-    F->setGenericEnvironment(Types.getConstantGenericEnvironment(constant));
+  if (F->getLoweredFunctionType()->isPolymorphic()) {
+    auto [genericEnv, capturedEnvs, forwardingSubs]
+        = Types.getForwardingSubstitutionsForLowering(constant);
+    F->setGenericEnvironment(genericEnv, capturedEnvs, forwardingSubs);
+  }
 
   // If we have global actor isolation for our constant, put the isolation onto
   // the function.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1260,6 +1260,9 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
                                     SILFunction *F) {
   emitLazyConformancesForFunction(F);
 
+  auto sig = Types.getGenericSignatureWithCapturedEnvironments(constant);
+  recontextualizeCapturedLocalArchetypes(F, sig);
+
   assert(!F->isExternalDeclaration() && "did not emit any function body?!");
   LLVM_DEBUG(llvm::dbgs() << "lowered sil:\n";
              F->print(llvm::dbgs()));

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -625,6 +625,11 @@ public:
   /// Emit a property descriptor for the given storage decl if it needs one.
   void tryEmitPropertyDescriptor(AbstractStorageDecl *decl);
 
+  /// Replace local archetypes captured from outer AST contexts with primary
+  /// archetypes.
+  void recontextualizeCapturedLocalArchetypes(
+      SILFunction *F, GenericSignatureWithCapturedEnvironments sig);
+
 private:
   /// The most recent declaration we considered for emission.
   SILDeclRef lastEmittedFunction;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1289,9 +1289,8 @@ public:
     auto captureInfo = SGF.SGM.Types.getLoweredLocalCaptures(constant);
     SGF.SGM.Types.setCaptureTypeExpansionContext(constant, SGF.SGM.M);
     
-    if (afd->getDeclContext()->isLocalContext() &&
-        !captureInfo.hasGenericParamCaptures())
-      subs = SubstitutionMap();
+    subs = SGF.SGM.Types.getSubstitutionMapWithCapturedEnvironments(
+        constant, captureInfo, subs);
 
     // Check whether we have to dispatch to the original implementation of a
     // dynamically_replaceable inside of a dynamic_replacement(for:) function.
@@ -1368,17 +1367,14 @@ public:
 
     // A directly-called closure can be emitted as a direct call instead of
     // really producing a closure object.
-
-    auto captureInfo = SGF.SGM.M.Types.getLoweredLocalCaptures(constant);
-
     SubstitutionMap subs;
-    if (captureInfo.hasGenericParamCaptures())
-      subs = SGF.getForwardingSubstitutionMap();
+    std::tie(std::ignore, std::ignore, subs)
+        = SGF.SGM.Types.getForwardingSubstitutionsForLowering(constant);
 
     setCallee(Callee::forDirect(SGF, constant, subs, e));
     
     // If the closure requires captures, emit them.
-    if (!captureInfo.getCaptures().empty()) {
+    if (SGF.SGM.Types.hasLoweredLocalCaptures(constant)) {
       SmallVector<ManagedValue, 4> captures;
       SGF.emitCaptures(e, constant, CaptureEmission::ImmediateApplication,
                        captures);
@@ -6771,14 +6767,9 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
         subs, loc, true);
   }
 
-  // The accessor might be a local function that does not capture any
-  // generic parameters, in which case we don't want to pass in any
-  // substitutions.
   auto captureInfo = SGF.SGM.Types.getLoweredLocalCaptures(constant);
-  if (decl->getDeclContext()->isLocalContext() &&
-      !captureInfo.hasGenericParamCaptures()) {
-    subs = SubstitutionMap();
-  }
+  subs = SGF.SGM.Types.getSubstitutionMapWithCapturedEnvironments(
+      constant, captureInfo, subs);
 
   // If this is a method in a protocol, generate it as a protocol call.
   if (isa<ProtocolDecl>(decl->getDeclContext())) {

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3056,14 +3056,11 @@ RValueEmitter::emitClosureReference(AbstractClosureExpr *e,
   // Emit the closure body.
   SGF.SGM.emitClosure(e, contextInfo);
 
-  SubstitutionMap subs;
-  if (e->getCaptureInfo().hasGenericParamCaptures())
-    subs = SGF.getForwardingSubstitutionMap();
-
   // Generate the closure value (if any) for the closure expr's function
   // reference.
   SILLocation loc = e;
-  return SGF.emitClosureValue(loc, SILDeclRef(e), contextInfo, subs);
+  return SGF.emitClosureValue(loc, SILDeclRef(e), contextInfo,
+                              SubstitutionMap());
 }
 
 RValue RValueEmitter::

--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -9,6 +9,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+//
+//  This file forces emission of lazily-generated ClangImporter-synthesized
+//  conformances.
+//
+//===----------------------------------------------------------------------===//
 
 #include "SILGen.h"
 #include "swift/AST/Decl.h"

--- a/lib/SILGen/SILGenLocalArchetype.cpp
+++ b/lib/SILGen/SILGenLocalArchetype.cpp
@@ -1,0 +1,166 @@
+//===--- SILGenLocalArchetype.cpp - Local archetype transform -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the transformation which rewrites captured local
+//  archetypes into primary archetypes in the enclosing function's generic
+//  signature.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SILGen.h"
+#include "swift/AST/LocalArchetypeRequirementCollector.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILCloner.h"
+
+using namespace swift;
+using namespace swift::Lowering;
+
+namespace {
+
+class LocalArchetypeTransform : public SILCloner<LocalArchetypeTransform> {
+  friend class SILCloner<LocalArchetypeTransform>;
+  friend class SILInstructionVisitor<LocalArchetypeTransform>;
+
+  GenericSignatureWithCapturedEnvironments sig;
+  GenericEnvironment *env;
+  SubstitutionMap subs;
+
+public:
+  LocalArchetypeTransform(SILFunction *F,
+                          GenericSignatureWithCapturedEnvironments sig)
+      : SILCloner(*F), env(sig.genericSig.getGenericEnvironment()) {
+
+    assert(!sig.capturedEnvs.empty() && "Why are we doing this?");
+
+    // The primary archetypes of the old generic environment map to
+    // primary archetypes of the new generic environment at the same
+    // index and depth.
+    subs = env->getForwardingSubstitutionMap();
+
+    // Local archetypes map to generic parameters at higher depths.
+    MapLocalArchetypesOutOfContext mapOutOfContext(sig.baseGenericSig,
+                                                   sig.capturedEnvs);
+
+    // For each captured environment...
+    for (auto *capturedEnv : sig.capturedEnvs) {
+      // For each introduced generic parameter...
+      auto localParams = capturedEnv->getGenericSignature()
+          .getInnermostGenericParams();
+      for (auto *gp : localParams) {
+        // Get the local archetype from the captured environment.
+        auto origArchetypeTy = capturedEnv->mapTypeIntoContext(gp)
+            ->castTo<LocalArchetypeType>();
+
+        // Map the local archetype to an interface type in the new generic
+        // signature.
+        auto substInterfaceTy = mapOutOfContext(origArchetypeTy);
+
+        // Map this interface type into the new generic environment to get
+        // a primary archetype.
+        auto substArchetypeTy = env->mapTypeIntoContext(substInterfaceTy)
+            ->castTo<PrimaryArchetypeType>();
+
+        // Remember this correspondence.
+        registerLocalArchetypeRemapping(origArchetypeTy, substArchetypeTy);
+      }
+    }
+  }
+
+  SILType remapType(SILType Ty) {
+    return Ty.subst(Builder.getModule().Types, subs);
+  }
+
+  CanType remapASTType(CanType ty) {
+    return ty.subst(subs)->getCanonicalType();
+  }
+
+  ProtocolConformanceRef remapConformance(Type Ty, ProtocolConformanceRef C) {
+    return C.subst(Ty, subs);
+  }
+
+  SubstitutionMap remapSubstitutionMap(SubstitutionMap subMap) {
+    return subMap.subst(subs);
+  }
+
+  void doIt() {
+    auto &F = getBuilder().getFunction();
+
+    // Collect the old basic blocks that we're going to delete.
+    llvm::SmallVector<SILBasicBlock *, 4> bbs;
+    for (auto &bb : F)
+      bbs.push_back(&bb);
+
+    // Make F.mapTypeIntoContext() use the new environment.
+    F.setGenericEnvironment(env);
+
+    // Start by cloning the entry block.
+    auto *origEntryBlock = F.getEntryBlock();
+    auto *clonedEntryBlock = F.createBasicBlock();
+
+    // Clone arguments.
+    SmallVector<SILValue, 4> entryArgs;
+    entryArgs.reserve(origEntryBlock->getArguments().size());
+    for (auto &origArg : origEntryBlock->getArguments()) {
+
+      // Remap the argument type into the new generic environment.
+      SILType mappedType = getOpType(origArg->getType());
+      auto *NewArg = clonedEntryBlock->createFunctionArgument(
+          mappedType, origArg->getDecl(), true);
+      NewArg->copyFlags(cast<SILFunctionArgument>(origArg));
+      entryArgs.push_back(NewArg);
+    }
+
+    // Clone the remaining body.
+    getBuilder().setInsertionPoint(clonedEntryBlock);
+    cloneFunctionBody(&F, clonedEntryBlock, entryArgs,
+                      true /*replaceOriginalFunctionInPlace*/);
+
+    // Insert the new entry block at the beginning.
+    F.moveBlockBefore(clonedEntryBlock, F.begin());
+
+    // FIXME: This should be a common utility.
+
+    // Erase the old basic blocks.
+    for (auto *bb : bbs) {
+      for (SILArgument *arg : bb->getArguments()) {
+        arg->replaceAllUsesWithUndef();
+        // To appease the ownership verifier, just set to None.
+        arg->setOwnershipKind(OwnershipKind::None);
+      }
+
+      // Instructions in the dead block may be used by other dead blocks. Replace
+      // any uses of them with undef values.
+      while (!bb->empty()) {
+        // Grab the last instruction in the bb.
+        auto *inst = &bb->back();
+
+        // Replace any still-remaining uses with undef values and erase.
+        inst->replaceAllUsesOfAllResultsWithUndef();
+        inst->eraseFromParent();
+      }
+
+      // Finally, erase the basic block itself.
+      bb->eraseFromParent();
+    }
+  }
+};
+
+} // end anonymous namespace
+
+void SILGenModule::recontextualizeCapturedLocalArchetypes(
+    SILFunction *F, GenericSignatureWithCapturedEnvironments sig) {
+  if (sig.capturedEnvs.empty())
+    return;
+
+  LocalArchetypeTransform(F, sig).doIt();
+  M.reclaimUnresolvedLocalArchetypeDefinitions();
+}

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -224,7 +224,11 @@ private:
         getPullback().getLoweredFunctionType()->getSubstGenericSignature());
     auto remappedSILType =
         SILType::getPrimitiveType(remappedType, ty.getCategory());
-    return getPullback().mapTypeIntoContext(remappedSILType);
+    // FIXME: Sometimes getPullback() doesn't have a generic environment, in which
+    // case callers are apparently happy to receive an interface type.
+    if (getPullback().getGenericEnvironment())
+      return getPullback().mapTypeIntoContext(remappedSILType);
+    return remappedSILType;
   }
 
   std::optional<TangentSpace> getTangentSpace(CanType type) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9411,35 +9411,6 @@ static std::optional<PackIterationInfo> applySolutionToForEachStmt(
         std::optional<SyntacticElementTarget>(SyntacticElementTarget)>
         rewriteTarget) {
 
-  // A special walker to record opened element environment for var decls in a
-  // for-each loop.
-  class Walker : public ASTWalker {
-    GenericEnvironment *Environment;
-
-  public:
-    Walker(GenericEnvironment *Environment) { this->Environment = Environment; }
-
-    PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
-      if (isa<ForEachStmt>(S)) {
-        return Action::SkipNode(S);
-      }
-      return Action::Continue(S);
-    }
-
-    PreWalkAction walkToDeclPre(Decl *D) override {
-      if (auto *decl = dyn_cast<VarDecl>(D)) {
-        decl->setOpenedElementEnvironment(Environment);
-      }
-      if (isa<AbstractFunctionDecl>(D)) {
-        return Action::SkipNode();
-      }
-      if (isa<NominalTypeDecl>(D)) {
-        return Action::SkipNode();
-      }
-      return Action::Continue();
-    }
-  };
-
   auto &cs = solution.getConstraintSystem();
   auto *sequenceExpr = stmt->getParsedSequence();
   PackExpansionExpr *expansion = cast<PackExpansionExpr>(sequenceExpr);
@@ -9452,11 +9423,6 @@ static std::optional<PackIterationInfo> applySolutionToForEachStmt(
 
   // Simplify the pattern type of the pack expansion.
   info.patternType = solution.simplifyType(info.patternType);
-
-  // Record the opened element environment for the VarDecls inside the loop
-  Walker forEachWalker(expansion->getGenericEnvironment());
-  stmt->getPattern()->walk(forEachWalker);
-  stmt->getBody()->walk(forEachWalker);
 
   return info;
 }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -460,6 +460,9 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
     Linkage = addExternalToLinkage(Linkage);
   }
 
+  assert(F.getCapturedEnvironments().empty() &&
+         "Captured local environments should not survive past SILGen");
+
   // If we have a body, we might have a generic environment.
   GenericSignatureID genericSigID = 0;
   if (!NoBody)

--- a/test/Interpreter/element_archetype_captures.swift
+++ b/test/Interpreter/element_archetype_captures.swift
@@ -1,0 +1,78 @@
+// RUN: %target-run-simple-swift
+
+func callee<X: P1, T: P2, U: P3, V: P4>(x: X, t: T, u: U, v: V)
+    -> (any P1, any P2, any P3, any P4) {
+  return (x, t, u, v)
+}
+
+protocol P1 { var f1: Bool { get } }
+protocol P2 { var f2: Bool { get } }
+protocol P3 { var f3: Bool { get } }
+protocol P4 { var f4: Bool { get } }
+
+func packFunction<X, each T, each U, each V>(x: X,
+                                             ts: repeat each T,
+                                             us: repeat each U,
+                                             vs: repeat each V)
+    where X: P1,
+          (repeat (each T, each U)): Any,
+          repeat each T: P2,
+          repeat each U: P3,
+          repeat each V: P4 {
+
+  var result: [(any P1, any P2, any P3, any P4)] = []
+  var bools: [Bool] = []
+
+  for t in repeat each ts {
+    for u in repeat each us {
+      for v in repeat each vs {
+
+        // Local function
+        do {
+          func localFunc() {
+            result.append(callee(x: x, t: t, u: u, v: v))
+            bools.append(true && x.f1 && t.f2 && u.f3 && v.f4)
+          }
+
+          localFunc()
+          let fn = localFunc
+          fn()
+
+          let closure = { localFunc() }
+          closure()
+        }
+
+        // Generic local function
+        do {
+          func localFunc<Y: P1>(_ y: Y) {
+            result.append(callee(x: y, t: t, u: u, v: v))
+            bools.append(true && y.f1 && t.f2 && u.f3 && v.f4)
+          }
+
+          localFunc(x)
+          let fn: (X) -> () = localFunc
+          fn(x)
+
+          let closure = { localFunc(x) }
+          closure()
+        }
+      }
+    }
+  }
+
+  assert(result.count == bools.count)
+
+  for (r, b) in zip(result, bools) {
+    assert(b == (r.0.f1 && r.1.f2 && r.2.f3 && r.3.f4))
+  }
+}
+
+struct S1: P1 { var f1: Bool }
+struct S2: P2 { var f2: Bool }
+struct S3: P3 { var f3: Bool }
+struct S4: P4 { var f4: Bool }
+
+packFunction(x: S1(f1: true),
+             ts: S2(f2: true), S2(f2: true),
+             us: S3(f3: true), S3(f3: false),
+             vs: S4(f4: false), S4(f4: false), S4(f4: true), S4(f4: true))

--- a/test/SILGen/element_archetype_captures.swift
+++ b/test/SILGen/element_archetype_captures.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// CHECK-LABEL: sil hidden [ossa] @$s26element_archetype_captures6calleeyyx_q_q0_tSTRzSTR_7ElementQy_ACRtzr1_lF : $@convention(thin) <T, U, V where T : Sequence, U : Sequence, T.Element == U.Element> (@in_guaranteed T, @in_guaranteed U, @in_guaranteed V) -> () {
+
+func callee<T, U, V>(_: T, _: U, _: V) where T: Sequence, U: Sequence, T.Element == U.Element {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26element_archetype_captures12packFunction2ts2us2vsyxxQp_q_xQpq0_q0_QptRvzRv_Rv0_STRzSTR_7ElementQy_AFRtzr1_lF : $@convention(thin) <each T, each U, each V where repeat each T : Sequence, repeat each U : Sequence, repeat (each T).Element == (each U).Element> (@pack_guaranteed Pack{repeat each T}, @pack_guaranteed Pack{repeat each U}, @pack_guaranteed Pack{repeat each V}) -> () {
+func packFunction<each T, each U, each V>(ts: repeat each T, us: repeat each U, vs: repeat each V)
+    where repeat each T: Sequence,
+          repeat each U: Sequence,
+          repeat (each T).Element == (each U).Element {
+  for (t, u) in repeat (each ts, each us) {
+
+    // // CHECK-LABEL: sil private [ossa] @$s26element_archetype_captures12packFunction2ts2us2vsyxxQp_q_xQpq0_q0_QptRvzRv_Rv0_STRzSTR_7ElementQy_AFRtzr1_lF10middleFuncL_yyRvzRv_Rv0_STRzSTR_AgHRSr1_lF : $@convention(thin) <each T, each U, each V where repeat each T : Sequence, repeat each U : Sequence, repeat (each T).Element == (each U).Element><τ_1_0, τ_1_1 where τ_1_0 : Sequence, τ_1_1 : Sequence, τ_1_0.Element == τ_1_1.Element> (@in_guaranteed (repeat each V), @in_guaranteed τ_1_0, @in_guaranteed τ_1_1) -> () {
+    func middleFunc() {
+      for v in repeat each vs {
+
+        // CHECK-LABEL: sil private [ossa] @$s26element_archetype_captures12packFunction2ts2us2vsyxxQp_q_xQpq0_q0_QptRvzRv_Rv0_STRzSTR_7ElementQy_AFRtzr1_lF10middleFuncL_yyRvzRv_Rv0_STRzSTR_AgHRSr1_lF05innerK0L_yyRvzRv_Rv0_STRzSTR_AgHRSr1_lF : $@convention(thin) <each T, each U, each V where repeat each T : Sequence, repeat each U : Sequence, repeat (each T).Element == (each U).Element><τ_1_0, τ_1_1 where τ_1_0 : Sequence, τ_1_1 : Sequence, τ_1_0.Element == τ_1_1.Element><τ_2_0> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed τ_2_0) -> () {
+        func innerFunc() {
+
+          // CHECK: [[FN:%.*]] = function_ref @$s26element_archetype_captures6calleeyyx_q_q0_tSTRzSTR_7ElementQy_ACRtzr1_lF : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : Sequence, τ_0_1 : Sequence, τ_0_0.Element == τ_0_1.Element> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
+          // CHECK: apply [[FN]]<τ_1_0, τ_1_1, τ_2_0>(%0, %1, %2) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : Sequence, τ_0_1 : Sequence, τ_0_0.Element == τ_0_1.Element> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
+          callee(t, u, v)
+        }
+
+        innerFunc()
+      }
+    }
+
+    middleFunc()
+  }
+}
+
+// Make sure we don't inadvertently say that `each T` is captured by
+// `localFunc()`.
+public func anotherPackFunction<each T>(_ ts: repeat each T) {
+  // CHECK-LABEL: sil private [ossa] @$s26element_archetype_captures19anotherPackFunctionyyxxQpRvzlF9localFuncL_yyRvzlF : $@convention(thin) <each T> (@in_guaranteed (repeat each T)) -> () {
+  func localFunc() {
+    for t in repeat each ts {
+      _ = t
+    }
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/issue-66917.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-66917.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public func values<each T>() -> (repeat (each T)?) {
+  (repeat { () -> (each T)? in
+    nil
+  }())
+}

--- a/validation-test/compiler_crashers_2_fixed/issue-69947.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-69947.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+class Thing<T> {
+  var value: T
+  init(_ value: T) { self.value = value }
+
+  func combineThings<each U>(head: Thing<T>, tail: repeat Thing<each U>) {
+    repeat (each tail).doSomething(each tail) { _ in }
+  }
+
+  func doSomething(_ value: AnyObject, closure: @escaping (T) -> Void) {}
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar113505724.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar113505724.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public struct G<T> {
+  var value: T { fatalError() }
+}
+
+public func f<T>(transform: () -> T) {}
+
+public func g<T, each V>(_ v: repeat G<each V>?, transform: (repeat (each V)?) -> T) {
+  f(transform: { transform(repeat (each v)?.value ?? nil) })
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar122293832.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar122293832.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public func withOptionalsAsPointers<T, each Opt>(
+	_ optional: repeat Optional<each Opt>,
+	body: (repeat UnsafePointer<each Opt>?) throws -> T
+) rethrows -> T {
+	return try body(repeat (each optional).map { withUnsafePointer(to: $0) { $0 } })
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar124329076.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar124329076.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+func withPointerToElements<each T, E, R>(
+    of tuple: borrowing (repeat each T),
+    _ body: (UnsafeBufferPointer<E>) -> R
+) -> R {
+    for t in repeat (each T).self {
+        if t != E.self {
+            preconditionFailure()
+        }
+    }
+    return withUnsafeBytes(of: tuple) { p in
+        return body(p.assumingMemoryBound(to: E.self))
+    }
+}


### PR DESCRIPTION
Partial 6.0 cherry-pick of https://github.com/apple/swift/pull/73712 and previous PRs.

* **Description**: Closures can capture values of pack element type, which are introduced by a `repeat` expression or a `for ... in repeat` loop. For example, here we accidentally capture a pack element type, because `&&` takes an autoclosure:
  ```
  protocol P { var foo: Bool { get } }

  func f<each T: P>(_ ts: repeat each T) {
    for t in repeat each ts {
      _ = true && t.foo
    }
  }
  ```
  This would cause crashes and type checking errors. This PR implements the SIL lowering support for closures that capture pack elements. Some solver support is incomplete, however a bunch of cases now work.

* **Scope of the issue**: Affects many users, and is even easier to hit now with `for ... in repeat` loops.

* **Origination**: This never worked.

* **Risk**: I believe **Low** for code that doesn't use packs, **Medium** for code using packs. There's a bunch of stuff here:
  * I redid ASTVerifier support for local archetypes. This is off in an noassert build.
  * I changed the HasArchetype bit in TypeBase into HasPrimaryArchetype and added a hasPrimaryArchetype() predicate to test it, but the existing hasArchetype() predicate has the same behavior as before. I only updated a few callers to use the new hasPrimaryArchetype().
  * There are some new assertions. I made a workaround in autodiff to simulate the old noassert behavior in a narrow case
  * Capture analysis now tracks uses of local archetypes. Any existing code that didn't crash before should end up getting an empty list of local archetype captures here. But a logic error might break existing code that uses packs.
  * Type lowering now consults the list of captured archetypes. If it's not empty, a bunch of new code runs to build a new generic signature, extend the substitution map for the call, etc. I hooked this into the existing mechanism which drops the generic signature for a closure in generic context that has no generic captures. It should all short-circuit trivially if the list of captured archetypes is empty.
  * There is a new pass that runs after SILGen to rewrite SIL instructions in a non-trivial way. This pass only runs if there were captured local archetypes.
  * There's a representation change for variables declared within the scope of a `for ... in repeat` loop. Some extra book-keeping that used to exist is now subsumed into my new logic. This might break existing code, but pack iteration is a new feature in 6.0. This change was separately reviewed on `main` by @simanerush.
  * For the most part validation tests pass at each intermediate commit so it should be easy to bisect any regressions.

* **Reviewed by**: review pending - @hborla @rjmccall @simanerush 

* **Radar**: rdar://113505724, rdar://122293832, rdar://124329076.