### PR TITLE
[SILGen]: diagnose unreachable opened existentials

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -356,21 +356,22 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
           continue;
         }
       } else if (auto *E = ESD.dyn_cast<Expr*>()) {
-        // Optional chaining expressions are wrapped in a structure like.
-        //
-        // (optional_evaluation_expr implicit type='T?'
-        //   (call_expr type='T?'
-        //     (exprs...
-        //
-        // Walk through it to find out if the statement is actually implicit.
-        if (auto *OEE = dyn_cast<OptionalEvaluationExpr>(E)) {
-          if (auto *IIO = dyn_cast<InjectIntoOptionalExpr>(OEE->getSubExpr()))
-            if (IIO->getSubExpr()->isImplicit()) continue;
-          if (auto *C = dyn_cast<CallExpr>(OEE->getSubExpr()))
-            if (C->isImplicit()) continue;
-        } else if (E->isImplicit()) {
-          // Ignore all other implicit expressions.
-          continue;
+        if (E->isImplicit()) {
+          // Some expressions, like `OptionalEvaluationExpr` and
+          // `OpenExistentialExpr`, are implicit but may contain non-implicit
+          // children that should be diagnosed as unreachable. Check
+          // descendants here to see if there is anything to diagnose.
+          bool hasDiagnosableDescendant = false;
+          E->forEachChildExpr([&](auto *childExpr) -> Expr * {
+            if (!childExpr->isImplicit())
+              hasDiagnosableDescendant = true;
+
+            return hasDiagnosableDescendant ? nullptr : childExpr;
+          });
+
+          // If there's nothing to diagnose, ignore this expression.
+          if (!hasDiagnosableDescendant)
+            continue;
         }
       } else if (auto D = ESD.dyn_cast<Decl*>()) {
         // Local declarations aren't unreachable - only their usages can be. To

--- a/test/SILGen/unreachable_code.swift
+++ b/test/SILGen/unreachable_code.swift
@@ -159,3 +159,20 @@ func f_56075() -> Int {
   }
   func appendix() {} // no-warning
 }
+
+// https://github.com/apple/swift/issues/73649
+func testUnreachableExistential() {
+  protocol P {
+    func run()
+  }
+
+  func unreachableExistential(_ it: any P) -> Bool {
+    return true
+    it.run() // expected-warning {{code after 'return' will never be executed}}
+  }
+
+  func unreachableOptionalChainedExistential(_ it: (any P)?) -> Bool {
+    return false
+    it?.run() // expected-warning {{code after 'return' will never be executed}}
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

updates unreachable code handling in `SILGenStmt.cpp` to diagnose unreachable opened existentials that were previously ignored since they were wrapped in 'implicit' nodes in the AST.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #73649

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
