### PR TITLE
[Concurrency] Add explicit test for dispatchMain() DispatchQueue.main.async + asserting

### DIFF
--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_dispatch_dispatchMain.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_dispatch_dispatchMain.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN:  %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+// REQUIRES: libdispatch
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+import Dispatch
+
+#if os(macOS)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+@main struct Main {
+  static func main() {
+    if #available(SwiftStdlib 6.0, *) {
+
+      Swift.print("start detached")
+      Task.detached {
+        Swift.print("DispatchQueue.main.async { MainActor.precondition }")
+
+        DispatchQueue.main.async {
+          MainActor.preconditionIsolated("I know I'm on the main queue")
+
+          Swift.print("OK")
+          exit(0)
+        }
+      }
+
+      dispatchMain()
+    }
+  }
+}


### PR DESCRIPTION
Add another explicit test for using dispatchMain() and asserting the isolation.

The debug output here would be (prints not comitted);

[Actor.cpp:385](swift_task_isCurrentExecutorImpl) expected is main
[Actor.cpp:390](swift_task_isCurrentExecutorImpl) IS NOT on main thread
[Actor.cpp:408](swift_task_isCurrentExecutorImpl) call checkIsolated did not crash

and it works even if the queue isn't implementing SerialExecutor because:

```
static void swift_task_checkIsolatedImpl(SerialExecutorRef executor) {
  // If it is the main executor, compare with the Main queue
  if (executor.isMainExecutor()) {
    dispatch_assert_queue(dispatch_get_main_queue());
    return;
  }

// before we actually go in and call `checkIsolated`
```

Did we miss some other edge case?

Related to rdar://110210541