### PR TITLE
[embedded] Explicitly install the embedded concurrency .a libraries with +x permissions

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -279,6 +279,12 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       DESTINATION "lib/swift/embedded/${mod}"
       COMPONENT "stdlib"
       )
+    swift_install_in_component(
+      FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswift_Concurrency.a"
+      DESTINATION "lib/swift/embedded/${mod}/"
+      COMPONENT "stdlib"
+      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+      )
     set_property(TARGET embedded-concurrency-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
 
     add_dependencies(embedded-concurrency embedded-concurrency-${mod})


### PR DESCRIPTION
The embedded concurrency .a libraries are produced and pass some basic tests, but they are missing from downloadable toolchains on swift.org. It seems like that static libraries need to be installed with +x file permissions to make it into the final toolchain, and it's something that is handled for normal libraries in `add_swift_target_library`, but since we're using `add_swift_target_library_single` we need to do that explicitly.