### PR TITLE
🍒[cxx-interop][Runtime] Initialize metadata of a Swift array of C++ references correctly

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -297,7 +297,6 @@ public:
     case MetadataKind::Class:
     case MetadataKind::ObjCClassWrapper:
     case MetadataKind::ForeignClass:
-    case MetadataKind::ForeignReferenceType:
       return true;
 
     default:

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1430,7 +1430,8 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite Apply) {
 ///  getContiguousArrayStorageType<Int>(for:)
 ///    => metatype @thick ContiguousArrayStorage<Int>.Type
 /// We know that `getContiguousArrayStorageType` will not return the AnyObject
-/// type optimization for any non class or objc existential type instantiation.
+/// type optimization for any non class or objc existential type instantiation
+/// or a C++ foreign reference type.
 static bool shouldReplaceCallByMetadataConstructor(CanType storageMetaTy) {
   auto metaTy = dyn_cast<MetatypeType>(storageMetaTy);
   if (!metaTy || metaTy->getRepresentation() != MetatypeRepresentation::Thick)
@@ -1451,7 +1452,7 @@ static bool shouldReplaceCallByMetadataConstructor(CanType storageMetaTy) {
   if (ty->getStructOrBoundGenericStruct() || ty->getEnumOrBoundGenericEnum() ||
       isa<BuiltinVectorType>(ty) || isa<BuiltinIntegerType>(ty) ||
       isa<BuiltinFloatType>(ty) || isa<TupleType>(ty) ||
-      isa<AnyFunctionType>(ty) ||
+      isa<AnyFunctionType>(ty) || ty->isForeignReferenceType() ||
       (ty->isAnyExistentialType() && !ty->isObjCExistentialType()))
     return true;
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1746,6 +1746,10 @@ shouldReplaceCallByContiguousArrayStorageAnyObject(SILFunction &F,
   auto ty = genericArgs[0]->getCanonicalType();
   if (!ty->getClassOrBoundGenericClass() && !ty->isObjCExistentialType())
     return std::nullopt;
+  // C++ foreign reference types have custom release/retain operations and are
+  // not AnyObjects.
+  if (ty->isForeignReferenceType())
+    return std::nullopt;
 
   auto anyObjectTy = ctxt.getAnyObjectType();
   auto arrayStorageTy =

--- a/test/Interop/Cxx/foreign-reference/not-any-object.swift
+++ b/test/Interop/Cxx/foreign-reference/not-any-object.swift
@@ -15,7 +15,9 @@ module Test {
 
 inline void* operator new(unsigned long, void* p) { return p; }
 
-struct __attribute__((swift_attr("import_reference"))) Empty {
+struct __attribute__((swift_attr("import_reference")))
+       __attribute__((swift_attr("retain:immortal")))
+       __attribute__((swift_attr("release:immortal"))) Empty {
   static Empty *create() { return new (malloc(sizeof(Empty))) Empty(); }
 };
 
@@ -27,3 +29,4 @@ public func test(_ _: AnyObject) {}
 
 // TODO: make this a better error.
 test(Empty.create()) // expected-error {{type of expression is ambiguous without a type annotation}}
+test([Empty.create()][0]) // expected-error {{argument type 'Any' expected to be an instance of a class or class-constrained type}}

--- a/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-irgen %s -I %S/Inputs -cxx-interoperability-mode=default -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
 // XFAIL: OS=linux-android, OS=linux-androideabi
+// XFAIL: OS=windows-msvc
 
 import ReferenceCounted
 
@@ -51,3 +52,17 @@ public func getNullable(wantNullptr: Bool) -> GlobalCountNullableInit? {
 // CHECK:      lifetime.cont:
 // CHECK:          ret i64 %2
 // CHECK-NEXT: }
+
+
+public func getArrayOfLocalCount() -> [NS.LocalCount] {
+    return [NS.LocalCount.create()]
+}
+
+// CHECK:      define {{.*}}swiftcc ptr @"$s4main20getArrayOfLocalCountSaySo2NSO0eF0VGyF"()
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   %0 = call swiftcc %swift.metadata_response @"$sSo2NSO10LocalCountVMa"(i64 0)
+// CHECK-NEXT:   %1 = extractvalue %swift.metadata_response %0, 0
+// CHECK-NEXT:   %2 = call swiftcc { ptr, ptr } @"$ss27_allocateUninitializedArrayySayxG_BptBwlF"(i64 1, ptr %1)
+// CHECK:        %5 = call ptr @{{_ZN2NS10LocalCount6createEv|"\?create\@LocalCount\@NS\@\@SAPEAU12\@XZ"}}()
+// CHECK-NEXT:   call void @{{_Z8LCRetainPN2NS10LocalCountE|"\?LCRetain\@\@YAXPEAULocalCount\@NS\@\@\@Z"}}(ptr %5)
+// CHECK:      }

--- a/test/Interop/Cxx/foreign-reference/reference-counted.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted.swift
@@ -67,4 +67,18 @@ ReferenceCountedTestSuite.test("Global") {
     expectEqual(globalCount, 0)
 }
 
+var globalArray: [GlobalCount] = []
+
+ReferenceCountedTestSuite.test("Global array") {
+    expectEqual(globalCount, 0)
+
+    globalArray = [GlobalCount.create()]
+#if NO_OPTIMIZATIONS
+    expectEqual(globalCount, 1)
+#endif
+
+    globalArray = []
+    expectEqual(globalCount, 0)
+}
+
 runAllTests()


### PR DESCRIPTION
**Explanation**: This fixes a crash at runtime when destroying a Swift array of values of a C++ foreign reference type. Swift optimizes the amount of metadata emitted for `_ContiguousArrayStorage<Element>` by reusing `_ContiguousArrayStorage<AnyObject>` whenever possible (see `getContiguousArrayStorageType`). However, C++ foreign reference types are not `AnyObject`s, since they have custom retain/release operations. This change disables the `_ContiguousArrayStorage` metadata optimization for C++ reference types, which makes sure that `swift_arrayDestroy` will call the correct release operation for elements of `[MyCxxRefType]`.
**Scope**: Changes the runtime handling of C++ foreign reference types – they will no longer be treated as AnyObjects by the runtime. Also changes the SIL logic that handles the `_ContiguousArrayStorage<AnyObject>` optimization.
**Risk**: Low, only affects C++ foreign reference types.
**Testing**: Added a compile test.
**Issue**:  rdar://127154770 / https://github.com/apple/swift/issues/72827
**Reviewer**: @mikeash @aschwaighofer @zoecarver 

Original PR: https://github.com/apple/swift/pull/73615