### PR TITLE
[Build] Don't include Compatiblity50/51 for 64-bit watchOS.

### DIFF
--- a/stdlib/cmake/modules/CompatibilityLibs.cmake
+++ b/stdlib/cmake/modules/CompatibilityLibs.cmake
@@ -10,9 +10,15 @@ function(get_compatibility_libs sdk arch result_var_name)
       swiftCompatibilityConcurrency${vsuffix}
       swiftCompatibilityDynamicReplacements${vsuffix}
       swiftCompatibilityPacks${vsuffix}
-      swiftCompatibility50${vsuffix}
-      swiftCompatibility51${vsuffix}
       swiftCompatibility56${vsuffix})
+
+    # 64-bit watchOS doesn't do 5.0 or 5.1 back-compat
+    set(arm64Archs "arm64;arm64e")
+    if(NOT (sdk STREQUAL "WATCHOS" AND arch IN_LIST arm64Archs))
+      list(APPEND compatibility_libs
+        swiftCompatibility50${vsuffix}
+        swiftCompatibility51${vsuffix})
+    endif()
   endif()
 
   set("${result_var_name}" "${compatibility_libs}" PARENT_SCOPE)


### PR DESCRIPTION
We don't support Swift 5.0 or 5.1 on ARM64 watchOS.

rdar://128445543
