### PR TITLE
Teach diagnostic about non-Sendable global `let`s to respect `@preconcurrency`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5614,9 +5614,9 @@ NOTE(shared_mutable_state_decl_note,none,
      "isolate %0 to a global actor, or convert it to a 'let' constant and "
      "conform it to 'Sendable'", (const ValueDecl *))
 ERROR(shared_immutable_state_decl,none,
-      "%kind0 is not concurrency-safe because non-'Sendable' type %1 may have "
+      "%kind1 is not concurrency-safe because non-'Sendable' type %0 may have "
       "shared mutable state",
-      (const ValueDecl *, Type))
+      (Type, const ValueDecl *))
 NOTE(shared_immutable_state_decl_note,none,
      "isolate %0 to a global actor, or conform %1 to 'Sendable'",
      (const ValueDecl *, Type))

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5013,13 +5013,17 @@ ActorIsolation ActorIsolationRequest::evaluate(
         }
         if (var->isLet()) {
           auto type = var->getInterfaceType();
-          if (!type->isSendableType()) {
-            diagVar->diagnose(diag::shared_immutable_state_decl,
-                              diagVar, type)
-                .warnUntilSwiftVersion(6);
+          bool diagnosed = diagnoseIfAnyNonSendableTypes(
+              type, SendableCheckContext(var->getDeclContext()),
+              /*inDerivedConformance=*/Type(), /*typeLoc=*/SourceLoc(),
+              /*diagnoseLoc=*/var->getLoc(),
+              diag::shared_immutable_state_decl, diagVar);
+
+          // If we diagnosed this 'let' as non-Sendable, tack on a note
+          // to suggest a course of action.
+          if (diagnosed)
             diagVar->diagnose(diag::shared_immutable_state_decl_note,
                               diagVar, type);
-          }
         } else {
           diagVar->diagnose(diag::shared_mutable_state_decl, diagVar)
               .warnUntilSwiftVersion(6);

--- a/test/Concurrency/Inputs/NonStrictModule.swift
+++ b/test/Concurrency/Inputs/NonStrictModule.swift
@@ -1,6 +1,7 @@
 public struct NonStrictStruct { }
 
 open class NonStrictClass {
+  public init() {}
   open func send(_ body: @Sendable () -> Void) {}
   open func dontSend(_ body: () -> Void) {}
 }

--- a/test/Concurrency/Inputs/StrictModule.swift
+++ b/test/Concurrency/Inputs/StrictModule.swift
@@ -1,4 +1,6 @@
-public struct StrictStruct: Hashable { }
+public struct StrictStruct: Hashable {
+  public init() {}
+}
 
 open class StrictClass {
   open func send(_ body: @Sendable () -> Void) {}

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -4,7 +4,7 @@
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
-class GlobalCounter {
+class GlobalCounter { // expected-note{{class 'GlobalCounter' does not conform to the 'Sendable' protocol}}
   var counter: Int = 0
 }
 

--- a/test/Concurrency/global_variables.swift
+++ b/test/Concurrency/global_variables.swift
@@ -23,7 +23,7 @@ final class TestSendable: Sendable {
   init() {}
 }
 
-final class TestNonsendable {
+final class TestNonsendable { // expected-note 2{{class 'TestNonsendable' does not conform to the 'Sendable' protocol}}
   init() {}
 }
 

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -3,10 +3,10 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
-// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -disable-region-based-isolation-with-strict-concurrency
-// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency
-// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify  -parse-as-library -enable-upcoming-feature GlobalConcurrency
+// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -disable-region-based-isolation-with-strict-concurrency  -parse-as-library -enable-upcoming-feature GlobalConcurrency
+// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency  -parse-as-library -enable-upcoming-feature GlobalConcurrency
+// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete  -parse-as-library -enable-upcoming-feature GlobalConcurrency
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -28,3 +28,8 @@ func test(
   acceptSendable(oma) // okay
   acceptSendable(ssc) // okay
 }
+
+let nonStrictGlobal = NonStrictClass() // no warning
+
+let strictGlobal = StrictStruct() // expected-warning{{let 'strictGlobal' is not concurrency-safe because non-'Sendable' type 'StrictStruct' may have shared mutable state}}
+// expected-note@-1{{isolate 'strictGlobal' to a global actor, or conform 'StrictStruct' to 'Sendable'}}

--- a/test/Concurrency/predates_concurrency_import_swift6.swift
+++ b/test/Concurrency/predates_concurrency_import_swift6.swift
@@ -2,8 +2,8 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 
-// RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify -parse-as-library
+// RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation -parse-as-library
 
 @preconcurrency import NonStrictModule
 @preconcurrency import StrictModule
@@ -15,3 +15,7 @@ func test(ss: StrictStruct, ns: NonStrictClass) {
   acceptSendable(ss) // expected-warning{{type 'StrictStruct' does not conform to the 'Sendable' protocol}}
   acceptSendable(ns)
 }
+
+let nonStrictGlobal = NonStrictClass()
+let strictGlobal = StrictStruct() // expected-warning{{let 'strictGlobal' is not concurrency-safe because non-'Sendable' type 'StrictStruct' may have shared mutable state}}
+// expected-note@-1{{isolate 'strictGlobal' to a global actor, or conform 'StrictStruct' to 'Sendable'}}

--- a/test/Concurrency/sendable_cycle.swift
+++ b/test/Concurrency/sendable_cycle.swift
@@ -6,7 +6,7 @@
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
-struct Bar {
+struct Bar { // expected-note*{{consider making struct 'Bar' conform to the 'Sendable' protocol}}
   lazy var foo = { // expected-error {{escaping closure captures mutating 'self' parameter}}
     self.x() // expected-note {{captured here}}
   }


### PR DESCRIPTION
The diagnostic for non-Sendable globa/static `let` properties was checking for a Sendable conformance without considering `@preconcurrency`. Emit this diagnostic via a `@preconcurrency`-sensitive path.

Fixes rdar://121889248.
Fixes #72182.
