### PR TITLE
[stdlib] Enforce that atomic representations are BitwiseCopyable

### DIFF
--- a/stdlib/public/Synchronization/AtomicOptional.swift
+++ b/stdlib/public/Synchronization/AtomicOptional.swift
@@ -18,7 +18,7 @@ public protocol AtomicOptionalRepresentable: AtomicRepresentable {
   /// The storage representation type that encodes to and decodes from
   /// `Optional<Self>` which is a suitable type when used in atomic operations
   /// on `Optional`.
-  associatedtype AtomicOptionalRepresentation
+  associatedtype AtomicOptionalRepresentation: BitwiseCopyable
 
   /// Destroys a value of `Self` and prepares an `AtomicOptionalRepresentation`
   /// storage type to be used for atomic operations on `Optional`.

--- a/stdlib/public/Synchronization/AtomicRepresentable.swift
+++ b/stdlib/public/Synchronization/AtomicRepresentable.swift
@@ -163,7 +163,7 @@
 public protocol AtomicRepresentable {
   /// The storage representation type that `Self` encodes to and decodes from
   /// which is a suitable type when used in atomic operations.
-  associatedtype AtomicRepresentation
+  associatedtype AtomicRepresentation: BitwiseCopyable
 
   /// Destroys a value of `Self` and prepares an `AtomicRepresentation` storage
   /// type to be used for atomic operations.

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -61,7 +61,9 @@
 @frozen
 public enum Never {}
 
-extension Never: Sendable { }
+extension Never: BitwiseCopyable {}
+
+extension Never: Sendable {}
 
 extension Never: Error {}
 


### PR DESCRIPTION
Now that `BitwiseCopyable` is a thing, let's enforce that atomic representations must always be bitwise copyable. This avoids a bunch of subtle issues that can occur with @_rawLayout now like not supporting non-bitwise movable values.

Resolves rdar://128296144