### PR TITLE
Platform: add new module for VC 17.10.0

### DIFF
--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -702,6 +702,11 @@ module std [system] {
   module _Private [system] {
     requires cplusplus
 
+    explicit module xatomic {
+      header "xatomic.h"
+      export *
+    }
+
     explicit module xhash {
       header "xhash"
       export *


### PR DESCRIPTION
The new headers for LWG-3268 in the new VC release broke the modularisation of `std.atomic`. Add the dependent private module to ensure that we correctly modularise the dependency and allow `std.atomic` to be built again.