### PR TITLE
Adding stage-0 toolchain build preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1003,6 +1003,23 @@ skip-build-benchmarks
 
 reconfigure
 
+[preset: buildbot_linux,no_test,stage0]
+build-subdir=buildbot_linux/stage0
+install-destdir=%(install_destdir)s
+skip-build-benchmarks
+skip-test-cmark
+skip-early-swift-driver
+skip-early-swiftsyntax
+bootstrapping=off
+llvm-targets-to-build=X86;ARM;AArch64
+libdispatch
+foundation
+swiftpm
+xctest
+llbuild
+swift-driver
+install-all
+
 [preset: buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build,aarch64]
 mixin-preset=buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build
 


### PR DESCRIPTION
This is a preset for building a stage-0 compiler toolchain that doesn't require an existing Swift installation. The resulting compiler should not be used outside of bringing up a stage-1 compiler, which in turn should build a stage 2 compiler. That stage 2 compiler should run and test cleanly. The stage-0 compiler will definitely fail its tests, and the stage-1 compiler may or may not depending on the weather. The stage-2 compiler is the compiler toolchain that should be shippable.