### PR TITLE
[6.0][TaskLocal] TL macro must handle force unwrapped optional types

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SyntaxExtensions.swift
+++ b/lib/Macros/Sources/SwiftMacros/SyntaxExtensions.swift
@@ -31,3 +31,16 @@ extension VariableDeclSyntax {
     }
   }
 }
+
+extension ImplicitlyUnwrappedOptionalTypeSyntax {
+  internal var asOptionalTypeSyntax: some TypeSyntaxProtocol {
+    OptionalTypeSyntax(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeWrappedType,
+      wrappedType: wrappedType,
+      self.unexpectedBetweenWrappedTypeAndExclamationMark,
+      self.unexpectedAfterExclamationMark,
+      trailingTrivia: self.trailingTrivia
+    )
+  }
+}

--- a/lib/Macros/Sources/SwiftMacros/SyntaxExtensions.swift
+++ b/lib/Macros/Sources/SwiftMacros/SyntaxExtensions.swift
@@ -33,7 +33,7 @@ extension VariableDeclSyntax {
 }
 
 extension ImplicitlyUnwrappedOptionalTypeSyntax {
-  internal var asOptionalTypeSyntax: some TypeSyntaxProtocol {
+  internal var asOptionalTypeSyntax: any TypeSyntaxProtocol {
     OptionalTypeSyntax(
       leadingTrivia: leadingTrivia,
       unexpectedBeforeWrappedType,

--- a/test/Concurrency/Runtime/async_task_locals_basic.swift
+++ b/test/Concurrency/Runtime/async_task_locals_basic.swift
@@ -31,6 +31,9 @@ enum TL {
 
   @TaskLocal
   static var clazz: ClassTaskLocal?
+
+  @TaskLocal
+  static var force: ForceUnwrapMe!
 }
 
 @TaskLocal
@@ -39,6 +42,8 @@ var globalTaskLocal: StringLike = StringLike("<not-set>")
 
 @available(SwiftStdlib 5.10, *)
 struct LessAvailable {}
+
+struct ForceUnwrapMe {}
 
 @TaskLocal
 @available(SwiftStdlib 5.10, *)


### PR DESCRIPTION
**Description**: The new TaskLocal macro does handle optional types, but did not handle force unwrapped optionals. Arguably, these are a bad idea with task locals, but they are permitted. This patch handles such types again, as the property wrapper approach did before.
**Scope/Impact**: Addresses source break from 5.x series where someone might have used a task local with a force unwrapped optional.
**Risk:** Low, relaxes handling of types.
**Testing**: CI testing with new test case.
**Reviewed by**: @hborla @ahoppen 

**Original PR:**  https://github.com/apple/swift/pull/73693
**Radar:** Resolves rdar://128225191