### PR TITLE
[Test] Fix signature mismatch in issue-58123-invalid-debug-info.swift

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/issue-58123-invalid-debug-info.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-58123-invalid-debug-info.swift
@@ -4,7 +4,7 @@
 // Mutating functions with control flow can cause assertion failure for
 // conflicting debug variable type
 
-// CHECK-LABEL: define internal swiftcc float @"$s4main8TestTypeV24doDifferentiableTimeStep04timeG0ySf_tFTJpSSpSrTA"
+// CHECK-LABEL: define internal swiftcc{{.*}} float @"$s4main8TestTypeV24doDifferentiableTimeStep04timeG0ySf_tFTJpSSpSrTA"
 // CHECK: [[SELF:%.*]] = alloca %T4main8TestTypeV06ManualB7TangentV
 // CHECK: call void @llvm.dbg.declare(metadata ptr [[SELF]]
 


### PR DESCRIPTION
rdar://128431000

Made the matcher more robust for potential future added modifiers.
