### PR TITLE
[Runtime] Use CMake variable to control os_trace_lazy_init usage.

### DIFF
--- a/include/swift/Runtime/TracingCommon.h
+++ b/include/swift/Runtime/TracingCommon.h
@@ -24,9 +24,7 @@
 
 extern "C" const char *__progname;
 
-// This function may not be present when building at desk, and isn't really
-// needed there, so just skip it in that case.
-#if SWIFT_BNI_OS_BUILD
+#if SWIFT_USE_OS_TRACE_LAZY_INIT
 extern "C" bool _os_trace_lazy_init_completed_4swift(void);
 #endif
 
@@ -47,7 +45,7 @@ static inline bool shouldEnableTracing() {
 }
 
 static inline bool tracingReady() {
-#if SWIFT_BNI_OS_BUILD
+#if SWIFT_USE_OS_TRACE_LAZY_INIT
   if (!_os_trace_lazy_init_completed_4swift())
     return false;
 #endif

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -474,6 +474,10 @@ function(_add_target_variant_c_compile_flags)
     list(APPEND result "-DSWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE")
   endif()
 
+  if(SWIFT_USE_OS_TRACE_LAZY_INIT)
+    list(APPEND result "-DSWIFT_USE_OS_TRACE_LAZY_INIT")
+  endif()
+
   list(APPEND result ${SWIFT_STDLIB_EXTRA_C_COMPILE_FLAGS})
 
   set("${CFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)

--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -210,6 +210,10 @@ option(SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY
        "Build the standard libraries assuming that they will be used in an environment with only a single thread."
        FALSE)
 
+option(SWIFT_USE_OS_TRACE_LAZY_INIT
+       "Use the os_trace call to check if lazy init has been completed before making os_signpost calls."
+       FALSE)
+
 # Use dispatch as the system scheduler by default.
 # For convenience, we set this to false when concurrency is disabled.
 set(SWIFT_CONCURRENCY_USES_DISPATCH FALSE)


### PR DESCRIPTION
SWIFT_BNI_OS_BUILD isn't exactly what we need. Use an option to turn it on/off instead.

rdar://128408295