### PR TITLE
🍒[cxx-interop] Enable a test for reference types on Linux

### DIFF
--- a/test/Interop/Cxx/foreign-reference/reference-counted.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted.swift
@@ -2,8 +2,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -Xfrontend -disable-availability-checking -O)
 //
 // REQUIRES: executable_test
-// TODO: This should work without ObjC interop in the future rdar://97497120
-// REQUIRES: objc_interop
+// XFAIL: OS=windows-msvc
 
 import StdlibUnittest
 import ReferenceCounted


### PR DESCRIPTION
**Explanation**: This enables a test for intrusively ref-counted C++ types on platforms that don't support Objective-C interop, such as Linux.
**Scope**: Only changes a test.
**Risk**: Low.
**Issue**: rdar://97497120

Original PR: https://github.com/apple/swift/pull/73790