### PR TITLE
[Sema] Warn about 'Any' to 'any Sendable' override

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -898,6 +898,25 @@ unsigned int TypeBase::getOptionalityDepth() {
 }
 
 Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {
+  if (auto *arrayTy = dyn_cast<ArraySliceType>(this)) {
+      auto newBaseTy =
+          arrayTy->getBaseType()->stripConcurrency(recurse, dropGlobalActor);
+      return newBaseTy->isEqual(arrayTy->getBaseType())
+                 ? Type(this)
+                 : ArraySliceType::get(newBaseTy);
+    }
+
+    if (auto *dictTy = dyn_cast<DictionaryType>(this)) {
+      auto keyTy = dictTy->getKeyType();
+      auto strippedKeyTy = keyTy->stripConcurrency(recurse, dropGlobalActor);
+      auto valueTy = dictTy->getValueType();
+      auto strippedValueTy = valueTy->stripConcurrency(recurse, dropGlobalActor);
+
+      return keyTy->isEqual(strippedKeyTy) && valueTy->isEqual(strippedValueTy)
+                 ? Type(this)
+                 : DictionaryType::get(strippedKeyTy, strippedValueTy);
+    }
+
   // Look through optionals.
   if (Type optionalObject = getOptionalObjectType()) {
     Type newOptionalObject =
@@ -1081,25 +1100,6 @@ Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {
         });
 
     return anyChanged ? TupleType::get(elts, getASTContext()) : Type(this);
-  }
-
-  if (auto *arrayTy = dyn_cast<ArraySliceType>(this)) {
-    auto newBaseTy =
-        arrayTy->getBaseType()->stripConcurrency(recurse, dropGlobalActor);
-    return newBaseTy->isEqual(arrayTy->getBaseType())
-               ? Type(this)
-               : ArraySliceType::get(newBaseTy);
-  }
-
-  if (auto *dictTy = dyn_cast<DictionaryType>(this)) {
-    auto keyTy = dictTy->getKeyType();
-    auto strippedKeyTy = keyTy->stripConcurrency(recurse, dropGlobalActor);
-    auto valueTy = dictTy->getValueType();
-    auto strippedValueTy = valueTy->stripConcurrency(recurse, dropGlobalActor);
-
-    return keyTy->isEqual(strippedKeyTy) && valueTy->isEqual(strippedValueTy)
-               ? Type(this)
-               : DictionaryType::get(strippedKeyTy, strippedValueTy);
   }
 
   return Type(this);

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -249,3 +249,21 @@ extension MainActorPreconcurrency: NotIsolated {
     }
   }
 }
+
+
+open class Parent {
+    init(userInfo: [String : Any]) {
+        self.userInfo = userInfo
+    }
+
+  @preconcurrency open var userInfo : [String : any Sendable] // expected-note {{overridden declaration is here}}
+}
+
+class Child : Parent {
+    override var userInfo: [String : Any] { // expected-warning {{declaration 'userInfo' has a type with different sendability from any potential overrides; this is an error in the Swift 6 language mode}}
+        get {
+            [:]
+        }
+        set {}
+    }
+}


### PR DESCRIPTION
Until Swift 6, warn about overriding Any property in parent class to any Sendable
