### PR TITLE
🍒[cxx-interop] Fix test for reference types on armv7k, part 2

### DIFF
--- a/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
@@ -39,8 +39,8 @@ public func getNullable(wantNullptr: Bool) -> GlobalCountNullableInit? {
 // CHECK:      define {{.*}}swiftcc i{{.*}} @"$s4main11getNullable11wantNullptrSo011GlobalCountC4InitVSgSb_tF"(i1 %0)
 // CHECK-NEXT: entry:
 // CHECK:        %1 = call ptr @{{_ZN23GlobalCountNullableInit6createEb|"\?create\@GlobalCountNullableInit\@\@SAPEAU1\@_N\@Z"}}
-// CHECK-NEXT:   %2 = ptrtoint ptr %1 to i64
-// CHECK-NEXT:   %3 = inttoptr i64 %2 to ptr
+// CHECK-NEXT:   %2 = ptrtoint ptr %1 to i{{.*}}
+// CHECK-NEXT:   %3 = inttoptr i{{.*}} %2 to ptr
 // CHECK-NEXT:   %4 = icmp ne ptr %3, null
 // CHECK-NEXT:   br i1 %4, label %lifetime.nonnull-value, label %lifetime.cont
 
@@ -49,5 +49,5 @@ public func getNullable(wantNullptr: Bool) -> GlobalCountNullableInit? {
 // CHECK-NEXT:   br label %lifetime.cont
 
 // CHECK:      lifetime.cont:
-// CHECK:          ret i64 %2
+// CHECK:          ret i{{.*}} %2
 // CHECK-NEXT: }


### PR DESCRIPTION
**Explanation**: This adjusts a test to be correct on 32-bit platforms.
**Scope**: Only changes a test.
**Risk**: Low.
**Issue**: rdar://127795392

Original PR: https://github.com/apple/swift/pull/73672