### PR TITLE
[Runtime] Don't emit signposts until the system is ready.

### DIFF
--- a/include/swift/Runtime/TracingCommon.h
+++ b/include/swift/Runtime/TracingCommon.h
@@ -22,7 +22,13 @@
 #include "swift/Runtime/Config.h"
 #include <os/signpost.h>
 
-extern const char *__progname;
+extern "C" const char *__progname;
+
+// This function may not be present when building at desk, and isn't really
+// needed there, so just skip it in that case.
+#if SWIFT_BNI_OS_BUILD
+extern "C" bool _os_trace_lazy_init_completed_4swift(void);
+#endif
 
 namespace swift {
 namespace runtime {
@@ -37,6 +43,15 @@ static inline bool shouldEnableTracing() {
                      strcmp(__progname, "xpcproxy") == 0 ||
                      strcmp(__progname, "logd_helper") == 0))
     return false;
+  return true;
+}
+
+static inline bool tracingReady() {
+#if SWIFT_BNI_OS_BUILD
+  if (!_os_trace_lazy_init_completed_4swift())
+    return false;
+#endif
+
   return true;
 }
 

--- a/stdlib/public/Concurrency/TracingSignpost.cpp
+++ b/stdlib/public/Concurrency/TracingSignpost.cpp
@@ -17,7 +17,6 @@
 #if SWIFT_STDLIB_CONCURRENCY_TRACING
 
 #include "TracingSignpost.h"
-#include "swift/Runtime/TracingCommon.h"
 #include <stdio.h>
 
 #define SWIFT_LOG_CONCURRENCY_SUBSYSTEM "com.apple.swift.concurrency"

--- a/stdlib/public/Concurrency/TracingSignpost.h
+++ b/stdlib/public/Concurrency/TracingSignpost.h
@@ -23,6 +23,7 @@
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/HeapObject.h"
+#include "swift/Runtime/TracingCommon.h"
 #include <inttypes.h>
 #include <os/log.h>
 #include <os/signpost.h>
@@ -79,6 +80,8 @@ void setupLogs(void *unused);
 // optimized out.
 #define ENSURE_LOGS(...)                                                       \
   do {                                                                         \
+    if (!runtime::trace::tracingReady())                                       \
+      return __VA_ARGS__;                                                      \
     swift::once(LogsToken, setupLogs, nullptr);                                \
     if (!TracingEnabled)                                                       \
       return __VA_ARGS__;                                                      \

--- a/stdlib/public/runtime/Tracing.cpp
+++ b/stdlib/public/runtime/Tracing.cpp
@@ -15,7 +15,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "Tracing.h"
-#include "swift/Runtime/TracingCommon.h"
 
 #if SWIFT_STDLIB_TRACING
 

--- a/stdlib/public/runtime/Tracing.h
+++ b/stdlib/public/runtime/Tracing.h
@@ -20,6 +20,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "swift/ABI/Metadata.h"
 #include "swift/Demangling/Demangler.h"
+#include "swift/Runtime/TracingCommon.h"
 
 #if SWIFT_STDLIB_TRACING
 #include <os/signpost.h>
@@ -49,6 +50,8 @@ void setupLogs(void *unused);
 // optimized out.
 #define ENSURE_LOG(log)                                                        \
   do {                                                                         \
+    if (!tracingReady())                                                       \
+      return {};                                                               \
     swift::once(LogsToken, setupLogs, nullptr);                                \
     if (!TracingEnabled)                                                       \
       return {};                                                               \


### PR DESCRIPTION
Emitting a signpost for the first time can trigger lazy setup of the logging system, and doing this in the wrong context can cause deadlocks. Check to see if the logging system is already set up, and only emit signposts if it has been to avoid triggering this.

As it's hard to determine if the "is it set up?" function is available in the SDK we're building against, only do this in OS builds, as it's not particularly useful in local builds.

rdar://124620772