### PR TITLE
[6.0] Suppress pointer conversion warnings for BitwiseCopyable elements.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -6170,6 +6170,11 @@ static void diagnoseImplicitRawConversion(Type sourceTy, Type pointerTy,
     return;
 
   auto *SM = SGF.getModule().getSwiftModule();
+  if (auto *bitwiseCopyableDecl = SM->getASTContext().getProtocol(
+        KnownProtocolKind::BitwiseCopyable)) {
+    if (SM->checkConformance(eltTy, bitwiseCopyableDecl))
+      return;
+  }
   if (auto *fixedWidthIntegerDecl = SM->getASTContext().getProtocol(
           KnownProtocolKind::FixedWidthInteger)) {
     if (SM->checkConformance(eltTy, fixedWidthIntegerDecl))


### PR DESCRIPTION
Now that BitwiseCopyable is accepted, it should work as the recommended workaround for unsafe pointer conversion warnings:

Forming 'UnsafeMutableRawPointer' to a variable of type 'S'; this is likely incorrect because 'S' may contain an object reference.

The check for trivial element types is in SILGenExpr, diagnoseImplicitRawConversion. For now, we can hack SILGenExpr to specifically disable the warning for BitwiseCopyable, just as it was done for FixedWidthInteger in prior releases.

Fixes rdar://128229439 (Conversion from BitwiseCopyable to UnsafeRawPointer should not warn.)

(cherry picked from commit 6bd0ef039adfa8ffe953486b42d21691f177f244)

--- CCC ---

Explanation: Suppress pointer conversion warnings for BitwiseCopyable elements.

Scope: Many Swift devs have complained about this warning and asked for a workaround. BitwiseCopyable was always the recommeded workaround, but only recently landed. Now they can deploy this workaround when building against 6.0.

Radar/SR Issue: rdar://128229439 (Conversion from BitwiseCopyable to UnsafeRawPointer should not warn.)

Original PR: https://github.com/apple/swift/pull/73687

Risk: None. This disables a warning for new adopters of BitwiseCopyable.

Testing: Dozens of unit tests.

Reviewer: @nate-chandler 