### PR TITLE
[6.0🍒] Switch Windows search path options to std::string

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -372,10 +372,10 @@ private:
                            FrameworkSearchPaths.size() - 1);
   }
 
-  std::optional<StringRef> WinSDKRoot = std::nullopt;
-  std::optional<StringRef> WinSDKVersion = std::nullopt;
-  std::optional<StringRef> VCToolsRoot = std::nullopt;
-  std::optional<StringRef> VCToolsVersion = std::nullopt;
+  std::optional<std::string> WinSDKRoot = std::nullopt;
+  std::optional<std::string> WinSDKVersion = std::nullopt;
+  std::optional<std::string> VCToolsRoot = std::nullopt;
+  std::optional<std::string> VCToolsVersion = std::nullopt;
 
 public:
   StringRef getSDKPath() const { return SDKPath; }


### PR DESCRIPTION
**Explanation**: A CompilerInvocation object may outlive the input argument list, so we need to copy these argument strings to avoid a use-after-free
**Scope**: This fixes a crash in sourcekit-lsp that occurs when any of these flags are present in `compile_commands.json`
Issue: https://github.com/apple/sourcekit-lsp/issues/1167
**Risk**: Very low. There is a (almost negligible) bump in memory usage to store copies of these strings. This change will only impact builds on Windows that specify these flags.
**Testing**: I've tested this patch locally and no longer see sourcekit-lsp crashing with the patch.
**Reviewer**: @compnerd @ahoppen 

(cherry picked from commit 7c640931ebbfd929720e428456b7d70e5c4df2cc)