### PR TITLE
[region-isolation] When inferring isolation for an argument, handle non-self isolated parameters as well as self parameters that are actor isolated.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -692,6 +692,18 @@ autorelease in the callee.
   type behaves like a non-generic type, as if the substitutions were
   actually applied to the underlying function type.
 
+- SIL functions may optionally mark a function parameter as
+  ``@sil_isolated``. An ``@sil_isolated`` parameter must be one of:
+
+  - An actor or any actor type.
+  - A generic type that conforms to Actor or AnyActor.
+
+  and must be the actor instance that a function is isolated to. Importantly
+  this means that global actor isolated nominal types are never
+  ``@sil_isolated``. Only one parameter can ever be marked as ``@sil_isolated``
+  since a function cannot be isolated to multiple actors at the same time.
+
+
 Async Functions
 ```````````````
 

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -271,10 +271,7 @@ public:
   void printForDiagnostics(llvm::raw_ostream &os,
                            StringRef openingQuotationMark = "'") const;
 
-  SWIFT_DEBUG_DUMP {
-    print(llvm::dbgs());
-    llvm::dbgs() << '\n';
-  }
+  SWIFT_DEBUG_DUMPER(dump());
 
   // Defined out of line to prevent linker errors since libswiftBasic would
   // include this header exascerbating a layering violation where libswiftBasic

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -266,6 +266,8 @@ public:
 
   void print(llvm::raw_ostream &os) const;
 
+  void printForSIL(llvm::raw_ostream &os) const;
+
   void printForDiagnostics(llvm::raw_ostream &os,
                            StringRef openingQuotationMark = "'") const;
 

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -205,6 +205,8 @@ public:
     return getKind() == GlobalActor;
   }
 
+  bool isActorInstanceIsolated() const { return getKind() == ActorInstance; }
+
   bool isMainActor() const;
 
   bool isDistributedActor() const;
@@ -262,29 +264,7 @@ public:
                               state.parameterIndex);
   }
 
-  void print(llvm::raw_ostream &os) const {
-    switch (getKind()) {
-    case Unspecified:
-      os << "unspecified";
-      return;
-    case ActorInstance:
-      os << "actor_instance";
-      return;
-    case Nonisolated:
-      os << "nonisolated";
-      return;
-    case NonisolatedUnsafe:
-      os << "nonisolated_unsafe";
-      return;
-    case GlobalActor:
-      os << "global_actor";
-      return;
-    case Erased:
-      os << "erased";
-      return;
-    }
-    llvm_unreachable("Covered switch isn't covered?!");
-  }
+  void print(llvm::raw_ostream &os) const;
 
   void printForDiagnostics(llvm::raw_ostream &os,
                            StringRef openingQuotationMark = "'") const;

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1551,6 +1551,17 @@ public:
     return getArguments().back();
   }
 
+  /// If we have an isolated argument, return that. Returns nullptr otherwise.
+  const SILArgument *maybeGetIsolatedArgument() const {
+    for (auto *arg : getArgumentsWithoutIndirectResults()) {
+      if (cast<SILFunctionArgument>(arg)->getKnownParameterInfo().hasOption(
+              SILParameterInfo::Isolated))
+        return arg;
+    }
+
+    return nullptr;
+  }
+
   const SILArgument *getDynamicSelfMetadata() const {
     assert(hasDynamicSelfMetadata() && "This method can only be called if the "
            "SILFunction has a self-metadata parameter");

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -305,7 +305,10 @@ public:
     os << "\n    Rep Value: " << getRepresentative();
   }
 
-  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
+  SWIFT_DEBUG_DUMP {
+    print(llvm::dbgs());
+    llvm::dbgs() << '\n';
+  }
 };
 
 class RegionAnalysis;

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -31,27 +31,6 @@ using TransferringOperandSetFactory = Partition::TransferringOperandSetFactory;
 using Element = PartitionPrimitives::Element;
 using Region = PartitionPrimitives::Region;
 
-/// Check if the passed in type is NonSendable.
-///
-/// NOTE: We special case RawPointer and NativeObject to ensure they are
-/// treated as non-Sendable and strict checking is applied to it.
-inline bool isNonSendableType(SILType type, SILFunction *fn) {
-  // Treat Builtin.NativeObject and Builtin.RawPointer as non-Sendable.
-  if (type.getASTType()->is<BuiltinNativeObjectType>() ||
-      type.getASTType()->is<BuiltinRawPointerType>()) {
-    return true;
-  }
-
-  // Treat Builtin.SILToken as Sendable. It cannot escape from the current
-  // function. We should change isSendable to hardwire this.
-  if (type.getASTType()->is<SILTokenType>()) {
-    return false;
-  }
-
-  // Otherwise, delegate to seeing if type conforms to the Sendable protocol.
-  return !type.isSendable(fn);
-}
-
 /// Return the ApplyIsolationCrossing for a specific \p inst if it
 /// exists. Returns std::nullopt otherwise.
 std::optional<ApplyIsolationCrossing>

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1784,6 +1784,11 @@ void ActorIsolation::printForSIL(llvm::raw_ostream &os) const {
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
+void ActorIsolation::dump() const {
+  print(llvm::dbgs());
+  llvm::dbgs() << '\n';
+}
+
 void ActorIsolation::dumpForDiagnostics() const {
   printForDiagnostics(llvm::dbgs());
   llvm::dbgs() << '\n';

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1760,6 +1760,30 @@ void ActorIsolation::print(llvm::raw_ostream &os) const {
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
+void ActorIsolation::printForSIL(llvm::raw_ostream &os) const {
+  switch (getKind()) {
+  case Unspecified:
+    os << "unspecified";
+    return;
+  case ActorInstance:
+    os << "actor_instance";
+    return;
+  case Nonisolated:
+    os << "nonisolated";
+    return;
+  case NonisolatedUnsafe:
+    os << "nonisolated_unsafe";
+    return;
+  case GlobalActor:
+    os << "global_actor";
+    return;
+  case Erased:
+    os << "erased";
+    return;
+  }
+  llvm_unreachable("Covered switch isn't covered?!");
+}
+
 void ActorIsolation::dumpForDiagnostics() const {
   printForDiagnostics(llvm::dbgs());
   llvm::dbgs() << '\n';

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1733,6 +1733,33 @@ void ActorIsolation::printForDiagnostics(llvm::raw_ostream &os,
   }
 }
 
+void ActorIsolation::print(llvm::raw_ostream &os) const {
+  switch (getKind()) {
+  case Unspecified:
+    os << "unspecified";
+    return;
+  case ActorInstance:
+    os << "actor_instance";
+    if (auto *vd = getActorInstance()) {
+      os << ". name: '" << vd->getBaseIdentifier() << "'";
+    }
+    return;
+  case Nonisolated:
+    os << "nonisolated";
+    return;
+  case NonisolatedUnsafe:
+    os << "nonisolated_unsafe";
+    return;
+  case GlobalActor:
+    os << "global_actor. type: " << getGlobalActor();
+    return;
+  case Erased:
+    os << "erased";
+    return;
+  }
+  llvm_unreachable("Covered switch isn't covered?!");
+}
+
 void ActorIsolation::dumpForDiagnostics() const {
   printForDiagnostics(llvm::dbgs());
   llvm::dbgs() << '\n';

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3328,6 +3328,12 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     P.printDebugScopeRef(getDebugScope(), SM);
   }
   OS << '\n';
+
+  if (auto functionIsolation = getActorIsolation()) {
+    OS << "// Isolation: ";
+    functionIsolation.print(OS);
+    OS << '\n';
+  }
   printClangQualifiedNameCommentIfPresent(OS, getClangDecl());
 
   OS << "sil ";

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1550,11 +1550,17 @@ public:
       *this << "[noasync] ";
     if (auto isolationCrossing = AI->getIsolationCrossing()) {
       auto callerIsolation = isolationCrossing->getCallerIsolation();
-      if (callerIsolation != ActorIsolation::Unspecified)
-        *this << "[callee_isolation=" << callerIsolation << "] ";
+      if (callerIsolation != ActorIsolation::Unspecified) {
+        *this << "[callee_isolation=";
+        callerIsolation.printForSIL(PrintState.OS);
+        *this << "] ";
+      }
       auto calleeIsolation = isolationCrossing->getCalleeIsolation();
-      if (calleeIsolation != ActorIsolation::Unspecified)
-        *this << "[caller_isolation=" << calleeIsolation << "] ";
+      if (calleeIsolation != ActorIsolation::Unspecified) {
+        *this << "[caller_isolation=";
+        calleeIsolation.printForSIL(PrintState.OS);
+        *this << "] ";
+      }
     }
     visitApplyInstBase(AI);
   }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6580,6 +6580,35 @@ public:
             "transferring result means all results are transferring");
 
     // We should only ever have a single sil_isolated parameter.
+    bool foundIsolatedParameter = false;
+    for (const auto &parameterInfo : FTy->getParameters()) {
+      if (parameterInfo.hasOption(SILParameterInfo::Isolated)) {
+        auto argType = parameterInfo.getArgumentType(F.getModule(),
+                                                     FTy,
+                                                     F.getTypeExpansionContext());
+        if (argType->isOptional())
+          argType = argType->lookThroughAllOptionalTypes()->getCanonicalType();
+
+        auto genericSig = FTy->getInvocationGenericSignature();
+        auto &ctx = F.getASTContext();
+        auto *actorProtocol = ctx.getProtocol(KnownProtocolKind::Actor);
+        auto *anyActorProtocol = ctx.getProtocol(KnownProtocolKind::AnyActor);
+        bool genericTypeWithActorRequirement = llvm::any_of(
+            genericSig.getRequirements(), [&](const Requirement &other) {
+              if (other.getKind() != RequirementKind::Conformance)
+                return false;
+              if (other.getFirstType()->getCanonicalType() != argType)
+                return false;
+              auto *otherProtocol = other.getProtocolDecl();
+              return otherProtocol->inheritsFrom(actorProtocol) ||
+                     otherProtocol->inheritsFrom(anyActorProtocol);
+            });
+        require(argType->isAnyActorType() || genericTypeWithActorRequirement,
+                "Only any actor types can be isolated");
+        require(!foundIsolatedParameter, "Two isolated parameters");
+        foundIsolatedParameter = true;
+      }
+    }
     require(1 >= std::count_if(FTy->getParameters().begin(), FTy->getParameters().end(),
                                [](const SILParameterInfo &parameterInfo) {
                                  return parameterInfo.hasOption(SILParameterInfo::Isolated);

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6578,6 +6578,13 @@ public:
                                     SILResultInfo::IsTransferring);
                               })),
             "transferring result means all results are transferring");
+
+    // We should only ever have a single sil_isolated parameter.
+    require(1 >= std::count_if(FTy->getParameters().begin(), FTy->getParameters().end(),
+                               [](const SILParameterInfo &parameterInfo) {
+                                 return parameterInfo.hasOption(SILParameterInfo::Isolated);
+                               }),
+            "Should only ever be isolated to a single parameter");
   }
 
   struct VerifyFlowSensitiveRulesDetails {

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -1527,8 +1527,8 @@ struct DiagnosticEvaluator final
     if (auto *svi =
             dyn_cast<SingleValueInstruction>(partitionOp.getSourceInst())) {
       if (isa<TupleElementAddrInst, StructElementAddrInst>(svi) &&
-          !regionanalysisimpl::isNonSendableType(svi->getType(),
-                                                 svi->getFunction())) {
+          !SILIsolationInfo::isNonSendableType(svi->getType(),
+                                               svi->getFunction())) {
         bool isCapture = operandState.isClosureCaptured;
         if (!isCapture) {
           return;

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -105,11 +105,8 @@ static DeclRefExpr *getDeclRefExprFromExpr(Expr *expr) {
 SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   if (auto fas = FullApplySite::isa(inst)) {
     if (auto crossing = fas.getIsolationCrossing()) {
-      if (crossing->getCalleeIsolation().isActorIsolated()) {
-        // SIL level, just let it through
-        return SILIsolationInfo::getActorIsolated(
-            SILValue(), SILValue(), crossing->getCalleeIsolation());
-      }
+      if (auto info = SILIsolationInfo::getWithIsolationCrossing(*crossing))
+        return info;
     }
 
     if (fas.hasSelfArgument()) {
@@ -118,8 +115,11 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
               SILParameterInfo::Isolated)) {
         if (auto *nomDecl =
                 self.get()->getType().getNominalOrBoundGenericNominal()) {
-          return SILIsolationInfo::getActorIsolated(SILValue(), self.get(),
-                                                    nomDecl);
+          // TODO: We really should be doing this based off of an Operand. Then
+          // we would get the SILValue() for the first element. Today this can
+          // only mess up isolation history.
+          return SILIsolationInfo::getActorInstanceIsolated(
+              SILValue(), self.get(), nomDecl);
         }
       }
     }
@@ -128,21 +128,44 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   if (auto *pai = dyn_cast<PartialApplyInst>(inst)) {
     if (auto *ace = pai->getLoc().getAsASTNode<AbstractClosureExpr>()) {
       auto actorIsolation = ace->getActorIsolation();
-      SILValue actorInstance;
-      if (actorIsolation.isActorIsolated()) {
-        if (actorIsolation.getKind() == ActorIsolation::ActorInstance) {
-          ApplySite as(pai);
-          for (auto &op : as.getArgumentOperands()) {
-            if (as.getArgumentParameterInfo(op).hasOption(
-                    SILParameterInfo::Isolated)) {
-              actorInstance = op.get();
-              break;
-            }
+
+      if (actorIsolation.isGlobalActor()) {
+        return SILIsolationInfo::getGlobalActorIsolated(
+            pai, actorIsolation.getGlobalActor());
+      }
+
+      if (actorIsolation.isActorInstanceIsolated()) {
+        ApplySite as(pai);
+        SILValue actorInstance;
+        for (auto &op : as.getArgumentOperands()) {
+          if (as.getArgumentParameterInfo(op).hasOption(
+                  SILParameterInfo::Isolated)) {
+            actorInstance = op.get();
+            break;
           }
         }
-        return SILIsolationInfo::getActorIsolated(pai, actorInstance,
-                                                  actorIsolation);
+
+        if (actorInstance) {
+          return SILIsolationInfo::getActorInstanceIsolated(
+              pai, actorInstance, actorIsolation.getActor());
+        }
+
+        // For now, if we do not have an actor instance, just create an actor
+        // instance isolated without an actor instance.
+        //
+        // If we do not have an actor instance, that means that we have a
+        // partial apply for which the isolated parameter was not closed over
+        // and is an actual argument that we pass in. This means that the
+        // partial apply is actually flow sensitive in terms of which specific
+        // actor instance we are isolated to.
+        //
+        // TODO: How do we want to resolve this.
+        return SILIsolationInfo::getPartialApplyActorInstanceIsolated(
+            pai, actorIsolation.getActor());
       }
+
+      assert(actorIsolation.getKind() != ActorIsolation::Erased &&
+             "Implement this!");
     }
   }
 
@@ -153,9 +176,16 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   if (auto *rei = dyn_cast<RefElementAddrInst>(inst)) {
     auto *nomDecl =
         rei->getOperand()->getType().getNominalOrBoundGenericNominal();
-    SILValue actorInstance =
-        nomDecl->isAnyActor() ? rei->getOperand() : SILValue();
-    return SILIsolationInfo::getActorIsolated(rei, actorInstance, nomDecl);
+
+    if (nomDecl->isAnyActor())
+      return SILIsolationInfo::getActorInstanceIsolated(rei, rei->getOperand(),
+                                                        nomDecl);
+
+    if (auto isolation = swift::getActorIsolation(nomDecl)) {
+      assert(isolation.isGlobalActor());
+      return SILIsolationInfo::getGlobalActorIsolated(
+          rei, isolation.getGlobalActor());
+    }
   }
 
   // Check if we have a global_addr inst.
@@ -164,7 +194,8 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       if (auto *globalDecl = global->getDecl()) {
         auto isolation = swift::getActorIsolation(globalDecl);
         if (isolation.isGlobalActor()) {
-          return SILIsolationInfo::getActorIsolated(ga, SILValue(), isolation);
+          return SILIsolationInfo::getGlobalActorIsolated(
+              ga, isolation.getGlobalActor());
         }
       }
     }
@@ -173,10 +204,24 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   // Treat function ref as either actor isolated or sendable.
   if (auto *fri = dyn_cast<FunctionRefInst>(inst)) {
     auto isolation = fri->getReferencedFunction()->getActorIsolation();
-    if (isolation.isActorIsolated() &&
-        (isolation.getKind() != ActorIsolation::ActorInstance ||
-         isolation.getActorInstanceParameter() == 0)) {
-      return SILIsolationInfo::getActorIsolated(fri, SILValue(), isolation);
+    if (isolation.isActorIsolated()) {
+      if (isolation.isGlobalActor()) {
+        return SILIsolationInfo::getGlobalActorIsolated(
+            fri, isolation.getGlobalActor());
+      }
+
+      // TODO: We need to be able to support flow sensitive actor instances like
+      // we do for partial apply. Until we do so, just store SILValue() for
+      // this. This could cause a problem if we can construct a function ref and
+      // invoke it with two different actor instances of the same type and pass
+      // in the same parameters to both. We should error and we would not with
+      // this impl since we could not distinguish the two.
+      if (isolation.getKind() == ActorIsolation::ActorInstance) {
+        return SILIsolationInfo::getFlowSensitiveActorIsolated(fri, isolation);
+      }
+
+      assert(isolation.getKind() != ActorIsolation::Erased &&
+             "Implement this!");
     }
 
     // Otherwise, lets look at the AST and see if our function ref is from an
@@ -185,18 +230,16 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       if (auto *funcType = autoclosure->getType()->getAs<AnyFunctionType>()) {
         if (funcType->hasGlobalActor()) {
           if (funcType->hasGlobalActor()) {
-            return SILIsolationInfo::getActorIsolated(
-                fri, SILValue(),
-                ActorIsolation::forGlobalActor(funcType->getGlobalActor()));
+            return SILIsolationInfo::getGlobalActorIsolated(
+                fri, funcType->getGlobalActor());
           }
         }
 
         if (auto *resultFType =
                 funcType->getResult()->getAs<AnyFunctionType>()) {
           if (resultFType->hasGlobalActor()) {
-            return SILIsolationInfo::getActorIsolated(
-                fri, SILValue(),
-                ActorIsolation::forGlobalActor(resultFType->getGlobalActor()));
+            return SILIsolationInfo::getGlobalActorIsolated(
+                fri, resultFType->getGlobalActor());
           }
         }
       }
@@ -214,10 +257,15 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
           if (isolation.isActorIsolated() &&
               (isolation.getKind() != ActorIsolation::ActorInstance ||
                isolation.getActorInstanceParameter() == 0)) {
-            auto actor = cmi->getOperand()->getType().isAnyActor()
-                             ? cmi->getOperand()
-                             : SILValue();
-            return SILIsolationInfo::getActorIsolated(cmi, actor, isolation);
+            if (cmi->getOperand()->getType().isAnyActor()) {
+              return SILIsolationInfo::getActorInstanceIsolated(
+                  cmi, cmi->getOperand(),
+                  cmi->getOperand()
+                      ->getType()
+                      .getNominalOrBoundGenericNominal());
+            }
+            return SILIsolationInfo::getGlobalActorIsolated(
+                cmi, isolation.getGlobalActor());
           }
         }
 
@@ -226,10 +274,15 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
             if (isolation.isActorIsolated() &&
                 (isolation.getKind() != ActorIsolation::ActorInstance ||
                  isolation.getActorInstanceParameter() == 0)) {
-              auto actor = cmi->getOperand()->getType().isAnyActor()
-                               ? cmi->getOperand()
-                               : SILValue();
-              return SILIsolationInfo::getActorIsolated(cmi, actor, isolation);
+              if (cmi->getOperand()->getType().isAnyActor()) {
+                return SILIsolationInfo::getActorInstanceIsolated(
+                    cmi, cmi->getOperand(),
+                    cmi->getOperand()
+                        ->getType()
+                        .getNominalOrBoundGenericNominal());
+              }
+              return SILIsolationInfo::getGlobalActorIsolated(
+                  cmi, isolation.getGlobalActor());
             }
           }
         }
@@ -239,25 +292,23 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
 
   // See if we have a struct_extract from a global actor isolated type.
   if (auto *sei = dyn_cast<StructExtractInst>(inst)) {
-    return SILIsolationInfo::getActorIsolated(sei, SILValue(),
-                                              sei->getStructDecl());
+    return SILIsolationInfo::getGlobalActorIsolated(sei, sei->getStructDecl());
   }
 
   if (auto *seai = dyn_cast<StructElementAddrInst>(inst)) {
-    return SILIsolationInfo::getActorIsolated(seai, SILValue(),
-                                              seai->getStructDecl());
+    return SILIsolationInfo::getGlobalActorIsolated(seai,
+                                                    seai->getStructDecl());
   }
 
   // See if we have an unchecked_enum_data from a global actor isolated type.
   if (auto *uedi = dyn_cast<UncheckedEnumDataInst>(inst)) {
-    return SILIsolationInfo::getActorIsolated(uedi, SILValue(),
-                                              uedi->getEnumDecl());
+    return SILIsolationInfo::getGlobalActorIsolated(uedi, uedi->getEnumDecl());
   }
 
   // See if we have an unchecked_enum_data from a global actor isolated type.
   if (auto *utedi = dyn_cast<UncheckedTakeEnumDataAddrInst>(inst)) {
-    return SILIsolationInfo::getActorIsolated(utedi, SILValue(),
-                                              utedi->getEnumDecl());
+    return SILIsolationInfo::getGlobalActorIsolated(utedi,
+                                                    utedi->getEnumDecl());
   }
 
   // Check if we have an unsafeMutableAddressor from a global actor, mark the
@@ -267,8 +318,8 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       if (calleeFunction->isGlobalInit()) {
         auto isolation = getGlobalActorInitIsolation(calleeFunction);
         if (isolation && isolation->isGlobalActor()) {
-          return SILIsolationInfo::getActorIsolated(applySite, SILValue(),
-                                                    *isolation);
+          return SILIsolationInfo::getGlobalActorIsolated(
+              applySite, isolation->getGlobalActor());
         }
       }
     }
@@ -324,13 +375,10 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   // of the actor.
   if (ApplyExpr *apply = inst->getLoc().getAsASTNode<ApplyExpr>()) {
     if (auto crossing = apply->getIsolationCrossing()) {
-      auto calleeIsolation = crossing->getCalleeIsolation();
-      if (calleeIsolation.isActorIsolated()) {
-        return SILIsolationInfo::getActorIsolated(
-            SILValue(), SILValue(), crossing->getCalleeIsolation());
-      }
+      if (auto info = SILIsolationInfo::getWithIsolationCrossing(*crossing))
+        return info;
 
-      if (calleeIsolation.isNonisolated()) {
+      if (crossing->getCalleeIsolation().isNonisolated()) {
         return SILIsolationInfo::getDisconnected();
       }
     }
@@ -340,13 +388,17 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
 }
 
 SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
+  // Return early if we do not have a non-Sendable type.
+  if (!SILIsolationInfo::isNonSendableType(arg->getType(), arg->getFunction()))
+    return {};
+
   // Handle a switch_enum from a global actor isolated type.
   if (auto *phiArg = dyn_cast<SILPhiArgument>(arg)) {
     if (auto *singleTerm = phiArg->getSingleTerminator()) {
       if (auto *swi = dyn_cast<SwitchEnumInst>(singleTerm)) {
         auto enumDecl =
             swi->getOperand()->getType().getEnumOrBoundGenericEnum();
-        return SILIsolationInfo::getActorIsolated(arg, SILValue(), enumDecl);
+        return SILIsolationInfo::getGlobalActorIsolated(arg, enumDecl);
       }
     }
     return SILIsolationInfo();
@@ -361,28 +413,41 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
        fArg->isTransferring()))
     return SILIsolationInfo::getDisconnected();
 
-  // If we have self and our function is actor isolated, all of our arguments
-  // should be marked as actor isolated.
-  if (auto *self = fArg->getFunction()->maybeGetSelfArgument()) {
+  // Before we do anything further, see if we have an isolated parameter. This
+  // handles isolated self and specifically marked isolated.
+  if (auto *isolatedArg = fArg->getFunction()->maybeGetIsolatedArgument()) {
     if (auto functionIsolation = fArg->getFunction()->getActorIsolation()) {
-      if (functionIsolation.isActorIsolated()) {
-        if (auto *nomDecl = self->getType().getNominalOrBoundGenericNominal()) {
-          return SILIsolationInfo::getActorIsolated(fArg, SILValue(), nomDecl);
-        }
+      assert(functionIsolation.isActorInstanceIsolated());
+      if (auto *nomDecl =
+              isolatedArg->getType().getNominalOrBoundGenericNominal()) {
+        return SILIsolationInfo::getActorInstanceIsolated(fArg, isolatedArg,
+                                                          nomDecl);
       }
     }
   }
 
-  if (auto *decl = fArg->getDecl()) {
-    auto isolation = swift::getActorIsolation(const_cast<ValueDecl *>(decl));
-    if (!bool(isolation)) {
-      if (auto *dc = decl->getDeclContext()) {
-        isolation = swift::getActorIsolationOfContext(dc);
+  // Otherwise, see if we have an allocator decl ref. If we do and we have an
+  // actor instance isolation, then we know that we are actively just calling
+  // the initializer. To just make region isolation work, treat this as
+  // disconnected so we can construct the actor value. Users cannot write
+  // allocator functions so we just need to worry about compiler generated
+  // code. In the case of a non-actor, we can only have an allocator that is
+  // global actor isolated, so we will never hit this code path.
+  if (auto declRef = fArg->getFunction()->getDeclRef()) {
+    if (declRef.kind == SILDeclRef::Kind::Allocator) {
+      if (fArg->getFunction()->getActorIsolation().isActorInstanceIsolated()) {
+        return SILIsolationInfo::getDisconnected();
       }
     }
+  }
 
-    if (isolation.isActorIsolated()) {
-      return SILIsolationInfo::getActorIsolated(fArg, SILValue(), isolation);
+  // Otherwise, if we do not have an isolated argument and are not in an
+  // alloactor, then we might be isolated via global isolation.
+  if (auto functionIsolation = fArg->getFunction()->getActorIsolation()) {
+    if (functionIsolation.isActorIsolated()) {
+      assert(functionIsolation.isGlobalActor());
+      return SILIsolationInfo::getGlobalActorIsolated(
+          fArg, functionIsolation.getGlobalActor());
     }
   }
 
@@ -534,6 +599,27 @@ void SILIsolationInfo::printForDiagnostics(llvm::raw_ostream &os) const {
     os << "task-isolated";
     return;
   }
+}
+
+// Check if the passed in type is NonSendable.
+//
+// NOTE: We special case RawPointer and NativeObject to ensure they are
+// treated as non-Sendable and strict checking is applied to it.
+bool SILIsolationInfo::isNonSendableType(SILType type, SILFunction *fn) {
+  // Treat Builtin.NativeObject and Builtin.RawPointer as non-Sendable.
+  if (type.getASTType()->is<BuiltinNativeObjectType>() ||
+      type.getASTType()->is<BuiltinRawPointerType>()) {
+    return true;
+  }
+
+  // Treat Builtin.SILToken as Sendable. It cannot escape from the current
+  // function. We should change isSendable to hardwire this.
+  if (type.getASTType()->is<SILTokenType>()) {
+    return false;
+  }
+
+  // Otherwise, delegate to seeing if type conforms to the Sendable protocol.
+  return !type.isSendable(fn);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -416,13 +416,10 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   // Before we do anything further, see if we have an isolated parameter. This
   // handles isolated self and specifically marked isolated.
   if (auto *isolatedArg = fArg->getFunction()->maybeGetIsolatedArgument()) {
-    if (auto functionIsolation = fArg->getFunction()->getActorIsolation()) {
-      assert(functionIsolation.isActorInstanceIsolated());
-      if (auto *nomDecl =
-              isolatedArg->getType().getNominalOrBoundGenericNominal()) {
-        return SILIsolationInfo::getActorInstanceIsolated(fArg, isolatedArg,
-                                                          nomDecl);
-      }
+    if (auto *nomDecl =
+        isolatedArg->getType().getNominalOrBoundGenericNominal()) {
+      return SILIsolationInfo::getActorInstanceIsolated(fArg, isolatedArg,
+                                                        nomDecl);
     }
   }
 

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -398,10 +398,26 @@ void SILIsolationInfo::print(llvm::raw_ostream &os) const {
     os << "disconnected";
     return;
   case Actor:
-    os << "actor";
+    if (SILValue instance = getActorInstance()) {
+      if (auto name = VariableNameInferrer::inferName(instance)) {
+        os << "'" << *name << "'-isolated\n";
+        os << "instance: " << *instance;
+        return;
+      }
+    }
+
+    if (getActorIsolation().getKind() == ActorIsolation::ActorInstance) {
+      if (auto *vd = getActorIsolation().getActorInstance()) {
+        os << "'" << vd->getBaseIdentifier() << "'-isolated";
+        return;
+      }
+    }
+
+    getActorIsolation().printForDiagnostics(os);
     return;
   case Task:
-    os << "task";
+    os << "task-isolated\n";
+    os << "instance: " << *getIsolatedValue();
     return;
   }
 }

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -812,26 +812,6 @@ func testActorWithInitAccessorInit() {
       print(a) // Ok (nonisolated)
     }
   }
-
-  class NonSendableKlass {
-    init(_ x: NonSendableKlass? = nil) {
-
-    }
-  }
-  
-  @available(SwiftStdlib 5.1, *)
-  actor NonSendableInit {
-    var first: NonSendableKlass
-    var second: NonSendableKlass? = nil {
-      @storageRestrictions(initializes: first)
-      init(initialValue)  {
-        first = initialValue!
-      }
-
-      get { fatalError() }
-      set { fatalError() }
-    }
-  }
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -812,6 +812,26 @@ func testActorWithInitAccessorInit() {
       print(a) // Ok (nonisolated)
     }
   }
+
+  class NonSendableKlass {
+    init(_ x: NonSendableKlass? = nil) {
+
+    }
+  }
+  
+  @available(SwiftStdlib 5.1, *)
+  actor NonSendableInit {
+    var first: NonSendableKlass
+    var second: NonSendableKlass? = nil {
+      @storageRestrictions(initializes: first)
+      init(initialValue)  {
+        first = initialValue!
+      }
+
+      get { fatalError() }
+      set { fatalError() }
+    }
+  }
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -97,7 +97,7 @@ public actor MyActor: MyProto {
   func g(ns1: NS1) async {
     await nonisolatedAsyncFunc1(ns1) // expected-targeted-and-complete-warning{{passing argument of non-sendable type 'NS1' outside of actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{sending 'ns1' risks causing data races}}
-    // expected-tns-note @-2 {{sending actor-isolated 'ns1' to nonisolated global function 'nonisolatedAsyncFunc1' risks causing data races between nonisolated and actor-isolated uses}}
+    // expected-tns-note @-2 {{sending 'self'-isolated 'ns1' to nonisolated global function 'nonisolatedAsyncFunc1' risks causing data races between nonisolated and 'self'-isolated uses}}
     _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable type 'NS1' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary}}
   }
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -15,10 +15,14 @@
 ////////////////////////
 
 /// Classes are always non-sendable, so this is non-sendable
-class NonSendableKlass { // expected-complete-note 46{{}}
+class NonSendableKlass { // expected-complete-note 48{{}}
   // expected-typechecker-only-note @-1 4{{}}
   // expected-tns-note @-2 2{{}}
   var field: NonSendableKlass? = nil
+
+  init() {}
+  init(_ x: NonSendableKlass) {
+  }
 
   func asyncCall() async {}
   func asyncCallWithIsolatedParameter(isolation: isolated (any Actor)? = #isolation) async {
@@ -626,7 +630,7 @@ func singleFieldVarMergeTest() async {
   await transferToMain(box) // expected-tns-warning {{sending 'box' risks causing data races}}
   // expected-tns-note @-1 {{sending 'box' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
-  
+
 
   // But if we use box.k here, we emit an error since we didn't reinitialize at
   // all.
@@ -641,7 +645,7 @@ func multipleFieldVarMergeTest1() async {
   await transferToMain(box.k1) // expected-tns-warning {{sending 'box.k1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'box.k1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  
+
 
   // So even if we reassign over k1, since we did a merge, this should error.
   box.k1 = NonSendableKlass() // expected-tns-note {{access can happen concurrently}}
@@ -727,7 +731,7 @@ class ClassFieldTests { // expected-complete-note 6{{}}
   let letNonSendableNonTrivial = NonSendableKlass()
   var varSendableTrivial = 0
   var varSendableNonTrivial = SendableKlass()
-  var varNonSendableNonTrivial = NonSendableKlass()  
+  var varNonSendableNonTrivial = NonSendableKlass()
 }
 
 func letSendableTrivialClassFieldTest() async {
@@ -795,7 +799,7 @@ final class FinalClassFieldTests { // expected-complete-note 6 {{}}
   let letNonSendableNonTrivial = NonSendableKlass()
   var varSendableTrivial = 0
   var varSendableNonTrivial = SendableKlass()
-  var varNonSendableNonTrivial = NonSendableKlass()  
+  var varNonSendableNonTrivial = NonSendableKlass()
 }
 
 func letSendableTrivialFinalClassFieldTest() async {
@@ -862,7 +866,7 @@ struct StructFieldTests { // expected-complete-note 31 {{}}
   let letNonSendableNonTrivial = NonSendableKlass()
   var varSendableTrivial = 0
   var varSendableNonTrivial = SendableKlass()
-  var varNonSendableNonTrivial = NonSendableKlass()  
+  var varNonSendableNonTrivial = NonSendableKlass()
 }
 
 func letSendableTrivialLetStructFieldTest() async {
@@ -1343,7 +1347,7 @@ func varNonSendableNonTrivialLetTupleFieldTest() async {
 }
 
 func varSendableTrivialVarTupleFieldTest() async {
-  var test = (0, SendableKlass(), NonSendableKlass()) 
+  var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -1353,7 +1357,7 @@ func varSendableTrivialVarTupleFieldTest() async {
 }
 
 func varSendableTrivialVarTupleFieldTest2() async {
-  var test = (0, SendableKlass(), NonSendableKlass()) 
+  var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test.2) // expected-tns-warning {{sending 'test.2' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test.2' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -1363,7 +1367,7 @@ func varSendableTrivialVarTupleFieldTest2() async {
 }
 
 func varSendableNonTrivialVarTupleFieldTest() async {
-  var test = (0, SendableKlass(), NonSendableKlass()) 
+  var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -1373,7 +1377,7 @@ func varSendableNonTrivialVarTupleFieldTest() async {
 }
 
 func varNonSendableNonTrivialVarTupleFieldTest() async {
-  var test = (0, SendableKlass(), NonSendableKlass()) 
+  var test = (0, SendableKlass(), NonSendableKlass())
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -1458,7 +1462,7 @@ actor ActorWithSetter {
     self.twoFieldBoxInTuple.1.k1 = x
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}    
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   // This triggers a crash in SILGen with tns enabled.
@@ -1645,4 +1649,52 @@ extension MyActor {
       // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     }
   }
+}
+
+func initAccessorTests() {
+  @available(SwiftStdlib 5.1, *)
+  actor NonisolatedAccessors {
+    nonisolated var a: Int = 0 {
+      init {
+      }
+
+      get { 0 }
+      set {}
+    }
+
+    init(value: Int) {
+      let escapingSelf: (NonisolatedAccessors) -> Void = { _ in }
+
+      // a is initialized here via default value
+
+      escapingSelf(self)
+
+      self.a = value // Ok (nonisolated)
+      print(a) // Ok (nonisolated)
+    }
+  }
+
+  @available(SwiftStdlib 5.1, *)
+  actor NonSendableInit {
+    var first: NonSendableKlass
+    var second: NonSendableKlass? = nil {
+      @storageRestrictions(initializes: first)
+      init(initialValue)  {
+        first = initialValue!
+      }
+
+      get { fatalError() }
+      set { fatalError() }
+    }
+  }
+}
+
+func differentInstanceTest(_ a: MyActor, _ b: MyActor) async {
+  let x = NonSendableKlass()
+  await a.useKlass(x)
+  // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
+  // expected-tns-note @-2 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+  await b.useKlass(x) // expected-tns-note {{access can happen concurrently}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
 }

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -75,9 +75,10 @@ func initActorWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
 
 actor ActorWithAsyncIsolatedInit {
   init(_ newK: NonSendableKlass) async {
+    // TODO: This should say actor isolated.
     let _ = { @MainActor in
       print(newK) // expected-error {{sending 'newK' risks causing data races}}
-      // expected-note @-1 {{actor-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'self'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 }

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -27,6 +27,8 @@ func useValue<T>(_ t: T) {}
 @MainActor func transferToMain<T>(_ t: T) {}
 @CustomActor func transferToCustom<T>(_ t: T) {}
 
+var boolValue: Bool { false }
+
 /////////////////
 // MARK: Tests //
 /////////////////
@@ -37,12 +39,19 @@ actor ProtectsNonSendable {
   var ns: NonSendableKlass = .init()
 
   nonisolated func testParameter(_ nsArg: NonSendableKlass) async {
-    // TODO: This is wrong, we should get an error saying that nsArg is task
-    // isolated since this is nonisolated.
     self.assumeIsolated { isolatedSelf in
       isolatedSelf.ns = nsArg // expected-warning {{sending 'nsArg' risks causing data races}}
       // expected-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
+  }
+
+  nonisolated func testParameterOutOfLine2(_ nsArg: NonSendableKlass) async {
+    let closure: (isolated ProtectsNonSendable) -> () = { isolatedSelf in
+      isolatedSelf.ns = nsArg // expected-warning {{sending 'nsArg' risks causing data races}}
+      // expected-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+    self.assumeIsolated(closure)
+    self.assumeIsolated(closure)
   }
 
   nonisolated func testParameterMergedIntoLocal(_ nsArg: NonSendableKlass) async {
@@ -103,4 +112,58 @@ func transferBeforeCaptureErrors() async {
   let _ = { @MainActor in // expected-note {{access can happen concurrently}}
     useValue(x)
   }
+}
+
+// TODO: This should have an error. We aren't disambiguating the actors.
+func testDifferentIsolationFromSameClassKindPartialApply() async {
+  let p1 = ProtectsNonSendable()
+  let p2 = ProtectsNonSendable()
+
+  let x = NonSendableKlass()
+
+  let closure: (isolated ProtectsNonSendable) -> () = { isolatedSelf in
+    print(x)
+  }
+
+  await closure(p1)
+  await closure(p2)
+}
+
+// TODO: This should have an error. We aren't disambiguating the actors.
+func testDifferentIsolationFromSameClassKindPartialApplyFlowSensitive() async {
+  let p1 = ProtectsNonSendable()
+  let p2 = ProtectsNonSendable()
+
+  let x = NonSendableKlass()
+
+  let closure: (isolated ProtectsNonSendable) -> () = { isolatedSelf in
+    print(x)
+  }
+
+  if await boolValue {
+    await closure(p1)
+    await closure(p1)
+  } else {
+    await closure(p2)
+    await closure(p2)
+  }
+}
+
+// TODO: This should have an error. We aren't disambiguating the actors.
+func testDifferentIsolationFromSameClassKindPartialApplyFlowSensitive2() async {
+  let p1 = ProtectsNonSendable()
+  let p2 = ProtectsNonSendable()
+
+  let x = NonSendableKlass()
+
+  let closure: (isolated ProtectsNonSendable) -> () = { isolatedSelf in
+    print(x)
+  }
+
+  if await boolValue {
+    await closure(p1)
+  } else {
+    await closure(p2)
+  }
+  await closure(p2)
 }

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -134,7 +134,7 @@ actor MyActor {
   func canTransferWithTransferringMethodArg(_ x: transferring Klass, _ y: Klass) async {
     await transferToMain(x)
     await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
-    // expected-note @-1 {{sending actor-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and actor-isolated uses}}
+    // expected-note @-1 {{sending 'self'-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -384,3 +384,20 @@ func testMergeWithTaskIsolated(_ x: transferring Klass, y: Klass) async {
   await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
+
+
+@available(SwiftStdlib 5.1, *)
+actor NonSendableInit {
+  var first: Klass
+  var second: Klass? = nil {
+    @storageRestrictions(initializes: first)
+    init(initialValue)  {
+      transferArg(initialValue!) // expected-warning {{sending 'initialValue' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated 'initialValue' is passed as a transferring parameter}}
+      first = initialValue!
+    }
+
+    get { fatalError() }
+    set { fatalError() }
+  }
+}

--- a/test/Distributed/distributed_actor_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_transfernonsendable.swift
@@ -54,7 +54,7 @@ distributed actor MyDistributedActor {
 
   distributed func transferActorIsolatedArg(_ x: NonSendableKlass) async {
     await transferToMain(x) // expected-error {{sending 'x' risks causing data races}}
-    // expected-note @-1 {{sending actor-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and actor-isolated uses}}
+    // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
   distributed func transferActorIsolatedArgIntoClosure(_ x: NonSendableKlass) async {
@@ -62,7 +62,7 @@ distributed actor MyDistributedActor {
       // TODO: In 2nd part of message should say actor-isolated instead of later
       // nonisolated uses in the case of a closure.
       print(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{actor-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'self'-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 }

--- a/test/SIL/Serialization/isolated_parameters.sil
+++ b/test/SIL/Serialization/isolated_parameters.sil
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name borrow
-// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name borrow
-// RUN: %target-sil-opt %t/tmp.2.sib -module-name borrow -emit-sorted-sil | %FileCheck %s
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name _Concurrency
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name _Concurrency
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name _Concurrency -emit-sorted-sil | %FileCheck %s
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
@@ -13,6 +13,7 @@ import Swift
 import SwiftShims
 
 // NOTE: In SIL we do not save/print out imports, so we cannot import _Concurrency here!
+
 public protocol AnyActor: AnyObject, Sendable {}
 public protocol Actor : AnyActor {}
 

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -488,6 +488,7 @@ func testNoescape() {
 // Despite being a noescape closure, this needs to capture 'a' by-box so it can
 // be passed to the capturing closure.closure
 // CHECK: closure #1 () -> () in functions.testNoescape() -> ()
+// CHECK-NEXT: Isolation: nonisolated
 // CHECK-NEXT: sil private [ossa] @$s9functions12testNoescapeyyFyyXEfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 
 
@@ -508,7 +509,9 @@ func testNoescape2() {
 // CHECK-LABEL: sil hidden [ossa] @$s9functions13testNoescape2yyF : $@convention(thin) () -> () {
 
 // CHECK: // closure #1 () -> () in functions.testNoescape2() -> ()
+// CHECK-NEXT: Isolation: nonisolated
 // CHECK-NEXT: sil private [ossa] @$s9functions13testNoescape2yyFyyXEfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {
 
 // CHECK: // closure #1 () -> () in closure #1 () -> () in functions.testNoescape2() -> ()
+// CHECK-NEXT: Isolation: nonisolated
 // CHECK-NEXT: sil private [ossa] @$s9functions13testNoescape2yyFyyXEfU_yycfU_ : $@convention(thin) (@guaranteed { var Int }) -> () {


### PR DESCRIPTION
[region-isolation] When inferring isolation for an argument, handle non-self isolated parameters as well as self parameters that are actor isolated.

As part of this I went through how we handled inference and rather than using a
grab-bag getActorIsolation that was confusing to use, I created split APIs for
specific use cases (actor instance, global actor, just an apply expr crossing)
that makes it clearer inside the SILIsolationInfo::get* APIs what we are
actually trying to model. I found a few issues as a result and fixed most of
them if they were small. I also fixed one bigger one around computed property
initializers in the next commit. There is a larger change I didn't fix around allowing function
ref/partial_apply with isolated self parameters have a delayed flow sensitive
actor isolation... this will be fixed in a subsequent commit.

This also fixes a bunch of cases where we were printing actor-isolated instead
of 'self' isolated.

rdar://127295657

----

NOTE: The third commit is the commit that fixes inferred isolation in property initializers in actors.

rdar://127844737

