### PR TITLE
[6.0][Tests] Remove erroneous swiftRemoteInspection dependency.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,10 +47,6 @@ function(get_test_dependencies SDK result_var_name)
     list(APPEND deps sdk-overlay)
   endif()
 
-  if(SWIFT_BUILD_REMOTE_MIRROR)
-    list(APPEND deps swiftRemoteInspection)
-  endif()
-
   set(deps_binaries)
 
   if (SWIFT_INCLUDE_TOOLS)


### PR DESCRIPTION
This was added by #71839 as part of a fix for the `TypeRoundTrip/round-trip.swift` test, but it isn't necessary and it's breaking nightly builds.

rdar://128000843
