### PR TITLE
Pack expansion closures, part 6

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -182,7 +182,7 @@ public:
     /// Contains a PackType.
     HasPack = 0x10000,
 
-    /// Contains a PackArchetypeType.
+    /// Contains a PackArchetypeType. Also implies HasPrimaryArchetype.
     HasPackArchetype = 0x20000,
 
     Last_Property = HasPackArchetype
@@ -205,7 +205,8 @@ public:
   bool hasTypeVariable() const { return Bits & HasTypeVariable; }
 
   /// Does a type with these properties structurally contain a primary
-  /// archetype?
+  /// or pack archetype? These are the archetypes instantiated from a
+  /// primary generic environment.
   bool hasPrimaryArchetype() const { return Bits & HasPrimaryArchetype; }
 
   /// Does a type with these properties structurally contain an
@@ -695,7 +696,9 @@ public:
     return getRecursiveProperties().hasPlaceholder();
   }
 
-  /// Determine whether the type involves a primary archetype.
+  /// Determine whether the type involves a PrimaryArchetypeType *or* a
+  /// PackArchetypeType. These are the archetypes instantiated from a
+  /// primary generic environment.
   bool hasPrimaryArchetype() const {
     return getRecursiveProperties().hasPrimaryArchetype();
   }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -448,9 +448,9 @@ protected:
 
   SILLocation remapLocation(SILLocation Loc) { return Loc; }
   const SILDebugScope *remapScope(const SILDebugScope *DS) { return DS; }
+
   SILType remapType(SILType Ty) {
-    // Substitute local archetypes, if we have any.
-    if (Ty.hasLocalArchetype()) {
+    if (Functor.SubsMap || Ty.hasLocalArchetype()) {
       Ty = Ty.subst(Builder.getModule(), Functor, Functor,
                     CanGenericSignature());
     }
@@ -459,16 +459,14 @@ protected:
   }
 
   CanType remapASTType(CanType ty) {
-    // Substitute local archetypes, if we have any.
-    if (ty->hasLocalArchetype())
+    if (Functor.SubsMap || ty->hasLocalArchetype())
       ty = ty.subst(Functor, Functor)->getCanonicalType();
 
     return ty;
   }
 
   ProtocolConformanceRef remapConformance(Type Ty, ProtocolConformanceRef C) {
-    // If we have local archetypes to substitute, do so now.
-    if (Ty->hasLocalArchetype())
+    if (Functor.SubsMap || Ty->hasLocalArchetype())
       C = C.subst(Ty, Functor, Functor);
 
     return C;
@@ -485,7 +483,7 @@ protected:
 
   SubstitutionMap remapSubstitutionMap(SubstitutionMap Subs) {
     // If we have local archetypes to substitute, do so now.
-    if (Subs.hasLocalArchetypes())
+    if (Subs.hasLocalArchetypes() || Functor.SubsMap)
       Subs = Subs.subst(Functor, Functor);
 
     return Subs;

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -477,6 +477,11 @@ public:
   /// This should only be the case during parsing or deserialization.
   bool hasUnresolvedLocalArchetypeDefinitions();
 
+  /// If we added any instructions that reference unresolved local archetypes
+  /// and then deleted those instructions without resolving those archetypes,
+  /// we must reclaim those unresolved local archetypes.
+  void reclaimUnresolvedLocalArchetypeDefinitions();
+
   /// Get a unique index for a struct or class field in layout order.
   ///
   /// Precondition: \p decl must be a non-resilient struct or class.

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -1073,6 +1073,12 @@ public:
   GenericSignatureWithCapturedEnvironments
   getGenericSignatureWithCapturedEnvironments(SILDeclRef constant);
 
+  /// Get the substitution map for calling a constant.
+  SubstitutionMap
+  getSubstitutionMapWithCapturedEnvironments(SILDeclRef constant,
+                                             const CaptureInfo &captureInfo,
+                                             SubstitutionMap subs);
+
   /// Get the generic environment for a constant.
   GenericEnvironment *getConstantGenericEnvironment(SILDeclRef constant);
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4104,7 +4104,7 @@ TypeConverter::getGenericSignatureWithCapturedEnvironments(SILDeclRef c) {
         vd->getDeclContext()->getGenericSignatureOfContext());
   case SILDeclRef::Kind::EntryPoint:
   case SILDeclRef::Kind::AsyncEntryPoint:
-    llvm_unreachable("Doesn't have generic signature");
+    return GenericSignatureWithCapturedEnvironments();
   }
 
   llvm_unreachable("Unhandled SILDeclRefKind in switch.");

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4110,6 +4110,21 @@ TypeConverter::getGenericSignatureWithCapturedEnvironments(SILDeclRef c) {
   llvm_unreachable("Unhandled SILDeclRefKind in switch.");
 }
 
+SubstitutionMap
+TypeConverter::getSubstitutionMapWithCapturedEnvironments(
+    SILDeclRef constant, const CaptureInfo &captureInfo,
+    SubstitutionMap subs) {
+  auto sig = getGenericSignatureWithCapturedEnvironments(constant);
+  if (!sig.genericSig) {
+    assert(!sig.baseGenericSig);
+    assert(sig.capturedEnvs.empty());
+    return SubstitutionMap();
+  }
+
+  return buildSubstitutionMapWithCapturedEnvironments(
+      subs, sig.genericSig, sig.capturedEnvs);
+}
+
 GenericEnvironment *
 TypeConverter::getConstantGenericEnvironment(SILDeclRef c) {
   return getGenericSignatureWithCapturedEnvironments(c)

--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -28,6 +28,7 @@ add_swift_host_library(swiftSILGen STATIC
   SILGenFunction.cpp
   SILGenGlobalVariable.cpp
   SILGenLazyConformance.cpp
+  SILGenLocalArchetype.cpp
   SILGenLValue.cpp
   SILGenPack.cpp
   SILGenPattern.cpp

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1260,6 +1260,9 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
                                     SILFunction *F) {
   emitLazyConformancesForFunction(F);
 
+  auto sig = Types.getGenericSignatureWithCapturedEnvironments(constant);
+  recontextualizeCapturedLocalArchetypes(F, sig);
+
   assert(!F->isExternalDeclaration() && "did not emit any function body?!");
   LLVM_DEBUG(llvm::dbgs() << "lowered sil:\n";
              F->print(llvm::dbgs()));

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -625,6 +625,11 @@ public:
   /// Emit a property descriptor for the given storage decl if it needs one.
   void tryEmitPropertyDescriptor(AbstractStorageDecl *decl);
 
+  /// Replace local archetypes captured from outer AST contexts with primary
+  /// archetypes.
+  void recontextualizeCapturedLocalArchetypes(
+      SILFunction *F, GenericSignatureWithCapturedEnvironments sig);
+
 private:
   /// The most recent declaration we considered for emission.
   SILDeclRef lastEmittedFunction;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3028,14 +3028,11 @@ RValueEmitter::emitClosureReference(AbstractClosureExpr *e,
   // Emit the closure body.
   SGF.SGM.emitClosure(e, contextInfo);
 
-  SubstitutionMap subs;
-  if (e->getCaptureInfo().hasGenericParamCaptures())
-    subs = SGF.getForwardingSubstitutionMap();
-
   // Generate the closure value (if any) for the closure expr's function
   // reference.
   SILLocation loc = e;
-  return SGF.emitClosureValue(loc, SILDeclRef(e), contextInfo, subs);
+  return SGF.emitClosureValue(loc, SILDeclRef(e), contextInfo,
+                              SubstitutionMap());
 }
 
 RValue RValueEmitter::

--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -9,6 +9,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+//
+//  This file forces emission of lazily-generated ClangImporter-synthesized
+//  conformances.
+//
+//===----------------------------------------------------------------------===//
 
 #include "SILGen.h"
 #include "swift/AST/Decl.h"

--- a/lib/SILGen/SILGenLocalArchetype.cpp
+++ b/lib/SILGen/SILGenLocalArchetype.cpp
@@ -1,0 +1,149 @@
+//===--- SILGenLocalArchetype.cpp - Local archetype transform -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the transformation which rewrites captured local
+//  archetypes into primary archetypes in the enclosing function's generic
+//  signature.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SILGen.h"
+#include "swift/AST/LocalArchetypeRequirementCollector.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILCloner.h"
+
+using namespace swift;
+using namespace swift::Lowering;
+
+namespace {
+
+class LocalArchetypeTransform : public SILCloner<LocalArchetypeTransform> {
+  friend class SILCloner<LocalArchetypeTransform>;
+  friend class SILInstructionVisitor<LocalArchetypeTransform>;
+
+  GenericSignatureWithCapturedEnvironments sig;
+  GenericEnvironment *env;
+
+public:
+  LocalArchetypeTransform(SILFunction *F,
+                          GenericSignatureWithCapturedEnvironments sig)
+      : SILCloner(*F), env(sig.genericSig.getGenericEnvironment()) {
+
+    assert(!sig.capturedEnvs.empty() && "Why are we doing this?");
+
+    // The primary archetypes of the old generic environment map to
+    // primary archetypes of the new generic environment at the same
+    // index and depth.
+    Functor.SubsMap = env->getForwardingSubstitutionMap();
+
+    // Local archetypes map to generic parameters at higher depths.
+    MapLocalArchetypesOutOfContext mapOutOfContext(sig.baseGenericSig,
+                                                   sig.capturedEnvs);
+
+    // For each captured environment...
+    for (auto *capturedEnv : sig.capturedEnvs) {
+      // For each introduced generic parameter...
+      auto localParams = capturedEnv->getGenericSignature()
+          .getInnermostGenericParams();
+      for (auto *gp : localParams) {
+        // Get the local archetype from the captured environment.
+        auto origArchetypeTy = capturedEnv->mapTypeIntoContext(gp)
+            ->castTo<LocalArchetypeType>();
+
+        // Map the local archetype to an interface type in the new generic
+        // signature.
+        auto substInterfaceTy = mapOutOfContext(origArchetypeTy);
+
+        // Map this interface type into the new generic environment to get
+        // a primary archetype.
+        auto substArchetypeTy = env->mapTypeIntoContext(substInterfaceTy)
+            ->castTo<PrimaryArchetypeType>();
+
+        // Remember this correspondence.
+        registerLocalArchetypeRemapping(origArchetypeTy, substArchetypeTy);
+      }
+    }
+  }
+
+  void doIt() {
+    auto &F = getBuilder().getFunction();
+
+    // Collect the old basic blocks that we're going to delete.
+    llvm::SmallVector<SILBasicBlock *, 4> bbs;
+    for (auto &bb : F)
+      bbs.push_back(&bb);
+
+    // Make F.mapTypeIntoContext() use the new environment.
+    F.setGenericEnvironment(env);
+
+    // Start by cloning the entry block.
+    auto *origEntryBlock = F.getEntryBlock();
+    auto *clonedEntryBlock = F.createBasicBlock();
+
+    // Clone arguments.
+    SmallVector<SILValue, 4> entryArgs;
+    entryArgs.reserve(origEntryBlock->getArguments().size());
+    for (auto &origArg : origEntryBlock->getArguments()) {
+
+      // Remap the argument type into the new generic environment.
+      SILType mappedType = remapType(origArg->getType());
+      auto *NewArg = clonedEntryBlock->createFunctionArgument(
+          mappedType, origArg->getDecl(), true);
+      NewArg->copyFlags(cast<SILFunctionArgument>(origArg));
+      entryArgs.push_back(NewArg);
+    }
+
+    // Clone the remaining body.
+    getBuilder().setInsertionPoint(clonedEntryBlock);
+    cloneFunctionBody(&F, clonedEntryBlock, entryArgs,
+                      true /*replaceOriginalFunctionInPlace*/);
+
+    // Insert the new entry block at the beginning.
+    F.moveBlockBefore(clonedEntryBlock, F.begin());
+
+    // FIXME: This should be a common utility.
+
+    // Erase the old basic blocks.
+    for (auto *bb : bbs) {
+      for (SILArgument *arg : bb->getArguments()) {
+        arg->replaceAllUsesWithUndef();
+        // To appease the ownership verifier, just set to None.
+        arg->setOwnershipKind(OwnershipKind::None);
+      }
+
+      // Instructions in the dead block may be used by other dead blocks. Replace
+      // any uses of them with undef values.
+      while (!bb->empty()) {
+        // Grab the last instruction in the bb.
+        auto *inst = &bb->back();
+
+        // Replace any still-remaining uses with undef values and erase.
+        inst->replaceAllUsesOfAllResultsWithUndef();
+        inst->eraseFromParent();
+      }
+
+      // Finally, erase the basic block itself.
+      bb->eraseFromParent();
+    }
+  }
+};
+
+} // end anonymous namespace
+
+void SILGenModule::recontextualizeCapturedLocalArchetypes(
+    SILFunction *F, GenericSignatureWithCapturedEnvironments sig) {
+  if (sig.capturedEnvs.empty())
+    return;
+
+  LocalArchetypeTransform(F, sig).doIt();
+  M.reclaimUnresolvedLocalArchetypeDefinitions();
+}

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -39,6 +39,10 @@ class FindCapturedVars : public ASTWalker {
   SmallVector<CapturedValue, 4> Captures;
   llvm::SmallDenseMap<ValueDecl*, unsigned, 4> captureEntryNumber;
 
+  /// We track the pack expansion expressions in ForEachStmts, because
+  /// their local generics remain in scope until the end of the statement.
+  llvm::DenseSet<PackExpansionExpr *> ForEachPatternSequences;
+
   /// A stack of pack element environments we're currently walking into.
   /// A reference to an element archetype defined by one of these is not
   /// a capture.
@@ -652,12 +656,51 @@ public:
     if (auto expansion = dyn_cast<PackExpansionExpr>(E)) {
       if (auto *env = expansion->getGenericEnvironment()) {
         assert(env == VisitingEnvironments.back());
-        VisitingEnvironments.pop_back();
         (void) env;
+
+        // If this is the pack expansion of a for .. in loop, the generic
+        // environment remains in scope until the end of the loop.
+        if (ForEachPatternSequences.count(expansion) == 0)
+          VisitingEnvironments.pop_back();
       }
     }
 
     return Action::Continue(E);
+  }
+
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
+    if (auto *forEachStmt = dyn_cast<ForEachStmt>(S)) {
+      if (auto *expansion =
+              dyn_cast<PackExpansionExpr>(forEachStmt->getParsedSequence())) {
+        if (auto *env = expansion->getGenericEnvironment()) {
+          // Remember this generic environment, so that it remains on the
+          // visited stack until the end of the for .. in loop.
+          assert(ForEachPatternSequences.count(expansion) == 0);
+          ForEachPatternSequences.insert(expansion);
+        }
+      }
+    }
+
+    return Action::Continue(S);
+  }
+
+  PostWalkResult<Stmt *> walkToStmtPost(Stmt *S) override {
+    if (auto *forEachStmt = dyn_cast<ForEachStmt>(S)) {
+      if (auto *expansion =
+              dyn_cast<PackExpansionExpr>(forEachStmt->getParsedSequence())) {
+        if (auto *env = expansion->getGenericEnvironment()) {
+          assert(ForEachPatternSequences.count(expansion) != 0);
+          ForEachPatternSequences.erase(expansion);
+
+          // Clean up the generic environment bound by the for loop.
+          assert(env == VisitingEnvironments.back());
+          VisitingEnvironments.pop_back();
+          (void) env;
+        }
+      }
+    }
+
+    return Action::Continue(S);
   }
 };
 

--- a/test/Interpreter/element_archetype_captures.swift
+++ b/test/Interpreter/element_archetype_captures.swift
@@ -1,0 +1,78 @@
+// RUN: %target-run-simple-swift
+
+func callee<X: P1, T: P2, U: P3, V: P4>(x: X, t: T, u: U, v: V)
+    -> (any P1, any P2, any P3, any P4) {
+  return (x, t, u, v)
+}
+
+protocol P1 { var f1: Bool { get } }
+protocol P2 { var f2: Bool { get } }
+protocol P3 { var f3: Bool { get } }
+protocol P4 { var f4: Bool { get } }
+
+func packFunction<X, each T, each U, each V>(x: X,
+                                             ts: repeat each T,
+                                             us: repeat each U,
+                                             vs: repeat each V)
+    where X: P1,
+          (repeat (each T, each U)): Any,
+          repeat each T: P2,
+          repeat each U: P3,
+          repeat each V: P4 {
+
+  var result: [(any P1, any P2, any P3, any P4)] = []
+  var bools: [Bool] = []
+
+  for t in repeat each ts {
+    for u in repeat each us {
+      for v in repeat each vs {
+
+        // Local function
+        do {
+          func localFunc() {
+            result.append(callee(x: x, t: t, u: u, v: v))
+            bools.append(true && x.f1 && t.f2 && u.f3 && v.f4)
+          }
+
+          localFunc()
+          let fn = localFunc
+          fn()
+
+          let closure = { localFunc() }
+          closure()
+        }
+
+        // Generic local function
+        do {
+          func localFunc<Y: P1>(_ y: Y) {
+            result.append(callee(x: y, t: t, u: u, v: v))
+            bools.append(true && y.f1 && t.f2 && u.f3 && v.f4)
+          }
+
+          localFunc(x)
+          let fn: (X) -> () = localFunc
+          fn(x)
+
+          let closure = { localFunc(x) }
+          closure()
+        }
+      }
+    }
+  }
+
+  assert(result.count == bools.count)
+
+  for (r, b) in zip(result, bools) {
+    assert(b == (r.0.f1 && r.1.f2 && r.2.f3 && r.3.f4))
+  }
+}
+
+struct S1: P1 { var f1: Bool }
+struct S2: P2 { var f2: Bool }
+struct S3: P3 { var f3: Bool }
+struct S4: P4 { var f4: Bool }
+
+packFunction(x: S1(f1: true),
+             ts: S2(f2: true), S2(f2: true),
+             us: S3(f3: true), S3(f3: false),
+             vs: S4(f4: false), S4(f4: false), S4(f4: true), S4(f4: true))

--- a/test/SILGen/element_archetype_captures.swift
+++ b/test/SILGen/element_archetype_captures.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// CHECK-LABEL: sil hidden [ossa] @$s26element_archetype_captures6calleeyyx_q_q0_tSTRzSTR_7ElementQy_ACRtzr1_lF : $@convention(thin) <T, U, V where T : Sequence, U : Sequence, T.Element == U.Element> (@in_guaranteed T, @in_guaranteed U, @in_guaranteed V) -> () {
+
+func callee<T, U, V>(_: T, _: U, _: V) where T: Sequence, U: Sequence, T.Element == U.Element {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26element_archetype_captures12packFunction2ts2us2vsyxxQp_q_xQpq0_q0_QptRvzRv_Rv0_STRzSTR_7ElementQy_AFRtzr1_lF : $@convention(thin) <each T, each U, each V where repeat each T : Sequence, repeat each U : Sequence, repeat (each T).Element == (each U).Element> (@pack_guaranteed Pack{repeat each T}, @pack_guaranteed Pack{repeat each U}, @pack_guaranteed Pack{repeat each V}) -> () {
+func packFunction<each T, each U, each V>(ts: repeat each T, us: repeat each U, vs: repeat each V)
+    where repeat each T: Sequence,
+          repeat each U: Sequence,
+          repeat (each T).Element == (each U).Element {
+  for (t, u) in repeat (each ts, each us) {
+
+    // // CHECK-LABEL: sil private [ossa] @$s26element_archetype_captures12packFunction2ts2us2vsyxxQp_q_xQpq0_q0_QptRvzRv_Rv0_STRzSTR_7ElementQy_AFRtzr1_lF10middleFuncL_yyRvzRv_Rv0_STRzSTR_AgHRSr1_lF : $@convention(thin) <each T, each U, each V where repeat each T : Sequence, repeat each U : Sequence, repeat (each T).Element == (each U).Element><τ_1_0, τ_1_1 where τ_1_0 : Sequence, τ_1_1 : Sequence, τ_1_0.Element == τ_1_1.Element> (@in_guaranteed (repeat each V), @in_guaranteed τ_1_0, @in_guaranteed τ_1_1) -> () {
+    func middleFunc() {
+      for v in repeat each vs {
+
+        // CHECK-LABEL: sil private [ossa] @$s26element_archetype_captures12packFunction2ts2us2vsyxxQp_q_xQpq0_q0_QptRvzRv_Rv0_STRzSTR_7ElementQy_AFRtzr1_lF10middleFuncL_yyRvzRv_Rv0_STRzSTR_AgHRSr1_lF05innerK0L_yyRvzRv_Rv0_STRzSTR_AgHRSr1_lF : $@convention(thin) <each T, each U, each V where repeat each T : Sequence, repeat each U : Sequence, repeat (each T).Element == (each U).Element><τ_1_0, τ_1_1 where τ_1_0 : Sequence, τ_1_1 : Sequence, τ_1_0.Element == τ_1_1.Element><τ_2_0> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed τ_2_0) -> () {
+        func innerFunc() {
+
+          // CHECK: [[FN:%.*]] = function_ref @$s26element_archetype_captures6calleeyyx_q_q0_tSTRzSTR_7ElementQy_ACRtzr1_lF : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : Sequence, τ_0_1 : Sequence, τ_0_0.Element == τ_0_1.Element> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
+          // CHECK: apply [[FN]]<τ_1_0, τ_1_1, τ_2_0>(%0, %1, %2) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : Sequence, τ_0_1 : Sequence, τ_0_0.Element == τ_0_1.Element> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
+          callee(t, u, v)
+        }
+
+        innerFunc()
+      }
+    }
+
+    middleFunc()
+  }
+}
+
+// Make sure we don't inadvertently say that `each T` is captured by
+// `localFunc()`.
+public func anotherPackFunction<each T>(_ ts: repeat each T) {
+  // CHECK-LABEL: sil private [ossa] @$s26element_archetype_captures19anotherPackFunctionyyxxQpRvzlF9localFuncL_yyRvzlF : $@convention(thin) <each T> (@in_guaranteed (repeat each T)) -> () {
+  func localFunc() {
+    for t in repeat each ts {
+      _ = t
+    }
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/issue-66917.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-66917.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public func values<each T>() -> (repeat (each T)?) {
+  (repeat { () -> (each T)? in
+    nil
+  }())
+}

--- a/validation-test/compiler_crashers_2_fixed/issue-69947.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-69947.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+class Thing<T> {
+  var value: T
+  init(_ value: T) { self.value = value }
+
+  func combineThings<each U>(head: Thing<T>, tail: repeat Thing<each U>) {
+    repeat (each tail).doSomething(each tail) { _ in }
+  }
+
+  func doSomething(_ value: AnyObject, closure: @escaping (T) -> Void) {}
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar113505724.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar113505724.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public struct G<T> {
+  var value: T { fatalError() }
+}
+
+public func f<T>(transform: () -> T) {}
+
+public func g<T, each V>(_ v: repeat G<each V>?, transform: (repeat (each V)?) -> T) {
+  f(transform: { transform(repeat (each v)?.value ?? nil) })
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar122293832.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar122293832.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public func withOptionalsAsPointers<T, each Opt>(
+	_ optional: repeat Optional<each Opt>,
+	body: (repeat UnsafePointer<each Opt>?) throws -> T
+) rethrows -> T {
+	return try body(repeat (each optional).map { withUnsafePointer(to: $0) { $0 } })
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar124329076.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar124329076.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+func withPointerToElements<each T, E, R>(
+    of tuple: borrowing (repeat each T),
+    _ body: (UnsafeBufferPointer<E>) -> R
+) -> R {
+    for t in repeat (each T).self {
+        if t != E.self {
+            preconditionFailure()
+        }
+    }
+    return withUnsafeBytes(of: tuple) { p in
+        return body(p.assumingMemoryBound(to: E.self))
+    }
+}


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/73685.

This implements support for autoclosures, closures and local functions nested within a pack iteration for loop, in what I believe is full generality.

Some combinations of closures also work with pack expansion expressions, but not all; this part needs more work in the solver.

General idea:
- Capture analysis records references to ElementArchetypeTypes that are defined outside of the scope of the current function.
- SIL type lowering extends the generic signature of the closure or local function with new generic parameters corresponding to the captured local archetypes.
- Interface types of AST declarations in local context may contain element archetypes; SIL type lowering maps them to interface types in the extended signature.
- SILGen lowers the code using the old generic signature's primary archetypes and local archetypes, which are out of scope, as before. A post-pass rewrites SIL instructions, replacing the old primary archetypes and local archetypes with primary archetypes for the new signature.
- SILGen rewrites substitution maps when calling a closure, forwarding substitutions for any local archetypes it captures.

When a closure doesn't capture any local archetypes, the extended generic signature is the same as the original generic signature, and we skip the substitution map transform, etc.

Fixes https://github.com/apple/swift/issues/66917.
Fixes https://github.com/apple/swift/issues/69947.
Fixes rdar://113505724.
Fixes rdar://122293832.
Fixes rdar://124329076.