### PR TITLE
utils: tweak the path before using a Swift toolchain

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -867,7 +867,7 @@ function Build-CMakeProject {
 
     if ($UseBuiltCompilers.Contains("Swift")) {
       $env:Path = "$($HostArch.SDKInstallRoot)\usr\bin;$($HostArch.BinaryCache)\cmark-gfm-0.29.0.gfm.13\src;$($HostArch.ToolchainInstallRoot)\usr\bin;${env:Path}"
-    } else if ($UsePinnedCompilers.Contains("Swift")) {
+    } elseif ($UsePinnedCompilers.Contains("Swift")) {
       $env:Path = "$(Get-PinnedToolchainRuntime);${env:Path}"
     }
     Invoke-Program cmake.exe @cmakeGenerateArgs

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -866,7 +866,9 @@ function Build-CMakeProject {
     }
 
     if ($UseBuiltCompilers.Contains("Swift")) {
-      $env:Path = "$($HostArch.SDKInstallRoot)\usr\bin;$($HostArch.ToolchainInstallRoot)\usr\bin;${env:Path}"
+      $env:Path = "$($HostArch.SDKInstallRoot)\usr\bin;$($HostArch.BinaryCache)\cmark-gfm-0.29.0.gfm.13\src;$($HostArch.ToolchainInstallRoot)\usr\bin;${env:Path}"
+    } else if ($UsePinnedCompilers.Contains("Swift")) {
+      $env:Path = "$(Get-PinnedToolchainRuntime);${env:Path}"
     }
     Invoke-Program cmake.exe @cmakeGenerateArgs
 
@@ -1106,8 +1108,6 @@ function Build-Compilers() {
         SWIFT_NATIVE_SWIFT_TOOLS_PATH = $BuildTools;
       }
     }
-
-    $env:Path = "$(Get-PinnedToolchainRuntime);${env:Path}"
 
     Build-CMakeProject `
       -Src $SourceCache\llvm-project\llvm `


### PR DESCRIPTION
We need to tweak the path before we can use the pinned or the just built toolchain. This becomes a problem when trying to cross-compile the toolchain.