### PR TITLE
[DO NOT MERGE] Add an always-triggering assertion to the compiler

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2465,6 +2465,7 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
       SDK = *It;
   }
 
+assert(false && "test symbolication!");
   bool EnableCXXInterop =
       IGM.getSILModule().getASTContext().LangOpts.EnableCXXInterop;
   bool EnableEmbeddedSwift =


### PR DESCRIPTION
This is to experiment with symbolication on the linux build bots.