### PR TITLE
Pack expansion closures, part 5

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -656,7 +656,8 @@ protected:
   void appendClosureEntity(const AbstractClosureExpr *closure);
 
   void appendClosureComponents(Type Ty, unsigned discriminator, bool isImplicit,
-                               const DeclContext *parentContext);
+                               const DeclContext *parentContext,
+                               ArrayRef<GenericEnvironment *> capturedEnvs);
 
   void appendDefaultArgumentEntity(const DeclContext *ctx, unsigned index);
 

--- a/include/swift/AST/LocalArchetypeRequirementCollector.h
+++ b/include/swift/AST/LocalArchetypeRequirementCollector.h
@@ -53,6 +53,17 @@ struct MapLocalArchetypesOutOfContext {
   Type operator()(SubstitutableType *type) const;
 };
 
+struct MapIntoLocalArchetypeContext {
+  GenericEnvironment *baseGenericEnv;
+  ArrayRef<GenericEnvironment *> capturedEnvs;
+
+  MapIntoLocalArchetypeContext(GenericEnvironment *baseGenericEnv,
+                               ArrayRef<GenericEnvironment *> capturedEnvs)
+      : baseGenericEnv(baseGenericEnv), capturedEnvs(capturedEnvs) {}
+
+  Type operator()(SubstitutableType *type) const;
+};
+
 GenericSignature buildGenericSignatureWithCapturedEnvironments(
     ASTContext &ctx,
     GenericSignature sig,

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -1080,7 +1080,7 @@ public:
   /// sends the generic parameters of the function's interface type into
   /// archetypes, which will either be primary archetypes from this
   /// environment, or local archetypes captured by this function.
-  std::pair<GenericEnvironment *, SubstitutionMap>
+  std::tuple<GenericEnvironment *, ArrayRef<GenericEnvironment *>, SubstitutionMap>
   getForwardingSubstitutionsForLowering(SILDeclRef constant);
 
   /// Returns the SIL type of a constant reference.

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
+#include "swift/AST/LocalArchetypeRequirementCollector.h"
 #include "swift/AST/MacroDiscriminatorContext.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Ownership.h"
@@ -3733,29 +3734,48 @@ void ASTMangler::appendAssociatedTypeName(DependentMemberType *dmt,
 
 void ASTMangler::appendClosureEntity(
                               const SerializedAbstractClosureExpr *closure) {
+  assert(!closure->getType()->hasLocalArchetype() &&
+         "Not enough information here to handle this case");
+
   appendClosureComponents(closure->getType(), closure->getDiscriminator(),
-                          closure->isImplicit(), closure->getParent());
+                          closure->isImplicit(), closure->getParent(),
+                          ArrayRef<GenericEnvironment *>());
 }
 
 void ASTMangler::appendClosureEntity(const AbstractClosureExpr *closure) {
-  appendClosureComponents(closure->getType(), closure->getDiscriminator(),
-                          isa<AutoClosureExpr>(closure), closure->getParent());
+  ArrayRef<GenericEnvironment *> capturedEnvs;
+
+  auto type = closure->getType();
+
+  // FIXME: CodeCompletionResultBuilder calls printValueDeclUSR() but the
+  // closure hasn't been type checked yet.
+  if (!type)
+    type = ErrorType::get(closure->getASTContext());
+
+  if (type->hasLocalArchetype())
+    capturedEnvs = closure->getCaptureInfo().getGenericEnvironments();
+
+  appendClosureComponents(type, closure->getDiscriminator(),
+                          isa<AutoClosureExpr>(closure), closure->getParent(),
+                          capturedEnvs);
 }
 
 void ASTMangler::appendClosureComponents(Type Ty, unsigned discriminator,
                                          bool isImplicit,
-                                         const DeclContext *parentContext) {
+                                         const DeclContext *parentContext,
+                                         ArrayRef<GenericEnvironment *> capturedEnvs) {
   assert(discriminator != AbstractClosureExpr::InvalidDiscriminator
          && "closure must be marked correctly with discriminator");
 
   BaseEntitySignature base(parentContext->getInnermostDeclarationDeclContext());
   appendContext(parentContext, base, StringRef());
 
-  if (!Ty)
-    Ty = ErrorType::get(parentContext->getASTContext());
-
   auto Sig = parentContext->getGenericSignatureOfContext();
-  Ty = Ty->mapTypeOutOfContext();
+
+  Ty = Ty.subst(MapLocalArchetypesOutOfContext(Sig, capturedEnvs),
+                MakeAbstractConformanceForGenericType(),
+                SubstFlags::PreservePackExpansionLevel);
+
   appendType(Ty->getCanonicalType(), Sig);
   appendOperator(isImplicit ? "fu" : "fU", Index(discriminator));
 }

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -245,7 +245,6 @@ void SILFunction::init(
          "function type has open type parameters");
 
   this->LoweredType = LoweredType;
-  this->GenericEnv = genericEnv;
   this->SpecializationInfo = nullptr;
   this->EntryCount = entryCount;
   this->Availability = AvailabilityContext::alwaysAvailable();
@@ -282,6 +281,7 @@ void SILFunction::init(
   assert(!Transparent || !IsDynamicReplaceable);
   validateSubclassScope(classSubclassScope, isThunk, nullptr);
   setDebugScope(DebugScope);
+  setGenericEnvironment(genericEnv);
 }
 
 SILFunction::~SILFunction() {
@@ -1033,14 +1033,10 @@ void SILFunction::eraseAllBlocks() {
   BlockList.clear();
 }
 
-SubstitutionMap SILFunction::getForwardingSubstitutionMap() {
-  if (ForwardingSubMap)
-    return ForwardingSubMap;
-
-  if (auto *env = getGenericEnvironment())
-    ForwardingSubMap = env->getForwardingSubstitutionMap();
-
-  return ForwardingSubMap;
+void SILFunction::setGenericEnvironment(GenericEnvironment *env) {
+  setGenericEnvironment(env, ArrayRef<GenericEnvironment *>(),
+                        env ? env->getForwardingSubstitutionMap()
+                            : SubstitutionMap());
 }
 
 bool SILFunction::shouldVerifyOwnership() const {

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
+#include "swift/AST/LocalArchetypeRequirementCollector.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Stmt.h"
 #include "swift/Basic/OptimizationMode.h"
@@ -492,24 +493,51 @@ bool SILFunction::shouldOptimize() const {
 }
 
 Type SILFunction::mapTypeIntoContext(Type type) const {
-  return GenericEnvironment::mapTypeIntoContext(
-      getGenericEnvironment(), type);
+  assert(!type->hasPrimaryArchetype());
+
+  if (GenericEnv) {
+    // The complication here is that we sometimes call this with an AST interface
+    // type, which might contain element archetypes, if it was the interface type
+    // of a closure or local variable.
+    if (type->hasElementArchetype())
+      return GenericEnv->mapTypeIntoContext(type);
+
+    // Otherwise, assume we have an interface type for the "combined" captured
+    // environment.
+    return type.subst(MapIntoLocalArchetypeContext(GenericEnv, CapturedEnvs),
+                      LookUpConformanceInModule(Module.getSwiftModule()),
+                      SubstFlags::AllowLoweredTypes |
+                      SubstFlags::PreservePackExpansionLevel);
+  }
+
+  assert(!type->hasTypeParameter());
+  return type;
 }
 
 SILType SILFunction::mapTypeIntoContext(SILType type) const {
-  if (auto *genericEnv = getGenericEnvironment())
-    return genericEnv->mapTypeIntoContext(getModule(), type);
+  assert(!type.hasPrimaryArchetype());
+
+  if (GenericEnv) {
+    auto genericSig = GenericEnv->getGenericSignature().getCanonicalSignature();
+    return type.subst(Module,
+                      MapIntoLocalArchetypeContext(GenericEnv, CapturedEnvs),
+                      LookUpConformanceInModule(Module.getSwiftModule()),
+                      genericSig,
+                      SubstFlags::PreservePackExpansionLevel);
+  }
+
+  assert(!type.hasTypeParameter());
   return type;
 }
 
 SILType GenericEnvironment::mapTypeIntoContext(SILModule &M,
                                                SILType type) const {
-  assert(!type.hasArchetype());
+  assert(!type.hasPrimaryArchetype());
 
   auto genericSig = getGenericSignature().getCanonicalSignature();
   return type.subst(M,
                     QueryInterfaceTypeSubstitutions(this),
-                    LookUpConformanceInSignature(genericSig.getPointer()),
+                    LookUpConformanceInModule(M.getSwiftModule()),
                     genericSig,
                     SubstFlags::PreservePackExpansionLevel);
 }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4116,17 +4116,15 @@ TypeConverter::getConstantGenericEnvironment(SILDeclRef c) {
       .genericSig.getGenericEnvironment();
 }
 
-std::pair<GenericEnvironment *, SubstitutionMap>
+std::tuple<GenericEnvironment *, ArrayRef<GenericEnvironment *>, SubstitutionMap>
 TypeConverter::getForwardingSubstitutionsForLowering(SILDeclRef constant) {
   auto sig = getGenericSignatureWithCapturedEnvironments(constant);
 
-  GenericEnvironment *genericEnv = nullptr;
+  auto *genericEnv = sig.baseGenericSig.getGenericEnvironment();
   SubstitutionMap forwardingSubs;
 
-  if (sig.baseGenericSig) {
-    genericEnv = sig.baseGenericSig.getGenericEnvironment();
+  if (sig.baseGenericSig)
     forwardingSubs = genericEnv->getForwardingSubstitutionMap();
-  }
 
   if (!sig.capturedEnvs.empty()) {
     assert(sig.genericSig && !sig.genericSig->isEqual(sig.baseGenericSig));
@@ -4135,7 +4133,7 @@ TypeConverter::getForwardingSubstitutionsForLowering(SILDeclRef constant) {
         forwardingSubs, sig.genericSig, sig.capturedEnvs);
   }
 
-  return std::make_pair(genericEnv, forwardingSubs);
+  return std::make_tuple(genericEnv, sig.capturedEnvs, forwardingSubs);
 }
 
 SILType TypeConverter::getSubstitutedStorageType(TypeExpansionContext context,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1224,8 +1224,9 @@ void SILGenModule::preEmitFunction(SILDeclRef constant, SILFunction *F,
   assert(F->empty() && "already emitted function?!");
 
   if (F->getLoweredFunctionType()->isPolymorphic()) {
-    auto pair = Types.getForwardingSubstitutionsForLowering(constant);
-    F->setGenericEnvironment(pair.first, pair.second);
+    auto [genericEnv, capturedEnvs, forwardingSubs]
+        = Types.getForwardingSubstitutionsForLowering(constant);
+    F->setGenericEnvironment(genericEnv, capturedEnvs, forwardingSubs);
   }
 
   // If we have global actor isolation for our constant, put the isolation onto

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -225,7 +225,11 @@ private:
         getPullback().getLoweredFunctionType()->getSubstGenericSignature());
     auto remappedSILType =
         SILType::getPrimitiveType(remappedType, ty.getCategory());
-    return getPullback().mapTypeIntoContext(remappedSILType);
+    // FIXME: Sometimes getPullback() doesn't have a generic environment, in which
+    // case callers are apparently happy to receive an interface type.
+    if (getPullback().getGenericEnvironment())
+      return getPullback().mapTypeIntoContext(remappedSILType);
+    return remappedSILType;
   }
 
   std::optional<TangentSpace> getTangentSpace(CanType type) {

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -460,6 +460,9 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
     Linkage = addExternalToLinkage(Linkage);
   }
 
+  assert(F.getCapturedEnvironments().empty() &&
+         "Captured local environments should not survive past SILGen");
+
   // If we have a body, we might have a generic environment.
   GenericSignatureID genericSigID = 0;
   if (!NoBody)


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/73570. More plumbing to convert between local and primary archetypes in the various places its needed. There is only one more PR remaining after this, which lands the SILGen local archetype transform, as well as end-to-end tests for all of this.