### PR TITLE
[6.0] Update swift-driver checkout

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -168,7 +168,7 @@
                 "swift-crypto": "3.0.0",
                 "swift-certificates": "1.0.1",
                 "swift-asn1": "1.0.0",
-                "swift-driver": "main",
+                "swift-driver": "release/6.0",
                 "swift-numerics": "1.0.2",
                 "swift-syntax": "release/6.0",
                 "swift-system": "1.2.1",


### PR DESCRIPTION
`update-checkout` should be checking out the release/6.0 driver for Swift-6.0 builds instead of the main branch driver.