### PR TITLE
[6.0] Make SwiftValue == support unconditional

### DIFF
--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -430,10 +430,10 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
     }
   }
 
-  if (runtime::bincompat::useLegacySwiftObjCHashing()) {
-    // Legacy behavior only proxies isEqual: for Hashable, not Equatable
-    return NO;
-  }
+//  if (runtime::bincompat::useLegacySwiftObjCHashing()) {
+//    // Legacy behavior only proxies isEqual: for Hashable, not Equatable
+//    return NO;
+//  }
 
   if (auto equatableConformance = selfHeader->getEquatableConformance()) {
     if (auto selfEquatableBaseType = selfHeader->getEquatableBaseType()) {
@@ -464,10 +464,10 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
 	    selfHeader->type, hashableConformance);
   }
 
-  if (runtime::bincompat::useLegacySwiftObjCHashing()) {
-    // Legacy behavior doesn't honor Equatable conformance, only Hashable
-    return (NSUInteger)self;
-  }
+//  if (runtime::bincompat::useLegacySwiftObjCHashing()) {
+//    // Legacy behavior doesn't honor Equatable conformance, only Hashable
+//    return (NSUInteger)self;
+//  }
 
   // If Swift type is Equatable but not Hashable,
   // we have to return something here that is compatible

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -430,11 +430,6 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
     }
   }
 
-//  if (runtime::bincompat::useLegacySwiftObjCHashing()) {
-//    // Legacy behavior only proxies isEqual: for Hashable, not Equatable
-//    return NO;
-//  }
-
   if (auto equatableConformance = selfHeader->getEquatableConformance()) {
     if (auto selfEquatableBaseType = selfHeader->getEquatableBaseType()) {
       auto otherEquatableBaseType = otherHeader->getEquatableBaseType();
@@ -463,11 +458,6 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
 				 getSwiftValuePayloadAlignMask(selfHeader->type)),
 	    selfHeader->type, hashableConformance);
   }
-
-//  if (runtime::bincompat::useLegacySwiftObjCHashing()) {
-//    // Legacy behavior doesn't honor Equatable conformance, only Hashable
-//    return (NSUInteger)self;
-//  }
 
   // If Swift type is Equatable but not Hashable,
   // we have to return something here that is compatible

--- a/test/stdlib/BridgeEquatableToObjC.swift
+++ b/test/stdlib/BridgeEquatableToObjC.swift
@@ -32,12 +32,7 @@ BridgeEquatableToObjC.test("Bridge equatable struct") {
   let objcResult = objcA.isEqual(objcB)
 
   expectEqual(swiftResult, true)
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
-  // Apple platforms use old semantics for now...
-  expectEqual(objcResult, false)
-#else
   expectEqual(objcResult, true)
-#endif
 }
 
 BridgeEquatableToObjC.test("Bridge non-equatable struct") {

--- a/test/stdlib/SwiftValueNSObject.swift
+++ b/test/stdlib/SwiftValueNSObject.swift
@@ -90,12 +90,7 @@ func TestHashableEquals<T: Equatable>(_ e1: T, _ e2: T) {
 // This has not always been true for Equatable value types
 func TestEquatableEquals<T: Equatable>(_ e1: T, _ e2: T) {
   if e1 == e2 {
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
-    // Legacy: Swift Equatable is not used in ObjC
-    TestSwiftValueNSObjectNotEquals(e1 as AnyObject, e2 as AnyObject)
-#else
     TestSwiftValueNSObjectEquals(e1 as AnyObject, e2 as AnyObject)
-#endif
   } else {
     TestSwiftValueNSObjectNotEquals(e1 as AnyObject, e2 as AnyObject)
   }
@@ -114,14 +109,8 @@ func TestHashable<T: Hashable>(_ h: T)
 // Test Obj-C hashValue for Swift types that are Equatable but not Hashable
 func TestEquatableHash<T: Equatable>(_ e: T)
 {
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-  // Legacy behavior used the pointer value, which is
-  // incompatible with user-defined equality.
-  TestSwiftValueNSObjectDefaultHashValue(e as AnyObject)
-#else
   // New behavior uses a constant hash value in this case
   TestSwiftValueNSObjectHashValue(e as AnyObject, 1)
-#endif
 }
 
 func TestNonEquatableHash<T>(_ e: T)


### PR DESCRIPTION
**Description:**  PR https://github.com/apple/swift/pull/71620 made this behavior conditional as a way to help provide binary compatibility for legacy software that might be relying on the old behavior.  However, it appears the only such problems arose from the Swift**Object** behavior changes, not from Swift**Value** behavior. So let's optimistically make the new Swift**Value** behavior unconditional and simplify future maintenance.  (This leaves the Swift**Object** behavior conditional, as we know there is old code that inadvertently relied on the old behavior.)

**Scope/Impact:** Changes how certain Swift values appear when bridged to Objective-C.  This only affects non-class types that implement Equatable but do _not_ implement Hashable.

**Risk:**  Medium.  Although we don't know of any, it's possible some existing/legacy code is relying on the old behavior.  In that case, we would have to restore the conditional logic here.

**Testing:**  Unit tests updated to uniformly verify the new behavior.

**Reviewed By:** @mikeash 

**Radar:** rdar://127839540