### PR TITLE
[6.0] [CS] Avoid creating placeholder var if skipping for completion

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -197,9 +197,6 @@ protected:
         return std::nullopt;
       }
 
-      // Allocate variable with a placeholder type
-      auto *resultVar = buildPlaceholderVar(stmt->getStartLoc(), newBody);
-
       if (ctx.CompletionCallback && stmt->getSourceRange().isValid() &&
           !containsIDEInspectionTarget(stmt->getSourceRange(), ctx.SourceMgr) &&
           !isa<GuardStmt>(stmt)) {
@@ -208,6 +205,9 @@ protected:
         // it to improve performance.
         return std::nullopt;
       }
+
+      // Allocate variable with a placeholder type
+      auto *resultVar = buildPlaceholderVar(stmt->getStartLoc(), newBody);
 
       auto result = visit(stmt, resultVar);
       if (!result)

--- a/validation-test/IDE/issues_fixed/rdar127838305.swift
+++ b/validation-test/IDE/issues_fixed/rdar127838305.swift
@@ -1,0 +1,19 @@
+// RUN: %batch-code-completion
+
+@resultBuilder struct MyBuilder {
+  static func buildBlock(_ components: [Int]...) -> [Int]
+  static func buildFinalResult(_ component: [Int]) -> Int
+}
+
+func build(@MyBuilder itemsBuilder: () -> Int) {}
+
+func test() {
+  let modifiers = build {
+    for modifier in invalid {
+    }
+  }
+
+  modifiers.#^COMPLETE^#
+}
+
+// COMPLETE: Keyword[self]/CurrNominal:          self[#Void#]; name=self


### PR DESCRIPTION
*6.0 cherry-pick of #73705*

- Explanation: Fixes a code completion crash that could occur with a result builder containing a statement.
- Scope: Affects completion on variables that rely on result builders being type-checked
- Issue: rdar://127838305
- Risk: Low, the fix is very simple
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich