### PR TITLE
[SILGen] Fix a crash when a closure is converted to a pointer to a function returning a non-trivial C++ type

### DIFF
--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -21,5 +21,6 @@ void cfuncARCStrong(void (*_Nonnull)(ARCStrong));
 #endif
 
 void cfuncReturnNonTrivial(NonTrivial (^_Nonnull)()) noexcept;
+void cfuncReturnNonTrivial2(NonTrivial (*_Nonnull)()) noexcept;
 
 #endif // __CLOSURE__

--- a/test/Interop/Cxx/class/closure-thunk-irgen.swift
+++ b/test/Interop/Cxx/class/closure-thunk-irgen.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swiftxx-frontend -I %S/Inputs -emit-irgen %s | %FileCheck %s
+
+// REQUIRES: OS=macosx || OS=linux-android
+
+import Closure
+
+// CHECK: define internal void @"$s4main36testClosureToFuncPtrReturnNonTrivialyyFSo0hI0VycfU_To"(ptr noalias sret(%{{.*}}) %[[V0:.*]])
+// CHECK: call swiftcc void @"$s4main36testClosureToFuncPtrReturnNonTrivialyyFSo0hI0VycfU_"(ptr noalias sret(%{{.*}}) %[[V0]])
+// CHECK: ret void
+
+public func testClosureToFuncPtrReturnNonTrivial() {
+  cfuncReturnNonTrivial2({() -> NonTrivial in return NonTrivial()});
+}

--- a/test/Interop/Cxx/class/closure-thunk.swift
+++ b/test/Interop/Cxx/class/closure-thunk.swift
@@ -19,3 +19,13 @@ import Closure
 public func testClosureToFuncPtr() {
  cfunc2({N in})
 }
+
+// CHECK: sil private [thunk] [ossa] @$s4main36testClosureToFuncPtrReturnNonTrivialyyFSo0hI0VycfU_To : $@convention(c) () -> @out NonTrivial {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+// CHECK: %[[V1:.*]] = function_ref @$s4main36testClosureToFuncPtrReturnNonTrivialyyFSo0hI0VycfU_ : $@convention(thin) () -> @out NonTrivial // user: %[[V2]]
+// CHECK: %[[V2:.*]] = apply %[[V1]](%[[V0]]) : $@convention(thin) () -> @out NonTrivial // user: %[[V3]]
+// CHECK: return %[[V2]] : $()
+
+public func testClosureToFuncPtrReturnNonTrivial() {
+  cfuncReturnNonTrivial2({() -> NonTrivial in return NonTrivial()});
+}

--- a/test/Interop/Cxx/class/closure-thunk.swift
+++ b/test/Interop/Cxx/class/closure-thunk.swift
@@ -22,8 +22,8 @@ public func testClosureToFuncPtr() {
 
 // CHECK: sil private [thunk] [ossa] @$s4main36testClosureToFuncPtrReturnNonTrivialyyFSo0hI0VycfU_To : $@convention(c) () -> @out NonTrivial {
 // CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
-// CHECK: %[[V1:.*]] = function_ref @$s4main36testClosureToFuncPtrReturnNonTrivialyyFSo0hI0VycfU_ : $@convention(thin) () -> @out NonTrivial // user: %[[V2]]
-// CHECK: %[[V2:.*]] = apply %[[V1]](%[[V0]]) : $@convention(thin) () -> @out NonTrivial // user: %[[V3]]
+// CHECK: %[[V1:.*]] = function_ref @$s4main36testClosureToFuncPtrReturnNonTrivialyyFSo0hI0VycfU_ : $@convention(thin) () -> @out NonTrivial
+// CHECK: %[[V2:.*]] = apply %[[V1]](%[[V0]]) : $@convention(thin) () -> @out NonTrivial
 // CHECK: return %[[V2]] : $()
 
 public func testClosureToFuncPtrReturnNonTrivial() {


### PR DESCRIPTION
When emitting a native-to-foreign thunk, pass the thunk's result address parameter to the native function if both the thunk and the native function return their results indirectly and the thunk is not for an async function.

Also, remove an outdated assertion.

rdar://124501345