### PR TITLE
rdar://127199021, fix compatibility with apps that accidentally do [[[aSwiftArray class] new] mutableCopy] 

### DIFF
--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -103,6 +103,19 @@ swift_stdlib_connectNSBaseClasses() {
   return true;
 }
 
+@interface __SwiftNativeNSArrayBase (Compatibility)
++ (id) new;
+@end
+
+@implementation __SwiftNativeNSArrayBase (Compatibility)
+
++ (id) new {
+  // Some apps accidentally do [[[aSwiftArray class] new] mutableCopy]
+  return [objc_lookUpClass("NSArray") new];
+}
+
+@end
+
 #endif
 
 // ${'Local Variables'}:

--- a/test/stdlib/ArrayBridge.swift.gyb
+++ b/test/stdlib/ArrayBridge.swift.gyb
@@ -422,6 +422,11 @@ tests.test("testThunks") {
   testBridgeableValue(Thunks())
 }
 
+tests.test("testHKTFilter") {
+  let base = ["hello", "world"]
+  let result = testHKTFilter(base) as! NSArray as! [String]
+  expectEqual(result, ["hello"])
+}
 
 tests.test("testRoundTrip") {
   class Test : NSObject {

--- a/test/stdlib/Inputs/ArrayBridge/ArrayBridge.h
+++ b/test/stdlib/Inputs/ArrayBridge/ArrayBridge.h
@@ -16,6 +16,7 @@ NSArray* idAsArray(id a);
 
 void testSubclass(id thunks);
 void testBridgeableValue(id thunks);
+id testHKTFilter(id array);
 
 @interface RDar27905230 : NSObject
 + (NSDictionary<NSString *, NSArray<id> *> *)mutableDictionaryOfMutableLists;

--- a/test/stdlib/Inputs/ArrayBridge/ArrayBridge.m
+++ b/test/stdlib/Inputs/ArrayBridge/ArrayBridge.m
@@ -67,6 +67,22 @@ void testBridgeableValue(id thunks) {
   [thunks acceptBridgeableValueArray: toSwiftArr];
 }
 
+static id filter(id<NSFastEnumeration, NSObject> container, BOOL (^predicate)(id)) {
+  id result = [[[container class] new] mutableCopy];
+  for (id object in container) {
+    if (predicate(object)) {
+      [result addObject:object];
+    }
+  }
+  return result;
+}
+
+id testHKTFilter(id array) {
+  return filter(array, ^(id obj) {
+    return [obj isEqual:@"hello"];
+  });
+}
+
 @implementation RDar27905230
 
 + (NSDictionary<NSString *, NSArray<id> *> *)mutableDictionaryOfMutableLists  {


### PR DESCRIPTION
Explanation: At least one app is managing to call +new on our private NSArray subclass, which doesn't work. This change makes it return a regular NSArray to maintain compatibility
Original PR: #73728
Reviewed by: @parkera 
Risk: Low. This method is never supposed to be called, and cannot be called from Swift code, so normal usage will never execute it. It also never worked in the past, so the set of potentially impacted applications is "ObjC apps that are doing very unusual things with certain objects that used to be ObjC but are now Swift under the hood"
Resolves: rdar://127199021
Tests: Adds a test