### PR TITLE
Don't diagnose accesses to global/static variables within the same module

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3094,6 +3094,14 @@ namespace {
         return false;
       }
 
+      // If global variable checking is enabled and the global variable is
+      // from the same module as the reference, we'll already have diagnosed
+      // the global variable itself.
+      if (ctx.LangOpts.hasFeature(Feature::GlobalConcurrency) &&
+          var->getDeclContext()->getParentModule() ==
+              getDeclContext()->getParentModule())
+        return false;
+
       const auto import = var->findImport(getDeclContext());
       const bool isPreconcurrencyImport =
           import && import->options.contains(ImportFlags::Preconcurrency);

--- a/test/Concurrency/Inputs/GlobalVariables.swift
+++ b/test/Concurrency/Inputs/GlobalVariables.swift
@@ -9,3 +9,6 @@ public struct Globals {
 
   public init() {}
 }
+
+public var mutableGlobal: String = "can't touch this"
+public var globalInt = 17

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/GlobalVariables.swiftmodule -module-name GlobalVariables %S/Inputs/GlobalVariables.swift -disable-availability-checking -parse-as-library
 
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature GlobalActorIsolatedTypesUsability %s
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature GlobalActorIsolatedTypesUsability %s
@@ -8,15 +9,10 @@
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
+import GlobalVariables
 import OtherActors // expected-warning{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'OtherActors'}}{{1-1=@preconcurrency }}
 
 let immutableGlobal: String = "hello"
-
-// expected-warning@+4 {{var 'mutableGlobal' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
-// expected-note@+3 {{convert 'mutableGlobal' to a 'let' constant to make the shared state immutable}}
-// expected-note@+2 {{restrict 'mutableGlobal' to the main actor if it will only be accessed from the main thread}}
-// expected-note@+1 {{unsafely mark 'mutableGlobal' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
-var mutableGlobal: String = "can't touch this" // expected-note 5{{var declared here}}
 
 @available(SwiftStdlib 5.1, *)
 func globalFunc() { }

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -1,5 +1,9 @@
-// RUN: %target-swift-frontend -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -disable-region-based-isolation-with-strict-concurrency
-// RUN: %target-swift-frontend -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/GlobalVariables.swiftmodule -module-name GlobalVariables %S/Inputs/GlobalVariables.swift -disable-availability-checking -parse-as-library
+
+// RUN: %target-swift-frontend -I %t -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -I %t -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -12,12 +16,7 @@ let rs = GlobalCounter() // expected-warning {{let 'rs' is not concurrency-safe 
 // expected-note@-1 {{restrict 'rs' to the main actor if it will only be accessed from the main thread}}
 // expected-note@-2 {{unsafely mark 'rs' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
 
-
-var globalInt = 17 // expected-warning {{var 'globalInt' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
-// expected-note@-1 {{restrict 'globalInt' to the main actor if it will only be accessed from the main thread}}
-// expected-note@-2 2{{var declared here}}
-// expected-note@-3 {{unsafely mark 'globalInt' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
-// expected-note@-4 {{convert 'globalInt' to a 'let' constant to make the shared state immutable}}
+import GlobalVariables
 
 class MyError: Error { // expected-warning{{non-final class 'MyError' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   var storage = 0 // expected-warning{{stored property 'storage' of 'Sendable'-conforming class 'MyError' is mutable}}

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -521,9 +521,8 @@ struct CardboardBox<T> {
 @available(SwiftStdlib 5.1, *)
 var globalVar: EscapeArtist? // expected-warning {{var 'globalVar' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
 // expected-note@-1 {{restrict 'globalVar' to the main actor if it will only be accessed from the main thread}}
-// expected-note@-2 2 {{var declared here}}
-// expected-note@-3 {{unsafely mark 'globalVar' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
-// expected-note@-4 {{convert 'globalVar' to a 'let' constant to make the shared state immutable}}
+// expected-note@-2 {{unsafely mark 'globalVar' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
+// expected-note@-3 {{convert 'globalVar' to a 'let' constant to make the shared state immutable}}
 
 @available(SwiftStdlib 5.1, *)
 actor EscapeArtist {
@@ -532,11 +531,9 @@ actor EscapeArtist {
     init(attempt1: Bool) {
         self.x = 0
 
-        // expected-note@+2 {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
-        // expected-warning@+1 {{reference to var 'globalVar' is not concurrency-safe because it involves shared mutable state}}
+        // expected-note@+1 {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
         globalVar = self
 
-        // expected-warning@+1 {{reference to var 'globalVar' is not concurrency-safe because it involves shared mutable state}}
         Task { await globalVar!.isolatedMethod() }
 
         if self.x == 0 {  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}

--- a/test/Concurrency/freestanding_top_level.swift
+++ b/test/Concurrency/freestanding_top_level.swift
@@ -1,12 +1,11 @@
 // RUN: %target-swift-frontend -concurrency-model=task-to-thread -typecheck  -verify %s
 // RUN: %target-swift-frontend -concurrency-model=task-to-thread -typecheck  -verify -verify-additional-prefix complete- -strict-concurrency=complete %s
 
-// expected-complete-warning@+5 {{var 'global' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
-// expected-complete-note@+4 {{restrict 'global' to the main actor if it will only be accessed from the main thread}}{{1-1=@MainActor }}
-// expected-complete-note@+3 {{var declared here}}
+// expected-complete-warning@+4 {{var 'global' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
+// expected-complete-note@+3 {{restrict 'global' to the main actor if it will only be accessed from the main thread}}{{1-1=@MainActor }}
 // expected-complete-note@+2 {{unsafely mark 'global' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}{{1-1=nonisolated(unsafe) }}
 // expected-complete-note@+1 {{convert 'global' to a 'let' constant to make the shared state immutable}}{{1-4=let}}
 var global = 10
 
-// expected-complete-warning@+1 {{reference to var 'global' is not concurrency-safe because it involves shared mutable state; this is an error in the Swift 6 language mode}}
+// No warning because we're in the same module.
 print(global)

--- a/test/Concurrency/global_variables.swift
+++ b/test/Concurrency/global_variables.swift
@@ -60,9 +60,8 @@ struct TestStatics {
   static let immutableInferredSendable = 0
   static var mutable = 0 // expected-error{{static property 'mutable' is not concurrency-safe because it is non-isolated global shared mutable state}}
   // expected-note@-1{{convert 'mutable' to a 'let' constant to make the shared state immutable}}
-  // expected-note@-2{{static property declared here}}
-  // expected-note@-3{{unsafely mark 'mutable' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
-  // expected-note@-4{{restrict 'mutable' to the main actor if it will only be accessed from the main thread}}
+  // expected-note@-2{{unsafely mark 'mutable' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
+  // expected-note@-3{{restrict 'mutable' to the main actor if it will only be accessed from the main thread}}
   static var computedProperty: Int { 0 } // computed property that, though static, has no storage so is not a global
   @TestWrapper static var wrapped: Int // expected-error{{static property 'wrapped' is not concurrency-safe because it is non-isolated global shared mutable state}}
   // expected-note@-1{{convert 'wrapped' to a 'let' constant to make the shared state immutable}}{{23-26=let}}
@@ -79,7 +78,7 @@ public actor TestPublicActor {
 func f() {
   print(TestStatics.immutableExplicitSendable)
   print(TestStatics.immutableInferredSendable)
-  print(TestStatics.mutable) // expected-error{{reference to static property 'mutable' is not concurrency-safe because it involves shared mutable state}}
+  print(TestStatics.mutable)
   print(Globals.actorInteger) // expected-error{{main actor-isolated static property 'actorInteger' can not be referenced from global actor 'TestGlobalActor'}}
 }
 


### PR DESCRIPTION
When [SE-0412](https://apple.github.io/swift-evolution/#?proposal=SE-0412) (strict concurrency for global variables) is enabled, each
global or static mutable variable will be diagnosed if it isn't
explicitly on a global actor or `nonisolated(unsafe)`.

Suppress diagnostics for references to such global variables when they
are in the same module as the declaration of the global variable
itself. While these diagnostics are technically correct, they are not
strictly necessary since we've already diagnosed the global variable
itself (with more actionable advice), and they tend to pile on the
developer in a manner that is not helpful.