### PR TITLE
Cherry-pick  adding sanitize-coverage args

### DIFF
--- a/lib/Option/SanitizerOptions.cpp
+++ b/lib/Option/SanitizerOptions.cpp
@@ -92,6 +92,12 @@ llvm::SanitizerCoverageOptions swift::parseSanitizerCoverageArgValue(
     } else if (StringRef(A->getValue(i)) == "trace-pc-guard") {
       opts.TracePCGuard = true;
       continue;
+    } else if (StringRef(A->getValue(i)) == "inline-8bit-counters") {
+      opts.Inline8bitCounters = true;
+      continue;
+    } else if (StringRef(A->getValue(i)) == "pc-table") {
+      opts.PCTable = true;
+      continue;
     }
 
     // Argument is not supported.

--- a/test/Driver/sanitize_coverage.swift
+++ b/test/Driver/sanitize_coverage.swift
@@ -5,7 +5,7 @@
 // REQUIRES: asan_runtime
 
 // Try some options
-// RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=edge,indirect-calls,trace-bb,trace-cmp,8bit-counters,inlnie-8bit-counters,pc-table  -sanitize=address %s | %FileCheck -check-prefix=SANCOV_EDGE_WITH_OPTIONS %s
+// RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=edge,indirect-calls,trace-bb,trace-cmp,8bit-counters,inline-8bit-counters,pc-table  -sanitize=address %s | %FileCheck -check-prefix=SANCOV_EDGE_WITH_OPTIONS %s
 
 // Invalid command line arguments
 // RUN: not %swiftc_driver -driver-print-jobs -sanitize-coverage=func %s 2>&1 | %FileCheck -check-prefix=SANCOV_WITHOUT_XSAN %s

--- a/test/Driver/sanitize_coverage.swift
+++ b/test/Driver/sanitize_coverage.swift
@@ -5,7 +5,7 @@
 // REQUIRES: asan_runtime
 
 // Try some options
-// RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=edge,indirect-calls,trace-bb,trace-cmp,8bit-counters  -sanitize=address %s | %FileCheck -check-prefix=SANCOV_EDGE_WITH_OPTIONS %s
+// RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=edge,indirect-calls,trace-bb,trace-cmp,8bit-counters,inlnie-8bit-counters,pc-table  -sanitize=address %s | %FileCheck -check-prefix=SANCOV_EDGE_WITH_OPTIONS %s
 
 // Invalid command line arguments
 // RUN: not %swiftc_driver -driver-print-jobs -sanitize-coverage=func %s 2>&1 | %FileCheck -check-prefix=SANCOV_WITHOUT_XSAN %s
@@ -16,6 +16,8 @@
 // RUN: not %swiftc_driver -driver-print-jobs -sanitize=address -sanitize-coverage=trace-bb %s 2>&1 | %FileCheck -check-prefix=SANCOV_MISSING_ARG %s
 // RUN: not %swiftc_driver -driver-print-jobs -sanitize=address -sanitize-coverage=trace-cmp %s 2>&1 | %FileCheck -check-prefix=SANCOV_MISSING_ARG %s
 // RUN: not %swiftc_driver -driver-print-jobs -sanitize=address -sanitize-coverage=8bit-counters %s 2>&1 | %FileCheck -check-prefix=SANCOV_MISSING_ARG %s
+// RUN: not %swiftc_driver -driver-print-jobs -sanitize=address -sanitize-coverage=inline-8bit-counters %s 2>&1 | %FileCheck -check-prefix=SANCOV_MISSING_ARG %s
+// RUN: not %swiftc_driver -driver-print-jobs -sanitize=address -sanitize-coverage=pc-table %s 2>&1 | %FileCheck -check-prefix=SANCOV_MISSING_ARG %s
 
 // SANCOV_FUNC: swift
 // SANCOV_FUNC-DAG: -sanitize-coverage=func


### PR DESCRIPTION
As is, you cannot set all default fuzzer options directly using -sanitize-coverage. Because of this you can use default fuzzer sanitize-coverage args, or a limited number coverage options.

This PR adds pc-table and inline-8bit-counter as valid args to be parsed for sanitize-coverage flag. These are default fuzzer options -- and will allow customizing sanitizer-coverage in variations of fuzzer defaults. (i.e. w/o pc-table enabled).

In upstream clang the option -fno-sanitize-coverage exists to disable various coverage options. Swift currently does not have a convention of using excluding args for sanitizer flags. This aims to limit the need for a new flag by inclusively setting desired coverage up to current fuzzer defaults.

Corresponding swift-driver change: https://github.com/apple/swift-driver/pull/1604

rdar://127881891