### PR TITLE
More preconcurrency fixes

### DIFF
--- a/include/swift/Sema/Concurrency.h
+++ b/include/swift/Sema/Concurrency.h
@@ -20,12 +20,16 @@
 #ifndef SWIFT_SEMA_CONCURRENCY_H
 #define SWIFT_SEMA_CONCURRENCY_H
 
+#include <optional>
+
 namespace swift {
 
 class DeclContext;
 class SourceFile;
 class NominalTypeDecl;
 class VarDecl;
+
+enum class DiagnosticBehavior: uint8_t;
 
 /// If any of the imports in this source file was @preconcurrency but there were
 /// no diagnostics downgraded or suppressed due to that @preconcurrency, suggest
@@ -43,6 +47,12 @@ bool hasExplicitSendableConformance(NominalTypeDecl *nominal,
 /// \returns true iff a diagnostic was emitted for this reference.
 bool diagnoseNonSendableFromDeinit(
     SourceLoc refLoc, VarDecl *var, DeclContext *dc);
+
+/// Determinate the appropriate diagnostic behavior when referencing
+/// the given nominal type from the given declaration context.
+std::optional<DiagnosticBehavior>
+getConcurrencyDiagnosticBehaviorLimit(NominalTypeDecl *nominal,
+                                      const DeclContext *fromDC);
 
 } // namespace swift
 

--- a/include/swift/Sema/Concurrency.h
+++ b/include/swift/Sema/Concurrency.h
@@ -52,7 +52,8 @@ bool diagnoseNonSendableFromDeinit(
 /// the given nominal type from the given declaration context.
 std::optional<DiagnosticBehavior>
 getConcurrencyDiagnosticBehaviorLimit(NominalTypeDecl *nominal,
-                                      const DeclContext *fromDC);
+                                      const DeclContext *fromDC,
+                                      bool ignoreExplicitConformance = false);
 
 } // namespace swift
 

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -69,20 +69,7 @@ getDiagnosticBehaviorLimitForValue(SILValue value) {
     return {};
 
   auto *fromDC = declRef.getInnermostDeclContext();
-  auto attributedImport = nom->findImport(fromDC);
-  if (!attributedImport ||
-      !attributedImport->options.contains(ImportFlags::Preconcurrency))
-    return {};
-
-  if (auto *sourceFile = fromDC->getParentSourceFile())
-    sourceFile->setImportUsedPreconcurrency(*attributedImport);
-
-  if (hasExplicitSendableConformance(nom))
-    return DiagnosticBehavior::Warning;
-
-  return attributedImport->module.importedModule->isConcurrencyChecked()
-             ? DiagnosticBehavior::Warning
-             : DiagnosticBehavior::Ignore;
+  return getConcurrencyDiagnosticBehaviorLimit(nom, fromDC);
 }
 
 static std::optional<SILDeclRef> getDeclRefForCallee(SILInstruction *inst) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -835,41 +835,47 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
 }
 
 std::optional<DiagnosticBehavior>
+swift::getConcurrencyDiagnosticBehaviorLimit(NominalTypeDecl *nominal,
+                                             const DeclContext *fromDC) {
+  ModuleDecl *importedModule = nullptr;
+  if (nominal->getAttrs().hasAttribute<PreconcurrencyAttr>()) {
+    // If the declaration itself has the @preconcurrency attribute,
+    // respect it.
+    importedModule = nominal->getParentModule();
+  } else {
+    // Determine whether this nominal type is visible via a @preconcurrency
+    // import.
+    auto import = nominal->findImport(fromDC);
+    auto sourceFile = fromDC->getParentSourceFile();
+
+    if (!import || !import->options.contains(ImportFlags::Preconcurrency))
+      return std::nullopt;
+
+    if (sourceFile)
+      sourceFile->setImportUsedPreconcurrency(*import);
+
+    importedModule = import->module.importedModule;
+  }
+
+  // When the type is explicitly non-Sendable, @preconcurrency imports
+  // downgrade the diagnostic to a warning in Swift 6.
+  if (hasExplicitSendableConformance(nominal))
+    return DiagnosticBehavior::Warning;
+
+  // When the type is implicitly non-Sendable, `@preconcurrency` suppresses
+  // diagnostics until the imported module enables Swift 6.
+  return importedModule->isConcurrencyChecked()
+      ? DiagnosticBehavior::Warning
+      : DiagnosticBehavior::Ignore;
+}
+
+std::optional<DiagnosticBehavior>
 SendableCheckContext::preconcurrencyBehavior(Decl *decl) const {
   if (!decl)
     return std::nullopt;
 
   if (auto *nominal = dyn_cast<NominalTypeDecl>(decl)) {
-    ModuleDecl *importedModule = nullptr;
-    if (nominal->getAttrs().hasAttribute<PreconcurrencyAttr>()) {
-      // If the declaration itself has the @preconcurrency attribute,
-      // respect it.
-      importedModule = nominal->getParentModule();
-    } else {
-      // Determine whether this nominal type is visible via a @preconcurrency
-      // import.
-      auto import = nominal->findImport(fromDC);
-      auto sourceFile = fromDC->getParentSourceFile();
-
-      if (!import || !import->options.contains(ImportFlags::Preconcurrency))
-        return std::nullopt;
-
-      if (sourceFile)
-        sourceFile->setImportUsedPreconcurrency(*import);
-
-      importedModule = import->module.importedModule;
-    }
-
-    // When the type is explicitly non-Sendable, @preconcurrency imports
-    // downgrade the diagnostic to a warning in Swift 6.
-    if (hasExplicitSendableConformance(nominal))
-      return DiagnosticBehavior::Warning;
-
-    // When the type is implicitly non-Sendable, `@preconcurrency` suppresses
-    // diagnostics until the imported module enables Swift 6.
-    return importedModule->isConcurrencyChecked()
-        ? DiagnosticBehavior::Warning
-        : DiagnosticBehavior::Ignore;
+    return getConcurrencyDiagnosticBehaviorLimit(nominal, fromDC);
   }
 
   return std::nullopt;

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -391,7 +391,9 @@ struct SendableCheckContext {
   /// type in this context.
   DiagnosticBehavior diagnosticBehavior(NominalTypeDecl *nominal) const;
 
-  std::optional<DiagnosticBehavior> preconcurrencyBehavior(Decl *decl) const;
+  std::optional<DiagnosticBehavior> preconcurrencyBehavior(
+      Decl *decl,
+      bool ignoreExplicitConformance = false) const;
 
   /// Whether we are in an explicit conformance to Sendable.
   bool isExplicitSendableConformance() const;

--- a/test/Concurrency/Inputs/NonStrictModule.swift
+++ b/test/Concurrency/Inputs/NonStrictModule.swift
@@ -10,3 +10,8 @@ public protocol NonStrictProtocol {
   func send(_ body: @Sendable () -> Void)
   func dontSend(_ body: () -> Void)
 }
+
+open class NonStrictClass2 { }
+open class NonStrictClass3 { }
+
+public protocol MySendableProto: Sendable {}

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -63,3 +63,8 @@ struct HasStatics {
   // expected-warning@-2{{static property 'ss' is not concurrency-safe because non-'Sendable' type 'StrictStruct' may have shared mutable state}}
   // expected-note@-3{{isolate 'ss' to a global actor, or conform 'StrictStruct' to 'Sendable'}}
 }
+
+extension NonStrictClass2: @retroactive MySendableProto { }
+
+extension NonStrictClass3: @retroactive Sendable { }
+// expected-warning@-1{{conformance to 'Sendable' must occur in the same source file as class 'NonStrictClass3'; use '@unchecked Sendable' for retroactive conformance}}


### PR DESCRIPTION
Introduce more pre concurrency fixes:
* Unify code paths for determining when `@preconcurrency` applies between SIL-based diagnostics and type checker diagnostics
* Allow `@preconcurrency` to suppress a warning about a retroactive implied `Sendable` conformance.

Fixes rdar://125080066.