### PR TITLE
[DebugInfo] Reenable 2 failings watch tests

### DIFF
--- a/test/DebugInfo/BuiltinStdlibTypes.swift
+++ b/test/DebugInfo/BuiltinStdlibTypes.swift
@@ -1,31 +1,28 @@
 // RUN: %target-swift-frontend %s -Onone -emit-ir -gdwarf-types -o - | %FileCheck %s
 
-// rdar://124465351
-// UNSUPPORTED: OS=watchos
-
 // File is empty as this test check for the builtin stdlib types that should 
 // always be emitted.
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$sBoD", 
-// CHECK-SAME: size: 64, num_extra_inhabitants: {{2147483647|4096}}, flags: DIFlagArtificial, 
+// CHECK-SAME: size: {{64|32}}, num_extra_inhabitants: {{2147483647|4096}}, flags: DIFlagArtificial, 
 // CHECK-SAME: runtimeLang: DW_LANG_Swift)
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$syXlD", 
-// CHECK-SAME: size: 64,
+// CHECK-SAME: size: {{64|32}},
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$sBbD", 
-// CHECK-SAME: size: 64, num_extra_inhabitants: {{2147483647|4096}}, flags: DIFlagArtificial, 
+// CHECK-SAME: size: {{64|32}}, num_extra_inhabitants: {{2147483647|4096}}, flags: DIFlagArtificial, 
 // CHECK-SAME: runtimeLang: DW_LANG_Swift)
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$sBpD", 
-// CHECK-SAME: size: 64, num_extra_inhabitants: 1, flags: DIFlagArtificial, 
+// CHECK-SAME: size: {{64|32}}, num_extra_inhabitants: 1, flags: DIFlagArtificial, 
 // CHECK-SAME: runtimeLang: DW_LANG_Swift)
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$syyXfD", 
-// CHECK-SAME: size: 64, 
+// CHECK-SAME: size: {{64|32}}, 
 // CHECK-SAME: runtimeLang: DW_LANG_Swift
 
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$sypXpD", size: 64,
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$sypXpD", size: {{64|32}},
 // CHECK-SAME: flags: DIFlagArtificial, runtimeLang: DW_LANG_Swift, identifier: "$sypXpD")
 
 

--- a/test/DebugInfo/classes.swift
+++ b/test/DebugInfo/classes.swift
@@ -1,18 +1,15 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -gdwarf-types -o - | %FileCheck %s
 
-// rdar://124465351
-// UNSUPPORTED: OS=watchos
-
 class SomeClass {
   let first = 4
   let second = "Hello"
 }
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "SomeClass", 
-// CHECK-SAME: size: 64, elements: 
+// CHECK-SAME: size: {{64|32}}, elements: 
 // CHECK-SAME: runtimeLang: DW_LANG_Swift, identifier: "$s7classes9SomeClassCD")
 
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "first",
-// CHECK-SAME: size: 64)
+// CHECK-SAME: size: {{64|32}})
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "second", 
-// CHECK-SAME: size: 128, offset: 64)
+// CHECK-SAME: size: {{128|96}}, offset: {{64|32}})


### PR DESCRIPTION
Explanation: Reenables two tests that were not taking into account running in 32 bit platforms.
Risk: Low, simply fixes a test failure.
Issue: rdar://124465351
Reviewer: @adrian-prantl
Original PR: https://github.com/apple/swift/pull/73622