### PR TITLE
[RemoteInspection] Hardcode DefaultActorStorage's type info

### DIFF
--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -184,6 +184,8 @@ public:
   explicit BuiltinTypeInfo(TypeRefBuilder &builder,
                            BuiltinTypeDescriptorBase &descriptor);
 
+  explicit BuiltinTypeInfo(unsigned Size, unsigned Alignment, unsigned Stride,
+                           unsigned NumExtraInhabitants, bool BitwiseTakable);
   /// Construct an empty builtin type info.
   BuiltinTypeInfo()
       : TypeInfo(TypeInfoKind::Builtin,
@@ -367,6 +369,7 @@ class TypeConverter {
   const TypeInfo *ThinFunctionTI = nullptr;
   const TypeInfo *ThickFunctionTI = nullptr;
   const TypeInfo *AnyMetatypeTI = nullptr;
+  const TypeInfo *DefaultActorStorageTI = nullptr;
   const TypeInfo *EmptyTI = nullptr;
 
 public:
@@ -424,6 +427,7 @@ private:
   const TypeInfo *getThinFunctionTypeInfo();
   const TypeInfo *getThickFunctionTypeInfo();
   const TypeInfo *getAnyMetatypeTypeInfo();
+  const TypeInfo *getDefaultActorStorageTypeInfo();
   const TypeInfo *getEmptyTypeInfo();
 
   template <typename TypeInfoTy, typename... Args>

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -243,6 +243,12 @@ BuiltinTypeInfo::BuiltinTypeInfo(TypeRefBuilder &builder,
                descriptor.IsBitwiseTakable),
       Name(descriptor.getMangledTypeName()) {}
 
+BuiltinTypeInfo::BuiltinTypeInfo(unsigned Size, unsigned Alignment,
+                                 unsigned Stride, unsigned NumExtraInhabitants,
+                                 bool BitwiseTakable)
+    : TypeInfo(TypeInfoKind::Builtin, Size, Alignment, Stride,
+               NumExtraInhabitants, BitwiseTakable) {}
+
 // Builtin.Int<N> is mangled as 'Bi' N '_'
 // Returns 0 if this isn't an Int
 static unsigned isIntType(std::string name) {
@@ -257,6 +263,7 @@ static unsigned isIntType(std::string name) {
   }
   return 0;
 }
+
 
 bool BuiltinTypeInfo::readExtraInhabitantIndex(
     remote::MemoryReader &reader, remote::RemoteAddress address,
@@ -1532,6 +1539,30 @@ TypeConverter::getAnyMetatypeTypeInfo() {
   return AnyMetatypeTI;
 }
 
+const TypeInfo *TypeConverter::getDefaultActorStorageTypeInfo() {
+  if (DefaultActorStorageTI != nullptr)
+    return DefaultActorStorageTI;
+
+  // The default actor storage is an opaque fixed-size buffer. Use the raw
+  // pointer descriptor to find the word size and pointer alignment in the
+  // current platform.
+  auto descriptor =
+      getBuilder().getBuiltinTypeDescriptor(getRawPointerTypeRef());
+  if (descriptor == nullptr) {
+    DEBUG_LOG(fprintf(stderr, "No TypeInfo for default actor storage type\n"));
+    return nullptr;
+  }
+
+  auto size = descriptor->Size * NumWords_DefaultActor;
+  auto alignment = 2 * descriptor->Alignment;
+
+  DefaultActorStorageTI = makeTypeInfo<BuiltinTypeInfo>(
+      /*Size=*/size, /*Alignment*/ alignment, /*Stride=*/size,
+      /*NumExtraInhabitants*/ 0, /*BitwiseTakable*/ true);
+
+  return DefaultActorStorageTI;
+}
+
 const TypeInfo *TypeConverter::getEmptyTypeInfo() {
   if (EmptyTI != nullptr)
     return EmptyTI;
@@ -2156,6 +2187,8 @@ public:
     } else if (B->getMangledName() == "BO") {
       return TC.getReferenceTypeInfo(ReferenceKind::Strong,
                                      ReferenceCounting::Unknown);
+    } else if (B->getMangledName() == "BD") {
+      return TC.getDefaultActorStorageTypeInfo();
     }
 
     /// Otherwise, get the fixed layout information from reflection

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1262,3 +1262,10 @@ BO
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
+
+BD
+// CHECK-64:      (builtin Builtin.DefaultActorStorage)
+// CHECK-64-NEXT:    (builtin size=96 alignment=16 stride=96 num_extra_inhabitants=0 bitwise_takable=1)
+
+// CHECK-32:      (builtin Builtin.DefaultActorStorage)
+// CHECK-32-NEXT:    (builtin size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1)


### PR DESCRIPTION



(cherry picked from commit 4417786be42084c144ff094789382e8ae361094e)

Explanation: No metadata is emitted for the builtin DefaultActorStorage type. Since its layout is fixed, hardcode its definition in Remote Mirrors.
Risk: Low, this is part of Remote Mirrors and doesn't affect the compiler. 
Testing: Added a compiler test, will add an lldb test.
Issue: rdar://128032250
Reviewer: @adrian-prantl
Original PR: https://github.com/apple/swift/pull/73723
