### PR TITLE
🍒[cxx-interop][SwiftToCxx] Do not crash while trying to expose a macro to C++

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2033,6 +2033,8 @@ ERROR(expose_move_only_to_cxx,none,
       "noncopyable %kind0 can not yet be represented in C++", (ValueDecl *))
 ERROR(expose_nested_type_to_cxx,none,
       "nested %kind0 can not yet be represented in C++", (ValueDecl *))
+ERROR(expose_macro_to_cxx,none,
+      "Swift macro can not yet be represented in C++", (ValueDecl *))
 ERROR(unexposed_other_decl_in_cxx,none,
       "%kind0 is not yet exposed to C++", (ValueDecl *))
 ERROR(unsupported_other_decl_in_cxx,none,

--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -83,6 +83,7 @@ enum RepresentationError {
   UnrepresentableProtocol,
   UnrepresentableMoveOnly,
   UnrepresentableNested,
+  UnrepresentableMacro,
 };
 
 /// Constructs a diagnostic that describes the given C++ representation error.

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -215,6 +215,8 @@ swift::cxx_translation::getDeclRepresentation(const ValueDecl *VD) {
     return {Unsupported, UnrepresentableObjC};
   if (getActorIsolation(const_cast<ValueDecl *>(VD)).isActorIsolated())
     return {Unsupported, UnrepresentableIsolatedInActor};
+  if (isa<MacroDecl>(VD))
+    return {Unsupported, UnrepresentableMacro};
   GenericSignature genericSignature;
   // Don't expose @_alwaysEmitIntoClient decls as they require their
   // bodies to be emitted into client.
@@ -382,5 +384,7 @@ swift::cxx_translation::diagnoseRepresenationError(RepresentationError error,
     return Diagnostic(diag::expose_move_only_to_cxx, vd);
   case UnrepresentableNested:
     return Diagnostic(diag::expose_nested_type_to_cxx, vd);
+  case UnrepresentableMacro:
+    return Diagnostic(diag::expose_macro_to_cxx, vd);
   }
 }

--- a/test/Interop/SwiftToCxx/macros/macro-name-collision.swift
+++ b/test/Interop/SwiftToCxx/macros/macro-name-collision.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name MacroNameCollision -clang-header-expose-decls=all-public -emit-clang-header-path %t/macros.h
+// RUN: %FileCheck %s < %t/macros.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/macros.h)
+
+// CHECK-LABEL: namespace MacroNameCollision SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("MacroNameCollision") {
+
+@freestanding(expression)
+public macro myLogMacro(error: String) = #externalMacro(module: "CompilerPlugin", type: "LogMacro")
+
+@freestanding(expression)
+public macro myLogMacro(fault: String) = #externalMacro(module: "CompilerPlugin", type: "LogMacro")
+
+// CHECK: // Unavailable in C++: Swift macro 'myLogMacro(error:)'
+// CHECK: // Unavailable in C++: Swift macro 'myLogMacro(fault:)'


### PR DESCRIPTION
**Explanation**: This fixes a compiler crash that happened when emitting a Clang header for a Swift module that declares multiple macros with the same base name and different argument names. Swift macros are not currently designed to be exposed to C++, so this change makes sure we don't try to emit them.
**Scope**: Changes the logic that generates C++ representation of Swift decls.
**Risk**: Low, only affects generation of a C++ header.
**Testing**: Added a compile test.
**Issue**: rdar://117969472 / https://github.com/apple/swift/issues/69656
**Reviewer**: @fahadnayyar

Original PR: https://github.com/apple/swift/pull/73510