### PR TITLE
[6.0] Consistently treat let properties as immutable within the type checker

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5571,6 +5571,21 @@ public:
   }
 };
 
+/// Describes whether a particular storage declaration is mutable.
+enum class StorageMutability {
+  /// The storage is immutable, meaning that it can neither be assigned
+  /// to nor passed inout.
+  Immutable,
+
+  /// The storage is mutable, meaning that it can be assigned and pased
+  /// inout.
+  Mutable,
+
+  /// The storage is immutable, but can be asigned for the purposes of
+  /// initialization.
+  Initializable
+};
+
 /// AbstractStorageDecl - This is the common superclass for VarDecl and
 /// SubscriptDecl, representing potentially settable memory locations.
 class AbstractStorageDecl : public ValueDecl {
@@ -5742,8 +5757,31 @@ public:
   /// Determine whether references to this storage declaration may appear
   /// on the left-hand side of an assignment, as the operand of a
   /// `&` or 'inout' operator, or as a component in a writable key path.
-  bool isSettable(const DeclContext *UseDC,
-                  const DeclRefExpr *base = nullptr) const;
+  bool isSettable(const DeclContext *useDC,
+                  const DeclRefExpr *base = nullptr) const {
+    switch (mutability(useDC, base)) {
+      case StorageMutability::Immutable:
+        return false;
+      case StorageMutability::Mutable:
+      case StorageMutability::Initializable:
+        return true;
+    }
+  }
+
+  /// Determine the mutability of this storage declaration when
+  /// accessed from a given declaration context.
+  StorageMutability mutability(const DeclContext *useDC,
+                               const DeclRefExpr *base = nullptr) const;
+
+  /// Determine the mutability of this storage declaration when
+  /// accessed from a given declaration context in Swift.
+  ///
+  /// This method differs only from 'mutability()' in its handling of
+  /// 'optional' storage requirements, which lack support for direct
+  /// writes in Swift.
+  StorageMutability mutabilityInSwift(
+      const DeclContext *useDC,
+      const DeclRefExpr *base = nullptr) const;
 
   /// Determine whether references to this storage declaration in Swift may
   /// appear on the left-hand side of an assignment, as the operand of a
@@ -5752,8 +5790,16 @@ public:
   /// This method is equivalent to \c isSettable with the exception of
   /// 'optional' storage requirements, which lack support for direct writes
   /// in Swift.
-  bool isSettableInSwift(const DeclContext *UseDC,
-                         const DeclRefExpr *base = nullptr) const;
+  bool isSettableInSwift(const DeclContext *useDC,
+                         const DeclRefExpr *base = nullptr) const {
+    switch (mutabilityInSwift(useDC, base)) {
+      case StorageMutability::Immutable:
+        return false;
+      case StorageMutability::Mutable:
+      case StorageMutability::Initializable:
+        return true;
+    }
+  }
 
   /// Does this storage declaration have explicitly-defined accessors
   /// written in the source?
@@ -6070,13 +6116,10 @@ public:
   /// precisely point to the variable type because of type aliases.
   SourceRange getTypeSourceRangeForDiagnostics() const;
 
-  /// Returns whether the var is settable in the specified context: this
-  /// is either because it is a stored var, because it has a custom setter, or
-  /// is a let member in an initializer.
-  ///
-  /// Pass a null context and null base to check if it's always settable.
-  bool isSettable(const DeclContext *UseDC,
-                  const DeclRefExpr *base = nullptr) const;
+  /// Determine the mutability of this variable declaration when
+  /// accessed from a given declaration context.
+  StorageMutability mutability(const DeclContext *useDC,
+                               const DeclRefExpr *base = nullptr) const;
 
   /// Return the parent pattern binding that may provide an initializer for this
   /// VarDecl.  This returns null if there is none associated with the VarDecl.
@@ -9314,26 +9357,6 @@ findGenericParameterReferences(const ValueDecl *value, CanGenericSignature sig,
                                GenericTypeParamType *genericParam,
                                bool treatNonResultCovarianceAsInvariant,
                                std::optional<unsigned> skipParamIndex);
-
-inline bool AbstractStorageDecl::isSettable(const DeclContext *UseDC,
-                                            const DeclRefExpr *base) const {
-  if (auto vd = dyn_cast<VarDecl>(this))
-    return vd->isSettable(UseDC, base);
-
-  auto sd = cast<SubscriptDecl>(this);
-  return sd->supportsMutation();
-}
-
-inline bool
-AbstractStorageDecl::isSettableInSwift(const DeclContext *UseDC,
-                                       const DeclRefExpr *base) const {
-  // TODO: Writing to an optional storage requirement is not supported in Swift.
-  if (getAttrs().hasAttribute<OptionalAttr>()) {
-    return false;
-  }
-
-  return isSettable(UseDC, base);
-}
 
 inline void
 AbstractStorageDecl::overwriteSetterAccess(AccessLevel accessLevel) {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2092,6 +2092,14 @@ struct ClosureIsolatedByPreconcurrency {
   bool operator()(const ClosureExpr *expr) const;
 };
 
+/// Determine whether the given expression is part of the left-hand side
+/// of an assignment expression.
+struct IsInLeftHandSideOfAssignment {
+  ConstraintSystem &cs;
+
+  bool operator()(Expr *expr) const;
+};
+
 /// Describes the type produced when referencing a declaration.
 struct DeclReferenceType {
   /// The "opened" type, which is the type of the declaration where any
@@ -4404,7 +4412,7 @@ public:
   /// \param wantInterfaceType Whether we want the interface type, if available.
   Type getUnopenedTypeOfReference(VarDecl *value, Type baseType,
                                   DeclContext *UseDC,
-                                  ConstraintLocator *memberLocator = nullptr,
+                                  ConstraintLocator *locator,
                                   bool wantInterfaceType = false,
                                   bool adjustForPreconcurrency = true);
 
@@ -4426,7 +4434,7 @@ public:
   getUnopenedTypeOfReference(
       VarDecl *value, Type baseType, DeclContext *UseDC,
       llvm::function_ref<Type(VarDecl *)> getType,
-      ConstraintLocator *memberLocator = nullptr,
+      ConstraintLocator *locator,
       bool wantInterfaceType = false,
       bool adjustForPreconcurrency = true,
       llvm::function_ref<Type(const AbstractClosureExpr *)> getClosureType =
@@ -4436,7 +4444,10 @@ public:
       llvm::function_ref<bool(const ClosureExpr *)> isolatedByPreconcurrency =
         [](const ClosureExpr *closure) {
           return closure->isIsolatedByPreconcurrency();
-        });
+        },
+      llvm::function_ref<bool(Expr *)> isAssignTarget = [](Expr *) {
+        return false;
+      });
 
   /// Given the opened type and a pile of information about a member reference,
   /// determine the reference type of the member reference.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3091,6 +3091,34 @@ bool AbstractStorageDecl::isSetterMutating() const {
     IsSetterMutatingRequest{const_cast<AbstractStorageDecl *>(this)}, {});
 }
 
+StorageMutability 
+AbstractStorageDecl::mutability(const DeclContext *useDC,
+                                const DeclRefExpr *base) const {
+  if (auto vd = dyn_cast<VarDecl>(this))
+    return vd->mutability(useDC, base);
+
+  auto sd = cast<SubscriptDecl>(this);
+  return sd->supportsMutation() ? StorageMutability::Mutable
+                                : StorageMutability::Immutable;
+}
+
+/// Determine the mutability of this storage declaration when
+/// accessed from a given declaration context in Swift.
+///
+/// This method differs only from 'mutability()' in its handling of
+/// 'optional' storage requirements, which lack support for direct
+/// writes in Swift.
+StorageMutability
+AbstractStorageDecl::mutabilityInSwift(const DeclContext *useDC,
+                                       const DeclRefExpr *base) const {
+  // TODO: Writing to an optional storage requirement is not supported in Swift.
+  if (getAttrs().hasAttribute<OptionalAttr>()) {
+    return StorageMutability::Immutable;
+  }
+
+  return mutability(useDC, base);
+}
+
 OpaqueReadOwnership AbstractStorageDecl::getOpaqueReadOwnership() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,
@@ -7267,14 +7295,21 @@ Type VarDecl::getTypeInContext() const {
   return getDeclContext()->mapTypeIntoContext(getInterfaceType());
 }
 
+/// Translate an "is mutable" bit into a StorageMutability value.
+static StorageMutability storageIsMutable(bool isMutable) {
+  return isMutable ? StorageMutability::Mutable
+                   : StorageMutability::Immutable;
+}
+
 /// Returns whether the var is settable in the specified context: this
 /// is either because it is a stored var, because it has a custom setter, or
 /// is a let member in an initializer.
-bool VarDecl::isSettable(const DeclContext *UseDC,
-                         const DeclRefExpr *base) const {
+StorageMutability
+VarDecl::mutability(const DeclContext *UseDC,
+                    const DeclRefExpr *base) const {
   // Parameters are settable or not depending on their ownership convention.
   if (auto *PD = dyn_cast<ParamDecl>(this))
-    return !PD->isImmutableInFunctionBody();
+    return storageIsMutable(!PD->isImmutableInFunctionBody());
 
   // If this is a 'var' decl, then we're settable if we have storage or a
   // setter.
@@ -7282,17 +7317,17 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
     if (hasInitAccessor()) {
       if (auto *ctor = dyn_cast_or_null<ConstructorDecl>(UseDC)) {
         if (base && ctor->getImplicitSelfDecl() != base->getDecl())
-          return supportsMutation();
-        return true;
+          return storageIsMutable(supportsMutation());
+        return StorageMutability::Initializable;
       }
     }
 
-    return supportsMutation();
+    return storageIsMutable(supportsMutation());
   }
 
   // Static 'let's are always immutable.
   if (isStatic()) {
-    return false;
+    return StorageMutability::Immutable;
   }
 
   //
@@ -7302,11 +7337,11 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
 
   // Debugger expression 'let's are initialized through a side-channel.
   if (isDebuggerVar())
-    return false;
+    return StorageMutability::Immutable;
 
   // 'let's are only ever settable from a specific DeclContext.
   if (UseDC == nullptr)
-    return false;
+    return StorageMutability::Immutable;
 
   // 'let' properties in structs/classes are only ever settable in their
   // designated initializer(s) or by init accessors.
@@ -7318,61 +7353,64 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
       // Check whether this property is part of `initializes` list,
       // and allow assignment/mutation if so. DI would be responsible
       // for checking for re-assignment.
-      return accessor->isInitAccessor() &&
+      if (accessor->isInitAccessor() &&
              llvm::is_contained(accessor->getInitializedProperties(),
-                                const_cast<VarDecl *>(this));
+                                const_cast<VarDecl *>(this)))
+        return StorageMutability::Initializable;
+
+      return StorageMutability::Immutable;
     }
 
     auto *CD = dyn_cast<ConstructorDecl>(UseDC);
-    if (!CD) return false;
-    
+    if (!CD) return StorageMutability::Immutable;
+
     auto *CDC = CD->getDeclContext();
 
     // 'let' properties are not valid inside protocols.
     if (CDC->getExtendedProtocolDecl())
-      return false;
+      return StorageMutability::Immutable;
 
     // If this init is defined inside of the same type (or in an extension
     // thereof) as the let property, then it is mutable.
     if (CDC->getSelfNominalTypeDecl() !=
         getDeclContext()->getSelfNominalTypeDecl())
-      return false;
+      return StorageMutability::Immutable;
 
     if (base && CD->getImplicitSelfDecl() != base->getDecl())
-      return false;
+      return StorageMutability::Immutable;
 
     // If this is a convenience initializer (i.e. one that calls
     // self.init), then let properties are never mutable in it.  They are
     // only mutable in designated initializers.
     auto initKindAndExpr = CD->getDelegatingOrChainedInitKind();
     if (initKindAndExpr.initKind == BodyInitKind::Delegating)
-      return false;
+      return StorageMutability::Immutable;
 
-    return true;
+    return StorageMutability::Initializable;
   }
 
   // If the 'let' has a value bound to it but has no PBD, then it is
   // already initializedand not settable.
   if (getParentPatternBinding() == nullptr)
-    return false;
+    return StorageMutability::Immutable;
 
   // If the 'let' has an explicitly written initializer with a pattern binding,
   // then it isn't settable.
   if (isParentInitialized())
-    return false;
+    return StorageMutability::Immutable;
 
   // Normal lets (e.g. globals) are only mutable in the context of the
   // declaration.  To handle top-level code properly, we look through
   // the TopLevelCode decl on the use (if present) since the vardecl may be
   // one level up.
   if (getDeclContext() == UseDC)
-    return true;
+    return StorageMutability::Initializable;
 
   if (isa<TopLevelCodeDecl>(UseDC) &&
       getDeclContext() == UseDC->getParent())
-    return true;
+    return StorageMutability::Initializable;
 
-  return false;
+  return StorageMutability::Immutable;
 }
 
 bool VarDecl::isLazilyInitializedGlobal() const {

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -647,7 +647,8 @@ bool SILGenFunction::unsafelyInheritsExecutor() {
 
 void ExecutorBreadcrumb::emit(SILGenFunction &SGF, SILLocation loc) {
   if (mustReturnToExecutor) {
-    assert(SGF.ExpectedExecutor || SGF.unsafelyInheritsExecutor());
+    assert(SGF.ExpectedExecutor || SGF.unsafelyInheritsExecutor() ||
+           SGF.isCtorWithHopsInjectedByDefiniteInit());
     if (auto executor = SGF.ExpectedExecutor)
       SGF.B.createHopToExecutor(
           RegularLocation::getDebugOnlyLocation(loc, SGF.getModule()), executor,

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -618,6 +618,19 @@ static bool ctorHopsInjectedByDefiniteInit(ConstructorDecl *ctor,
   }
 }
 
+bool SILGenFunction::isCtorWithHopsInjectedByDefiniteInit() {
+  auto declRef = F.getDeclRef();
+  if (!declRef || !declRef.isConstructor())
+    return false;
+
+  auto ctor = dyn_cast_or_null<ConstructorDecl>(declRef.getDecl());
+  if (!ctor)
+    return false;
+
+  auto isolation = getActorIsolation(ctor);
+  return ctorHopsInjectedByDefiniteInit(ctor, isolation);
+}
+
 void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   MagicFunctionName = SILGenModule::getMagicFunctionName(ctor);
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -820,6 +820,10 @@ public:
   /// the fields.
   void emitDeallocatingMoveOnlyDestructor(DestructorDecl *dd);
 
+  /// Whether we are inside a constructor whose hops are injected by
+  /// definite initialization.
+  bool isCtorWithHopsInjectedByDefiniteInit();
+
   /// Generates code for a struct constructor.
   /// This allocates the new 'self' value, emits the
   /// body code, then returns the final initialized 'self'.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1426,12 +1426,14 @@ ConstraintSystem::getWrappedPropertyInformation(
 ///   is being accessed; must be null if and only if this is not
 ///   a type member
 static bool
-doesStorageProduceLValue(AbstractStorageDecl *storage, Type baseType,
-                         DeclContext *useDC,
-                         ConstraintLocator *memberLocator = nullptr) {
+doesStorageProduceLValue(
+    AbstractStorageDecl *storage, Type baseType,
+    DeclContext *useDC,
+    llvm::function_ref<bool(Expr *)> isAssignTarget,
+    ConstraintLocator *locator) {
   const DeclRefExpr *base = nullptr;
-  if (memberLocator) {
-    if (auto *const E = getAsExpr(memberLocator->getAnchor())) {
+  if (locator) {
+    if (auto *const E = getAsExpr(locator->getAnchor())) {
       if (auto *MRE = dyn_cast<MemberRefExpr>(E)) {
         base = dyn_cast<DeclRefExpr>(MRE->getBase());
       } else if (auto *UDE = dyn_cast<UnresolvedDotExpr>(E)) {
@@ -1440,9 +1442,33 @@ doesStorageProduceLValue(AbstractStorageDecl *storage, Type baseType,
     }
   }
 
-  // Unsettable storage decls always produce rvalues.
-  if (!storage->isSettableInSwift(useDC, base))
-    return false;
+  switch (storage->mutabilityInSwift(useDC, base)) {
+    case StorageMutability::Immutable:
+      // Immutable storage decls always produce rvalues.
+      return false;
+
+    case StorageMutability::Mutable:
+      break;
+
+    case StorageMutability::Initializable: {
+      // If the member is not known to be on the left-hand side of
+      // an assignment, treat it as an rvalue so we can't pass it
+      // inout.
+      if (!locator)
+        return false;
+
+      auto *anchor = getAsExpr(simplifyLocatorToAnchor(locator));
+      if (!anchor)
+        return false;
+
+      // If the anchor isn't known to be the target of an assignment,
+      // treat as immutable.
+      if (!isAssignTarget(anchor))
+        return false;
+
+      break;
+    }
+  }
 
   if (!storage->isSetterAccessibleFrom(useDC))
     return false;
@@ -1482,7 +1508,7 @@ ClosureIsolatedByPreconcurrency::operator()(const ClosureExpr *expr) const {
 
 Type ConstraintSystem::getUnopenedTypeOfReference(
     VarDecl *value, Type baseType, DeclContext *UseDC,
-    ConstraintLocator *memberLocator, bool wantInterfaceType,
+    ConstraintLocator *locator, bool wantInterfaceType,
     bool adjustForPreconcurrency) {
   return ConstraintSystem::getUnopenedTypeOfReference(
       value, baseType, UseDC,
@@ -1496,18 +1522,20 @@ Type ConstraintSystem::getUnopenedTypeOfReference(
 
         return wantInterfaceType ? var->getInterfaceType() : var->getTypeInContext();
       },
-      memberLocator, wantInterfaceType, adjustForPreconcurrency,
+      locator, wantInterfaceType, adjustForPreconcurrency,
       GetClosureType{*this},
-      ClosureIsolatedByPreconcurrency{*this});
+      ClosureIsolatedByPreconcurrency{*this},
+      IsInLeftHandSideOfAssignment{*this});
 }
 
 Type ConstraintSystem::getUnopenedTypeOfReference(
     VarDecl *value, Type baseType, DeclContext *UseDC,
     llvm::function_ref<Type(VarDecl *)> getType,
-    ConstraintLocator *memberLocator,
+    ConstraintLocator *locator,
     bool wantInterfaceType, bool adjustForPreconcurrency,
     llvm::function_ref<Type(const AbstractClosureExpr *)> getClosureType,
-    llvm::function_ref<bool(const ClosureExpr *)> isolatedByPreconcurrency) {
+    llvm::function_ref<bool(const ClosureExpr *)> isolatedByPreconcurrency,
+    llvm::function_ref<bool(Expr *)> isAssignTarget) {
   Type requestedType =
       getType(value)->getWithoutSpecifierType()->getReferenceStorageReferent();
 
@@ -1532,7 +1560,8 @@ Type ConstraintSystem::getUnopenedTypeOfReference(
 
   // Qualify storage declarations with an lvalue when appropriate.
   // Otherwise, they yield rvalues (and the access must be a load).
-  if (doesStorageProduceLValue(value, baseType, UseDC, memberLocator) &&
+  if (doesStorageProduceLValue(value, baseType, UseDC, isAssignTarget,
+                               locator) &&
       !requestedType->hasError()) {
     return LValueType::get(requestedType);
   }
@@ -1905,7 +1934,8 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
   // FIXME: @preconcurrency
   bool wantInterfaceType = !varDecl->getDeclContext()->isLocalContext();
   Type valueType =
-      getUnopenedTypeOfReference(varDecl, Type(), useDC, /*base=*/nullptr,
+      getUnopenedTypeOfReference(varDecl, Type(), useDC, 
+                                 getConstraintLocator(locator),
                                  wantInterfaceType);
 
   Type thrownErrorType;
@@ -2579,6 +2609,48 @@ bool ConstraintSystem::isPartialApplication(ConstraintLocator *locator) {
   return level < (baseTy->is<MetatypeType>() ? 1 : 2);
 }
 
+bool IsInLeftHandSideOfAssignment::operator()(Expr *expr) const {
+  // Walk up the parent tree.
+  auto parent = cs.getParentExpr(expr);
+  if (!parent)
+    return false;
+
+  // If the parent is an assignment expression, check whether we are
+  // the left-hand side.
+  if (auto assignParent = dyn_cast<AssignExpr>(parent)) {
+    return expr == assignParent->getDest();
+  }
+
+  // Always look up through these parent kinds.
+  if (isa<TupleExpr>(parent) || isa<IdentityExpr>(parent) ||
+      isa<AnyTryExpr>(parent) || isa<BindOptionalExpr>(parent)) {
+    return (*this)(parent);
+  }
+
+  // If the parent is a lookup expression, only follow from the base.
+  if (auto lookupParent = dyn_cast<LookupExpr>(parent)) {
+    if (lookupParent->getBase() == expr)
+      return (*this)(parent);
+
+    // The expression wasn't in the base, so this isn't part of the
+    // left-hand side.
+    return false;
+  }
+
+  // If the parent is an unresolved member reference a.b, only follow
+  // from the base.
+  if (auto dotParent = dyn_cast<UnresolvedDotExpr>(parent)) {
+    if (dotParent->getBase() == expr)
+      return (*this)(parent);
+
+    // The expression wasn't in the base, so this isn't part of the
+    // left-hand side.
+    return false;
+  }
+
+  return false;
+}
+
 DeclReferenceType
 ConstraintSystem::getTypeOfMemberReference(
     Type baseTy, ValueDecl *value, DeclContext *useDC,
@@ -2684,7 +2756,9 @@ ConstraintSystem::getTypeOfMemberReference(
     if (auto *subscript = dyn_cast<SubscriptDecl>(value)) {
       auto elementTy = subscript->getElementInterfaceType();
 
-      if (doesStorageProduceLValue(subscript, baseTy, useDC, locator))
+      if (doesStorageProduceLValue(
+              subscript, baseTy, useDC,
+              IsInLeftHandSideOfAssignment{*this}, locator))
         elementTy = LValueType::get(elementTy);
 
       auto indices = subscript->getInterfaceType()
@@ -2939,7 +3013,10 @@ Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,
     if (auto subscript = dyn_cast<SubscriptDecl>(decl)) {
       auto elementTy = subscript->getElementInterfaceType();
 
-      if (doesStorageProduceLValue(subscript, overload.getBaseType(), useDC))
+      if (doesStorageProduceLValue(subscript, overload.getBaseType(),
+                                   useDC,
+                                   IsInLeftHandSideOfAssignment{*this},
+                                   locator))
         elementTy = LValueType::get(elementTy);
       else if (elementTy->hasDynamicSelfType()) {
         elementTy = withDynamicSelfResultReplaced(elementTy,
@@ -2963,7 +3040,9 @@ Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,
           locator);
     } else if (auto var = dyn_cast<VarDecl>(decl)) {
       type = var->getValueInterfaceType();
-      if (doesStorageProduceLValue(var, overload.getBaseType(), useDC)) {
+      if (doesStorageProduceLValue(
+              var, overload.getBaseType(), useDC,
+              IsInLeftHandSideOfAssignment{*this}, locator)) {
         type = LValueType::get(type);
       } else if (type->hasDynamicSelfType()) {
         type = withDynamicSelfResultReplaced(type, /*uncurryLevel=*/0);

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -581,17 +581,6 @@ bool TypeChecker::requireArrayLiteralIntrinsics(ASTContext &ctx,
   return true;
 }
 
-Expr *TypeChecker::buildCheckedRefExpr(VarDecl *value, DeclContext *UseDC,
-                                       DeclNameLoc loc, bool Implicit) {
-  auto type = constraints::ConstraintSystem::getUnopenedTypeOfReference(
-      value, Type(), UseDC,
-      [&](VarDecl *var) -> Type { return value->getTypeInContext(); });
-  auto semantics = value->getAccessSemanticsFromContext(UseDC,
-                                                       /*isAccessOnSelf*/false);
-  return new (value->getASTContext())
-      DeclRefExpr(value, loc, Implicit, semantics, type);
-}
-
 Expr *TypeChecker::buildRefExpr(ArrayRef<ValueDecl *> Decls,
                                 DeclContext *UseDC, DeclNameLoc NameLoc,
                                 bool Implicit, FunctionRefKind functionRefKind) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -944,10 +944,6 @@ Comparison compareDeclarations(DeclContext *dc, ValueDecl *decl1,
 /// of the first one and the expression will still type check.
 bool isDeclRefinementOf(ValueDecl *declA, ValueDecl *declB);
 
-/// Build a type-checked reference to the given value.
-Expr *buildCheckedRefExpr(VarDecl *D, DeclContext *UseDC, DeclNameLoc nameLoc,
-                          bool Implicit);
-
 /// Build a reference to a declaration, where name lookup returned
 /// the given set of declarations.
 Expr *buildRefExpr(ArrayRef<ValueDecl *> Decls, DeclContext *UseDC,

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1396,7 +1396,9 @@ do {
   func generic<T>(_ value: inout T, _ closure: (S<T>) -> Void) {}
 
   let arg: Int
+  // expected-note@-1{{change 'let' to 'var' to make it mutable}}
   generic(&arg) { (g: S<Double>) -> Void in } // expected-error {{cannot convert value of type '(S<Double>) -> Void' to expected argument type '(S<Int>) -> Void'}}
+  // expected-error@-1{{cannot pass immutable value as inout argument: 'arg' is a 'let' constant}}
 }
 
 // rdar://problem/62428353 - bad error message for passing `T` where `inout T` was expected
@@ -1556,18 +1558,17 @@ func testNilCoalescingOperatorRemoveFix() {
   let _ = "" /* This is a comment */ ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{13-43=}}
 
   let _ = "" // This is a comment
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1558:13-1559:10=}}
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1560:13-1561:10=}}
 
   let _ = "" // This is a comment
     /*
      * The blank line below is part of the test case, do not delete it
      */
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1563:13-1567:10=}}
 
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1561:13-1566:10=}}
-
-  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-1569:9=}}
+  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-1570:9=}}
       "").isEmpty {}
 
   if ("" // This is a comment
-      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1571:9-1572:12=}}
+      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1572:9-1573:12=}}
 }

--- a/test/SILOptimizer/definite_init_existential_let.swift
+++ b/test/SILOptimizer/definite_init_existential_let.swift
@@ -15,7 +15,6 @@ class ImmutableP {
 
   init(field: P) {
     self.field = field
-    self.field.foo() // expected-error{{}}
     self.field.bar = 4 // expected-error{{}}
   }
 }
@@ -24,6 +23,5 @@ func immutableP(field: P) {
   let x: P // expected-note* {{}}
 
   x = field
-  x.foo() // expected-error{{}}
   x.bar = 4 // expected-error{{}}
 }

--- a/test/SILOptimizer/definite_init_inout_super_init.swift
+++ b/test/SILOptimizer/definite_init_inout_super_init.swift
@@ -15,7 +15,7 @@ class A : B {
 
   init() {
     self.x = 12
-    super.init(x: &x) // expected-error {{immutable value 'self.x' must not be passed inout}}
+    super.init(x: &x) // expected-error {{cannot pass immutable value as inout argument: 'x' is a 'let' constant}}
   }
 }
 
@@ -24,7 +24,7 @@ class C : B {
 
   init() {
     self.x = Klass()
-    super.init(x: &x) // expected-error {{immutable value 'self.x' must not be passed inout}}
+    super.init(x: &x) // expected-error {{cannot pass immutable value as inout argument: 'x' is a 'let' constant}}
   }
 }
 

--- a/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
+++ b/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
@@ -42,10 +42,8 @@ extension TestProtocol {
 
 // Mark: - Case3: Illegally mutating let constant in a function scope
 
-let testObject2: TestProtocol  // expected-note 2 {{change 'let' to 'var' to make it mutable}}
+let testObject2: TestProtocol
 testObject2 = TestStruct(foo: 42)
-testObject2.messThingsUp() // expected-error {{mutating method 'messThingsUp' may not be used on immutable value 'testObject2'}}
-try! testObject2.messThingsUpAndThenThrow() // expected-error {{mutating method 'messThingsUpAndThenThrow' may not be used on immutable value 'testObject2'}}
 
 func testFunc() {
     let testObject: TestProtocol // expected-note {{change 'let' to 'var' to make it mutable}}
@@ -56,10 +54,9 @@ func testFunc() {
 
 // Mark: - Case4: Illegally passing a let constants property as an inout parameter
 
-let testObject3: TestProtocol  // expected-note {{change 'let' to 'var' to make it mutable}}
+let testObject3: TestProtocol
 testObject3 = TestStruct(foo: 42)
 
 func mutateThis(mutatee: inout Int) {
     mutatee = 666
 }
-mutateThis(mutatee: &testObject3.foo) // expected-error {{cannot mutate property 'foo' of immutable value 'testObject3'}}

--- a/test/SILOptimizer/definite_init_value_types_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_value_types_diagnostics.swift
@@ -78,3 +78,16 @@ struct AddressStruct {
     self = AddressStruct()
   } // expected-error {{return from initializer without initializing all stored properties}}
 }
+
+// Old versions of swift-syntax have this logical use-before-definition; make
+// sure we keep it working.
+struct InitLogicalUseBeforeDef {
+  let offset: UInt16
+
+  init?(value: Int) {
+    if value > type(of: self.offset).max {
+      return nil
+    }
+    offset = UInt16(value)
+  }
+}

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -404,14 +404,19 @@ func takesClosure(_: (Int) -> Int) {
 
 func updateInt(_ x : inout Int) {}
 
+extension Int {
+  mutating func negateMe() { }
+}
+
 // rdar://15785677 - allow 'let' declarations in structs/classes be initialized in init()
 class LetClassMembers {
-  let a : Int       // expected-note 2 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}}
+  let a : Int       // expected-note 4 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}}
   let b : Int       // expected-note {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
 
   init(arg : Int) {
     a = arg             // ok, a is mutable in init()
-    updateInt(&a)       // ok, a is mutable in init() and has been initialized
+    a.negateMe()        // expected-error{{cannot use mutating member on immutable value: 'a' is a 'let' constant}}
+    updateInt(&a)       // expected-error{{cannot pass immutable value as inout argument: 'a' is a 'let' constant}}
     b = 17              // ok, b is mutable in init()
   }
 
@@ -422,12 +427,13 @@ class LetClassMembers {
   }
 }
 struct LetStructMembers {
-  let a : Int       // expected-note 2 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}}
+  let a : Int       // expected-note 4 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}}
   let b : Int       // expected-note {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
 
   init(arg : Int) {
     a = arg             // ok, a is mutable in init()
-    updateInt(&a)       // ok, a is mutable in init() and has been initialized
+    updateInt(&a)       // expected-error {{cannot pass immutable value as inout argument: 'a' is a 'let' constant}}
+    a += 1              // expected-error {{left side of mutating operator isn't mutable: 'a' is a 'let' constant}}
     b = 17              // ok, b is mutable in init()
   }
 

--- a/test/Sema/immutability_overload_async.swift
+++ b/test/Sema/immutability_overload_async.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+protocol Iterator {
+  associatedtype Failure: Error
+  mutating func next() async throws -> Int?
+}
+
+extension Iterator {
+  mutating func next() async throws(Failure) -> Int? {
+    nil
+  }
+}
+
+actor C: Iterator {
+  typealias Failure = any Error
+  func next() throws -> Int? { nil }
+}
+
+actor A {
+  let c = C()
+
+  init() async {
+    _ = try! await self.c.next()
+  }
+}


### PR DESCRIPTION
**Explanation**: Rework our handling of let properties so that they are treated as rvalues uniformly except when they are being assigned to. This moves the inout/mutating checking up into the type checker, whereas it was previously handled at a later stage in Definite Initialization. This change allows overload resolution to correctly reject a call to a `mutable` function on a `let` property in an initializer, and therefore choose another option, which is a more appropriate way to model the language semantics.  
**Original PR**: https://github.com/apple/swift/pull/73609
**Radar/issue**: rdar://127258363, a source compatibility issue with `AsyncIteratorProtocol.next()`'s default implementation that required this semantic improvement.
**Risk**: Medium-low. This changes the modeling of references to `let` instance properties within an initializer and uninitialized local `let` properties within the type checker to make them rvalues unless they're the target of an assignment (in which case they remain lvalues). The type checker, however, still creates an AST that treats them as lvalues (that are immediately loaded), because later compiler passes (SILGen and DI) expect this modeling. The overall effect is expected to be very small, and should only serve to make some ill-formed programs (where the type checker picked a `mutable` function on an lvalue) well-formed or diagnose in an earlier phase of the compiler.
**Reviewed by**: @xedin 