### PR TITLE
Avoid using Double in HashTable implementation

### DIFF
--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -70,13 +70,13 @@ extension _HashTable: Sendable {}
 
 extension _HashTable {
   /// The inverse of the maximum hash table load factor.
-  private static var maxLoadFactor: Double {
-    @inline(__always) get { return 3 / 4 }
+  private static var maxLoadFactor: (nominator: Int, denominator: Int) {
+    @inline(__always) get { return (nominator: 3, denominator: 4) } // 3/4
   }
 
   internal static func capacity(forScale scale: Int8) -> Int {
     let bucketCount = (1 as Int) &<< scale
-    return Int(Double(bucketCount) * maxLoadFactor)
+    return bucketCount * maxLoadFactor.nominator / maxLoadFactor.denominator
   }
 
   internal static func scale(forCapacity capacity: Int) -> Int8 {
@@ -84,8 +84,9 @@ extension _HashTable {
     // Calculate the minimum number of entries we need to allocate to satisfy
     // the maximum load factor. `capacity + 1` below ensures that we always
     // leave at least one hole.
-    let minimumEntries = Swift.max(
-      Int((Double(capacity) / maxLoadFactor).rounded(.up)),
+    func divideRoundingUp(n: Int, by: Int) -> Int { (n + (by - 1)) / by }
+    let minimumEntries = Swift.max(divideRoundingUp(
+      n: capacity * maxLoadFactor.denominator, by: maxLoadFactor.nominator),
       capacity + 1)
     // The actual number of entries we need to allocate is the lowest power of
     // two greater than or equal to the minimum entry count. Calculate its

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -70,13 +70,13 @@ extension _HashTable: Sendable {}
 
 extension _HashTable {
   /// The inverse of the maximum hash table load factor.
-  private static var maxLoadFactor: (nominator: Int, denominator: Int) {
-    @inline(__always) get { return (nominator: 3, denominator: 4) } // 3/4
+  private static var maxLoadFactor: (numerator: Int, denominator: Int) {
+    @inline(__always) get { return (numerator: 3, denominator: 4) } // 3/4
   }
 
   internal static func capacity(forScale scale: Int8) -> Int {
     let bucketCount = (1 as Int) &<< scale
-    return bucketCount * maxLoadFactor.nominator / maxLoadFactor.denominator
+    return bucketCount * maxLoadFactor.numerator / maxLoadFactor.denominator
   }
 
   internal static func scale(forCapacity capacity: Int) -> Int8 {
@@ -86,7 +86,7 @@ extension _HashTable {
     // leave at least one hole.
     func divideRoundingUp(n: Int, by: Int) -> Int { (n + (by - 1)) / by }
     let minimumEntries = Swift.max(divideRoundingUp(
-      n: capacity * maxLoadFactor.denominator, by: maxLoadFactor.nominator),
+      n: capacity * maxLoadFactor.denominator, by: maxLoadFactor.numerator),
       capacity + 1)
     // The actual number of entries we need to allocate is the lowest power of
     // two greater than or equal to the minimum entry count. Calculate its


### PR DESCRIPTION
Using floating point in the HashTable implementation is (1) unfriendly to embedded environments which might not have floating point support in hardware and/or would need to pay the codesize cost of software fp libraries, (2) seemingly not necessary.

rdar://164643483 (Dictionary should not require Double to compute load)