### PR TITLE
[cxx-interop][IRGen] Do not pass a foreign reference type to objc_retainAutoreleasedReturnValue

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -38,6 +38,7 @@
 #include <optional>
 
 #include "CallEmission.h"
+#include "ClassTypeInfo.h"
 #include "EntryPointArgumentEmission.h"
 #include "Explosion.h"
 #include "GenCall.h"
@@ -2612,9 +2613,16 @@ public:
     if (fnConv.getNumDirectSILResults() == 1
         && (fnConv.getDirectSILResults().begin()->getConvention()
             == ResultConvention::Autoreleased)) {
-      if (IGF.IGM.Context.LangOpts.EnableObjCInterop)
-        result = emitObjCRetainAutoreleasedReturnValue(IGF, result);
-      else
+      if (IGF.IGM.Context.LangOpts.EnableObjCInterop) {
+        auto ty = fnConv.getSILResultType(IGF.IGM.getMaximalTypeExpansionContext());
+        auto *classTypeInfo = dyn_cast<ClassTypeInfo>(&IGF.IGM.getTypeInfo(ty));
+        if (classTypeInfo && classTypeInfo->getReferenceCounting() == ReferenceCounting::Custom) {
+          Explosion e(result);
+          classTypeInfo->strongCustomRetain(IGF, e, true);
+        } else {
+          result = emitObjCRetainAutoreleasedReturnValue(IGF, result);
+        }
+      } else
         IGF.emitNativeStrongRetain(result, IGF.getDefaultAtomicity());
     }
 

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -28,6 +28,12 @@ module ReferenceCounted {
   requires cplusplus
 }
 
+module ReferenceCountedObjCProperty {
+  header "reference-counted-objc-property.h"
+  requires cplusplus
+  export *
+}
+
 module MemberLayout {
   header "member-layout.h"
   requires cplusplus

--- a/test/Interop/Cxx/foreign-reference/Inputs/reference-counted-objc-property.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/reference-counted-objc-property.h
@@ -1,0 +1,15 @@
+#ifndef REFERENCE_COUNTED_OBJC_PROPERTY_H
+#define REFERENCE_COUNTED_OBJC_PROPERTY_H
+
+#include "reference-counted.h"
+
+SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+
+@interface C0
+@property (nonnull, readonly) NS::LocalCount *lc;
+- (instancetype)init;
+@end
+
+SWIFT_END_NULLABILITY_ANNOTATIONS
+
+#endif // REFERENCE_COUNTED_OBJC_PROPERTY_H

--- a/test/Interop/Cxx/foreign-reference/reference-counted-objc-property.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-objc-property.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-emit-irgen %s -I %S/Inputs -cxx-interoperability-mode=default -Xcc -fno-exceptions -Xcc -fno-objc-exceptions | %FileCheck %s
 
-// REQUIRES: OS=macosx
+// REQUIRES: objc_interop
 
 import ReferenceCountedObjCProperty
 

--- a/test/Interop/Cxx/foreign-reference/reference-counted-objc-property.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-objc-property.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-irgen %s -I %S/Inputs -cxx-interoperability-mode=default -Xcc -fno-exceptions -Xcc -fno-objc-exceptions | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+import ReferenceCountedObjCProperty
+
+// CHECK: define swiftcc void @"$s4main10testGetteryyF"()
+// CHECK: alloca ptr, align 8
+// CHECK: %[[LC:.*]] = alloca ptr, align 8
+// CHECK: %[[V4:.*]] = load ptr, ptr @"\01L_selector(lc)", align 8
+// CHECK: %[[V5:.*]] = call ptr @objc_msgSend(ptr %{{.*}}, ptr %[[V4]])
+// CHECK: %[[V6:.*]] = icmp ne ptr %[[V5]], null
+// CHECK: br i1 %[[V6]], label %[[LIFETIME_NONNULL_VALUE:.*]], label %[[LIFETIME_CONT:.*]]
+
+// CHECK: [[LIFETIME_NONNULL_VALUE]]:
+// CHECK-NEXT: call void @_Z8LCRetainPN2NS10LocalCountE(ptr %[[V5]])
+// CHECK-NEXT: br label %[[LIFETIME_CONT]]
+
+// CHECK: [[LIFETIME_CONT]]:
+// CHECK: store ptr %[[V5]], ptr %[[LC]], align 8
+// CHECK: %[[TODESTROY:.*]] = load ptr, ptr %[[LC]], align 8
+// CHECK: call void @_Z9LCReleasePN2NS10LocalCountE(ptr %[[TODESTROY]])
+
+public func testGetter() {
+  var c0 = C0()
+  var lc = c0.lc
+}


### PR DESCRIPTION
If a foreign reference type has a custom retain function, emit a call to it instead of emitting a call to objc_retainAutoreleasedReturnValue.

rdar://117353222