### PR TITLE
embedded: fix a compiler crash when using dynamic casts

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCheckedCast.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCheckedCast.swift
@@ -18,7 +18,10 @@ extension CheckedCastAddrBranchInst : OnoneSimplifyable {
       return
     }
     if castWillSucceed {
-      replaceSuccess(context)
+      // TODO: handle cases where the operand address types are different.
+      if source.type == destination.type {
+        replaceSuccess(context)
+      }
     } else {
       replaceFailure(context)
     }

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -390,6 +390,8 @@ ERROR(embedded_swift_metatype,none,
       "cannot use metatype in embedded Swift", ())
 ERROR(embedded_swift_keypath,none,
       "cannot use key path in embedded Swift", ())
+ERROR(embedded_swift_dynamic_cast,none,
+      "cannot do dynamic casting in embedded Swift", ())
 ERROR(embedded_swift_allocating_type,none,
       "cannot use allocating type %0 in -no-allocations mode", (Type))
 ERROR(embedded_swift_allocating,none,

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -526,6 +526,10 @@ bool PerformanceDiagnostics::visitInst(SILInstruction *inst,
         diagnose(loc, diag::embedded_swift_keypath);
         return true;
       }
+      if (isa<CheckedCastAddrBranchInst>(inst) || isa<UnconditionalCheckedCastAddrInst>(inst)) {
+        diagnose(loc, diag::embedded_swift_dynamic_cast);
+        return true;
+      }
       if (!allowedMetadataUseInEmbeddedSwift(inst)) {
         PrettyStackTracePerformanceDiagnostics stackTrace("metatype", inst);
         if (impactType) {

--- a/test/SILOptimizer/simplify_checked_cast_addr_br.sil
+++ b/test/SILOptimizer/simplify_checked_cast_addr_br.sil
@@ -129,3 +129,14 @@ bb2:
   unreachable
 }
 
+// Check that we don't crash on this
+sil @success_but_different_operand_type : $@convention(thin) (@in D) -> @out X {
+bb0(%0 : $*X, %1 : $*D):
+  checked_cast_addr_br copy_on_success D in %1 : $*D to X in %0 : $*X, bb1, bb2
+bb1:
+  %r = tuple()
+  return %r : $()
+bb2:
+  unreachable
+}
+

--- a/test/embedded/metatypes.swift
+++ b/test/embedded/metatypes.swift
@@ -11,3 +11,13 @@ public func test() -> Int {
   sink(t: metatype)
   return 42
 }
+
+func castToExistential<T>(x: T) {
+  if x is any FixedWidthInteger {    // expected-error {{cannot do dynamic casting in embedded Swift}}
+  }
+}
+
+public func callCastToExistential() {
+  castToExistential(x: 42)    // expected-note {{called from here}}
+}
+


### PR DESCRIPTION
in SimplifyCheckedCast: only simplify if source and destination address types match
Also diagnose dynamic casts to avoid an internal IRGen error:

rdar://128195403