### PR TITLE
utils: do not install testable corelibs builds

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1391,12 +1391,18 @@ function Build-Runtime([Platform]$Platform, $Arch) {
 }
 
 function Build-Dispatch([Platform]$Platform, $Arch, [switch]$Test = $false) {
-  $Targets = if ($Test) { @("default", "ExperimentalTest") } else { @("default", "install") }
+  if ($Test) {
+    $Targets = @("default", "ExperimentalTest")
+    $InstallPath = ""
+  } else {
+    $Targets = @("default", "install")
+    $InstallPath = "$($Arch.SDKInstallRoot)\usr"
+  }
 
   Build-CMakeProject `
     -Src $SourceCache\swift-corelibs-libdispatch `
     -Bin (Get-TargetProjectBinaryCache $Arch Dispatch) `
-    -InstallTo "$($Arch.SDKInstallRoot)\usr" `
+    -InstallTo $InstallPath `
     -Arch $Arch `
     -Platform $Platform `
     -UseBuiltCompilers C,CXX,Swift `
@@ -1420,16 +1426,18 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
       }
       $Targets = @("default", "test")
       $env:Path = "$XCTestBinaryCache;$FoundationBinaryCache\bin;$DispatchBinaryCache;$(Get-TargetProjectBinaryCache $Arch Runtime)\bin;$env:Path"
+      $InstallPath = ""
     } else {
       $TestingDefines = @{ ENABLE_TESTING = "NO" }
       $Targets = @("default", "install")
+      $InstallPath = "$($Arch.SDKInstallRoot)\usr"
     }
 
     $env:CTEST_OUTPUT_ON_FAILURE = 1
     Build-CMakeProject `
       -Src $SourceCache\swift-corelibs-foundation `
       -Bin $FoundationBinaryCache `
-      -InstallTo "$($Arch.SDKInstallRoot)\usr" `
+      -InstallTo $InstallPath `
       -Arch $Arch `
       -Platform $Platform `
       -UseBuiltCompilers ASM,C,Swift `
@@ -1469,16 +1477,18 @@ function Build-XCTest([Platform]$Platform, $Arch, [switch]$Test = $false) {
         XCTEST_PATH_TO_FOUNDATION_BUILD = $FoundationBinaryCache;
       }
       $Targets = @("default", "check-xctest")
+      $InstallPath = ""
       $env:Path = "$XCTestBinaryCache;$FoundationBinaryCache\bin;$DispatchBinaryCache;$(Get-TargetProjectBinaryCache $Arch Runtime)\bin;$env:Path;$UnixToolsBinDir"
     } else {
       $TestingDefines = @{ ENABLE_TESTING = "NO" }
       $Targets = @("default", "install")
+      $InstallPath = "$($Arch.XCTestInstallRoot)\usr"
     }
 
     Build-CMakeProject `
       -Src $SourceCache\swift-corelibs-xctest `
       -Bin $XCTestBinaryCache `
-      -InstallTo "$($Arch.XCTestInstallRoot)\usr" `
+      -InstallTo $InstallPath `
       -Arch $Arch `
       -Platform $Platform `
       -UseBuiltCompilers Swift `


### PR DESCRIPTION
I believe we don't need testable builds to be installed by CMake. Release binaries are already bundled/staged at that point. While installing is not a big deal, it still a bit annoying. Especially for Foundation, as install would trigger rebuild for some reason after testing and flood console with build warnings.

Passing empty install path effectively skips CMake install target invocation in `Build-CMakeProject`.
