### PR TITLE
[6.0] Remove an old, horrible compatibility hack in the _Concurrency module

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -470,13 +470,6 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     interleave(RenderedArgs,
                [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
                [&] { OS << " "; });
-
-    // Backward-compatibility hack: disable availability checking in the
-    // _Concurrency module, so that older (Swift 5.5) compilers that did not
-    // support back deployment of concurrency do not complain about 'async'
-    // with older availability.
-    if (FOpts.ModuleName == "_Concurrency")
-      OS << " -disable-availability-checking";
   }
   {
     llvm::raw_string_ostream OS(Opts.IgnorablePrivateFlags);


### PR DESCRIPTION
**Explanation**: Remove a Swift 5.6-era compatibility hack that disabled availability checking in the `_Concurrency` module, which can lead to back-deployment issues with some algorithms and the new `AsyncIteratorProtocol`. 
**Original PR**: https://github.com/apple/swift/pull/73662
**Radar/issue**: rdar://127672617
**Risk**: Low. Makes the Swift interface for `_Concurrency` build the same way the original module does.
