### PR TITLE
[embedded] Mark embedded Concurrency as INSTALL_WITH_SHARED so that it actually makes it into toolchains

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -273,6 +273,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       ARCHITECTURE "${mod}"
       DEPENDS embedded-stdlib-${mod}
       INSTALL_IN_COMPONENT stdlib
+      INSTALL_WITH_SHARED
       )
     swift_install_in_component(
       TARGETS embedded-concurrency-${mod}


### PR DESCRIPTION
The embedded concurrency .a libraries are produced and pass some basic tests, but they are missing from downloadable toolchains on swift.org. Let's fix that with INSTALL_WITH_SHARED.