### PR TITLE
[6.0][Availability] Diagnose unavailable conformances in `UnderlyingToOpaqueExpr`.

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2896,7 +2896,7 @@ bool swift::diagnoseExplicitUnavailability(SourceLoc loc,
   diags.diagnose(loc, diag::conformance_availability_unavailable,
                  type, proto,
                  platform.empty(), platform, EncodedMessage.Message)
-      .limitBehavior(behavior)
+      .limitBehaviorUntilSwiftVersion(behavior, 6)
       .warnUntilSwiftVersionIf(warnIfConformanceUnavailablePreSwift6, 6);
 
   switch (attr->getVersionAvailability(ctx)) {
@@ -3452,6 +3452,11 @@ public:
         diagnoseConformanceAvailability(E->getLoc(), C, Where, Type(), Type(),
                                         /*useConformanceAvailabilityErrorsOpt=*/true);
       }
+    }
+
+    if (auto UTO = dyn_cast<UnderlyingToOpaqueExpr>(E)) {
+      diagnoseSubstitutionMapAvailability(
+          UTO->getLoc(), UTO->substitutions, Where);
     }
 
     if (auto ME = dyn_cast<MacroExpansionExpr>(E)) {

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -427,3 +427,15 @@ extension ImplicitSendableViaMain {
 struct TestImplicitSendable: Sendable {
   var x: ImplicitSendableViaMain
 }
+
+struct UnavailableSendable {}
+
+@available(*, unavailable)
+extension UnavailableSendable: Sendable {}
+// expected-note@-1 {{conformance of 'UnavailableSendable' to 'Sendable' has been explicitly marked unavailable here}}
+
+@available(SwiftStdlib 5.1, *)
+func checkOpaqueType() -> some Sendable {
+  UnavailableSendable()
+  // expected-warning@-1 {{conformance of 'UnavailableSendable' to 'Sendable' is unavailable; this is an error in the Swift 6 language mode}}
+}

--- a/test/Concurrency/sendable_checking_swift6.swift
+++ b/test/Concurrency/sendable_checking_swift6.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 %s -o /dev/null -verify
+
+// REQUIRES: concurrency
+
+
+struct UnavailableSendable {}
+
+@available(*, unavailable)
+extension UnavailableSendable: Sendable {}
+// expected-note@-1 {{conformance of 'UnavailableSendable' to 'Sendable' has been explicitly marked unavailable here}}
+
+@available(SwiftStdlib 5.1, *)
+func checkOpaqueType() -> some Sendable {
+  UnavailableSendable()
+  // expected-error@-1 {{conformance of 'UnavailableSendable' to 'Sendable' is unavailable}}
+}

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -169,3 +169,14 @@ struct DeferBody {
   }
 }
 
+struct NotP {}
+
+protocol P {}
+
+@available(*, unavailable)
+extension NotP: P {} // expected-note {{conformance of 'NotP' to 'P' has been explicitly marked unavailable here}}
+
+@available(SwiftStdlib 5.1, *)
+func requireP() -> some P {
+  NotP() // expected-error {{conformance of 'NotP' to 'P' is unavailable}}
+}


### PR DESCRIPTION
* **Explanation**: The compiler was not diagnosing unavailable conformances used for opaque result types. This changes the availability checker to check substitution maps of underlying values for opaque result types to diagnose unavailable conformances. This change also makes sure `Sendable` availability diagnostics are errors in Swift 6 mode.
* **Scope**: Impacts opaque result types whose underlying types have unavailable conformances or missing `Sendable` conformances.
* **Issue**: rdar://125421098, https://github.com/apple/swift/issues/72926
* **Risk**: Low. This could cause some miscompiling code to fail to build, but the most likely case of code violating these rules is for `Sendable`, which is staged in as a warning until Swift 6 mode.
* **Testing**: Added new tests.
* **Reviewer**: @slavapestov @tshortli  
* **Main branch PR**: https://github.com/apple/swift/pull/73695