### PR TITLE
[Gardening] SIL: Spelling of live range.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/InstructionRange.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/InstructionRange.swift
@@ -20,7 +20,7 @@ import SIL
 /// One or more "potential" end instructions can be inserted.
 /// Though, not all inserted instructions end up as "end" instructions.
 ///
-/// `InstructionRange` is useful for calculating the liferange of values.
+/// `InstructionRange` is useful for calculating the liverange of values.
 ///
 /// The `InstructionRange` is similar to a `BasicBlockRange`, but defines the range
 /// in a "finer" granularity, i.e. on instructions instead of blocks.

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
@@ -19,7 +19,7 @@ import SIL
 /// are initialized, a statically initialized global is created where the initializer is a
 /// `vector` instruction.
 ///
-/// TODO: liferange computation is done very ad-hoc and should be eventually done by inspecting
+/// TODO: liverange computation is done very ad-hoc and should be eventually done by inspecting
 ///       forwarding instructions.
 let allocVectorLowering = FunctionPass(name: "alloc-vector-lowering") {
   (function: Function, context: FunctionPassContext) in
@@ -203,9 +203,9 @@ private func lower(allocVectorBuiltin: BuiltinInst, _ context: FunctionPassConte
   case .storeToGlobal(let storeInst):
     createOutlinedGlobal(for: allocVectorBuiltin, storeToGlobal: storeInst, context)
 
-  case .liferange(var liferange):
-    defer { liferange.deinitialize() }
-    createStackAllocatedVector(for: allocVectorBuiltin, liferange: liferange, context)
+  case .liverange(var liverange):
+    defer { liverange.deinitialize() }
+    createStackAllocatedVector(for: allocVectorBuiltin, liverange: liverange, context)
 
   case .invalid:
     context.diagnosticEngine.diagnose(allocVectorBuiltin.location.sourceLoc, .lifetime_value_outside_scope)
@@ -255,7 +255,7 @@ private func createOutlinedGlobal(
 
 private func createStackAllocatedVector(
   for allocVectorBuiltin: BuiltinInst,
-  liferange: InstructionRange,
+  liverange: InstructionRange,
   _ context: FunctionPassContext
 ) {
   let builder = Builder(before: allocVectorBuiltin, context)
@@ -267,7 +267,7 @@ private func createStackAllocatedVector(
   allocVectorBuiltin.uses.replaceAll(with: rawVectorPointer, context)
   context.erase(instruction: allocVectorBuiltin)
 
-  for endInst in liferange.ends {
+  for endInst in liverange.ends {
     let builder = Builder(after: endInst, context)
     builder.createDeallocStack(allocVec)
   }
@@ -339,44 +339,44 @@ private func findInitStores(of address: Value, atIndex: Int, _ initStores: inout
 private struct ComputeNonEscapingLiferange : EscapeVisitorWithResult {
 
   enum Result {
-    case liferange(InstructionRange)
+    case liverange(InstructionRange)
     case storeToGlobal(StoreInst)
     case invalid
   }
 
-  var liferange: InstructionRange
+  var liverange: InstructionRange
   var storeToGlobal: StoreInst? = nil
   let domTree: DominatorTree
 
   init(of instruction: Instruction, _ context: FunctionPassContext) {
-    self.liferange = InstructionRange(begin: instruction, context)
+    self.liverange = InstructionRange(begin: instruction, context)
     self.domTree = context.dominatorTree
   }
 
   var result: Result {
     if let storeToGlobal = storeToGlobal {
       defer {
-        var lr = liferange
+        var lr = liverange
         lr.deinitialize()
       }
-      precondition(liferange.inclusiveRangeContains(storeToGlobal))
-      if liferange.inclusiveRangeContains(storeToGlobal.next!) ||
-         liferange.ends.contains(where: { $0 != storeToGlobal }) ||
+      precondition(liverange.inclusiveRangeContains(storeToGlobal))
+      if liverange.inclusiveRangeContains(storeToGlobal.next!) ||
+         liverange.ends.contains(where: { $0 != storeToGlobal }) ||
          !storeToGlobal.isInitializingGlobal
       {
         return .invalid
       }
       return .storeToGlobal(storeToGlobal)
     }
-    return .liferange(liferange)
+    return .liverange(liverange)
   }
 
   mutating func cleanupOnAbort() {
-    liferange.deinitialize()
+    liverange.deinitialize()
   }
 
   mutating func visitDef(def: Value, path: EscapePath) -> DefResult {
-    if def.definingInstruction == liferange.begin {
+    if def.definingInstruction == liverange.begin {
       return .walkDown
     }
     switch def {
@@ -392,12 +392,12 @@ private struct ComputeNonEscapingLiferange : EscapeVisitorWithResult {
 
   mutating func visitUse(operand: Operand, path: EscapePath) -> UseResult {
     let user = operand.instruction
-    let beginBlockOfRange = liferange.blockRange.begin
+    let beginBlockOfRange = liverange.blockRange.begin
     let dominates = beginBlockOfRange.dominates(user.parentBlock, domTree)
     switch user {
     case let store as StoreInst:
       if dominates {
-        liferange.insert(store)
+        liverange.insert(store)
       }
       let accessPath = store.destination.accessPath
       if case .global = accessPath.base {
@@ -412,7 +412,7 @@ private struct ComputeNonEscapingLiferange : EscapeVisitorWithResult {
       return .continueWalk
     case let apply as ApplyInst:
       if dominates {
-        liferange.insert(user)
+        liverange.insert(user)
       }
       if !apply.isEscapable {
         return .abort
@@ -422,7 +422,7 @@ private struct ComputeNonEscapingLiferange : EscapeVisitorWithResult {
       return .continueWalk
     default:
       if dominates {
-        liferange.insert(user)
+        liverange.insert(user)
       }
       return .continueWalk
     }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
@@ -190,7 +190,7 @@ private extension StructInst {
 /// Lowers the allocateVector builtin either to an stack-allocated vector (`alloc_vector`)
 /// or to a statically initialized global.
 private func lower(allocVectorBuiltin: BuiltinInst, _ context: FunctionPassContext) {
-  let visitor = ComputeNonEscapingLiferange(of: allocVectorBuiltin, context)
+  let visitor = ComputeNonEscapingLiverange(of: allocVectorBuiltin, context)
 
   guard let result = allocVectorBuiltin.visit(using: visitor, context) else {
     if allocVectorBuiltin.parentFunction.isTransparent {
@@ -336,7 +336,7 @@ private func findInitStores(of address: Value, atIndex: Int, _ initStores: inout
 
 // This is very experimental and not ideal at all.
 // TODO: replace this with DiagnoseLifetimeDependence from https://github.com/apple/swift/pull/68682
-private struct ComputeNonEscapingLiferange : EscapeVisitorWithResult {
+private struct ComputeNonEscapingLiverange : EscapeVisitorWithResult {
 
   enum Result {
     case liverange(InstructionRange)

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
@@ -161,11 +161,11 @@ private extension LoadInst {
     _ context: FunctionPassContext
   ) -> DataflowResult {
 
-    var liferange = Liferange(endBlock: self.parentBlock, context)
-    defer { liferange.deinitialize() }
-    liferange.pushPredecessors(of: self.parentBlock)
+    var liverange = Liferange(endBlock: self.parentBlock, context)
+    defer { liverange.deinitialize() }
+    liverange.pushPredecessors(of: self.parentBlock)
 
-    while let block = liferange.pop() {
+    while let block = liverange.pop() {
       switch scanner.scan(instructions: block.instructions.reversed(),
                           in: block,
                           complexityBudget: &complexityBudget)
@@ -173,18 +173,18 @@ private extension LoadInst {
       case .overwritten:
         return DataflowResult(notRedundantWith: scanner.potentiallyRedundantSubpath)
       case .available:
-        liferange.add(beginBlock: block)
+        liverange.add(beginBlock: block)
       case .transparent:
-        liferange.pushPredecessors(of: block)
+        liverange.pushPredecessors(of: block)
       }
     }
-    if !self.canReplaceWithoutInsertingCopies(liferange: liferange, context) {
+    if !self.canReplaceWithoutInsertingCopies(liverange: liverange, context) {
       return DataflowResult(notRedundantWith: scanner.potentiallyRedundantSubpath)
     }
     return .redundant(scanner.availableValues)
   }
 
-  func canReplaceWithoutInsertingCopies(liferange: Liferange,_ context: FunctionPassContext) -> Bool {
+  func canReplaceWithoutInsertingCopies(liverange: Liferange,_ context: FunctionPassContext) -> Bool {
     switch self.loadOwnership {
     case .trivial, .unqualified:
       return true
@@ -192,7 +192,7 @@ private extension LoadInst {
     case .copy, .take:
       let deadEndBlocks = context.deadEndBlocks
 
-      // The liferange of the value has an "exit", i.e. a path which doesn't lead to the load,
+      // The liverange of the value has an "exit", i.e. a path which doesn't lead to the load,
       // it means that we would have to insert a destroy on that exit to satisfy ownership rules.
       // But an inserted destroy also means that we would need to insert copies of the value which
       // were not there originally. For example:
@@ -201,9 +201,9 @@ private extension LoadInst {
       //     cond_br bb1, bb2
       //   bb1:
       //     %2 = load [take] %addr
-      //   bb2:                      // liferange exit
+      //   bb2:                      // liverange exit
       //
-      // TODO: we could extend OSSA to transfer ownership to support liferange exits without copying. E.g.:
+      // TODO: we could extend OSSA to transfer ownership to support liverange exits without copying. E.g.:
       //
       //     %b = store_and_borrow %1 to [init] %addr   // %b is borrowed from %addr
       //     cond_br bb1, bb2
@@ -213,18 +213,18 @@ private extension LoadInst {
       //   bb2:
       //     end_borrow %b
       //
-      if liferange.hasExits(deadEndBlocks) {
+      if liverange.hasExits(deadEndBlocks) {
         return false
       }
 
-      // Handle a corner case: if the load is in an infinite loop, the liferange doesn't have an exit,
+      // Handle a corner case: if the load is in an infinite loop, the liverange doesn't have an exit,
       // but we still would need to insert a copy. For example:
       //
       //     store %1 to [init] %addr
       //     br bb1
       //   bb1:
       //     %2 = load [copy] %addr   // would need to insert a copy here
-      //    br bb1                    // no exit from the liferange
+      //    br bb1                    // no exit from the liverange
       //
       // For simplicity, we don't handle this in OSSA.
       if deadEndBlocks.isDeadEnd(parentBlock) {
@@ -508,8 +508,8 @@ private struct InstructionScanner {
       break
     }
     if load.loadOwnership == .take {
-      // In case of `take`, don't allow reading instructions in the liferange.
-      // Otherwise we cannot shrink the memory liferange afterwards.
+      // In case of `take`, don't allow reading instructions in the liverange.
+      // Otherwise we cannot shrink the memory liverange afterwards.
       if instruction.mayReadOrWrite(address: load.address, aliasAnalysis) {
         return .overwritten
       }
@@ -522,9 +522,9 @@ private struct InstructionScanner {
   }
 }
 
-/// Represents the liferange (in terms of basic blocks) of the loaded value.
+/// Represents the liverange (in terms of basic blocks) of the loaded value.
 ///
-/// In contrast to a BlockRange, this liferange has multiple begin blocks (containing the
+/// In contrast to a BlockRange, this liverange has multiple begin blocks (containing the
 /// available values) and a single end block (containing the original load). For example:
 ///
 ///   bb1:

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
@@ -161,7 +161,7 @@ private extension LoadInst {
     _ context: FunctionPassContext
   ) -> DataflowResult {
 
-    var liverange = Liferange(endBlock: self.parentBlock, context)
+    var liverange = Liverange(endBlock: self.parentBlock, context)
     defer { liverange.deinitialize() }
     liverange.pushPredecessors(of: self.parentBlock)
 
@@ -184,7 +184,7 @@ private extension LoadInst {
     return .redundant(scanner.availableValues)
   }
 
-  func canReplaceWithoutInsertingCopies(liverange: Liferange,_ context: FunctionPassContext) -> Bool {
+  func canReplaceWithoutInsertingCopies(liverange: Liverange,_ context: FunctionPassContext) -> Bool {
     switch self.loadOwnership {
     case .trivial, .unqualified:
       return true
@@ -536,7 +536,7 @@ private struct InstructionScanner {
 ///   bb3:
 ///     %3 = load %addr     // end block
 ///
-private struct Liferange {
+private struct Liverange {
   private var worklist: BasicBlockWorklist
   private var containingBlocks: Stack<BasicBlock> // doesn't include the end-block
   private var beginBlocks: BasicBlockSet

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
@@ -146,7 +146,7 @@ private func tryPromoteAlloc(_ allocRef: AllocRefInstBase,
 
   // The "inner" liverange contains all use points which are dominated by the allocation block.
   // Note that this `visit` cannot fail because otherwise our initial `isEscaping` check would have failed already.
-  var innerRange = allocRef.visit(using: ComputeInnerLiferange(of: allocRef, domTree, context), context)!
+  var innerRange = allocRef.visit(using: ComputeInnerLiverange(of: allocRef, domTree, context), context)!
   defer { innerRange.deinitialize() }
 
   // The "outer" liverange contains all use points.
@@ -236,7 +236,7 @@ private func getDominatingBlockOfAllUsePoints(context: FunctionPassContext,
   return value.visit(using: FindDominatingBlock(result: value.parentBlock, domTree: domTree), context)!
 }
 
-private struct ComputeInnerLiferange : EscapeVisitorWithResult {
+private struct ComputeInnerLiverange : EscapeVisitorWithResult {
   var result: InstructionRange
   let domTree: DominatorTree
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
@@ -116,14 +116,14 @@ private func tryPromoteAlloc(_ allocRef: AllocRefInstBase,
   //     ...                                                   |
   //   bb1:           // allocation block      _               |
   //     %k = alloc_ref $Klass                  |              | "outer"
-  //     %f = ref_element_addr %o, #Outer.f     | "inner"      | liferange
-  //     store %k to %f                         | liferange    |
+  //     %f = ref_element_addr %o, #Outer.f     | "inner"      | liverange
+  //     store %k to %f                         | liverange    |
   //     ...                                    |              |
   //     destroy_value %o                      _|             _|
   //
   // * Finding the `outerDominatingBlock` is not guaranteed to work.
   //   In this example, the top most dominator block is `bb0`, but `bb0` has no
-  //   use points in the outer liferange. We'll get `bb3` as outerDominatingBlock.
+  //   use points in the outer liverange. We'll get `bb3` as outerDominatingBlock.
   //   This is no problem because 1. it's an unusual case and 2. the `outerBlockRange`
   //   is invalid in this case and we'll bail later.
   //
@@ -144,12 +144,12 @@ private func tryPromoteAlloc(_ allocRef: AllocRefInstBase,
   let domTree = context.dominatorTree
   let outerDominatingBlock = getDominatingBlockOfAllUsePoints(context: context, allocRef, domTree: domTree)
 
-  // The "inner" liferange contains all use points which are dominated by the allocation block.
+  // The "inner" liverange contains all use points which are dominated by the allocation block.
   // Note that this `visit` cannot fail because otherwise our initial `isEscaping` check would have failed already.
   var innerRange = allocRef.visit(using: ComputeInnerLiferange(of: allocRef, domTree, context), context)!
   defer { innerRange.deinitialize() }
 
-  // The "outer" liferange contains all use points.
+  // The "outer" liverange contains all use points.
   // Same here: this `visit` cannot fail.
   var outerBlockRange = allocRef.visit(using: ComputeOuterBlockrange(dominatedBy: outerDominatingBlock, context), context)!
   defer { outerBlockRange.deinitialize() }
@@ -161,9 +161,9 @@ private func tryPromoteAlloc(_ allocRef: AllocRefInstBase,
     return false
   }
 
-  // Check if there is a control flow edge from the inner to the outer liferange, which
-  // would mean that the promoted object can escape to the outer liferange.
-  // This can e.g. be the case if the inner liferange does not post dominate the outer range:
+  // Check if there is a control flow edge from the inner to the outer liverange, which
+  // would mean that the promoted object can escape to the outer liverange.
+  // This can e.g. be the case if the inner liverange does not post dominate the outer range:
   //                                                              _
   //     %o = alloc_ref $Outer                                     |
   //     cond_br %c, bb1, bb2                                      |
@@ -191,7 +191,7 @@ private func tryPromoteAlloc(_ allocRef: AllocRefInstBase,
     return false
   }
 
-  // There shouldn't be any critical exit edges from the liferange, because that would mean
+  // There shouldn't be any critical exit edges from the liverange, because that would mean
   // that the promoted allocation is leaking.
   // Just to be on the safe side, do a check and bail if we find critical exit edges: we
   // cannot insert instructions on critical edges.
@@ -200,7 +200,7 @@ private func tryPromoteAlloc(_ allocRef: AllocRefInstBase,
   }
 
   // Do the transformation!
-  // Insert `dealloc_stack_ref` instructions at the exit- and end-points of the inner liferange.
+  // Insert `dealloc_stack_ref` instructions at the exit- and end-points of the inner liverange.
   for exitInst in innerRange.exits {
     if !deadEndBlocks.isDeadEnd(exitInst.parentBlock) {
       let builder = Builder(before: exitInst, context)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -240,7 +240,7 @@ extension Value {
 
     useToDefRange.insert(destBlock)
 
-    // The value needs to be destroyed at every exit of the liferange.
+    // The value needs to be destroyed at every exit of the liverange.
     for exitBlock in useToDefRange.exits {
       let builder = Builder(before: exitBlock.instructions.first!, context)
       builder.createDestroyValue(operand: self)

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -555,9 +555,9 @@ bool CapturePropagation::optimizePartialApply(PartialApplyInst *PAI) {
       // refers to the callee function.
       if (argConv != SILArgumentConvention::Direct_Guaranteed)
         return false;
-      
+
       // For escaping closures:
-      // To keep things simple, we don't do a liferange analysis to insert
+      // To keep things simple, we don't do a liverange analysis to insert
       // compensating destroys of the keypath.
       // Instead we require that the PAI is the only use of the keypath (= the
       // common case). This allows us to just delete the now unused keypath

--- a/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
@@ -316,7 +316,7 @@ static bool isOutOfLifetime(SILInstruction *inst, SSAPrunedLiveness &liveness) {
   //
   // A more sophisticated analysis would be to check if there are no
   // (potential) loads from the store's destination address after the store,
-  // but within the object's liferange. But without a good alias analysis (and
+  // but within the object's liverange. But without a good alias analysis (and
   // we don't want to use AliasAnalysis in a mandatory pass) it's practically
   // impossible that a use of the object is not a potential load. So we would
   // always see a potential load if the lifetime of the object goes beyond the

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -664,7 +664,7 @@ bool SILCombiner::eraseApply(FullApplySite FAS, const UserListTy &Users) {
       return false;
     // As we are extending the lifetimes of owned parameters, we have to make
     // sure that no dealloc_ref or dealloc_stack_ref instructions are
-    // within this extended liferange.
+    // within this extended liverange.
     // It could be that the dealloc_ref is deallocating a parameter and then
     // we would have a release after the dealloc.
     if (VLA.containsDeallocRef(Frontier))

--- a/lib/SILOptimizer/Transforms/TempLValueOpt.cpp
+++ b/lib/SILOptimizer/Transforms/TempLValueOpt.cpp
@@ -128,7 +128,7 @@ void TempLValueOptPass::tempLValueOpt(CopyAddrInst *copyInst) {
   //
   //   alloc_stack %temp
   //   ...
-  //   first_use_of %temp // beginOfLiferange
+  //   first_use_of %temp // beginOfLiverange
   //   ... // no reads or writes from/to %destination
   //   copy_addr [take] %temp to %destination // copyInst
   //   ... // no further uses of %temp (copyInst is the end of %temp liverange)
@@ -186,8 +186,8 @@ void TempLValueOptPass::tempLValueOpt(CopyAddrInst *copyInst) {
 
   // Iterate over the liverange of the temporary and make some validity checks.
   AliasAnalysis *AA = nullptr;
-  SILInstruction *beginOfLiferange = nullptr;
-  bool endOfLiferangeReached = false;
+  SILInstruction *beginOfLiverange = nullptr;
+  bool endOfLiverangeReached = false;
   for (auto iter = temporary->getIterator(); iter != block->end(); ++iter) {
     SILInstruction *inst = &*iter;
     // The dealloc_stack is the last user of the temporary.
@@ -197,19 +197,19 @@ void TempLValueOptPass::tempLValueOpt(CopyAddrInst *copyInst) {
     if (users.contains(inst) != 0) {
       // Check if the copyInst is the last user of the temporary (beside the
       // dealloc_stack).
-      if (endOfLiferangeReached)
+      if (endOfLiverangeReached)
         return;
 
       // Find the first user of the temporary to get a more precise liverange.
       // It would be too conservative to treat the alloc_stack itself as the
       // begin of the liverange.
-      if (!beginOfLiferange)
-        beginOfLiferange = inst;
+      if (!beginOfLiverange)
+        beginOfLiverange = inst;
 
       if (inst == copyInst)
-        endOfLiferangeReached = true;
+        endOfLiverangeReached = true;
     }
-    if (beginOfLiferange && !endOfLiferangeReached) {
+    if (beginOfLiverange && !endOfLiverangeReached) {
       // If the root address of the destination is within the liverange of the
       // temporary, we cannot replace all uses of the temporary with the
       // destination (it would break the def-use dominance rule).
@@ -233,21 +233,21 @@ void TempLValueOptPass::tempLValueOpt(CopyAddrInst *copyInst) {
         return;
     }
   }
-  assert(endOfLiferangeReached);
+  assert(endOfLiverangeReached);
 
   // Move all projections of the destination address before the liverange of
   // the temporary.
-  for (auto iter = beginOfLiferange->getIterator();
+  for (auto iter = beginOfLiverange->getIterator();
        iter != copyInst->getIterator();) {
     SILInstruction *inst = &*iter++;
     if (projections.contains(inst))
-      inst->moveBefore(beginOfLiferange);
+      inst->moveBefore(beginOfLiverange);
   }
 
   if (!copyInst->isInitializationOfDest()) {
     // Make sure the destination is uninitialized before the liverange of
     // the temporary.
-    SILBuilderWithScope builder(beginOfLiferange);
+    SILBuilderWithScope builder(beginOfLiverange);
     builder.createDestroyAddr(copyInst->getLoc(), destination);
   }
 

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -403,12 +403,12 @@ bool TempRValueOptPass::extendAccessScopes(
       // Is this the end of an access scope of the copy-source?
       if (!aa->isNoAlias(copySrc, endAccess->getSource()) &&
 
-          // There cannot be any aliasing modifying accesses within the liferange
-          // of the temporary, because we would have cought this in
+          // There cannot be any aliasing modifying accesses within the
+          // liverange of the temporary, because we would have cought this in
           // `getLastUseWhileSourceIsNotModified`.
-          // But there are cases where `AliasAnalysis::isNoAlias` is less precise
-          // than `AliasAnalysis::mayWriteToMemory`. Therefore, just ignore any
-          // non-read accesses.
+          // But there are cases where `AliasAnalysis::isNoAlias` is less
+          // precise than `AliasAnalysis::mayWriteToMemory`. Therefore, just
+          // ignore any non-read accesses.
           endAccess->getBeginAccess()->getAccessKind() == SILAccessKind::Read) {
 
         // Don't move instructions beyond the block's terminator.

--- a/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
+++ b/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
@@ -90,7 +90,7 @@ bool PartialApplyCombiner::copyArgsToTemporaries(
   if (argsToHandle.empty() && storeBorrowsToHandle.empty()) {
     return true;
   }
-  // Also include all destroys in the liferange for the arguments.
+  // Also include all destroys in the liverange for the arguments.
   // This is needed for later processing in tryDeleteDeadClosure: in case the
   // pai gets dead after this optimization, tryDeleteDeadClosure relies on
   // that we already copied the pai arguments to extend their lifetimes until

--- a/test/SILOptimizer/closure_specialize.sil
+++ b/test/SILOptimizer/closure_specialize.sil
@@ -236,7 +236,7 @@ bb3:
   br bb2(%15 : $Builtin.Int64)
 }
 
-// CHECK-LABEL: sil @insert_release_in_liferange_exit_block
+// CHECK-LABEL: sil @insert_release_in_liverange_exit_block
 // CHECK: bb0(%0 : $A):
 // CHECK:   retain_value %0
 // CHECK: bb1:
@@ -249,7 +249,7 @@ bb3:
 // CHECK: bb3:
 // CHECK-NOT: %0
 // CHECK:   return
-sil @insert_release_in_liferange_exit_block : $@convention(thin) (@guaranteed A) -> () {
+sil @insert_release_in_liverange_exit_block : $@convention(thin) (@guaranteed A) -> () {
 bb0(%0 : $A):
   strong_retain %0 : $A
   %2 = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()

--- a/test/SILOptimizer/closure_specialize_and_cfg.sil
+++ b/test/SILOptimizer/closure_specialize_and_cfg.sil
@@ -23,7 +23,7 @@ bb0(%0 : $@callee_owned () -> (), %1 : $@callee_owned () -> ()):
   return %3 : $()
 }
 
-sil @insert_release_in_liferange_exit_block : $@convention(thin) () -> () {
+sil @insert_release_in_liverange_exit_block : $@convention(thin) () -> () {
 bb0:
   %2 = function_ref @closure : $@convention(thin) () -> ()
   %3 = partial_apply %2() : $@convention(thin) () -> ()

--- a/test/SILOptimizer/dead_array_elim.sil
+++ b/test/SILOptimizer/dead_array_elim.sil
@@ -83,7 +83,7 @@ bb0(%0 : $TrivialDestructor):
 }
 
 // Test the soundness check in dead object elimination which checks that all stores
-// to the array are within the array's liferange.
+// to the array are within the array's liverange.
 
 // CHECK-LABEL: sil @malformed_deadarray
 // CHECK: apply

--- a/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
@@ -353,11 +353,11 @@ bb0(%0 : @owned $AB):
   return %6 : $()
 }
 
-// CHECK-LABEL: no_rle_liferange_with_exit :
+// CHECK-LABEL: no_rle_liverange_with_exit :
 // CHECK:       bb3:
 // CHECK-NEXT:    load
-// CHECK-LABEL: } // end sil function 'no_rle_liferange_with_exit'
-sil [ossa] @no_rle_liferange_with_exit : $@convention(thin) (@owned Klass) -> () {
+// CHECK-LABEL: } // end sil function 'no_rle_liverange_with_exit'
+sil [ossa] @no_rle_liverange_with_exit : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
   %copy0 = copy_value %0 : $Klass
   %g = global_addr @total_klass : $*Klass

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -1209,10 +1209,10 @@ bb3:
   br bb3
 }
 
-// CHECK-LABEL: sil @inner_liferange_jumps_to_outer_in_header_block
+// CHECK-LABEL: sil @inner_liverange_jumps_to_outer_in_header_block
 // CHECK:         alloc_ref $XX
-// CHECK-LABEL: } // end sil function 'inner_liferange_jumps_to_outer_in_header_block'
-sil @inner_liferange_jumps_to_outer_in_header_block : $@convention(thin) (@owned XX) -> () {
+// CHECK-LABEL: } // end sil function 'inner_liverange_jumps_to_outer_in_header_block'
+sil @inner_liverange_jumps_to_outer_in_header_block : $@convention(thin) (@owned XX) -> () {
 bb0(%0 : $XX):
   %1 = alloc_stack $XX
   br bb1(%0 : $XX)

--- a/test/SILOptimizer/templvalueopt.sil
+++ b/test/SILOptimizer/templvalueopt.sil
@@ -134,15 +134,15 @@ bb0(%0 : $*Optional<Any>, %1 : $*Any):
   return %6 : $()
 }
 
-// CHECK-LABEL: sil @write_to_dest_ok_if_before_liferange :
+// CHECK-LABEL: sil @write_to_dest_ok_if_before_liverange :
 // CHECK:      bb0(%0 : $*Optional<Any>, %1 : $*Any):
 // CHECK-NEXT:   destroy_addr
 // CHECK-NEXT:   init_enum_data_addr
 // CHECK-NEXT:   copy_addr
 // CHECK-NEXT:   inject_enum_addr
 // CHECK-NOT:    copy_addr
-// CHECK: } // end sil function 'write_to_dest_ok_if_before_liferange'
-sil @write_to_dest_ok_if_before_liferange : $@convention(thin) (@inout Optional<Any>, @in Any) -> () {
+// CHECK: } // end sil function 'write_to_dest_ok_if_before_liverange'
+sil @write_to_dest_ok_if_before_liverange : $@convention(thin) (@inout Optional<Any>, @in Any) -> () {
 bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   destroy_addr %0 : $*Optional<Any>

--- a/test/SILOptimizer/templvalueopt_ossa.sil
+++ b/test/SILOptimizer/templvalueopt_ossa.sil
@@ -134,15 +134,15 @@ bb0(%0 : $*Optional<Any>, %1 : $*Any):
   return %6 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @write_to_dest_ok_if_before_liferange :
+// CHECK-LABEL: sil [ossa] @write_to_dest_ok_if_before_liverange :
 // CHECK:      bb0(%0 : $*Optional<Any>, %1 : $*Any):
 // CHECK-NEXT:   destroy_addr
 // CHECK-NEXT:   init_enum_data_addr
 // CHECK-NEXT:   copy_addr
 // CHECK-NEXT:   inject_enum_addr
 // CHECK-NOT:    copy_addr
-// CHECK: } // end sil function 'write_to_dest_ok_if_before_liferange'
-sil [ossa] @write_to_dest_ok_if_before_liferange : $@convention(thin) (@inout Optional<Any>, @in Any) -> () {
+// CHECK: } // end sil function 'write_to_dest_ok_if_before_liverange'
+sil [ossa] @write_to_dest_ok_if_before_liverange : $@convention(thin) (@inout Optional<Any>, @in Any) -> () {
 bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   destroy_addr %0 : $*Optional<Any>


### PR DESCRIPTION
Standardize on the standard spelling of the term "liverange"/"live range" replacing uses of "liferange"/"life range".
