### PR TITLE
[Caching] Mark `-typecheck` action as caching supported

### DIFF
--- a/include/swift/Basic/CASOptions.h
+++ b/include/swift/Basic/CASOptions.h
@@ -49,6 +49,9 @@ public:
   /// Cache key for imported bridging header.
   std::string BridgingHeaderPCHCacheKey;
 
+  /// Has immutable file system input.
+  bool HasImmutableFileSystem = false;
+
   /// Get the CAS configuration flags.
   void enumerateCASConfigurationFlags(
       llvm::function_ref<void(llvm::StringRef)> Callback) const;

--- a/lib/Frontend/CASOutputBackends.cpp
+++ b/lib/Frontend/CASOutputBackends.cpp
@@ -149,7 +149,10 @@ void SwiftCASOutputBackend::Implementation::initBackend(
   // any commands write output to `-`.
   file_types::ID mainOutputType = InputsAndOutputs.getPrincipalOutputType();
   auto addInput = [&](const InputFile &Input, unsigned Index) {
-    if (!Input.outputFilename().empty())
+    // Ignore the outputFilename for typecheck action since it is not producing
+    // an output file for that.
+    if (!Input.outputFilename().empty() &&
+        Action != FrontendOptions::ActionType::Typecheck)
       OutputToInputMap.insert(
           {Input.outputFilename(), {Index, mainOutputType}});
     Input.getPrimarySpecificPaths()

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -571,13 +571,8 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
   if (const Arg*A = Args.getLastArg(OPT_bridging_header_pch_key))
     Opts.BridgingHeaderPCHCacheKey = A->getValue();
 
-  if (Opts.EnableCaching && Opts.CASFSRootIDs.empty() &&
-      Opts.ClangIncludeTrees.empty() &&
-      FrontendOptions::supportCompilationCaching(
-          FrontendOpts.RequestedAction)) {
-    Diags.diagnose(SourceLoc(), diag::error_caching_no_cas_fs);
-    return true;
-  }
+  if (!Opts.CASFSRootIDs.empty() || !Opts.ClangIncludeTrees.empty())
+    Opts.HasImmutableFileSystem = true;
 
   return false;
 }

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -230,7 +230,6 @@ bool FrontendOptions::supportCompilationCaching(ActionType action) {
   case ActionType::EmitImportedModules:
   case ActionType::ScanDependencies:
   case ActionType::ResolveImports:
-  case ActionType::Typecheck:
   case ActionType::DumpAST:
   case ActionType::PrintAST:
   case ActionType::PrintASTDecl:
@@ -240,6 +239,7 @@ bool FrontendOptions::supportCompilationCaching(ActionType action) {
   case ActionType::Immediate:
   case ActionType::DumpTypeInfo:
     return false;
+  case ActionType::Typecheck:
   case ActionType::TypecheckModuleFromInterface:
   case ActionType::CompileModuleFromInterface:
   case ActionType::EmitPCH:

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1765,6 +1765,8 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
   if (casOpts.EnableCaching) {
     genericSubInvocation.getCASOptions().EnableCaching = casOpts.EnableCaching;
     genericSubInvocation.getCASOptions().CASOpts = casOpts.CASOpts;
+    genericSubInvocation.getCASOptions().HasImmutableFileSystem =
+        casOpts.HasImmutableFileSystem;
     casOpts.enumerateCASConfigurationFlags(
         [&](StringRef Arg) { GenericArgs.push_back(ArgSaver.save(Arg)); });
     // ClangIncludeTree is default on when caching is enabled.

--- a/test/CAS/cached_diagnostics.swift
+++ b/test/CAS/cached_diagnostics.swift
@@ -58,3 +58,10 @@ let _ : MyEnum? = .none // expected-warning {{assuming you mean 'Optional<MyEnum
 
 /// Verify the serialized diags have the right magic at the top.
 // CHECK-SERIALIZED: DIA
+
+// RUN: %target-swift-frontend -c -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
+// RUN:   -typecheck -serialize-diagnostics -serialize-diagnostics-path %t/test.diag -Rcache-compile-job 2>&1 | %FileCheck %s -check-prefix CACHE-MISS
+// RUN: %target-swift-frontend -c -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
+// RUN:   -typecheck -serialize-diagnostics -serialize-diagnostics-path %t/test.diag -Rcache-compile-job 2>&1 | %FileCheck %s -check-prefix CACHE-HIT
+// CACHE-MISS: remark: cache miss
+// CACHE-HIT: remark: replay output file '<cached-diagnostics>'


### PR DESCRIPTION
This is a regression causing lots of cached diagnostics tests not functioning since the cached diagnostics processors are not initialized for those tests which are supposed to test diagnostics caching.

The regression is caused by the fix that the typecheck module interface job need to run a typecheck job in the sub-invocation. Now the typecheck module interface job is correctly setup to avoid diagnostics about unsupported file system error.