### PR TITLE
Set the linker to gold for smoketests

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1074,6 +1074,11 @@ reconfigure
 test-optimized
 skip-test-swiftdocc
 
+# gcc version on amazon linux 2 is too old to configure and build tablegen.
+# Use the clang that we install in the path for macros
+llvm-cmake-options=
+  -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
+  -DCLANG_DEFAULT_LINKER=gold
 
 [preset: buildbot_linux_1404_no_lldb]
 mixin-preset=buildbot_incremental_linux


### PR DESCRIPTION
I missed setting the default linker used by the clang-linker to `gold` in smoketests, so they're seeing the broken link jobs now.