### PR TITLE
Disable Interpreter/element_archetype_captures.swift

### DIFF
--- a/test/Interpreter/element_archetype_captures.swift
+++ b/test/Interpreter/element_archetype_captures.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift
 
+// REQUIRES: rdar128492212
+
 func callee<X: P1, T: P2, U: P3, V: P4>(x: X, t: T, u: U, v: V)
     -> (any P1, any P2, any P3, any P4) {
   return (x, t, u, v)


### PR DESCRIPTION
Tracked by rdar://128492212 (Swift CI: test:
Interpreter/element_archetype_captures.swift)
