### PR TITLE
[Sema] Strip off LValueType from opened existentials

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2327,21 +2327,37 @@ static Type typeEraseExistentialSelfReferences(
               return parameterized->getBaseType();
           }
         }
-        /*
+
         if (auto lvalue = dyn_cast<LValueType>(t)) {
           auto objTy = lvalue->getObjectType();
-          auto erasedTy =
+          Type erasedTy;
+
+          if (auto *memberTy = objTy->getAs<DependentMemberType>()) {
+            if (memberTy->getBase()->is<TypeVariableType>()) {
+              erasedTy =
+              typeEraseExistentialSelfReferences(
+                objTy, baseTy, currPos,
+                existentialSig, containsFn, predicateFn, projectionFn,
+                force);
+
+              if (erasedTy.getPointer() == objTy.getPointer())
+                return Type(lvalue);
+
+              return erasedTy;
+            }
+          } else if (auto arch = dyn_cast<OpenedArchetypeType>(objTy)){
+            erasedTy =
             typeEraseExistentialSelfReferences(
               objTy, baseTy, currPos,
               existentialSig, containsFn, predicateFn, projectionFn,
               force);
 
-          if (erasedTy.getPointer() == objTy.getPointer())
-            return Type(lvalue);
+            if (erasedTy.getPointer() == objTy.getPointer())
+              return Type(lvalue);
 
-          return erasedTy;
+            return erasedTy;
+          }
         }
-        */
 
         if (!predicateFn(t)) {
           // Recurse.

--- a/test/Sema/open_existential_lvalue.swift
+++ b/test/Sema/open_existential_lvalue.swift
@@ -1,8 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
-// rdar://121214563
-// REQUIRES: rdar121214563
-
 protocol Q {}
 
 protocol P {
@@ -40,29 +37,4 @@ func f(s: inout S, t: any Q.Type) -> (any Q) {
   takesAny(x: s[t])
   takesRValue(x: s[t])
   takesInOut(x: &s[t]) // expected-error {{cannot pass immutable value as inout argument: 's' is immutable}}
-}
-
-// https://github.com/apple/swift/issues/62219
-do {
-  struct Action {
-      var intVar: Int
-      var strVar: String
-  }
-
-  protocol TestDelegate: AnyObject {
-      associatedtype ActionType
-      var actions: [ActionType] { get set }
-  }
-
-  class TestDelegateImpl: TestDelegate {
-      typealias ActionType = Action
-      var actions: [Action] = []
-  }
-
-  class TestViewController {
-      var testDelegate: (any TestDelegate)?
-      func testFunc() {
-          testDelegate?.actions.removeAll() // expected-error {{cannot use mutating member on immutable value: 'self' is immutable}}
-      }
-  }
 }

--- a/test/Sema/open_existential_lvalue_sugar_type.swift
+++ b/test/Sema/open_existential_lvalue_sugar_type.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://121214563
+// REQUIRES: rdar121214563
+
+// https://github.com/apple/swift/issues/62219
+do {
+  struct Action {
+      var intVar: Int
+      var strVar: String
+  }
+
+  protocol TestDelegate: AnyObject {
+      associatedtype ActionType
+      var actions: [ActionType] { get set }
+  }
+
+  class TestDelegateImpl: TestDelegate {
+      typealias ActionType = Action
+      var actions: [Action] = []
+  }
+
+  class TestViewController {
+      var testDelegate: (any TestDelegate)?
+      func testFunc() {
+          testDelegate?.actions.removeAll() // expected-error {{cannot use mutating member on immutable value: 'self' is immutable}}
+      }
+  }
+}


### PR DESCRIPTION
Only do this for existentials with type variables and open archetypes.

Fixes rdar://121214563
