### PR TITLE
[6.0][Macros] Ensure reaping executable plugin process

### DIFF
--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -172,11 +172,11 @@ LoadedExecutablePlugin::PluginProcess::~PluginProcess() {
 #if defined(_WIN32)
   _close(input);
   _close(output);
-  CloseHandle(process.Process);
 #else
   close(input);
   close(output);
 #endif
+  llvm::sys::Wait(process, /*SecondsToWait=*/0);
 }
 
 LoadedExecutablePlugin::~LoadedExecutablePlugin() {

--- a/lib/Basic/Program.cpp
+++ b/lib/Basic/Program.cpp
@@ -187,6 +187,7 @@ swift::ExecuteWithPipe(llvm::StringRef program,
   close(p2.write);
   llvm::sys::ProcessInfo proc;
   proc.Pid = pid;
+  proc.Process = pid;
   return ChildProcessInfo(proc, p1.write, p2.read);
 }
 
@@ -277,6 +278,7 @@ swift::ExecuteWithPipe(llvm::StringRef program,
   output[PI_READ].release();
 
   llvm::sys::ProcessInfo proc;
+  proc.Pid = pi.dwProcessId;
   proc.Process = pi.hProcess;
   return ChildProcessInfo(proc, ifd, ofd);
 }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/73547 into release/6.0

* **Explanation**: Previously the compiler didn't `waitpid` for plugins. This hasn't been an issue because usually the lifetime of plugin process is the same as the host process (i.e. `swift-frontend` or `SourceKitService`). But when the plugin somehow decided to crash, it went zombie and the compiler respawn another process to recover. This patch ensures reaping the existed plugin process, so the system can clear the process
* **Scope**: Executable macro plugins.
* **Risk**: Low. `llvm::sys::Wait`does `wait` for the child process, or terminate it. This `LoadedExecutablePlugin::PluginProcess::~PluginProcess()` is called when the plugin process crashed, or the host process exits.
* **Testing**: Passes current test cases. Local testing with PR toolchain. No added test case because simulating the issue is not easy
* **Issue**: rdar://126489446
* **Reviewer**: Hamish Knight (@hamishknight) Saleem Abdulrasool (@compnerd)