### PR TITLE
[Build] Add compatibility library deps to target executables.

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1,6 +1,7 @@
 
 include(AddSwift)
 include(SwiftSource)
+include(CompatibilityLibs)
 
 function(add_dependencies_multiple_targets)
   cmake_parse_arguments(
@@ -2798,6 +2799,15 @@ function(_add_swift_target_executable_single name)
       ${SWIFTEXE_SINGLE_SOURCES}
       ${SWIFTEXE_SINGLE_EXTERNAL_SOURCES})
 
+  # Darwin may need the compatibility libraries
+  set(compatibility_libs)
+  if(SWIFTEXE_SINGLE_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+    get_compatibility_libs(
+      "${SWIFTEXE_SINGLE_SDK}"
+      "${SWIFTEXE_SINGLE_ARCHITECTURE}"
+      compatibility_libs)
+  endif()
+
   # ELF and COFF need swiftrt
   if(("${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_OBJECT_FORMAT}" STREQUAL "ELF" OR
       "${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_OBJECT_FORMAT}" STREQUAL "COFF")
@@ -2811,6 +2821,7 @@ function(_add_swift_target_executable_single name)
       TARGETS "${name}"
       DEPENDS
         ${dependency_target}
+        ${compatibility_libs}
         ${LLVM_COMMON_DEPENDS}
         ${SWIFTEXE_SINGLE_DEPENDS})
   llvm_update_compile_flags("${name}")

--- a/stdlib/cmake/modules/CompatibilityLibs.cmake
+++ b/stdlib/cmake/modules/CompatibilityLibs.cmake
@@ -1,0 +1,19 @@
+# Generate a list of the compatibility library targets given an sdk and
+# architecture.
+function(get_compatibility_libs sdk arch result_var_name)
+  set(compatibility_libs)
+
+  if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
+    set(vsuffix "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+
+    list(APPEND compatibility_libs
+      swiftCompatibilityConcurrency${vsuffix}
+      swiftCompatibilityDynamicReplacements${vsuffix}
+      swiftCompatibilityPacks${vsuffix}
+      swiftCompatibility50${vsuffix}
+      swiftCompatibility51${vsuffix}
+      swiftCompatibility56${vsuffix})
+  endif()
+
+  set("${result_var_name}" "${compatibility_libs}" PARENT_SCOPE)
+endfunction()

--- a/stdlib/toolchain/CMakeLists.txt
+++ b/stdlib/toolchain/CMakeLists.txt
@@ -3,6 +3,7 @@
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../cmake/modules)
 include(StdlibOptions)
 include(AddSwiftStdlib)
+include(CompatibilityLibs)
 
 set(CXX_COMPILE_FLAGS)
 set(CXX_LINK_FLAGS)
@@ -58,13 +59,13 @@ if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
   # of all the compatibility libraries needed to build
   # host tools in a single place
   add_library(HostCompatibilityLibs INTERFACE)
-  set(vsuffix "-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
+  get_compatibility_libs(
+    "${SWIFT_HOST_VARIANT_SDK}"
+    "${SWIFT_HOST_VARIANT_ARCH}"
+    compatibility_libs
+    )
   target_link_libraries(HostCompatibilityLibs INTERFACE
-    swiftCompatibilityConcurrency${vsuffix}
-    swiftCompatibilityDynamicReplacements${vsuffix}
-    swiftCompatibilityPacks${vsuffix}
-    swiftCompatibility50${vsuffix}
-    swiftCompatibility51${vsuffix}
-    swiftCompatibility56${vsuffix})
+    ${compatibility_libs}
+    )
   set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS HostCompatibilityLibs)
 endif()


### PR DESCRIPTION
We need to make sure that we add the compatibility libraries as dependencies for target executables, otherwise we can end up with a race condition in the build where the build will fail if the compatibility libraries haven't been built by the time e.g. `swift-backtrace` is linked.

rdar://128197532
