### PR TITLE
[6.0][Concurrency] Fix missing return in legacy isSameExecutor mode detection

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -339,7 +339,7 @@ static IsCurrentExecutorCheckMode isCurrentExecutorMode =
 // these symbols defined
 bool swift_bincompat_useLegacyNonCrashingExecutorChecks() {
 #if !SWIFT_CONCURRENCY_EMBEDDED
-  swift::runtime::bincompat::
+  return swift::runtime::bincompat::
       swift_bincompat_useLegacyNonCrashingExecutorChecks();
 #endif
   return false;


### PR DESCRIPTION

**Description**: Fixes a missing return inside the #if !SWIFT_CONCURRENCY_EMBEDDED region which caused the entire dyld sdk detection not to work in practice.

**Scope/Impact**: dyld detection of "compiled against old sdk" was rendered useless by this typo; which may cause old applications to start crashing without recompiling.
**Risk:** Low; fixes trivial missing return statement.
**Testing**: CI testing
**Reviewed by**: @mikeash 

**Original PR:** 
**Radar:** rdar://128425368 rdar://127400013
