### PR TITLE
IRGen: support read-only statically initialized arrays in embedded swift

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -370,6 +370,7 @@ extension Instruction {
          is VectorInst,
          is AllocVectorInst,
          is UncheckedRefCastInst,
+         is UpcastInst,
          is ValueToBridgeObjectInst,
          is ConvertFunctionInst,
          is ThinToThickFunctionInst,

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -127,6 +127,9 @@ class LinkEntity {
     // This field appears in the TypeMetadata and ObjCResilientClassStub kinds.
     MetadataAddressShift = 8, MetadataAddressMask = 0x0300,
 
+    // This field appears in the TypeMetadata kind.
+    ForceSharedShift = 12, ForceSharedMask = 0x1000,
+
     // This field appears in associated type access functions.
     AssociatedTypeIndexShift = 8, AssociatedTypeIndexMask = ~KindMask,
 
@@ -847,12 +850,14 @@ public:
   }
 
   static LinkEntity forTypeMetadata(CanType concreteType,
-                                    TypeMetadataAddress addr) {
+                                    TypeMetadataAddress addr,
+                                    bool forceShared = false) {
     assert(!isObjCImplementation(concreteType));
     assert(!isEmbedded(concreteType) || isMetadataAllowedInEmbedded(concreteType));
     LinkEntity entity;
     entity.setForType(Kind::TypeMetadata, concreteType);
     entity.Data |= LINKENTITY_SET_FIELD(MetadataAddress, unsigned(addr));
+    entity.Data |= LINKENTITY_SET_FIELD(ForceShared, unsigned(forceShared));
     return entity;
   }
 
@@ -1583,6 +1588,10 @@ public:
            getKind() == Kind::NoncanonicalSpecializedGenericTypeMetadata ||
            getKind() == Kind::ObjCResilientClassStub);
     return (TypeMetadataAddress)LINKENTITY_GET_FIELD(Data, MetadataAddress);
+  }
+  bool isForcedShared() const {
+    assert(getKind() == Kind::TypeMetadata);
+    return (bool)LINKENTITY_GET_FIELD(Data, ForceShared);
   }
   bool isObjCClassRef() const {
     return getKind() == Kind::ObjCClassRef;

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1251,6 +1251,10 @@ public:
   UpcastInst *createUpcast(SILLocation Loc, SILValue Op, SILType Ty,
                            ValueOwnershipKind forwardingOwnershipKind) {
     assert(Ty.isObject());
+    if (isInsertingIntoGlobal()) {
+      return insert(UpcastInst::create(getSILDebugLocation(Loc), Op, Ty,
+                                       getModule(), forwardingOwnershipKind));
+    }
     return insert(UpcastInst::create(getSILDebugLocation(Loc), Op, Ty,
                                      getFunction(), forwardingOwnershipKind));
   }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5880,6 +5880,10 @@ class UpcastInst final : public UnaryInstructionWithTypeDependentOperandsBase<
   }
 
   static UpcastInst *create(SILDebugLocation DebugLoc, SILValue Operand,
+                            SILType Ty, SILModule &Mod,
+                            ValueOwnershipKind forwardingOwnershipKind);
+
+  static UpcastInst *create(SILDebugLocation DebugLoc, SILValue Operand,
                             SILType Ty, SILFunction &F,
                             ValueOwnershipKind forwardingOwnershipKind);
 };

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -358,6 +358,9 @@ Explosion irgen::emitConstantValue(IRGenModule &IGM, SILValue operand,
   } else if (auto *URCI = dyn_cast<UncheckedRefCastInst>(operand)) {
     return emitConstantValue(IGM, URCI->getOperand(), flatten);
 
+  } else if (auto *UCI = dyn_cast<UpcastInst>(operand)) {
+    return emitConstantValue(IGM, UCI->getOperand(), flatten);
+
   } else if (auto *T2TFI = dyn_cast<ThinToThickFunctionInst>(operand)) {
     SILType type = operand->getType();
     auto *sTy = cast<llvm::StructType>(IGM.getTypeInfo(type).getStorageType());

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -456,22 +456,37 @@ llvm::Constant *irgen::emitConstantObject(IRGenModule &IGM, ObjectInst *OI,
 
   if (IGM.canMakeStaticObjectReadOnly(OI->getType())) {
     if (!IGM.swiftImmortalRefCount) {
-      auto *var = new llvm::GlobalVariable(IGM.Module, IGM.Int8Ty,
-                                        /*constant*/ true, llvm::GlobalValue::ExternalLinkage,
-                                        /*initializer*/ nullptr, "_swiftImmortalRefCount");
-      IGM.swiftImmortalRefCount = var;
+      if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+        // = HeapObject.immortalRefCount
+        IGM.swiftImmortalRefCount = llvm::ConstantInt::get(IGM.IntPtrTy, -1);
+      } else {
+        IGM.swiftImmortalRefCount = llvm::ConstantExpr::getPtrToInt(
+            new llvm::GlobalVariable(IGM.Module, IGM.Int8Ty,
+              /*constant*/ true, llvm::GlobalValue::ExternalLinkage,
+              /*initializer*/ nullptr, "_swiftImmortalRefCount"),
+            IGM.IntPtrTy);
+      }
     }
     if (!IGM.swiftStaticArrayMetadata) {
       auto *classDecl = IGM.getStaticArrayStorageDecl();
       assert(classDecl && "no __StaticArrayStorage in stdlib");
       CanType classTy = CanType(ClassType::get(classDecl, Type(), IGM.Context));
-      LinkEntity entity = LinkEntity::forTypeMetadata(classTy, TypeMetadataAddress::AddressPoint);
-      auto *metatype = IGM.getAddrOfLLVMVariable(entity, NotForDefinition, DebugTypeInfo());
-      IGM.swiftStaticArrayMetadata = cast<llvm::GlobalVariable>(metatype);
+      if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+        LinkEntity entity = LinkEntity::forTypeMetadata(classTy, TypeMetadataAddress::AddressPoint,
+                                                        /*forceShared=*/ true);
+        // In embedded swift, the metadata for the array buffer class only needs to be very minimal:
+        // No vtable needed, because the object is never destructed. It only contains the null super-
+        // class pointer.
+        llvm::Constant *superClass = llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
+        IGM.swiftStaticArrayMetadata = IGM.getAddrOfLLVMVariable(entity, superClass, DebugTypeInfo());
+      } else {
+        LinkEntity entity = LinkEntity::forTypeMetadata(classTy, TypeMetadataAddress::AddressPoint);
+        IGM.swiftStaticArrayMetadata = IGM.getAddrOfLLVMVariable(entity, NotForDefinition, DebugTypeInfo());
+      }
     }
     elements[0].add(llvm::ConstantStruct::get(ObjectHeaderTy, {
       IGM.swiftStaticArrayMetadata,
-      llvm::ConstantExpr::getPtrToInt(IGM.swiftImmortalRefCount, IGM.IntPtrTy)}));
+      IGM.swiftImmortalRefCount }));
   } else {
     elements[0].add(llvm::Constant::getNullValue(ObjectHeaderTy));
   }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2029,8 +2029,14 @@ void IRGenModule::error(SourceLoc loc, const Twine &message) {
 
 bool IRGenModule::useDllStorage() { return ::useDllStorage(Triple); }
 
+// In embedded swift features are available independent of deployment and
+// runtime targets because the runtime library is always statically linked
+// to the program.
+
 #define FEATURE(N, V)                                                   \
 bool IRGenModule::is##N##FeatureAvailable(const ASTContext &context) {  \
+  if (Context.LangOpts.hasFeature(Feature::Embedded))                   \
+    return true;                                                        \
   auto deploymentAvailability                                           \
     = AvailabilityContext::forDeploymentTarget(context);                \
   auto runtimeAvailability                                              \

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -837,8 +837,8 @@ public:
 
   llvm::GlobalVariable *TheTrivialPropertyDescriptor = nullptr;
 
-  llvm::GlobalVariable *swiftImmortalRefCount = nullptr;
-  llvm::GlobalVariable *swiftStaticArrayMetadata = nullptr;
+  llvm::Constant *swiftImmortalRefCount = nullptr;
+  llvm::Constant *swiftStaticArrayMetadata = nullptr;
 
   /// Used to create unique names for class layout types with tail allocated
   /// elements.

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -642,6 +642,9 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
     return SILLinkage::Shared;
 
   case Kind::TypeMetadata: {
+    if (isForcedShared())
+      return SILLinkage::Shared;
+
     auto *nominal = getType().getAnyNominal();
     switch (getMetadataAddress()) {
     case TypeMetadataAddress::FullMetadata:

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2715,6 +2715,15 @@ MetatypeInst *MetatypeInst::create(SILDebugLocation Loc, SILType Ty,
 }
 
 UpcastInst *UpcastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
+                               SILType Ty, SILModule &Mod,
+                               ValueOwnershipKind forwardingOwnershipKind) {
+  unsigned size = totalSizeToAlloc<swift::Operand>(1);
+  void *Buffer = Mod.allocateInst(size, alignof(UpcastInst));
+  return ::new (Buffer) UpcastInst(DebugLoc, Operand, {}, Ty,
+                                   forwardingOwnershipKind);
+}
+
+UpcastInst *UpcastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
                                SILType Ty, SILFunction &F,
                                ValueOwnershipKind forwardingOwnershipKind) {
   SILModule &Mod = F.getModule();

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -46,6 +46,7 @@ public struct HeapObject {
   static let refcountMask = Int(bitPattern: 0x7fff_ffff)
 #endif
 
+  // Note: The immortalRefCount value of -1 is also hard-coded in IRGen in `irgen::emitConstantObject`.
   static let immortalRefCount = -1
 }
 

--- a/test/embedded/static-object.swift
+++ b/test/embedded/static-object.swift
@@ -1,27 +1,128 @@
-// RUN: %target-swift-frontend -O -emit-irgen %s -module-name main -parse-as-library -enable-experimental-feature Embedded | %FileCheck %s --check-prefix CHECK-IR
-// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded %s -O -wmo -sil-verify-all -module-name=test -emit-ir | %FileCheck %s
 
-// REQUIRES: swift_in_compiler
-// REQUIRES: executable_test
-// REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// Also do an end-to-end test to check all components, including IRGen.
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -parse-as-library -enable-experimental-feature Embedded -O -wmo -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
+
+// Check if the optimizer is able to convert array literals to constant statically initialized arrays.
+
+// CHECK-DAG: @"$s4test11arrayLookupyS2iFTv_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} -1
+// CHECK-DAG: @"$s4test11returnArraySaySiGyFTv_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} -1
+// CHECK-DAG: @"$s4test9passArrayyyFTv_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} -1
+// CHECK-DAG: @"$s4test9passArrayyyFTv0_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} -1
+// CHECK-DAG: @"$s4test10storeArrayyyFTv_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} -1
+// CHECK-DAG: @"$s4test3StrV9staticLet_WZTv_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} -1
+// CHECK-DAG: @"$s4test3StrV9staticVar_WZTv_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} -1
+// CHECK-DAG: @"$s4test3StrV9staticVarSaySiGvpZ" = global {{.*}} ptr @"$s4test3StrV9staticVar_WZTv_r"
+// CHECK-DAG: @"$s4test3StrV14twoDimensionalSaySaySiGGvpZ" = global {{.*}} ptr @"$s4test3StrV14twoDimensional_WZTv{{[0-9]*}}_r"
+
+// Currently, constant static arrays only work on Darwin platforms.
+// REQUIRES: VENDOR=apple
+
+
+public struct Str {
+  public static let staticLet = [ 200, 201, 202 ]
+  public static var staticVar = [ 300, 301, 302 ]
+  public static var twoDimensional = [[1, 2], [3, 4], [5, 6]]
+}
+
+@inline(never)
+public func arrayLookup(_ i: Int) -> Int {
+  let lookupTable = [10, 11, 12]
+  return lookupTable[i]
+}
+
+@inline(never)
+public func returnArray() -> [Int] {
+  return [20, 21]
+}
+
+@inline(never)
+public func modifyArray() -> [Int] {
+  var a = returnArray()
+  a[1] = 27
+  return a
+}
+
+public var gg: [Int]?
+
+@inline(never)
+public func receiveArray(_ a: [Int]) {
+  gg = a
+}
+
+@inline(never)
+public func passArray() {
+  receiveArray([27, 28])
+  receiveArray([29])
+}
+
+@inline(never)
+public func storeArray() {
+  gg = [227, 228]
+}
 
 public func stringArray() -> [StaticString] {
   return ["a", "b", "c", "d"]
 }
-// CHECK-IR:      define {{.*}}@"$s4main11stringArraySays12StaticStringVGyF"
-// CHECK-IR-NEXT: entry:
-// CHECK-IR-NEXT:   call {{.*}}@swift_initStaticObject
 
-@main
-struct Main {
+@main struct Main {
   static func main() {
+
+    // CHECK-OUTPUT:      [200, 201, 202]
+    printArray(Str.staticLet)
+
+    // CHECK-OUTPUT:      [300, 301, 302]
+    printArray(Str.staticVar)
+
+    // CHECK-OUTPUT:      [1, 2]
+    // CHECK-OUTPUT-NEXT: [3, 4]
+    // CHECK-OUTPUT-NEXT: [5, 6]
+    for x in Str.twoDimensional {
+      printArray(x)
+    }
+
+    // CHECK-OUTPUT-NEXT: 11
+    print(arrayLookup(1))
+
+    // CHECK-OUTPUT-NEXT: [20, 21]
+    printArray(returnArray())
+
+    // CHECK-OUTPUT-NEXT: [20, 27]
+    // CHECK-OUTPUT-NEXT: [20, 27]
+    // CHECK-OUTPUT-NEXT: [20, 27]
+    // CHECK-OUTPUT-NEXT: [20, 27]
+    // CHECK-OUTPUT-NEXT: [20, 27]
+    for _ in 0..<5 {
+      printArray(modifyArray())
+    }
+
+    passArray()
+    // CHECK-OUTPUT-NEXT: [29]
+    printArray(gg!)
+
+    storeArray()
+    // CHECK-OUTPUT-NEXT: [227, 228]
+    printArray(gg!)
+
     for c in stringArray() {
+      // CHECK-OUTPUT-NEXT: a
+      // CHECK-OUTPUT-NEXT: b
+      // CHECK-OUTPUT-NEXT: c
+      // CHECK-OUTPUT-NEXT: d
       print(c)
-      // CHECK: a
-      // CHECK: b
-      // CHECK: c
-      // CHECK: d
     }
   }
 }
+
+func printArray(_ a: [Int]) {
+  print("[", terminator: "")
+  for (i, x) in a.enumerated() {
+    print(x, terminator: i == a.count - 1 ? "" :  ", ")
+  }
+  print("]")
+}
+


### PR DESCRIPTION
Arrays buffers need to be initialized with a (minimal) metatype and with an immortal reference count.

Also, disable feature availability checking for embedded swift: In embedded swift features are available independent of deployment and runtime targets because the runtime library is always statically linked to the program.