### PR TITLE
Deserializer: flush the diag engine to see a function type mismatch error

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -430,10 +430,11 @@ SILFunction *SILDeserializer::getFuncForReference(StringRef name,
         if (auto *decl = dyn_cast_or_null<AbstractFunctionDecl>(dc->getAsDecl()))
           fnName = decl->getNameStr();
       }
-      fn->getModule().getASTContext().Diags.diagnose(
-        fn->getLocation().getSourceLoc(),
-        diag::deserialize_function_type_mismatch,
-        fnName, fnType.getASTType(), type.getASTType());
+      auto &diags = fn->getModule().getASTContext().Diags;
+      diags.diagnose(fn->getLocation().getSourceLoc(),
+                     diag::deserialize_function_type_mismatch,
+                     fnName, fnType.getASTType(), type.getASTType());
+      diags.flushConsumers();
       exit(1);
     }
     return fn;


### PR DESCRIPTION
Fixes a not-printed error message.
rdar://127767886

