### PR TITLE
[CodeCompletion] Remove warning for 'async in non-concurrency context'

### DIFF
--- a/include/swift/AST/DiagnosticsIDE.def
+++ b/include/swift/AST/DiagnosticsIDE.def
@@ -15,10 +15,6 @@
 
 //===----------------------------------------------------------------------===//
 
-ERROR(ide_async_in_nonasync_context, none,
-      "async %0 used in a context that does not support concurrency",
-      (StringRef))
-
 // NOTE: This is WARNING because this is emitted for cross actor references with
 // non-'Sendable' types. That is optionally ('-warn-concurrency') warning in
 // Swift 5.5.

--- a/include/swift/AST/DiagnosticsIDE.def
+++ b/include/swift/AST/DiagnosticsIDE.def
@@ -15,13 +15,6 @@
 
 //===----------------------------------------------------------------------===//
 
-// NOTE: This is WARNING because this is emitted for cross actor references with
-// non-'Sendable' types. That is optionally ('-warn-concurrency') warning in
-// Swift 5.5.
-WARNING(ide_cross_actor_reference_swift5, none,
-        "actor-isolated %0 should only be referenced from inside the actor",
-        (StringRef))
-
 WARNING(ide_has_async_alternative, none,
         "%0 has an async alternative that should be preferred in an async "
         "context", (StringRef))

--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -261,7 +261,6 @@ enum class NotRecommendedReason : uint8_t {
   RedundantImportIndirect,               // contextual
   Deprecated,                            // context-free
   SoftDeprecated,                        // context-free
-  CrossActorReference,                   // contextual
   VariableUsedInOwnDefinition,           // contextual
   NonAsyncAlternativeUsedInAsyncContext, // contextual
 
@@ -299,7 +298,6 @@ enum class ContextualNotRecommendedReason : uint8_t {
   None = 0,
   RedundantImport,
   RedundantImportIndirect,
-  CrossActorReference,
   VariableUsedInOwnDefinition,
   /// A method that is sync and has an async alternative is used in an async
   /// context.
@@ -710,8 +708,6 @@ public:
       return NotRecommendedReason::RedundantImportIndirect;
     case ContextualNotRecommendedReason::NonAsyncAlternativeUsedInAsyncContext:
       return NotRecommendedReason::NonAsyncAlternativeUsedInAsyncContext;
-    case ContextualNotRecommendedReason::CrossActorReference:
-      return NotRecommendedReason::CrossActorReference;
     case ContextualNotRecommendedReason::VariableUsedInOwnDefinition:
       return NotRecommendedReason::VariableUsedInOwnDefinition;
     }

--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -371,7 +371,6 @@ class ContextFreeCodeCompletionResult {
   CodeCompletionMacroRoles MacroRoles;
 
   bool IsSystem : 1;
-  bool IsAsync : 1;
   /// Whether the result has been annotated as having an async alternative that
   /// should be preferred in async contexts.
   bool HasAsyncAlternative : 1;
@@ -406,7 +405,7 @@ public:
   ContextFreeCodeCompletionResult(
       CodeCompletionResultKind Kind, uint8_t AssociatedKind,
       CodeCompletionOperatorKind KnownOperatorKind,
-      CodeCompletionMacroRoles MacroRoles, bool IsSystem, bool IsAsync,
+      CodeCompletionMacroRoles MacroRoles, bool IsSystem,
       bool HasAsyncAlternative, CodeCompletionString *CompletionString,
       NullTerminatedStringRef ModuleName,
       NullTerminatedStringRef BriefDocComment,
@@ -418,7 +417,7 @@ public:
       NullTerminatedStringRef FilterName,
       NullTerminatedStringRef NameForDiagnostics)
       : Kind(Kind), KnownOperatorKind(KnownOperatorKind),
-        MacroRoles(MacroRoles), IsSystem(IsSystem), IsAsync(IsAsync),
+        MacroRoles(MacroRoles), IsSystem(IsSystem),
         HasAsyncAlternative(HasAsyncAlternative),
         CompletionString(CompletionString), ModuleName(ModuleName),
         BriefDocComment(BriefDocComment), AssociatedUSRs(AssociatedUSRs),
@@ -435,8 +434,6 @@ public:
            "Completion item should have diagnostic message iff the diagnostics "
            "severity is not none");
     assert(CompletionString && "Result should have a completion string");
-    assert(!(HasAsyncAlternative && IsAsync) &&
-           "A function shouldn't be both async and have an async alternative");
     if (isOperator() && KnownOperatorKind == CodeCompletionOperatorKind::None) {
       this->KnownOperatorKind = getCodeCompletionOperatorKind(CompletionString);
     }
@@ -453,7 +450,7 @@ public:
   static ContextFreeCodeCompletionResult *createPatternOrBuiltInOperatorResult(
       CodeCompletionResultSink &Sink, CodeCompletionResultKind Kind,
       CodeCompletionString *CompletionString,
-      CodeCompletionOperatorKind KnownOperatorKind, bool IsAsync,
+      CodeCompletionOperatorKind KnownOperatorKin,
       NullTerminatedStringRef BriefDocComment,
       CodeCompletionResultType ResultType,
       ContextFreeNotRecommendedReason NotRecommended,
@@ -491,7 +488,7 @@ public:
   static ContextFreeCodeCompletionResult *
   createDeclResult(CodeCompletionResultSink &Sink,
                    CodeCompletionString *CompletionString,
-                   const Decl *AssociatedDecl, bool IsAsync,
+                   const Decl *AssociatedDecl,
                    bool HasAsyncAlternative, NullTerminatedStringRef ModuleName,
                    NullTerminatedStringRef BriefDocComment,
                    ArrayRef<NullTerminatedStringRef> AssociatedUSRs,
@@ -529,8 +526,6 @@ public:
   CodeCompletionMacroRoles getMacroRoles() const { return MacroRoles; }
 
   bool isSystem() const { return IsSystem; };
-
-  bool isAsync() const { return IsAsync; };
 
   bool hasAsyncAlternative() const { return HasAsyncAlternative; };
 

--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -261,7 +261,6 @@ enum class NotRecommendedReason : uint8_t {
   RedundantImportIndirect,               // contextual
   Deprecated,                            // context-free
   SoftDeprecated,                        // context-free
-  InvalidAsyncContext,                   // contextual
   CrossActorReference,                   // contextual
   VariableUsedInOwnDefinition,           // contextual
   NonAsyncAlternativeUsedInAsyncContext, // contextual
@@ -300,8 +299,6 @@ enum class ContextualNotRecommendedReason : uint8_t {
   None = 0,
   RedundantImport,
   RedundantImportIndirect,
-  /// A method that is async is being used in a non-async context.
-  InvalidAsyncContext,
   CrossActorReference,
   VariableUsedInOwnDefinition,
   /// A method that is sync and has an async alternative is used in an async
@@ -716,8 +713,6 @@ public:
       return NotRecommendedReason::RedundantImport;
     case ContextualNotRecommendedReason::RedundantImportIndirect:
       return NotRecommendedReason::RedundantImportIndirect;
-    case ContextualNotRecommendedReason::InvalidAsyncContext:
-      return NotRecommendedReason::InvalidAsyncContext;
     case ContextualNotRecommendedReason::NonAsyncAlternativeUsedInAsyncContext:
       return NotRecommendedReason::NonAsyncAlternativeUsedInAsyncContext;
     case ContextualNotRecommendedReason::CrossActorReference:

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -236,7 +236,6 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
     auto diagSeverity =
         static_cast<CodeCompletionDiagnosticSeverity>(*cursor++);
     auto isSystem = static_cast<bool>(*cursor++);
-    auto isAsync = static_cast<bool>(*cursor++);
     auto hasAsyncAlternative = static_cast<bool>(*cursor++);
     auto chunkIndex = read32le(cursor);
     auto moduleIndex = read32le(cursor);
@@ -267,8 +266,8 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
 
     ContextFreeCodeCompletionResult *result =
         new (*V.Allocator) ContextFreeCodeCompletionResult(
-            kind, associatedKind, opKind, roles, isSystem, isAsync,
-            hasAsyncAlternative, string, moduleName, briefDocComment,
+            kind, associatedKind, opKind, roles, isSystem,
+                                                           hasAsyncAlternative, string, moduleName, briefDocComment,
             llvm::ArrayRef(assocUSRs).copy(*V.Allocator),
             CodeCompletionResultType(resultTypes), notRecommended, diagSeverity,
             diagMessage, filterName, nameForDiagnostics);
@@ -428,7 +427,6 @@ static void writeCachedModule(llvm::raw_ostream &out,
       LE.write(static_cast<uint8_t>(R->getNotRecommendedReason()));
       LE.write(static_cast<uint8_t>(R->getDiagnosticSeverity()));
       LE.write(static_cast<uint8_t>(R->isSystem()));
-      LE.write(static_cast<uint8_t>(R->isAsync()));
       LE.write(static_cast<uint8_t>(R->hasAsyncAlternative()));
       LE.write(
           static_cast<uint32_t>(addCompletionString(R->getCompletionString())));

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -104,7 +104,7 @@ CodeCompletionCache::~CodeCompletionCache() {}
 /// This should be incremented any time we commit a change to the format of the
 /// cached results. This isn't expected to change very often.
 static constexpr uint32_t onDiskCompletionCacheVersion =
-    11; // Added macro roles
+    12; // Removed 'IsAsync'.
 
 /// Deserializes CodeCompletionResults from \p in and stores them in \p V.
 /// \see writeCacheModule.

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -166,10 +166,6 @@ bool swift::ide::getContextualCompletionDiagnostics(
     const ASTContext &Ctx) {
   CodeCompletionDiagnostics Diag(Ctx);
   switch (Reason) {
-  case ContextualNotRecommendedReason::InvalidAsyncContext:
-    // FIXME: Could we use 'diag::async_in_nonasync_function'?
-    return Diag.getDiagnostics(
-        Severity, Out, diag::ide_async_in_nonasync_context, NameForDiagnostics);
   case ContextualNotRecommendedReason::CrossActorReference:
     return Diag.getDiagnostics(Severity, Out,
                                diag::ide_cross_actor_reference_swift5,

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -166,10 +166,6 @@ bool swift::ide::getContextualCompletionDiagnostics(
     const ASTContext &Ctx) {
   CodeCompletionDiagnostics Diag(Ctx);
   switch (Reason) {
-  case ContextualNotRecommendedReason::CrossActorReference:
-    return Diag.getDiagnostics(Severity, Out,
-                               diag::ide_cross_actor_reference_swift5,
-                               NameForDiagnostics);
   case ContextualNotRecommendedReason::RedundantImport:
     return Diag.getDiagnostics(Severity, Out, diag::ide_redundant_import,
                                NameForDiagnostics);

--- a/lib/IDE/CodeCompletionResult.cpp
+++ b/lib/IDE/CodeCompletionResult.cpp
@@ -121,8 +121,7 @@ ContextFreeCodeCompletionResult *
 ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
     CodeCompletionResultSink &Sink, CodeCompletionResultKind Kind,
     CodeCompletionString *CompletionString,
-    CodeCompletionOperatorKind KnownOperatorKind, bool IsAsync,
-    NullTerminatedStringRef BriefDocComment,
+    CodeCompletionOperatorKind KnownOperatorKind, NullTerminatedStringRef BriefDocComment,
     CodeCompletionResultType ResultType,
     ContextFreeNotRecommendedReason NotRecommended,
     CodeCompletionDiagnosticSeverity DiagnosticSeverity,
@@ -138,7 +137,7 @@ ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
   }
   return new (Sink.getAllocator()) ContextFreeCodeCompletionResult(
       Kind, /*AssociatedKind=*/0, KnownOperatorKind, /*MacroRoles=*/{},
-      /*IsSystem=*/false, IsAsync, /*HasAsyncAlternative=*/false,
+      /*IsSystem=*/false, /*HasAsyncAlternative=*/false,
       CompletionString,
       /*ModuleName=*/"", BriefDocComment,
       /*AssociatedUSRs=*/{}, ResultType, NotRecommended, DiagnosticSeverity,
@@ -159,8 +158,7 @@ ContextFreeCodeCompletionResult::createKeywordResult(
   return new (Sink.getAllocator()) ContextFreeCodeCompletionResult(
       CodeCompletionResultKind::Keyword, static_cast<uint8_t>(Kind),
       CodeCompletionOperatorKind::None, /*MacroRoles=*/{},
-      /*IsSystem=*/false, /*IsAsync=*/false,
-      /*HasAsyncAlternative=*/false, CompletionString,
+      /*IsSystem=*/false, /*HasAsyncAlternative=*/false, CompletionString,
       /*ModuleName=*/"", BriefDocComment,
       /*AssociatedUSRs=*/{}, ResultType, ContextFreeNotRecommendedReason::None,
       CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"",
@@ -179,7 +177,7 @@ ContextFreeCodeCompletionResult::createLiteralResult(
   return new (Sink.getAllocator()) ContextFreeCodeCompletionResult(
       CodeCompletionResultKind::Literal, static_cast<uint8_t>(LiteralKind),
       CodeCompletionOperatorKind::None, /*MacroRoles=*/{},
-      /*IsSystem=*/false, /*IsAsync=*/false, /*HasAsyncAlternative=*/false,
+      /*IsSystem=*/false, /*HasAsyncAlternative=*/false,
       CompletionString,
       /*ModuleName=*/"",
       /*BriefDocComment=*/"",
@@ -207,7 +205,7 @@ getDeclNameForDiagnostics(const Decl *D, CodeCompletionResultSink &Sink) {
 ContextFreeCodeCompletionResult *
 ContextFreeCodeCompletionResult::createDeclResult(
     CodeCompletionResultSink &Sink, CodeCompletionString *CompletionString,
-    const Decl *AssociatedDecl, bool IsAsync, bool HasAsyncAlternative,
+    const Decl *AssociatedDecl, bool HasAsyncAlternative,
     NullTerminatedStringRef ModuleName, NullTerminatedStringRef BriefDocComment,
     ArrayRef<NullTerminatedStringRef> AssociatedUSRs,
     CodeCompletionResultType ResultType,
@@ -222,7 +220,7 @@ ContextFreeCodeCompletionResult::createDeclResult(
       CodeCompletionResultKind::Declaration,
       static_cast<uint8_t>(getCodeCompletionDeclKind(AssociatedDecl)),
       CodeCompletionOperatorKind::None, getCompletionMacroRoles(AssociatedDecl),
-      getDeclIsSystem(AssociatedDecl), IsAsync, HasAsyncAlternative,
+      getDeclIsSystem(AssociatedDecl), HasAsyncAlternative,
       CompletionString, ModuleName, BriefDocComment, AssociatedUSRs, ResultType,
       NotRecommended, DiagnosticSeverity, DiagnosticMessage,
       getCodeCompletionResultFilterName(CompletionString, Sink.getAllocator()),

--- a/lib/IDE/CodeCompletionResult.cpp
+++ b/lib/IDE/CodeCompletionResult.cpp
@@ -399,9 +399,6 @@ ContextFreeCodeCompletionResult::calculateContextualNotRecommendedReason(
   if (explicitReason != ContextualNotRecommendedReason::None) {
     return explicitReason;
   }
-  if (IsAsync && !canCurrDeclContextHandleAsync) {
-    return ContextualNotRecommendedReason::InvalidAsyncContext;
-  }
   if (HasAsyncAlternative && canCurrDeclContextHandleAsync) {
     return ContextualNotRecommendedReason::
         NonAsyncAlternativeUsedInAsyncContext;

--- a/lib/IDE/CodeCompletionResultBuilder.cpp
+++ b/lib/IDE/CodeCompletionResultBuilder.cpp
@@ -128,7 +128,7 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
     }
 
     ContextFreeResult = ContextFreeCodeCompletionResult::createDeclResult(
-        Sink, CCS, AssociatedDecl, IsAsync, HasAsyncAlternative, ModuleName,
+        Sink, CCS, AssociatedDecl, HasAsyncAlternative, ModuleName,
         NullTerminatedStringRef(BriefDocComment, Allocator),
         copyAssociatedUSRs(Allocator, AssociatedDecl), ResultType,
         ContextFreeNotRecReason, ContextFreeDiagnosticSeverity,
@@ -145,7 +145,7 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
   case CodeCompletionResultKind::Pattern:
     ContextFreeResult =
         ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
-            Sink, Kind, CCS, CodeCompletionOperatorKind::None, IsAsync,
+            Sink, Kind, CCS, CodeCompletionOperatorKind::None,
             NullTerminatedStringRef(BriefDocComment, Allocator), ResultType,
             ContextFreeNotRecReason, ContextFreeDiagnosticSeverity,
             ContextFreeDiagnosticMessage);

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -43,7 +43,6 @@ class CodeCompletionResultBuilder {
   CodeCompletionFlair Flair;
   unsigned NumBytesToErase = 0;
   const Decl *AssociatedDecl = nullptr;
-  bool IsAsync = false;
   bool HasAsyncAlternative = false;
   std::optional<CodeCompletionLiteralKind> LiteralKind;
   CodeCompletionKeywordKind KeywordKind = CodeCompletionKeywordKind::None;
@@ -116,7 +115,6 @@ public:
 
   void setAssociatedDecl(const Decl *D);
 
-  void setIsAsync(bool IsAsync) { this->IsAsync = IsAsync; }
   void setHasAsyncAlternative(bool HasAsyncAlternative) {
     this->HasAsyncAlternative = HasAsyncAlternative;
   }

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -807,32 +807,6 @@ void CompletionLookup::analyzeActorIsolation(
   case ActorIsolation::NonisolatedUnsafe:
     return;
   }
-
-  // If the reference is 'async', all types must be 'Sendable'.
-  if (Ctx.LangOpts.StrictConcurrencyLevel >= StrictConcurrency::Complete &&
-      implicitlyAsync && T) {
-    if (isa<VarDecl>(VD)) {
-      if (!T->isSendableType()) {
-        NotRecommended = ContextualNotRecommendedReason::CrossActorReference;
-      }
-    } else {
-      assert(isa<FuncDecl>(VD) || isa<SubscriptDecl>(VD));
-      // Check if the result and the param types are all 'Sendable'.
-      auto *AFT = T->castTo<AnyFunctionType>();
-      if (!AFT->getResult()->isSendableType()) {
-        NotRecommended = ContextualNotRecommendedReason::CrossActorReference;
-      } else {
-        for (auto &param : AFT->getParams()) {
-          Type paramType = param.getPlainType();
-          if (!paramType->isSendableType()) {
-            NotRecommended =
-                ContextualNotRecommendedReason::CrossActorReference;
-            break;
-          }
-        }
-      }
-    }
-  }
 }
 
 void CompletionLookup::addVarDeclRef(const VarDecl *VD,

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -864,14 +864,9 @@ void CompletionLookup::addVarDeclRef(const VarDecl *VD,
   }
   bool implicitlyAsync = false;
   analyzeActorIsolation(VD, VarType, implicitlyAsync, NotRecommended);
-  bool explicitlyAsync = false;
-  if (auto accessor = VD->getEffectfulGetAccessor()) {
-    explicitlyAsync = accessor->hasAsync();
-  }
   CodeCompletionResultBuilder Builder =
       makeResultBuilder(CodeCompletionResultKind::Declaration,
                         getSemanticContext(VD, Reason, dynamicLookupInfo));
-  Builder.setIsAsync(explicitlyAsync || implicitlyAsync);
   Builder.setCanCurrDeclContextHandleAsync(CanCurrDeclContextHandleAsync);
   Builder.setAssociatedDecl(VD);
   addLeadingDot(Builder);
@@ -1272,7 +1267,6 @@ void CompletionLookup::addFunctionCallPattern(
     else
       addTypeAnnotation(Builder, AFT->getResult(), genericSig);
 
-    Builder.setIsAsync(AFT->hasExtInfo() && AFT->isAsync());
     Builder.setCanCurrDeclContextHandleAsync(CanCurrDeclContextHandleAsync);
   };
 
@@ -1394,7 +1388,6 @@ void CompletionLookup::addMethodCall(const FuncDecl *FD,
     CodeCompletionResultBuilder Builder =
         makeResultBuilder(CodeCompletionResultKind::Declaration,
                           getSemanticContext(FD, Reason, dynamicLookupInfo));
-    Builder.setIsAsync(implictlyAsync || (AFT->hasExtInfo() && AFT->isAsync()));
     Builder.setHasAsyncAlternative(
         FD->getAsyncAlternative() &&
         !FD->getAsyncAlternative()->shouldHideFromEditor());
@@ -1591,8 +1584,6 @@ void CompletionLookup::addConstructorCall(const ConstructorDecl *CD,
       addTypeAnnotation(Builder, *Result, CD->getGenericSignatureOfContext());
     }
 
-    Builder.setIsAsync(ConstructorType->hasExtInfo() &&
-                       ConstructorType->isAsync());
     Builder.setCanCurrDeclContextHandleAsync(CanCurrDeclContextHandleAsync);
   };
 
@@ -1655,7 +1646,6 @@ void CompletionLookup::addSubscriptCall(const SubscriptDecl *SD,
   CodeCompletionResultBuilder Builder =
       makeResultBuilder(CodeCompletionResultKind::Declaration,
                         getSemanticContext(SD, Reason, dynamicLookupInfo));
-  Builder.setIsAsync(implictlyAsync);
   Builder.setCanCurrDeclContextHandleAsync(CanCurrDeclContextHandleAsync);
   Builder.setAssociatedDecl(SD);
 

--- a/test/IDE/complete_actorisolation.swift
+++ b/test/IDE/complete_actorisolation.swift
@@ -40,14 +40,14 @@ extension MyActor {
         let _ = other.#^IN_SYNCFUNC_OTHER_DOT^#
 // IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceVar]/CurrNominal: property[#Int#][' async'];
 // IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal: syncFunc()[' async'][#Int#];
-// IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: syncNonSendable({#arg: MyNonSendable#})[' async'][#Int#];
+// IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal: syncNonSendable({#arg: MyNonSendable#})[' async'][#Int#];
 // IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal: syncSendable({#arg: MySendable#})[' async'][#Int#];
 // IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal: asyncFunc()[' async'][#Int#];
 
         let _ = other#^IN_SYNCFUNC_OTHER_NODOT^#
 // IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceVar]/CurrNominal: .property[#Int#][' async'];
 // IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .syncFunc()[' async'][#Int#];
-// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .syncNonSendable({#arg: MyNonSendable#})[' async'][#Int#];
+// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .syncNonSendable({#arg: MyNonSendable#})[' async'][#Int#];
 // IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .syncSendable({#arg: MySendable#})[' async'][#Int#];
 // IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .asyncFunc()[' async'][#Int#];
 // IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[Subscript]/CurrNominal: [{#(idx): Int#}][' async'][#Int#];
@@ -79,14 +79,14 @@ extension MyActor {
         let _ = other.#^IN_ASYNCFUNC_OTHER_DOT^#
 // IN_ASYNCFUNC_OTHER_DOT-DAG: Decl[InstanceVar]/CurrNominal:      property[#Int#][' async'];
 // IN_ASYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   syncFunc()[' async'][#Int#];
-// IN_ASYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: syncNonSendable({#arg: MyNonSendable#})[' async'][#Int#];
+// IN_ASYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal: syncNonSendable({#arg: MyNonSendable#})[' async'][#Int#];
 // IN_ASYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   syncSendable({#arg: MySendable#})[' async'][#Int#];
 // IN_ASYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   asyncFunc()[' async'][#Int#];
 
         let _ = other#^IN_ASYNCFUNC_OTHER_NODOT^#
 // IN_ASYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .property[#Int#][' async'];
 // IN_ASYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .syncFunc()[' async'][#Int#];
-// IN_ASYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .syncNonSendable({#arg: MyNonSendable#})[' async'][#Int#];
+// IN_ASYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .syncNonSendable({#arg: MyNonSendable#})[' async'][#Int#];
 // IN_ASYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .syncSendable({#arg: MySendable#})[' async'][#Int#];
 // IN_ASYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .asyncFunc()[' async'][#Int#];
 // IN_ASYNCFUNC_OTHER_NODOT-DAG: Decl[Subscript]/CurrNominal:        [{#(idx): Int#}][' async'][#Int#];

--- a/test/IDE/complete_actorisolation.swift
+++ b/test/IDE/complete_actorisolation.swift
@@ -20,37 +20,37 @@ extension MyActor {
 // IN_SYNCFUNC-DAG: Decl[InstanceMethod]/CurrNominal:   syncFunc()[#Int#];
 // IN_SYNCFUNC-DAG: Decl[InstanceMethod]/CurrNominal:   syncNonSendable({#arg: MyNonSendable#})[#Int#];
 // IN_SYNCFUNC-DAG: Decl[InstanceMethod]/CurrNominal:   syncSendable({#arg: MySendable#})[#Int#];
-// IN_SYNCFUNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: asyncFunc()[' async'][#Int#];
+// IN_SYNCFUNC-DAG: Decl[InstanceMethod]/CurrNominal: asyncFunc()[' async'][#Int#];
 
         let _ = self.#^IN_SYNCFUNC_SELF_DOT^#
 // IN_SYNCFUNC_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal:      property[#Int#];
 // IN_SYNCFUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   syncFunc()[#Int#];
 // IN_SYNCFUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   syncNonSendable({#arg: MyNonSendable#})[#Int#];
 // IN_SYNCFUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   syncSendable({#arg: MySendable#})[#Int#];
-// IN_SYNCFUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: asyncFunc()[' async'][#Int#];
+// IN_SYNCFUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal: asyncFunc()[' async'][#Int#];
 
         let _ = self#^IN_SYNCFUNC_SELF_NODOT^#
 // IN_SYNCFUNC_SELF_NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .property[#Int#];
 // IN_SYNCFUNC_SELF_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .syncFunc()[#Int#];
 // IN_SYNCFUNC_SELF_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .syncNonSendable({#arg: MyNonSendable#})[#Int#];
 // IN_SYNCFUNC_SELF_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .syncSendable({#arg: MySendable#})[#Int#];
-// IN_SYNCFUNC_SELF_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .asyncFunc()[' async'][#Int#];
+// IN_SYNCFUNC_SELF_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .asyncFunc()[' async'][#Int#];
 // IN_SYNCFUNC_SELF_NODOT-DAG: Decl[Subscript]/CurrNominal:        [{#(idx): Int#}][#Int#];
 
         let _ = other.#^IN_SYNCFUNC_OTHER_DOT^#
-// IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: property[#Int#][' async'];
-// IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: syncFunc()[' async'][#Int#];
+// IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceVar]/CurrNominal: property[#Int#][' async'];
+// IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal: syncFunc()[' async'][#Int#];
 // IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: syncNonSendable({#arg: MyNonSendable#})[' async'][#Int#];
-// IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: syncSendable({#arg: MySendable#})[' async'][#Int#];
-// IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: asyncFunc()[' async'][#Int#];
+// IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal: syncSendable({#arg: MySendable#})[' async'][#Int#];
+// IN_SYNCFUNC_OTHER_DOT-DAG: Decl[InstanceMethod]/CurrNominal: asyncFunc()[' async'][#Int#];
 
         let _ = other#^IN_SYNCFUNC_OTHER_NODOT^#
-// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: .property[#Int#][' async'];
-// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .syncFunc()[' async'][#Int#];
+// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceVar]/CurrNominal: .property[#Int#][' async'];
+// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .syncFunc()[' async'][#Int#];
 // IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .syncNonSendable({#arg: MyNonSendable#})[' async'][#Int#];
-// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .syncSendable({#arg: MySendable#})[' async'][#Int#];
-// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .asyncFunc()[' async'][#Int#];
-// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[Subscript]/CurrNominal/NotRecommended: [{#(idx): Int#}][' async'][#Int#];
+// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .syncSendable({#arg: MySendable#})[' async'][#Int#];
+// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .asyncFunc()[' async'][#Int#];
+// IN_SYNCFUNC_OTHER_NODOT-DAG: Decl[Subscript]/CurrNominal: [{#(idx): Int#}][' async'][#Int#];
     }
     func testAsyncFunc(other: MyActor) async {
         let _ = #^IN_ASYNCFUNC^#

--- a/test/IDE/complete_async_context.swift
+++ b/test/IDE/complete_async_context.swift
@@ -28,12 +28,12 @@ func throwingTask() async throws -> String {
 }
 
 // CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule: funcThrows()[' throws'][#Void#];
-// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule/NotRecommended: asyncRethrows({#fn: () async throws -> Int##() async throws -> Int#})[' async'][' rethrows'][#Int#];
-// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule/NotRecommended: asyncRethrows({#fn: () async throws -> String##() async throws -> String#})[' async'][' rethrows'][#String#];
-// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule/NotRecommended: invokeAuto({#(val): T#})[' async'][' rethrows'][#T#];
-// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule/NotRecommended: throwingTask()[' async'][' throws'][#String#];
-// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule/NotRecommended: invoke({#fn: () async throws -> T##() async throws -> T#})[' async'][' rethrows'][#T#];
-// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule/NotRecommended: normalTask()[' async'][#Int#];
+// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule: asyncRethrows({#fn: () async throws -> Int##() async throws -> Int#})[' async'][' rethrows'][#Int#];
+// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule: asyncRethrows({#fn: () async throws -> String##() async throws -> String#})[' async'][' rethrows'][#String#];
+// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule: invokeAuto({#(val): T#})[' async'][' rethrows'][#T#];
+// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule: throwingTask()[' async'][' throws'][#String#];
+// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule: invoke({#fn: () async throws -> T##() async throws -> T#})[' async'][' rethrows'][#T#];
+// CHECK_syncContext-DAG: Decl[FreeFunction]/CurrModule: normalTask()[' async'][#Int#];
 
 // CHECK_asyncContext-DAG: Decl[FreeFunction]/CurrModule: funcThrows()[' throws'][#Void#];
 // CHECK_asyncContext-DAG: Decl[FreeFunction]/CurrModule: asyncRethrows({#fn: () async throws -> Int##() async throws -> Int#})[' async'][' rethrows'][#Int#];

--- a/test/IDE/complete_cache_notrecommended.swift
+++ b/test/IDE/complete_cache_notrecommended.swift
@@ -20,7 +20,7 @@ import MyModule
 
 func testSync() -> Int{
     #^GLOBAL_IN_SYNC^#
-// GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/NotRecommended/TypeRelation[Convertible]: globalAsyncFunc()[' async'][#Int#];
+// GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/TypeRelation[Convertible]: globalAsyncFunc()[' async'][#Int#];
 // GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/NotRecommended: deprecatedFunc()[#Void#];
 // GLOBAL_IN_SYNC-DAG: Decl[Actor]/OtherModule[MyModule]:  MyActor[#MyActor#];
 }
@@ -34,7 +34,7 @@ func testSyncMember(obj: MyActor) -> Int {
     obj.#^MEMBER_IN_SYNC^#
 // MEMBER_IN_SYNC: Begin completions, 9 items
 // MEMBER_IN_SYNC-DAG: Keyword[self]/CurrNominal:          self[#MyActor#];
-// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Convertible]: actorMethod()[' async'][#Int#];
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: actorMethod()[' async'][#Int#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: deprecatedMethod()[' async'][#Void#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceVar]/CurrNominal:      unownedExecutor[#UnownedSerialExecutor#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated()[#Void#]; name=preconditionIsolated()

--- a/test/IDE/complete_diagnostics_concurrency.swift
+++ b/test/IDE/complete_diagnostics_concurrency.swift
@@ -17,7 +17,7 @@ actor MyActor {
 
 func testAsyncContext() {
     #^SYNC_CONTEXT^#
-// SYNC_CONTEXT-DAG: Decl[FreeFunction]/CurrModule/NotRecommended: asyncFunc()[' async'][#Void#]; name=asyncFunc(); diagnostics=error:async 'asyncFunc()' used in a context that does not support concurrency{{$}}
+// SYNC_CONTEXT-DAG: Decl[FreeFunction]/CurrModule: asyncFunc()[' async'][#Void#]; name=asyncFunc(){{$}}
 // SYNC_CONTEXT-DAG: Decl[FreeFunction]/CurrModule:      syncFunc()[#Void#]; name=syncFunc(){{$}}
 }
 
@@ -29,7 +29,7 @@ func testActor(obj: MyActor) async {
 
 func testClosure(obj: (Int) async -> Void) {
   obj(#^CLOSURE_CALL^#)
-// CLOSURE_CALL-DAG: Pattern/Local/Flair[ArgLabels]/NotRecommended: ['(']{#Int#}[')'][' async'][#Void#]; name=; diagnostics=error:async function used in a context that does not support concurrency
+// CLOSURE_CALL-DAG: Pattern/Local/Flair[ArgLabels]: ['(']{#Int#}[')'][' async'][#Void#]; name={{$}}
 }
 
 func test() {
@@ -45,9 +45,9 @@ func test() {
 
   let foo = Foo()
   foo.#^EXPLICITLY_ASYNC_PROPERTY^#
-// EXPLICITLY_ASYNC_PROPERTY-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: value[#String?#][' async']; name=value; diagnostics=error:async 'value' used in a context that does not support concurrency
+// EXPLICITLY_ASYNC_PROPERTY-DAG: Decl[InstanceVar]/CurrNominal: value[#String?#][' async']; name=value{{$}}
 
   #^EXPLICIT_GLOBAL_VAR^#
-// EXPLICIT_GLOBAL_VAR-DAG: Decl[LocalVar]/Local/NotRecommended: globalValue[#String?#][' async']; name=globalValue; diagnostics=error:async 'globalValue' used in a context that does not support concurrency
+// EXPLICIT_GLOBAL_VAR-DAG: Decl[LocalVar]/Local: globalValue[#String?#][' async']; name=globalValue{{$}}
 
 }

--- a/test/IDE/complete_diagnostics_concurrency.swift
+++ b/test/IDE/complete_diagnostics_concurrency.swift
@@ -24,7 +24,7 @@ func testAsyncContext() {
 func testActor(obj: MyActor) async {
     obj.#^ACTOR^#
 // ACTOR-DAG: Decl[InstanceMethod]/CurrNominal:   receiveSendable({#arg: MySendable#})[' async'][#Void#]; name=receiveSendable(arg:){{$}}
-// ACTOR-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: receiveNonSendable({#arg: MyNonSendable#})[' async'][#Void#]; name=receiveNonSendable(arg:); diagnostics=warning:actor-isolated 'receiveNonSendable(arg:)' should only be referenced from inside the actor{{$}}
+// ACTOR-DAG: Decl[InstanceMethod]/CurrNominal: receiveNonSendable({#arg: MyNonSendable#})[' async'][#Void#]; name=receiveNonSendable(arg:){{$}}
 }
 
 func testClosure(obj: (Int) async -> Void) {

--- a/test/IDE/complete_global_actorisolation.swift
+++ b/test/IDE/complete_global_actorisolation.swift
@@ -41,35 +41,35 @@ extension MyClass {
   @MyGlobalActor func testOnGlobalActor() {
     let _ = #^IN_FUNC_ON_GLOBAL_ACTOR^#
 // IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal:   funcOnGlobalActor()[#Int#]; name=funcOnGlobalActor()
-// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
+// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
 // IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal:   funcSync()[#Int#]; name=funcSync()
 // IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal:   nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[#Int#]; name=nonSenableFuncOnGlobalActor(arg:)
-// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
+// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
 // IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceVar]/CurrNominal:      varOnGlobalActor[#Int#]; name=varOnGlobalActor
-// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
+// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceVar]/CurrNominal: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
 // IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceVar]/CurrNominal:      varSync[#Int#]; name=varSync
 
     let _ = self.#^IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT^#
 // IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   funcOnGlobalActor()[#Int#]; name=funcOnGlobalActor()
-// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
 // IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   funcSync()[#Int#]; name=funcSync()
 // IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[#Int#]; name=nonSenableFuncOnGlobalActor(arg:)
-// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
 // IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal:      varOnGlobalActor[#Int#]; name=varOnGlobalActor
-// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
 // IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal:      varSync[#Int#]; name=varSync
 
     let _ = self#^IN_FUNC_ON_GLOBAL_ACTOR_NODOT^#
 // IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .funcOnGlobalActor()[#Int#]; name=funcOnGlobalActor()
-// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
 // IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .funcSync()[#Int#]; name=funcSync()
 // IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[#Int#]; name=nonSenableFuncOnGlobalActor(arg:)
-// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
 // IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .varOnGlobalActor[#Int#]; name=varOnGlobalActor
-// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: .varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceVar]/CurrNominal: .varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
 // IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .varSync[#Int#]; name=varSync
 // IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[Subscript]/CurrNominal:        [{#onGlobalActor: Int#}][#Int#]; name=[onGlobalActor:]
-// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[Subscript]/CurrNominal/NotRecommended: [{#onOtherGlobalActor: Int#}][' async'][#Int#]; name=[onOtherGlobalActor:]
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[Subscript]/CurrNominal: [{#onOtherGlobalActor: Int#}][' async'][#Int#]; name=[onOtherGlobalActor:]
 // IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[Subscript]/CurrNominal:        [{#sync: Int#}][#Int#]; name=[sync:]
 
     let _ = otherInstanceOfMyClass.#^IN_FUNC_ON_GLOBAL_ACTOR_OTHER_DOT?check=IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT^#
@@ -78,36 +78,36 @@ extension MyClass {
 
   func testInSyncFunc() {
     let _ = #^IN_SYNC_FUNC^#
-// IN_SYNC_FUNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   funcOnGlobalActor()[' async'][#Int#]; name=funcOnGlobalActor()
-// IN_SYNC_FUNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
+// IN_SYNC_FUNC-DAG: Decl[InstanceMethod]/CurrNominal:   funcOnGlobalActor()[' async'][#Int#]; name=funcOnGlobalActor()
+// IN_SYNC_FUNC-DAG: Decl[InstanceMethod]/CurrNominal: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
 // IN_SYNC_FUNC-DAG: Decl[InstanceMethod]/CurrNominal:   funcSync()[#Int#]; name=funcSync()
-// IN_SYNC_FUNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnGlobalActor(arg:)
-// IN_SYNC_FUNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
-// IN_SYNC_FUNC-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended:      varOnGlobalActor[#Int#][' async']; name=varOnGlobalActor
-// IN_SYNC_FUNC-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
+// IN_SYNC_FUNC-DAG: Decl[InstanceMethod]/CurrNominal:   nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnGlobalActor(arg:)
+// IN_SYNC_FUNC-DAG: Decl[InstanceMethod]/CurrNominal: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
+// IN_SYNC_FUNC-DAG: Decl[InstanceVar]/CurrNominal:      varOnGlobalActor[#Int#][' async']; name=varOnGlobalActor
+// IN_SYNC_FUNC-DAG: Decl[InstanceVar]/CurrNominal: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
 // IN_SYNC_FUNC-DAG: Decl[InstanceVar]/CurrNominal:      varSync[#Int#]; name=varSync
 
     let _ = self.#^IN_SYNC_FUNC_SELF_DOT^#
-// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   funcOnGlobalActor()[' async'][#Int#]; name=funcOnGlobalActor()
-// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   funcOnGlobalActor()[' async'][#Int#]; name=funcOnGlobalActor()
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
 // IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   funcSync()[#Int#]; name=funcSync()
-// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnGlobalActor(arg:)
-// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
-// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended:      varOnGlobalActor[#Int#][' async']; name=varOnGlobalActor
-// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnGlobalActor(arg:)
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal:      varOnGlobalActor[#Int#][' async']; name=varOnGlobalActor
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
 // IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal:      varSync[#Int#]; name=varSync
 
     let _ = self#^IN_SYNC_FUNC_NODOT^#
-// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   .funcOnGlobalActor()[' async'][#Int#]; name=funcOnGlobalActor()
-// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .funcOnGlobalActor()[' async'][#Int#]; name=funcOnGlobalActor()
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor()
 // IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .funcSync()[#Int#]; name=funcSync()
-// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   .nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnGlobalActor(arg:)
-// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
-// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended:      .varOnGlobalActor[#Int#][' async']; name=varOnGlobalActor
-// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: .varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnGlobalActor(arg:)
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal: .nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg:)
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .varOnGlobalActor[#Int#][' async']; name=varOnGlobalActor
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceVar]/CurrNominal: .varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor
 // IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .varSync[#Int#]; name=varSync
-// IN_SYNC_FUNC_NODOT-DAG: Decl[Subscript]/CurrNominal/NotRecommended:        [{#onGlobalActor: Int#}][' async'][#Int#]; name=[onGlobalActor:]
-// IN_SYNC_FUNC_NODOT-DAG: Decl[Subscript]/CurrNominal/NotRecommended: [{#onOtherGlobalActor: Int#}][' async'][#Int#]; name=[onOtherGlobalActor:]
+// IN_SYNC_FUNC_NODOT-DAG: Decl[Subscript]/CurrNominal:        [{#onGlobalActor: Int#}][' async'][#Int#]; name=[onGlobalActor:]
+// IN_SYNC_FUNC_NODOT-DAG: Decl[Subscript]/CurrNominal: [{#onOtherGlobalActor: Int#}][' async'][#Int#]; name=[onOtherGlobalActor:]
 // IN_SYNC_FUNC_NODOT-DAG: Decl[Subscript]/CurrNominal:        [{#sync: Int#}][#Int#]; name=[sync:]
 
     let _ = otherInstanceOfMyClass.#^IN_SYNC_FUNC_OTHER_DOT?check=IN_SYNC_FUNC_SELF_DOT^#

--- a/test/IDE/complete_globalactorunsafe.swift
+++ b/test/IDE/complete_globalactorunsafe.swift
@@ -3,11 +3,11 @@
 
 // SAFE_NOTREC: Begin completions, 2 items
 // SAFE_NOTREC-DAG: Keyword[self]/CurrNominal:          self[#SafelyIsolatedCls#];
-// SAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: method()[' async'][#Void#];
+// SAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal: method()[' async'][#Void#];
 
 // UNSAFE_NOTREC: Begin completions, 2 items
 // UNSAFE_NOTREC-DAG: Keyword[self]/CurrNominal:          self[#UnsafelyIsolatedCls#];
-// UNSAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: method()[' async'][#Void#];
+// UNSAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal: method()[' async'][#Void#];
 
 // SAFE_OK: Begin completions, 2 items
 // SAFE_OK-DAG: Keyword[self]/CurrNominal:          self[#SafelyIsolatedCls#];

--- a/test/IDE/complete_globalactorunsafe_strict.swift
+++ b/test/IDE/complete_globalactorunsafe_strict.swift
@@ -3,11 +3,11 @@
 
 // SAFE_NOTREC: Begin completions, 2 items
 // SAFE_NOTREC-DAG: Keyword[self]/CurrNominal:          self[#SafelyIsolatedCls#];
-// SAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: method()[' async'][#Void#];
+// SAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal: method()[' async'][#Void#];
 
 // UNSAFE_NOTREC: Begin completions, 2 items
 // UNSAFE_NOTREC-DAG: Keyword[self]/CurrNominal:          self[#UnsafelyIsolatedCls#];
-// UNSAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: method()[' async'][#Void#];
+// UNSAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal: method()[' async'][#Void#];
 
 // SAFE_OK: Begin completions, 2 items
 // SAFE_OK-DAG: Keyword[self]/CurrNominal:          self[#SafelyIsolatedCls#];

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -135,7 +135,7 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
     auto *contextFreeResult =
         ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
             sink.swiftSink, CodeCompletionResultKind::Pattern, completionString,
-            CodeCompletionOperatorKind::None, /*IsAsync=*/false,
+            CodeCompletionOperatorKind::None,
             /*BriefDocComment=*/"", CodeCompletionResultType::unknown(),
             ContextFreeNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
@@ -1156,7 +1156,7 @@ Completion *CompletionBuilder::finish() {
             contextFreeBase.getKind(),
             contextFreeBase.getOpaqueAssociatedKind(), opKind,
             contextFreeBase.getMacroRoles(), contextFreeBase.isSystem(),
-            contextFreeBase.isAsync(), contextFreeBase.hasAsyncAlternative(),
+            contextFreeBase.hasAsyncAlternative(),
             newCompletionString, contextFreeBase.getModuleName(),
             contextFreeBase.getBriefDocComment(),
             contextFreeBase.getAssociatedUSRs(),

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -909,7 +909,6 @@ static void transformAndForwardResults(
         ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
             innerSink.swiftSink, CodeCompletionResultKind::BuiltinOperator,
             completionString, CodeCompletionOperatorKind::None,
-            /*IsAsync=*/false,
             /*BriefDocComment=*/"", CodeCompletionResultType::notApplicable(),
             ContextFreeNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None,


### PR DESCRIPTION
This warnings don't give much benefits for developers. Code completion UI tends to show them unusable. But usually, developers can modify the context to accept async calls, e.g. by wrapping it with `Task { }`

rdar://126737530
