### PR TITLE
Various fixes for `@preconcurrency`

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -694,9 +694,6 @@ ERROR(isolated_after_nonisolated, none,
 NOTE(nonisolated_blame, none, "after %1%2 %3, "
      "only non-isolated properties of 'self' can be accessed from "
      "%select{this init|a deinit}0", (bool, StringRef, StringRef, DeclName))
-ERROR(non_sendable_from_deinit,none,
-        "cannot access %1 %2 with a non-sendable type %0 from non-isolated deinit",
-        (Type, DescriptiveDeclKind, DeclName))
 ERROR(isolated_property_mutation_in_nonisolated_context,none,
       "actor-isolated %kind0 can not be %select{referenced|mutated}1 "
       "from a non-isolated context",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5796,6 +5796,10 @@ ERROR(nonisolated_wrapped_property,none,
       "'nonisolated' is not supported on properties with property wrappers",
       ())
 
+ERROR(non_sendable_from_deinit,none,
+        "cannot access %1 %2 with a non-sendable type %0 from non-isolated deinit",
+        (Type, DescriptiveDeclKind, DeclName))
+
 ERROR(actor_instance_property_wrapper,none,
       "%0 property in property wrapper type %1 cannot be isolated to "
       "the actor instance; consider 'nonisolated'",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5520,8 +5520,8 @@ ERROR(sendable_isolated_sync_function,none,
       "%0 synchronous %kind1 cannot be marked as '@Sendable'",
       (ActorIsolation, const ValueDecl *))
 ERROR(nonsendable_instance_method,none,
-      "instance methods of non-Sendable types cannot be marked as '@Sendable'",
-      ())
+      "instance method of non-Sendable type %0 cannot be marked as '@Sendable'",
+      (Type))
 ERROR(concurrent_access_of_local_capture,none,
       "%select{mutation of|reference to}0 captured %kind1 in "
       "concurrently-executing code",

--- a/include/swift/Sema/Concurrency.h
+++ b/include/swift/Sema/Concurrency.h
@@ -22,8 +22,10 @@
 
 namespace swift {
 
+class DeclContext;
 class SourceFile;
 class NominalTypeDecl;
+class VarDecl;
 
 /// If any of the imports in this source file was @preconcurrency but there were
 /// no diagnostics downgraded or suppressed due to that @preconcurrency, suggest
@@ -34,6 +36,13 @@ void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf);
 /// conformance (regardless of its availability).
 bool hasExplicitSendableConformance(NominalTypeDecl *nominal,
                                     bool applyModuleDefault = true);
+
+/// Diagnose the use of an instance property of non-sendable type from an
+/// nonisolated deinitializer within an actor-isolated type.
+///
+/// \returns true iff a diagnostic was emitted for this reference.
+bool diagnoseNonSendableFromDeinit(
+    SourceLoc refLoc, VarDecl *var, DeclContext *dc);
 
 } // namespace swift
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6968,13 +6968,16 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
 
       // 'nonisolated' without '(unsafe)' is not allowed on non-Sendable variables.
       auto type = var->getTypeInContext();
-      if (!attr->isUnsafe() && !type->hasError() &&
-          !type->isSendableType()) {
-        Ctx.Diags.diagnose(attr->getLocation(),
-                           diag::nonisolated_non_sendable,
-                           type)
-          .warnUntilSwiftVersion(6);
-        return;
+      if (!attr->isUnsafe() && !type->hasError()) {
+        bool diagnosed = diagnoseIfAnyNonSendableTypes(
+            type,
+            SendableCheckContext(dc),
+            Type(),
+            SourceLoc(),
+            attr->getLocation(),
+            diag::nonisolated_non_sendable);
+        if (diagnosed)
+          return;
       }
 
       if (auto nominal = dyn_cast<NominalTypeDecl>(dc)) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6938,10 +6938,13 @@ void AttributeChecker::visitSendableAttr(SendableAttr *attr) {
   // Prevent Sendable Attr from being added to methods of non-sendable types
   if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(D)) {
     if (auto selfDecl = funcDecl->getImplicitSelfDecl()) {
-      if (!selfDecl->getTypeInContext()->isSendableType()) {
-        diagnose(attr->getLocation(), diag::nonsendable_instance_method)
-        .warnUntilSwiftVersion(6);
-      }
+      diagnoseIfAnyNonSendableTypes(
+          selfDecl->getTypeInContext(),
+          SendableCheckContext(funcDecl),
+          Type(),
+          SourceLoc(),
+          attr->getLocation(),
+          diag::nonsendable_instance_method);
     }
   }
 }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -511,7 +511,6 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
     return true;
 
   if (!var->isLet()) {
-    ASTContext &ctx = var->getASTContext();
     // A mutable storage of a value type accessed from within the module is
     // okay.
     if (dyn_cast_or_null<StructDecl>(var->getDeclContext()->getAsDecl()) &&

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6830,3 +6830,14 @@ ActorReferenceResult ActorReferenceResult::forReference(
 
   return forEntersActor(declIsolation, options);
 }
+
+bool swift::diagnoseNonSendableFromDeinit(
+    SourceLoc refLoc, VarDecl *var, DeclContext *dc) {
+  return diagnoseIfAnyNonSendableTypes(var->getTypeInContext(),
+                                SendableCheckContext(dc),
+                                Type(),
+                                SourceLoc(),
+                                refLoc,
+                                diag::non_sendable_from_deinit,
+                                var->getDescriptiveKind(), var->getName());
+}

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -441,7 +441,7 @@ bool diagnoseNonSendableTypes(
       type, fromContext, derivedConformance, typeLoc,
       [&](Type specificType, DiagnosticBehavior behavior) {
         auto preconcurrency =
-            fromContext.preconcurrencyBehavior(type->getAnyNominal());
+          fromContext.preconcurrencyBehavior(specificType->getAnyNominal());
 
         ctx.Diags.diagnose(diagnoseLoc, diag, type, diagArgs...)
             .limitBehaviorUntilSwiftVersion(behavior, 6)
@@ -477,7 +477,7 @@ bool diagnoseIfAnyNonSendableTypes(
       type, fromContext, derivedConformance, typeLoc,
       [&](Type specificType, DiagnosticBehavior behavior) {
         auto preconcurrency =
-            fromContext.preconcurrencyBehavior(type->getAnyNominal());
+          fromContext.preconcurrencyBehavior(specificType->getAnyNominal());
 
         if (behavior == DiagnosticBehavior::Ignore ||
             preconcurrency == DiagnosticBehavior::Ignore)

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -215,7 +215,7 @@ func testUnsafeSendableInAsync() async {
 // ----------------------------------------------------------------------
 // Sendable restriction on key paths.
 // ----------------------------------------------------------------------
-class NC: Hashable { // expected-note 2{{class 'NC' does not conform to the 'Sendable' protocol}}
+class NC: Hashable { // expected-note 3{{class 'NC' does not conform to the 'Sendable' protocol}}
   func hash(into: inout Hasher) { }
   static func==(_: NC, _: NC) -> Bool { true }
 }

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -15,7 +15,7 @@ func takeNonSendable(_ ns: NonSendableType) {}
 @available(SwiftStdlib 5.1, *)
 func takeSendable(_ s: SendableType) {}
 
-class NonSendableType {
+class NonSendableType { // expected-note *{{class 'NonSendableType' does not conform to the 'Sendable' protocol}}
   var x: Int = 0
   func f() {}
 }

--- a/test/Concurrency/global_variables.swift
+++ b/test/Concurrency/global_variables.swift
@@ -23,7 +23,7 @@ final class TestSendable: Sendable {
   init() {}
 }
 
-final class TestNonsendable { // expected-note 2{{class 'TestNonsendable' does not conform to the 'Sendable' protocol}}
+final class TestNonsendable { // expected-note 3{{class 'TestNonsendable' does not conform to the 'Sendable' protocol}}
   init() {}
 }
 

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -41,3 +41,13 @@ extension NonStrictClass {
 extension StrictStruct {
   @Sendable func f() { } // expected-warning{{instance method of non-Sendable type 'StrictStruct' cannot be marked as '@Sendable'}}
 }
+
+
+struct HasStatics {
+  nonisolated static let ns: NonStrictClass = NonStrictClass()
+
+  nonisolated static let ss: StrictStruct = StrictStruct()
+  // expected-warning@-1{{'nonisolated' can not be applied to variable with non-'Sendable' type 'StrictStruct'}}
+  // expected-warning@-2{{static property 'ss' is not concurrency-safe because non-'Sendable' type 'StrictStruct' may have shared mutable state}}
+  // expected-note@-3{{isolate 'ss' to a global actor, or conform 'StrictStruct' to 'Sendable'}}
+}

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -16,17 +16,29 @@
 @preconcurrency import OtherActors
 // expected-warning@-1{{'@preconcurrency' attribute on module 'OtherActors' has no effect}}{{1-17=}}
 
+@preconcurrency
+class MyPredatesConcurrencyClass { }
+
+enum EnumWithPredatesConcurrencyValue {
+  case stored(MyPredatesConcurrencyClass)
+}
+
 func acceptSendable<T: Sendable>(_: T) { }
 
 @available(SwiftStdlib 5.1, *)
 func test(
   ss: StrictStruct, ns: NonStrictClass, oma: OtherModuleActor,
-  ssc: SomeSendableClass
+  ssOpt: StrictStruct?, nsOpt: NonStrictClass?
+  ssc: SomeSendableClass,
+  mpcc: MyPredatesConcurrencyClass
 ) async {
   acceptSendable(ss) // expected-warning{{type 'StrictStruct' does not conform to the 'Sendable' protocol}}
   acceptSendable(ns) // silence issue entirely
+  acceptSendable(ssOpt) // expected-warning{{type 'StrictStruct?' does not conform to the 'Sendable' protocol}}
+  acceptSendable(nsOpt) // silence issue entirely
   acceptSendable(oma) // okay
   acceptSendable(ssc) // okay
+  acceptSendable(mpcc)
 }
 
 let nonStrictGlobal = NonStrictClass() // no warning

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -33,3 +33,11 @@ let nonStrictGlobal = NonStrictClass() // no warning
 
 let strictGlobal = StrictStruct() // expected-warning{{let 'strictGlobal' is not concurrency-safe because non-'Sendable' type 'StrictStruct' may have shared mutable state}}
 // expected-note@-1{{isolate 'strictGlobal' to a global actor, or conform 'StrictStruct' to 'Sendable'}}
+
+extension NonStrictClass {
+  @Sendable func f() { }
+}
+
+extension StrictStruct {
+  @Sendable func f() { } // expected-warning{{instance method of non-Sendable type 'StrictStruct' cannot be marked as '@Sendable'}}
+}

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -28,13 +28,13 @@ func acceptSendable<T: Sendable>(_: T) { }
 @available(SwiftStdlib 5.1, *)
 func test(
   ss: StrictStruct, ns: NonStrictClass, oma: OtherModuleActor,
-  ssOpt: StrictStruct?, nsOpt: NonStrictClass?
+  ssOpt: StrictStruct?, nsOpt: NonStrictClass?,
   ssc: SomeSendableClass,
   mpcc: MyPredatesConcurrencyClass
 ) async {
   acceptSendable(ss) // expected-warning{{type 'StrictStruct' does not conform to the 'Sendable' protocol}}
   acceptSendable(ns) // silence issue entirely
-  acceptSendable(ssOpt) // expected-warning{{type 'StrictStruct?' does not conform to the 'Sendable' protocol}}
+  acceptSendable(ssOpt) // expected-warning{{type 'StrictStruct' does not conform to the 'Sendable' protocol}}
   acceptSendable(nsOpt) // silence issue entirely
   acceptSendable(oma) // okay
   acceptSendable(ssc) // okay

--- a/test/Concurrency/predates_concurrency_import_deinit.swift
+++ b/test/Concurrency/predates_concurrency_import_deinit.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+
+// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+@preconcurrency import NonStrictModule
+@preconcurrency import StrictModule
+
+@available(SwiftStdlib 5.1, *)
+actor ActorWithDeinit {
+  var ns: NonStrictClass = NonStrictClass()
+  var ss: StrictStruct = StrictStruct()
+
+  deinit {
+    print(ns)
+    print(ss) // expected-warning{{cannot access property 'ss' with a non-sendable type 'StrictStruct' from non-isolated deinit}}
+  }
+}

--- a/test/Concurrency/predates_concurrency_import_swift6.swift
+++ b/test/Concurrency/predates_concurrency_import_swift6.swift
@@ -19,3 +19,11 @@ func test(ss: StrictStruct, ns: NonStrictClass) {
 let nonStrictGlobal = NonStrictClass()
 let strictGlobal = StrictStruct() // expected-warning{{let 'strictGlobal' is not concurrency-safe because non-'Sendable' type 'StrictStruct' may have shared mutable state}}
 // expected-note@-1{{isolate 'strictGlobal' to a global actor, or conform 'StrictStruct' to 'Sendable'}}
+
+extension NonStrictClass {
+  @Sendable func f() { }
+}
+
+extension StrictStruct {
+  @Sendable func f() { } // expected-warning{{instance method of non-Sendable type 'StrictStruct' cannot be marked as '@Sendable'}}
+}

--- a/test/Concurrency/predates_concurrency_import_swift6.swift
+++ b/test/Concurrency/predates_concurrency_import_swift6.swift
@@ -2,8 +2,8 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 
-// RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify -parse-as-library
-// RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation -parse-as-library
+// RUN: %target-swift-frontend -swift-version 6 -I %t %s -emit-sil -o /dev/null -verify -parse-as-library
+// RUN: %target-swift-frontend -swift-version 6 -I %t %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation -parse-as-library
 
 @preconcurrency import NonStrictModule
 @preconcurrency import StrictModule

--- a/test/Concurrency/sendable_functions.swift
+++ b/test/Concurrency/sendable_functions.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=targeted
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
@@ -23,18 +22,18 @@ actor A {
   }
 }
 
-class NonSendableC {
+class NonSendableC { // expected-note{{class 'NonSendableC' does not conform to the 'Sendable' protocol}}
     var x: Int = 0
 
-    @Sendable func inc() { // expected-warning{{instance methods of non-Sendable types cannot be marked as '@Sendable'}}
+    @Sendable func inc() { // expected-warning{{instance method of non-Sendable type 'NonSendableC' cannot be marked as '@Sendable'}}
         x += 1
     }
 }
 
-struct S<T> {
+struct S<T> { // expected-note{{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
   let t: T
 
-  @Sendable func test() {} // expected-warning{{instance methods of non-Sendable types cannot be marked as '@Sendable'}}
+  @Sendable func test() {} // expected-warning{{instance method of non-Sendable type 'S<T>' cannot be marked as '@Sendable'}}
 }
 
 extension S: Sendable where T: Sendable {

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-upcoming-feature InferSendableFromCaptures -disable-availability-checking
-// RUN: %target-swift-emit-silgen %s -verify -enable-upcoming-feature InferSendableFromCaptures -disable-availability-checking -module-name sendable_methods | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature InferSendableFromCaptures -disable-availability-checking -strict-concurrency=complete
+// RUN: %target-swift-emit-silgen %s -verify -enable-upcoming-feature InferSendableFromCaptures -disable-availability-checking -module-name sendable_methods -strict-concurrency=complete | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -151,10 +151,10 @@ struct World {
 
 let helloworld:  @Sendable () -> Void = World.greet
 
-class NonSendableC {
+class NonSendableC { // expected-note{{class 'NonSendableC' does not conform to the 'Sendable' protocol}}
     var x: Int = 0
 
-    @Sendable func inc() { // expected-warning {{instance methods of non-Sendable types cannot be marked as '@Sendable'; this is an error in the Swift 6 language mode}}
+    @Sendable func inc() { // expected-warning {{instance method of non-Sendable type 'NonSendableC' cannot be marked as '@Sendable'}}
         x += 1
     }
 }
@@ -185,10 +185,6 @@ actor TestActor {}
 struct SomeGlobalActor {
   static var shared: TestActor { TestActor() }
 }
-
-@SomeGlobalActor
-let globalValue: NonSendable = NonSendable()
-
 
 @SomeGlobalActor
 // CHECK-LABEL: sil hidden [ossa] @$s16sendable_methods8generic3yyxYalF : $@convention(thin) @async <T> (@in_guaranteed T) -> ()

--- a/test/Concurrency/transfernonsendable_preconcurrency.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency.swift
@@ -6,9 +6,6 @@
 // A swift 5 module /with/ concurrency checking
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/PreconcurrencyChecked.swiftmodule -module-name PreconcurrencyChecked %S/Inputs/transfernonsendable_preconcurrency_checked.swift -disable-availability-checking -swift-version 5 -strict-concurrency=complete
 
-// Test swift 5 with strict concurrency with region isolation disabled
-// RUN: %target-swift-frontend -swift-version 5 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-5-no-tns- -parse-as-library -I %t -strict-concurrency=complete -disable-availability-checking -disable-region-based-isolation-with-strict-concurrency
-
 // Test swift 5 with strict concurrency
 // RUN: %target-swift-frontend -swift-version 5 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-5- -parse-as-library -I %t -strict-concurrency=complete -disable-availability-checking
 
@@ -26,7 +23,7 @@
 ////////////////////////
 
 @preconcurrency import PreconcurrencyUnchecked
-import PreconcurrencyChecked // expected-swift-5-no-tns-warning {{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'PreconcurrencyChecked'}}
+import PreconcurrencyChecked
 
 typealias PreCUncheckedNonSendableKlass = PreconcurrencyUnchecked.NonSendableKlass
 typealias PreCUncheckedExplicitlyNonSendableKlass = PreconcurrencyUnchecked.ExplicitlyNonSendableKlass
@@ -62,11 +59,10 @@ func testPreconcurrencyImplicitlyNonSendable() async {
 func testPreconcurrencyExplicitlyNonSendable() async {
   let x = PreCUncheckedExplicitlyNonSendableKlass()
   await transferToMain(x)
-  // expected-swift-5-no-tns-warning @-1 {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-2 {{sending 'x' risks causing data races}}
-  // expected-swift-5-note @-3 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-swift-6-warning @-4 {{sending 'x' risks causing data races}}
-  // expected-swift-6-note @-5 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
+  // expected-swift-5-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-warning @-3 {{sending 'x' risks causing data races}}
+  // expected-swift-6-note @-4 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x)
   // expected-swift-5-note @-1 {{access can happen concurrently}}
   // expected-swift-6-note @-2 {{access can happen concurrently}}
@@ -75,7 +71,7 @@ func testPreconcurrencyExplicitlyNonSendable() async {
 // In swift 5 this is a warning and in swift 6 this is an error.
 func testNormal() async {
   let x = PostCUncheckedNonSendableKlass()
-  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
+  await transferToMain(x)
   // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-6-error @-2 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-3 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -90,11 +86,10 @@ func testOnlyErrorOnExactValue() async {
   // We would squelch this if we transferred it directly. Also we error even
   // though we use x later.
   await transferToMain(y)
-  // expected-swift-5-no-tns-warning @-1 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
-  // expected-swift-5-warning @-2 {{sending 'y' risks causing data races}}
-  // expected-swift-5-note @-3 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-swift-6-error @-4 {{sending 'y' risks causing data races}}
-  // expected-swift-6-note @-5 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-swift-5-warning @-1 {{sending 'y' risks causing data races}}
+  // expected-swift-5-note @-2 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-swift-6-error @-3 {{sending 'y' risks causing data races}}
+  // expected-swift-6-note @-4 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x)
   // expected-swift-5-note @-1 {{access can happen concurrently}}
   // expected-swift-6-note @-2 {{access can happen concurrently}}
@@ -117,7 +112,7 @@ func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
 }
 
 func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
-  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PreCUncheckedExplicitlyNonSendableKlass' (aka 'ExplicitlyNonSendableKlass') into main actor-isolated context may introduce data races}}
+  await transferToMain(x)
   // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-swift-6-warning @-3 {{sending 'x' risks causing data races}}
@@ -125,7 +120,7 @@ func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) asy
 }
 
 func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
-  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type 'PostCUncheckedNonSendableKlass' (aka 'NonSendableKlass') into main actor-isolated context may introduce data races}}
+  await transferToMain(x)
   // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-swift-6-error @-3 {{sending 'x' risks causing data races}}
@@ -134,7 +129,7 @@ func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)) async {
-  await transferToMain(x) // expected-swift-5-no-tns-warning 2{{passing argument of non-sendable type '(PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)' (aka '(NonSendableKlass, NonSendableKlass)') into main actor-isolated context may introduce data races}}
+  await transferToMain(x)
   // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-swift-6-error @-3 {{sending 'x' risks causing data races}}
@@ -143,7 +138,7 @@ func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUnch
 
 // Inexact match => normal behavior.
 func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
-  await transferToMain(x) // expected-swift-5-no-tns-warning {{passing argument of non-sendable type '(PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)' (aka '(ExplicitlyNonSendableKlass, ExplicitlyNonSendableKlass)') into main actor-isolated context may introduce data races}}
+  await transferToMain(x)
   // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
   // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-swift-6-error @-3 {{sending 'x' risks causing data races}}


### PR DESCRIPTION
Audit the places where we do `Sendable` checking to ensure that they handle `@preconcurrency` appropriately, and fix several issues:
* Diagnosing `@Sendable` methods on a non-`Sendable` type
* Diagnosing a non-`Sendable` `nonisolated let`
* Diagnosing access to non-`Sendable` instance properties of an actor-isolated type within the deinitializer

Moreover, make sure that we correctly check for `@preconcurrency` for the actual non-Sendable nominal types that occur within a larger type expression, e.g., the `NS` in `NS?` rather than only looking at the outer optional. This makes `@preconcurrency` work properly for arrays, optionals, sets, etc. of non-`Sendable` types. Fixes rdar://125081249