### PR TITLE
[IRGenDebugInfo] Disable usage of dbg.declare in optimized code

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3165,6 +3165,11 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
   if (DbgTy.getType()->hasLocalArchetype())
     return;
 
+  // We don't support dbg.declare in optimized code, as variables can be moved
+  // by SIL optimization passes.
+  if (DS->getInlinedFunction()->shouldOptimize())
+    AddrDInstrKind = AddrDbgInstrKind::DbgValueDeref;
+
   auto *Scope = dyn_cast_or_null<llvm::DILocalScope>(getOrCreateScope(DS));
   assert(Scope && "variable has no local scope");
   auto DInstLoc = getStartLocation(DbgInstLoc);


### PR DESCRIPTION
We don't support dbg.declare in optimized code, as variables can be moved by SIL optimization passes. If a partial store is eliminated, we want a dbg.value on the allocation, and another dbg.value with a fragment in place of the partial store.

rdar://128155050

tests failing.