### PR TITLE
Suppress pointer conversion warnings for BitwiseCopyable elements.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -6142,6 +6142,11 @@ static void diagnoseImplicitRawConversion(Type sourceTy, Type pointerTy,
     return;
 
   auto *SM = SGF.getModule().getSwiftModule();
+  if (auto *bitwiseCopyableDecl = SM->getASTContext().getProtocol(
+        KnownProtocolKind::BitwiseCopyable)) {
+    if (SM->checkConformance(eltTy, bitwiseCopyableDecl))
+      return;
+  }
   if (auto *fixedWidthIntegerDecl = SM->getASTContext().getProtocol(
           KnownProtocolKind::FixedWidthInteger)) {
     if (SM->checkConformance(eltTy, fixedWidthIntegerDecl))


### PR DESCRIPTION
Now that BitwiseCopyable is accepted, it should work as the recommended workaround for unsafe pointer conversion warnings:

Forming 'UnsafeMutableRawPointer' to a variable of type 'S'; this is likely incorrect because 'S' may contain an object reference.

The check for trivial element types is in SILGenExpr, diagnoseImplicitRawConversion. For now, we can hack SILGenExpr to specifically disable the warning for BitwiseCopyable, just as it was done for FixedWidthInteger in prior releases.

Fixes rdar://128229439 (Conversion from BitwiseCopyable to UnsafeRawPointer should not warn.)
