### PR TITLE
Re-enable StringNormalization validation test

### DIFF
--- a/validation-test/stdlib/StringNormalization.swift
+++ b/validation-test/stdlib/StringNormalization.swift
@@ -10,9 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// rdar://85480347
-// REQUIRES: rdar85480347
-
 // RUN: %empty-directory(%t)
 // RUN: %target-clang -fobjc-arc %S/Inputs/NSSlowString/NSSlowString.m -c -o %t/NSSlowString.o
 // RUN: %target-build-swift -I %S/Inputs/NSSlowString/ %t/NSSlowString.o %s -o %t/a.out


### PR DESCRIPTION
The test works for me. It's Darwin-only as well, so if it also works on CI, it's probably fine? Let's see.