### PR TITLE
Suggest `@preconcurrency` on conformances it could help

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2655,6 +2655,8 @@ WARNING(add_predates_concurrency_import,none,
      "%select{| as warnings}0", (bool, Identifier))
 WARNING(remove_predates_concurrency_import,none,
      "'@preconcurrency' attribute on module %0 has no effect", (Identifier))
+NOTE(add_preconcurrency_to_conformance,none,
+     "add '@preconcurrency' to the %0 conformance to suppress isolation-related diagnostics", (DeclName))
 WARNING(remove_public_import,none,
         "public import of %0 was not used in public declarations or inlinable code",
         (const ModuleDecl *))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2656,7 +2656,7 @@ WARNING(add_predates_concurrency_import,none,
 WARNING(remove_predates_concurrency_import,none,
      "'@preconcurrency' attribute on module %0 has no effect", (Identifier))
 NOTE(add_preconcurrency_to_conformance,none,
-     "add '@preconcurrency' to the %0 conformance to suppress isolation-related diagnostics", (DeclName))
+     "add '@preconcurrency' to the %0 conformance to defer isolation checking to run time", (DeclName))
 WARNING(remove_public_import,none,
         "public import of %0 was not used in public declarations or inlinable code",
         (const ModuleDecl *))
@@ -5617,12 +5617,12 @@ ERROR(shared_immutable_state_decl,none,
       "shared mutable state",
       (Type, const ValueDecl *))
 NOTE(shared_state_make_immutable,none,
-     "convert %0 to a 'let' constant to make the shared state immutable",
+     "convert %0 to a 'let' constant to make 'Sendable' shared state immutable",
      (const ValueDecl *))
 NOTE(shared_state_main_actor_node,none,
-     "restrict %0 to the main actor if it will only be accessed from the main thread", (const ValueDecl *))
+     "annotate %0 with '@MainActor' if property should only be accessed from the main actor", (const ValueDecl *))
 NOTE(shared_state_nonisolated_unsafe,none,
-     "unsafely mark %0 as concurrency-safe if all accesses are protected by an external synchronization mechanism", (const ValueDecl *))
+     "disable concurrency-safety checks if accesses are protected by an external synchronization mechanism", (const ValueDecl *))
 ERROR(actor_isolated_witness,none,
      "%select{|distributed }0%1 %kind2 cannot be used to satisfy %3 protocol "
      "requirement",

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -530,6 +530,9 @@ class NormalProtocolConformance : public RootProtocolConformance,
   /// The location of this protocol conformance in the source.
   SourceLoc Loc;
 
+  /// The location of the protocol name within the conformance.
+  SourceLoc ProtocolNameLoc;
+
   /// The location of the `@preconcurrency` attribute, if any.
   SourceLoc PreconcurrencyLoc;
 
@@ -569,7 +572,8 @@ public:
                             SourceLoc preconcurrencyLoc)
       : RootProtocolConformance(ProtocolConformanceKind::Normal,
                                 conformingType),
-        Protocol(protocol), Loc(loc), PreconcurrencyLoc(preconcurrencyLoc),
+        Protocol(protocol), Loc(extractNearestSourceLoc(dc)),
+        ProtocolNameLoc(loc), PreconcurrencyLoc(preconcurrencyLoc),
         Context(dc) {
     assert(!conformingType->hasArchetype() &&
            "ProtocolConformances should store interface types");
@@ -589,6 +593,9 @@ public:
 
   /// Retrieve the location of this conformance.
   SourceLoc getLoc() const { return Loc; }
+
+  /// Retrieve the name of the protocol location.
+  SourceLoc getProtocolNameLoc() const { return ProtocolNameLoc; }
 
   /// Get the declaration context that contains the conforming extension or
   /// nominal type declaration.

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -573,6 +573,8 @@ public:
         Context(dc) {
     assert(!conformingType->hasArchetype() &&
            "ProtocolConformances should store interface types");
+    assert((preconcurrencyLoc.isInvalid() || isPreconcurrency) &&
+           "Cannot have a @preconcurrency location without isPreconcurrency");
     setState(state);
     Bits.NormalProtocolConformance.IsInvalid = false;
     Bits.NormalProtocolConformance.IsUnchecked = isUnchecked;

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -969,10 +969,11 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
     assert(!isa<ProtocolDecl>(conformingDC->getSelfNominalTypeDecl()));
     Type conformingType = conformingDC->getSelfInterfaceType();
 
-    SourceLoc conformanceLoc
-      = conformingNominal == conformingDC
-          ? conformingNominal->getLoc()
-          : cast<ExtensionDecl>(conformingDC)->getLoc();
+    SourceLoc conformanceLoc =
+      entry->getLoc().isValid() ? entry->getLoc()
+        : (conformingNominal == conformingDC
+             ? conformingNominal->getLoc()
+             : cast<ExtensionDecl>(conformingDC)->getLoc());
 
     NormalProtocolConformance *implyingConf = nullptr;
     if (entry->Source.getKind() == ConformanceEntryKind::Implied) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3313,10 +3313,10 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
         !Conformance->isPreconcurrency() &&
         !suggestedPreconcurrency &&
         !requirementIsolation.isActorIsolated()) {
-      Context.Diags.diagnose(Conformance->getLoc(),
+      Context.Diags.diagnose(Conformance->getProtocolNameLoc(),
                              diag::add_preconcurrency_to_conformance,
                              Proto->getName())
-          .fixItInsert(Conformance->getLoc(), "@preconcurrency ");
+          .fixItInsert(Conformance->getProtocolNameLoc(), "@preconcurrency ");
       suggestedPreconcurrency = true;
     }
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2063,7 +2063,7 @@ static void diagnoseConformanceImpliedByConditionalConformance(
   auto proto = conformance->getProtocol();
   Type protoType = proto->getDeclaredInterfaceType();
   auto implyingProto = implyingConf->getProtocol()->getDeclaredInterfaceType();
-  auto loc = implyingConf->getLoc();
+  auto loc = extractNearestSourceLoc(implyingConf->getDeclContext());
   Diags.diagnose(loc, diag::conditional_conformances_cannot_imply_conformances,
                  conformance->getType(), implyingProto, protoType);
 
@@ -3297,13 +3297,28 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
     missingOptions -= MissingFlags::WitnessDistributed;
   }
 
-  // One way to address the issue is to make the witness function nonisolated.
-  if ((isa<AbstractFunctionDecl>(witness) || isa<SubscriptDecl>(witness)) &&
-      !hasExplicitGlobalActorAttr(witness) &&
-      !isDistributedDecl(requirement) &&
-      !isDistributedDecl(witness)) {
-    witness->diagnose(diag::note_add_nonisolated_to_decl, witness)
-          .fixItInsert(witness->getAttributeInsertionLoc(true), "nonisolated ");
+  // If 'nonisolated' or 'preconcurrency' might help us, provide those as
+  // options.
+  if (!isDistributedDecl(requirement) && !isDistributedDecl(witness)) {
+    // One way to address the issue is to make the witness function nonisolated.
+    if ((isa<AbstractFunctionDecl>(witness) || isa<SubscriptDecl>(witness)) &&
+        !hasExplicitGlobalActorAttr(witness)) {
+      witness->diagnose(diag::note_add_nonisolated_to_decl, witness)
+            .fixItInsert(witness->getAttributeInsertionLoc(true), "nonisolated ");
+    }
+
+    // Another way to address the issue is to mark the conformance as
+    // "preconcurrency".
+    if (Conformance->getSourceKind() == ConformanceEntryKind::Explicit &&
+        !Conformance->isPreconcurrency() &&
+        !suggestedPreconcurrency &&
+        !requirementIsolation.isActorIsolated()) {
+      Context.Diags.diagnose(Conformance->getLoc(),
+                             diag::add_preconcurrency_to_conformance,
+                             Proto->getName())
+          .fixItInsert(Conformance->getLoc(), "@preconcurrency ");
+      suggestedPreconcurrency = true;
+    }
   }
 
   // If there are remaining options, they are missing async/throws on the

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5141,9 +5141,8 @@ void ConformanceChecker::resolveValueWitnesses() {
 
     SourceLoc preconcurrencyLoc = Conformance->getPreconcurrencyLoc();
     if (preconcurrencyLoc.isValid()) {
-      SourceLoc endLoc =
-          preconcurrencyLoc.getAdvancedLoc(strlen("@preconcurrency "));
-      diag.fixItRemoveChars(preconcurrencyLoc, endLoc);
+      SourceLoc endLoc = preconcurrencyLoc.getAdvancedLoc(1);
+      diag.fixItRemove(SourceRange(preconcurrencyLoc, endLoc));
     }
   }
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -112,6 +112,9 @@ enum class ResolveWitnessResult {
 /// This helper class handles most of the details of checking whether a
 /// given type (\c Adoptee) conforms to a protocol (\c Proto).
 class ConformanceChecker : public WitnessChecker {
+  /// Whether we already suggested adding `@preconcurrency`.
+  bool suggestedPreconcurrency = false;
+
 public:
   NormalProtocolConformance *Conformance;
   SourceLoc Loc;

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -9,7 +9,7 @@ import APINotesFrameworkTest
 
 // CHECK-DIAGS-5-NOT: versioned-objc.swift:[[@LINE-1]]:
 class ProtoWithVersionedUnavailableMemberImpl: ProtoWithVersionedUnavailableMember {
-  // CHECK-DIAGS-4: versioned-objc.swift:[[@LINE-1]]:48: error: type 'ProtoWithVersionedUnavailableMemberImpl' cannot conform to protocol 'ProtoWithVersionedUnavailableMember' because it has requirements that cannot be satisfied
+  // CHECK-DIAGS-4: versioned-objc.swift:[[@LINE-1]]:7: error: type 'ProtoWithVersionedUnavailableMemberImpl' cannot conform to protocol 'ProtoWithVersionedUnavailableMember' because it has requirements that cannot be satisfied
   func requirement() -> Any? { return nil }
 }
 

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -9,7 +9,7 @@ import APINotesFrameworkTest
 
 // CHECK-DIAGS-5-NOT: versioned-objc.swift:[[@LINE-1]]:
 class ProtoWithVersionedUnavailableMemberImpl: ProtoWithVersionedUnavailableMember {
-  // CHECK-DIAGS-4: versioned-objc.swift:[[@LINE-1]]:7: error: type 'ProtoWithVersionedUnavailableMemberImpl' cannot conform to protocol 'ProtoWithVersionedUnavailableMember' because it has requirements that cannot be satisfied
+  // CHECK-DIAGS-4: versioned-objc.swift:[[@LINE-1]]:48: error: type 'ProtoWithVersionedUnavailableMemberImpl' cannot conform to protocol 'ProtoWithVersionedUnavailableMember' because it has requirements that cannot be satisfied
   func requirement() -> Any? { return nil }
 }
 

--- a/test/Concurrency/Inputs/sendable_cycle_other.swift
+++ b/test/Concurrency/Inputs/sendable_cycle_other.swift
@@ -1,5 +1,5 @@
 struct Foo {
   static let member = Bar() // expected-complete-warning {{static property 'member' is not concurrency-safe because non-'Sendable' type 'Bar' may have shared mutable state; this is an error in the Swift 6 language mode}}
-  // expected-complete-note@-1 {{restrict 'member' to the main actor if it will only be accessed from the main thread}}
-  // expected-complete-note@-2{{unsafely mark 'member' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
+  // expected-complete-note@-1 {{annotate 'member' with '@MainActor' if property should only be accessed from the main actor}}
+  // expected-complete-note@-2{{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1586,6 +1586,8 @@ protocol NonisolatedProtocol {
 }
 
 actor ActorWithNonSendableLet: NonisolatedProtocol {
+  // expected-note@-1{{add '@preconcurrency' to the 'NonisolatedProtocol' conformance to suppress isolation-related diagnostics}}{{32-32=@preconcurrency }}
+
   // expected-warning@+1 {{actor-isolated property 'ns' cannot be used to satisfy nonisolated protocol requirement; this is an error in the Swift 6 language mode}}
   let ns = NonSendable()
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1586,7 +1586,7 @@ protocol NonisolatedProtocol {
 }
 
 actor ActorWithNonSendableLet: NonisolatedProtocol {
-  // expected-note@-1{{add '@preconcurrency' to the 'NonisolatedProtocol' conformance to suppress isolation-related diagnostics}}{{32-32=@preconcurrency }}
+  // expected-note@-1{{add '@preconcurrency' to the 'NonisolatedProtocol' conformance to defer isolation checking to run time}}{{32-32=@preconcurrency }}
 
   // expected-warning@+1 {{actor-isolated property 'ns' cannot be used to satisfy nonisolated protocol requirement; this is an error in the Swift 6 language mode}}
   let ns = NonSendable()

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -13,8 +13,8 @@ class GlobalCounter { // expected-note{{class 'GlobalCounter' does not conform t
 }
 
 let rs = GlobalCounter() // expected-warning {{let 'rs' is not concurrency-safe because non-'Sendable' type 'GlobalCounter' may have shared mutable state; this is an error in the Swift 6 language mode}}
-// expected-note@-1 {{restrict 'rs' to the main actor if it will only be accessed from the main thread}}
-// expected-note@-2 {{unsafely mark 'rs' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
+// expected-note@-1 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
+// expected-note@-2 {{annotate 'rs' with '@MainActor' if property should only be accessed from the main actor}}
 
 import GlobalVariables
 

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -274,9 +274,9 @@ typealias BadGenericCF<T> = @Sendable () -> T?
 typealias GoodGenericCF<T: Sendable> = @Sendable () -> T? // okay
 
 var concurrentFuncVar: (@Sendable (NotConcurrent) -> Void)? = nil // expected-warning{{var 'concurrentFuncVar' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
-// expected-note@-1 {{restrict 'concurrentFuncVar' to the main actor if it will only be accessed from the main thread}}
-// expected-note@-2 {{unsafely mark 'concurrentFuncVar' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
-// expected-note@-3 {{convert 'concurrentFuncVar' to a 'let' constant to make the shared state immutable}}
+// expected-note@-1 {{annotate 'concurrentFuncVar' with '@MainActor' if property should only be accessed from the main actor}}
+// expected-note@-2 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
+// expected-note@-3 {{convert 'concurrentFuncVar' to a 'let' constant to make 'Sendable' shared state immutable}}
 
 // ----------------------------------------------------------------------
 // Sendable restriction on @Sendable closures.

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -520,9 +520,9 @@ struct CardboardBox<T> {
 
 @available(SwiftStdlib 5.1, *)
 var globalVar: EscapeArtist? // expected-warning {{var 'globalVar' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
-// expected-note@-1 {{restrict 'globalVar' to the main actor if it will only be accessed from the main thread}}
-// expected-note@-2 {{unsafely mark 'globalVar' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
-// expected-note@-3 {{convert 'globalVar' to a 'let' constant to make the shared state immutable}}
+// expected-note@-1 {{annotate 'globalVar' with '@MainActor' if property should only be accessed from the main actor}}
+// expected-note@-2 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
+// expected-note@-3 {{convert 'globalVar' to a 'let' constant to make 'Sendable' shared state immutable}}
 
 @available(SwiftStdlib 5.1, *)
 actor EscapeArtist {

--- a/test/Concurrency/freestanding_top_level.swift
+++ b/test/Concurrency/freestanding_top_level.swift
@@ -2,9 +2,9 @@
 // RUN: %target-swift-frontend -concurrency-model=task-to-thread -typecheck  -verify -verify-additional-prefix complete- -strict-concurrency=complete %s
 
 // expected-complete-warning@+4 {{var 'global' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
-// expected-complete-note@+3 {{restrict 'global' to the main actor if it will only be accessed from the main thread}}{{1-1=@MainActor }}
-// expected-complete-note@+2 {{unsafely mark 'global' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}{{1-1=nonisolated(unsafe) }}
-// expected-complete-note@+1 {{convert 'global' to a 'let' constant to make the shared state immutable}}{{1-4=let}}
+// expected-complete-note@+3 {{annotate 'global' with '@MainActor' if property should only be accessed from the main actor}}{{1-1=@MainActor }}
+// expected-complete-note@+2 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}{{1-1=nonisolated(unsafe) }}
+// expected-complete-note@+1 {{convert 'global' to a 'let' constant to make 'Sendable' shared state immutable}}{{1-4=let}}
 var global = 10
 
 // No warning because we're in the same module.

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -117,7 +117,7 @@ protocol Interface {
 
 @MainActor
 class Object: Interface {
-  // expected-note@-1{{add '@preconcurrency' to the 'Interface' conformance to suppress isolation-related diagnostics}}{{15-15=@preconcurrency }}
+  // expected-note@-1{{add '@preconcurrency' to the 'Interface' conformance to defer isolation checking to run time}}{{15-15=@preconcurrency }}
 
   var baz: Int = 42 // expected-warning{{main actor-isolated property 'baz' cannot be used to satisfy nonisolated protocol requirement}}
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -117,6 +117,8 @@ protocol Interface {
 
 @MainActor
 class Object: Interface {
+  // expected-note@-1{{add '@preconcurrency' to the 'Interface' conformance to suppress isolation-related diagnostics}}{{15-15=@preconcurrency }}
+
   var baz: Int = 42 // expected-warning{{main actor-isolated property 'baz' cannot be used to satisfy nonisolated protocol requirement}}
 }
 

--- a/test/Concurrency/global_variables.swift
+++ b/test/Concurrency/global_variables.swift
@@ -15,9 +15,9 @@ actor TestGlobalActor {
 var mutableIsolatedGlobal = 1
 
 var mutableNonisolatedGlobal = 1 // expected-error{{var 'mutableNonisolatedGlobal' is not concurrency-safe because it is non-isolated global shared mutable state}}
-// expected-note@-1{{restrict 'mutableNonisolatedGlobal' to the main actor if it will only be accessed from the main thread}}{{1-1=@MainActor }}
-// expected-note@-2{{unsafely mark 'mutableNonisolatedGlobal' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}{{1-1=nonisolated(unsafe) }}
-// expected-note@-3{{convert 'mutableNonisolatedGlobal' to a 'let' constant to make the shared state immutable}}{{1-4=let}}
+// expected-note@-1{{annotate 'mutableNonisolatedGlobal' with '@MainActor' if property should only be accessed from the main actor}}{{1-1=@MainActor }}
+// expected-note@-2{{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}{{1-1=nonisolated(unsafe) }}
+// expected-note@-3{{convert 'mutableNonisolatedGlobal' to a 'let' constant to make 'Sendable' shared state immutable}}{{1-4=let}}
 
 let immutableGlobal = 1
 
@@ -48,25 +48,25 @@ actor TestActor {
 struct TestStatics {
   static let immutableExplicitSendable = TestSendable()
   static let immutableNonsendable = TestNonsendable() // expected-error{{static property 'immutableNonsendable' is not concurrency-safe because non-'Sendable' type 'TestNonsendable' may have shared mutable state}}
-  // expected-note@-1 {{restrict 'immutableNonsendable' to the main actor if it will only be accessed from the main thread}}
-  // expected-note@-2 {{unsafely mark 'immutableNonsendable' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
+  // expected-note@-1 {{annotate 'immutableNonsendable' with '@MainActor' if property should only be accessed from the main actor}}
+  // expected-note@-2 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
   static nonisolated(unsafe) let immutableNonisolatedUnsafe = TestNonsendable()
   static nonisolated let immutableNonisolated = TestNonsendable() // expected-error{{static property 'immutableNonisolated' is not concurrency-safe because non-'Sendable' type 'TestNonsendable' may have shared mutable state}}
-  // expected-note@-1 {{restrict 'immutableNonisolated' to the main actor if it will only be accessed from the main thread}}
+  // expected-note@-1 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
   // expected-error@-2 {{'nonisolated' can not be applied to variable with non-'Sendable' type 'TestNonsendable'}}
-  // expected-note@-3{{unsafely mark 'immutableNonisolated' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
+  // expected-note@-3{{annotate 'immutableNonisolated' with '@MainActor' if property should only be accessed from the main actor}}
   static nonisolated(unsafe) let immutableNonisolatedUnsafeSendable = TestSendable()
   // expected-warning@-1 {{'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'TestSendable', consider removing it}} {{10-30=}}
   static let immutableInferredSendable = 0
   static var mutable = 0 // expected-error{{static property 'mutable' is not concurrency-safe because it is non-isolated global shared mutable state}}
-  // expected-note@-1{{convert 'mutable' to a 'let' constant to make the shared state immutable}}
-  // expected-note@-2{{unsafely mark 'mutable' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
-  // expected-note@-3{{restrict 'mutable' to the main actor if it will only be accessed from the main thread}}
+  // expected-note@-1{{convert 'mutable' to a 'let' constant to make 'Sendable' shared state immutable}}
+  // expected-note@-2{{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
+  // expected-note@-3{{annotate 'mutable' with '@MainActor' if property should only be accessed from the main actor}}
   static var computedProperty: Int { 0 } // computed property that, though static, has no storage so is not a global
   @TestWrapper static var wrapped: Int // expected-error{{static property 'wrapped' is not concurrency-safe because it is non-isolated global shared mutable state}}
-  // expected-note@-1{{convert 'wrapped' to a 'let' constant to make the shared state immutable}}{{23-26=let}}
-  // expected-note@-2{{unsafely mark 'wrapped' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}{{16-16=nonisolated(unsafe) }}
-  // expected-note@-3{{restrict 'wrapped' to the main actor if it will only be accessed from the main thread}}{{3-3=@MainActor }}
+  // expected-note@-1{{convert 'wrapped' to a 'let' constant to make 'Sendable' shared state immutable}}{{23-26=let}}
+  // expected-note@-2{{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}{{16-16=nonisolated(unsafe) }}
+  // expected-note@-3{{annotate 'wrapped' with '@MainActor' if property should only be accessed from the main actor}}{{3-3=@MainActor }}
 }
 
 public actor TestPublicActor {

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -101,7 +101,7 @@ final class K : @preconcurrency Initializable {
 
 @MainActor
 final class MainActorK: Initializable {
-  // expected-note@-1{{add '@preconcurrency' to the 'Initializable' conformance to suppress isolation-related diagnostics}}{{25-25=@preconcurrency }}
+  // expected-note@-1{{add '@preconcurrency' to the 'Initializable' conformance to defer isolation checking to run time}}{{25-25=@preconcurrency }}
   init() { } // expected-warning{{main actor-isolated initializer 'init()' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@-1{{add 'nonisolated' to 'init()' to make this initializer not isolated to the actor}}
 }

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -91,11 +91,19 @@ extension MyActor : @preconcurrency TestSendability {
 
 protocol Initializable {
   init()
+  // expected-note@-1{{mark the protocol requirement 'init()' 'async' to allow actor-isolated conformances}}
 }
 
 final class K : @preconcurrency Initializable {
   // expected-warning@-1 {{@preconcurrency attribute on conformance to 'Initializable' has no effect}}
   init() {} // Ok
+}
+
+@MainActor
+final class MainActorK: Initializable {
+  // expected-note@-1{{add '@preconcurrency' to the 'Initializable' conformance to suppress isolation-related diagnostics}}{{25-25=@preconcurrency }}
+  init() { } // expected-warning{{main actor-isolated initializer 'init()' cannot be used to satisfy nonisolated protocol requirement}}
+  // expected-note@-1{{add 'nonisolated' to 'init()' to make this initializer not isolated to the actor}}
 }
 
 protocol WithAssoc {

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -231,7 +231,7 @@ protocol NotIsolated {
 
 extension MainActorPreconcurrency: NotIsolated {
   // expected-complete-note@-1{{add '@preconcurrency' to the 'NotIsolated' conformance to suppress isolation-related diagnostics}}{{36-36=@preconcurrency }}
-  // expected-complete-tns-note@-2{{add '@preconcurrency' to the 'NotIsolated' conformance to suppress isolation-related diagnostics}}{{36-36=@preconcurrency }}
+  // expected-complete-tns-note@-2{{add '@preconcurrency' to the 'NotIsolated' conformance to defer isolation checking to run time}}{{36-36=@preconcurrency }}
 
   func requirement() {}
   // expected-complete-tns-warning@-1 {{main actor-isolated instance method 'requirement()' cannot be used to satisfy nonisolated protocol requirement}}

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -230,6 +230,9 @@ protocol NotIsolated {
 }
 
 extension MainActorPreconcurrency: NotIsolated {
+  // expected-complete-note@-1{{add '@preconcurrency' to the 'NotIsolated' conformance to suppress isolation-related diagnostics}}{{36-36=@preconcurrency }}
+  // expected-complete-tns-note@-2{{add '@preconcurrency' to the 'NotIsolated' conformance to suppress isolation-related diagnostics}}{{36-36=@preconcurrency }}
+
   func requirement() {}
   // expected-complete-tns-warning@-1 {{main actor-isolated instance method 'requirement()' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-complete-tns-note@-2 {{add 'nonisolated' to 'requirement()' to make this instance method not isolated to the actor}}

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -44,8 +44,8 @@ func test(
 let nonStrictGlobal = NonStrictClass() // no warning
 
 let strictGlobal = StrictStruct() // expected-warning{{let 'strictGlobal' is not concurrency-safe because non-'Sendable' type 'StrictStruct' may have shared mutable state}}
-// expected-note@-1{{restrict 'strictGlobal' to the main actor if it will only be accessed from the main thread}}
-// expected-note@-2{{unsafely mark 'strictGlobal' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
+// expected-note@-1{{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
+// expected-note@-2{{annotate 'strictGlobal' with '@MainActor' if property should only be accessed from the main actor}}
 
 extension NonStrictClass {
   @Sendable func f() { }
@@ -62,8 +62,8 @@ struct HasStatics {
   nonisolated static let ss: StrictStruct = StrictStruct()
   // expected-warning@-1{{'nonisolated' can not be applied to variable with non-'Sendable' type 'StrictStruct'}}
   // expected-warning@-2{{static property 'ss' is not concurrency-safe because non-'Sendable' type 'StrictStruct' may have shared mutable state}}
-  // expected-note@-3{{restrict 'ss' to the main actor if it will only be accessed from the main thread}}
-  // expected-note@-4{{unsafely mark 'ss' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
+  // expected-note@-3{{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
+  // expected-note@-4{{annotate 'ss' with '@MainActor' if property should only be accessed from the main actor}}
 }
 
 extension NonStrictClass2: @retroactive MySendableProto { }

--- a/test/Concurrency/predates_concurrency_import_swift6.swift
+++ b/test/Concurrency/predates_concurrency_import_swift6.swift
@@ -18,8 +18,8 @@ func test(ss: StrictStruct, ns: NonStrictClass) {
 
 let nonStrictGlobal = NonStrictClass()
 let strictGlobal = StrictStruct() // expected-warning{{let 'strictGlobal' is not concurrency-safe because non-'Sendable' type 'StrictStruct' may have shared mutable state}}
-// expected-note@-1{{restrict 'strictGlobal' to the main actor if it will only be accessed from the main thread}}
-// expected-note@-2{{unsafely mark 'strictGlobal' as concurrency-safe if all accesses are protected by an external synchronization mechanism}}
+// expected-note@-1{{annotate 'strictGlobal' with '@MainActor' if property should only be accessed from the main actor}}
+// expected-note@-2{{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
 
 extension NonStrictClass {
   @Sendable func f() { }

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -106,7 +106,7 @@ protocol StrictlyLocal {
 }
 
 distributed actor Nope1_StrictlyLocal: StrictlyLocal {
-  // expected-note@-1{{add '@preconcurrency' to the 'StrictlyLocal' conformance to suppress isolation-related diagnostics}}
+  // expected-note@-1{{add '@preconcurrency' to the 'StrictlyLocal' conformance to defer isolation checking to run time}}
 
   func local() {}
   // expected-error@-1{{distributed actor-isolated instance method 'local()' cannot be used to satisfy nonisolated protocol requirement}}
@@ -159,7 +159,7 @@ actor LocalOK_ImplicitlyThrowsAsync_AsyncThrowsAll: AsyncThrowsAll {
 }
 
 distributed actor Nope1_AsyncThrowsAll: AsyncThrowsAll {
-  // expected-note@-1{{add '@preconcurrency' to the 'AsyncThrowsAll' conformance to suppress isolation-related diagnostics}}
+  // expected-note@-1{{add '@preconcurrency' to the 'AsyncThrowsAll' conformance to defer isolation checking to run time}}
 
   func maybe(param: String, int: Int) async throws -> Int { 111 }
   // expected-error@-1{{distributed actor-isolated instance method 'maybe(param:int:)' cannot be used to satisfy nonisolated protocol requirement}}
@@ -206,7 +206,7 @@ func test_watching_A(a: A_TerminationWatchingA) async throws {
 }
 
 distributed actor DA_TerminationWatchingA: TerminationWatchingA {
-  // expected-note@-1{{add '@preconcurrency' to the 'TerminationWatchingA' conformance to suppress isolation-related diagnostics}}
+  // expected-note@-1{{add '@preconcurrency' to the 'TerminationWatchingA' conformance to defer isolation checking to run time}}
 
   func terminated(a: String) { }
   // expected-error@-1{{distributed actor-isolated instance method 'terminated(a:)' cannot be used to satisfy nonisolated protocol requirement}}

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -106,6 +106,8 @@ protocol StrictlyLocal {
 }
 
 distributed actor Nope1_StrictlyLocal: StrictlyLocal {
+  // expected-note@-1{{add '@preconcurrency' to the 'StrictlyLocal' conformance to suppress isolation-related diagnostics}}
+
   func local() {}
   // expected-error@-1{{distributed actor-isolated instance method 'local()' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@-2{{add 'nonisolated' to 'local()' to make this instance method not isolated to the actor}}
@@ -157,6 +159,8 @@ actor LocalOK_ImplicitlyThrowsAsync_AsyncThrowsAll: AsyncThrowsAll {
 }
 
 distributed actor Nope1_AsyncThrowsAll: AsyncThrowsAll {
+  // expected-note@-1{{add '@preconcurrency' to the 'AsyncThrowsAll' conformance to suppress isolation-related diagnostics}}
+
   func maybe(param: String, int: Int) async throws -> Int { 111 }
   // expected-error@-1{{distributed actor-isolated instance method 'maybe(param:int:)' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@-2{{add 'nonisolated' to 'maybe(param:int:)' to make this instance method not isolated to the actor}}
@@ -202,6 +206,8 @@ func test_watching_A(a: A_TerminationWatchingA) async throws {
 }
 
 distributed actor DA_TerminationWatchingA: TerminationWatchingA {
+  // expected-note@-1{{add '@preconcurrency' to the 'TerminationWatchingA' conformance to suppress isolation-related diagnostics}}
+
   func terminated(a: String) { }
   // expected-error@-1{{distributed actor-isolated instance method 'terminated(a:)' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@-2{{add 'nonisolated' to 'terminated(a:)' to make this instance method not isolated to the actor}}

--- a/test/Sema/extension_retroactive_conformances.swift
+++ b/test/Sema/extension_retroactive_conformances.swift
@@ -83,11 +83,11 @@ protocol ClientProtocol {}
 // ok, conforming a type from another module to a protocol within this module is totally fine
 extension Sample1: ClientProtocol {}
 
-struct Sample7: @retroactive SampleProtocol1 {} // expected-error {{'retroactive' attribute only applies in inheritance clauses in extensions}}
+struct Sample7: @retroactive SampleProtocol1 {} // expected-error {{'retroactive' attribute only applies in inheritance clauses in extensions}}{{17-30=}}
 
-extension Sample7: @retroactive ClientProtocol {} // expected-warning {{'retroactive' attribute does not apply; 'Sample7' is declared in this module}}
+extension Sample7: @retroactive ClientProtocol {} // expected-warning {{'retroactive' attribute does not apply; 'Sample7' is declared in this module}}{{20-33=}}
 
-extension Int: @retroactive ClientProtocol {} // expected-warning {{'retroactive' attribute does not apply; 'ClientProtocol' is declared in this module}}
+extension Int: @retroactive ClientProtocol {} // expected-warning {{'retroactive' attribute does not apply; 'ClientProtocol' is declared in this module}}{{16-29=}}
 
 func f(_ x: @retroactive Int) {} // expected-error {{'retroactive' attribute only applies in inheritance clauses in extensions}}
 

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -36,6 +36,8 @@ protocol SyncProtocol {
 
 
 actor OtherActor: SyncProtocol {
+  // expected-note@-1{{add '@preconcurrency' to the 'SyncProtocol' conformance to suppress isolation-related diagnostics}}{{19-19=@preconcurrency }}
+
   var propertyB: Int = 17
   // expected-error@-1{{actor-isolated property 'propertyB' cannot be used to satisfy nonisolated protocol requirement}}
 

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -36,7 +36,7 @@ protocol SyncProtocol {
 
 
 actor OtherActor: SyncProtocol {
-  // expected-note@-1{{add '@preconcurrency' to the 'SyncProtocol' conformance to suppress isolation-related diagnostics}}{{19-19=@preconcurrency }}
+  // expected-note@-1{{add '@preconcurrency' to the 'SyncProtocol' conformance to defer isolation checking to run time}}{{19-19=@preconcurrency }}
 
   var propertyB: Int = 17
   // expected-error@-1{{actor-isolated property 'propertyB' cannot be used to satisfy nonisolated protocol requirement}}

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -30,6 +30,8 @@ protocol P2 {
 }
 
 class C1 : P1, P2 {
+  // expected-note@-1{{add '@preconcurrency' to the 'P1' conformance to suppress isolation-related diagnostics}}
+
   typealias Assoc = String
 
   func method1() { }
@@ -52,6 +54,8 @@ protocol NonIsolatedRequirement {
 @MainActor class OnMain {}
 
 extension OnMain: NonIsolatedRequirement {
+  // expected-note@-1{{add '@preconcurrency' to the 'NonIsolatedRequirement' conformance to suppress isolation-related diagnostics}}
+
   // expected-warning@+2 {{main actor-isolated instance method 'requirement()' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@+1 {{add 'nonisolated' to 'requirement()' to make this instance method not isolated to the actor}}
   func requirement() {}

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -30,7 +30,7 @@ protocol P2 {
 }
 
 class C1 : P1, P2 {
-  // expected-note@-1{{add '@preconcurrency' to the 'P1' conformance to suppress isolation-related diagnostics}}
+  // expected-note@-1{{add '@preconcurrency' to the 'P1' conformance to defer isolation checking to run time}}
 
   typealias Assoc = String
 
@@ -54,7 +54,7 @@ protocol NonIsolatedRequirement {
 @MainActor class OnMain {}
 
 extension OnMain: NonIsolatedRequirement {
-  // expected-note@-1{{add '@preconcurrency' to the 'NonIsolatedRequirement' conformance to suppress isolation-related diagnostics}}
+  // expected-note@-1{{add '@preconcurrency' to the 'NonIsolatedRequirement' conformance to defer isolation checking to run time}}
 
   // expected-warning@+2 {{main actor-isolated instance method 'requirement()' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@+1 {{add 'nonisolated' to 'requirement()' to make this instance method not isolated to the actor}}

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -144,10 +144,10 @@ struct CountSteps1<T> : Collection {
   subscript(i: Int) -> Int { return i }
 }
 
-extension CountSteps1 // expected-error {{type 'CountSteps1<T>' does not conform to protocol 'RandomAccessCollection'}}
+extension CountSteps1 // expected-error {{type 'CountSteps1<T>' does not conform to protocol 'BidirectionalCollection'}}
   // expected-error@-1 {{conditional conformance of type 'CountSteps1<T>' to protocol 'RandomAccessCollection' does not imply conformance to inherited protocol 'BidirectionalCollection'}}
   // expected-note@-2 {{did you mean to explicitly state the conformance like 'extension CountSteps1: BidirectionalCollection where ...'?}}
-  // expected-error@-3 {{type 'CountSteps1<T>' does not conform to protocol 'BidirectionalCollection'}}
+  // expected-error@+1 {{type 'CountSteps1<T>' does not conform to protocol 'RandomAccessCollection'}}
   : RandomAccessCollection
      where T : Equatable
 {

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -144,10 +144,10 @@ struct CountSteps1<T> : Collection {
   subscript(i: Int) -> Int { return i }
 }
 
-extension CountSteps1 // expected-error {{type 'CountSteps1<T>' does not conform to protocol 'BidirectionalCollection'}}
+extension CountSteps1 // expected-error {{type 'CountSteps1<T>' does not conform to protocol 'RandomAccessCollection'}}
   // expected-error@-1 {{conditional conformance of type 'CountSteps1<T>' to protocol 'RandomAccessCollection' does not imply conformance to inherited protocol 'BidirectionalCollection'}}
   // expected-note@-2 {{did you mean to explicitly state the conformance like 'extension CountSteps1: BidirectionalCollection where ...'?}}
-  // expected-error@+1 {{type 'CountSteps1<T>' does not conform to protocol 'RandomAccessCollection'}}
+  // expected-error@-3 {{type 'CountSteps1<T>' does not conform to protocol 'BidirectionalCollection'}}
   : RandomAccessCollection
      where T : Equatable
 {


### PR DESCRIPTION
When diagnosing a case where an actor-isolated witness cannot satisfy a non-isolated requirement, also suggest that the conformance could be annotated with `@preconcurrency`.
