### PR TITLE
Serialization: Write the target SDK in the binary swiftmodule

### DIFF
--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -42,6 +42,7 @@ namespace swift {
     llvm::VersionTuple UserModuleVersion;
     std::set<std::string> AllowableClients;
     std::string SDKName;
+    std::string SDKVersion;
 
     StringRef GroupInfoPath;
     StringRef ImportedHeader;

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -103,6 +103,7 @@ struct ValidationInfo {
   version::Version compatibilityVersion = {};
   llvm::VersionTuple userModuleVersion;
   StringRef sdkName = {};
+  StringRef sdkVersion = {};
   StringRef problematicRevision = {};
   StringRef problematicChannel = {};
   size_t bytes = 0;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/PluginLoader.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/FileTypes.h"
+#include "swift/Basic/Platform.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Frontend/CachingUtils.h"
@@ -202,6 +203,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   serializationOpts.PublicDependentLibraries =
       getIRGenOptions().PublicLinkLibraries;
   serializationOpts.SDKName = getLangOptions().SDKName;
+  serializationOpts.SDKVersion = swift::getSDKBuildVersion(
+                                          getSearchPathOptions().getSDKPath());
   serializationOpts.ABIDescriptorPath = outs.ABIDescriptorOutputPath.c_str();
   serializationOpts.emptyABIDescriptor = opts.emptyABIDescriptor;
 

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -354,6 +354,9 @@ static ValidationInfo validateControlBlock(
     case control_block::ALLOWABLE_CLIENT_NAME:
       result.allowableClients.push_back(blobData);
       break;
+    case control_block::SDK_VERSION:
+      result.sdkVersion = blobData;
+      break;
     case control_block::SDK_NAME: {
       result.sdkName = blobData;
 
@@ -690,6 +693,7 @@ void ModuleFileSharedCore::outputDiagnosticInfo(llvm::raw_ostream &os) const {
      << "', builder version '" << MiscVersion
      << "', built from "
      << (Bits.IsBuiltFromInterface? "swiftinterface": "source")
+     << " against SDK " << SDKVersion
      << ", " << (resilient? "resilient": "non-resilient");
   if (Bits.AllowNonResilientAccess)
     os << ", built with -experimental-allow-non-resilient-access";
@@ -1453,6 +1457,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       Bits.AllowNonResilientAccess = extInfo.allowNonResilientAccess();
       Bits.SerializePackageEnabled = extInfo.serializePackageEnabled();
       MiscVersion = info.miscVersion;
+      SDKVersion = info.sdkVersion;
       ModuleABIName = extInfo.getModuleABIName();
       ModulePackageName = extInfo.getModulePackageName();
       ModuleExportAsName = extInfo.getExportAsName();

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -66,6 +66,9 @@ class ModuleFileSharedCore {
   /// The canonical name of the SDK the module was built with.
   StringRef SDKName;
 
+  /// Version string of the SDK against which the module was built.
+  StringRef SDKVersion;
+
   /// The name of the module interface this module was compiled from.
   ///
   /// Empty if this module didn't come from an interface file.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 873; // [serialized_for_package] for SILFunctionLayout
+const uint16_t SWIFTMODULE_VERSION_MINOR = 874; // SDKVersion
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -861,6 +861,7 @@ namespace control_block {
     MODULE_NAME,
     TARGET,
     SDK_NAME,
+    SDK_VERSION,
     REVISION,
     CHANNEL,
     IS_OSSA,
@@ -892,6 +893,11 @@ namespace control_block {
 
   using SDKNameLayout = BCRecordLayout<
     SDK_NAME,
+    BCBlob
+  >;
+
+  using SDKVersionLayout = BCRecordLayout<
+    SDK_VERSION,
     BCBlob
   >;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -834,6 +834,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(control_block, MODULE_NAME);
   BLOCK_RECORD(control_block, TARGET);
   BLOCK_RECORD(control_block, SDK_NAME);
+  BLOCK_RECORD(control_block, SDK_VERSION);
   BLOCK_RECORD(control_block, REVISION);
   BLOCK_RECORD(control_block, CHANNEL);
   BLOCK_RECORD(control_block, IS_OSSA);
@@ -984,6 +985,7 @@ void Serializer::writeHeader() {
     control_block::MetadataLayout Metadata(Out);
     control_block::TargetLayout Target(Out);
     control_block::SDKNameLayout SDKName(Out);
+    control_block::SDKVersionLayout SDKVersion(Out);
     control_block::RevisionLayout Revision(Out);
     control_block::ChannelLayout Channel(Out);
     control_block::IsOSSALayout IsOSSA(Out);
@@ -1025,6 +1027,9 @@ void Serializer::writeHeader() {
 
     if (!Options.SDKName.empty())
       SDKName.emit(ScratchRecord, Options.SDKName);
+
+    if (!Options.SDKVersion.empty())
+      SDKVersion.emit(ScratchRecord, Options.SDKVersion);
 
     for (auto &name : Options.AllowableClients) {
       Allowable.emit(ScratchRecord, name);

--- a/test/Serialization/Recovery/crash-xref.swift
+++ b/test/Serialization/Recovery/crash-xref.swift
@@ -33,7 +33,7 @@
 // NORMALFAILURE-LABEL: *** DESERIALIZATION FAILURE ***
 // NORMALFAILURE-LABEL: *** If any module named here was modified in the SDK, please delete the ***
 // NORMALFAILURE-LABEL: *** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***
-// NORMALFAILURE-NEXT: module 'Client', builder version {{.*}}', built from source, resilient, loaded from
+// NORMALFAILURE-NEXT: module 'Client', builder version {{.*}}', built from source against SDK {{.*}}, resilient, loaded from
 // NORMALFAILURE-NEXT: Could not deserialize type for 'foo()'
 // NORMALFAILURE-NEXT: Caused by: modularization issue on 'SomeType', reference from 'Client' not resolvable: expected in 'A' but found in 'B'
 // NORMALFAILURE-NEXT: Cross-reference to module 'A'
@@ -43,7 +43,7 @@
 // ALLOWFAILURE-LABEL: *** DESERIALIZATION FAILURE ***
 // ALLOWFAILURE-LABEL: *** If any module named here was modified in the SDK, please delete the ***
 // ALLOWFAILURE-LABEL: *** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***
-// ALLOWFAILURE-NEXT: module 'Client', builder version {{.*}}', built from source, non-resilient, built with -experimental-allow-module-with-compiler-errors, loaded from
+// ALLOWFAILURE-NEXT: module 'Client', builder version {{.*}}', built from source against SDK {{.*}}, non-resilient, built with -experimental-allow-module-with-compiler-errors, loaded from
 // ALLOWFAILURE-NEXT: Could not deserialize type for 'foo()'
 // ALLOWFAILURE-NEXT: Caused by: modularization issue on 'SomeType', reference from 'Client' not resolvable: expected in 'A' but found in 'B'
 // ALLOWFAILURE-NEXT: Cross-reference to module 'A'
@@ -52,7 +52,7 @@
 /// Test a swiftmodule rebuilt from the swiftinterface.
 // RUN: not --crash %target-swift-frontend -emit-sil %t/cache/Client-*.swiftmodule -module-name Client -I %t/partials -disable-deserialization-recovery 2> %t/cache_stderr
 // RUN: cat %t/cache_stderr | %FileCheck %s -check-prefixes=CACHEFAILURE
-// CACHEFAILURE: module 'Client', builder version {{.*}}', built from swiftinterface, resilient
+// CACHEFAILURE: module 'Client', builder version {{.*}}', built from swiftinterface against SDK {{.*}}, resilient
 
 #if LIB
 public struct SomeType {


### PR DESCRIPTION
Keep track of the SDK version the swiftmodule file was built against and display that information in case of a crash. This can help understand the failure and see unsupported configurations.

We should reject swiftmodules built against a mismatching SDK version and let the compiler rebuild resilient modules from swiftinterfaces, but that isn't part of this PR for performance concerns.