### PR TITLE
[Concurrency][SE-0434] Treat globally-isolated local captured functions as `Sendable`.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2810,6 +2810,14 @@ namespace {
             ->mapTypeIntoContext(decl->getInterfaceType())
             ->getReferenceStorageReferent();
 
+        if (ctx.LangOpts.hasFeature(
+                Feature::GlobalActorIsolatedTypesUsability)) {
+          // If the local capture is globally-isolated, it is implicitly
+          // Sendable.
+          if (isolation.isGlobalActor())
+            continue;
+        }
+
         if (type->hasError())
           continue;
 
@@ -4133,6 +4141,13 @@ namespace {
       }
 
       if (auto func = dyn_cast<FuncDecl>(value)) {
+        if (ctx.LangOpts.hasFeature(
+                Feature::GlobalActorIsolatedTypesUsability)) {
+          bool globallyIsolated = getActorIsolation(value).isGlobalActor();
+          if (func->isSendable() || globallyIsolated)
+            return false;
+        }
+
         if (func->isSendable())
           return false;
 

--- a/test/Concurrency/global_actor_sendable_fn_type_inference.swift
+++ b/test/Concurrency/global_actor_sendable_fn_type_inference.swift
@@ -5,9 +5,11 @@
 
 func inferSendableFunctionType() {
   let closure: @MainActor () -> Void = {}
+  @MainActor func f() {}
 
   Task {
     await closure() // okay
+    await f() // okay
   }
 }
 


### PR DESCRIPTION
Fix a bug where global isolation was not checked for globally-isolated local function captures. Such functions should be treated as `Sendable` when captured.

Resolves #73562, #75799