### PR TITLE
[TypeCheckAttr] @frozen is valid even when building without enable-library-evolution

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3960,11 +3960,6 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
 
 void AttributeChecker::visitFrozenAttr(FrozenAttr *attr) {
   if (auto *ED = dyn_cast<EnumDecl>(D)) {
-    if (!ED->getModuleContext()->isResilient()) {
-      attr->setInvalid();
-      return;
-    }
-
     if (ED->getFormalAccess() < AccessLevel::Package &&
         !ED->getAttrs().hasAttribute<UsableFromInlineAttr>()) {
       diagnoseAndRemoveAttr(attr, diag::enum_frozen_nonpublic, attr);

--- a/test/SILOptimizer/moveonly_generics_complex.swift
+++ b/test/SILOptimizer/moveonly_generics_complex.swift
@@ -8,7 +8,6 @@
 
 import Builtin
 
-@frozen
 enum MyLittleLayout<T : ~Copyable> {
   @_transparent
   static var size: Int {
@@ -20,7 +19,6 @@ enum MyLittleLayout<T : ~Copyable> {
   }
 }
 
-@frozen
 enum MyLittleResult<Success : ~Copyable, Failure : Error> : ~Copyable {
   case success(Success)
   case failure(Failure)

--- a/test/Sema/bitwise_copyable_nonresilient.swift
+++ b/test/Sema/bitwise_copyable_nonresilient.swift
@@ -38,9 +38,7 @@ func passOopsional<T>(_ t: Oopsional<T>) { take(t) } // expected-error{{type_doe
 
 
 struct S_Explicit_With_Woopsional<T> : BitwiseCopyable {
-  var o: Woopsional<T> // expected-error{{non_bitwise_copyable_type_member}}
+  var o: Woopsional<T>
 }
 
-func passWoopsional<T>(_ t: Woopsional<T>) { take(t) } // expected-error{{type_does_not_conform_decl_owner}}
-                                                       // expected-note@-15{{where_requirement_failure_one_subst}}
-
+func passWoopsional<T>(_ t: Woopsional<T>) { take(t) }

--- a/test/Serialization/attr-frozen.swift
+++ b/test/Serialization/attr-frozen.swift
@@ -6,7 +6,7 @@
 
 // These two should be checking for the same thing.
 // CHECK-RESILIENT: Frozen_DECL_ATTR
-// CHECK-NON-RESILIENT-NOT: Frozen_DECL_ATTR
+// CHECK-NON-RESILIENT: Frozen_DECL_ATTR
 
 @frozen // expected-no-warning
 public enum SomeEnum {

--- a/test/Serialization/inferred_nonfrozen_conformance.swift
+++ b/test/Serialization/inferred_nonfrozen_conformance.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module %t/Library.swift -emit-module-path %t/Library.swiftmodule -module-name Library
+// RUN: %target-swift-frontend -typecheck -verify -strict-concurrency=complete -swift-version 6 %s -I %t
+
+//--- Library.swift
+
+@frozen public enum Numquam {}
+
+@_fixed_layout public struct Nunca {} // expected-warning {{}}
+
+//--- Client.swift
+
+public protocol WithSendable {
+  associatedtype AssocSendable : Sendable
+}
+
+extension Numquam : WithSendable {
+  public typealias AssocSendable = Numquam
+}
+
+extension Nunca : WithSendable {
+  public typealias AssocSendable = Nunca
+}
+
+public protocol WithBitwiseCopyable {
+  associatedtype AssocBitwiseCopyable : BitwiseCopyable
+}
+
+extension Numquam : WithBitwiseCopyable {
+  public typealias AssocBitwiseCopyable = Numquam
+}
+
+extension Nunca : WithBitwiseCopyable {
+  public typealias AssocBitwiseCopyable = Nunca
+}

--- a/test/api-digester/Outputs/Cake-binary-vs-interface.txt
+++ b/test/api-digester/Outputs/Cake-binary-vs-interface.txt
@@ -3,8 +3,6 @@ cake: Accessor GlobalLetChangedToVar.Get() is a new API without @available attri
 cake: Accessor GlobalVarChangedToLet.Get() is a new API without @available attribute
 cake: Accessor GlobalVarChangedToLet.Modify() is a new API without @available attribute
 cake: Accessor GlobalVarChangedToLet.Set() is a new API without @available attribute
-cake: Enum FrozenKind is now with @frozen
-cake: Enum IceKind is now with @frozen
 cake: Func FrozenKind.==(_:_:) is a new API without @available attribute
 cake: Var C1.CIIns1 is no longer a stored property
 cake: Var C1.CIIns2 is no longer a stored property

--- a/test/decl/enum/frozen-nonresilient.swift
+++ b/test/decl/enum/frozen-nonresilient.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -warnings-as-errors
+// RUN: %target-typecheck-verify-swift
 
 @frozen public enum Exhaustive {} // expected-no-warning
 
-@frozen enum NotPublic {} // expected-no-warning
+@frozen enum NotPublic {} // expected-warning{{@frozen has no effect on non-public enums}}


### PR DESCRIPTION
Even when building not for library evolution, `@frozen` is a valid attribute on enums.

Fixes an issue where conformances to `Sendable` and `BitwiseCopyable` of `@frozen` enums are not inferred in targets not built for library evolution such as the embedded stdlib.

rdar://128358780
