### PR TITLE
ASTPrinter: handle inverses in compositions

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -7861,7 +7861,24 @@ swift::getInheritedForPrinting(
   // Collect explicit inherited types.
   for (auto i : inherited.getIndices()) {
     if (auto ty = inherited.getResolvedType(i)) {
+      // Preserve inverses separately, because the `foundUnprintable` logic
+      // doesn't handle compositions with a mix of printable and unprintable
+      // types! That's handled later by `InheritedProtocolCollector`.
+      //
+      // Generally speaking, `getInheritedForPrinting` needs to be
+      // querying `InheritedProtocolCollector` to find out what protocols it
+      // should print in the inheritance clause, to reduce code duplication
+      // in the printer.
+      InvertibleProtocolSet printableInverses;
+
       bool foundUnprintable = ty.findIf([&](Type subTy) {
+        {
+          // We canonicalize the composition to ensure no inverses are missed.
+          auto subCanTy = subTy->getCanonicalType();
+          if (auto PCT = subCanTy->getAs<ProtocolCompositionType>()) {
+            printableInverses.insertAll(PCT->getInverses());
+          }
+        }
         if (auto aliasTy = dyn_cast<TypeAliasType>(subTy.getPointer()))
           return !options.shouldPrint(aliasTy->getDecl());
         if (auto NTD = subTy->getAnyNominal()) {
@@ -7870,8 +7887,22 @@ swift::getInheritedForPrinting(
         }
         return false;
       });
-      if (foundUnprintable)
+
+      // Preserve any inverses that appeared in the unprintable type.
+      if (foundUnprintable) {
+        if (printableInverses.contains(InvertibleProtocolKind::Copyable)
+            && options.SuppressNoncopyableGenerics)
+          printableInverses.remove(InvertibleProtocolKind::Copyable);
+
+        if (!printableInverses.empty()) {
+          auto inversesTy = ProtocolCompositionType::get(decl->getASTContext(),
+                                                         /*members=*/{},
+                                                         printableInverses,
+                                                         /*anyObject=*/false);
+          Results.push_back(InheritedEntry(TypeLoc::withoutLoc(inversesTy)));
+        }
         continue;
+      }
 
       // Suppress Copyable and ~Copyable.
       if (options.SuppressNoncopyableGenerics) {

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -127,3 +127,13 @@ public func substCopyable(_ t: String?) {}
 public func substGenericCopyable<T>(_ t: T?) {}
 public func substNC(_ t: borrowing NoCopyPls?) {}
 public func substGenericNC<T: ~Copyable>(_ t: borrowing T?) {}
+
+// coverage for rdar://126090425
+protocol P : ~Copyable {} // NOTE: it's important that this is NOT public.
+protocol Q: ~Copyable {}  // NOTE: it's important that this is NOT public.
+public protocol Publik: ~Copyable {}
+public struct Concrete : (P & ~Copyable) {}
+public struct Generic<T: Publik & ~Copyable> : (P & ~Copyable) {}
+public struct VeryNested: (P & (Q & ~Copyable & Publik) & (P & ~Copyable)) {}
+public struct Twice: P & ~Copyable, Q & ~Copyable {}
+public struct RegularTwice: ~Copyable, ~Copyable {}

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -192,6 +192,31 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC-NEXT: public func substGenericNC<T>(_ t: borrowing T?)
 // CHECK-MISC-NEXT: #endif
 
+// CHECK-MISC:      #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public protocol Publik : ~Copyable {
+// CHECK-MISC-NEXT: }
+// CHECK-MISC-NEXT: #else
+// CHECK-MISC-NEXT: public protocol Publik {
+// CHECK-MISC-NEXT: }
+// CHECK-MISC-NEXT: #endif
+// CHECK-MISC-NEXT: public struct Concrete : ~Copyable {
+// CHECK-MISC-NEXT: }
+// CHECK-MISC-NEXT: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public struct Generic<T> : ~Copyable where T : {{.*}}.Publik, T : ~Copyable {
+// CHECK-MISC-NEXT: }
+// CHECK-MISC-NEXT: #else
+// CHECK-MISC-NEXT: public struct Generic<T> where T : {{.*}}.Publik {
+// CHECK-MISC-NEXT: }
+// CHECK-MISC-NEXT: #endif
+// CHECK-MISC-NEXT: public struct VeryNested : ~Copyable {
+// CHECK-MISC-NEXT: }
+// CHECK-MISC-NEXT: public struct Twice : ~Copyable, ~Copyable {
+// CHECK-MISC-NEXT: }
+// CHECK-MISC-NEXT: public struct RegularTwice : ~Swift.Copyable, ~Swift.Copyable {
+// CHECK-MISC-NEXT: }
+
+// NOTE: below are extensions emitted at the end of NoncopyableGenerics_Misc.swift
+// CHECK-MISC: extension {{.*}}.VeryNested : {{.*}}.Publik {}
 
 import Swiftskell
 


### PR DESCRIPTION
The basic inheritance clause emission in ASTPrinter operates on InheritedEntry's, but does not canonicalize types. It's been designed to consider an entire composition unprintable because one member is unprintable (e.g., the protocol is not public).

This rejection is what was causing `~Copyable` in some compositions to be missing from interface files (rdar://126090425). Fixing that is the purpose of this patch.

What happens, then, if you mix public and nonpublic protocols in a composition? A second facility called the InheritedProtocolCollector later does find the public protocols, and emits extensions at the end of the interface file to declare the additional conformances the ininitial declaration printer missed.

We can't generally emit `~Copyable` on an extension, so the fix can't happening there. Refactoring things so there's one source of truth about the protocols being printed is a sizable refactoring that I will defer for another time.

resolves rdar://126090425