### PR TITLE
Fix opaque type substitution in the package cmo resilience domain

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6621,6 +6621,8 @@ enum class OpaqueSubstitutionKind {
   // Can be done if the underlying type is accessible from the context we
   // substitute into. Private types cannot be accessed from a different TU.
   SubstituteSameModuleMaximalResilience,
+  // Same as previous but with package and above visibility.
+  SubstituteSamePackageMaximalResilience,
   // Substitute in a different module from the opaque defining decl. Can only
   // be done if the underlying type is public.
   SubstituteNonResilientModule

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10078,6 +10078,11 @@ bool OpaqueTypeDecl::exportUnderlyingType() const {
   if (mod->getResilienceStrategy() != ResilienceStrategy::Resilient)
     return true;
 
+  // If we perform package CMO, in-package clients must have access to the
+  // underlying type.
+  if (mod->serializePackageEnabled())
+    return true;
+
   ValueDecl *namingDecl = getNamingDecl();
   if (auto *AFD = dyn_cast<AbstractFunctionDecl>(namingDecl))
     return AFD->getResilienceExpansion() == ResilienceExpansion::Minimal;

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -982,6 +982,14 @@ ReplaceOpaqueTypesWithUnderlyingTypes::shouldPerformSubstitution(
       module == contextModule)
     return OpaqueSubstitutionKind::SubstituteSameModuleMaximalResilience;
 
+  // Allow replacement of opaque result types in the context of maximal
+  // resilient expansion if the context's and the opaque type's module are in
+  // the same package.
+  if (contextExpansion == ResilienceExpansion::Maximal &&
+      module->isResilient() && module->serializePackageEnabled() &&
+      module->inSamePackage(contextModule))
+    return OpaqueSubstitutionKind::SubstituteSamePackageMaximalResilience;
+
   // Allow general replacement from non resilient modules. Otherwise, disallow.
   if (module->isResilient())
     return OpaqueSubstitutionKind::DontSubstitute;
@@ -1046,6 +1054,10 @@ static bool canSubstituteTypeInto(Type ty, const DeclContext *dc,
       return true;
 
     return typeDecl->getEffectiveAccess() > AccessLevel::FilePrivate;
+
+  case OpaqueSubstitutionKind::SubstituteSamePackageMaximalResilience: {
+    return typeDecl->getEffectiveAccess() >= AccessLevel::Package;
+  }
 
   case OpaqueSubstitutionKind::SubstituteNonResilientModule:
     // Can't access types that are not public from a different module.

--- a/test/SILOptimizer/package-cmo-opaque-result.swift
+++ b/test/SILOptimizer/package-cmo-opaque-result.swift
@@ -5,7 +5,7 @@
 // RUN: -module-name=Lib -package-name Pkg \
 // RUN: -parse-as-library -emit-module -emit-module-path %t/Lib.swiftmodule -I%t \
 // RUN: -Xfrontend -experimental-package-cmo -Xfrontend -experimental-allow-non-resilient-access \
-// RUN: -O -wmo -enable-library-evolution
+// RUN: -O -wmo -enable-library-evolution -Xfrontend -disable-availability-checking
 
 // RUN: %target-build-swift -module-name=Main -package-name Pkg -I%t -emit-sil -O %t/main.swift -o %t/Main-res.sil
 // RUN: %FileCheck %s --check-prefixes=CHECK-OPAQUE < %t/Main-res.sil

--- a/test/SILOptimizer/package-cmo-opaque-result.swift
+++ b/test/SILOptimizer/package-cmo-opaque-result.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift %t/Lib.swift \
+// RUN: -module-name=Lib -package-name Pkg \
+// RUN: -parse-as-library -emit-module -emit-module-path %t/Lib.swiftmodule -I%t \
+// RUN: -Xfrontend -experimental-package-cmo -Xfrontend -experimental-allow-non-resilient-access \
+// RUN: -O -wmo -enable-library-evolution
+
+// RUN: %target-build-swift -module-name=Main -package-name Pkg -I%t -emit-sil -O %t/main.swift -o %t/Main-res.sil
+// RUN: %FileCheck %s --check-prefixes=CHECK-OPAQUE < %t/Main-res.sil
+
+// REQUIRES: swift_in_compiler
+
+//--- main.swift
+
+import Lib
+
+// CHECK-OPAQUE: sil @$s4Main023testPackageInSerializedC4FuncyyF : $@convention(thin) () -> ()
+// CHECK-OPAQUE: struct $Thing
+// CHECK-OPAQUE: struct $Thing1
+// CHECK-OPAQUE: function_ref @$s3Lib13getSomeProto2QryF
+// CHECK-OPAQUE: function_ref @$s3Lib13getSomeProto3QryF
+// CHECK-OPAQUE: } // end sil function '$s4Main023testPackageInSerializedC4FuncyyF'
+
+public func testPackageInSerializedPackageFunc() {
+    print(getSomeProto())
+    print(getSomeProto1())
+    print(getSomeProto2())
+    print(getSomeProto3())
+}
+
+//--- Lib.swift
+
+public protocol SomeProto {}
+
+public struct Thing : SomeProto {}
+package struct Thing1 : SomeProto {}
+internal struct Thing2 : SomeProto {}
+private struct Thing3 : SomeProto {}
+
+// Don't crash on this example.
+public func getSomeProto() -> some SomeProto {
+    return Thing()
+}
+public func getSomeProto1() -> some SomeProto {
+    return Thing1()
+}
+public func getSomeProto2() -> some SomeProto {
+    return Thing2()
+}
+public func getSomeProto3() -> some SomeProto {
+    return Thing3()
+}


### PR DESCRIPTION
We need to serialize the underlying type if we want to see the underlying type accross the package resilience domain.

rdar://128482863
