### PR TITLE
[RemoteInspection] Hardcode DefaultActorStorage's type info

### DIFF
--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -184,6 +184,8 @@ public:
   explicit BuiltinTypeInfo(TypeRefBuilder &builder,
                            BuiltinTypeDescriptorBase &descriptor);
 
+  explicit BuiltinTypeInfo(unsigned Size, unsigned Alignment, unsigned Stride,
+                           unsigned NumExtraInhabitants, bool BitwiseTakable);
   /// Construct an empty builtin type info.
   BuiltinTypeInfo()
       : TypeInfo(TypeInfoKind::Builtin,
@@ -367,6 +369,7 @@ class TypeConverter {
   const TypeInfo *ThinFunctionTI = nullptr;
   const TypeInfo *ThickFunctionTI = nullptr;
   const TypeInfo *AnyMetatypeTI = nullptr;
+  const TypeInfo *DefaultActorStorageTI = nullptr;
   const TypeInfo *EmptyTI = nullptr;
 
 public:
@@ -424,6 +427,7 @@ private:
   const TypeInfo *getThinFunctionTypeInfo();
   const TypeInfo *getThickFunctionTypeInfo();
   const TypeInfo *getAnyMetatypeTypeInfo();
+  const TypeInfo *getDefaultActorStorageTypeInfo();
   const TypeInfo *getEmptyTypeInfo();
 
   template <typename TypeInfoTy, typename... Args>

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1262,3 +1262,10 @@ BO
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
+
+BD
+// CHECK-64:      (builtin Builtin.DefaultActorStorage)
+// CHECK-64-NEXT:    (builtin size=96 alignment=16 stride=96 num_extra_inhabitants=0 bitwise_takable=1)
+
+// CHECK-32:      (builtin Builtin.DefaultActorStorage)
+// CHECK-32-NEXT:    (builtin size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1)


### PR DESCRIPTION
No metadata is emitted for the builtin DefaultActorStorage type. Since its layout is fixed, hardcode its definition in Remote Mirrors.

rdar://128032250
