### PR TITLE
6.0: [PrunedLiveness] Fix boundary check for dead-ends.

### DIFF
--- a/lib/SIL/Utils/BasicBlockUtils.cpp
+++ b/lib/SIL/Utils/BasicBlockUtils.cpp
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SIL/BasicBlockUtils.h"
-#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/STLExtras.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/LoopInfo.h"
 #include "swift/SIL/SILArgument.h"
@@ -21,6 +21,7 @@
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/TerminatorUtils.h"
+#include "swift/SIL/Test.h"
 #include "llvm/ADT/STLExtras.h"
 
 using namespace swift;
@@ -412,6 +413,27 @@ bool DeadEndBlocks::triviallyEndsInUnreachable(SILBasicBlock *block) {
     block = singleSucc;
   return isa<UnreachableInst>(block->getTerminator());
 }
+
+namespace swift::test {
+// Arguments:
+// - none
+// Dumps:
+// - the function
+// - the blocks which are dead-end blocks
+static FunctionTest DeadEndBlocksTest("dead_end_blocks", [](auto &function,
+                                                            auto &arguments,
+                                                            auto &test) {
+  std::unique_ptr<DeadEndBlocks> DeadEnds;
+  DeadEnds.reset(new DeadEndBlocks(&function));
+  function.print(llvm::outs());
+#ifndef NDEBUG
+  for (auto &block : function) {
+    if (DeadEnds->isDeadEnd(&block))
+      block.printID(llvm::outs(), true);
+  }
+#endif
+});
+} // end namespace swift::test
 
 //===----------------------------------------------------------------------===//
 //                  Post Dominance Set Completion Utilities

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -489,8 +489,51 @@ bool PrunedLiveRange<LivenessWithDefs>::isWithinBoundary(
   llvm_unreachable("instruction must be in its parent block");
 }
 
-static bool checkDeadEnd(SILInstruction *inst, DeadEndBlocks *deadEndBlocks) {
-  return deadEndBlocks && deadEndBlocks->isDeadEnd(inst->getParent());
+/// Whether \p parent is a dead (reported to be dead by `liveBlocks`), dead-end
+/// (such as an infinite loop) block within the availability boundary (where
+/// the value has not been consumed).
+static bool checkDeadEnd(SILBasicBlock *parent, DeadEndBlocks *deadEndBlocks,
+                         PrunedLiveBlocks const &liveBlocks) {
+  if (!deadEndBlocks) {
+    return false;
+  }
+  if (!deadEndBlocks->isDeadEnd(parent)) {
+    return false;
+  }
+  if (liveBlocks.getBlockLiveness(parent) != PrunedLiveBlocks::Dead) {
+    return false;
+  }
+  // Check whether the value is available in `parent` (i.e. not consumed on any
+  // path to it):
+  //
+  // Search backward until LiveOut or LiveWithin blocks are reached.
+  // (1) If ALL the reached blocks are LiveOut, then `parent` IS within the
+  //     availability boundary.
+  // (2) If ANY reached block is LiveWithin, the value was consumed in that
+  //     reached block, preventing the value from being available at `parent`,
+  //     so `parent` is NOT within the availability boundary.
+  BasicBlockWorklist worklist(parent->getFunction());
+  worklist.push(parent);
+  while (auto *block = worklist.pop()) {
+    auto isLive = liveBlocks.getBlockLiveness(block);
+    switch (isLive) {
+    case PrunedLiveBlocks::Dead: {
+      // Availability is unchanged; continue the backwards walk.
+      for (auto *predecessor : block->getPredecessorBlocks()) {
+        worklist.pushIfNotVisited(predecessor);
+      }
+      break;
+    }
+    case PrunedLiveBlocks::LiveWithin:
+      // Availability ended in this block.  Some path to `parent` consumed the
+      // value.  Case (2) above.
+      return false;
+    case PrunedLiveBlocks::LiveOut:
+      // Availability continued out of this block.  Case (1) above.
+      continue;
+    }
+  }
+  return true;
 }
 
 template <typename LivenessWithDefs>
@@ -500,7 +543,8 @@ bool PrunedLiveRange<LivenessWithDefs>::areUsesWithinBoundary(
 
   for (auto *use : uses) {
     auto *user = use->getUser();
-    if (!asImpl().isWithinBoundary(user) && !checkDeadEnd(user, deadEndBlocks))
+    if (!asImpl().isWithinBoundary(user) &&
+        !checkDeadEnd(user->getParent(), deadEndBlocks, liveBlocks))
       return false;
   }
   return true;
@@ -513,7 +557,8 @@ bool PrunedLiveRange<LivenessWithDefs>::areUsesOutsideBoundary(
 
   for (auto *use : uses) {
     auto *user = use->getUser();
-    if (asImpl().isWithinBoundary(user) || checkDeadEnd(user, deadEndBlocks))
+    if (asImpl().isWithinBoundary(user) ||
+        checkDeadEnd(user->getParent(), deadEndBlocks, liveBlocks))
       return false;
   }
   return true;

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -489,17 +489,18 @@ bool PrunedLiveRange<LivenessWithDefs>::isWithinBoundary(
   llvm_unreachable("instruction must be in its parent block");
 }
 
+static bool checkDeadEnd(SILInstruction *inst, DeadEndBlocks *deadEndBlocks) {
+  return deadEndBlocks && deadEndBlocks->isDeadEnd(inst->getParent());
+}
+
 template <typename LivenessWithDefs>
 bool PrunedLiveRange<LivenessWithDefs>::areUsesWithinBoundary(
     ArrayRef<Operand *> uses, DeadEndBlocks *deadEndBlocks) const {
   assert(asImpl().isInitialized());
 
-  auto checkDeadEnd = [deadEndBlocks](SILInstruction *inst) {
-    return deadEndBlocks && deadEndBlocks->isDeadEnd(inst->getParent());
-  };
   for (auto *use : uses) {
     auto *user = use->getUser();
-    if (!asImpl().isWithinBoundary(user) && !checkDeadEnd(user))
+    if (!asImpl().isWithinBoundary(user) && !checkDeadEnd(user, deadEndBlocks))
       return false;
   }
   return true;
@@ -510,12 +511,9 @@ bool PrunedLiveRange<LivenessWithDefs>::areUsesOutsideBoundary(
     ArrayRef<Operand *> uses, DeadEndBlocks *deadEndBlocks) const {
   assert(asImpl().isInitialized());
 
-  auto checkDeadEnd = [deadEndBlocks](SILInstruction *inst) {
-    return deadEndBlocks && deadEndBlocks->isDeadEnd(inst->getParent());
-  };
   for (auto *use : uses) {
     auto *user = use->getUser();
-    if (asImpl().isWithinBoundary(user) || checkDeadEnd(user))
+    if (asImpl().isWithinBoundary(user) || checkDeadEnd(user, deadEndBlocks))
       return false;
   }
   return true;

--- a/test/SILOptimizer/cse_ossa_nontrivial.sil
+++ b/test/SILOptimizer/cse_ossa_nontrivial.sil
@@ -723,6 +723,29 @@ bb0(%0 : @guaranteed $WrapperKlass):
   return %res : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_refelementaddr_loop : {{.*}} {
+// CHECK:         ref_element_addr
+// CHECK:         ref_element_addr
+// CHECK-LABEL: } // end sil function 'test_refelementaddr_loop'
+sil [ossa] @test_refelementaddr_loop : $@convention(thin) () -> () {
+bb0:
+  %2 = apply undef() : $@convention(thin) () -> @owned WrapperKlass
+  %3 = move_value [lexical] [var_decl] %2 : $WrapperKlass
+  br bb1 
+
+bb1:
+  %func  = function_ref @use_object : $@convention(thin) (@inout Builtin.NativeObject) -> ()
+  %borrow1 = begin_borrow %3 : $WrapperKlass
+  %ele1 = ref_element_addr %borrow1 : $WrapperKlass, #WrapperKlass.val
+  apply %func(%ele1) : $@convention(thin) (@inout Builtin.NativeObject) -> ()
+  end_borrow %borrow1 : $WrapperKlass
+  %borrow2 = begin_borrow %3 : $WrapperKlass
+  %ele2 = ref_element_addr %borrow2 : $WrapperKlass, #WrapperKlass.val
+  apply %func(%ele2) : $@convention(thin) (@inout Builtin.NativeObject) -> ()
+  end_borrow %borrow2 : $WrapperKlass
+  br bb1 
+}
+
 sil [ossa] @use_word2 : $@convention(thin) (@inout Builtin.Word) -> ()
 
 /*

--- a/test/SILOptimizer/dead_end_blocks.sil
+++ b/test/SILOptimizer/dead_end_blocks.sil
@@ -1,0 +1,50 @@
+// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+// REQUIRES: asserts
+
+// CHECK-LABEL: begin running test {{.*}} on with_trap: dead_end_blocks
+// CHECK-LABEL: sil @with_trap : {{.*}} {
+// CHECK:         cond_br undef, [[DIE:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'with_trap'
+// CHECK:       [[DIE]]
+// CHECK-LABEL: end running test {{.*}} on with_trap: dead_end_blocks
+sil @with_trap : $@convention(thin) () -> () {
+entry:
+  specify_test "dead_end_blocks"
+  cond_br undef, die, exit
+
+die:
+  unreachable
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on with_infinite_loop: dead_end_blocks
+// CHECK-LABEL: sil @with_infinite_loop : $@convention(thin) () -> () {
+// CHECK:         cond_br undef, [[EXIT:bb[0-9]+]], [[HEADER:bb[0-9]+]]
+// CHECK:       [[HEADER]]:
+// CHECK:         br [[LOOP:bb[0-9]+]]
+// CHECK:       [[LOOP]]:
+// CHECK:         br [[LOOP]]
+// CHECK-LABEL: } // end sil function 'with_infinite_loop'
+// CHECK:       [[HEADER]]
+// CHECK:       [[LOOP]]
+// CHECK-LABEL: end running test {{.*}} on with_infinite_loop: dead_end_blocks
+sil @with_infinite_loop : $@convention(thin) () -> () {
+entry:
+  specify_test "dead_end_blocks"
+  cond_br undef, exit, header
+header:
+  br loop
+loop:
+  br loop
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -1,0 +1,12 @@
+# Make a local copy of the substitutions.
+config.substitutions = list(config.substitutions)
+
+if config.target_sdk_name == 'macosx':
+  def do_fixup(key, value):
+    if isinstance(value, str):
+      value = value.replace("-apple-macosx10.13", "-apple-macos14")
+    elif isinstance(value, SubstituteCaptures):
+      value.substitution = value.substitution.replace("-apple-macosx10.13", "-apple-macos14")
+    return (key, value)
+
+  config.substitutions = [do_fixup(a, b) for (a, b) in config.substitutions]

--- a/validation-test/embedded/lit.local.cfg
+++ b/validation-test/embedded/lit.local.cfg
@@ -1,0 +1,9 @@
+import sys
+import platform
+
+# Load the config at test/embedded/lit.local.cfg
+lit_config.load_config(config,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 
+        'test', 'embedded', 'lit.local.cfg'))
+

--- a/validation-test/embedded/rdar126965232.swift
+++ b/validation-test/embedded/rdar126965232.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swiftc_driver                     \
+// RUN:     -c                                    \
+// RUN:     %s                                    \
+// RUN:     -Xfrontend -sil-verify-all            \
+// RUN:     -enable-experimental-feature Embedded \
+// RUN:     -wmo                                  \
+// RUN:     -Osize                                \
+// RUN:     -o %t/bin
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+class MyClass {
+  var x: Int? = nil
+  var enabled: Bool = true
+}
+
+public func app_main() {
+  let object = MyClass()
+  while true {
+    let enabled = object.enabled
+    object.enabled = !enabled
+  }
+}


### PR DESCRIPTION
**Explanation**: Fix an edge-case in a fundamental SIL utility.

The `PrunedLiveness` utility is the fundamental tool used in the SIL optimizer to track where a value is live.  For example, CSE uses it by way of the tool used to replace uses in OSSA, namely `OwnershipRAUWHelper`.  `PrunedLiveness` allows clients to specify the points at which a value is known to be live.  It uses those points to determine all places in the function where a value is live.

Often (and as used by `OwnershipRAUWHelper`) this is done by only considering the consuming uses.  So long as a value must be consumed on all paths this makes sense: the consuming uses are the last uses of the value; everything before them is live, everything after them is dead.  While _soon_ (via LifetimeCompletion) it will be a correct and verified assumption that a value is consumed on all paths, unfortunately, currently, it is not: a value _needn't_ be consumed on all paths.  In particular, it can be "leaked" in so-called "dead-end blocks".  A "dead-end block" is a block from which there are no function exiting paths--infinite loops, blocks that trap, and blocks all paths out of which lead into one or the other of those.

The lack of consumes in dead-end blocks means that it's not enough to only consider only consuming uses to determine whether a value is live.  Special care must be taken with the dead-end blocks.  Previously, it was only checked whether the block in question was a dead-end block; if so, the value was determined to be live within the block.  That was not correct, however.  If the value is consumed in a dead-end block, it is not available after that consume.  Additionally, if the value is consumed on some but not all paths into the dead-end block, the value would not be available in it.  Here, this check is tightened to only consider a dead-end block to be live if (1) the value is _not_ consumed in the block and (2) the value is actually _available_ in it (i.e. if the value is not consumed on any path into the block).

Fixes a SIL verifier error when building a simple project with an infinite loop for embedded.

**Scope**: Affects SIL optimizations.
**Issue**: rdar://126965232
**Original PR**: https://github.com/apple/swift/pull/73647
**Risk**: Low.  Corrects and tightens an edge case.
**Testing**: Added a SIL test and the original source-level test.
**Reviewer**: Andrew Trick ( @atrick )
