### PR TITLE
FrontendOpts: teach the compiler to accept project name via an argument

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -541,6 +541,11 @@ def module_name : Separate<["-"], "module-name">,
   Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption,
          SwiftSymbolGraphExtractOption]>,
   HelpText<"Name of the module to build">;
+def project_name : Separate<["-"], "project-name">,
+  Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption,
+         SwiftSymbolGraphExtractOption]>,
+  HelpText<"Name of the project this module to build belongs to">;
+
 def module_name_EQ : Joined<["-"], "module-name=">, Flags<[FrontendOption]>,
   Alias<module_name>;
 


### PR DESCRIPTION
the blocklist mechanism supports using project-name as a key for specific actions. We usually retrieve that name via other means such as querying env vars, which isn't CAS friendly. Instead, we should pass the owning project name down to the compiler via a formal compiler argument.
