### PR TITLE
[ScanDependency] Pass crossimport overlay file to swift-frontend

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -812,8 +812,9 @@ public:
   /// Collect a map from a secondary module name to a list of cross-import
   /// overlays, when this current module serves as the primary module.
   llvm::StringMap<llvm::SmallSetVector<Identifier, 4>>
-  collectCrossImportOverlayNames(ASTContext &ctx, StringRef moduleName,
-                                 std::vector<std::string> &overlayFiles) const;
+  collectCrossImportOverlayNames(
+      ASTContext &ctx, StringRef moduleName,
+      std::vector<std::pair<std::string, std::string>> &overlayFiles) const;
 };
 
 using ModuleDependencyVector = llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>;

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -504,6 +504,14 @@ public:
   /// version inheritance.
   std::optional<std::string> PlatformAvailabilityInheritanceMapPath;
 
+  /// Cross import module information. Map from module name to the list of cross
+  /// import overlay files that associate with that module.
+  using CrossImportMap = llvm::StringMap<std::vector<std::string>>;
+  CrossImportMap CrossImportInfo;
+
+  /// Whether to search for cross import overlay on file system.
+  bool DisableCrossImportOverlaySearch = false;
+
   /// Debug path mappings to apply to serialized search paths. These are
   /// specified in LLDB from the target.source-map entries.
   PathRemapper SearchPathRemapper;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -220,6 +220,13 @@ def swift_module_file: Joined<["-"], "swift-module-file=">,
   MetaVarName<"<name>=<path>">,
   HelpText<"Specify Swift module input explicitly built from textual interface">;
 
+def swift_module_cross_import: MultiArg<["-"], "swift-module-cross-import", 2>,
+  MetaVarName<"<moduleName> <crossImport.swiftoverlay>">,
+  HelpText<"Specify the cross import module">;
+
+def disable_cross_import_overlay_search: Flag<["-"], "disable-cross-import-overlay-search">,
+  HelpText<"Disable searching for cross import overlay file">;
+
 def explicit_swift_module_map
   : Separate<["-"], "explicit-swift-module-map-file">, MetaVarName<"<path>">,
     HelpText<"Specify a JSON file containing information of explicit Swift modules">;

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -171,6 +171,19 @@ void ModuleLoader::findOverlayFiles(SourceLoc diagLoc, ModuleDecl *module,
   using namespace llvm::sys;
   using namespace file_types;
 
+  // If cross import information is passed on command-line, prefer use that.
+  auto &crossImports = module->getASTContext().SearchPathOpts.CrossImportInfo;
+  auto overlays = crossImports.find(module->getNameStr());
+  if (overlays != crossImports.end()) {
+    for (auto entry : overlays->second) {
+      module->addCrossImportOverlayFile(entry);
+      if (dependencyTracker)
+        dependencyTracker->addDependency(entry, module->isSystemModule());
+    }
+  }
+  if (module->getASTContext().SearchPathOpts.DisableCrossImportOverlaySearch)
+    return;
+
   if (file->getModuleDefiningPath().empty())
     return;
   findOverlayFilesInternal(module->getASTContext(),
@@ -188,7 +201,7 @@ void ModuleLoader::findOverlayFiles(SourceLoc diagLoc, ModuleDecl *module,
 llvm::StringMap<llvm::SmallSetVector<Identifier, 4>>
 ModuleDependencyInfo::collectCrossImportOverlayNames(
     ASTContext &ctx, StringRef moduleName,
-    std::vector<std::string> &overlayFiles) const {
+    std::vector<std::pair<std::string, std::string>> &overlayFiles) const {
   using namespace llvm::sys;
   using namespace file_types;
   std::optional<std::string> modulePath;
@@ -240,7 +253,7 @@ ModuleDependencyInfo::collectCrossImportOverlayNames(
       ModuleDecl::collectCrossImportOverlay(ctx, file, moduleName,
                                             bystandingModule);
     result[bystandingModule] = std::move(overlayNames);
-    overlayFiles.push_back(file.str());
+    overlayFiles.push_back({moduleName.str(), file.str()});
   });
   return result;
 }

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -800,7 +800,7 @@ void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
     llvm::function_ref<void(ModuleDependencyID)> action) {
   // Modules explicitly imported. Only these can be secondary module.
   llvm::SetVector<Identifier> newOverlays;
-  std::vector<std::string> overlayFiles;
+  std::vector<std::pair<std::string, std::string>> overlayFiles;
   for (auto dep : allDependencies) {
     auto moduleName = dep.ModuleName;
     // Do not look for overlays of main module under scan
@@ -887,9 +887,15 @@ void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
                     mainDep.addModuleDependency(crossImportOverlayModID);
                 });
 
-  llvm::for_each(overlayFiles, [&mainDep](const std::string &file) {
-    mainDep.addAuxiliaryFile(file);
-  });
+  auto cmdCopy = mainDep.getCommandline();
+  cmdCopy.push_back("-disable-cross-import-overlay-search");
+  for (auto &entry : overlayFiles) {
+    mainDep.addAuxiliaryFile(entry.second);
+    cmdCopy.push_back("-swift-module-cross-import");
+    cmdCopy.push_back(entry.first);
+    cmdCopy.push_back(entry.second);
+  }
+  mainDep.updateCommandLine(cmdCopy);
 
   cache.updateDependency(
       {mainModuleName.str(), ModuleDependencyKind::SwiftSource}, mainDep);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2068,6 +2068,12 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts, ArgList &Args,
                      *forceModuleLoadingMode);
   }
 
+  for (auto *A : Args.filtered(OPT_swift_module_cross_import))
+    Opts.CrossImportInfo[A->getValue(0)].push_back(A->getValue(1));
+
+  Opts.DisableCrossImportOverlaySearch |=
+      Args.hasArg(OPT_disable_cross_import_overlay_search);
+
   // Opts.RuntimeIncludePath is set by calls to
   // setRuntimeIncludePath() or setMainExecutablePath().
   // Opts.RuntimeImportPath is set by calls to

--- a/test/CrossImport/explicit-overlay-file.swift
+++ b/test/CrossImport/explicit-overlay-file.swift
@@ -1,0 +1,14 @@
+// This file tests that the -Rcross-import option causes an appropriate remark to be emitted
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/lib-templates/* %t/
+// RUN: %target-swift-frontend -typecheck %s -enable-cross-import-overlays -Rcross-import -I %t/include -I %t/lib/swift -F %t/Frameworks 2>&1 | %FileCheck %s -check-prefix IMPORT
+// RUN: %target-swift-frontend -typecheck %s -disable-cross-import-overlay-search -enable-cross-import-overlays -Rcross-import -I %t/include -I %t/lib/swift -F %t/Frameworks 2>&1 \
+// RUN:   | %FileCheck %s -check-prefix NO-IMPORT -allow-empty
+// RUN: %target-swift-frontend -typecheck %s -disable-cross-import-overlay-search -enable-cross-import-overlays -Rcross-import -I %t/include -I %t/lib/swift -F %t/Frameworks 2>&1 \
+// RUN:   -swift-module-cross-import DeclaringLibrary %t/lib/swift/DeclaringLibrary.swiftcrossimport/BystandingLibrary.swiftoverlay | %FileCheck %s -check-prefix IMPORT
+
+import DeclaringLibrary
+import BystandingLibrary
+
+// IMPORT: import of 'DeclaringLibrary' and 'BystandingLibrary' triggered a cross-import of '_OverlayLibrary'
+// NO-IMPORT-NOT: import of 'DeclaringLibrary' and 'BystandingLibrary' triggered a cross-import of '_OverlayLibrary'

--- a/test/ScanDependencies/module_deps_cross_import_overlay.swift
+++ b/test/ScanDependencies/module_deps_cross_import_overlay.swift
@@ -30,5 +30,12 @@ import SubEWrapper
 // CHECK-NOT:   "clang": "X"
 // CHECK: ],
 
+// CHECK: "swift": {
+// CHECK-NEXT: "commandLine": [
+// CHECK-NEXT: "-disable-cross-import-overlay-search",
+// CHECK-NEXT: "-swift-module-cross-import",
+// CHECK-NEXT: "E",
+// CHECK-NEXT: SubE.swiftoverlay
+
 // Ensure a transitive dependency via "_cross_import_E" is recorded in the graph still
 // CHECK:   "clang": "X"


### PR DESCRIPTION
Teach dependency scanner to pass cross import overlay file to swift-frontend for main module compilation. This allows swift-frontend not to repeat the file system search for overlay files when loading modules.

This also fixes the issue when caching is enabled, the cross import doesn't work when the first module is a clang module because the module built with caching using clang include tree does not preserve DefinitionLoc which is used to inferred the modulemap location for cross import overlay search.

rdar://127844120