### PR TITLE
[6.0] SIL: fix runtime effects of initializing store

### DIFF
--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -780,9 +780,8 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
     switch (cast<StoreInst>(inst)->getOwnershipQualifier()) {
       case StoreOwnershipQualifier::Unqualified:
       case StoreOwnershipQualifier::Trivial:
-        return RuntimeEffect::NoEffect;
       case StoreOwnershipQualifier::Init:
-        return RuntimeEffect::RefCounting;
+        return RuntimeEffect::NoEffect;
       case StoreOwnershipQualifier::Assign:
         return RuntimeEffect::Releasing;
     }

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -505,3 +505,12 @@ func testLargeTuple() {
     _ = GenericStruct<SixInt8s>()
 }
 
+struct NonCopyableStruct: ~Copyable {
+  func foo() {}
+}
+
+@_noLocks
+func testNonCopyable() {
+  let t = NonCopyableStruct()
+  t.foo()
+}


### PR DESCRIPTION
* **Explanation**: This fixes a false performance error when using non-copyable types. An initializing store is not a copy and therefore doesn't perform ref counting operations.
* **Scope**: Only affects performance diagnostics, i.e. diagnostics for functions which are annotated with `@_noLocks` or `@_noAllocation`.
* **Risk**: very low. The change is trivial and does not impact code generation.
* **Testing**: Tested by a test case
* **Issue**: rdar://128113745, https://github.com/apple/swift/issues/73582
* **Reviewer**:  @meg-gupta 
* **Main branch PR**: https://github.com/apple/swift/pull/73611
