### PR TITLE
SIL Parser: abort parsing a sil_global if there is an error in an initializer instruction

### DIFF
--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -7432,7 +7432,8 @@ bool SILParserState::parseSILGlobal(Parser &P) {
   if (State.P.consumeIf(tok::equal) && State.P.consumeIf(tok::l_brace)) {
     SILBuilder B(GV);
     do {
-      State.parseSILInstruction(B);
+      if (State.parseSILInstruction(B))
+        return true;
     } while (! State.P.consumeIf(tok::r_brace));
   }
   return false;

--- a/test/SIL/Parser/error_in_global.sil
+++ b/test/SIL/Parser/error_in_global.sil
@@ -1,0 +1,15 @@
+// RUN: %target-sil-opt -inline -verify %s
+
+// Check that the parser doesn't end up in an infinite error loop in case there is an error in a sil_global
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+sil_global @referencing_object : $Int = {
+  %initval = struct $Int_ ()
+  // expected-error @-1 {{cannot find type 'Int_' in scope}}
+}
+


### PR DESCRIPTION
Otherwise the parser ends up printing errors indefinitely.
