### PR TITLE
[Macros] Fix source location for declaration syntax of attached macros

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -888,7 +888,7 @@ func expandAttachedMacroIPC(
 
   let declSyntax = PluginMessage.Syntax(
     syntax: Syntax(declarationNode),
-    in: customAttrSourceFilePtr
+    in: declarationSourceFilePtr
   )!
 
   let parentDeclSyntax: PluginMessage.Syntax?

--- a/test/Macros/DebugDescription/error_complex_implementation.swift
+++ b/test/Macros/DebugDescription/error_complex_implementation.swift
@@ -2,6 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -verify -plugin-path %swift-plugin-dir
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -verify -external-plugin-path %swift-plugin-dir#%swift-plugin-server
 
 @DebugDescription
 struct MyStruct {


### PR DESCRIPTION
Use the correct source file.
Previously, the location of declaration macros were sent to executable plugins as if the node were in the source file of the attribute. This was problematic when the attribute is synsthesized by a macro. When source location were used in the plugin, for example, as a diagnostic location, it ended up with an unknown location.

