### PR TITLE
[Concurrency] Fix missing return in legacy isSameExecutor mode detection

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -340,7 +340,7 @@ static IsCurrentExecutorCheckMode isCurrentExecutorMode =
 // these symbols defined
 bool swift_bincompat_useLegacyNonCrashingExecutorChecks() {
 #if !SWIFT_CONCURRENCY_EMBEDDED
-  swift::runtime::bincompat::
+  return swift::runtime::bincompat::
       swift_bincompat_useLegacyNonCrashingExecutorChecks();
 #endif
   return false;


### PR DESCRIPTION
Fixes a missing `return` inside the `#if !SWIFT_CONCURRENCY_EMBEDDED` region which caused the entire dyld sdk detection not to work in practice.

Thank you @mikeash for help diagnosing.

resolves rdar://128425368
resolves rdar://127400013
