### PR TITLE
SIL: fix runtime effects of initializing store

### DIFF
--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -781,9 +781,8 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
     switch (cast<StoreInst>(inst)->getOwnershipQualifier()) {
       case StoreOwnershipQualifier::Unqualified:
       case StoreOwnershipQualifier::Trivial:
-        return RuntimeEffect::NoEffect;
       case StoreOwnershipQualifier::Init:
-        return RuntimeEffect::RefCounting;
+        return RuntimeEffect::NoEffect;
       case StoreOwnershipQualifier::Assign:
         return RuntimeEffect::Releasing;
     }

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -505,3 +505,12 @@ func testLargeTuple() {
     _ = GenericStruct<SixInt8s>()
 }
 
+struct NonCopyableStruct: ~Copyable {
+  func foo() {}
+}
+
+@_noLocks
+func testNonCopyable() {
+  let t = NonCopyableStruct()
+  t.foo()
+}


### PR DESCRIPTION
An initializing store is not a copy and therefore doesn't perform ref counting operations

Fixes a false performance error when using non-copyable types. Resolves https://github.com/apple/swift/issues/73582.
