### PR TITLE
Allow AddressUseDefWalker to continue past MarkUninitializedInst

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtilsTest.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtilsTest.swift
@@ -1,0 +1,23 @@
+//===--- AccessUtils.swift - Utilities for analyzing memory accesses ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// TODO: Move this to AccessUtils.swift when FunctionTest is available.
+//
+//===----------------------------------------------------------------------===//
+
+let getAccessBaseTest = FunctionTest("swift_get_access_base") {
+  function, arguments, context in
+  let address = arguments.takeValue()
+  print("Address: \(address)")
+  let base = address.accessBase
+  print("Base: \(base)")
+}

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
@@ -7,6 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 swift_compiler_sources(Optimizer
+  AccessUtilsTest.swift
   AddressUtils.swift
   BorrowedFromUpdater.swift
   BorrowUtils.swift

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -153,6 +153,7 @@ extension BridgedTestArguments {
 public func registerOptimizerTests() {
   // Register each test.
   registerFunctionTests(
+    getAccessBaseTest,
     argumentConventionsTest,
     borrowIntroducersTest,
     enclosingValuesTest,

--- a/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
@@ -777,8 +777,8 @@ extension AddressUseDefWalker {
       } else {
         return walkUp(address: ia.base, path: path.push(.anyIndexedElement, index: 0))
       }
-    case let mdi as MarkDependenceInst:
-      return walkUp(address: mdi.operands[0].value, path: path)
+    case is MarkDependenceInst, is MarkUninitializedInst:
+      return walkUp(address: (def as! Instruction).operands[0].value, path: path)
     case is MoveOnlyWrapperToCopyableAddrInst,
          is CopyableToMoveOnlyWrapperAddrInst:
       return walkUp(address: (def as! Instruction).operands[0].value, path: path)

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2087,13 +2087,14 @@ struct AccessUseTestVisitor : public AccessUseVisitor {
   }
 };
 
-static FunctionTest AccessPathBaseTest("accesspath-base", [](auto &function,
-                                                             auto &arguments,
-                                                             auto &test) {
+static FunctionTest AccessPathBaseTest("accesspath", [](auto &function,
+                                                        auto &arguments,
+                                                        auto &test) {
   auto value = arguments.takeValue();
   function.print(llvm::outs());
-  llvm::outs() << "Access path base: " << value;
+  llvm::outs() << "Access path for: " << value;
   auto accessPathWithBase = AccessPathWithBase::compute(value);
+  llvm::outs() << "  base: " << accessPathWithBase.base;
   AccessUseTestVisitor visitor;
   visitAccessPathBaseUses(visitor, accessPathWithBase, &function);
 });

--- a/test/SILOptimizer/accessbase_unit.sil
+++ b/test/SILOptimizer/accessbase_unit.sil
@@ -65,3 +65,24 @@ sil @test_access_global : $@convention(thin) () -> () {
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test {{.*}} on test_mark_uninitialized_inst: get_access_base
+// CHECK: Address:  %{{.*}} = mark_uninitialized [var] [[ALLOC:%.*]] : $*C
+// CHECK: Base:     [[ALLOC]] = alloc_stack [var_decl] $C
+// CHECK-LABEL: end running test {{.*}} on test_mark_uninitialized_inst: get_access_base
+// CHECK-LABEL: begin running test {{.*}} on test_mark_uninitialized_inst: swift_get_access_base
+// CHECK: Address:  %{{.*}} = mark_uninitialized [var] [[ALLOC:%.*]] : $*C
+// CHECK: Base: stack - [[ALLOC]] = alloc_stack [var_decl] $C
+// CHECK-LABEL: end running test {{.*}} on test_mark_uninitialized_inst: swift_get_access_base
+sil [ossa] @test_mark_uninitialized_inst : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  %1 = alloc_stack [var_decl] $C, let
+  %2 = mark_uninitialized [var] %1 : $*C
+  specify_test "get_access_base %2"
+  specify_test "swift_get_access_base %2"
+  assign %0 to %2 : $*C
+  destroy_addr %2 : $*C
+  dealloc_stack %1 : $*C
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/accessbase_unit.sil
+++ b/test/SILOptimizer/accessbase_unit.sil
@@ -27,10 +27,10 @@ class C {}
 // CHECK:       Class [[BOX]] = argument of bb0
 // CHECK:         Field: var value: T Index: 0
 // CHECK-LABEL: end running test {{.*}} on test_phi_nested_access: compute_access_storage with
-// CHECK-LABEL: begin running test 3 of 3 on test_phi_nested_access: accesspath-base
-// CHECK:       Access path base: %6 = argument of bb1
+// CHECK-LABEL: begin running test 3 of 3 on test_phi_nested_access: accesspath
+// CHECK:       Access path for: %6 = argument of bb1
 // CHECK:       Exact Use:   end_access %2
-// CHECK-LABEL: end running test 3 of 3 on test_phi_nested_access: accesspath-base
+// CHECK-LABEL: end running test 3 of 3 on test_phi_nested_access: accesspath
 sil @test_phi_nested_access : $@convention(method) (@guaranteed Box<C>) -> () {
 bb1(%box : $Box<C>):         
   %value_addr = ref_element_addr %box : $Box<C>, #Box.value 
@@ -42,7 +42,7 @@ bb1(%box : $Box<C>):
 exit(%phi : $Builtin.RawPointer):                   
   specify_test "get_access_base @argument"
   specify_test "compute_access_storage @argument"
-  specify_test "accesspath-base @argument"
+  specify_test "accesspath @argument"
   %retval = tuple ()
   return %retval : $()
 } 

--- a/test/SILOptimizer/accesspath_unit.sil
+++ b/test/SILOptimizer/accesspath_unit.sil
@@ -20,34 +20,36 @@ struct S2 {
 sil_global hidden @globalKlass : $Klass
 sil_global hidden @globalStruct : $S2
 
-// CHECK-LABEL: begin running test 1 of 2 on testRefElement: accesspath-base with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 2 on testRefElement: accesspath with: @trace[0]
 // CHECK: [[P1:%.*]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]] : $*S
 // CHECK: [[P2:%.*]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]] : $*S
-// CHECK: Access path base:  [[P1]] = ref_element_addr %0 : $Klass, #Klass.f
+// CHECK: Access path for:  [[P1]] = ref_element_addr %0 : $Klass, #Klass.f
+// CHECK-NEXT: base: [[P1]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK-NEXT: Exact Use:   %{{.*}} = load [trivial] [[A1]] : $*S
 // CHECK-NEXT: Exact Use:   end_access [[A1]] : $*S
-// CHECK: end running test 1 of 2 on testRefElement: accesspath-base with: @trace[0]
+// CHECK: end running test 1 of 2 on testRefElement: accesspath with: @trace[0]
 
-// CHECK-LABEL: begin running test 2 of 2 on testRefElement: accesspath-base with: @trace[1]
+// CHECK-LABEL: begin running test 2 of 2 on testRefElement: accesspath with: @trace[1]
 // CHECK: [[P1:%.*]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]] : $*S
 // CHECK: [[P2:%.*]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]] : $*S
-// CHECK: Access path base:  [[P2]] = ref_element_addr %0 : $Klass, #Klass.f
+// CHECK: Access path for:  [[P2]] = ref_element_addr %0 : $Klass, #Klass.f
+// CHECK: base: [[P2]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK-NEXT: Exact Use:   %{{.*}} = load [trivial] [[A2]] : $*S
 // CHECK-NEXT: Exact Use:   end_access [[A2]] : $*S
-// CHECK: end running test 2 of 2 on testRefElement: accesspath-base with: @trace[1]
+// CHECK: end running test 2 of 2 on testRefElement: accesspath with: @trace[1]
 sil hidden [ossa] @testRefElement : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  specify_test "accesspath-base @trace[0]"
+  specify_test "accesspath @trace[0]"
   %p1 = ref_element_addr %0 : $Klass, #Klass.f
   debug_value [trace] %p1 : $*S
   %a1 = begin_access [read] [dynamic] %p1 : $*S
   %l1 = load [trivial] %a1 : $*S
   end_access %a1 : $*S
-  specify_test "accesspath-base @trace[1]"
+  specify_test "accesspath @trace[1]"
   %p2 = ref_element_addr %0 : $Klass, #Klass.f
   debug_value [trace] %p2 : $*S
   %a2 = begin_access [read] [dynamic] %p2 : $*S
@@ -57,28 +59,30 @@ bb0(%0 : @guaranteed $Klass):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 2 on testGlobalAddrKlass: accesspath with: @trace[0]
 // CHECK: [[P1:%.*]] = global_addr @globalKlass : $*Klass
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]] : $*Klass
 // CHECK: [[P2:%.*]] = global_addr @globalKlass : $*Klass
 // CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]] : $*Klass
-// CHECK: Access path base:  [[P1]] = global_addr @globalKlass : $*Klass
+// CHECK: Access path for:  [[P1]] = global_addr @globalKlass : $*Klass
+// CHECK: base:  [[P1]] = global_addr @globalKlass : $*Klass
 // CHECK-NEXT: Exact Use:   %{{.*}} = load_borrow [[A1]]
 // CHECK-NEXT: Exact Use:   end_access [[A1]]
-// CHECK: end running test 1 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[0]
+// CHECK: end running test 1 of 2 on testGlobalAddrKlass: accesspath with: @trace[0]
 
-// CHECK-LABEL: begin running test 2 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[1]
+// CHECK-LABEL: begin running test 2 of 2 on testGlobalAddrKlass: accesspath with: @trace[1]
 // CHECK: [[P1:%.*]] = global_addr @globalKlass : $*Klass
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]] : $*Klass
 // CHECK: [[P2:%.*]] = global_addr @globalKlass : $*Klass
 // CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]] : $*Klass
-// CHECK: Access path base:  [[P2]] = global_addr @globalKlass : $*Klass
+// CHECK: Access path for:  [[P2]] = global_addr @globalKlass : $*Klass
+// CHECK: base:  [[P2]] = global_addr @globalKlass : $*Klass
 // CHECK-NEXT: Exact Use:   %{{.*}} = load_borrow [[A2]]
 // CHECK-NEXT: Exact Use:   end_access [[A2]]
-// CHECK: end running test 2 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[1]
+// CHECK: end running test 2 of 2 on testGlobalAddrKlass: accesspath with: @trace[1]
 sil [ossa] @testGlobalAddrKlass : $@convention(thin) () -> () {
 bb0:
-  specify_test "accesspath-base @trace[0]"
+  specify_test "accesspath @trace[0]"
   %p1 = global_addr @globalKlass : $*Klass
   debug_value [trace] %p1 : $*Klass
   %a1 = begin_access [read] [dynamic] %p1 : $*Klass
@@ -86,7 +90,7 @@ bb0:
   end_borrow %l1 : $Klass
   end_access %a1 : $*Klass
 
-  specify_test "accesspath-base @trace[1]"
+  specify_test "accesspath @trace[1]"
   %p2 = global_addr @globalKlass : $*Klass
   debug_value [trace] %p2 : $*Klass
   %a2 = begin_access [read] [dynamic] %p2 : $*Klass
@@ -98,7 +102,7 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 3 on testGlobalAddrStruct: accesspath with: @trace[0]
 // CHECK: [[P1:%.*]] = global_addr @globalStruct
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]]
 // CHECK: [[P2:%.*]] = global_addr @globalStruct
@@ -107,12 +111,13 @@ bb0:
 // CHECK: [[P3:%.*]] = global_addr @globalStruct
 // CHECK: [[A3:%.*]] = begin_access [read] [dynamic] [[P3]]
 // CHECK: [[GEP3:%.*]] = struct_element_addr [[A3]]
-// CHECK: Access path base:  [[P1]] = global_addr @globalStruct
+// CHECK: Access path for:  [[P1]] = global_addr @globalStruct
+// CHECK: base:  [[P1]] = global_addr @globalStruct
 // CHECK-NEXT: Exact Use:   %{{.*}} = load_borrow [[A1]]
 // CHECK-NEXT: Exact Use:   end_access [[A1]]
-// CHECK: end running test 1 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[0]
+// CHECK: end running test 1 of 3 on testGlobalAddrStruct: accesspath with: @trace[0]
 
-// CHECK-LABEL: begin running test 2 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[1]
+// CHECK-LABEL: begin running test 2 of 3 on testGlobalAddrStruct: accesspath with: @trace[1]
 // CHECK: [[P1:%.*]] = global_addr @globalStruct
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]]
 // CHECK: [[P2:%.*]] = global_addr @globalStruct
@@ -121,12 +126,13 @@ bb0:
 // CHECK: [[P3:%.*]] = global_addr @globalStruct
 // CHECK: [[A3:%.*]] = begin_access [read] [dynamic] [[P3]]
 // CHECK: [[GEP3:%.*]] = struct_element_addr [[A3]]
-// CHECK: Access path base:  [[P2]] = global_addr @globalStruct
+// CHECK: Access path for:  [[P2]] = global_addr @globalStruct
+// CHECK: base:  [[P2]] = global_addr @globalStruct
 // CHECK-NEXT: Inner Use:   %{{.*}} = load_borrow [[GEP2]]
 // CHECK-NEXT: Exact Use:   end_access [[A2]]
-// CHECK: end running test 2 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[1]
+// CHECK: end running test 2 of 3 on testGlobalAddrStruct: accesspath with: @trace[1]
 
-// CHECK-LABEL: begin running test 3 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[2]
+// CHECK-LABEL: begin running test 3 of 3 on testGlobalAddrStruct: accesspath with: @trace[2]
 // CHECK: [[P1:%.*]] = global_addr @globalStruct
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]]
 // CHECK: [[P2:%.*]] = global_addr @globalStruct
@@ -135,13 +141,14 @@ bb0:
 // CHECK: [[P3:%.*]] = global_addr @globalStruct
 // CHECK: [[A3:%.*]] = begin_access [read] [dynamic] [[P3]]
 // CHECK: [[GEP3:%.*]] = struct_element_addr [[A3]]
-// CHECK: Access path base:  [[P3]] = global_addr @globalStruct
+// CHECK: Access path for:  [[P3]] = global_addr @globalStruct
+// CHECK: base:  [[P3]] = global_addr @globalStruct
 // CHECK-NEXT: Inner Use:   %{{.*}} = load_borrow [[GEP3]]
 // CHECK-NEXT: Exact Use:   end_access [[A3]]
-// CHECK: end running test 3 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[2]
+// CHECK: end running test 3 of 3 on testGlobalAddrStruct: accesspath with: @trace[2]
 sil [ossa] @testGlobalAddrStruct : $@convention(thin) () -> () {
 bb0:
-  specify_test "accesspath-base @trace[0]"
+  specify_test "accesspath @trace[0]"
   %p3 = global_addr @globalStruct : $*S2
   debug_value [trace] %p3 : $*S2
   %a3 = begin_access [read] [dynamic] %p3 : $*S2
@@ -149,7 +156,7 @@ bb0:
   end_borrow %l3 : $S2
   end_access %a3 : $*S2
 
-  specify_test "accesspath-base @trace[1]"
+  specify_test "accesspath @trace[1]"
   %p4 = global_addr @globalStruct : $*S2
   debug_value [trace] %p4 : $*S2
   %a4 = begin_access [read] [dynamic] %p4 : $*S2
@@ -158,7 +165,7 @@ bb0:
   end_borrow %l4 : $Klass
   end_access %a4 : $*S2
 
-  specify_test "accesspath-base @trace[2]"
+  specify_test "accesspath @trace[2]"
   %p5 = global_addr @globalStruct : $*S2
   debug_value [trace] %p5 : $*S2
   %a5 = begin_access [read] [dynamic] %p5 : $*S2


### PR DESCRIPTION
Also adds test infrastructure to match the C++ tests so we can guarantee consistency across code bases.