### PR TITLE
[6.0][Concurrency] Un-gate implicit `nonisolated` access to struct vars and isolated subclassing.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -512,16 +512,14 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
 
   if (!var->isLet()) {
     ASTContext &ctx = var->getASTContext();
-    if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability)) {
-      // A mutable storage of a value type accessed from within the module is
-      // okay.
-      if (dyn_cast_or_null<StructDecl>(var->getDeclContext()->getAsDecl()) &&
-          !var->isStatic() && 
-          var->hasStorage() &&
-          var->getTypeInContext()->isSendableType() &&
-          accessWithinModule) {
-        return true;
-      }
+    // A mutable storage of a value type accessed from within the module is
+    // okay.
+    if (dyn_cast_or_null<StructDecl>(var->getDeclContext()->getAsDecl()) &&
+        !var->isStatic() &&
+        var->hasStorage() &&
+        var->getTypeInContext()->isSendableType() &&
+        accessWithinModule) {
+      return true;
     }
     // Otherwise, must be immutable.
     return false;
@@ -4806,12 +4804,7 @@ static bool checkClassGlobalActorIsolation(
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
   case ActorIsolation::NonisolatedUnsafe: {
-    auto &ctx = classDecl->getASTContext();
-    if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability))
-      return false;
-
-    downgradeToWarning = true;
-    break;
+    return false;
   }
 
   case ActorIsolation::Erased:
@@ -6054,8 +6047,8 @@ ProtocolConformance *swift::deriveImplicitSendableConformance(
 
       // Classes that add global actor isolation to non-Sendable
       // superclasses cannot be 'Sendable'.
-      if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability) &&
-          nominal->getGlobalActorAttr()) {
+      auto superclassDecl = classDecl->getSuperclassDecl();
+      if (nominal->getGlobalActorAttr() && !superclassDecl->isNSObject()) {
         return nullptr;
       }
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4805,9 +4805,14 @@ static bool checkClassGlobalActorIsolation(
   switch (superIsolation) {
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
-  case ActorIsolation::NonisolatedUnsafe:
+  case ActorIsolation::NonisolatedUnsafe: {
+    auto &ctx = classDecl->getASTContext();
+    if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability))
+      return false;
+
     downgradeToWarning = true;
     break;
+  }
 
   case ActorIsolation::Erased:
     llvm_unreachable("class cannot have erased isolation");
@@ -6045,6 +6050,13 @@ ProtocolConformance *swift::deriveImplicitSendableConformance(
               nominal->getDeclaredInterfaceType(),
               inheritedConformance.getConcrete());
         }
+      }
+
+      // Classes that add global actor isolation to non-Sendable
+      // superclasses cannot be 'Sendable'.
+      if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability) &&
+          nominal->getGlobalActorAttr()) {
+        return nullptr;
       }
     }
   }

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -298,7 +298,7 @@ class BarFrame: PictureFrame {
 @available(SwiftStdlib 5.5, *)
 @SomeGlobalActor
 class BazFrame: NotIsolatedPictureFrame {
-// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'BazFrame' has different actor isolation from nonisolated superclass 'NotIsolatedPictureFrame'; this is an error in the Swift 6 language mode}}
+// expected-note@-1 2 {{class 'BazFrame' does not conform to the 'Sendable' protocol}}
   init() {
     super.init(size: 0)
   }
@@ -322,10 +322,12 @@ func check() async {
   _ = await BarFrame()
   _ = await FooFrame()
   _ = await BazFrame()
+  // expected-warning@-1 {{non-sendable type 'BazFrame' returned by call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary; this is an error in the Swift 6 language mode}}
 
   _ = await BarFrame(size: 0)
   _ = await FooFrame(size: 0)
   _ = await BazFrame(size: 0)
+  // expected-warning@-1 {{non-sendable type 'BazFrame' returned by call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary; this is an error in the Swift 6 language mode}}
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1282,8 +1282,14 @@ actor Counter {
 class C2 { }
 
 @SomeGlobalActor
-class C3: C2 { }
-// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'C3' has different actor isolation from nonisolated superclass 'C2'; this is an error in the Swift 6 language mode}}
+class C3: C2 { // expected-note {{class 'C3' does not conform to the 'Sendable' protocol}}
+  func requireSendableSelf() {
+    Task.detached {
+      _ = self
+      // expected-warning@-1 {{capture of 'self' with non-sendable type 'C3' in a `@Sendable` closure; this is an error in the Swift 6 language mode}}
+    }
+  }
+}
 
 @GenericGlobalActor<U>
 class GenericSuper<U> { }
@@ -1463,7 +1469,6 @@ class None {
 // try to add inferred isolation while overriding
 @MainActor
 class MA_None1: None {
-// expected-warning@-1 {{main actor-isolated class 'MA_None1' has different actor isolation from nonisolated superclass 'None'; this is an error in the Swift 6 language mode}}
 
   // FIXME: bad note, since the problem is a mismatch in overridden vs inferred isolation; this wont help.
   // expected-note@+1 {{add '@MainActor' to make instance method 'method()' part of global actor 'MainActor'}}
@@ -1494,7 +1499,6 @@ class None_MADirect: MADirect {
 
 @SomeGlobalActor
 class SGA_MADirect: MADirect {
-// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'SGA_MADirect' has different actor isolation from nonisolated superclass 'MADirect'; this is an error in the Swift 6 language mode}}
 
   // inferred-SomeGlobalActor vs overridden-MainActor = mainactor
   override func method1() { beets_ma() }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -248,8 +248,6 @@ class SuperclassWithGlobalActors {
 
 @GenericGlobalActor<String>
 class SubclassWithGlobalActors : SuperclassWithGlobalActors {
-// expected-warning@-1 {{global actor 'GenericGlobalActor<String>'-isolated class 'SubclassWithGlobalActors' has different actor isolation from nonisolated superclass 'SuperclassWithGlobalActors'; this is an error in the Swift 6 language mode}}
-
   override func f() { } // okay: inferred to @GenericGlobalActor<Int>
 
   @GenericGlobalActor<String> override func g() { } // expected-error{{global actor 'GenericGlobalActor<String>'-isolated instance method 'g()' has different actor isolation from global actor 'GenericGlobalActor<Int>'-isolated overridden declaration}}

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -239,7 +239,7 @@ func testConversionsAndSendable(a: MyActor, s: any Sendable, f: @Sendable () -> 
 
 @available(SwiftStdlib 5.1, *)
 final class NonSendable {
-  // expected-note @-1 3 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+  // expected-note @-1 4 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   // TransferNonSendable emits 3 fewer errors here.
   // expected-targeted-and-complete-note @-3 5 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   // expected-complete-and-tns-note @-4 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
@@ -397,12 +397,13 @@ struct DowngradeForPreconcurrency {
     }
   }
 
-  var x: Int
-  func createStream() -> AsyncStream<Int> {
-    AsyncStream<Int> {
+  var x: NonSendable
+  func createStream() -> AsyncStream<NonSendable> {
+    AsyncStream<NonSendable> {
       self.x
       // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
       // expected-note@-2 {{property access is 'async'}}
+      // expected-warning@-3 {{non-sendable type 'NonSendable' in implicitly asynchronous access to main actor-isolated property 'x' cannot cross actor boundary; this is an error in the Swift 6 language mode}}
     }
   }
 }

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -588,9 +588,7 @@ struct Container {
     // CHECK: [[SOME_BB]]:
     // CHECK:       [[DATA_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[ACCESS]] : $*Optional<Container>, #Optional.some!enumelt
     // CHECK:       [[ELEM_ADDR:%[0-9]+]] = struct_element_addr [[DATA_ADDR]] : $*Container, #Container.iso
-    // CHECK:       hop_to_executor {{%[0-9]+}} : $Cat
     // CHECK:       {{%[0-9]+}} = load [trivial] [[ELEM_ADDR]] : $*Float
-    // CHECK:       hop_to_executor [[GENERIC_EXEC]] :
     // CHECK:       hop_to_executor [[GENERIC_EXEC]] :
     // CHECK: } // end sil function '$s4test9ContainerV10getOrCrashSfyYaFZ'
     static func getOrCrash() async -> Float {
@@ -628,7 +626,7 @@ struct Container {
 
 @propertyWrapper
 struct StateObject<ObjectType> {
-    @MainActor(unsafe)
+    @preconcurrency @MainActor
     var wrappedValue: ObjectType {
         fatalError()
     }


### PR DESCRIPTION
* **Explanation**: Allows the additive parts of SE-0434 to be used without enabling the `GlobalActorIsolatedTypesUsability ` upcoming feature. The other inference changes, including `@Sendable` inference for global-actor-isolated function types, and global-actor inference on protocol refinements, remain gated behind the upcoming flag.
* **Scope**: Only impacts `var`s of value types with `Sendable` type, and global-actor-isolated classes of non-isolated, non-`Sendable` superclasses (except `NSObject`).
* **Risk**: Low; this change only lifts data-race safety limitations, removing warnings in Swift 5 mode and removing errors in Swift 6 mode.
* **Testing**: Added new tests.
* **Reviewer**: @ktoso 
* **Main branch PR**: https://github.com/apple/swift/pull/73497, https://github.com/apple/swift/pull/73608