### PR TITLE
[6.0] modulewrap: Disable ObjC interop by default on non-Darwin platforms

### DIFF
--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -48,6 +48,7 @@ private:
   llvm::Triple TargetTriple;
   std::vector<std::string> InputFilenames;
   bool UseSharedResourceFolder = true;
+  bool EnableObjCInterop = true;
 
 public:
   bool hasSingleInput() const { return InputFilenames.size() == 1; }
@@ -65,6 +66,7 @@ public:
   llvm::Triple &getTargetTriple() { return TargetTriple; }
 
   bool useSharedResourceFolder() { return UseSharedResourceFolder; }
+  bool enableObjCInterop() { return EnableObjCInterop; }
 
   int parseArgs(llvm::ArrayRef<const char *> Args, DiagnosticEngine &Diags) {
     using namespace options;
@@ -123,6 +125,9 @@ public:
         ParsedArgs.hasArg(OPT_static)) {
       UseSharedResourceFolder = false;
     }
+
+    EnableObjCInterop = ParsedArgs.hasFlag(OPT_enable_objc_interop,
+        OPT_disable_objc_interop, TargetTriple.isOSDarwin());
 
     return 0;
   }
@@ -184,6 +189,7 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   CASOptions CASOpts;
   LangOpts.Target = Invocation.getTargetTriple();
+  LangOpts.EnableObjCInterop = Invocation.enableObjCInterop();
   ASTContext &ASTCtx = *ASTContext::get(
       LangOpts, TypeCheckOpts, SILOpts, SearchPathOpts, ClangImporterOpts,
       SymbolGraphOpts, CASOpts, SrcMgr, Instance.getDiags(),


### PR DESCRIPTION
**Explanation**: Fixes crash regression on modulewrap with WebAssembly target by disabling ObjC interop by default on non-Darwin platforms as swift-frontend does. The crash was introduced by https://github.com/apple/swift/pull/73371
**Scope**: Only affects non-Darwin platforms
**Risk**: Low; just applies the same ObjC interop availability rule to modulewrap as swift-frtonend does
**Testing**: CI testing
**Reviewer**: @MaxDesiatov 
**Original PR:** https://github.com/apple/swift/pull/73440
