### PR TITLE
[cxx-interop] Fix a test on older macOS versions

### DIFF
--- a/test/Interop/Cxx/foreign-reference/Inputs/witness-table.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/witness-table.h
@@ -32,7 +32,7 @@ CxxLinkedList * _Nonnull makeLinkedList() {
 
 struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:immortal")))
-__attribute__((swift_attr("release:immortal"))) CxxSequence {
+__attribute__((swift_attr("release:immortal"))) MyCxxSequence {
   CxxLinkedList * _Nullable list = nullptr;
 
   CxxLinkedList * _Nullable next() {
@@ -45,14 +45,14 @@ __attribute__((swift_attr("release:immortal"))) CxxSequence {
   }
 };
 
-CxxSequence * _Nonnull makeSequence() {
+MyCxxSequence * _Nonnull makeSequence() {
   CxxLinkedList *buff = (CxxLinkedList *)malloc(sizeof(CxxLinkedList) * 4);
   buff[0].value = 0;
   buff[1].value = 1;
   buff[2].value = 2;
   buff[3].value = 3;
 
-  CxxSequence *seq = (CxxSequence *)malloc(sizeof(CxxSequence));
+  MyCxxSequence *seq = (MyCxxSequence *)malloc(sizeof(MyCxxSequence));
   seq->list = buff;
   return seq;
 }

--- a/test/Interop/Cxx/foreign-reference/witness-table.swift
+++ b/test/Interop/Cxx/foreign-reference/witness-table.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -Xfrontend -disable-availability-checking -g)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
 //
 // REQUIRES: executable_test
 // XFAIL: OS=windows-msvc
@@ -26,7 +26,13 @@ public struct List<NodeType: ListNode> : Sequence, IteratorProtocol
   }
 }
 
+@available(SwiftStdlib 5.8, *)
 extension CxxLinkedList : ListNode { }
+
+@available(SwiftStdlib 5.8, *)
+extension MyCxxSequence : Sequence, IteratorProtocol { }
+
+if #available(SwiftStdlib 5.8, *) {
 
 var WitnessTableTestSuite = TestSuite("Use foreign reference in a generic context")
 
@@ -41,8 +47,6 @@ WitnessTableTestSuite.test("As generic argument to List") {
   expectEqual(count, 4)
 }
 
-extension CxxSequence : Sequence, IteratorProtocol { }
-
 WitnessTableTestSuite.test("As a Sequence") {
   let list = makeSequence()
   var count = 0
@@ -51,6 +55,8 @@ WitnessTableTestSuite.test("As a Sequence") {
     count += 1
   }
   expectEqual(count, 3)
+}
+
 }
 
 runAllTests()


### PR DESCRIPTION
This is a test for C++ foreign reference types, which require Swift runtime support that was added in macOS 13.3.

rdar://127991790