### PR TITLE
[cxx-interop] Import the attributes from clang decl for synthesized s…

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2522,6 +2522,15 @@ namespace {
           VarDecl *pointeeProperty =
               synthesizer.makeDereferencedPointeeProperty(
                   getterAndSetter.first, getterAndSetter.second);
+
+          // Import the attributes from clang decl of dereference operator to
+          // synthesized pointee property.
+          FuncDecl *getterOrSetterImpl = getterAndSetter.first
+                                             ? getterAndSetter.first
+                                             : getterAndSetter.second;
+          Impl.importAttributesFromClangDeclToSynthesizedSwiftDecl(
+              getterOrSetterImpl, pointeeProperty);
+
           result->addMember(pointeeProperty);
         }
       }
@@ -3320,6 +3329,10 @@ namespace {
           // This is a pre-increment operator. We synthesize a
           // non-mutating function called `successor() -> Self`.
           FuncDecl *successorFunc = synthesizer.makeSuccessorFunc(func);
+
+          // Import the clang decl attributes to synthesized successor function.
+          Impl.importAttributesFromClangDeclToSynthesizedSwiftDecl(func, successorFunc);
+
           typeDecl->addMember(successorFunc);
 
           Impl.markUnavailable(func, "use .successor()");
@@ -8233,6 +8246,17 @@ static bool isUsingMacroName(clang::SourceManager &SM,
     return false;
   StringRef content(SM.getCharacterData(Sloc), MacroName.size());
   return content == MacroName;
+}
+
+void ClangImporter::Implementation::importAttributesFromClangDeclToSynthesizedSwiftDecl(Decl *sourceDecl, Decl* synthesizedDecl)
+{
+  // sourceDecl->getClangDecl() can be null because some lazily instantiated cases like C++ members that were instantiated from using-shadow-decls have no corresponding Clang decl.
+  // FIXME: Need to include the cases where correspondoing clang decl is not present.
+  if (auto clangDeclForSource =
+          dyn_cast_or_null<clang::NamedDecl>(
+              sourceDecl->getClangDecl())) {
+    importAttributes(clangDeclForSource, synthesizedDecl);
+  }
 }
 
 /// Import Clang attributes as Swift attributes.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1064,6 +1064,15 @@ public:
   /// in the given module.
   SourceFile &getClangSwiftAttrSourceFile(ModuleDecl &module);
 
+  /// Utility function to import Clang attributes from a source Swift decl to
+  /// synthesized Swift decl.
+  ///
+  /// \param SourceDecl The Swift decl to copy the atteribute from.
+  /// \param SynthesizedDecl The synthesized Swift decl to attach attributes to.
+  void
+  importAttributesFromClangDeclToSynthesizedSwiftDecl(Decl *SourceDecl,
+                                                      Decl *SynthesizedDecl);
+
   /// Import attributes from the given Clang declaration to its Swift
   /// equivalent.
   ///

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -492,4 +492,47 @@ public:
    }
 };
 
+struct ClassWithOperatorStarAvailable {
+  int value;
+
+public:
+  int &operator*() { return value; }
+};
+
+struct DerivedClassWithOperatorStarAvailable : ClassWithOperatorStarAvailable {
+};
+
+struct ClassWithOperatorStarUnavailable {
+  int value;
+
+public:
+  int &operator*() __attribute__((availability(swift, unavailable))) {
+    return value;
+  }
+};
+
+struct DerivedClassWithOperatorStarUnavailable
+    : ClassWithOperatorStarUnavailable {};
+
+struct ClassWithSuccessorAvailable {
+  int value;
+
+public:
+  ClassWithSuccessorAvailable &operator++() {
+    value++;
+    return *this;
+  }
+};
+
+struct ClassWithSuccessorUnavailable {
+  int value;
+
+public:
+  ClassWithSuccessorUnavailable &operator++()
+      __attribute__((availability(swift, unavailable))) {
+    value++;
+    return *this;
+  }
+};
+
 #endif

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -78,3 +78,22 @@ let _ = derivedConstIterWithUD.pointee
 
 var derivedIntWrapper = DerivedFromLoadableIntWrapperWithUsingDecl()
 derivedIntWrapper += LoadableIntWrapper()
+
+let classWithSuccessorAvailable = ClassWithSuccessorAvailable()
+let _ = classWithSuccessorAvailable.successor();
+let classWithSuccessorUnavailable = ClassWithSuccessorUnavailable()
+let _ = classWithSuccessorUnavailable.successor(); // expected-error {{'successor()' is unavailable in Swift}}
+
+var classWithOperatorStarAvailable = ClassWithOperatorStarAvailable()
+let _ = classWithOperatorStarAvailable.pointee
+let derivedClassWithOperatorStarAvailable = DerivedClassWithOperatorStarAvailable()
+let _ = derivedClassWithOperatorStarAvailable.pointee
+
+var classWithOperatorStarUnavailable = ClassWithOperatorStarUnavailable()
+let _ = classWithOperatorStarUnavailable.pointee // expected-error {{'pointee' is unavailable in Swift}}
+
+// FIXME: The below test should also fail with 'pointee' is unavailable in Swift error, 
+// but currently pointee is not hidden in derived classes.
+let derivedClassWithOperatorStarUnavailable = DerivedClassWithOperatorStarUnavailable()
+let _ = derivedClassWithOperatorStarUnavailable.pointee  
+


### PR DESCRIPTION
Attributes like availability were not being copied from clang decl of C++ operator * to swift decl of pointee property. Because of this pointee property was not hidden in swift even if C++ operator * (dereference operator) was marked with __attribute__((availability(swift, unavailable))).

rdar://116775023