### PR TITLE
[SE-0415] Enable function body macros by default

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -195,6 +195,7 @@ LANGUAGE_FEATURE(BitwiseCopyable, 426, "BitwiseCopyable protocol")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ConformanceSuppression, 426, "Suppressible inferred conformances")
 SUPPRESSIBLE_LANGUAGE_FEATURE(BitwiseCopyable2, 426, "BitwiseCopyable feature")
 SUPPRESSIBLE_LANGUAGE_FEATURE(NoncopyableGenerics, 427, "Noncopyable generics")
+LANGUAGE_FEATURE(BodyMacros, 415, "Function body macros")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
@@ -224,7 +225,7 @@ EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
 EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
 EXPERIMENTAL_FEATURE(CodeItemMacros, false)
-EXPERIMENTAL_FEATURE(BodyMacros, true)
+EXPERIMENTAL_FEATURE(PreambleMacros, false)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
 EXPERIMENTAL_FEATURE(FullTypedThrows, true)
 

--- a/include/swift/Basic/MacroRoles.def
+++ b/include/swift/Basic/MacroRoles.def
@@ -75,10 +75,10 @@ EXPERIMENTAL_FREESTANDING_MACRO_ROLE(CodeItem, "codeItem", CodeItemMacros)
 ATTACHED_MACRO_ROLE(Extension, "extension", "e")
 
 /// An attached macro that expands to a preamble to a function.
-EXPERIMENTAL_ATTACHED_MACRO_ROLE(Preamble, "preamble", "q", BodyMacros)
+EXPERIMENTAL_ATTACHED_MACRO_ROLE(Preamble, "preamble", "q", PreambleMacros)
 
 /// An attached macro that expands to a function body.
-EXPERIMENTAL_ATTACHED_MACRO_ROLE(Body, "body", "b", BodyMacros)
+ATTACHED_MACRO_ROLE(Body, "body", "b")
 
 #undef ATTACHED_MACRO_ROLE
 #undef FREESTANDING_MACRO_ROLE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -415,6 +415,7 @@ static bool usesFeatureCodeItemMacros(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(BodyMacros)
+UNINTERESTING_FEATURE(PreambleMacros)
 UNINTERESTING_FEATURE(TupleConformances)
 
 static bool usesFeatureSymbolLinkageMarkers(Decl *decl) {

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -56,6 +56,7 @@ extension Parser.ExperimentalFeatures {
         insert(feature)
       }
     }
+
     mapFeature(.ThenStatements, to: .thenStatements)
     mapFeature(.DoExpressions, to: .doExpressions)
     mapFeature(.NonescapableTypes, to: .nonescapableTypes)

--- a/test/IDE/complete_macro_attribute.swift
+++ b/test/IDE/complete_macro_attribute.swift
@@ -10,8 +10,9 @@ macro FreestandingMacro
 @attached(#^ATTACHED_ROLE^#)
 macro AttachedMacro
 
-// ATTACHED_ROLE: Begin completions, 6 items
+// ATTACHED_ROLE: Begin completions, 7 items
 // ATTACHED_ROLE-DAG: Keyword/None:                       accessor; name=accessor
+// ATTACHED_ROLE-DAG: Keyword/None:                       body; name=body
 // ATTACHED_ROLE-DAG: Keyword/None:                       memberAttribute; name=memberAttribute
 // ATTACHED_ROLE-DAG: Keyword/None:                       member; name=member
 // ATTACHED_ROLE-DAG: Keyword/None:                       peer; name=peer

--- a/test/Macros/macro_expand_body.swift
+++ b/test/Macros/macro_expand_body.swift
@@ -3,10 +3,10 @@
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
 
 // Diagnostics testing
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature BodyMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature PreambleMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS
 
 // Execution testing
-// RUN: %target-build-swift -swift-version 5 -g -enable-experimental-feature BodyMacros -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
+// RUN: %target-build-swift -swift-version 5 -g -enable-experimental-feature PreambleMacros -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -121,7 +121,7 @@ func remoteCall<Result: ConjureRemoteValue>(function: String, arguments: [String
   return Result.conjureValue()
 }
 
-// REQUIRES: swift_swift_parser, executable_test, shell
+// REQUIRES: swift_swift_parser, executable_test, shell, asserts
 
 // RUN: %empty-directory(%t)
 
@@ -132,7 +132,7 @@ func remoteCall<Result: ConjureRemoteValue>(function: String, arguments: [String
 // RUN:   -swift-version 5 \
 // RUN:   -load-plugin-library %t/%target-library-name(MacroDefinition) \
 // RUN:   -module-name MacroUser \
-// RUN:   -enable-experimental-feature BodyMacros \
+// RUN:   -enable-experimental-feature PreambleMacros \
 // RUN: )
 
 // RUN: COMPILER_ARGS=( \


### PR DESCRIPTION
Preamble macros are *not* part of the revised SE-0415, so leave them experimental.

Tracked by rdar://119687390.
