### PR TITLE
Consistently treat `let` properties as immutable within the type checker

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2092,6 +2092,14 @@ struct ClosureIsolatedByPreconcurrency {
   bool operator()(const ClosureExpr *expr) const;
 };
 
+/// Determine whether the given expression is part of the left-hand side
+/// of an assignment expression.
+struct IsInLeftHandSideOfAssignment {
+  ConstraintSystem &cs;
+
+  bool operator()(Expr *expr) const;
+};
+
 /// Describes the type produced when referencing a declaration.
 struct DeclReferenceType {
   /// The "opened" type, which is the type of the declaration where any
@@ -4421,7 +4429,7 @@ public:
   /// \param wantInterfaceType Whether we want the interface type, if available.
   Type getUnopenedTypeOfReference(VarDecl *value, Type baseType,
                                   DeclContext *UseDC,
-                                  ConstraintLocator *memberLocator = nullptr,
+                                  ConstraintLocator *locator,
                                   bool wantInterfaceType = false,
                                   bool adjustForPreconcurrency = true);
 
@@ -4443,7 +4451,7 @@ public:
   getUnopenedTypeOfReference(
       VarDecl *value, Type baseType, DeclContext *UseDC,
       llvm::function_ref<Type(VarDecl *)> getType,
-      ConstraintLocator *memberLocator = nullptr,
+      ConstraintLocator *locator,
       bool wantInterfaceType = false,
       bool adjustForPreconcurrency = true,
       llvm::function_ref<Type(const AbstractClosureExpr *)> getClosureType =
@@ -4453,7 +4461,10 @@ public:
       llvm::function_ref<bool(const ClosureExpr *)> isolatedByPreconcurrency =
         [](const ClosureExpr *closure) {
           return closure->isIsolatedByPreconcurrency();
-        });
+        },
+      llvm::function_ref<bool(Expr *)> isAssignTarget = [](Expr *) {
+        return false;
+      });
 
   /// Given the opened type and a pile of information about a member reference,
   /// determine the reference type of the member reference.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3091,6 +3091,34 @@ bool AbstractStorageDecl::isSetterMutating() const {
     IsSetterMutatingRequest{const_cast<AbstractStorageDecl *>(this)}, {});
 }
 
+StorageMutability 
+AbstractStorageDecl::mutability(const DeclContext *useDC,
+                                const DeclRefExpr *base) const {
+  if (auto vd = dyn_cast<VarDecl>(this))
+    return vd->mutability(useDC, base);
+
+  auto sd = cast<SubscriptDecl>(this);
+  return sd->supportsMutation() ? StorageMutability::Mutable
+                                : StorageMutability::Immutable;
+}
+
+/// Determine the mutability of this storage declaration when
+/// accessed from a given declaration context in Swift.
+///
+/// This method differs only from 'mutability()' in its handling of
+/// 'optional' storage requirements, which lack support for direct
+/// writes in Swift.
+StorageMutability
+AbstractStorageDecl::mutabilityInSwift(const DeclContext *useDC,
+                                       const DeclRefExpr *base) const {
+  // TODO: Writing to an optional storage requirement is not supported in Swift.
+  if (getAttrs().hasAttribute<OptionalAttr>()) {
+    return StorageMutability::Immutable;
+  }
+
+  return mutability(useDC, base);
+}
+
 OpaqueReadOwnership AbstractStorageDecl::getOpaqueReadOwnership() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,
@@ -7263,14 +7291,21 @@ Type VarDecl::getTypeInContext() const {
   return getDeclContext()->mapTypeIntoContext(getInterfaceType());
 }
 
+/// Translate an "is mutable" bit into a StorageMutability value.
+static StorageMutability storageIsMutable(bool isMutable) {
+  return isMutable ? StorageMutability::Mutable
+                   : StorageMutability::Immutable;
+}
+
 /// Returns whether the var is settable in the specified context: this
 /// is either because it is a stored var, because it has a custom setter, or
 /// is a let member in an initializer.
-bool VarDecl::isSettable(const DeclContext *UseDC,
-                         const DeclRefExpr *base) const {
+StorageMutability
+VarDecl::mutability(const DeclContext *UseDC,
+                    const DeclRefExpr *base) const {
   // Parameters are settable or not depending on their ownership convention.
   if (auto *PD = dyn_cast<ParamDecl>(this))
-    return !PD->isImmutableInFunctionBody();
+    return storageIsMutable(!PD->isImmutableInFunctionBody());
 
   // If this is a 'var' decl, then we're settable if we have storage or a
   // setter.
@@ -7278,17 +7313,17 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
     if (hasInitAccessor()) {
       if (auto *ctor = dyn_cast_or_null<ConstructorDecl>(UseDC)) {
         if (base && ctor->getImplicitSelfDecl() != base->getDecl())
-          return supportsMutation();
-        return true;
+          return storageIsMutable(supportsMutation());
+        return StorageMutability::Initializable;
       }
     }
 
-    return supportsMutation();
+    return storageIsMutable(supportsMutation());
   }
 
   // Static 'let's are always immutable.
   if (isStatic()) {
-    return false;
+    return StorageMutability::Immutable;
   }
 
   //
@@ -7298,11 +7333,11 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
 
   // Debugger expression 'let's are initialized through a side-channel.
   if (isDebuggerVar())
-    return false;
+    return StorageMutability::Immutable;
 
   // 'let's are only ever settable from a specific DeclContext.
   if (UseDC == nullptr)
-    return false;
+    return StorageMutability::Immutable;
 
   // 'let' properties in structs/classes are only ever settable in their
   // designated initializer(s) or by init accessors.
@@ -7314,61 +7349,64 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
       // Check whether this property is part of `initializes` list,
       // and allow assignment/mutation if so. DI would be responsible
       // for checking for re-assignment.
-      return accessor->isInitAccessor() &&
+      if (accessor->isInitAccessor() &&
              llvm::is_contained(accessor->getInitializedProperties(),
-                                const_cast<VarDecl *>(this));
+                                const_cast<VarDecl *>(this)))
+        return StorageMutability::Initializable;
+
+      return StorageMutability::Immutable;
     }
 
     auto *CD = dyn_cast<ConstructorDecl>(UseDC);
-    if (!CD) return false;
-    
+    if (!CD) return StorageMutability::Immutable;
+
     auto *CDC = CD->getDeclContext();
 
     // 'let' properties are not valid inside protocols.
     if (CDC->getExtendedProtocolDecl())
-      return false;
+      return StorageMutability::Immutable;
 
     // If this init is defined inside of the same type (or in an extension
     // thereof) as the let property, then it is mutable.
     if (CDC->getSelfNominalTypeDecl() !=
         getDeclContext()->getSelfNominalTypeDecl())
-      return false;
+      return StorageMutability::Immutable;
 
     if (base && CD->getImplicitSelfDecl() != base->getDecl())
-      return false;
+      return StorageMutability::Immutable;
 
     // If this is a convenience initializer (i.e. one that calls
     // self.init), then let properties are never mutable in it.  They are
     // only mutable in designated initializers.
     auto initKindAndExpr = CD->getDelegatingOrChainedInitKind();
     if (initKindAndExpr.initKind == BodyInitKind::Delegating)
-      return false;
+      return StorageMutability::Immutable;
 
-    return true;
+    return StorageMutability::Initializable;
   }
 
   // If the 'let' has a value bound to it but has no PBD, then it is
   // already initializedand not settable.
   if (getParentPatternBinding() == nullptr)
-    return false;
+    return StorageMutability::Immutable;
 
   // If the 'let' has an explicitly written initializer with a pattern binding,
   // then it isn't settable.
   if (isParentInitialized())
-    return false;
+    return StorageMutability::Immutable;
 
   // Normal lets (e.g. globals) are only mutable in the context of the
   // declaration.  To handle top-level code properly, we look through
   // the TopLevelCode decl on the use (if present) since the vardecl may be
   // one level up.
   if (getDeclContext() == UseDC)
-    return true;
+    return StorageMutability::Initializable;
 
   if (isa<TopLevelCodeDecl>(UseDC) &&
       getDeclContext() == UseDC->getParent())
-    return true;
+    return StorageMutability::Initializable;
 
-  return false;
+  return StorageMutability::Immutable;
 }
 
 bool VarDecl::isLazilyInitializedGlobal() const {

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -647,7 +647,8 @@ bool SILGenFunction::unsafelyInheritsExecutor() {
 
 void ExecutorBreadcrumb::emit(SILGenFunction &SGF, SILLocation loc) {
   if (mustReturnToExecutor) {
-    assert(SGF.ExpectedExecutor || SGF.unsafelyInheritsExecutor());
+    assert(SGF.ExpectedExecutor || SGF.unsafelyInheritsExecutor() ||
+           SGF.isCtorWithHopsInjectedByDefiniteInit());
     if (auto executor = SGF.ExpectedExecutor)
       SGF.B.createHopToExecutor(
           RegularLocation::getDebugOnlyLocation(loc, SGF.getModule()), executor,

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -618,6 +618,19 @@ static bool ctorHopsInjectedByDefiniteInit(ConstructorDecl *ctor,
   }
 }
 
+bool SILGenFunction::isCtorWithHopsInjectedByDefiniteInit() {
+  auto declRef = F.getDeclRef();
+  if (!declRef || !declRef.isConstructor())
+    return false;
+
+  auto ctor = dyn_cast_or_null<ConstructorDecl>(declRef.getDecl());
+  if (!ctor)
+    return false;
+
+  auto isolation = getActorIsolation(ctor);
+  return ctorHopsInjectedByDefiniteInit(ctor, isolation);
+}
+
 void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   MagicFunctionName = SILGenModule::getMagicFunctionName(ctor);
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -820,6 +820,10 @@ public:
   /// the fields.
   void emitDeallocatingMoveOnlyDestructor(DestructorDecl *dd);
 
+  /// Whether we are inside a constructor whose hops are injected by
+  /// definite initialization.
+  bool isCtorWithHopsInjectedByDefiniteInit();
+
   /// Generates code for a struct constructor.
   /// This allocates the new 'self' value, emits the
   /// body code, then returns the final initialized 'self'.

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -581,17 +581,6 @@ bool TypeChecker::requireArrayLiteralIntrinsics(ASTContext &ctx,
   return true;
 }
 
-Expr *TypeChecker::buildCheckedRefExpr(VarDecl *value, DeclContext *UseDC,
-                                       DeclNameLoc loc, bool Implicit) {
-  auto type = constraints::ConstraintSystem::getUnopenedTypeOfReference(
-      value, Type(), UseDC,
-      [&](VarDecl *var) -> Type { return value->getTypeInContext(); });
-  auto semantics = value->getAccessSemanticsFromContext(UseDC,
-                                                       /*isAccessOnSelf*/false);
-  return new (value->getASTContext())
-      DeclRefExpr(value, loc, Implicit, semantics, type);
-}
-
 Expr *TypeChecker::buildRefExpr(ArrayRef<ValueDecl *> Decls,
                                 DeclContext *UseDC, DeclNameLoc NameLoc,
                                 bool Implicit, FunctionRefKind functionRefKind) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -944,10 +944,6 @@ Comparison compareDeclarations(DeclContext *dc, ValueDecl *decl1,
 /// of the first one and the expression will still type check.
 bool isDeclRefinementOf(ValueDecl *declA, ValueDecl *declB);
 
-/// Build a type-checked reference to the given value.
-Expr *buildCheckedRefExpr(VarDecl *D, DeclContext *UseDC, DeclNameLoc nameLoc,
-                          bool Implicit);
-
 /// Build a reference to a declaration, where name lookup returned
 /// the given set of declarations.
 Expr *buildRefExpr(ArrayRef<ValueDecl *> Decls, DeclContext *UseDC,

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1396,7 +1396,9 @@ do {
   func generic<T>(_ value: inout T, _ closure: (S<T>) -> Void) {}
 
   let arg: Int
+  // expected-note@-1{{change 'let' to 'var' to make it mutable}}
   generic(&arg) { (g: S<Double>) -> Void in } // expected-error {{cannot convert value of type '(S<Double>) -> Void' to expected argument type '(S<Int>) -> Void'}}
+  // expected-error@-1{{cannot pass immutable value as inout argument: 'arg' is a 'let' constant}}
 }
 
 // rdar://problem/62428353 - bad error message for passing `T` where `inout T` was expected
@@ -1556,18 +1558,17 @@ func testNilCoalescingOperatorRemoveFix() {
   let _ = "" /* This is a comment */ ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{13-43=}}
 
   let _ = "" // This is a comment
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1558:13-1559:10=}}
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1560:13-1561:10=}}
 
   let _ = "" // This is a comment
     /*
      * The blank line below is part of the test case, do not delete it
      */
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1563:13-1567:10=}}
 
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1561:13-1566:10=}}
-
-  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-1569:9=}}
+  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-1570:9=}}
       "").isEmpty {}
 
   if ("" // This is a comment
-      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1571:9-1572:12=}}
+      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1572:9-1573:12=}}
 }

--- a/test/SILOptimizer/definite_init_existential_let.swift
+++ b/test/SILOptimizer/definite_init_existential_let.swift
@@ -15,7 +15,6 @@ class ImmutableP {
 
   init(field: P) {
     self.field = field
-    self.field.foo() // expected-error{{}}
     self.field.bar = 4 // expected-error{{}}
   }
 }
@@ -24,6 +23,5 @@ func immutableP(field: P) {
   let x: P // expected-note* {{}}
 
   x = field
-  x.foo() // expected-error{{}}
   x.bar = 4 // expected-error{{}}
 }

--- a/test/SILOptimizer/definite_init_inout_super_init.swift
+++ b/test/SILOptimizer/definite_init_inout_super_init.swift
@@ -15,7 +15,7 @@ class A : B {
 
   init() {
     self.x = 12
-    super.init(x: &x) // expected-error {{immutable value 'self.x' must not be passed inout}}
+    super.init(x: &x) // expected-error {{cannot pass immutable value as inout argument: 'x' is a 'let' constant}}
   }
 }
 
@@ -24,7 +24,7 @@ class C : B {
 
   init() {
     self.x = Klass()
-    super.init(x: &x) // expected-error {{immutable value 'self.x' must not be passed inout}}
+    super.init(x: &x) // expected-error {{cannot pass immutable value as inout argument: 'x' is a 'let' constant}}
   }
 }
 

--- a/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
+++ b/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
@@ -42,10 +42,8 @@ extension TestProtocol {
 
 // Mark: - Case3: Illegally mutating let constant in a function scope
 
-let testObject2: TestProtocol  // expected-note 2 {{change 'let' to 'var' to make it mutable}}
+let testObject2: TestProtocol
 testObject2 = TestStruct(foo: 42)
-testObject2.messThingsUp() // expected-error {{mutating method 'messThingsUp' may not be used on immutable value 'testObject2'}}
-try! testObject2.messThingsUpAndThenThrow() // expected-error {{mutating method 'messThingsUpAndThenThrow' may not be used on immutable value 'testObject2'}}
 
 func testFunc() {
     let testObject: TestProtocol // expected-note {{change 'let' to 'var' to make it mutable}}
@@ -56,10 +54,9 @@ func testFunc() {
 
 // Mark: - Case4: Illegally passing a let constants property as an inout parameter
 
-let testObject3: TestProtocol  // expected-note {{change 'let' to 'var' to make it mutable}}
+let testObject3: TestProtocol
 testObject3 = TestStruct(foo: 42)
 
 func mutateThis(mutatee: inout Int) {
     mutatee = 666
 }
-mutateThis(mutatee: &testObject3.foo) // expected-error {{cannot mutate property 'foo' of immutable value 'testObject3'}}

--- a/test/SILOptimizer/definite_init_value_types_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_value_types_diagnostics.swift
@@ -78,3 +78,16 @@ struct AddressStruct {
     self = AddressStruct()
   } // expected-error {{return from initializer without initializing all stored properties}}
 }
+
+// Old versions of swift-syntax have this logical use-before-definition; make
+// sure we keep it working.
+struct InitLogicalUseBeforeDef {
+  let offset: UInt16
+
+  init?(value: Int) {
+    if value > type(of: self.offset).max {
+      return nil
+    }
+    offset = UInt16(value)
+  }
+}

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -404,14 +404,19 @@ func takesClosure(_: (Int) -> Int) {
 
 func updateInt(_ x : inout Int) {}
 
+extension Int {
+  mutating func negateMe() { }
+}
+
 // rdar://15785677 - allow 'let' declarations in structs/classes be initialized in init()
 class LetClassMembers {
-  let a : Int       // expected-note 2 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}}
+  let a : Int       // expected-note 4 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}}
   let b : Int       // expected-note {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
 
   init(arg : Int) {
     a = arg             // ok, a is mutable in init()
-    updateInt(&a)       // ok, a is mutable in init() and has been initialized
+    a.negateMe()        // expected-error{{cannot use mutating member on immutable value: 'a' is a 'let' constant}}
+    updateInt(&a)       // expected-error{{cannot pass immutable value as inout argument: 'a' is a 'let' constant}}
     b = 17              // ok, b is mutable in init()
   }
 
@@ -422,12 +427,13 @@ class LetClassMembers {
   }
 }
 struct LetStructMembers {
-  let a : Int       // expected-note 2 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}}
+  let a : Int       // expected-note 4 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}}
   let b : Int       // expected-note {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
 
   init(arg : Int) {
     a = arg             // ok, a is mutable in init()
-    updateInt(&a)       // ok, a is mutable in init() and has been initialized
+    updateInt(&a)       // expected-error {{cannot pass immutable value as inout argument: 'a' is a 'let' constant}}
+    a += 1              // expected-error {{left side of mutating operator isn't mutable: 'a' is a 'let' constant}}
     b = 17              // ok, b is mutable in init()
   }
 

--- a/test/Sema/immutability_overload_async.swift
+++ b/test/Sema/immutability_overload_async.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+protocol Iterator {
+  associatedtype Failure: Error
+  mutating func next() async throws -> Int?
+}
+
+extension Iterator {
+  mutating func next() async throws(Failure) -> Int? {
+    nil
+  }
+}
+
+actor C: Iterator {
+  typealias Failure = any Error
+  func next() throws -> Int? { nil }
+}
+
+actor A {
+  let c = C()
+
+  init() async {
+    _ = try! await self.c.next()
+  }
+}


### PR DESCRIPTION
There are a number of places where references `let` properties are treated as lvalues by the type checker, and we rely on Definite Initialization to detect and diagnose `inout` uses of these properties. This includes:
* `let` instance properties of a type within an initializer.
* Local `let` properties that aren't initialized at point of declaration.

The result of modeling these as lvalues in the type checker is that we could end up selecting a `mutating` function for a `let` base, which would then get diagnosed in Definite Initialization. If there was an alternative non-`mutating` overload that is otherwise not preferred, it will essentially get ignored.

Rework our handling of `let` properties so that they are treated as rvalues uniformly *except* when they are being assigned to. This moves the inout/mutating checking up into the type checker, allowing overload resolution to choose appropriately.

Fixes rdar://127258363, a source compatibility issue with `AsyncIteratorProtocol.next()` that uncovered this issue.