### PR TITLE
[5.10] Replace assertEquals with assertEqual

### DIFF
--- a/utils/swift_build_support/tests/test_build_graph.py
+++ b/utils/swift_build_support/tests/test_build_graph.py
@@ -54,4 +54,4 @@ class BuildGraphTestCase(unittest.TestCase):
         selectedProducts = [products['swiftpm']]
         schedule = build_graph.produce_scheduled_build(selectedProducts)
         names = [x.name for x in schedule[0]]
-        self.assertEquals(['cmark', 'llvm', 'swift', 'swiftpm'], names)
+        self.assertEqual(['cmark', 'llvm', 'swift', 'swiftpm'], names)


### PR DESCRIPTION
`assertEquals` was deprecated in Python 3.3 and finally removed in Python 3.12. Replacing it with `assertEqual`.