### PR TITLE
Override flags that prevent package-cmo if allow-non-resilient-access is enabled

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1576,6 +1576,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
 static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
                                  DiagnosticEngine &Diags,
+                                 const LangOptions &LangOpts,
                                  const FrontendOptions &FrontendOpts) {
   using namespace options;
 
@@ -1616,17 +1617,43 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   // Check for SkipFunctionBodies arguments in order from skipping less to
   // skipping more.
   if (Args.hasArg(
-        OPT_experimental_skip_non_inlinable_function_bodies_without_types))
-    Opts.SkipFunctionBodies = FunctionBodySkipping::NonInlinableWithoutTypes;
+        OPT_experimental_skip_non_inlinable_function_bodies_without_types)) {
+    if (LangOpts.AllowNonResilientAccess)
+      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+                     "-experimental-skip-non-inlinable-function-bodies-without-types",
+                     "-experimental-allow-non-resilient-access");
+    else
+      Opts.SkipFunctionBodies = FunctionBodySkipping::NonInlinableWithoutTypes;
+  }
 
   // If asked to perform InstallAPI, go ahead and enable non-inlinable function
   // body skipping.
-  if (Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) ||
-      Args.hasArg(OPT_tbd_is_installapi))
-    Opts.SkipFunctionBodies = FunctionBodySkipping::NonInlinable;
+  if (Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies)) {
+    if (LangOpts.AllowNonResilientAccess)
+      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+                     "-experimental-skip-non-inlinable-function-bodies",
+                     "-experimental-allow-non-resilient-access");
+    else
+      Opts.SkipFunctionBodies = FunctionBodySkipping::NonInlinable;
+  }
 
-  if (Args.hasArg(OPT_experimental_skip_all_function_bodies))
-    Opts.SkipFunctionBodies = FunctionBodySkipping::All;
+  if (Args.hasArg(OPT_tbd_is_installapi)) {
+    if (LangOpts.AllowNonResilientAccess)
+      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+                     "-tbd-is-installapi",
+                     "-experimental-allow-non-resilient-access");
+    else
+      Opts.SkipFunctionBodies = FunctionBodySkipping::NonInlinable;
+  }
+
+  if (Args.hasArg(OPT_experimental_skip_all_function_bodies)) {
+    if (LangOpts.AllowNonResilientAccess)
+      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+                     "-experimental-skip-all-function-bodies",
+                     "-experimental-allow-non-resilient-access");
+    else
+      Opts.SkipFunctionBodies = FunctionBodySkipping::All;
+  }
 
   if (Opts.SkipFunctionBodies != FunctionBodySkipping::None &&
       FrontendOpts.ModuleName == SWIFT_ONONE_SUPPORT) {
@@ -1696,6 +1723,14 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
       Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
                      "-experimental-skip-non-inlinable-function-bodies-is-lazy",
                      "-enable-library-evolution");
+  }
+
+  if (LangOpts.AllowNonResilientAccess &&
+      Opts.EnableLazyTypecheck) {
+    Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+                   "-experimental-lazy-typecheck",
+                   "-experimental-allow-non-resilient-access");
+    Opts.EnableLazyTypecheck = false;
   }
 
   // HACK: The driver currently erroneously passes all flags to module interface
@@ -3423,7 +3458,7 @@ bool CompilerInvocation::parseArgs(
     return true;
   }
 
-  if (ParseTypeCheckerArgs(TypeCheckerOpts, ParsedArgs, Diags, FrontendOpts)) {
+  if (ParseTypeCheckerArgs(TypeCheckerOpts, ParsedArgs, Diags, LangOpts, FrontendOpts)) {
     return true;
   }
 

--- a/test/SILGen/package_bypass_resilience.swift
+++ b/test/SILGen/package_bypass_resilience.swift
@@ -43,8 +43,73 @@
 // RUN:   -experimental-skip-non-exportable-decls \
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
-// RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-EXP
-// CHECK-DIAG-EXP: warning: ignoring -experimental-skip-non-exportable-decls (overriden by -experimental-allow-non-resilient-access)
+// RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-1
+// CHECK-DIAG-1: warning: ignoring -experimental-skip-non-exportable-decls (overriden by -experimental-allow-non-resilient-access)
+// RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
+
+/// Override -experimental-skip-non-inlinable-function-bodies-without-types with warning
+// RUN: rm -rf %t/Utils.swiftmodule
+// RUN: %target-swift-frontend %t/Utils.swift \
+// RUN:   -module-name Utils -swift-version 5 -I %t \
+// RUN:   -package-name mypkg \
+// RUN:   -enable-library-evolution \
+// RUN:   -experimental-skip-non-inlinable-function-bodies-without-types \
+// RUN:   -experimental-allow-non-resilient-access \
+// RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
+// RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-2
+// CHECK-DIAG-2: warning: ignoring -experimental-skip-non-inlinable-function-bodies-without-types (overriden by -experimental-allow-non-resilient-access)
+// RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
+
+/// Override -experimental-skip-non-inlinable-function-bodies with warning
+// RUN: rm -rf %t/Utils.swiftmodule
+// RUN: %target-swift-frontend %t/Utils.swift \
+// RUN:   -module-name Utils -swift-version 5 -I %t \
+// RUN:   -package-name mypkg \
+// RUN:   -enable-library-evolution \
+// RUN:   -experimental-skip-non-inlinable-function-bodies \
+// RUN:   -experimental-allow-non-resilient-access \
+// RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
+// RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-3
+// CHECK-DIAG-3: warning: ignoring -experimental-skip-non-inlinable-function-bodies (overriden by -experimental-allow-non-resilient-access)
+// RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
+
+/// Override -experimental-skip-all-function-bodies with warning
+// RUN: rm -rf %t/Utils.swiftmodule
+// RUN: %target-swift-frontend %t/Utils.swift \
+// RUN:   -module-name Utils -swift-version 5 -I %t \
+// RUN:   -package-name mypkg \
+// RUN:   -enable-library-evolution \
+// RUN:   -experimental-skip-all-function-bodies \
+// RUN:   -experimental-allow-non-resilient-access \
+// RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
+// RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-4
+// CHECK-DIAG-4: warning: ignoring -experimental-skip-all-function-bodies (overriden by -experimental-allow-non-resilient-access)
+// RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
+
+/// Override -experimental-lazy-typecheck with warning
+// RUN: rm -rf %t/Utils.swiftmodule
+// RUN: %target-swift-frontend %t/Utils.swift \
+// RUN:   -module-name Utils -swift-version 5 -I %t \
+// RUN:   -package-name mypkg \
+// RUN:   -enable-library-evolution \
+// RUN:   -experimental-lazy-typecheck \
+// RUN:   -experimental-allow-non-resilient-access \
+// RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
+// RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-5
+// CHECK-DIAG-5: warning: ignoring -experimental-lazy-typecheck (overriden by -experimental-allow-non-resilient-access)
+// RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
+
+/// Override -tbd-is-installapi with warning
+// RUN: rm -rf %t/Utils.swiftmodule
+// RUN: %target-swift-frontend %t/Utils.swift \
+// RUN:   -module-name Utils -swift-version 5 -I %t \
+// RUN:   -package-name mypkg \
+// RUN:   -enable-library-evolution \
+// RUN:   -tbd-is-installapi \
+// RUN:   -experimental-allow-non-resilient-access \
+// RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
+// RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-TBD
+// CHECK-DIAG-TBD: warning: ignoring -tbd-is-installapi (overriden by -experimental-allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Build Utils interface files.


### PR DESCRIPTION
Flags that skip non-inlinable function bodies prevent serializing decls when package-cmo is enabled. 
This PR overrides such flag if allow-non-resilient-access that is a prerequisite of package-cmo is passed. 

rdar://128413200