### PR TITLE
[region-isolation] When computing isolation for isolated parameters, use getAnyActor instead of getNominalOrBoundGenericNominal().

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -192,7 +192,10 @@ private:
         actorInstance(ActorInstance::getForValue(actorInstance)) {
     assert((!actorInstance ||
             (actorIsolation.getKind() == ActorIsolation::ActorInstance &&
-             actorInstance->getType().isAnyActor())) &&
+             actorInstance->getType()
+                 .getASTType()
+                 ->lookThroughAllOptionalTypes()
+                 ->getAnyActor())) &&
            "actorInstance must be an actor if it is non-empty");
   }
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6574,36 +6574,6 @@ public:
                               })),
             "transferring result means all results are transferring");
 
-    // We should only ever have a single sil_isolated parameter.
-    bool foundIsolatedParameter = false;
-    for (const auto &parameterInfo : FTy->getParameters()) {
-      if (parameterInfo.hasOption(SILParameterInfo::Isolated)) {
-        auto argType = parameterInfo.getArgumentType(F.getModule(),
-                                                     FTy,
-                                                     F.getTypeExpansionContext());
-        if (argType->isOptional())
-          argType = argType->lookThroughAllOptionalTypes()->getCanonicalType();
-
-        auto genericSig = FTy->getInvocationGenericSignature();
-        auto &ctx = F.getASTContext();
-        auto *actorProtocol = ctx.getProtocol(KnownProtocolKind::Actor);
-        auto *anyActorProtocol = ctx.getProtocol(KnownProtocolKind::AnyActor);
-        bool genericTypeWithActorRequirement = llvm::any_of(
-            genericSig.getRequirements(), [&](const Requirement &other) {
-              if (other.getKind() != RequirementKind::Conformance)
-                return false;
-              if (other.getFirstType()->getCanonicalType() != argType)
-                return false;
-              auto *otherProtocol = other.getProtocolDecl();
-              return otherProtocol->inheritsFrom(actorProtocol) ||
-                     otherProtocol->inheritsFrom(anyActorProtocol);
-            });
-        require(argType->isAnyActorType() || genericTypeWithActorRequirement,
-                "Only any actor types can be isolated");
-        require(!foundIsolatedParameter, "Two isolated parameters");
-        foundIsolatedParameter = true;
-      }
-    }
     require(1 >= std::count_if(FTy->getParameters().begin(), FTy->getParameters().end(),
                                [](const SILParameterInfo &parameterInfo) {
                                  return parameterInfo.hasOption(SILParameterInfo::Isolated);
@@ -7014,11 +6984,37 @@ public:
     }
   }
 
+  void verifyParentFunctionSILFunctionType(CanSILFunctionType FTy) {
+    bool foundIsolatedParameter = false;
+    for (const auto &parameterInfo : FTy->getParameters()) {
+      if (parameterInfo.hasOption(SILParameterInfo::Isolated)) {
+           auto argType = parameterInfo.getArgumentType(F.getModule(),
+                                                     FTy,
+                                                     F.getTypeExpansionContext());
+
+        if (argType->isOptional())
+          argType = argType->lookThroughAllOptionalTypes()->getCanonicalType();
+
+        auto genericSig = FTy->getInvocationGenericSignature();
+        auto &ctx = F.getASTContext();
+        auto *actorProtocol = ctx.getProtocol(KnownProtocolKind::Actor);
+        auto *anyActorProtocol = ctx.getProtocol(KnownProtocolKind::AnyActor);
+        require(argType->isAnyActorType() ||
+                    genericSig->requiresProtocol(argType, actorProtocol) ||
+                    genericSig->requiresProtocol(argType, anyActorProtocol),
+                "Only any actor types can be isolated");
+        require(!foundIsolatedParameter, "Two isolated parameters");
+        foundIsolatedParameter = true;
+      }
+    }
+  }
+
   void visitSILFunction(SILFunction *F) {
     PrettyStackTraceSILFunction stackTrace("verifying", F);
 
     CanSILFunctionType FTy = F->getLoweredFunctionType();
     verifySILFunctionType(FTy);
+    verifyParentFunctionSILFunctionType(FTy);
 
     SILModule &mod = F->getModule();
     bool embedded = mod.getASTContext().LangOpts.hasFeature(Feature::Embedded);

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -113,8 +113,9 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       auto &self = fas.getSelfArgumentOperand();
       if (fas.getArgumentParameterInfo(self).hasOption(
               SILParameterInfo::Isolated)) {
+        CanType astType = self.get()->getType().getASTType();
         if (auto *nomDecl =
-                self.get()->getType().getNominalOrBoundGenericNominal()) {
+                astType->lookThroughAllOptionalTypes()->getAnyActor()) {
           // TODO: We really should be doing this based off of an Operand. Then
           // we would get the SILValue() for the first element. Today this can
           // only mess up isolation history.
@@ -416,8 +417,8 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   // Before we do anything further, see if we have an isolated parameter. This
   // handles isolated self and specifically marked isolated.
   if (auto *isolatedArg = fArg->getFunction()->maybeGetIsolatedArgument()) {
-    if (auto *nomDecl =
-        isolatedArg->getType().getNominalOrBoundGenericNominal()) {
+    auto astType = isolatedArg->getType().getASTType();
+    if (auto *nomDecl = astType->lookThroughAllOptionalTypes()->getAnyActor()) {
       return SILIsolationInfo::getActorInstanceIsolated(fArg, isolatedArg,
                                                         nomDecl);
     }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -15,7 +15,7 @@
 ////////////////////////
 
 /// Classes are always non-sendable, so this is non-sendable
-class NonSendableKlass { // expected-complete-note 48{{}}
+class NonSendableKlass { // expected-complete-note 49{{}}
   // expected-typechecker-only-note @-1 4{{}}
   // expected-tns-note @-2 2{{}}
   var field: NonSendableKlass? = nil
@@ -1697,4 +1697,17 @@ func differentInstanceTest(_ a: MyActor, _ b: MyActor) async {
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   await b.useKlass(x) // expected-tns-note {{access can happen concurrently}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+}
+
+protocol AssociatedTypeTestProtocol {
+  associatedtype A: Actor
+}
+
+func associatedTypeTestBasic<T: AssociatedTypeTestProtocol>(_: T, _: isolated T.A) {
+}
+
+func associatedTypeTestBasic2<T: AssociatedTypeTestProtocol>(_: T, iso: isolated T.A, x: NonSendableKlass) async {
+  await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'iso'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'iso'-isolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }

--- a/test/Distributed/distributed_actor_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_transfernonsendable.swift
@@ -66,3 +66,19 @@ distributed actor MyDistributedActor {
     }
   }
 }
+
+/////////////////////////////////
+// MARK: Associated Type Tests //
+/////////////////////////////////
+
+protocol AssociatedTypeTestProtocol {
+  associatedtype A: DistributedActor
+}
+
+func associatedTypeTestBasic<T: AssociatedTypeTestProtocol>(_: T, _: isolated T.A) {
+}
+
+func associatedTypeTestBasic2<T: AssociatedTypeTestProtocol>(_: T, iso: isolated T.A, x: NonSendableKlass) async {
+  await transferToMain(x) // expected-error {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'iso'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'iso'-isolated uses}}
+}


### PR DESCRIPTION
[region-isolation] When computing isolation for isolated parameters, use getAnyActor instead of getNominalOrBoundGenericNominal().

This ensures that we can properly compute isolation for generic types that
conform to AnyActor.

I found this by playing with test cases from the previous commit. We would not
find an actor type for the actor instance isolation and would fall back along an
incorrect path.

rdar://128021548

----

This also fixes up the verifier check from #73556 to be more correct.
