### PR TITLE
[6.0 🍒] Apply the `@_alwaysEmitConformanceMetadata` semantics to conformances originating from macro-expanded declarations and extensions

### DIFF
--- a/test/Reflection/Inputs/Macros.swift
+++ b/test/Reflection/Inputs/Macros.swift
@@ -1,0 +1,77 @@
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct AddStructDeclMacro: DeclarationMacro {
+    public static func expansion(
+      of node: some FreestandingMacroExpansionSyntax,
+      in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        return [
+            """
+            struct MacroAddedStruct : TestEntity {}
+            """
+        ]
+    }
+}
+
+public struct AddPeerStructMacro: PeerMacro {
+    public static func expansion(
+      of node: AttributeSyntax,
+      providingPeersOf declaration: some DeclSyntaxProtocol,
+      in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        let name = declaration.declName
+        return [
+            """
+            struct _Peer_\(name) : TestEntity {}
+            """
+        ]
+    }
+}
+
+public struct AddExtensionMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let typeName = declaration.declGroupName
+    return protocols.map {
+      ("""
+      extension \(typeName): \($0) {
+        struct _Extension_\($0): \($0) {}
+      }
+      """ as DeclSyntax)
+      .cast(ExtensionDeclSyntax.self)
+    }
+  }
+}
+
+extension DeclSyntaxProtocol {
+    var declName: TokenSyntax {
+        if let varDecl = self.as(VariableDeclSyntax.self),
+           let first = varDecl.bindings.first,
+           let pattern = first.pattern.as(IdentifierPatternSyntax.self) {
+            return pattern.identifier.trimmed
+        } else if let funcDecl = self.as(FunctionDeclSyntax.self) {
+            return funcDecl.name.trimmed
+        } else if let structDecl = self.as(StructDeclSyntax.self) {
+            return structDecl.name.trimmed
+        }
+        fatalError("Not implemented")
+    }
+}
+
+extension DeclGroupSyntax {
+    var declGroupName: TokenSyntax {
+        if let structDecl = self.as(StructDeclSyntax.self) {
+            return structDecl.name.trimmed
+        }
+        fatalError("Not implemented")
+    }
+}

--- a/test/Reflection/preserve_conformance_metadata_attr_macros.swift
+++ b/test/Reflection/preserve_conformance_metadata_attr_macros.swift
@@ -1,0 +1,41 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/includes)
+
+// Build support Protocols module
+// RUN: %target-build-swift %S/Inputs/PreservedConformanceProtocols.swift -parse-as-library -emit-module -emit-library -module-name PreservedConformanceProtocols -o %t/includes/PreservedConformanceProtocols.o
+
+// Build the macro library
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/Macros.swift -g -no-toolchain-stdlib-rpath
+
+// Build the test into a binary
+// RUN: %target-build-swift %s -parse-as-library -emit-module -emit-library -module-name PreservedConformances -O -whole-module-optimization -I %t/includes -o %t/PreservedConformances -Xlinker %t/includes/PreservedConformanceProtocols.o -load-plugin-library %t/%target-library-name(MacroDefinition)
+
+// RUN: %target-swift-reflection-dump %t/PreservedConformances | %FileCheck %s
+
+import PreservedConformanceProtocols
+
+@freestanding(declaration, names: named(MacroAddedStruct))
+macro AddMacroAddedStruct() = #externalMacro(module: "MacroDefinition", type: "AddStructDeclMacro")
+
+@attached(peer, names: prefixed(_Peer_))
+macro AddPeerStruct() = #externalMacro(module: "MacroDefinition", type: "AddPeerStructMacro")
+
+@attached(extension, conformances: TestEntity, names: prefixed(_extension_), named(_Extension_TestEntity))
+macro AddExtension() = #externalMacro(module: "MacroDefinition", type: "AddExtensionMacro")
+
+#AddMacroAddedStruct
+
+struct internalTestEntity : TestEntity {}
+public struct publicTestEntity : TestEntity {}
+@AddPeerStruct
+struct internalMacroAidedEntityHelper {}
+@AddExtension
+struct internalMacroExtensionAidedEntityHelper {}
+// CHECK: CONFORMANCES:
+// CHECK: =============
+// CHECK-DAG: 21PreservedConformances16publicTestEntityV (PreservedConformances.publicTestEntity) : PreservedConformanceProtocols.TestEntity
+// CHECK-DAG: 21PreservedConformances18internalTestEntityV (PreservedConformances.internalTestEntity) : PreservedConformanceProtocols.TestEntity
+// CHECK-DAG: 21PreservedConformances16MacroAddedStructV (PreservedConformances.MacroAddedStruct) : PreservedConformanceProtocols.TestEntity
+// CHECK-DAG: 21PreservedConformances36_Peer_internalMacroAidedEntityHelperV (PreservedConformances._Peer_internalMacroAidedEntityHelper) : PreservedConformanceProtocols.TestEntity
+// CHECK-DAG: 21PreservedConformances39internalMacroExtensionAidedEntityHelperV (PreservedConformances.internalMacroExtensionAidedEntityHelper) : PreservedConformanceProtocols.TestEntity


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/73680
-------------------------------------------
**Explanation**: The attribute added in https://github.com/apple/swift/pull/60367 causes the compiler to ensure that conformances to protocols annotated with the `@_alwaysEmitConformanceMetadata` attribute are in the resulting binaries even if the conformance itself is not `public` or even used elsewhere in the code. The current implementation (https://github.com/apple/swift/pull/69609) of this attribute does not account that such conformances may originate from macro-expansions. This change fixes that by causing the detection logic to consider macro-expanded contexts.

**Risk**: Low. This change extends the existing declaration walker by causing it to also walk macro-expanded declarations in order to find conformances to attribute annotated protocols. For code not annotated with this attribute this will not result in any changes. And for code that is annotated, the produced binaries will contain the expected results, whereas they did not before. 

**Testing**: Automated test added to the compiler test suite.

Resolves rdar://127903662