### PR TITLE
[CodeCompletion] Don’t compute isolated parameter captures during code completion

### DIFF
--- a/validation-test/IDE/crashers_2_fixed/rdar126923558.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar126923558.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+
+actor Foo {
+  func bar() {}
+}
+
+func takeClosure(_ x: () -> Void) {}
+
+actor Foo {
+  func tests(myInt: Int) {
+    takeClosure {
+      myInt.#^COMPLETE^#
+    }
+  }
+}


### PR DESCRIPTION
Computing capture information requires a type checked AST, which we don’t have during code completion. To fix an assertion failure, don’t look for a captured `isolated` parameter while computing a closure’s actor isolation during code completion.

rdar://126923558
