### PR TITLE
[stdlib] Refactor Unicode normalization

### DIFF
--- a/stdlib/public/core/NFC.swift
+++ b/stdlib/public/core/NFC.swift
@@ -12,38 +12,392 @@
 
 import SwiftShims
 
-extension Unicode {
-  internal struct _InternalNFC<S: StringProtocol> {
-    let base: S
+extension Sequence where Element == Unicode.Scalar {
+  internal var _internalNFC: Unicode._InternalNFC<Self> {
+    Unicode._InternalNFC(self)
   }
 }
 
-extension Unicode._InternalNFC {
-  internal struct Iterator {
-    var buffer = Unicode._NormDataBuffer()
+extension Unicode {
 
+  /// The contents of the source sequence, in Normalization Form C.
+  ///
+  /// Normalization to NFC preserves canonical equivalence.
+  ///
+  internal struct _InternalNFC<Source> where Source: Sequence<Unicode.Scalar> {
+
+    internal let source: Source
+
+    internal init(_ source: Source) {
+      self.source = source
+    }
+  }
+}
+
+extension Unicode._InternalNFC: Sequence {
+
+  internal consuming func makeIterator() -> Iterator {
+    Iterator(source: source.makeIterator())
+  }
+
+  internal struct Iterator: IteratorProtocol {
+
+    internal var source: Source.Iterator
+    internal var normalizer: Unicode._NFCNormalizer
+
+    internal init(source: Source.Iterator) {
+      self.source = source
+      if let strIter = source as? String.UnicodeScalarView.Iterator {
+        self.normalizer = Unicode._NFCNormalizer(sourceString: strIter._guts)
+      } else if let substrIter = source as? Substring.UnicodeScalarView.Iterator {
+        self.normalizer = Unicode._NFCNormalizer(sourceString: substrIter._elements._wholeGuts)
+      } else {
+        self.normalizer = Unicode._NFCNormalizer()
+      }
+    }
+
+    internal mutating func next() -> Unicode.Scalar? {
+      normalizer.resume { source.next() } ?? normalizer.flush()
+    }
+  }
+}
+
+extension Unicode._InternalNFC: Sendable where Source: Sendable {}
+extension Unicode._InternalNFC.Iterator: Sendable where Source.Iterator: Sendable {}
+
+extension Unicode {
+
+  /// A stateful normalizer, producing a single logical stream
+  /// of normalized text from chunked inputs.
+  ///
+  /// To use the normalizer, first create an instance.
+  /// Next, feed it a chunk of a text stream using the `resume(consuming:)`
+  /// function. The normalizer will consume from the stream and buffer
+  /// it as needed, so continue feeding the same source until
+  /// it returns `nil`, indicating that the source was exhausted.
+  ///
+  /// ```swift
+  /// var normalizer = Unicode.NFCNormalizer()
+  ///
+  /// var input: some IteratorProtocol<Unicode.Scalar> = ...
+  /// while let scalar = normalizer.resume(consuming: &input) {
+  ///   print(scalar)
+  /// }
+  ///
+  /// // assert(input.next() == nil)
+  /// ```
+  ///
+  /// You may continue consuming sources until you reach the end
+  /// of the logical text stream. Once you reach the end,
+  /// call `flush()` to drain any remaining content
+  /// from the normalizer's buffers.
+  ///
+  /// ```swift
+  /// while let scalar = normalizer.flush() {
+  ///   print(scalar)
+  /// }
+  /// ```
+  ///
+  /// The chunks of input text do not need to be aligned on any normalization
+  /// boundary. The normalizer state has value semantics, so it is possible
+  /// to copy and store and is inherently thread-safe.
+  ///
+  internal struct _NFCNormalizer: Sendable {
+
+    internal enum State {
+      case emittingSegment
+      case consuming
+    }
+
+    internal var state = State.consuming
+    internal var isTerminated = false
+    internal var sourceIsAlreadyNFC = false
+
+    internal var nfd = Unicode._NFDNormalizer()
+    internal var buffer = Unicode._NormDataBuffer()
     // This is our starter that is currently being composed with other scalars
     // into new scalars. For example, "e\u{301}", here our first scalar is 'e',
     // which is a starter, thus we assign composee to this 'e' and move to the
     // next scalar. We attempt to compose our composee, 'e', with '\u{301}' and
     // find that there is a composition. Thus our new composee is now 'é' and
     // we continue to try and compose following scalars with this composee.
-    var composee: Unicode.Scalar? = nil
+    internal var composee = Optional<Unicode.Scalar>.none
 
-    var iterator: Unicode._InternalNFD<S>.Iterator
+    internal init(sourceString: borrowing _StringGuts) {
+      sourceIsAlreadyNFC = sourceString.isNFC
+    }
+
+    /// Creates a new normalizer.
+    ///
+    internal init() { }
+
+    /// Resume normalizing the text stream.
+    ///
+    /// Each call to `resume` returns the next scalar in the normalized output,
+    /// consuming elements from the given source as necessary.
+    ///
+    /// If the normalizer returns `nil`, the source was exhausted.
+    /// One a source is exhausted, you may:
+    ///
+    /// - Call `resume` again some time later with a different source
+    ///   to continue processing the same logical text stream, or
+    ///
+    /// - Call `flush` in order to mark the end of the stream
+    ///   and consume data remaining in the normalizer's internal buffers.
+    ///
+    /// Typical usage looks like the following:
+    ///
+    /// ```swift
+    /// var normalizer = Unicode.NFCNormalizer()
+    ///
+    /// var input: some IteratorProtocol<Unicode.Scalar> = ...
+    /// while let scalar = normalizer.resume(consuming: &input) {
+    ///   print(scalar)
+    /// }
+    ///
+    /// // We could resume again, consuming from another input here.
+    /// // Finally, when we are done consuming inputs:
+    ///
+    /// while let scalar = normalizer.flush() {
+    ///   print(scalar)
+    /// }
+    /// ```
+    ///
+    /// The normalizer consumes data from the source as needed,
+    /// meaning even if a call to `resume` returns a value,
+    /// that value may have come from the normalizer's internal buffers
+    /// without consuming the input source at all.
+    ///
+    /// Be careful to ensure each input source has been fully consumed
+    /// before moving on to the next source (marked by `resume` returning `nil`).
+    ///
+    internal mutating func resume(
+      consuming source: inout some IteratorProtocol<Unicode.Scalar>
+    ) -> Unicode.Scalar? {
+      resume(consuming: { source.next() })
+    }
+
+    // Intended ABI barrier for resume(consuming: inout some IteratorProtocol<Unicode.Scalar>).
+    // when it becomes public.
+    internal mutating func resume(
+      consuming nextFromSource: () -> Unicode.Scalar?
+    ) -> Unicode.Scalar? {
+
+      guard !isTerminated else {
+        return nil
+      }
+      guard !sourceIsAlreadyNFC else {
+        return nextFromSource()
+      }
+      return _resume(consumingNFD: { $0.nfd._resume(consuming: nextFromSource) })
+    }
+
+    /// Marks the end of the text stream and
+    /// returns the next scalar from the normalizer's internal buffer.
+    ///
+    /// Once you have finished feeding input data to the normalizer,
+    /// call `flush` until it returns `nil`.
+    ///
+    /// ```swift
+    /// while let scalar = normalizer.flush() {
+    ///   print(scalar)
+    /// }
+    /// ```
+    ///
+    /// After calling `flush`, all future calls to `resume`
+    /// will immediately return `nil` without consuming from its source.
+    /// This allows optional chaining to be used to
+    /// fully normalize a stream:
+    ///
+    /// ```swift
+    /// // Normalize the concatenation of inputA and inputB
+    ///
+    /// while let scalar =
+    ///   normalizer.resume(consuming: &inputA) ??
+    ///   normalizer.resume(consuming: &inputB) ??
+    ///   normalizer.flush()
+    /// {
+    ///   print(scalar)
+    /// }
+    /// ```
+    ///
+    internal mutating func flush() -> Unicode.Scalar? {
+
+      isTerminated = true
+
+      guard !sourceIsAlreadyNFC else {
+        return nil
+      }
+
+      // Process anything remaining from the NFD normalizer.
+      if let next = _resume(consumingNFD: { $0.nfd._flush() }) {
+        return next
+      }
+
+      // If we have a leftover composee, make sure to return it.
+      // We may still have things in the buffer which are not complete segments.
+      return composee._take() ?? buffer.next()?.scalar
+    }
   }
 }
 
-extension Unicode._InternalNFC.Iterator: IteratorProtocol {
-  internal func compose(
-    _ x: Unicode.Scalar,
-    and y: Unicode.Scalar
+extension Unicode._NFCNormalizer {
+
+  internal mutating func _resume(
+    consumingNFD nextNFD: (inout Self) -> ScalarAndNormData?
   ) -> Unicode.Scalar? {
-    // Fast path: ASCII and some latiny scalars never compose when they're on
-    // the rhs.
-    if _fastPath(y.value < 0x300) {
+
+    switch state {
+    case .emittingSegment:
+
+      if let buffered = buffer.next() {
+        return buffered.scalar
+      }
+      state = .consuming
+      fallthrough
+
+    case .consuming:
+
+      while let current = nextNFD(&self) {
+
+        // The first starter in the sequence is our initial 'composee'.
+        // Any scalars preceding the first starter have nothing to compose with
+        // and are just emitted directly.
+
+        guard let currentComposee = composee else {
+          guard current.normData.canonicalCombiningClass == .notReordered else {
+            return current.scalar
+          }
+          composee = current.scalar
+          continue
+        }
+
+        guard let lastBufferedNormData = buffer.last?.normData else {
+
+          // The buffer is empty so we have a simple Non-Blocked Pair,
+          // <composee, current>. Look for an equivalent Primary Composite.
+          // If 'current' is NFC_QC, we already know there won't be a composite.
+
+          guard
+            !current.normData.isNFCQC,
+            let composed = compose(currentComposee, andNonNFCQC: current.scalar)
+          else {
+
+            // No Primary Composite found.
+            // If 'current' is a starter, yield 'composee',
+            // and begin a new segment with 'current' as the new 'composee'.
+            // Otherwise, 'current' is a non-composing mark
+            // that we need to buffer until we are finished composing.
+
+            if current.normData.canonicalCombiningClass == .notReordered {
+              composee = current.scalar
+              return currentComposee
+            }
+            buffer.append(current)
+            continue
+          }
+
+          // Primary Composite found. 
+          // It becomes our new 'composee' and 'current' is discarded.
+
+          composee = composed
+          continue
+        }
+
+        // We have the sequence <composee, [...buffer contents...], current>.
+        // Check whether 'current' may compose with 'composee',
+        // or whether it is blocked by the buffer contents.
+        //
+        // Blocking refers to the presence of a scalar X in the buffer
+        // where CCC(X) == 0 or CCC(X) >= CCC(current).
+        //
+        // Example:
+        //
+        // - "a\u{0305}\u{0300}b" (a̅̀b) => NFC "a\u{0305}\u{0300}b" (a̅̀b)
+        // - "a\u{0300}\u{0305}b" (à̅b) => NFC "\u{00E0}\u{0305}b"  (à̅b)
+        //         ^^^     ^^^
+        //
+        // These strings contain two combining marks with the same combining
+        // class: U+0305 COMBINING OVERLINE and U+0300 COMBINING GRAVE ACCENT.
+        // Because these marks have the same class, they cannot be reordered
+        // (their existing order is important). In one ordering, the accent
+        // appears above the overline, and in the other the order is reversed.
+        //
+        // It turns out, there is no composite for <"a", overline>,
+        // but there is one for <"a", grave accent>: the
+        // U+00E0 LATIN SMALL LETTER A WITH GRAVE we see in the second example.
+        //
+        // Despite the overline not composing, it would be wrong
+        // if the grave accent could squeeze ahead of it
+        // via composition with the "a".
+        // So the presence of the overline must block the composition.
+
+        _internalInvariant(
+          lastBufferedNormData.canonicalCombiningClass != .notReordered,
+          "We never buffer starters"
+        )
+
+        // Since we consume an NFD stream
+        // the buffer contents are already in canonical order,
+        // and 'lastBufferedNormData' has the highest CCC in the buffer.
+
+        _internalInvariant(
+          lastBufferedNormData.canonicalCombiningClass <= current.normData.canonicalCombiningClass
+          || current.normData.canonicalCombiningClass == .notReordered,
+          "NFD stream not in canonical order"
+        )
+
+        guard lastBufferedNormData.canonicalCombiningClass < current.normData.canonicalCombiningClass else {
+
+          // 'current' is blocked from composing with 'composee'.
+          //
+          // If 'current' is a starter, yield 'composee', 
+          // emit the segment that we have in the buffer,
+          // and begin a new segment with 'current' as the new 'composee'.
+          // Otherwise, 'current' is a non-composing mark
+          // that we need to buffer until we are finished composing.
+
+          if current.normData.canonicalCombiningClass == .notReordered {
+            composee = current.scalar
+            state = .emittingSegment
+            return currentComposee
+          }
+          buffer.append(current)
+          continue
+        }
+
+        _internalInvariant(current.normData.canonicalCombiningClass != .notReordered)
+
+        // Look for a Primary Composite equivalent to <composee, current>.
+        // If 'current' is NFC_QC, we already know there won't be any composite.
+
+        guard
+          !current.normData.isNFCQC,
+          let composed = compose(currentComposee, andNonNFCQC: current.scalar)
+        else {
+
+          // No Primary Composite found.
+          // We know 'current' is not a starter, so it is a non-composing mark
+          // that we need to buffer until we are finished composing.
+          buffer.append(current)
+          continue
+        }
+
+        // Primary Composite found.
+        // It becomes our new 'composee', and 'current' is discarded.
+
+        composee = composed
+      }
+
+      // NFD source is exhausted.
       return nil
     }
+  }
+
+  private func compose(
+    _ x: Unicode.Scalar,
+    andNonNFCQC y: Unicode.Scalar
+  ) -> Unicode.Scalar? {
 
     if let hangul = composeHangul(x, and: y) {
       return hangul
@@ -60,7 +414,7 @@ extension Unicode._InternalNFC.Iterator: IteratorProtocol {
   }
 
   @inline(never)
-  internal func composeHangul(
+  private func composeHangul(
     _ x: Unicode.Scalar,
     and y: Unicode.Scalar
   ) -> Unicode.Scalar? {
@@ -96,128 +450,5 @@ extension Unicode._InternalNFC.Iterator: IteratorProtocol {
     default:
       return nil
     }
-  }
-
-  internal mutating func next() -> Unicode.Scalar? {
-    // Empty out our buffer before attempting to compose anything with our new
-    // composee.
-    if let nextBuffered = buffer.next() {
-      return nextBuffered.scalar
-    }
-
-    while let current = iterator.next() {
-      guard let currentComposee = composee else {
-        // If we don't have a composee at this point, we're most likely looking
-        // at the start of a string. If our class is 0, then attempt to compose
-        // the following scalars with this one. Otherwise, it's a one off scalar
-        // that needs to be emitted.
-        if current.normData.ccc == 0 {
-          composee = current.scalar
-          continue
-        } else {
-          return current.scalar
-        }
-      }
-
-      // If we have any scalars in the buffer, it means those scalars couldn't
-      // compose with our composee to form a new scalar. However, scalars
-      // following them may still compose with our composee, so take the last
-      // scalar in the buffer and get its normalization data so that we can
-      // perform the check underneath this one about whether this current scalar
-      // is "blocked". We get the last scalar because the scalars we receive are
-      // already NFD, so the last scalar in the buffer will have the highest
-      // CCC value in this normalization segment.
-      guard let lastBufferedNormData = buffer.last?.normData else {
-        // If we do not have any scalars in our buffer yet, then this step is
-        // trivial. Attempt to compose our current scalar with whatever composee
-        // we're currently building up.
-
-        // If our right hand side scalar IS NFC_QC, then that means it can
-        // never compose with any scalars previous to it. So, if our current
-        // scalar is NFC_QC, then we have no composition.
-        guard !current.normData.isNFCQC,
-            let composed = compose(currentComposee, and: current.scalar) else {
-          // We did not find a composition between the two. If our current class
-          // is 0, then set that as the new composee and return whatever built
-          // up scalar we have. Otherwise, add our current scalar to the buffer
-          // for eventual removal!
-
-          if current.normData.ccc == 0 {
-            composee = current.scalar
-            return currentComposee
-          }
-
-          buffer.append(current)
-          continue
-        }
-
-        // We found a composition! Record it as our new composee and repeat the
-        // process.
-        composee = composed
-        continue
-      }
-
-      // Check if our current scalar is not blocked from our current composee.
-      // In this case blocked means there is some scalar whose class
-      // (lastBufferedNormData.ccc) is either == 0 or >= current.normData.ccc.
-      //
-      // Example:
-      //
-      //     "z\u{0335}\u{0327}\u{0324}\u{0301}"
-      //
-      // In this example, there are several combining marks following a 'z', but
-      // none of them actually compose with the composee 'z'. However, the last
-      // scalar U+0301 does actually compose. So this check makes sure that the
-      // last scalar doesn't have any scalar in between it and the composee that
-      // would otherwise "block" it from composing.
-      guard lastBufferedNormData.ccc < current.normData.ccc else {
-        // We had a scalar block it. That means our current scalar is either a
-        // starter or has a same class (preserve ordering).
-
-        // Starters are the "start" of a new normalization segment. Set it as
-        // the new composee and return our current composee. This will trigger
-        // any other scalars in the buffer to be emitted before we handle
-        // normalizing this new segment.
-        if current.normData.ccc == 0 {
-          composee = current.scalar
-          return currentComposee
-        }
-
-        _internalInvariant(current.normData.ccc == lastBufferedNormData.ccc)
-        buffer.append(current)
-        continue
-      }
-
-      // There were no blockers! Attempt to compose the two! (Again, if our rhs
-      // scalar IS NFC_QC, then it can never compose with anything previous to
-      // it).
-      guard !current.normData.isNFCQC,
-            let composed = compose(currentComposee, and: current.scalar) else {
-        // No composition found. Stick it at the end of the buffer with the rest
-        // of non-composed scalars.
-
-        buffer.append(current)
-        continue
-      }
-
-      // They composed! Assign the composition as our new composee and iterate
-      // to the next scalar.
-      composee = composed
-    }
-
-    // If we have a leftover composee, make sure to return it.
-    return composee._take()
-  }
-}
-
-extension Unicode._InternalNFC: Sequence {
-  internal func makeIterator() -> Iterator {
-    Iterator(iterator: base._internalNFD.makeIterator())
-  }
-}
-
-extension StringProtocol {
-  internal var _internalNFC: Unicode._InternalNFC<Self> {
-    Unicode._InternalNFC(base: self)
   }
 }

--- a/stdlib/public/core/NFC.swift
+++ b/stdlib/public/core/NFC.swift
@@ -243,6 +243,7 @@ extension Unicode {
 
 extension Unicode._NFCNormalizer {
 
+  @inline(never)
   internal mutating func _resume(
     consumingNFD nextNFD: (inout Self) -> ScalarAndNormData?
   ) -> Unicode.Scalar? {

--- a/stdlib/public/core/NFD.swift
+++ b/stdlib/public/core/NFD.swift
@@ -10,52 +10,308 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension Unicode {
-  internal struct _InternalNFD<S: StringProtocol> {
-    let base: S.UnicodeScalarView
+extension Sequence where Element == Unicode.Scalar {
+  internal var _internalNFD: Unicode._InternalNFD<Self> {
+    Unicode._InternalNFD(self)
   }
 }
 
-extension Unicode._InternalNFD {
-  internal struct Iterator {
-    var buffer = Unicode._NormDataBuffer()
+extension Unicode  {
 
-    // This index always points at the next starter of a normalization segment.
-    // Each iteration of 'next()' moves this index up to the next starter.
-    var index: S.UnicodeScalarView.Index
+  /// The contents of the source sequence, in Normalization Form D.
+  ///
+  /// Normalization to NFD preserves canonical equivalence.
+  ///
+  internal struct _InternalNFD<Source> where Source: Sequence<Unicode.Scalar> {
 
-    let unicodeScalars: S.UnicodeScalarView
+    internal let source: Source
+
+    internal init(_ source: Source) {
+      self.source = source
+    }
   }
 }
 
-extension Unicode._InternalNFD.Iterator: IteratorProtocol {
-  internal mutating func decompose(
-    _ scalar: Unicode.Scalar,
-    with normData: Unicode._NormData
-  ) {
-    // ASCII always decomposes to itself.
-    if _fastPath(scalar.value < 0xC0) {
-      // ASCII always has normData of 0.
-      // CCC = 0, NFC_QC = Yes, NFD_QC = Yes
-      buffer.append((scalar, normData))
-      return
+extension Unicode._InternalNFD: Sequence {
+
+  internal consuming func makeIterator() -> Iterator {
+    Iterator(source: source.makeIterator())
+  }
+
+  internal struct Iterator: IteratorProtocol {
+
+    internal var source: Source.Iterator
+    internal var normalizer: Unicode._NFDNormalizer
+
+    internal init(source: Source.Iterator) {
+      self.source = source
+      self.normalizer = Unicode._NFDNormalizer()
     }
 
+    internal mutating func next() -> Unicode.Scalar? {
+      normalizer.resume(consuming: &source) ?? normalizer.flush()
+    }
+  }
+}
+
+extension Unicode._InternalNFD: Sendable where Source: Sendable {}
+extension Unicode._InternalNFD.Iterator: Sendable where Source.Iterator: Sendable {}
+
+extension Unicode {
+
+  /// A stateful normalizer, producing a single logical stream
+  /// of normalized text from chunked inputs.
+  ///
+  /// To use the normalizer, first create an instance.
+  /// Next, feed it a chunk of a text stream using the `resume(consuming:)`
+  /// function. The normalizer will consume from the stream and buffer
+  /// it as needed, so continue feeding the same source until
+  /// it returns `nil`, indicating that the source was exhausted.
+  ///
+  /// ```swift
+  /// var normalizer = Unicode.NFDNormalizer()
+  ///
+  /// var input: some IteratorProtocol<Unicode.Scalar> = ...
+  /// while let scalar = normalizer.resume(consuming: &input) {
+  ///   print(scalar)
+  /// }
+  ///
+  /// // assert(input.next() == nil)
+  /// ```
+  ///
+  /// You may continue consuming sources until you reach the end
+  /// of the logical text stream. Once you reach the end,
+  /// call `flush()` to drain any remaining content
+  /// from the normalizer's buffers.
+  ///
+  /// ```swift
+  /// while let scalar = normalizer.flush() {
+  ///   print(scalar)
+  /// }
+  /// ```
+  ///
+  /// The chunks of input text do not need to be aligned on any normalization
+  /// boundary. The normalizer state has value semantics, so it is possible
+  /// to copy and store and is inherently thread-safe.
+  ///
+  internal struct _NFDNormalizer: Sendable {
+
+    internal enum State {
+      case emittingSegment
+      case consuming
+      case terminated
+    }
+
+    internal var state = State.consuming
+
+    internal var buffer = Unicode._NormDataBuffer()
+    internal var pendingStarter = Optional<ScalarAndNormData>.none
+    internal var bufferIsSorted = false
+
+    /// Creates a new normalizer.
+    ///
+    internal init() { }
+
+    /// Resume normalizing the text stream.
+    ///
+    /// Each call to `resume` returns the next scalar in the normalized output,
+    /// consuming elements from the given source as necessary.
+    ///
+    /// If the normalizer returns `nil`, the source was exhausted.
+    /// One a source is exhausted, you may:
+    ///
+    /// - Call `resume` again some time later with a different source
+    ///   to continue processing the same logical text stream, or
+    ///
+    /// - Call `flush` in order to mark the end of the stream
+    ///   and consume data remaining in the normalizer's internal buffers.
+    ///
+    /// Typical usage looks like the following:
+    ///
+    /// ```swift
+    /// var normalizer = Unicode.NFDNormalizer()
+    ///
+    /// var input: some IteratorProtocol<Unicode.Scalar> = ...
+    /// while let scalar = normalizer.resume(consuming: &input) {
+    ///   print(scalar)
+    /// }
+    ///
+    /// // We could resume again, consuming from another input here.
+    /// // Finally, when we are done consuming inputs:
+    ///
+    /// while let scalar = normalizer.flush() {
+    ///   print(scalar)
+    /// }
+    /// ```
+    ///
+    /// The normalizer consumes data from the source as needed,
+    /// meaning even if a call to `resume` returns a value,
+    /// that value may have come from the normalizer's internal buffers
+    /// without consuming the input source at all.
+    ///
+    /// Be careful to ensure each input source has been fully consumed
+    /// before moving on to the next source (marked by `resume` returning `nil`).
+    ///
+    internal mutating func resume(
+      consuming source: inout some IteratorProtocol<Unicode.Scalar>
+    ) -> Unicode.Scalar? {
+      resume(consuming: { source.next() })
+    }
+
+    // Intended ABI barrier for resume(consuming: inout some IteratorProtocol<Unicode.Scalar>).
+    // when it becomes public.
+    internal mutating func resume(
+      consuming nextFromSource: () -> Unicode.Scalar?
+    ) -> Unicode.Scalar? {
+      _resume(consuming: nextFromSource)?.scalar
+    }
+
+    /// Marks the end of the text stream and
+    /// returns the next scalar from the normalizer's internal buffer.
+    ///
+    /// Once you have finished feeding input data to the normalizer,
+    /// call `flush` until it returns `nil`.
+    ///
+    /// ```swift
+    /// while let scalar = normalizer.flush() {
+    ///   print(scalar)
+    /// }
+    /// ```
+    ///
+    /// After calling `flush`, all future calls to `resume`
+    /// will immediately return `nil` without consuming from its source.
+    /// This allows optional chaining to be used to
+    /// fully normalize a stream:
+    ///
+    /// ```swift
+    /// // Normalize the concatenation of inputA and inputB
+    ///
+    /// while let scalar =
+    ///   normalizer.resume(consuming: &inputA) ??
+    ///   normalizer.resume(consuming: &inputB) ??
+    ///   normalizer.flush()
+    /// {
+    ///   print(scalar)
+    /// }
+    /// ```
+    internal mutating func flush() -> Unicode.Scalar? {
+      _flush()?.scalar
+    }
+  }
+}
+
+extension Unicode._NFDNormalizer {
+
+  internal mutating func _resume(
+    consuming nextFromSource: () -> Unicode.Scalar?
+  ) -> ScalarAndNormData? {
+
+    switch state {
+    case .emittingSegment:
+      _internalInvariant(
+        pendingStarter != nil,
+        "Must find next segment starter before emitting buffered segment"
+      )
+      _internalInvariant(
+        bufferIsSorted,
+        "Buffered segment must be sorted before being emitted"
+      )
+
+      if let buffered = buffer.next() {
+        return buffered
+      }
+      bufferIsSorted = false
+      state = .consuming
+      fallthrough
+
+    case .consuming:
+
+      while let (scalar, normData) = takePendingOrConsume(nextFromSource) {
+
+        // If this scalar is a starter, stash it and emit the decomposed segment
+        // we have in the buffer. The buffer must be sorted first.
+
+        if normData.canonicalCombiningClass == .notReordered, !buffer.isEmpty {
+          pendingStarter = (scalar, normData)
+          buffer.sort()
+          bufferIsSorted = true
+          state = .emittingSegment
+          return buffer.next()
+        }
+
+        // If this scalar is NFD_QC, it does not need to be decomposed.
+
+        if normData.isNFDQC {
+
+          // If the scalar is a starter its CCC is 0,
+          // so it does not need to be sorted and can be emitted directly.
+
+          if normData.canonicalCombiningClass == .notReordered {
+            return (scalar, normData)
+          }
+          buffer.append((scalar, normData))
+          continue
+        }
+
+        // Otherwise, append the scalar's decomposition to the buffer.
+
+        decomposeNonNFDQC((scalar, normData))
+      }
+
+      // Source is exhausted.
+      return nil
+
+    case .terminated:
+      return nil
+    }
+  }
+
+  internal mutating func _flush() -> ScalarAndNormData? {
+
+    state = .terminated
+
+    if !bufferIsSorted {
+      buffer.sort()
+      bufferIsSorted = true
+    }
+
+    // The buffer contains the decomposed segment *prior to*
+    // any pending starter we might have.
+
+    return buffer.next() ?? pendingStarter._take()
+  }
+
+  private mutating func takePendingOrConsume(
+    _ nextFromSource: () -> Unicode.Scalar?
+  ) -> ScalarAndNormData? {
+
+    if let pendingStarter = pendingStarter._take() {
+      return pendingStarter
+    } else if let nextScalar = nextFromSource() {
+      return (nextScalar, Unicode._NormData(nextScalar))
+    } else {
+      return nil
+    }
+  }
+
+  private mutating func decomposeNonNFDQC(
+    _ scalarInfo: ScalarAndNormData
+  ) {
     // Handle Hangul decomposition algorithmically.
     // S.base = 0xAC00
     // S.count = 11172
     // S.base + S.count - 1 = 0xD7A3
-    if (0xAC00 ... 0xD7A3).contains(scalar.value) {
-      decomposeHangul(scalar)
+    if (0xAC00 ... 0xD7A3).contains(scalarInfo.scalar.value) {
+      decomposeHangul(scalarInfo.scalar)
       return
     }
 
     // Otherwise, we need to lookup the decomposition (if there is one).
-    decomposeSlow(scalar, with: normData)
+    decomposeSlow(scalarInfo)
   }
 
   @inline(never)
-  internal mutating func decomposeHangul(_ scalar: Unicode.Scalar) {
+  private mutating func decomposeHangul(_ scalar: Unicode.Scalar) {
     // L = Hangul leading consonants
     let L: (base: UInt32, count: UInt32) = (base: 0x1100, count: 19)
     // V = Hangul vowels
@@ -92,20 +348,19 @@ extension Unicode._InternalNFD.Iterator: IteratorProtocol {
   }
 
   @inline(never)
-  internal mutating func decomposeSlow(
-    _ scalar: Unicode.Scalar,
-    with normData: Unicode._NormData
+  private mutating func decomposeSlow(
+    _ original: ScalarAndNormData
   ) {
     // Look into the decomposition perfect hash table.
-    let decompEntry = Unicode._DecompositionEntry(scalar)
+    let decompEntry = Unicode._DecompositionEntry(original.scalar)
 
     // If this is not our original scalar, then we have no decomposition for this
     // scalar, so just emit itself. This is required because perfect hashing
     // does not know the original set of keys that it used to create itself, so
     // we store the original scalar in our decomposition entry to ensure that
     // scalars that hash to the same index don't succeed.
-    guard scalar == decompEntry.hashedScalar else {
-      buffer.append((scalar, normData))
+    guard original.scalar == decompEntry.hashedScalar else {
+      buffer.append(original)
       return
     }
 
@@ -122,60 +377,5 @@ extension Unicode._InternalNFD.Iterator: IteratorProtocol {
 
       buffer.append((scalar, normData))
     }
-  }
-
-  internal mutating func next() -> ScalarAndNormData? {
-    // Empty out our buffer before attempting to decompose the next
-    // normalization segment.
-    if let nextBuffered = buffer.next() {
-      return nextBuffered
-    }
-
-    while index < unicodeScalars.endIndex {
-      let scalar = unicodeScalars[index]
-      let normData = Unicode._NormData(scalar)
-
-      // If we've reached a starter, stop.
-      if normData.ccc == 0, !buffer.isEmpty {
-        break
-      }
-
-      unicodeScalars.formIndex(after: &index)
-
-      // If our scalar IS NFD quick check, then it's as simple as appending to
-      // our buffer and moving on the next scalar. Otherwise, we need to
-      // decompose this and append each decomposed scalar.
-      if normData.isNFDQC {
-        // Fast path: If our scalar is also ccc = 0, then this doesn't need to
-        // be appended to the buffer at all.
-        if normData.ccc == 0 {
-          return (scalar, normData)
-        }
-
-        buffer.append((scalar, normData))
-      } else {
-        decompose(scalar, with: normData)
-      }
-    }
-
-    // Sort the entire buffer based on the canonical combining class.
-    buffer.sort()
-
-    return buffer.next()
-  }
-}
-
-extension Unicode._InternalNFD: Sequence {
-  internal func makeIterator() -> Iterator {
-    Iterator(
-      index: base.startIndex,
-      unicodeScalars: base
-    )
-  }
-}
-
-extension StringProtocol {
-  internal var _internalNFD: Unicode._InternalNFD<Self> {
-    Unicode._InternalNFD(base: unicodeScalars)
   }
 }

--- a/stdlib/public/core/NFD.swift
+++ b/stdlib/public/core/NFD.swift
@@ -202,6 +202,7 @@ extension Unicode {
 
 extension Unicode._NFDNormalizer {
 
+  @inline(never)
   internal mutating func _resume(
     consuming nextFromSource: () -> Unicode.Scalar?
   ) -> ScalarAndNormData? {
@@ -281,6 +282,7 @@ extension Unicode._NFDNormalizer {
     return buffer.next() ?? pendingStarter._take()
   }
 
+  @inline(__always)
   private mutating func takePendingOrConsume(
     _ nextFromSource: () -> Unicode.Scalar?
   ) -> ScalarAndNormData? {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1159,7 +1159,7 @@ extension _StringGutsSlice {
       }
     }
 
-    for scalar in substring._internalNFC {
+    for scalar in substring.unicodeScalars._internalNFC {
       try scalar.withUTF8CodeUnits {
         for byte in $0 {
           try f(byte)

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -333,8 +333,8 @@ extension _StringGutsSlice {
     with other: _StringGutsSlice,
     expecting: _StringComparisonResult
   ) -> Bool {
-    var iter1 = Substring(self)._internalNFC.makeIterator()
-    var iter2 = Substring(other)._internalNFC.makeIterator()
+    var iter1 = Substring(self).unicodeScalars._internalNFC.makeIterator()
+    var iter2 = Substring(other).unicodeScalars._internalNFC.makeIterator()
 
     var scalar1: Unicode.Scalar? = nil
     var scalar2: Unicode.Scalar? = nil

--- a/stdlib/public/core/UnicodeData.swift
+++ b/stdlib/public/core/UnicodeData.swift
@@ -52,6 +52,10 @@ extension Unicode {
       UInt8(truncatingIfNeeded: rawValue >> 3)
     }
 
+    var canonicalCombiningClass: Unicode.CanonicalCombiningClass {
+      Unicode.CanonicalCombiningClass(rawValue: ccc)
+    }
+
     var isNFCQC: Bool {
       rawValue & 0x6 == 0
     }

--- a/stdlib/public/core/UnicodeSPI.swift
+++ b/stdlib/public/core/UnicodeSPI.swift
@@ -32,7 +32,7 @@ extension Unicode._NFD {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
   public struct Iterator {
-    var base: Unicode._InternalNFD<Substring>.Iterator
+    var base: Unicode._InternalNFD<Substring.UnicodeScalarView>.Iterator
   }
 }
 
@@ -44,7 +44,7 @@ extension Unicode._NFD.Iterator: IteratorProtocol {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
   public mutating func next() -> Unicode.Scalar? {
-    base.next()?.scalar
+    base.next()
   }
 }
 
@@ -53,7 +53,7 @@ extension Unicode._NFD: Sequence {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
   public func makeIterator() -> Iterator {
-    Iterator(base: Unicode._InternalNFD(base: base).makeIterator())
+    Iterator(base: base._internalNFD.makeIterator())
   }
 }
 
@@ -93,7 +93,7 @@ extension Unicode._NFC {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
   public struct Iterator {
-    var base: Unicode._InternalNFC<Substring>.Iterator
+    var base: Unicode._InternalNFC<Substring.UnicodeScalarView>.Iterator
   }
 }
 
@@ -114,11 +114,7 @@ extension Unicode._NFC: Sequence {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
   public func makeIterator() -> Iterator {
-    Iterator(
-      base: Unicode._InternalNFC<Substring>.Iterator(
-        iterator: Unicode._InternalNFD<Substring>(base: base).makeIterator()
-      )
-    )
+    Iterator(base: base._internalNFC.makeIterator())
   }
 }
 


### PR DESCRIPTION
Refactors the standard library's internal normalization routines to make them independent of using String as a storage type.

This doesn't expose any public APIs or ABI symbols (it's all still just `internal`, and not `@usableFromInline`), and should be performance-neutral.