### PR TITLE
IRGen: Large types reg2mem - Fix visitUncheckedTrivialBitCastInst

### DIFF
--- a/test/IRGen/Inputs/large_c.h
+++ b/test/IRGen/Inputs/large_c.h
@@ -43,7 +43,7 @@ typedef struct _ContainerType {
 
 typedef unsigned char arr_t[32];
 
-typedef enum {
+typedef enum : unsigned int {
     entry_0       = 0,
     entry_1       = 1,
     entry_2       = 2,

--- a/test/IRGen/Inputs/large_c.h
+++ b/test/IRGen/Inputs/large_c.h
@@ -40,3 +40,40 @@ typedef struct _ContainerType {
   char x1;
   ContainedType l[10];
 }  __attribute__((packed)) ContainerType;
+
+typedef unsigned char arr_t[32];
+
+typedef enum {
+    entry_0       = 0,
+    entry_1       = 1,
+    entry_2       = 2,
+    entry_3       = 3,
+    entry_4       = 4,
+    entry_5       = 5,
+    entry_6       = 6,
+    entry_7       = 7,
+    entry_8       = 8,
+    entry_9       = 9,
+    entry_10      = 10,
+    entry_11      = 11,
+    entry_12      = 12,
+    entry_13      = 13,
+    entry_14      = 14,
+    entry_15      = 15,
+    entry_16      = 16,
+    entry_17      = 17,
+    entry_18      = 18,
+    entry_invalid = 255,
+} enum_t;
+
+typedef union {
+    struct {
+        enum_t  slot;
+        arr_t   buf;
+    } in;
+    struct {
+        int     result;
+        arr_t   buff;
+        unsigned char cnt;
+    } out;
+} union_t;

--- a/test/IRGen/large_union.swift
+++ b/test/IRGen/large_union.swift
@@ -7,13 +7,13 @@ public func test1(_ s: some_struct) -> some_struct {
 }
 // CHECK: sil @$s1t5test1ySo11some_structaADF : $@convention(thin) (@in_guaranteed some_struct) -> @out some_struct {
 // CHECK-NOT: unchecked_trivial_bitcast
-// CHECK: unchecked_addr_cast {{.*}} : $*some_struct.__Unnamed_struct_out to $*some_struct
+// CHECK: unchecked_addr_cast {{.*}} : $*some_struct to $*some_struct.__Unnamed_struct_out
 // CHECK-NOT: unchecked_trivial_bitcast
 // CHECK: } // end sil function '$s1t5test1ySo11some_structaADF'
 
 // CHECK: sil @$s1t5test2yySo11some_structazF : $@convention(thin) (@inout some_struct) -> () {
 // CHECK-NOT: unchecked_trivial_bitcast
-// CHECK: unchecked_addr_cast {{.*}} : $*some_struct.__Unnamed_struct_out to $*some_struct
+// CHECK: unchecked_addr_cast {{.*}} : $*some_struct to $*some_struct.__Unnamed_struct_out
 // CHECK-NOT: unchecked_trivial_bitcast
 // CHECK: } // end sil function '$s1t5test2yySo11some_structazF'
 

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -269,3 +269,30 @@ bb0(%0 : $*C1, %1 : $*Small):
   %t = tuple ()
   return %t : $()
 }
+
+sil @use : $@convention(thin) (UInt32) -> ()
+
+// We need to make sure we use the bigger alloc_stack for the address of
+// unchecked_trivial_bit_cast. A bitcast can go from bigger to smaller type.
+
+// CHECK: sil @test11 : $@convention(thin) (@in union_t) -> () {
+// CHECK-NOT: unchecked_addr_cast %1 : $*union_t.__Unnamed_struct_in to $*union_t
+// CHECK: unchecked_addr_cast {{.*}} : $*union_t to $*union_t.__Unnamed_struct_in
+// CHECK: } // end sil function 'test11'
+
+sil @test11 : $@convention(thin) (@in union_t) -> () {
+bb0(%0 : $*union_t):
+  %1 = alloc_stack $union_t
+  %2 = alloc_stack $union_t
+  copy_addr [take] %0 to [init] %2 : $*union_t
+  %4 = load %2 : $*union_t
+  %7 = unchecked_trivial_bit_cast %4 : $union_t to $union_t.__Unnamed_struct_in
+  %8 = struct_extract %7 : $union_t.__Unnamed_struct_in, #union_t.__Unnamed_struct_in.slot
+  %10 = struct_extract %8 : $enum_t, #enum_t.rawValue
+  %11 = function_ref @use : $@convention(thin) (UInt32) -> ()
+  %12 = apply %11(%10) : $@convention(thin) (UInt32) -> ()
+  %13 = tuple ()
+  dealloc_stack %2 : $*union_t
+  dealloc_stack %1 : $*union_t
+  return %13 : $()
+}


### PR DESCRIPTION
An unchecked_trivial_bit_cast can go from a bigger type to a smaller type. Therefore we must allocate stack storage for the operand type rather than the result type. Otherwise, we can end up storing bigger values into smaller storage -- not good.

rdar://128086028