### PR TITLE
SILGen: Bug fix handling `consuming`/`borrowing` parameters and optional chaining.

### DIFF
--- a/test/SILGen/unmanaged-chain.swift
+++ b/test/SILGen/unmanaged-chain.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+extension Unmanaged {
+    func something1(with x: consuming Unmanaged<Instance>?) -> UnsafeMutableRawPointer? {
+        x?.toOpaque()
+    }
+
+    func something2(with x: consuming Unmanaged<Instance>?) -> UnsafeMutableRawPointer? {
+        let y = x
+        return y?.toOpaque()
+    }
+    func something3(with x: __owned Unmanaged<Instance>?) -> UnsafeMutableRawPointer? {
+        x?.toOpaque()
+    }
+}


### PR DESCRIPTION
Make sure we remove the `@moveOnly` marker while projecting the payload as expected for the (no longer non-implicitly-copyable) projected result. Fixes rdar://116127887.