### PR TITLE
[SILVerifier] Disable debug info type assertion for boxes

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1496,7 +1496,7 @@ public:
     
     SILType DebugVarTy = varInfo->Type ? *varInfo->Type :
       SSAType.getObjectType();
-    if (!varInfo->DIExpr && !isa<AllocBoxInst>(inst)) {
+    if (!varInfo->DIExpr && !isa<SILBoxType>(SSAType.getASTType())) {
       // FIXME: Remove getObjectType() below when we fix create/createAddr
       require(DebugVarTy.removingMoveOnlyWrapper()
               == SSAType.getObjectType().removingMoveOnlyWrapper(),


### PR DESCRIPTION
Temporarily disable the matching type assertion for debug_value pointing to an alloc_box

rdar://128091794