### PR TITLE
[RemoteInspection] Add TypeInfoProvider to ReflectionContext function

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1276,7 +1276,9 @@ public:
   /// the superclass's fields. For a version of this function that performs the
   /// same job but starting out with an instance pointer check
   /// MetadataReader::readInstanceStartFromClassMetadata.
-  std::optional<unsigned> computeUnalignedFieldStartOffset(const TypeRef *TR) {
+  std::optional<unsigned>
+  computeUnalignedFieldStartOffset(const TypeRef *TR,
+                                   remote::TypeInfoProvider *ExternalTypeInfo) {
     size_t isaAndRetainCountSize = sizeof(StoredSize) + sizeof(long long);
 
     const TypeRef *superclass = getBuilder().lookupSuperclass(TR);
@@ -1286,12 +1288,12 @@ public:
       return isaAndRetainCountSize;
 
     auto superclassStart =
-        computeUnalignedFieldStartOffset(superclass);
+        computeUnalignedFieldStartOffset(superclass, ExternalTypeInfo);
     if (!superclassStart)
       return std::nullopt;
 
     auto *superTI = getBuilder().getTypeConverter().getClassInstanceTypeInfo(
-        superclass, *superclassStart, nullptr);
+        superclass, *superclassStart, ExternalTypeInfo);
     if (!superTI)
       return std::nullopt;
 


### PR DESCRIPTION
Explanation: Pass in a TypeInfoProvider parameter to computeUnalignedFieldStartOffset because it calls getClassInstanceTypeInfo which might need the external type info provider to find clang types.
Risk: Low, this is part of Remote Mirrors and doesn't affect the compiler. Also the change is simply threading a parameter   which was simply set as null.
Testing: Added an lldb test.
Issue: rdar://128141491
Reviewer: @adrian-prantl
Original PR: https://github.com/apple/swift/pull/73684