### PR TITLE
[Autodiff] Adds logic to rewrite call-sites using functions specialized by the closure-spec optimization

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -60,6 +60,10 @@ extension Context {
       _bridged.lookupFunction($0).function
     }
   }
+
+  func notifyNewFunction(function: Function, derivedFrom: Function) {
+    _bridged.addFunctionToPassManagerWorklist(function.bridged, derivedFrom.bridged)
+  }
 }
 
 /// A context which allows mutation of a function's SIL.
@@ -357,7 +361,7 @@ struct FunctionPassContext : MutatingContext {
     return String(taking: _bridged.mangleOutlinedVariable(function.bridged))
   }
 
-  func mangle(withClosureArgs closureArgs: [Value], closureArgIndices: [Int], from applySiteCallee: Function) -> String {
+  func mangle(withClosureArguments closureArgs: [Value], closureArgIndices: [Int], from applySiteCallee: Function) -> String {
     closureArgs.withBridgedValues { bridgedClosureArgsRef in
       closureArgIndices.withBridgedArrayRef{bridgedClosureArgIndicesRef in 
         String(taking: _bridged.mangleWithClosureArgs(
@@ -392,13 +396,13 @@ struct FunctionPassContext : MutatingContext {
     }
   }
 
-  func buildSpecializedFunction(specializedFunction: Function, buildFn: (Function, FunctionPassContext) -> ()) {
+  func buildSpecializedFunction<T>(specializedFunction: Function, buildFn: (Function, FunctionPassContext) -> T) -> T {
     let nestedFunctionPassContext = 
         FunctionPassContext(_bridged: _bridged.initializeNestedPassContext(specializedFunction.bridged))
 
       defer { _bridged.deinitializedNestedPassContext() }
 
-      buildFn(specializedFunction, nestedFunctionPassContext)
+      return buildFn(specializedFunction, nestedFunctionPassContext)
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -166,7 +166,8 @@ public func registerOptimizerTests() {
     parseTestSpecificationTest,
     variableIntroducerTest,
     gatherCallSitesTest,
-    specializedFunctionSignatureAndBodyTest
+    specializedFunctionSignatureAndBodyTest,
+    rewrittenCallerBodyTest
   )
 
   // Finally register the thunk they all call through.

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -152,6 +152,18 @@ public struct Builder {
   }
 
   @discardableResult
+  public func createRetainValue(operand: Value) -> RetainValueInst {
+    let retain = bridged.createRetainValue(operand.bridged)
+    return notifyNew(retain.getAs(RetainValueInst.self))
+  }
+
+  @discardableResult
+  public func createReleaseValue(operand: Value) -> ReleaseValueInst {
+    let release = bridged.createReleaseValue(operand.bridged)
+    return notifyNew(release.getAs(ReleaseValueInst.self))
+  }
+
+  @discardableResult
   public func createStrongRetain(operand: Value) -> StrongRetainInst {
     let retain = bridged.createStrongRetain(operand.bridged)
     return notifyNew(retain.getAs(StrongRetainInst.self))

--- a/SwiftCompilerSources/Sources/SIL/Operand.swift
+++ b/SwiftCompilerSources/Sources/SIL/Operand.swift
@@ -62,6 +62,10 @@ public struct OperandArray : RandomAccessCollection, CustomReflectable {
     self.count = count
   }
 
+  static public var empty: OperandArray {
+    OperandArray(base: OptionalBridgedOperand(bridged: nil), count: 0)
+  }
+
   public var startIndex: Int { return 0 }
   public var endIndex: Int { return count }
   

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1210,6 +1210,10 @@ struct BridgedBuilder{
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createBeginDeallocRef(BridgedValue reference,
                                                                               BridgedValue allocation) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createEndInitLetRef(BridgedValue op) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction
+  createRetainValue(BridgedValue op) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction
+  createReleaseValue(BridgedValue op) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createStrongRetain(BridgedValue op) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createStrongRelease(BridgedValue op) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createUnownedRetain(BridgedValue op) const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_SIL_SILBRIDGING_IMPL_H
 #define SWIFT_SIL_SILBRIDGING_IMPL_H
 
+#include "SILBridging.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/SubstitutionMap.h"

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1590,6 +1590,18 @@ BridgedInstruction BridgedBuilder::createEndInitLetRef(BridgedValue op) const {
   return {unbridged().createEndInitLetRef(regularLoc(), op.getSILValue())};
 }
 
+BridgedInstruction BridgedBuilder::createRetainValue(BridgedValue op) const {
+  auto b = unbridged();
+  return {b.createRetainValue(regularLoc(), op.getSILValue(),
+                              b.getDefaultAtomicity())};
+}
+
+BridgedInstruction BridgedBuilder::createReleaseValue(BridgedValue op) const {
+  auto b = unbridged();
+  return {b.createReleaseValue(regularLoc(), op.getSILValue(),
+                               b.getDefaultAtomicity())};
+}
+
 BridgedInstruction BridgedBuilder::createStrongRetain(BridgedValue op) const {
   auto b = unbridged();
   return {b.createStrongRetain(regularLoc(), op.getSILValue(), b.getDefaultAtomicity())};

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -337,6 +337,9 @@ struct BridgedPassContext {
   BRIDGED_INLINE bool continueWithNextSubpassRun(OptionalBridgedInstruction inst) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedPassContext initializeNestedPassContext(BridgedFunction newFunction) const;
   BRIDGED_INLINE void deinitializedNestedPassContext() const;
+  BRIDGED_INLINE void
+  addFunctionToPassManagerWorklist(BridgedFunction newFunction,
+                                   BridgedFunction oldFunction) const;
 
   // SSAUpdater
 

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -454,6 +454,13 @@ void BridgedPassContext::SSAUpdater_initialize(
                                    BridgedValue::castToOwnership(ownership));
 }
 
+void BridgedPassContext::addFunctionToPassManagerWorklist(
+    BridgedFunction newFunction, BridgedFunction oldFunction) const {
+  swift::SILPassManager *pm = invocation->getPassManager();
+  pm->addFunctionToWorklist(newFunction.getFunction(),
+                            oldFunction.getFunction());
+}
+
 void BridgedPassContext::SSAUpdater_addAvailableValue(BridgedBasicBlock block, BridgedValue value) const {
   invocation->getSSAUpdater()->addAvailableValue(block.unbridged(),
                                                  value.getSILValue());

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -1008,9 +1008,13 @@ SILPassPipelinePlan::getPerformancePassPipeline(const SILOptions &Options) {
   if (Options.StopOptimizationAfterSerialization)
     return P;
 
+  P.addAutodiffClosureSpecialization();
+
   // After serialization run the function pass pipeline to iteratively lower
   // high-level constructs like @_semantics calls.
   addMidLevelFunctionPipeline(P);
+
+  P.addAutodiffClosureSpecialization();
 
   // Perform optimizations that specialize.
   addClosureSpecializePassPipeline(P);

--- a/test/AutoDiff/SILOptimizer/closure_specialization.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization.sil
@@ -10,21 +10,21 @@ import SwiftShims
 
 import _Differentiation
 
-//////////////////////////////
-// Single closure call site //
-//////////////////////////////
+////////////////////////////////////////////////////////////////
+// Single closure call site where closure is passed as @owned //
+////////////////////////////////////////////////////////////////
 sil @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
 
 sil private @$pullback_f : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float {
 bb0(%0 : $Float, %1 : $@callee_guaranteed (Float) -> (Float, Float)):
-  %2 = apply %1(%0) : $@callee_guaranteed (Float) -> (Float, Float) // users: %5, %4
+  %2 = apply %1(%0) : $@callee_guaranteed (Float) -> (Float, Float) 
   strong_release %1 : $@callee_guaranteed (Float) -> (Float, Float) // id: %3
-  %4 = tuple_extract %2 : $(Float, Float), 0      // user: %7
-  %5 = tuple_extract %2 : $(Float, Float), 1      // user: %6
-  %6 = struct_extract %5 : $Float, #Float._value  // user: %8
-  %7 = struct_extract %4 : $Float, #Float._value  // user: %8
-  %8 = builtin "fadd_FPIEEE32"(%6 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %9
-  %9 = struct $Float (%8 : $Builtin.FPIEEE32)     // users: %11, %10
+  %4 = tuple_extract %2 : $(Float, Float), 0      
+  %5 = tuple_extract %2 : $(Float, Float), 1      
+  %6 = struct_extract %5 : $Float, #Float._value  
+  %7 = struct_extract %4 : $Float, #Float._value  
+  %8 = builtin "fadd_FPIEEE32"(%6 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  %9 = struct $Float (%8 : $Builtin.FPIEEE32)     
   debug_value %9 : $Float, let, name "x", argno 1 // id: %10
   return %9 : $Float                              // id: %11
 }
@@ -35,9 +35,9 @@ bb0(%0 : $Float):
   //=========== Test callsite and closure gathering logic ===========//
   specify_test "closure_specialize_gather_call_sites"
   // CHECK-LABEL: Specializing closures in function: $s4test1fyS2fFTJrSpSr
-  // CHECK: PartialApply call site:   %8 = partial_apply [callee_guaranteed] %7(%6) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %9
+  // CHECK: PartialApply call site:   %8 = partial_apply [callee_guaranteed] %7(%6) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float 
   // CHECK: Passed in closures:
-  // CHECK: 1.   %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %8
+  // CHECK: 1.   %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
 
 
  //=========== Test specialized function signature and body ===========//
@@ -45,9 +45,9 @@ bb0(%0 : $Float):
   // CHECK-LABEL: Generated specialized function: $s11$pullback_f12$vjpMultiplyS2fTf1nc_n
   // CHECK: sil private @$s11$pullback_f12$vjpMultiplyS2fTf1nc_n : $@convention(thin) (Float, Float, Float) -> Float {
   // CHECK: bb0(%0 : $Float, %1 : $Float, %2 : $Float):
-  // CHECK: %3 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %4
-  // CHECK: %4 = partial_apply [callee_guaranteed] %3(%1, %2) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // users: %6, %5
-  // CHECK: %5 = apply %4(%0) : $@callee_guaranteed (Float) -> (Float, Float) // users: %8, %7
+  // CHECK: %3 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK: %4 = partial_apply [callee_guaranteed] %3(%1, %2) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK: %5 = apply %4(%0) : $@callee_guaranteed (Float) -> (Float, Float) 
   // CHECK: strong_release %4 : $@callee_guaranteed (Float) -> (Float, Float) // id: %6
   // CHECK: return
 
@@ -56,52 +56,123 @@ bb0(%0 : $Float):
   // CHECK-LABEL: Rewritten caller body for: $s4test1fyS2fFTJrSpSr
   // CHECK: sil hidden @$s4test1fyS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {                                 
   // CHECK: bb0(%0 : $Float):
-  // CHECK: %2 = struct_extract %0 : $Float, #Float._value  // users: %3, %3
-  // CHECK: %3 = builtin "fmul_FPIEEE32"(%2 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %4
-  // CHECK: %4 = struct $Float (%3 : $Builtin.FPIEEE32)     // user: %11
-  // CHECK: %5 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %6
-  // CHECK: %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %10
-  // CHECK: %8 = function_ref @$s11$pullback_f12$vjpMultiplyS2fTf1nc_n : $@convention(thin) (Float, Float, Float) -> Float // user: %9
-  // CHECK: %9 = partial_apply [callee_guaranteed] %8(%0, %0) : $@convention(thin) (Float, Float, Float) -> Float // user: %11
+  // CHECK: %2 = struct_extract %0 : $Float, #Float._value  
+  // CHECK: %3 = builtin "fmul_FPIEEE32"(%2 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  // CHECK: %4 = struct $Float (%3 : $Builtin.FPIEEE32)     
+  // CHECK: %5 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK: %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK: %8 = function_ref @$s11$pullback_f12$vjpMultiplyS2fTf1nc_n : $@convention(thin) (Float, Float, Float) -> Float 
+  // CHECK: %9 = partial_apply [callee_guaranteed] %8(%0, %0) : $@convention(thin) (Float, Float, Float) -> Float 
   // CHECK: release_value %6 : $@callee_guaranteed (Float) -> (Float, Float) // id: %10
-  // CHECK: %11 = tuple (%4 : $Float, %9 : $@callee_guaranteed (Float) -> Float) // user: %12
+  // CHECK: %11 = tuple (%4 : $Float, %9 : $@callee_guaranteed (Float) -> Float) 
   // CHECK: return %11
 
   debug_value %0 : $Float, let, name "x", argno 1 // id: %1
-  %2 = struct_extract %0 : $Float, #Float._value  // users: %3, %3
-  %3 = builtin "fmul_FPIEEE32"(%2 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %4
-  %4 = struct $Float (%3 : $Builtin.FPIEEE32)     // user: %9
+  %2 = struct_extract %0 : $Float, #Float._value  
+  %3 = builtin "fmul_FPIEEE32"(%2 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  %4 = struct $Float (%3 : $Builtin.FPIEEE32)     
   // function_ref closure #1 in static Float._vjpMultiply(lhs:rhs:)
-  %5 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %6
-  %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %8
+  %5 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
   // function_ref pullback of f(_:)
-  %7 = function_ref @$pullback_f : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %8
-  %8 = partial_apply [callee_guaranteed] %7(%6) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %9
-  %9 = tuple (%4 : $Float, %8 : $@callee_guaranteed (Float) -> Float) // user: %10
+  %7 = function_ref @$pullback_f : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float 
+  %8 = partial_apply [callee_guaranteed] %7(%6) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float 
+  %9 = tuple (%4 : $Float, %8 : $@callee_guaranteed (Float) -> Float) 
   return %9 : $(Float, @callee_guaranteed (Float) -> Float) // id: %10
 }
+
+/////////////////////////////////////////////////////////////////////
+// Single closure call site where closure is passed as @guaranteed //
+/////////////////////////////////////////////////////////////////////
+sil private @$pullback_k : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> Float {
+// %0                                             
+// %1                                             
+bb0(%0 : $Float, %1 : $@callee_guaranteed (Float) -> (Float, Float)):
+  %2 = apply %1(%0) : $@callee_guaranteed (Float) -> (Float, Float) 
+  %3 = tuple_extract %2 : $(Float, Float), 0      
+  %4 = tuple_extract %2 : $(Float, Float), 1      
+  %5 = struct_extract %4 : $Float, #Float._value  
+  %6 = struct_extract %3 : $Float, #Float._value  
+  %7 = builtin "fadd_FPIEEE32"(%5 : $Builtin.FPIEEE32, %6 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  %8 = struct $Float (%7 : $Builtin.FPIEEE32)     
+  debug_value %8 : $Float, let, name "x", argno 1 // id: %9
+  return %8 : $Float                              // id: %10
+} // end sil function '$pullback_k'
+
+// reverse-mode derivative of k(_:)
+sil hidden @$s4test1kyS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  //=========== Test callsite and closure gathering logic ===========//
+  specify_test "closure_specialize_gather_call_sites"
+  // CHECK-LABEL: Specializing closures in function: $s4test1kyS2fFTJrSpSr
+  // CHECK: PartialApply call site:   %8 = partial_apply [callee_guaranteed] %7(%6) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> Float 
+  // CHECK: Passed in closures:
+  // CHECK: 1.   %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+
+
+ //=========== Test specialized function signature and body ===========//
+  specify_test "closure_specialize_specialized_function_signature_and_body"
+  // CHECK-LABEL: Generated specialized function: $s11$pullback_k12$vjpMultiplyS2fTf1nc_n
+  // CHECK: sil private @$s11$pullback_k12$vjpMultiplyS2fTf1nc_n : $@convention(thin) (Float, Float, Float) -> Float {
+  // CHECK: bb0(%0 : $Float, %1 : $Float, %2 : $Float):
+  // CHECK:   %3 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK:   %4 = partial_apply [callee_guaranteed] %3(%1, %2) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK:   %5 = apply %4(%0) : $@callee_guaranteed (Float) -> (Float, Float) 
+  // CHECK:   release_value %4 : $@callee_guaranteed (Float) -> (Float, Float) // id: %13
+  // CHECK:   return %11
+
+   //=========== Test rewritten body ===========//
+  specify_test "closure_specialize_rewritten_caller_body"
+  // CHECK-LABEL: Rewritten caller body for: $s4test1kyS2fFTJrSpSr
+  // CHECK: sil hidden @$s4test1kyS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {                                 
+  // CHECK: bb0(%0 : $Float):
+  // CHECK: %2 = struct_extract %0 : $Float, #Float._value  
+  // CHECK: %3 = builtin "fmul_FPIEEE32"(%2 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  // CHECK: %4 = struct $Float (%3 : $Builtin.FPIEEE32)
+  // CHECK: %5 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float)
+  // CHECK: %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float)
+  // CHECK: %8 = function_ref @$s11$pullback_k12$vjpMultiplyS2fTf1nc_n : $@convention(thin) (Float, Float, Float) -> Float 
+  // CHECK: %9 = partial_apply [callee_guaranteed] %8(%0, %0) : $@convention(thin) (Float, Float, Float) -> Float 
+  // CHECK: strong_release %6 : $@callee_guaranteed (Float) -> (Float, Float)
+  // CHECK: %11 = tuple (%4 : $Float, %9 : $@callee_guaranteed (Float) -> Float) 
+  // CHECK: return %11
+
+  debug_value %0 : $Float, let, name "x", argno 1 // id: %1
+  %2 = struct_extract %0 : $Float, #Float._value  
+  %3 = builtin "fmul_FPIEEE32"(%2 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  %4 = struct $Float (%3 : $Builtin.FPIEEE32)     
+  // function_ref $vjpMultiply
+  %5 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // function_ref $pullback_k
+  %7 = function_ref @$pullback_k : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> Float 
+  %8 = partial_apply [callee_guaranteed] %7(%6) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> Float 
+  strong_release %6 : $@callee_guaranteed (Float) -> (Float, Float) // id: %9
+  %10 = tuple (%4 : $Float, %8 : $@callee_guaranteed (Float) -> Float) 
+  return %10 : $(Float, @callee_guaranteed (Float) -> Float) // id: %11
+} // end sil function '$s4test1kyS2fFTJrSpSr'
 
 ///////////////////////////////
 // Multiple closure callsite //
 ///////////////////////////////
-sil @$vjpSin : $@convention(thin) (Float, Float) -> Float // user: %6
-sil @$vjpCos : $@convention(thin) (Float, Float) -> Float // user: %10
+sil @$vjpSin : $@convention(thin) (Float, Float) -> Float 
+sil @$vjpCos : $@convention(thin) (Float, Float) -> Float 
 
 // pullback of g(_:)
 sil private @$pullback_g : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float {
 bb0(%0 : $Float, %1 : $@callee_guaranteed (Float) -> Float, %2 : $@callee_guaranteed (Float) -> Float, %3 : $@callee_guaranteed (Float) -> (Float, Float)):
-  %4 = apply %3(%0) : $@callee_guaranteed (Float) -> (Float, Float) // users: %7, %6
+  %4 = apply %3(%0) : $@callee_guaranteed (Float) -> (Float, Float) 
   strong_release %3 : $@callee_guaranteed (Float) -> (Float, Float) // id: %5
-  %6 = tuple_extract %4 : $(Float, Float), 0      // user: %10
-  %7 = tuple_extract %4 : $(Float, Float), 1      // user: %8
-  %8 = apply %2(%7) : $@callee_guaranteed (Float) -> Float // user: %12
+  %6 = tuple_extract %4 : $(Float, Float), 0      
+  %7 = tuple_extract %4 : $(Float, Float), 1      
+  %8 = apply %2(%7) : $@callee_guaranteed (Float) -> Float 
   strong_release %2 : $@callee_guaranteed (Float) -> Float // id: %9
-  %10 = apply %1(%6) : $@callee_guaranteed (Float) -> Float // user: %13
+  %10 = apply %1(%6) : $@callee_guaranteed (Float) -> Float 
   strong_release %1 : $@callee_guaranteed (Float) -> Float // id: %11
-  %12 = struct_extract %8 : $Float, #Float._value // user: %14
-  %13 = struct_extract %10 : $Float, #Float._value // user: %14
-  %14 = builtin "fadd_FPIEEE32"(%13 : $Builtin.FPIEEE32, %12 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %15
-  %15 = struct $Float (%14 : $Builtin.FPIEEE32)   // users: %17, %16
+  %12 = struct_extract %8 : $Float, #Float._value 
+  %13 = struct_extract %10 : $Float, #Float._value 
+  %14 = builtin "fadd_FPIEEE32"(%13 : $Builtin.FPIEEE32, %12 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  %15 = struct $Float (%14 : $Builtin.FPIEEE32)   
   debug_value %15 : $Float, let, name "x", argno 1 // id: %16
   return %15 : $Float                             // id: %17
 }
@@ -112,28 +183,28 @@ bb0(%0 : $Float):
   //=========== Test callsite and closure gathering logic ===========//
   specify_test "closure_specialize_gather_call_sites"
   // CHECK-LABEL: Specializing closures in function: $s4test1gyS2fFTJrSpSr
-  // CHECK: PartialApply call site:   %16 = partial_apply [callee_guaranteed] %15(%6, %10, %14) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %17
+  // CHECK: PartialApply call site:   %16 = partial_apply [callee_guaranteed] %15(%6, %10, %14) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float 
   // CHECK: Passed in closures:
-  // CHECK: 1.   %6 = partial_apply [callee_guaranteed] %5(%0) : $@convention(thin) (Float, Float) -> Float // user: %16
-  // CHECK: 2.   %10 = partial_apply [callee_guaranteed] %9(%0) : $@convention(thin) (Float, Float) -> Float // user: %16
-  // CHECK: 3.   %14 = partial_apply [callee_guaranteed] %13(%8, %4) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %16
+  // CHECK: 1.   %6 = partial_apply [callee_guaranteed] %5(%0) : $@convention(thin) (Float, Float) -> Float 
+  // CHECK: 2.   %10 = partial_apply [callee_guaranteed] %9(%0) : $@convention(thin) (Float, Float) -> Float 
+  // CHECK: 3.   %14 = partial_apply [callee_guaranteed] %13(%8, %4) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
 
   //=========== Test specialized function signature and body ===========//
   specify_test "closure_specialize_specialized_function_signature_and_body"
   // CHECK-LABEL: Generated specialized function: $s11$pullback_g7$vjpSinSf0B3CosSf0B8MultiplyS2fTf1nccc_n
   // CHECK: sil private @$s11$pullback_g7$vjpSinSf0B3CosSf0B8MultiplyS2fTf1nccc_n : $@convention(thin) (Float, Float, Float, Float, Float) -> Float {
   // CHECK: bb0(%0 : $Float, %1 : $Float, %2 : $Float, %3 : $Float, %4 : $Float):
-  // CHECK: %5 = function_ref @$vjpSin : $@convention(thin) (Float, Float) -> Float // user: %6
-  // CHECK: %6 = partial_apply [callee_guaranteed] %5(%1) : $@convention(thin) (Float, Float) -> Float // users: %18, %17
-  // CHECK: %7 = function_ref @$vjpCos : $@convention(thin) (Float, Float) -> Float // user: %8
-  // CHECK: %8 = partial_apply [callee_guaranteed] %7(%2) : $@convention(thin) (Float, Float) -> Float // users: %16, %15
-  // CHECK: %9 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %10
-  // CHECK: %10 = partial_apply [callee_guaranteed] %9(%3, %4) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // users: %12, %11
-  // CHECK: %11 = apply %10(%0) : $@callee_guaranteed (Float) -> (Float, Float) // users: %14, %13
+  // CHECK: %5 = function_ref @$vjpSin : $@convention(thin) (Float, Float) -> Float 
+  // CHECK: %6 = partial_apply [callee_guaranteed] %5(%1) : $@convention(thin) (Float, Float) -> Float 
+  // CHECK: %7 = function_ref @$vjpCos : $@convention(thin) (Float, Float) -> Float 
+  // CHECK: %8 = partial_apply [callee_guaranteed] %7(%2) : $@convention(thin) (Float, Float) -> Float 
+  // CHECK: %9 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK: %10 = partial_apply [callee_guaranteed] %9(%3, %4) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK: %11 = apply %10(%0) : $@callee_guaranteed (Float) -> (Float, Float) 
   // CHECK: strong_release %10 : $@callee_guaranteed (Float) -> (Float, Float) // id: %12
-  // CHECK: %15 = apply %8(%14) : $@callee_guaranteed (Float) -> Float // user: %19
+  // CHECK: %15 = apply %8(%14) : $@callee_guaranteed (Float) -> Float 
   // CHECK: strong_release %8 : $@callee_guaranteed (Float) -> Float // id: %16
-  // CHECK: %17 = apply %6(%13) : $@callee_guaranteed (Float) -> Float // user: %20
+  // CHECK: %17 = apply %6(%13) : $@callee_guaranteed (Float) -> Float 
   // CHECK: strong_release %6 : $@callee_guaranteed (Float) -> Float // id: %18
   // CHECK: return  
 
@@ -142,48 +213,48 @@ bb0(%0 : $Float):
   // CHECK-LABEL: Rewritten caller body for: $s4test1gyS2fFTJrSpSr
   // CHECK: sil hidden @$s4test1gyS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
   // CHECK: bb0(%0 : $Float):
-  // CHECK:  %2 = struct_extract %0 : $Float, #Float._value  // users: %7, %3
-  // CHECK:  %3 = builtin "int_sin_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // users: %11, %4
-  // CHECK:  %4 = struct $Float (%3 : $Builtin.FPIEEE32)     // users: %17, %14
-  // CHECK:  %5 = function_ref @$vjpSin : $@convention(thin) (Float, Float) -> Float // user: %6
-  // CHECK:  %6 = partial_apply [callee_guaranteed] %5(%0) : $@convention(thin) (Float, Float) -> Float // user: %18
-  // CHECK:  %7 = builtin "int_cos_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // users: %11, %8
-  // CHECK:  %8 = struct $Float (%7 : $Builtin.FPIEEE32)     // users: %17, %14
-  // CHECK:  %9 = function_ref @$vjpCos : $@convention(thin) (Float, Float) -> Float // user: %10
-  // CHECK:  %10 = partial_apply [callee_guaranteed] %9(%0) : $@convention(thin) (Float, Float) -> Float // user: %19
-  // CHECK:  %11 = builtin "fmul_FPIEEE32"(%3 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %12
-  // CHECK:  %12 = struct $Float (%11 : $Builtin.FPIEEE32)   // user: %21
-  // CHECK:  %13 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %14
-  // CHECK:  %14 = partial_apply [callee_guaranteed] %13(%8, %4) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %20
-  // CHECK:  %16 = function_ref @$s11$pullback_g7$vjpSinSf0B3CosSf0B8MultiplyS2fTf1nccc_n : $@convention(thin) (Float, Float, Float, Float, Float) -> Float // user: %17
-  // CHECK:  %17 = partial_apply [callee_guaranteed] %16(%0, %0, %8, %4) : $@convention(thin) (Float, Float, Float, Float, Float) -> Float // user: %21
+  // CHECK:  %2 = struct_extract %0 : $Float, #Float._value  
+  // CHECK:  %3 = builtin "int_sin_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  // CHECK:  %4 = struct $Float (%3 : $Builtin.FPIEEE32)     
+  // CHECK:  %5 = function_ref @$vjpSin : $@convention(thin) (Float, Float) -> Float 
+  // CHECK:  %6 = partial_apply [callee_guaranteed] %5(%0) : $@convention(thin) (Float, Float) -> Float 
+  // CHECK:  %7 = builtin "int_cos_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  // CHECK:  %8 = struct $Float (%7 : $Builtin.FPIEEE32)     
+  // CHECK:  %9 = function_ref @$vjpCos : $@convention(thin) (Float, Float) -> Float 
+  // CHECK:  %10 = partial_apply [callee_guaranteed] %9(%0) : $@convention(thin) (Float, Float) -> Float 
+  // CHECK:  %11 = builtin "fmul_FPIEEE32"(%3 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  // CHECK:  %12 = struct $Float (%11 : $Builtin.FPIEEE32)   
+  // CHECK:  %13 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK:  %14 = partial_apply [callee_guaranteed] %13(%8, %4) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK:  %16 = function_ref @$s11$pullback_g7$vjpSinSf0B3CosSf0B8MultiplyS2fTf1nccc_n : $@convention(thin) (Float, Float, Float, Float, Float) -> Float 
+  // CHECK:  %17 = partial_apply [callee_guaranteed] %16(%0, %0, %8, %4) : $@convention(thin) (Float, Float, Float, Float, Float) -> Float 
   // CHECK:  release_value %6 : $@callee_guaranteed (Float) -> Float // id: %18
   // CHECK:  release_value %10 : $@callee_guaranteed (Float) -> Float // id: %19
   // CHECK:  release_value %14 : $@callee_guaranteed (Float) -> (Float, Float) // id: %20
-  // CHECK:  %21 = tuple (%12 : $Float, %17 : $@callee_guaranteed (Float) -> Float) // user: %22
+  // CHECK:  %21 = tuple (%12 : $Float, %17 : $@callee_guaranteed (Float) -> Float) 
   // CHECK:  return %21
 
   debug_value %0 : $Float, let, name "x", argno 1 // id: %1
-  %2 = struct_extract %0 : $Float, #Float._value  // users: %7, %3
-  %3 = builtin "int_sin_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // users: %11, %4
-  %4 = struct $Float (%3 : $Builtin.FPIEEE32)     // user: %14
+  %2 = struct_extract %0 : $Float, #Float._value  
+  %3 = builtin "int_sin_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  %4 = struct $Float (%3 : $Builtin.FPIEEE32)     
   // function_ref closure #1 in _vjpSin(_:)
-  %5 = function_ref @$vjpSin : $@convention(thin) (Float, Float) -> Float // user: %6
-  %6 = partial_apply [callee_guaranteed] %5(%0) : $@convention(thin) (Float, Float) -> Float // user: %16
-  %7 = builtin "int_cos_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // users: %11, %8
-  %8 = struct $Float (%7 : $Builtin.FPIEEE32)     // user: %14
+  %5 = function_ref @$vjpSin : $@convention(thin) (Float, Float) -> Float 
+  %6 = partial_apply [callee_guaranteed] %5(%0) : $@convention(thin) (Float, Float) -> Float 
+  %7 = builtin "int_cos_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  %8 = struct $Float (%7 : $Builtin.FPIEEE32)     
   // function_ref closure #1 in _vjpCos(_:)
-  %9 = function_ref @$vjpCos : $@convention(thin) (Float, Float) -> Float // user: %10
-  %10 = partial_apply [callee_guaranteed] %9(%0) : $@convention(thin) (Float, Float) -> Float // user: %16
-  %11 = builtin "fmul_FPIEEE32"(%3 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %12
-  %12 = struct $Float (%11 : $Builtin.FPIEEE32)   // user: %17
+  %9 = function_ref @$vjpCos : $@convention(thin) (Float, Float) -> Float 
+  %10 = partial_apply [callee_guaranteed] %9(%0) : $@convention(thin) (Float, Float) -> Float 
+  %11 = builtin "fmul_FPIEEE32"(%3 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  %12 = struct $Float (%11 : $Builtin.FPIEEE32)   
   // function_ref closure #1 in static Float._vjpMultiply(lhs:rhs:)
-  %13 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %14
-  %14 = partial_apply [callee_guaranteed] %13(%8, %4) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %16
+  %13 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  %14 = partial_apply [callee_guaranteed] %13(%8, %4) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
   // function_ref pullback of g(_:)
-  %15 = function_ref @$pullback_g : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %16
-  %16 = partial_apply [callee_guaranteed] %15(%6, %10, %14) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %17
-  %17 = tuple (%12 : $Float, %16 : $@callee_guaranteed (Float) -> Float) // user: %18
+  %15 = function_ref @$pullback_g : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float 
+  %16 = partial_apply [callee_guaranteed] %15(%6, %10, %14) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float 
+  %17 = tuple (%12 : $Float, %16 : $@callee_guaranteed (Float) -> Float) 
   return %17 : $(Float, @callee_guaranteed (Float) -> Float) // id: %18
 }
 
@@ -223,20 +294,20 @@ bb0(%0 : $X):
   //=========== Test callsite and closure gathering logic ===========//
   specify_test "closure_specialize_gather_call_sites"
   // CHECK-LABEL: Specializing closures in function: $s5test21g1xSfAA1XV_tFTJrSpSr
-  // CHECK: PartialApply call site:   %7 = partial_apply [callee_guaranteed] %6(%5) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) -> X.TangentVector // user: %8
+  // CHECK: PartialApply call site:   %7 = partial_apply [callee_guaranteed] %6(%5) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) -> X.TangentVector 
   // CHECK: Passed in closures:
-  // CHECK: 1.   %3 = thin_to_thick_function %2 : $@convention(thin) (Float, Double) -> X.TangentVector to $@callee_guaranteed (Float, Double) -> X.TangentVector // user: %5
+  // CHECK: 1.   %3 = thin_to_thick_function %2 : $@convention(thin) (Float, Double) -> X.TangentVector to $@callee_guaranteed (Float, Double) -> X.TangentVector 
 
   //=========== Test specialized function signature and body ===========//
   specify_test "closure_specialize_specialized_function_signature_and_body"
   // CHECK-LABEL: Generated specialized function: $s10pullback_g0A2_fTf1nc_n
   // CHECK: sil shared @$s10pullback_g0A2_fTf1nc_n : $@convention(thin) (Float) -> X.TangentVector {
   // CHECK: bb0(%0 : $Float):
-  // CHECK:   %1 = function_ref @pullback_f : $@convention(thin) (Float, Double) -> X.TangentVector // user: %2
-  // CHECK:   %2 = thin_to_thick_function %1 : $@convention(thin) (Float, Double) -> X.TangentVector to $@callee_guaranteed (Float, Double) -> X.TangentVector // user: %4
-  // CHECK:   %3 = function_ref @subset_parameter_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector // user: %4
-  // CHECK:   %4 = partial_apply [callee_guaranteed] %3(%2) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector // users: %6, %5
-  // CHECK:   %5 = apply %4(%0) : $@callee_guaranteed (Float) -> X.TangentVector // user: %7
+  // CHECK:   %1 = function_ref @pullback_f : $@convention(thin) (Float, Double) -> X.TangentVector 
+  // CHECK:   %2 = thin_to_thick_function %1 : $@convention(thin) (Float, Double) -> X.TangentVector to $@callee_guaranteed (Float, Double) -> X.TangentVector 
+  // CHECK:   %3 = function_ref @subset_parameter_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector 
+  // CHECK:   %4 = partial_apply [callee_guaranteed] %3(%2) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector 
+  // CHECK:   %5 = apply %4(%0) : $@callee_guaranteed (Float) -> X.TangentVector 
   // CHECK:   strong_release %4 : $@callee_guaranteed (Float) -> X.TangentVector // id: %6
   // CHECK:   return %5 : $X.TangentVector                    // id: %7
   
@@ -245,28 +316,28 @@ bb0(%0 : $X):
   // CHECK-LABEL: Rewritten caller body for: $s5test21g1xSfAA1XV_tFTJrSpSr
   // CHECK: sil hidden @$s5test21g1xSfAA1XV_tFTJrSpSr : $@convention(thin) (X) -> (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) {
   // CHECK: bb0(%0 : $X):
-  // CHECK:  %1 = struct_extract %0 : $X, #X.a               // user: %10
-  // CHECK:  %2 = function_ref @pullback_f : $@convention(thin) (Float, Double) -> X.TangentVector // user: %3
-  // CHECK:  %3 = thin_to_thick_function %2 : $@convention(thin) (Float, Double) -> X.TangentVector to $@callee_guaranteed (Float, Double) -> X.TangentVector // users: %9, %5
-  // CHECK:  %4 = function_ref @subset_parameter_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector // user: %5
+  // CHECK:  %1 = struct_extract %0 : $X, #X.a               
+  // CHECK:  %2 = function_ref @pullback_f : $@convention(thin) (Float, Double) -> X.TangentVector 
+  // CHECK:  %3 = thin_to_thick_function %2 : $@convention(thin) (Float, Double) -> X.TangentVector to $@callee_guaranteed (Float, Double) -> X.TangentVector 
+  // CHECK:  %4 = function_ref @subset_parameter_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector 
   // CHECK:  %5 = partial_apply [callee_guaranteed] %4(%3) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector
-  // CHECK:  %7 = function_ref @$s10pullback_g0A2_fTf1nc_n : $@convention(thin) (Float) -> X.TangentVector // user: %8
-  // CHECK:  %8 = partial_apply [callee_guaranteed] %7() : $@convention(thin) (Float) -> X.TangentVector // user: %10
+  // CHECK:  %7 = function_ref @$s10pullback_g0A2_fTf1nc_n : $@convention(thin) (Float) -> X.TangentVector 
+  // CHECK:  %8 = partial_apply [callee_guaranteed] %7() : $@convention(thin) (Float) -> X.TangentVector 
   // CHECK:  release_value %3 : $@callee_guaranteed (Float, Double) -> X.TangentVector // id: %9
-  // CHECK:  %10 = tuple (%1 : $Float, %8 : $@callee_guaranteed (Float) -> X.TangentVector) // user: %11
+  // CHECK:  %10 = tuple (%1 : $Float, %8 : $@callee_guaranteed (Float) -> X.TangentVector) 
   // CHECK:  return %10
   
-  %1 = struct_extract %0 : $X, #X.a               // user: %8
+  %1 = struct_extract %0 : $X, #X.a               
   // function_ref pullback_f
-  %2 = function_ref @pullback_f : $@convention(thin) (Float, Double) -> X.TangentVector // user: %3
-  %3 = thin_to_thick_function %2 : $@convention(thin) (Float, Double) -> X.TangentVector to $@callee_guaranteed (Float, Double) -> X.TangentVector // user: %5
+  %2 = function_ref @pullback_f : $@convention(thin) (Float, Double) -> X.TangentVector 
+  %3 = thin_to_thick_function %2 : $@convention(thin) (Float, Double) -> X.TangentVector to $@callee_guaranteed (Float, Double) -> X.TangentVector 
   // function_ref subset_parameter_thunk
-  %4 = function_ref @subset_parameter_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector // user: %5
-  %5 = partial_apply [callee_guaranteed] %4(%3) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector // user: %7
+  %4 = function_ref @subset_parameter_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector 
+  %5 = partial_apply [callee_guaranteed] %4(%3) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector 
   // function_ref pullback_g
-  %6 = function_ref @pullback_g : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) -> X.TangentVector // user: %7
-  %7 = partial_apply [callee_guaranteed] %6(%5) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) -> X.TangentVector // user: %8
-  %8 = tuple (%1 : $Float, %7 : $@callee_guaranteed (Float) -> X.TangentVector) // user: %9
+  %6 = function_ref @pullback_g : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) -> X.TangentVector 
+  %7 = partial_apply [callee_guaranteed] %6(%5) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) -> X.TangentVector 
+  %8 = tuple (%1 : $Float, %7 : $@callee_guaranteed (Float) -> X.TangentVector) 
   return %8 : $(Float, @callee_guaranteed (Float) -> X.TangentVector) // id: %9
 }
 
@@ -299,25 +370,25 @@ bb0(%0 : $Float):
   //=========== Test callsite and closure gathering logic ===========//
   specify_test "closure_specialize_gather_call_sites"
   // CHECK-LABEL: Specializing closures in function: $s5test21h1xS2f_tFTJrSpSr
-  // CHECK: PartialApply call site:     %14 = partial_apply [callee_guaranteed] %13(%11) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %15
+  // CHECK: PartialApply call site:     %14 = partial_apply [callee_guaranteed] %13(%11) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float 
   // CHECK: Passed in closures:
-  // CHECK: 1.   %4 = partial_apply [callee_guaranteed] %3(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %6
+  // CHECK: 1.   %4 = partial_apply [callee_guaranteed] %3(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
 
   //=========== Test specialized function signature and body ===========//
   specify_test "closure_specialize_specialized_function_signature_and_body"
   // CHECK-LABEL: Generated specialized function: $s10pullback_h073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbackti1_j5FZSf_J6SfcfU_S2fTf1nc_n
   // CHECK: sil private [signature_optimized_thunk] [always_inline] @$s10pullback_h073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbackti1_j5FZSf_J6SfcfU_S2fTf1nc_n : $@convention(thin) (Float, Float, Float) -> Float {
   // CHECK: bb0(%0 : $Float, %1 : $Float, %2 : $Float):
-  // CHECK:   %3 = function_ref @$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktSf_SftFZSf_SftSfcfU_ : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %4
-  // CHECK:   %4 = partial_apply [callee_guaranteed] %3(%1, %2) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %6
-  // CHECK:   %5 = function_ref @$sS3fIegydd_S3fIegnrr_TR : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) // user: %6
-  // CHECK:   %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) // user: %7
-  // CHECK:   %7 = convert_function %6 : $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @out Float) to $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float> // user: %9
-  // CHECK:   %8 = function_ref @pullback_f_specialized : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float // user: %9
-  // CHECK:   %9 = partial_apply [callee_guaranteed] %8(%7) : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float // user: %11
-  // CHECK:   %10 = function_ref @$sS2fIegnr_S2fIegyd_TR : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %11
-  // CHECK:   %11 = partial_apply [callee_guaranteed] %10(%9) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // users: %13, %12
-  // CHECK:   %12 = apply %11(%0) : $@callee_guaranteed (Float) -> Float // user: %14
+  // CHECK:   %3 = function_ref @$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktSf_SftFZSf_SftSfcfU_ : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK:   %4 = partial_apply [callee_guaranteed] %3(%1, %2) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK:   %5 = function_ref @$sS3fIegydd_S3fIegnrr_TR : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) 
+  // CHECK:   %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) 
+  // CHECK:   %7 = convert_function %6 : $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @out Float) to $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float> 
+  // CHECK:   %8 = function_ref @pullback_f_specialized : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float 
+  // CHECK:   %9 = partial_apply [callee_guaranteed] %8(%7) : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float 
+  // CHECK:   %10 = function_ref @$sS2fIegnr_S2fIegyd_TR : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float 
+  // CHECK:   %11 = partial_apply [callee_guaranteed] %10(%9) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float 
+  // CHECK:   %12 = apply %11(%0) : $@callee_guaranteed (Float) -> Float 
   // CHECK:   strong_release %11 : $@callee_guaranteed (Float) -> Float // id: %13
   // CHECK:   return %12 : $Float
 
@@ -326,49 +397,49 @@ bb0(%0 : $Float):
   // CHECK-LABEL: Rewritten caller body for: $s5test21h1xS2f_tFTJrSpSr
   // CHECK:sil hidden @$s5test21h1xS2f_tFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
   // CHECK:bb0(%0 : $Float):
-  // CHECK:  %1 = struct_extract %0 : $Float, #Float._value  // users: %2, %2
-  // CHECK:  %2 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %12
-  // CHECK:  %3 = function_ref @$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktSf_SftFZSf_SftSfcfU_ : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %4
-  // CHECK:  %4 = partial_apply [callee_guaranteed] %3(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // users: %16, %6
-  // CHECK:  %5 = function_ref @$sS3fIegydd_S3fIegnrr_TR : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) // user: %6
-  // CHECK:  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) // user: %7
-  // CHECK:  %7 = convert_function %6 : $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @out Float) to $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float> // user: %9
-  // CHECK:  %8 = function_ref @pullback_f_specialized : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float // user: %9
-  // CHECK:  %9 = partial_apply [callee_guaranteed] %8(%7) : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float // user: %11
-  // CHECK:  %10 = function_ref @$sS2fIegnr_S2fIegyd_TR : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %11
+  // CHECK:  %1 = struct_extract %0 : $Float, #Float._value  
+  // CHECK:  %2 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
+  // CHECK:  %3 = function_ref @$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktSf_SftFZSf_SftSfcfU_ : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK:  %4 = partial_apply [callee_guaranteed] %3(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  // CHECK:  %5 = function_ref @$sS3fIegydd_S3fIegnrr_TR : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) 
+  // CHECK:  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) 
+  // CHECK:  %7 = convert_function %6 : $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @out Float) to $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float> 
+  // CHECK:  %8 = function_ref @pullback_f_specialized : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float 
+  // CHECK:  %9 = partial_apply [callee_guaranteed] %8(%7) : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float 
+  // CHECK:  %10 = function_ref @$sS2fIegnr_S2fIegyd_TR : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float 
   // CHECK:  %11 = partial_apply [callee_guaranteed] %10(%9) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float
-  // CHECK:  %12 = struct $Float (%2 : $Builtin.FPIEEE32)    // user: %17
-  // CHECK:  %14 = function_ref @$s10pullback_h073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbackti1_j5FZSf_J6SfcfU_S2fTf1nc_n : $@convention(thin) (Float, Float, Float) -> Float // user: %15
-  // CHECK:  %15 = partial_apply [callee_guaranteed] %14(%0, %0) : $@convention(thin) (Float, Float, Float) -> Float // user: %17
+  // CHECK:  %12 = struct $Float (%2 : $Builtin.FPIEEE32)    
+  // CHECK:  %14 = function_ref @$s10pullback_h073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbackti1_j5FZSf_J6SfcfU_S2fTf1nc_n : $@convention(thin) (Float, Float, Float) -> Float 
+  // CHECK:  %15 = partial_apply [callee_guaranteed] %14(%0, %0) : $@convention(thin) (Float, Float, Float) -> Float 
   // CHECK:  release_value %4 : $@callee_guaranteed (Float) -> (Float, Float) // id: %16
-  // CHECK:  %17 = tuple (%12 : $Float, %15 : $@callee_guaranteed (Float) -> Float) // user: %18
+  // CHECK:  %17 = tuple (%12 : $Float, %15 : $@callee_guaranteed (Float) -> Float) 
   // CHECK:  return %17
 
-  %1 = struct_extract %0 : $Float, #Float._value  // users: %2, %2
-  %2 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %12
+  %1 = struct_extract %0 : $Float, #Float._value  
+  %2 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 
   
   // function_ref closure #1 in static Float._vjpMultiply(lhs:rhs:)
-  %3 = function_ref @$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktSf_SftFZSf_SftSfcfU_ : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %4
-  %4 = partial_apply [callee_guaranteed] %3(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %6
+  %3 = function_ref @$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktSf_SftFZSf_SftSfcfU_ : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+  %4 = partial_apply [callee_guaranteed] %3(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
   
   // function_ref thunk for @escaping @callee_guaranteed (@unowned Float) -> (@unowned Float, @unowned Float)
-  %5 = function_ref @$sS3fIegydd_S3fIegnrr_TR : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) // user: %6
-  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) // user: %7
-  %7 = convert_function %6 : $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @out Float) to $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float> // user: %9
+  %5 = function_ref @$sS3fIegydd_S3fIegnrr_TR : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) 
+  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) 
+  %7 = convert_function %6 : $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @out Float) to $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float> 
   
   // function_ref pullback_f_specialized
-  %8 = function_ref @pullback_f_specialized : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float // user: %9
-  %9 = partial_apply [callee_guaranteed] %8(%7) : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float // user: %11
+  %8 = function_ref @pullback_f_specialized : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float 
+  %9 = partial_apply [callee_guaranteed] %8(%7) : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float 
   
   // function_ref thunk for @escaping @callee_guaranteed (@in_guaranteed Float) -> (@out Float)
-  %10 = function_ref @$sS2fIegnr_S2fIegyd_TR : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %11
-  %11 = partial_apply [callee_guaranteed] %10(%9) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %14
-  %12 = struct $Float (%2 : $Builtin.FPIEEE32)    // user: %15
+  %10 = function_ref @$sS2fIegnr_S2fIegyd_TR : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float 
+  %11 = partial_apply [callee_guaranteed] %10(%9) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float 
+  %12 = struct $Float (%2 : $Builtin.FPIEEE32)    
   
   // function_ref pullback_h
-  %13 = function_ref @pullback_h : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %14
-  %14 = partial_apply [callee_guaranteed] %13(%11) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %15
-  %15 = tuple (%12 : $Float, %14 : $@callee_guaranteed (Float) -> Float) // user: %16
+  %13 = function_ref @pullback_h : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float 
+  %14 = partial_apply [callee_guaranteed] %13(%11) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float 
+  %15 = tuple (%12 : $Float, %14 : $@callee_guaranteed (Float) -> Float) 
   return %15 : $(Float, @callee_guaranteed (Float) -> Float) // id: %16
 }
 
@@ -392,20 +463,20 @@ bb0(%0 : $Float):
   //=========== Test callsite and closure gathering logic ===========//
   specify_test "closure_specialize_gather_call_sites"
   // CHECK-LABEL: Specializing closures in function: $s5test21z1xS2f_tFTJrSpSr
-  // CHECK: PartialApply call site:   %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %7
+  // CHECK: PartialApply call site:   %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float 
   // CHECK: Passed in closures:
-  // CHECK: 1.   %2 = thin_to_thick_function %1 : $@convention(thin) (@in_guaranteed Float) -> @out Float to $@callee_guaranteed (@in_guaranteed Float) -> @out Float // user: %4
+  // CHECK: 1.   %2 = thin_to_thick_function %1 : $@convention(thin) (@in_guaranteed Float) -> @out Float to $@callee_guaranteed (@in_guaranteed Float) -> @out Float 
 
   //=========== Test specialized function signature and body ===========//
   specify_test "closure_specialize_specialized_function_signature_and_body"
   // CHECK-LABEL: Generated specialized function: $s10pullback_z0A14_y_specializedTf1nc_n
   // CHECK: sil private [signature_optimized_thunk] [always_inline] @$s10pullback_z0A14_y_specializedTf1nc_n : $@convention(thin) (Float) -> Float {
   // CHECK: bb0(%0 : $Float):
-  // CHECK:   %1 = function_ref @pullback_y_specialized : $@convention(thin) (@in_guaranteed Float) -> @out Float // user: %2
-  // CHECK:   %2 = thin_to_thick_function %1 : $@convention(thin) (@in_guaranteed Float) -> @out Float to $@callee_guaranteed (@in_guaranteed Float) -> @out Float // user: %4
-  // CHECK:   %3 = function_ref @reabstraction_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %4
-  // CHECK:   %4 = partial_apply [callee_guaranteed] %3(%2) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // users: %6, %5
-  // CHECK:   %5 = apply %4(%0) : $@callee_guaranteed (Float) -> Float // user: %7
+  // CHECK:   %1 = function_ref @pullback_y_specialized : $@convention(thin) (@in_guaranteed Float) -> @out Float 
+  // CHECK:   %2 = thin_to_thick_function %1 : $@convention(thin) (@in_guaranteed Float) -> @out Float to $@callee_guaranteed (@in_guaranteed Float) -> @out Float 
+  // CHECK:   %3 = function_ref @reabstraction_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float 
+  // CHECK:   %4 = partial_apply [callee_guaranteed] %3(%2) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float 
+  // CHECK:   %5 = apply %4(%0) : $@callee_guaranteed (Float) -> Float 
   // CHECK:   strong_release %4 : $@callee_guaranteed (Float) -> Float // id: %6
   // CHECK:   return %5 : $Float
 
@@ -414,25 +485,25 @@ bb0(%0 : $Float):
   // CHECK-LABEL: Rewritten caller body for: $s5test21z1xS2f_tFTJrSpSr
   // CHECK: sil hidden @$s5test21z1xS2f_tFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
   // CHECK: bb0(%0 : $Float):
-  // CHECK:   %1 = function_ref @pullback_y_specialized : $@convention(thin) (@in_guaranteed Float) -> @out Float // user: %2
-  // CHECK:   %2 = thin_to_thick_function %1 : $@convention(thin) (@in_guaranteed Float) -> @out Float to $@callee_guaranteed (@in_guaranteed Float) -> @out Float // users: %8, %4
-  // CHECK:   %3 = function_ref @reabstraction_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %4
+  // CHECK:   %1 = function_ref @pullback_y_specialized : $@convention(thin) (@in_guaranteed Float) -> @out Float 
+  // CHECK:   %2 = thin_to_thick_function %1 : $@convention(thin) (@in_guaranteed Float) -> @out Float to $@callee_guaranteed (@in_guaranteed Float) -> @out Float 
+  // CHECK:   %3 = function_ref @reabstraction_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float 
   // CHECK:   %4 = partial_apply [callee_guaranteed] %3(%2) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float
-  // CHECK:   %6 = function_ref @$s10pullback_z0A14_y_specializedTf1nc_n : $@convention(thin) (Float) -> Float // user: %7
-  // CHECK:   %7 = partial_apply [callee_guaranteed] %6() : $@convention(thin) (Float) -> Float // user: %9
+  // CHECK:   %6 = function_ref @$s10pullback_z0A14_y_specializedTf1nc_n : $@convention(thin) (Float) -> Float 
+  // CHECK:   %7 = partial_apply [callee_guaranteed] %6() : $@convention(thin) (Float) -> Float 
   // CHECK:   release_value %2 : $@callee_guaranteed (@in_guaranteed Float) -> @out Float // id: %8
-  // CHECK:   %9 = tuple (%0 : $Float, %7 : $@callee_guaranteed (Float) -> Float) // user: %10
+  // CHECK:   %9 = tuple (%0 : $Float, %7 : $@callee_guaranteed (Float) -> Float) 
   // CHECK:   return %9
 
   // function_ref pullback_y_specialized
-  %1 = function_ref @pullback_y_specialized : $@convention(thin) (@in_guaranteed Float) -> @out Float // user: %2
-  %2 = thin_to_thick_function %1 : $@convention(thin) (@in_guaranteed Float) -> @out Float to $@callee_guaranteed (@in_guaranteed Float) -> @out Float // user: %4
+  %1 = function_ref @pullback_y_specialized : $@convention(thin) (@in_guaranteed Float) -> @out Float 
+  %2 = thin_to_thick_function %1 : $@convention(thin) (@in_guaranteed Float) -> @out Float to $@callee_guaranteed (@in_guaranteed Float) -> @out Float 
   // function_ref reabstraction_thunk
-  %3 = function_ref @reabstraction_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %4
-  %4 = partial_apply [callee_guaranteed] %3(%2) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %6
+  %3 = function_ref @reabstraction_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float 
+  %4 = partial_apply [callee_guaranteed] %3(%2) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float 
   // function_ref pullback_z
-  %5 = function_ref @pullback_z : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %6
-  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %7
-  %7 = tuple (%0 : $Float, %6 : $@callee_guaranteed (Float) -> Float) // user: %8
+  %5 = function_ref @pullback_z : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float 
+  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float 
+  %7 = tuple (%0 : $Float, %6 : $@callee_guaranteed (Float) -> Float) 
   return %7 : $(Float, @callee_guaranteed (Float) -> Float) // id: %8
 }

--- a/test/AutoDiff/SILOptimizer/closure_specialization.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization.sil
@@ -51,6 +51,22 @@ bb0(%0 : $Float):
   // CHECK: strong_release %4 : $@callee_guaranteed (Float) -> (Float, Float) // id: %6
   // CHECK: return
 
+   //=========== Test rewritten body ===========//
+  specify_test "closure_specialize_rewritten_caller_body"
+  // CHECK-LABEL: Rewritten caller body for: $s4test1fyS2fFTJrSpSr
+  // CHECK: sil hidden @$s4test1fyS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {                                 
+  // CHECK: bb0(%0 : $Float):
+  // CHECK: %2 = struct_extract %0 : $Float, #Float._value  // users: %3, %3
+  // CHECK: %3 = builtin "fmul_FPIEEE32"(%2 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %4
+  // CHECK: %4 = struct $Float (%3 : $Builtin.FPIEEE32)     // user: %11
+  // CHECK: %5 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %6
+  // CHECK: %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %10
+  // CHECK: %8 = function_ref @$s11$pullback_f12$vjpMultiplyS2fTf1nc_n : $@convention(thin) (Float, Float, Float) -> Float // user: %9
+  // CHECK: %9 = partial_apply [callee_guaranteed] %8(%0, %0) : $@convention(thin) (Float, Float, Float) -> Float // user: %11
+  // CHECK: release_value %6 : $@callee_guaranteed (Float) -> (Float, Float) // id: %10
+  // CHECK: %11 = tuple (%4 : $Float, %9 : $@callee_guaranteed (Float) -> Float) // user: %12
+  // CHECK: return %11
+
   debug_value %0 : $Float, let, name "x", argno 1 // id: %1
   %2 = struct_extract %0 : $Float, #Float._value  // users: %3, %3
   %3 = builtin "fmul_FPIEEE32"(%2 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %4
@@ -120,6 +136,32 @@ bb0(%0 : $Float):
   // CHECK: %17 = apply %6(%13) : $@callee_guaranteed (Float) -> Float // user: %20
   // CHECK: strong_release %6 : $@callee_guaranteed (Float) -> Float // id: %18
   // CHECK: return  
+
+  //=========== Test rewritten body ===========//
+  specify_test "closure_specialize_rewritten_caller_body"
+  // CHECK-LABEL: Rewritten caller body for: $s4test1gyS2fFTJrSpSr
+  // CHECK: sil hidden @$s4test1gyS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+  // CHECK: bb0(%0 : $Float):
+  // CHECK:  %2 = struct_extract %0 : $Float, #Float._value  // users: %7, %3
+  // CHECK:  %3 = builtin "int_sin_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // users: %11, %4
+  // CHECK:  %4 = struct $Float (%3 : $Builtin.FPIEEE32)     // users: %17, %14
+  // CHECK:  %5 = function_ref @$vjpSin : $@convention(thin) (Float, Float) -> Float // user: %6
+  // CHECK:  %6 = partial_apply [callee_guaranteed] %5(%0) : $@convention(thin) (Float, Float) -> Float // user: %18
+  // CHECK:  %7 = builtin "int_cos_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // users: %11, %8
+  // CHECK:  %8 = struct $Float (%7 : $Builtin.FPIEEE32)     // users: %17, %14
+  // CHECK:  %9 = function_ref @$vjpCos : $@convention(thin) (Float, Float) -> Float // user: %10
+  // CHECK:  %10 = partial_apply [callee_guaranteed] %9(%0) : $@convention(thin) (Float, Float) -> Float // user: %19
+  // CHECK:  %11 = builtin "fmul_FPIEEE32"(%3 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %12
+  // CHECK:  %12 = struct $Float (%11 : $Builtin.FPIEEE32)   // user: %21
+  // CHECK:  %13 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %14
+  // CHECK:  %14 = partial_apply [callee_guaranteed] %13(%8, %4) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %20
+  // CHECK:  %16 = function_ref @$s11$pullback_g7$vjpSinSf0B3CosSf0B8MultiplyS2fTf1nccc_n : $@convention(thin) (Float, Float, Float, Float, Float) -> Float // user: %17
+  // CHECK:  %17 = partial_apply [callee_guaranteed] %16(%0, %0, %8, %4) : $@convention(thin) (Float, Float, Float, Float, Float) -> Float // user: %21
+  // CHECK:  release_value %6 : $@callee_guaranteed (Float) -> Float // id: %18
+  // CHECK:  release_value %10 : $@callee_guaranteed (Float) -> Float // id: %19
+  // CHECK:  release_value %14 : $@callee_guaranteed (Float) -> (Float, Float) // id: %20
+  // CHECK:  %21 = tuple (%12 : $Float, %17 : $@callee_guaranteed (Float) -> Float) // user: %22
+  // CHECK:  return %21
 
   debug_value %0 : $Float, let, name "x", argno 1 // id: %1
   %2 = struct_extract %0 : $Float, #Float._value  // users: %7, %3
@@ -197,7 +239,23 @@ bb0(%0 : $X):
   // CHECK:   %5 = apply %4(%0) : $@callee_guaranteed (Float) -> X.TangentVector // user: %7
   // CHECK:   strong_release %4 : $@callee_guaranteed (Float) -> X.TangentVector // id: %6
   // CHECK:   return %5 : $X.TangentVector                    // id: %7
-
+  
+  //=========== Test rewritten body ===========//
+  specify_test "closure_specialize_rewritten_caller_body"
+  // CHECK-LABEL: Rewritten caller body for: $s5test21g1xSfAA1XV_tFTJrSpSr
+  // CHECK: sil hidden @$s5test21g1xSfAA1XV_tFTJrSpSr : $@convention(thin) (X) -> (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) {
+  // CHECK: bb0(%0 : $X):
+  // CHECK:  %1 = struct_extract %0 : $X, #X.a               // user: %10
+  // CHECK:  %2 = function_ref @pullback_f : $@convention(thin) (Float, Double) -> X.TangentVector // user: %3
+  // CHECK:  %3 = thin_to_thick_function %2 : $@convention(thin) (Float, Double) -> X.TangentVector to $@callee_guaranteed (Float, Double) -> X.TangentVector // users: %9, %5
+  // CHECK:  %4 = function_ref @subset_parameter_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector // user: %5
+  // CHECK:  %5 = partial_apply [callee_guaranteed] %4(%3) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector
+  // CHECK:  %7 = function_ref @$s10pullback_g0A2_fTf1nc_n : $@convention(thin) (Float) -> X.TangentVector // user: %8
+  // CHECK:  %8 = partial_apply [callee_guaranteed] %7() : $@convention(thin) (Float) -> X.TangentVector // user: %10
+  // CHECK:  release_value %3 : $@callee_guaranteed (Float, Double) -> X.TangentVector // id: %9
+  // CHECK:  %10 = tuple (%1 : $Float, %8 : $@callee_guaranteed (Float) -> X.TangentVector) // user: %11
+  // CHECK:  return %10
+  
   %1 = struct_extract %0 : $X, #X.a               // user: %8
   // function_ref pullback_f
   %2 = function_ref @pullback_f : $@convention(thin) (Float, Double) -> X.TangentVector // user: %3
@@ -263,6 +321,29 @@ bb0(%0 : $Float):
   // CHECK:   strong_release %11 : $@callee_guaranteed (Float) -> Float // id: %13
   // CHECK:   return %12 : $Float
 
+  //=========== Test rewritten body ===========//
+  specify_test "closure_specialize_rewritten_caller_body"
+  // CHECK-LABEL: Rewritten caller body for: $s5test21h1xS2f_tFTJrSpSr
+  // CHECK:sil hidden @$s5test21h1xS2f_tFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+  // CHECK:bb0(%0 : $Float):
+  // CHECK:  %1 = struct_extract %0 : $Float, #Float._value  // users: %2, %2
+  // CHECK:  %2 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %12
+  // CHECK:  %3 = function_ref @$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktSf_SftFZSf_SftSfcfU_ : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %4
+  // CHECK:  %4 = partial_apply [callee_guaranteed] %3(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // users: %16, %6
+  // CHECK:  %5 = function_ref @$sS3fIegydd_S3fIegnrr_TR : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) // user: %6
+  // CHECK:  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) // user: %7
+  // CHECK:  %7 = convert_function %6 : $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @out Float) to $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float> // user: %9
+  // CHECK:  %8 = function_ref @pullback_f_specialized : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float // user: %9
+  // CHECK:  %9 = partial_apply [callee_guaranteed] %8(%7) : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float // user: %11
+  // CHECK:  %10 = function_ref @$sS2fIegnr_S2fIegyd_TR : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %11
+  // CHECK:  %11 = partial_apply [callee_guaranteed] %10(%9) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float
+  // CHECK:  %12 = struct $Float (%2 : $Builtin.FPIEEE32)    // user: %17
+  // CHECK:  %14 = function_ref @$s10pullback_h073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbackti1_j5FZSf_J6SfcfU_S2fTf1nc_n : $@convention(thin) (Float, Float, Float) -> Float // user: %15
+  // CHECK:  %15 = partial_apply [callee_guaranteed] %14(%0, %0) : $@convention(thin) (Float, Float, Float) -> Float // user: %17
+  // CHECK:  release_value %4 : $@callee_guaranteed (Float) -> (Float, Float) // id: %16
+  // CHECK:  %17 = tuple (%12 : $Float, %15 : $@callee_guaranteed (Float) -> Float) // user: %18
+  // CHECK:  return %17
+
   %1 = struct_extract %0 : $Float, #Float._value  // users: %2, %2
   %2 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %12
   
@@ -327,6 +408,21 @@ bb0(%0 : $Float):
   // CHECK:   %5 = apply %4(%0) : $@callee_guaranteed (Float) -> Float // user: %7
   // CHECK:   strong_release %4 : $@callee_guaranteed (Float) -> Float // id: %6
   // CHECK:   return %5 : $Float
+
+  //=========== Test rewritten body ===========//
+  specify_test "closure_specialize_rewritten_caller_body"
+  // CHECK-LABEL: Rewritten caller body for: $s5test21z1xS2f_tFTJrSpSr
+  // CHECK: sil hidden @$s5test21z1xS2f_tFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+  // CHECK: bb0(%0 : $Float):
+  // CHECK:   %1 = function_ref @pullback_y_specialized : $@convention(thin) (@in_guaranteed Float) -> @out Float // user: %2
+  // CHECK:   %2 = thin_to_thick_function %1 : $@convention(thin) (@in_guaranteed Float) -> @out Float to $@callee_guaranteed (@in_guaranteed Float) -> @out Float // users: %8, %4
+  // CHECK:   %3 = function_ref @reabstraction_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %4
+  // CHECK:   %4 = partial_apply [callee_guaranteed] %3(%2) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float
+  // CHECK:   %6 = function_ref @$s10pullback_z0A14_y_specializedTf1nc_n : $@convention(thin) (Float) -> Float // user: %7
+  // CHECK:   %7 = partial_apply [callee_guaranteed] %6() : $@convention(thin) (Float) -> Float // user: %9
+  // CHECK:   release_value %2 : $@callee_guaranteed (@in_guaranteed Float) -> @out Float // id: %8
+  // CHECK:   %9 = tuple (%0 : $Float, %7 : $@callee_guaranteed (Float) -> Float) // user: %10
+  // CHECK:   return %9
 
   // function_ref pullback_y_specialized
   %1 = function_ref @pullback_y_specialized : $@convention(thin) (@in_guaranteed Float) -> @out Float // user: %2

--- a/test/AutoDiff/SILOptimizer/pullback_inlining.swift
+++ b/test/AutoDiff/SILOptimizer/pullback_inlining.swift
@@ -31,7 +31,7 @@ func with_control_flow(_ x: Float) -> Float {
 func caller_of_with_control_flow(x: Float) -> Float {
     gradient(at: x, of: with_control_flow)
 }
-// CHECK-LABEL: decision {{{.*}}, b=70, {{.*}}} $s17pullback_inlining17with_control_flowyS2fFTJpSpSr
+// CHECK-LABEL: decision {{.*}} $s17pullback_inlining17with_control_flowyS2fFTJpSpSr
 // CHECK-NEXT: "pullback of pullback_inlining.with_control_flow(_:)" inlined into "caller_of_with_control_flow"
 
 // ====================================================================== //
@@ -84,5 +84,5 @@ func caller_of_more_complex_pb_with_control_flow() -> Float {
     gradient(at: Float(1), of: more_complex_pb_with_control_flow)
 }
 
-// CHECK: decision {{{.*}}, b=70, {{.*}}} $s17pullback_inlining33more_complex_pb_with_control_flow1xS2f_tFTJpSpSr
+// CHECK: decision {{.*}} $s17pullback_inlining33more_complex_pb_with_control_flow1xS2f_tFTJpSpSr
 // CHECK-NEXT: "pullback of pullback_inlining.more_complex_pb_with_control_flow(x:)" inlined into "caller_of_more_complex_pb_with_control_flow"

--- a/test/AutoDiff/SILOptimizer/pullback_inlining.swift
+++ b/test/AutoDiff/SILOptimizer/pullback_inlining.swift
@@ -1,4 +1,4 @@
-// VJP and pullback inlining tests.
+// Pullback inlining tests.
 
 // RUN: %target-swift-frontend -emit-sil -O -verify -Xllvm -debug-only=sil-inliner %s 2>&1 | %FileCheck %s
 
@@ -13,34 +13,11 @@ import Glibc
 import Foundation
 #endif
 
-// ======================== Simple case without control-flow ======================== //
+// =============================================================== //
+// Pullbacks with control-flow are inlined into non-VJP callers
+// =============================================================== //
+
 @differentiable(reverse)
-@_silgen_name("simple")
-func simple(x: Float) -> Float {
-    let a = x * x;
-    let b = x + x;
-    let c = x * a;
-    let d = a + b;
-    let e = b * c;
-
-    return a * b / c + d - e ;
-}
-
-@inline(never)
-@_silgen_name("caller_of_simple")
-func caller_of_simple(x: Float) -> Float {
-  gradient(at: Float(4), of: simple)
-}
-
-// CHECK: decision {{{.*}}, b=30, {{.*}}} simpleTJrSpSr
-// CHECK-NEXT: "simpleTJrSpSr" inlined into "caller_of_simple"
-// PB inlining check
-// CHECK: decision {{{.*}}, b=70, {{.*}}} simpleTJpSpSr
-// CHECK-NEXT: "simpleTJpSpSr" inlined into "caller_of_simple"
-
-// ======================== Simple case with control-flow ======================== //
-@differentiable(reverse)
-@_silgen_name("with_control_flow")
 func with_control_flow(_ x: Float) -> Float {
   if (x > 0) {
     return sin(x) * cos(x)
@@ -54,17 +31,13 @@ func with_control_flow(_ x: Float) -> Float {
 func caller_of_with_control_flow(x: Float) -> Float {
     gradient(at: x, of: with_control_flow)
 }
+// CHECK-LABEL: decision {{{.*}}, b=70, {{.*}}} $s17pullback_inlining17with_control_flowyS2fFTJpSpSr
+// CHECK-NEXT: "pullback of pullback_inlining.with_control_flow(_:)" inlined into "caller_of_with_control_flow"
 
-// VJP inlining check
-// CHECK: decision {{{.*}}, b=30, {{.*}}} with_control_flowTJrSpSr
-// CHECK-NEXT: "with_control_flowTJrSpSr" inlined into "caller_of_with_control_flow"
-// PB inlining check
-// CHECK: decision {{{.*}}, b=70, {{.*}}} with_control_flowTJpSpSr
-// CHECK-NEXT: "with_control_flowTJpSpSr" inlined into "caller_of_with_control_flow"
-
-// ======================== Complex case with control-flow ======================== //
+// ====================================================================== //
+// Pullbacks with complex control-flow are inlined into non-VJP callers
+// ====================================================================== //
 @differentiable(reverse)
-@_silgen_name("more_complex_pb_with_control_flow")
 func more_complex_pb_with_control_flow(x: Float) -> Float {
     if (x > 0) {
         if ((x+1) < 5) {
@@ -111,5 +84,5 @@ func caller_of_more_complex_pb_with_control_flow() -> Float {
     gradient(at: Float(1), of: more_complex_pb_with_control_flow)
 }
 
-// CHECK: decision {{{.*}}, b=70, {{.*}}} more_complex_pb_with_control_flowTJpSpSr
-// CHECK-NEXT: "more_complex_pb_with_control_flowTJpSpSr" inlined into "caller_of_more_complex_pb_with_control_flow"
+// CHECK: decision {{{.*}}, b=70, {{.*}}} $s17pullback_inlining33more_complex_pb_with_control_flow1xS2f_tFTJpSpSr
+// CHECK-NEXT: "pullback of pullback_inlining.more_complex_pb_with_control_flow(x:)" inlined into "caller_of_more_complex_pb_with_control_flow"

--- a/test/AutoDiff/SILOptimizer/vjp_inlining.swift
+++ b/test/AutoDiff/SILOptimizer/vjp_inlining.swift
@@ -30,7 +30,7 @@ func with_control_flow(_ x: Float) -> Float {
 func caller_of_with_control_flow(x: Float) -> Float {
     gradient(at: x, of: with_control_flow)
 }
-// CHECK-LABEL: decision {{{.*}}, b=30, {{.*}}} $s12vjp_inlining17with_control_flowyS2fFTJrSpSr
+// CHECK-LABEL: decision {{.*}} $s12vjp_inlining17with_control_flowyS2fFTJrSpSr
 // CHECK-NEXT: "reverse-mode derivative of vjp_inlining.with_control_flow(_:)" inlined into "caller_of_with_control_flow"
 
 // =============================================================== //
@@ -41,7 +41,7 @@ func caller_of_with_control_flow(x: Float) -> Float {
 func wrapperOnWithControlFlow(x: Float) -> Float {
     return with_control_flow(x)
 }
-// CHECK-LABEL: decision {{{.*}}, b=40, {{.*}}} $s12vjp_inlining17with_control_flowyS2fFTJrSpSr
+// CHECK-LABEL: decision {{.*}} $s12vjp_inlining17with_control_flowyS2fFTJrSpSr
 // CHECK-NEXT: "reverse-mode derivative of vjp_inlining.with_control_flow(_:)" inlined into "reverse-mode derivative of vjp_inlining.wrapperOnWithControlFlow(x:)"
 
 // =============================================================== //
@@ -85,5 +85,5 @@ func wrapperWithControlFlowOnSimple(x: Float) -> Float {
 func wrapperOnSimple(x: Float) -> Float {
     return simple(x: x)
 }
-// CHECK-LABEL: decision {{{.*}}, b=40, {{.*}}} $s12vjp_inlining6simple1xS2f_tFTJrSpSr
+// CHECK-LABEL: decision {{.*}} $s12vjp_inlining6simple1xS2f_tFTJrSpSr
 // CHECK-NEXT: "reverse-mode derivative of vjp_inlining.simple(x:)" inlined into "reverse-mode derivative of vjp_inlining.wrapperOnSimple(x:)"

--- a/test/AutoDiff/SILOptimizer/vjp_inlining.swift
+++ b/test/AutoDiff/SILOptimizer/vjp_inlining.swift
@@ -1,0 +1,89 @@
+// VJP inlining tests.
+
+// RUN: %target-swift-frontend -emit-sil -O -verify -Xllvm -debug-only=sil-inliner %s 2>&1 | %FileCheck %s
+
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
+// UNSUPPORTED: OS=windows-msvc
+
+import _Differentiation
+#if canImport(Glibc)
+import Glibc
+#else
+import Foundation
+#endif
+
+// =============================================================== //
+// VJPs with control-flow are inlined into non-VJP callers
+// =============================================================== //
+@differentiable(reverse)
+func with_control_flow(_ x: Float) -> Float {
+  if (x > 0) {
+    return sin(x) * cos(x)
+  } else {
+    return sin(x) + cos(x)
+  }
+}
+
+@inline(never)
+@_silgen_name("caller_of_with_control_flow")
+func caller_of_with_control_flow(x: Float) -> Float {
+    gradient(at: x, of: with_control_flow)
+}
+// CHECK-LABEL: decision {{{.*}}, b=30, {{.*}}} $s12vjp_inlining17with_control_flowyS2fFTJrSpSr
+// CHECK-NEXT: "reverse-mode derivative of vjp_inlining.with_control_flow(_:)" inlined into "caller_of_with_control_flow"
+
+// =============================================================== //
+// VJPs with control-flow are inlined into VJP callers
+// =============================================================== //
+
+@differentiable(reverse)
+func wrapperOnWithControlFlow(x: Float) -> Float {
+    return with_control_flow(x)
+}
+// CHECK-LABEL: decision {{{.*}}, b=40, {{.*}}} $s12vjp_inlining17with_control_flowyS2fFTJrSpSr
+// CHECK-NEXT: "reverse-mode derivative of vjp_inlining.with_control_flow(_:)" inlined into "reverse-mode derivative of vjp_inlining.wrapperOnWithControlFlow(x:)"
+
+// =============================================================== //
+// VJPs without control-flow are not inlined into non-VJP callers
+// =============================================================== //
+@differentiable(reverse)
+func simple(x: Float) -> Float {
+    let a = x * x;
+    let b = x + x;
+    let c = x * a;
+    let d = a + b;
+    let e = b * c;
+
+    return a * b / c + d - e ;
+}
+
+@inline(never)
+@_silgen_name("caller_of_simple")
+func caller_of_simple(x: Float) -> Float {
+  gradient(at: Float(4), of: simple)
+}
+// CHECK-NOT: "reverse-mode derivative of vjp_inlining.simple(x:)" inlined into "caller_of_simple"
+
+// ============================================================================ //
+// VJPs without control-flow are not inlined into VJP callers with control-flow
+// ============================================================================ //
+@differentiable(reverse)
+func wrapperWithControlFlowOnSimple(x: Float) -> Float {
+    if (x > 0) {
+        return simple(x: x) + simple(x: x)
+    } else {
+        return simple(x: x) * simple(x: x)
+    }
+}
+// CHECK-NOT: "reverse-mode derivative of vjp_inlining.simple(x:)" inlined into "reverse-mode derivative of vjp_inlining.wrapperWithControlFlowOnSimple(x:)"
+
+// =============================================================== //
+// VJPs without control-flow are inlined into VJP callers
+// =============================================================== //
+@differentiable(reverse)
+func wrapperOnSimple(x: Float) -> Float {
+    return simple(x: x)
+}
+// CHECK-LABEL: decision {{{.*}}, b=40, {{.*}}} $s12vjp_inlining6simple1xS2f_tFTJrSpSr
+// CHECK-NEXT: "reverse-mode derivative of vjp_inlining.simple(x:)" inlined into "reverse-mode derivative of vjp_inlining.wrapperOnSimple(x:)"


### PR DESCRIPTION
This PR adds the final part of the initial autodiff specific closure-specialization optimization implementation. 

The previous parts of the optimization have been implemented in:
1. [Adds part of the Autodiff specific closure-specialization optimization pass](https://github.com/apple/swift/pull/71775)
2. [Adds logic to generate specialized functions in the closure-spec pass](https://github.com/jkshtj/swift/pull/1)
