### PR TITLE
[6.0] SILGen: Bug fix handling `consuming`/`borrowing` parameters and optional chaining.

### DIFF
--- a/test/SILGen/unmanaged-chain.swift
+++ b/test/SILGen/unmanaged-chain.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+extension Unmanaged {
+    func something1(with x: consuming Unmanaged<Instance>?) -> UnsafeMutableRawPointer? {
+        x?.toOpaque()
+    }
+
+    func something2(with x: consuming Unmanaged<Instance>?) -> UnsafeMutableRawPointer? {
+        let y = x
+        return y?.toOpaque()
+    }
+    func something3(with x: __owned Unmanaged<Instance>?) -> UnsafeMutableRawPointer? {
+        x?.toOpaque()
+    }
+}


### PR DESCRIPTION
Explanation: Fixes a compiler crash when a copyable Optional value is used as a `consuming` parameter and involved in an optional chain.
Scope: Bug fix.
Issue: rdar://116127887.
Original PR: https://github.com/apple/swift/pull/73658
Risk: Low. Small bug fix.
Testing: Swift CI, test case from bug report
Reviewer: @kavon 