### PR TITLE
[embedded] Add a mechanism to opt-in for using String, and for using Unicode data tables

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -503,6 +503,13 @@ SIMPLE_DECL_ATTR(sensitive, Sensitive,
   OnStruct | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   159)
 
+SIMPLE_DECL_ATTR(_needsStringsInEmbedded, NeedsStringsInEmbedded,
+  OnAnyDecl | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  160)
+SIMPLE_DECL_ATTR(_needsUnicodeDataTablesInEmbedded, NeedsUnicodeDataTablesInEmbedded,
+  OnAnyDecl | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  161)
+
 LAST_DECL_ATTR(PreInverseGenerics)
 
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -585,6 +585,8 @@ ERROR(objc_with_embedded,none,
       "Objective-C interoperability cannot be enabled with embedded Swift.", ())
 ERROR(no_allocations_without_embedded,none,
       "-no-allocations is only applicable with embedded Swift.", ())
+ERROR(enable_strings_without_embedded,none,
+      "-enable-strings is only applicable with embedded Swift.", ())
 ERROR(no_swift_sources_with_embedded,none,
       "embedded swift cannot be enabled in a compiler built without Swift sources", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6829,6 +6829,11 @@ ERROR(conformance_availability_only_version_newer, none,
       "conformance of %0 to %1 is only available in %2 %3 or newer",
       (Type, Type, StringRef, llvm::VersionTuple))
 
+ERROR(embedded_string_without_opt_in, none,
+      "String has large associated codesize cost; only available in embedded Swift by explicitly passing -enable-strings", ())
+ERROR(embedded_string_needs_data_tables, none,
+      "This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost", ())
+
 //------------------------------------------------------------------------------
 // MARK: @discardableResult
 //------------------------------------------------------------------------------

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -94,6 +94,12 @@ namespace swift {
     TaskToThread,
   };
 
+  enum class EmbeddedSwiftStringsLevel : uint8_t {
+    None,
+    Core,
+    FullWithUnicodeDataTables,
+  };
+
   /// Describes the code size optimization behavior for code associated with
   /// declarations that are marked unavailable.
   enum class UnavailableDeclOptimization : uint8_t {
@@ -594,6 +600,9 @@ namespace swift {
 
     /// Disables `DynamicActorIsolation` feature.
     bool DisableDynamicActorIsolation = false;
+
+    /// Whether the user has opted in to using Swift.String via -enable-strings
+    EmbeddedSwiftStringsLevel EnableStringsInEmbeddedSwift = EmbeddedSwiftStringsLevel::None;
 
     /// Whether or not to allow experimental features that are only available
     /// in "production".

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -894,6 +894,13 @@ def no_allocations : Flag<["-"], "no-allocations">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Diagnose any code that needs to heap allocate (classes, closures, etc.)">;
 
+def enable_strings : Flag<["-"], "enable-strings">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Allow using the String type in embedded Swift (which has a large associated codesize cost)">;
+def enable_strings_full_unicode_data_tables : Flag<["-"], "enable-strings-full-unicode-data-tables">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Allow using the String type in embedded Swift, including Unicode data tables (which has a large associated codesize cost)">;
+
 // Platform options.
 def enable_app_extension : Flag<["-"], "application-extension">,
   Flags<[FrontendOption, NoInteractiveOption]>,

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -140,6 +140,10 @@ extension ASTGenVisitor {
         fatalError("unimplemented")
       case .noObjCBridging:
         fatalError("unimplemented")
+      case .needsStringsInEmbedded:
+        fatalError("unimplemented")
+      case .needsUnicodeDataTablesInEmbedded:
+        fatalError("unimplemented")
       case .noRuntime:
         fatalError("unimplemented")
       case .nonSendable:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -662,6 +662,13 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back("-track-system-dependencies");
   }
 
+  if (context.Args.hasArg(options::OPT_enable_strings)) {
+    Arguments.push_back("-enable-strings");
+  }
+  if (context.Args.hasArg(options::OPT_enable_strings_full_unicode_data_tables)) {
+    Arguments.push_back("-enable-strings-full-unicode-data-tables");
+  }
+
   if (context.Args.hasFlag(options::OPT_static_executable,
                            options::OPT_no_static_executable, false) ||
       context.Args.hasFlag(options::OPT_static_stdlib,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1511,6 +1511,13 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  if (Args.hasArg(OPT_enable_strings)) {
+    Opts.EnableStringsInEmbeddedSwift = EmbeddedSwiftStringsLevel::Core;
+  }
+  if (Args.hasArg(OPT_enable_strings_full_unicode_data_tables)) {
+    Opts.EnableStringsInEmbeddedSwift = EmbeddedSwiftStringsLevel::FullWithUnicodeDataTables;
+  }
+
   if (auto A = Args.getLastArg(OPT_checked_async_objc_bridging)) {
     auto value = llvm::StringSwitch<std::optional<bool>>(A->getValue())
                      .Case("off", false)
@@ -3455,6 +3462,10 @@ bool CompilerInvocation::parseArgs(
   } else {
     if (SILOpts.NoAllocations) {
       Diags.diagnose(SourceLoc(), diag::no_allocations_without_embedded);
+      return true;
+    }
+    if (LangOpts.EnableStringsInEmbeddedSwift != EmbeddedSwiftStringsLevel::None) {
+      Diags.diagnose(SourceLoc(), diag::enable_strings_without_embedded);
       return true;
     }
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -141,6 +141,8 @@ public:
   IGNORED_ATTR(NoRuntime)
   IGNORED_ATTR(NoExistentials)
   IGNORED_ATTR(NoObjCBridging)
+  IGNORED_ATTR(NeedsStringsInEmbedded)
+  IGNORED_ATTR(NeedsUnicodeDataTablesInEmbedded)
   IGNORED_ATTR(EmitAssemblyVisionRemarks)
   IGNORED_ATTR(ShowInInterface)
   IGNORED_ATTR(SILGenName)

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1513,6 +1513,8 @@ namespace  {
     UNINTERESTING_ATTR(NoRuntime)
     UNINTERESTING_ATTR(NoExistentials)
     UNINTERESTING_ATTR(NoObjCBridging)
+    UNINTERESTING_ATTR(NeedsStringsInEmbedded)
+    UNINTERESTING_ATTR(NeedsUnicodeDataTablesInEmbedded)
     UNINTERESTING_ATTR(Inlinable)
     UNINTERESTING_ATTR(Effects)
     UNINTERESTING_ATTR(Expose)

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -440,6 +440,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       SWIFT_COMPILE_FLAGS
         ${swift_stdlib_compile_flags} -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded
         -Xfrontend -enable-ossa-modules
+        -Xfrontend -enable-strings-full-unicode-data-tables
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -211,22 +211,27 @@ extension String {
   }
 }
 
+@_needsUnicodeDataTablesInEmbedded
 extension Character: Equatable {
   @inlinable @inline(__always)
   @_effects(readonly)
+  @_needsUnicodeDataTablesInEmbedded
   public static func == (lhs: Character, rhs: Character) -> Bool {
     return lhs._str == rhs._str
   }
 }
 
+@_needsUnicodeDataTablesInEmbedded
 extension Character: Comparable {
   @inlinable @inline(__always)
   @_effects(readonly)
+  @_needsUnicodeDataTablesInEmbedded
   public static func < (lhs: Character, rhs: Character) -> Bool {
     return lhs._str < rhs._str
   }
 }
 
+@_needsUnicodeDataTablesInEmbedded
 extension Character: Hashable {
   // not @inlinable (performance)
   /// Hashes the essential components of this value by feeding them into the

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -350,6 +350,7 @@ internal func unimplemented_utf8_32bit(
 /// [equivalence]: http://www.unicode.org/glossary/#canonical_equivalent
 @frozen
 @_eagerMove
+@_needsStringsInEmbedded
 public struct String {
   public // @SPI(Foundation)
   var _guts: _StringGuts

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -19,6 +19,7 @@ extension StringProtocol {
   @_specialize(where Self == Substring, RHS == String)
   @_specialize(where Self == Substring, RHS == Substring)
   @_effects(readonly)
+  @_needsUnicodeDataTablesInEmbedded
   public static func == <RHS: StringProtocol>(lhs: Self, rhs: RHS) -> Bool {
     return _stringCompare(
       lhs._wholeGuts, lhs._offsetRange,
@@ -28,6 +29,7 @@ extension StringProtocol {
 
   @inlinable @inline(__always) // forward to other operator
   @_effects(readonly)
+  @_needsUnicodeDataTablesInEmbedded
   public static func != <RHS: StringProtocol>(lhs: Self, rhs: RHS) -> Bool {
     return !(lhs == rhs)
   }
@@ -38,6 +40,7 @@ extension StringProtocol {
   @_specialize(where Self == Substring, RHS == String)
   @_specialize(where Self == Substring, RHS == Substring)
   @_effects(readonly)
+  @_needsUnicodeDataTablesInEmbedded
   public static func < <RHS: StringProtocol>(lhs: Self, rhs: RHS) -> Bool {
     return _stringCompare(
       lhs._wholeGuts, lhs._offsetRange,
@@ -47,40 +50,48 @@ extension StringProtocol {
 
   @inlinable @inline(__always) // forward to other operator
   @_effects(readonly)
+  @_needsUnicodeDataTablesInEmbedded
   public static func > <RHS: StringProtocol>(lhs: Self, rhs: RHS) -> Bool {
     return rhs < lhs
   }
 
   @inlinable @inline(__always) // forward to other operator
   @_effects(readonly)
+  @_needsUnicodeDataTablesInEmbedded
   public static func <= <RHS: StringProtocol>(lhs: Self, rhs: RHS) -> Bool {
     return !(rhs < lhs)
   }
 
   @inlinable @inline(__always) // forward to other operator
   @_effects(readonly)
+  @_needsUnicodeDataTablesInEmbedded
   public static func >= <RHS: StringProtocol>(lhs: Self, rhs: RHS) -> Bool {
     return !(lhs < rhs)
   }
 }
 
+@_needsUnicodeDataTablesInEmbedded
 extension String: Equatable {
   @inlinable @inline(__always) // For the bitwise comparison
   @_effects(readonly)
   @_semantics("string.equals")
+  @_needsUnicodeDataTablesInEmbedded
   public static func == (lhs: String, rhs: String) -> Bool {
     return _stringCompare(lhs._guts, rhs._guts, expecting: .equal)
   }
 }
 
+@_needsUnicodeDataTablesInEmbedded
 extension String: Comparable {
   @inlinable @inline(__always) // For the bitwise comparison
   @_effects(readonly)
+  @_needsUnicodeDataTablesInEmbedded
   public static func < (lhs: String, rhs: String) -> Bool {
     return _stringCompare(lhs._guts, rhs._guts, expecting: .less)
   }
 }
 
+@_needsUnicodeDataTablesInEmbedded
 extension Substring: Equatable {}
 
 // TODO: Generalize `~=` over `StringProtocol` (https://github.com/apple/swift/issues/54896)
@@ -90,6 +101,7 @@ extension String {
   @_alwaysEmitIntoClient
   @inline(__always)
   @_effects(readonly)
+  @_needsUnicodeDataTablesInEmbedded
   public static func ~= (lhs: String, rhs: Substring) -> Bool {
     return lhs == rhs
   }
@@ -98,6 +110,7 @@ extension Substring {
   @_alwaysEmitIntoClient
   @inline(__always)
   @_effects(readonly)
+  @_needsUnicodeDataTablesInEmbedded
   public static func ~= (lhs: Substring, rhs: String) -> Bool {
     return lhs == rhs
   }

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -12,12 +12,14 @@
 
 import SwiftShims
 
+@_needsUnicodeDataTablesInEmbedded
 extension String: Hashable {
   /// Hashes the essential components of this value by feeding them into the
   /// given hasher.
   ///
   /// - Parameter hasher: The hasher to use when combining the components
   ///   of this instance.
+  @_needsUnicodeDataTablesInEmbedded
   public func hash(into hasher: inout Hasher) {
     if _fastPath(self._guts.isNFCFastUTF8) {
       self._guts.withFastUTF8 {
@@ -28,8 +30,14 @@ extension String: Hashable {
       _gutsSlice._normalizedHash(into: &hasher)
     }
   }
+
+  // Avoid using the compiler-synthesized hashValue implementation, because
+  // we need the attribute to apply.
+  @_needsUnicodeDataTablesInEmbedded
+  public var hashValue: Int { _hashValue(for: self) }
 }
 
+@_needsUnicodeDataTablesInEmbedded
 extension StringProtocol {
   /// Hashes the essential components of this value by feeding them into the
   /// given hasher.
@@ -38,13 +46,21 @@ extension StringProtocol {
   ///   of this instance.
   @_specialize(where Self == String)
   @_specialize(where Self == Substring)
+  @_needsUnicodeDataTablesInEmbedded
   public func hash(into hasher: inout Hasher) {
     _gutsSlice._normalizedHash(into: &hasher)
   }
+
+  // Avoid using the compiler-synthesized hashValue implementation, because
+  // we need the attribute to apply.
+  @_needsUnicodeDataTablesInEmbedded
+  public var hashValue: Int { _hashValue(for: self) }
 }
 
+@_needsUnicodeDataTablesInEmbedded
 extension _StringGutsSlice {
   @_effects(releasenone) @inline(never) // slow-path
+  @_needsUnicodeDataTablesInEmbedded
   internal func _normalizedHash(into hasher: inout Hasher) {
     if self.isNFCFastUTF8 {
       self.withFastUTF8 {

--- a/test/embedded/stdlib-strings-unavailable.swift
+++ b/test/embedded/stdlib-strings-unavailable.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -verify
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -enable-strings
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public func test1() {
+  print("x") // OK
+}
+
+public func test2(_ s: String) {  // expected-error {{String has large associated codesize cost; only available in embedded Swift by explicitly passing -enable-strings}}
+}
+
+public func test3() {
+  let _ = "abc" // expected-error {{String has large associated codesize cost; only available in embedded Swift by explicitly passing -enable-strings}}
+}
+
+public func test4() {
+  let _ = "abc \(42)" // expected-error {{String has large associated codesize cost; only available in embedded Swift by explicitly passing -enable-strings}}
+  // expected-error@-1 {{String has large associated codesize cost; only available in embedded Swift by explicitly passing -enable-strings}}
+  // expected-error@-2 {{String has large associated codesize cost; only available in embedded Swift by explicitly passing -enable-strings}}
+}
+
+@_unavailableInEmbedded
+public func test5() {
+  let _ = "abc" // OK
+}

--- a/test/embedded/stdlib-strings-unavailable2.swift
+++ b/test/embedded/stdlib-strings-unavailable2.swift
@@ -1,0 +1,74 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -enable-strings -verify
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -enable-strings-full-unicode-data-tables
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public func test1() {
+  print("x")
+  let x = "string"
+  print(x)
+  let _ = "abc \(42)"
+  func takesString(s: String) { }
+  takesString(s: "hi")
+  let _ = "abc" + "def"
+  for _ in "abc" + "def" { }
+  print("abc" + "def")
+}
+
+public func test2(s1: String, s2: String) {
+  let _ = s1 == s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1 != s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1 < s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1 <= s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1 > s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1 >= s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+
+  var hasher = Hasher()
+  let _ = s1.hash(into: &hasher) // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1.hashValue // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  var d: [String:Int] // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  d = ["abc": 42] // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  d["def"] = 52 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  print(d["def"]!) // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+
+  var s: Set<String> // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  s = .init() // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  s.insert("abc") // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+
+  let _ = s1.split(separator: "\n") // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1.firstIndex(of: "\n") // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+}
+
+public func test3(s1: Character, s2: Character) {
+  let _ = s1 == s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1 != s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1 < s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1 <= s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1 > s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}
+  let _ = s1 >= s2 // expected-error {{This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost}}  
+}
+
+@_unavailableInEmbedded
+public func test4(s1: String, s2: String) {
+  let _ = s1 == s2
+  let _ = s1 != s2
+  let _ = s1 < s2
+  let _ = s1 <= s2
+  let _ = s1 > s2
+  let _ = s1 >= s2
+
+  var hasher = Hasher()
+  let _ = s1.hash(into: &hasher)
+  let _ = s1.hashValue
+  var d: [String:Int]
+  d = ["abc": 42]
+  d["def"] = 52
+  print(d["def"]!)
+
+  var s: Set<String>
+  s = .init()
+  s.insert("abc")
+
+  let _ = s1.split(separator: "\n")
+}


### PR DESCRIPTION
Building on top the previous parts of porting String into Embedded Swift (https://github.com/apple/swift/pull/70446, https://github.com/apple/swift/pull/73585), this PR adds a mechanism to select whether an Embedded Swift program wants to use (dynamic) Strings or not, and whether it wants to use Unicode data tables that are needed for operations like comparing strings for equality, or using strings as keys in a dictionary.

**Background + motivation**:
- Today, we only have StaticString in Embedded Swift. Some meaningful programs can be written without Swift.String, but it's a big limitation -- it's desirable to be able to produce, concatenate, interpolate, print strings, etc.
- While Swift.String, which is dynamic and Unicode correct, might not be the best solution everywhere, it would fit the needs for some set of Embedded Swift users, who don't mind the dynamism (heap usage) and the codesize/data cost as long as the programs still fits into the Flash/RAM memory of their embedded device.
- This means we can't view Swift.String as a "one size fits all", and some users will be willing to accept the cost, others will want to stay away from Swift.String.
- The codesize/data cost is roughly the following (this isn't super rigorous data, but just a summary of some trial observations):

|                                                             | Extra cost                                            |
|-------------------------------------------------------------|-------------------------------------------------------|
| Level 0: No String, only StaticString                       | 0 kB                                                  |
| Level 1: "Basic" String usage, print, interpolation, append | ~30 kB (codesize)                                     |
| Level 2: "Almost full" String usage, comparisons, hashing            | ~30 kB (codesize) + ~35 kB (NFC/NFD data tables)      |
| Level 3: "Pathological" String usage (querying character properties)                      | ~30 kB (codesize) + ~635 kB (all Unicode data tables) |

**Approach in this PR**
- The idea is to make sure users are aware of the cost of String, and that they can use compilation flags to choose which "level" they want their program to be. While compilation flags might not be the best solution (perhaps some "import ..." statements could be used instead?) I would like to consider going forward with the compiler flags as a starting point.
- This PR implements an availability-based solution, where by default we're at level 0, and the compiler warns about using String and asks the user to opt-in by passing `-enable-strings`:
```
let s = "abc" // (!) ERROR: String has large associated codesize cost; only available in embedded Swift by explicitly passing -enable-strings
```
- It's not clear to me whether that's the best default behavior, but given the experimental status of Embedded Swift, it should be a good starting point and we can change the default behavior later based on user feedback.
- Similarly, even in level 1, the compiler will flag attempts to rely on String APIs that need the NFC/NFD data tables, for example comparing two strings:
```
let eq = string1 == string2 // (!) ERROR: This operation on String needs Unicode data tables; pass -enable-string=full-unicode-data-tables to acknowledge the associated codesize cost
```
- Passing `-enable-string=full-unicode-data-tables` gets us into level 2.
- Level 3 is about asking Characters for their name ("LATIN SMALL LETTER A") and other properties, and I consider it to be rare and "pathological" enough (apologies for using this word) that we don't need a separate flag for it, but it would be easy to extend the scheme to this level too. The program just needs to stay away from using Unicode.Scalar.Properties.
