### PR TITLE
[ClangImporter] `-Xclang -fbuiltin-headers-in-system-modules` is being passed when it shouldn't

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -554,8 +554,8 @@ ClangInvocationFileMapping swift::getClangInvocationFileMapping(
     libcFileMapping =
         getLibcFileMapping(ctx, "wasi-libc.modulemap", std::nullopt, vfs);
 
-    // WASI's module map needs fixing
-    result.requiresBuiltinHeadersInSystemModules = true;
+    // WASI's module map needs fixing (rdar://119563706)
+    result.requiresBuiltinHeadersInSystemModules = !libcFileMapping.empty();
   } else if (triple.isMusl()) {
     libcFileMapping =
         getLibcFileMapping(ctx, "musl.modulemap", StringRef("SwiftMusl.h"), vfs);
@@ -564,8 +564,8 @@ ClangInvocationFileMapping swift::getClangInvocationFileMapping(
     libcFileMapping = getLibcFileMapping(ctx, "glibc.modulemap",
                                          StringRef("SwiftGlibc.h"), vfs);
 
-    // glibc.modulemap needs fixing
-    result.requiresBuiltinHeadersInSystemModules = true;
+    // glibc.modulemap needs fixing (rdar://119563686&123317003)
+    result.requiresBuiltinHeadersInSystemModules = !libcFileMapping.empty();
   }
   result.redirectedFiles.append(libcFileMapping);
 


### PR DESCRIPTION
swift::getClangInvocationFileMapping is called for non-Linux platforms, but will unconditionally set requiresBuiltinHeadersInSystemModules in the else case, or if getLibcFileMapping doesn't return a mapping.

rdar://128219177