### PR TITLE
Improve debug performance of `UnsafePointer.pointer(to:)`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyKeyPath.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyKeyPath.swift
@@ -34,6 +34,7 @@ fileprivate func allUsesRemovable(instruction: Instruction) -> Bool {
       switch use.instruction {
       case is UpcastInst,
            is DestroyValueInst,
+           is StrongReleaseInst,
            is BeginBorrowInst,
            is EndBorrowInst,
            is MoveValueInst,

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -444,9 +444,7 @@ extension UnsafePointer {
   /// - Returns: A pointer to the stored property represented
   ///            by the key path, or `nil`.
   @_alwaysEmitIntoClient
-  #if $Embedded
   @_transparent
-  #endif
   public func pointer<Property>(
     to property: KeyPath<Pointee, Property>
   ) -> UnsafePointer<Property>? {
@@ -1332,9 +1330,7 @@ extension UnsafeMutablePointer {
   /// - Returns: A pointer to the stored property represented
   ///            by the key path, or `nil`.
   @_alwaysEmitIntoClient
-  #if $Embedded
   @_transparent
-  #endif
   public func pointer<Property>(
     to property: KeyPath<Pointee, Property>
   ) -> UnsafePointer<Property>? {
@@ -1356,9 +1352,7 @@ extension UnsafeMutablePointer {
   /// - Returns: A mutable pointer to the stored property represented
   ///            by the key path, or `nil`.
   @_alwaysEmitIntoClient
-  #if $Embedded
   @_transparent
-  #endif
   public func pointer<Property>(
     to property: WritableKeyPath<Pointee, Property>
   ) -> UnsafeMutablePointer<Property>? {

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -453,7 +453,7 @@ extension UnsafePointer {
     guard let o = property._storedInlineOffset else { return nil }
     _internalInvariant(o >= 0)
     _debugPrecondition(
-      o == 0 || UnsafeRawPointer(self) < UnsafeRawPointer(bitPattern: 0 &- o)!,
+      !UInt(bitPattern: self).addingReportingOverflow(UInt(bitPattern: o)).overflow,
       "Overflow in pointer arithmetic"
     )
     return .init(Builtin.gepRaw_Word(_rawValue, o._builtinWordValue))
@@ -1341,7 +1341,7 @@ extension UnsafeMutablePointer {
     guard let o = property._storedInlineOffset else { return nil }
     _internalInvariant(o >= 0)
     _debugPrecondition(
-      o == 0 || UnsafeRawPointer(self) < UnsafeRawPointer(bitPattern: 0 &- o)!,
+      !UInt(bitPattern: self).addingReportingOverflow(UInt(bitPattern: o)).overflow,
       "Overflow in pointer arithmetic"
     )
     return .init(Builtin.gepRaw_Word(_rawValue, o._builtinWordValue))
@@ -1365,7 +1365,7 @@ extension UnsafeMutablePointer {
     guard let o = property._storedInlineOffset else { return nil }
     _internalInvariant(o >= 0)
     _debugPrecondition(
-      o == 0 || UnsafeRawPointer(self) < UnsafeRawPointer(bitPattern: 0 &- o)!,
+      !UInt(bitPattern: self).addingReportingOverflow(UInt(bitPattern: o)).overflow,
       "Overflow in pointer arithmetic"
     )
     return .init(Builtin.gepRaw_Word(_rawValue, o._builtinWordValue))

--- a/test/SILOptimizer/pointer-performance.swift
+++ b/test/SILOptimizer/pointer-performance.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend %s -module-name=test -parse-as-library -emit-sil | %FileCheck %s
+
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+public struct S {
+  var a: Int
+  var b: Int
+}
+
+// Check that even with -Onone, no keypath is created.
+
+// CHECK-LABEL: sil @$s4test6testitySPySiGSgSPyAA1SVGF :
+// CHECK-NOT:     keypath
+// CHECK:       } // end sil function '$s4test6testitySPySiGSgSPyAA1SVGF'
+public func testit(_ p: UnsafePointer<S>) -> UnsafePointer<Int>? {
+  return p.pointer(to: \.b)
+}

--- a/test/SILOptimizer/simplify_keypath.sil
+++ b/test/SILOptimizer/simplify_keypath.sil
@@ -1,0 +1,47 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=keypath | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct S {
+  @_hasStorage var a: Int
+  @_hasStorage var b: Int
+}
+
+// CHECK-LABEL: sil [ossa] @remove_dead_keypath_ossa :
+// CHECK-NOT:     keypath
+// CHECK-NOT:     destroy_value
+// CHECK:         %0 = tuple
+// CHECK-NEXT:    return
+// CHECK:       } // end sil function 'remove_dead_keypath_ossa'
+sil [ossa] @remove_dead_keypath_ossa : $@convention(thin) () -> () {
+bb0:
+  %0 = keypath $WritableKeyPath<S, Int>, (root $S; stored_property #S.b : $Int)
+  %1 = upcast %0 : $WritableKeyPath<S, Int> to $KeyPath<S, Int>
+  %2 = begin_borrow %1 : $KeyPath<S, Int>
+  end_borrow %2 : $KeyPath<S, Int>
+  %4 = copy_value %1 : $KeyPath<S, Int>
+  %5 = move_value %4 : $KeyPath<S, Int>
+  destroy_value %1 : $KeyPath<S, Int>
+  destroy_value %5 : $KeyPath<S, Int>
+  %r = tuple()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @remove_dead_keypath :
+// CHECK-NOT:     keypath
+// CHECK-NOT:     strong_release
+// CHECK:         %0 = tuple
+// CHECK-NEXT:    return
+// CHECK:       } // end sil function 'remove_dead_keypath'
+sil @remove_dead_keypath : $@convention(thin) () -> () {
+bb0:
+  %0 = keypath $WritableKeyPath<S, Int>, (root $S; stored_property #S.b : $Int)
+  %1 = upcast %0 : $WritableKeyPath<S, Int> to $KeyPath<S, Int>
+  strong_release %1 : $KeyPath<S, Int>
+  %r = tuple()
+  return %r : $()
+}
+


### PR DESCRIPTION
Making those functions transparent enables to completely remove the creation of keypaths, even with -Onone.

Also, make pointer overflow checks in those functions more efficient.
Doing the overflow check with an UInt comparison instead of an UnsafePointer comparison saves the optional nil check for unwrapping the pointer.

rdar://127793797