### PR TITLE
[debug] Print strings using their description in the debugger

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -148,6 +148,8 @@ public enum _DebuggerSupport {
       return count == 1 ? "1 element" : "\(count) elements"
     case .`struct`?, .`enum`?, nil:
       switch value {
+      case let x as String:
+        return x.description
       case let x as CustomDebugStringConvertible:
         return x.debugDescription
       case let x as CustomStringConvertible:

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -148,8 +148,6 @@ public enum _DebuggerSupport {
       return count == 1 ? "1 element" : "\(count) elements"
     case .`struct`?, .`enum`?, nil:
       switch value {
-      case let x as String:
-        return x.description
       case let x as CustomDebugStringConvertible:
         return x.debugDescription
       case let x as CustomStringConvertible:
@@ -240,7 +238,13 @@ public enum _DebuggerSupport {
       print("\(name) : ", terminator: "", to: &target)
     }
 
-    if let str = asStringRepresentation(value: value, mirror: mirror, count: count) {
+    if isRoot, let value = value as? String {
+      // We don't want to use string's debug desciprtion for 'po' because it
+      // escapes the string and prints it raw (e.g. prints "\n" instead of
+      // actually printing a newline), but only if its the root value. Otherwise,
+      // continue using the debug description.
+      print(value, terminator: "", to: &target)
+    } else if let str = asStringRepresentation(value: value, mirror: mirror, count: count) {
       print(str, terminator: "", to: &target)
     }
   

--- a/test/stdlib/BridgedObjectDebuggerSupport.swift
+++ b/test/stdlib/BridgedObjectDebuggerSupport.swift
@@ -77,7 +77,7 @@ StringForPrintObjectTests.test("NSStringUTF8") {
   let debug = debugVal(&newNSUTF16)
   expectEqual("🏂☃❅❆❄︎⛄️❄️", String(reflecting: nsUTF16))
   expectEqual("\"🏂☃❅❆❄︎⛄️❄️\"", String(reflecting: newNSUTF16))
-  expectEqual("\"🏂☃❅❆❄︎⛄️❄️\"\n", printed)
+  expectEqual("🏂☃❅❆❄︎⛄️❄️\n", printed)
   expectEqual(printed, debug)
 }
 

--- a/test/stdlib/BridgedObjectDebuggerSupport.swift
+++ b/test/stdlib/BridgedObjectDebuggerSupport.swift
@@ -77,7 +77,12 @@ StringForPrintObjectTests.test("NSStringUTF8") {
   let debug = debugVal(&newNSUTF16)
   expectEqual("🏂☃❅❆❄︎⛄️❄️", String(reflecting: nsUTF16))
   expectEqual("\"🏂☃❅❆❄︎⛄️❄️\"", String(reflecting: newNSUTF16))
-  expectEqual("🏂☃❅❆❄︎⛄️❄️\n", printed)
+
+  if #available(SwiftStdlib 6.0, *) {
+    expectEqual("🏂☃❅❆❄︎⛄️❄️\n", printed)
+  } else {
+    expectEqual("\"🏂☃❅❆❄︎⛄️❄️\"\n", printed)
+  }
   expectEqual(printed, debug)
 }
 

--- a/test/stdlib/DebuggerSupport.swift
+++ b/test/stdlib/DebuggerSupport.swift
@@ -101,6 +101,13 @@ StringForPrintObjectTests.test("DontBridgeThisStruct") {
 }
 #endif
 
+if #available(SwiftStdlib 6.0, *) {
+  StringForPrintObjectTests.test("String") {
+    let printed = _stringForPrintObject("hello\nworld")
+    expectEqual(printed, "hello\nworld\n")
+  }
+}
+
 class RefCountedObj {
   var patatino : Int
   init(_ p : Int) {


### PR DESCRIPTION
When using `po` in the debugger on a string, it currently prints out the debugDescription which should be used when using `p`. Check for string and just return the description.

Resolves: rdar://109902298