### PR TITLE
[6.0] Fix initialization of imported ObjC block types.

### DIFF
--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -637,8 +637,21 @@ UNOWNED_OR_NONE_DEPENDING_ON_RESULT(AtomicLoad)
 UNOWNED_OR_NONE_DEPENDING_ON_RESULT(ExtractElement)
 UNOWNED_OR_NONE_DEPENDING_ON_RESULT(InsertElement)
 UNOWNED_OR_NONE_DEPENDING_ON_RESULT(ShuffleVector)
-UNOWNED_OR_NONE_DEPENDING_ON_RESULT(ZeroInitializer)
 #undef UNOWNED_OR_NONE_DEPENDING_ON_RESULT
+
+#define OWNED_OR_NONE_DEPENDING_ON_RESULT(ID)                                  \
+  ValueOwnershipKind ValueOwnershipKindBuiltinVisitor::visit##ID(              \
+      BuiltinInst *BI, StringRef Attr) {                                       \
+    if (BI->getType().isTrivial(*BI->getFunction())) {                         \
+      return OwnershipKind::None;                                              \
+    }                                                                          \
+    return OwnershipKind::Owned;                                               \
+  }
+// A zeroInitializer may initialize an imported struct with __unsafe_unretained
+// fields. The initialized value is immediately consumed by an assignment, so it
+// must be owned.
+OWNED_OR_NONE_DEPENDING_ON_RESULT(ZeroInitializer)
+#undef OWNED_OR_NONE_DEPENDING_ON_RESULT
 
 #define BUILTIN(X,Y,Z)
 #define BUILTIN_SIL_OPERATION(ID, NAME, CATEGORY) \

--- a/test/ClangImporter/Inputs/objc_init_blocks.h
+++ b/test/ClangImporter/Inputs/objc_init_blocks.h
@@ -1,0 +1,7 @@
+#import <CoreFoundation/CoreFoundation.h>
+
+typedef bool (^boolBlock)(void);
+
+struct objc_bool_block {
+  __unsafe_unretained boolBlock block;
+};

--- a/test/ClangImporter/objc_init_blocks.swift
+++ b/test/ClangImporter/objc_init_blocks.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/objc_init_blocks.h %s -emit-sil -sil-verify-all
+
+// REQUIRES: objc_interop
+
+// rdar://126142109: import an __unsafe_unretained block as zero-initialized.
+//
+// Make sure that the SIL ownership verifier passes.
+// UnsafeUnretainedBlockClass.init()
+// CHECK-LABEL: sil hidden @$s16objc_init_blocks26UnsafeUnretainedBlockClassCACycfc : $@convention(method) (@owned UnsafeUnretainedBlockClass) -> @owned UnsafeUnretainedBlockClass {
+// CHECK: [[ZI:%.*]] = builtin "zeroInitializer"<objc_bool_block>() : $objc_bool_block
+// CHECK:   store [[ZI]] to %{{.*}} : $*objc_bool_block
+// CHECK-LABEL: } // end sil function '$s16objc_init_blocks26UnsafeUnretainedBlockClassCACycfc'
+open class UnsafeUnretainedBlockClass {
+  public internal(set) var sc: objc_bool_block
+  init() {
+    self.sc = objc_bool_block()
+  }
+}


### PR DESCRIPTION
This fixes a SIL ownership verification error when importing structs like:

typedef bool (^boolBlock)(void);

struct objc_bool_block {
  __unsafe_unretained boolBlock block;
};

Fixes rdar://126142109 (Found an operand with a value that is not compatible with the operand's operand ownership kind map)

(cherry picked from commit c112e03a32ef2c7ba8dd51b8d3344769bbfb91eb)

--- CCC ---

Explanation: This fixes a SIL ownership verification error when importing ObjC blocks by making Builtin.zeroInitializer produce an owned SIL value.

Scope: The bug produces invalid SIL, but is unlikely to affect release builds.

Radar/SR Issue: rdar://126142109 (Found an operand with a value that is not compatible with the operand's operand ownership kind map)

main PR: https://github.com/apple/swift/pull/73577

Risk: Makes it valid in SIL to destroy a zero-initialized value. If that actualy happens, it would be a runtime crash.

Testing: Unit test added.

Reviewer: Egor Zhdan

