### PR TITLE
SIL: Ignore AEIC on package declaration inside declarations without effective public access

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -625,7 +625,11 @@ SILLinkage SILDeclRef::getDefinitionLinkage() const {
     case Limit::None:
       return SILLinkage::Package;
     case Limit::AlwaysEmitIntoClient:
-      return SILLinkage::PackageNonABI;
+      // Drop the AEIC if the enclosing decl is not effectively public.
+      // This matches what we do in the `internal` case.
+      if (isSerialized())
+        return SILLinkage::PackageNonABI;
+      else return SILLinkage::Package;
     case Limit::OnDemand:
       return SILLinkage::Shared;
     case Limit::NeverPublic:

--- a/test/SILGen/always_emit_into_client_attribute.swift
+++ b/test/SILGen/always_emit_into_client_attribute.swift
@@ -58,3 +58,21 @@ public final class C {
   @_alwaysEmitIntoClient
   deinit {}
 }
+
+
+// We drop AEIC if the containing context does not have effective public
+// visibility.
+internal struct InternalContext {
+// CHECK-LABEL: sil hidden [ossa] @$s33always_emit_into_client_attribute15InternalContextV1vSivgZ
+  @_alwaysEmitIntoClient
+  internal static var v : Int { 1 }
+}
+
+// We drop AEIC if the containing context does not have effective public
+// visibility.
+package struct PackageContext {
+// CHECK-LABEL: sil package [ossa] @$s33always_emit_into_client_attribute14PackageContextV1vSivgZ
+
+  @_alwaysEmitIntoClient
+  package static var v : Int { 1 }
+}


### PR DESCRIPTION

Quoting Slava:

"The AST-level access is allowed to be 'more public'. I honestly don't know why, but it's always worked this way and the 'lowered' access levels must always intersect the access levels of the parents but with @uic, @aeic and @inlinable, that means just ignoring those attributes if some enclosing context is not @uic"

rdar://128270848