### PR TITLE
Add a Fix-It to the warning about unnecessary `@preconcurrency` conformance

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1238,7 +1238,8 @@ public:
                        DeclContext *dc,
                        ProtocolConformanceState state,
                        bool isUnchecked,
-                       bool isPreconcurrency);
+                       bool isPreconcurrency,
+                       SourceLoc preconcurrencyLoc = SourceLoc());
 
   /// Produce a self-conformance for the given protocol.
   SelfProtocolConformance *

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -530,6 +530,9 @@ class NormalProtocolConformance : public RootProtocolConformance,
   /// The location of this protocol conformance in the source.
   SourceLoc Loc;
 
+  /// The location of the `@preconcurrency` attribute, if any.
+  SourceLoc PreconcurrencyLoc;
+
   /// The declaration context containing the ExtensionDecl or
   /// NominalTypeDecl that declared the conformance.
   DeclContext *Context;
@@ -562,10 +565,12 @@ public:
   NormalProtocolConformance(Type conformingType, ProtocolDecl *protocol,
                             SourceLoc loc, DeclContext *dc,
                             ProtocolConformanceState state, bool isUnchecked,
-                            bool isPreconcurrency)
+                            bool isPreconcurrency,
+                            SourceLoc preconcurrencyLoc)
       : RootProtocolConformance(ProtocolConformanceKind::Normal,
                                 conformingType),
-        Protocol(protocol), Loc(loc), Context(dc) {
+        Protocol(protocol), Loc(loc), PreconcurrencyLoc(preconcurrencyLoc),
+        Context(dc) {
     assert(!conformingType->hasArchetype() &&
            "ProtocolConformances should store interface types");
     setState(state);
@@ -580,7 +585,7 @@ public:
   /// Get the protocol being conformed to.
   ProtocolDecl *getProtocol() const { return Protocol; }
 
-  /// Retrieve the location of this
+  /// Retrieve the location of this conformance.
   SourceLoc getLoc() const { return Loc; }
 
   /// Get the declaration context that contains the conforming extension or
@@ -628,6 +633,10 @@ public:
   bool isPreconcurrency() const {
     return Bits.NormalProtocolConformance.IsPreconcurrency;
   }
+
+  /// Retrieve the location of `@preconcurrency`, if there is one and it is
+  /// known.
+  SourceLoc getPreconcurrencyLoc() const { return PreconcurrencyLoc; }
 
   /// Determine whether we've lazily computed the associated conformance array
   /// already.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2593,7 +2593,8 @@ ASTContext::getNormalConformance(Type conformingType,
                                  DeclContext *dc,
                                  ProtocolConformanceState state,
                                  bool isUnchecked,
-                                 bool isPreconcurrency) {
+                                 bool isPreconcurrency,
+                                 SourceLoc preconcurrencyLoc) {
   assert(dc->isTypeContext());
 
   llvm::FoldingSetNodeID id;
@@ -2609,7 +2610,7 @@ ASTContext::getNormalConformance(Type conformingType,
   // Build a new normal protocol conformance.
   auto result = new (*this, AllocationArena::Permanent)
       NormalProtocolConformance(conformingType, protocol, loc, dc, state,
-                                isUnchecked, isPreconcurrency);
+                                isUnchecked, isPreconcurrency, preconcurrencyLoc);
   normalConformances.InsertNode(result, insertPos);
 
   return result;

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -989,7 +989,8 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
         conformingType, protocol, conformanceLoc, conformingDC,
         ProtocolConformanceState::Incomplete,
         entry->Source.getUncheckedLoc().isValid(),
-        entry->Source.getPreconcurrencyLoc().isValid());
+        entry->Source.getPreconcurrencyLoc().isValid(),
+        entry->Source.getPreconcurrencyLoc());
     // Invalid code may cause the getConformance call below to loop, so break
     // the infinite recursion by setting this eagerly to shortcircuit with the
     // early return at the start of this function.

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -147,7 +147,7 @@ SourceLoc TypeRepr::findAttrLoc(TypeAttrKind kind) const {
     for (auto attr : attrTypeRepr->getAttrs()) {
       if (auto typeAttr = attr.dyn_cast<TypeAttribute*>())
         if (typeAttr->getKind() == kind)
-          return typeAttr->getAttrLoc();
+          return typeAttr->getStartLoc();
     }
 
     typeRepr = attrTypeRepr->getTypeRepr();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5120,9 +5120,16 @@ void ConformanceChecker::resolveValueWitnesses() {
   }
 
   if (Conformance->isPreconcurrency() && !usesPreconcurrencyConformance) {
-    DC->getASTContext().Diags.diagnose(
+    auto diag = DC->getASTContext().Diags.diagnose(
         Conformance->getLoc(), diag::preconcurrency_conformance_not_used,
         Proto->getDeclaredInterfaceType());
+
+    SourceLoc preconcurrencyLoc = Conformance->getPreconcurrencyLoc();
+    if (preconcurrencyLoc.isValid()) {
+      SourceLoc endLoc =
+          preconcurrencyLoc.getAdvancedLoc(strlen("@preconcurrency "));
+      diag.fixItRemoveChars(preconcurrencyLoc, endLoc);
+    }
   }
 
   // Finally, check some ad-hoc protocol requirements.

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -152,7 +152,7 @@ protocol WithNonIsolated {
 
 do {
   class TestExplicitOtherIsolation : @preconcurrency WithNonIsolated {
-    // expected-warning@-1 {{@preconcurrency attribute on conformance to 'WithNonIsolated' has no effect}}
+    // expected-warning@-1 {{@preconcurrency attribute on conformance to 'WithNonIsolated' has no effect}}{{38-54=}}
 
     @GlobalActor var prop: Int = 42
     // expected-warning@-1 {{global actor 'GlobalActor'-isolated property 'prop' cannot be used to satisfy main actor-isolated protocol requirement}}
@@ -164,7 +164,7 @@ do {
 
 do {
   class InferredGlobalActorAttrs : @preconcurrency WithNonIsolated {
-    // expected-warning@-1 {{@preconcurrency attribute on conformance to 'WithNonIsolated' has no effect}}
+    // expected-warning@-1 {{@preconcurrency attribute on conformance to 'WithNonIsolated' has no effect}}{{36-52=}}
     var prop: Int = 42
     func test() {}
   }


### PR DESCRIPTION
When we diagnose an unnecessary `@preconcurrency` on a conformance, also provide a Fix-It to remove the `@preconcurrency`.
