### PR TITLE
Remove an old, horrible compatibility hack in the _Concurrency module

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -470,13 +470,6 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     interleave(RenderedArgs,
                [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
                [&] { OS << " "; });
-
-    // Backward-compatibility hack: disable availability checking in the
-    // _Concurrency module, so that older (Swift 5.5) compilers that did not
-    // support back deployment of concurrency do not complain about 'async'
-    // with older availability.
-    if (FOpts.ModuleName == "_Concurrency")
-      OS << " -disable-availability-checking";
   }
   {
     llvm::raw_string_ostream OS(Opts.IgnorablePrivateFlags);


### PR DESCRIPTION
The concurrency module was getting an implicit
`-disable-availability-checking` as a workaround from the Swift 5.6 days. Remove it, because it causes problems with the new `Failure` type in the async for..in loop.

Fixes a back-deployment issue with async algorithms in the _Concurrency library that use the async for..in loop.
