### PR TITLE
[embedded] Mark test/embedded/lto-multiple-object-files.swift as REQUIRES: optimized_stdlib

### DIFF
--- a/test/embedded/lto-multiple-object-files.swift
+++ b/test/embedded/lto-multiple-object-files.swift
@@ -14,6 +14,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
 
 // For LTO, the linker dlopen()'s the libLTO library, which is a scenario that


### PR DESCRIPTION
To resolve this test failure: https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulators/4261/console