### PR TITLE
[Availability] Diagnose unavailable conformances in `UnderlyingToOpaqueExpr`.

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2910,7 +2910,7 @@ bool swift::diagnoseExplicitUnavailability(SourceLoc loc,
   diags.diagnose(loc, diag::conformance_availability_unavailable,
                  type, proto,
                  platform.empty(), platform, EncodedMessage.Message)
-      .limitBehavior(behavior)
+      .limitBehaviorUntilSwiftVersion(behavior, 6)
       .warnUntilSwiftVersionIf(warnIfConformanceUnavailablePreSwift6, 6);
 
   switch (attr->getVersionAvailability(ctx)) {
@@ -3466,6 +3466,11 @@ public:
         diagnoseConformanceAvailability(E->getLoc(), C, Where, Type(), Type(),
                                         /*useConformanceAvailabilityErrorsOpt=*/true);
       }
+    }
+
+    if (auto UTO = dyn_cast<UnderlyingToOpaqueExpr>(E)) {
+      diagnoseSubstitutionMapAvailability(
+          UTO->getLoc(), UTO->substitutions, Where);
     }
 
     if (auto ME = dyn_cast<MacroExpansionExpr>(E)) {

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -427,3 +427,15 @@ extension ImplicitSendableViaMain {
 struct TestImplicitSendable: Sendable {
   var x: ImplicitSendableViaMain
 }
+
+struct UnavailableSendable {}
+
+@available(*, unavailable)
+extension UnavailableSendable: Sendable {}
+// expected-note@-1 {{conformance of 'UnavailableSendable' to 'Sendable' has been explicitly marked unavailable here}}
+
+@available(SwiftStdlib 5.1, *)
+func checkOpaqueType() -> some Sendable {
+  UnavailableSendable()
+  // expected-warning@-1 {{conformance of 'UnavailableSendable' to 'Sendable' is unavailable; this is an error in the Swift 6 language mode}}
+}

--- a/test/Concurrency/sendable_checking_swift6.swift
+++ b/test/Concurrency/sendable_checking_swift6.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 %s -o /dev/null -verify
+
+// REQUIRES: concurrency
+
+
+struct UnavailableSendable {}
+
+@available(*, unavailable)
+extension UnavailableSendable: Sendable {}
+// expected-note@-1 {{conformance of 'UnavailableSendable' to 'Sendable' has been explicitly marked unavailable here}}
+
+@available(SwiftStdlib 5.1, *)
+func checkOpaqueType() -> some Sendable {
+  UnavailableSendable()
+  // expected-error@-1 {{conformance of 'UnavailableSendable' to 'Sendable' is unavailable}}
+}

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -169,3 +169,14 @@ struct DeferBody {
   }
 }
 
+struct NotP {}
+
+protocol P {}
+
+@available(*, unavailable)
+extension NotP: P {} // expected-note {{conformance of 'NotP' to 'P' has been explicitly marked unavailable here}}
+
+@available(SwiftStdlib 5.1, *)
+func requireP() -> some P {
+  NotP() // expected-error {{conformance of 'NotP' to 'P' is unavailable}}
+}


### PR DESCRIPTION
Change the availability checker to check substitution maps of underlying values for opaque result types to diagnose unavailable conformances. This change also makes sure `Sendable` availability diagnostics are errors in Swift 6 mode.

Resolves: rdar://125421098, https://github.com/apple/swift/issues/72926