### PR TITLE
Mark more linux linkers

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1157,6 +1157,8 @@ reconfigure
 # in Linux CI bots
 relocate-xdg-cache-home-under-build-subdir
 
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold
 
 [preset: buildbot_incremental_linux]
 mixin-preset=
@@ -1802,6 +1804,9 @@ skip-test-foundation
 skip-test-libdispatch
 skip-test-xctest
 
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold
+
 # Builds enough of the toolchain to build a swift package on macOS.
 [preset: mixin_swiftpm_package_macos_platform]
 mixin-preset=mixin_swiftpm_macos_platform
@@ -1824,6 +1829,8 @@ mixin-preset=mixin_swiftpm_linux_platform
 skip-test-llbuild
 skip-test-swiftpm
 
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold
 
 #===------------------------------------------------------------------------===#
 # Test swiftPM on macOS builder
@@ -2094,6 +2101,9 @@ skip-test-cmark
 skip-test-swift
 skip-test-libdispatch
 skip-test-foundation
+
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold
 
 #===------------------------------------------------------------------------===#
 # Remote Mirror Library
@@ -2920,6 +2930,9 @@ install-foundation
 install-libdispatch
 install-xctest
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;libexec;swift-remote-mirror;sdk-overlay;license
+
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold
 
 [preset: source_compat_suite_macos_DA]
 mixin-preset=source_compat_suite_macos_base


### PR DESCRIPTION
This patch fixes more build presets. Anything that builds a clang-linker needs to set the linker to use gold. bfd won't work!