### PR TITLE
stdlib: Fix a borrowing switch condfail

### DIFF
--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -112,8 +112,8 @@ extension Duration {
   public static func seconds<T: BinaryInteger>(_ seconds: T) -> Duration {
     guard let high = Int64(exactly: seconds >> 64) else { fatalError() }
     let low = UInt64(truncatingIfNeeded: seconds)
-    var lowScaled = low.multipliedFullWidth(by: 1_000_000_000_000_000_000)
-    var highScaled = high * 1_000_000_000_000_000_000
+    let lowScaled = low.multipliedFullWidth(by: 1_000_000_000_000_000_000)
+    let highScaled = high * 1_000_000_000_000_000_000
     return Duration(_high: highScaled + Int64(lowScaled.high), low: lowScaled.low)
   }
   
@@ -158,8 +158,8 @@ extension Duration {
   ) -> Duration {
     guard let high = Int64(exactly: milliseconds >> 64) else { fatalError() }
     let low = UInt64(truncatingIfNeeded: milliseconds)
-    var lowScaled = low.multipliedFullWidth(by: 1_000_000_000_000_000)
-    var highScaled = high * 1_000_000_000_000_000
+    let lowScaled = low.multipliedFullWidth(by: 1_000_000_000_000_000)
+    let highScaled = high * 1_000_000_000_000_000
     return Duration(_high: highScaled + Int64(lowScaled.high), low: lowScaled.low)
   }
 
@@ -187,8 +187,8 @@ extension Duration {
   ) -> Duration {
     guard let high = Int64(exactly: microseconds >> 64) else { fatalError() }
     let low = UInt64(truncatingIfNeeded: microseconds)
-    var lowScaled = low.multipliedFullWidth(by: 1_000_000_000_000)
-    var highScaled = high * 1_000_000_000_000
+    let lowScaled = low.multipliedFullWidth(by: 1_000_000_000_000)
+    let highScaled = high * 1_000_000_000_000
     return Duration(_high: highScaled + Int64(lowScaled.high), low: lowScaled.low)
   }
 
@@ -216,8 +216,8 @@ extension Duration {
   ) -> Duration {
     guard let high = Int64(exactly: nanoseconds >> 64) else { fatalError() }
     let low = UInt64(truncatingIfNeeded: nanoseconds)
-    var lowScaled = low.multipliedFullWidth(by: 1_000_000_000)
-    var highScaled = high * 1_000_000_000
+    let lowScaled = low.multipliedFullWidth(by: 1_000_000_000)
+    let highScaled = high * 1_000_000_000
     return Duration(_high: highScaled + Int64(lowScaled.high), low: lowScaled.low)
   }
 }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -230,7 +230,7 @@ extension Optional where Wrapped: ~Copyable {
   public borrowing func _borrowingMap<U: ~Copyable, E: Error>(
     _ transform: (borrowing Wrapped) throws(E) -> U
   ) throws(E) -> U? {
-    #if $NoncopyableGenerics
+    #if compiler(>=6.0) && $NoncopyableGenerics
     switch self {
     case .some(_borrowing y):
       return .some(try transform(y))
@@ -289,7 +289,6 @@ extension Optional {
   }
 }
 
-@_disallowFeatureSuppression(NoncopyableGenerics)
 extension Optional where Wrapped: ~Copyable {
   // FIXME(NCG): Make this public.
   @_alwaysEmitIntoClient
@@ -309,12 +308,16 @@ extension Optional where Wrapped: ~Copyable {
   public func _borrowingFlatMap<U: ~Copyable, E: Error>(
     _ transform: (borrowing Wrapped) throws(E) -> U?
   ) throws(E) -> U? {
+    #if compiler(>=6.0) && $NoncopyableGenerics
     switch self {
     case .some(_borrowing y):
       return try transform(y)
     case .none:
       return .none
     }
+    #else
+    fatalError("Unsupported compiler")
+    #endif
   }
 }
 


### PR DESCRIPTION
Also, address some recently introduced, spammy warnings in `Duration.swift`.

Resolves rdar://128249510