### PR TITLE
Add some additional test coverage for duration static methods

### DIFF
--- a/test/stdlib/Duration.swift
+++ b/test/stdlib/Duration.swift
@@ -1,10 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// Int128 operations are not supported on 32bit platforms, 128-bit types are not
-// provided by the 32-bit LLVM. See `dividingFullWidth` in IntegerTypes.swift.gyb
-// UNSUPPORTED: PTRSIZE=32
-
 // These test a codepath that was fixed in the Swift 5.9 stdlib, so it will
 // fail if run against earlier standard library versions.
 // UNSUPPORTED: use_os_stdlib
@@ -12,7 +8,7 @@
 
 import StdlibUnittest
 
-var suite = TestSuite("StringIndexTests")
+var suite = TestSuite("DurationTests")
 defer { runAllTests() }
 
 if #available(SwiftStdlib 5.7, *) {
@@ -53,5 +49,179 @@ if #available(SwiftStdlib 5.7, *) {
       expectEqual(sec, Int64(integerValue) / 1_000_000)
       expectEqual(attosec, Int64(integerValue) % 1_000_000 * 1_000_000_000_000)
     }
+  }
+  
+  suite.test("seconds from Int64") {
+    let one = Duration.seconds(1 as Int64)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000_000_000_000)
+    let mone = Duration.seconds(-1 as Int64)
+    expectEqual(mone._high, -1)
+    expectEqual(mone._low, .max - 999_999_999_999_999_999)
+    let max64 = Duration.seconds(Int64.max)
+    expectEqual(max64._high, 499_999_999_999_999_999)
+    expectEqual(max64._low, .max - 999_999_999_999_999_999)
+    let min64 = Duration.seconds(Int64.min)
+    expectEqual(min64._high,-500_000_000_000_000_000)
+    expectEqual(min64._low, 0)
+  }
+  
+  suite.test("seconds from UInt64") {
+    let one = Duration.seconds(1 as UInt64)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000_000_000_000)
+    let max64 = Duration.seconds(UInt64.max)
+    expectEqual(max64._high, 999_999_999_999_999_999)
+    expectEqual(max64._low, .max - 999_999_999_999_999_999)
+  }
+  
+  suite.test("milliseconds from Int64") {
+    let one = Duration.milliseconds(1 as Int64)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000_000_000)
+    let mone = Duration.milliseconds(-1 as Int64)
+    expectEqual(mone._high, -1)
+    expectEqual(mone._low, .max - 999_999_999_999_999)
+    let max64 = Duration.milliseconds(Int64.max)
+    expectEqual(max64._high, 499_999_999_999_999)
+    expectEqual(max64._low, .max - 999_999_999_999_999)
+    let min64 = Duration.milliseconds(Int64.min)
+    expectEqual(min64._high,-500_000_000_000_000)
+    expectEqual(min64._low, 0)
+  }
+  
+  suite.test("milliseconds from UInt64") {
+    let one = Duration.milliseconds(1 as UInt64)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000_000_000)
+    let max64 = Duration.milliseconds(UInt64.max)
+    expectEqual(max64._high, 999_999_999_999_999)
+    expectEqual(max64._low, .max - 999_999_999_999_999)
+  }
+  
+  suite.test("microseconds from Int64") {
+    let one = Duration.microseconds(1 as Int64)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000_000)
+    let mone = Duration.microseconds(-1 as Int64)
+    expectEqual(mone._high, -1)
+    expectEqual(mone._low, .max - 999_999_999_999)
+    let max64 = Duration.microseconds(Int64.max)
+    expectEqual(max64._high, 499_999_999_999)
+    expectEqual(max64._low, .max - 999_999_999_999)
+    let min64 = Duration.microseconds(Int64.min)
+    expectEqual(min64._high,-500_000_000_000)
+    expectEqual(min64._low, 0)
+  }
+  
+  suite.test("microseconds from UInt64") {
+    let one = Duration.microseconds(1 as UInt64)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000_000)
+    let max64 = Duration.microseconds(UInt64.max)
+    expectEqual(max64._high, 999_999_999_999)
+    expectEqual(max64._low, .max - 999_999_999_999)
+  }
+  
+  suite.test("nanoseconds from Int64") {
+    let one = Duration.nanoseconds(1 as Int64)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000)
+    let mone = Duration.nanoseconds(-1 as Int64)
+    expectEqual(mone._high, -1)
+    expectEqual(mone._low, .max - 999_999_999)
+    let max64 = Duration.nanoseconds(Int64.max)
+    expectEqual(max64._high, 499_999_999)
+    expectEqual(max64._low, .max - 999_999_999)
+    let min64 = Duration.nanoseconds(Int64.min)
+    expectEqual(min64._high,-500_000_000)
+    expectEqual(min64._low, 0)
+  }
+  
+  suite.test("nanoseconds from UInt64") {
+    let one = Duration.nanoseconds(1 as UInt64)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000)
+    let max64 = Duration.nanoseconds(UInt64.max)
+    expectEqual(max64._high, 999_999_999)
+    expectEqual(max64._low, .max - 999_999_999)
+  }
+}
+ 
+if #available(SwiftStdlib 6.0, *) {
+  suite.test("seconds from Int128") {
+    let one = Duration.seconds(1 as Int128)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000_000_000_000)
+    let mone = Duration.seconds(-1 as Int128)
+    expectEqual(mone._high, -1)
+    expectEqual(mone._low, .max - 999_999_999_999_999_999)
+    let maxRep = Duration.seconds( 170141183460469231731 as Int128)
+    expectEqual(maxRep._high, 9_223_372_036_854_775_807)
+    expectEqual(maxRep._low, 17_759_440_357_825_445_888)
+    //  negative overflow boundary is _smaller_ than positive for seconds;
+    //  this could be avoided by reworking how highScaled is computed, but
+    //  it's already so large (5 trillion years) that this probably isn't
+    //  necessary.
+    let minRep = Duration.seconds(-166020696663385964544 as Int128)
+    expectEqual(minRep._high,-9_000_000_000_000_000_000)
+    expectEqual(minRep._low, 0)
+    //  Check just above the overflow boundary
+    expectCrashLater()
+    let _ = Duration.seconds( 170141183460469231732 as Int128)
+  }
+  
+  suite.test("milliseconds from Int128") {
+    let one = Duration.milliseconds(1 as Int128)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000_000_000)
+    let mone = Duration.milliseconds(-1 as Int128)
+    expectEqual(mone._high, -1)
+    expectEqual(mone._low, .max - 999_999_999_999_999)
+    let maxRep = Duration.milliseconds( 170141183460469231731687 as Int128)
+    expectEqual(maxRep._high, 9_223_372_036_854_775_807)
+    expectEqual(maxRep._low, 18_446_440_357_825_445_888)
+    let minRep = Duration.milliseconds(-170134320591823194554368 as Int128)
+    expectEqual(minRep._high,-9_223_000_000_000_000_000)
+    expectEqual(minRep._low, 0)
+    //  Check just above the overflow boundary
+    expectCrashLater()
+    let _ = Duration.milliseconds( 170141183460469231731689 as Int128)
+  }
+  
+  suite.test("microseconds from Int128") {
+    let one = Duration.microseconds(1 as Int128)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000_000)
+    let mone = Duration.microseconds(-1 as Int128)
+    expectEqual(mone._high, -1)
+    expectEqual(mone._low, .max - 999_999_999_999)
+    let maxRep = Duration.microseconds( 170141183460469231731687303 as Int128)
+    expectEqual(maxRep._high, 9_223_372_036_854_775_807)
+    expectEqual(maxRep._low, 18_446_743_357_825_445_888)
+    let minRep = Duration.microseconds(-170141182780618614507569152 as Int128)
+    expectEqual(minRep._high,-9_223_372_000_000_000_000)
+    expectEqual(minRep._low, 0)
+    //  Check just above the overflow boundary
+    expectCrashLater()
+    let _ = Duration.microseconds( 170141183460469231731687304 as Int128)
+  }
+  
+  suite.test("nanoseconds from Int128") {
+    let one = Duration.nanoseconds(1 as Int128)
+    expectEqual(one._high, 0)
+    expectEqual(one._low, 1_000_000_000)
+    let mone = Duration.nanoseconds(-1 as Int128)
+    expectEqual(mone._high, -1)
+    expectEqual(mone._low, .max - 999_999_999)
+    let maxRep = Duration.nanoseconds( 170141183460469231731687303715 as Int128)
+    expectEqual(maxRep._high, 9_223_372_036_854_775_807)
+    expectEqual(maxRep._low, 18_446_744_072_825_445_888)
+    let minRep = Duration.nanoseconds(-170141183444701401161113010176 as Int128)
+    expectEqual(minRep._high,-9_223_372_036_000_000_000)
+    expectEqual(minRep._low, 0)
+    //  Check just above the overflow boundary
+    expectCrashLater()
+    let _ = Duration.nanoseconds( 170141183460469231731687303716 as Int128)
   }
 }


### PR DESCRIPTION
The numerics of these operations is fairly subtle, and the overflow boundaries are somewhat surprising, so additional test coverage isn't a bad thing (also gives us an excuse to exercise Int128 more)

Also attempts to reinstate testing for these on PTRSIZE=32, which I think ought to work now.