### PR TITLE
[cxx-interop] Avoid treating some Obj-C types as foreign reference types

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6355,7 +6355,14 @@ bool ClassDecl::walkSuperclasses(
 }
 
 bool ClassDecl::isForeignReferenceType() const {
-  return getClangDecl() && isa<clang::RecordDecl>(getClangDecl());
+  auto clangRecordDecl = dyn_cast_or_null<clang::RecordDecl>(getClangDecl());
+  if (!clangRecordDecl)
+    return false;
+
+  CxxRecordSemanticsKind kind = evaluateOrDefault(
+      getASTContext().evaluator,
+      CxxRecordSemantics({clangRecordDecl, getASTContext()}), {});
+  return kind == CxxRecordSemanticsKind::Reference;
 }
 
 bool ClassDecl::hasRefCountingAnnotations() const {


### PR DESCRIPTION
This makes sure we don't apply logic that is specific to C++ reference types to Objective-C types.

Previously we were mistakenly treating some Objective-C types as foreign reference types. This meant that IRGen would try to emit calls to custom lifetime operations. This should not happen for non-C++ types.

rdar://128447046