### PR TITLE
🌸 [C++] Fix double pointers to foreign ref types

### DIFF
--- a/test/Interop/Cxx/ergonomics/swift-bridging-annotations.swift
+++ b/test/Interop/Cxx/ergonomics/swift-bridging-annotations.swift
@@ -27,6 +27,19 @@ public protocol Proto {
 #if BRIDGING_HEADER_TEST
 func f() -> SharedObject { return SharedObject.create() }
 
+func g() {
+  var logger: LoggerSingleton?
+  var loggerPtr: UnsafeMutablePointer<LoggerSingleton?>?
+  var loggerPtrPtr: UnsafeMutablePointer<UnsafeMutablePointer<LoggerSingleton?>?>?
+
+  takeLoggersByPointer(logger, &logger, &loggerPtr)
+  takeLoggersByPointer(logger, loggerPtr, loggerPtrPtr)
+  takeLoggersByPointer(nil, nil, nil)
+  
+  takeLoggersByReference(logger!, &logger, &loggerPtr)
+  takeLoggersByReference(logger!, &loggerPtr!.pointee, &loggerPtrPtr!.pointee)
+}
+
 func releaseSharedObject(_: SharedObject) { }
 #endif
 
@@ -71,6 +84,12 @@ public:
     static LoggerSingleton *getInstance();
 };
 
+void takeLoggersByPointer(LoggerSingleton *ptr, LoggerSingleton **ptr_ptr, LoggerSingleton ***ptr_ptr_ptr);
+void takeLoggersByReference(LoggerSingleton &ref, LoggerSingleton *&ref_ptr, LoggerSingleton **&ref_ptr_ptr);
+
+void takeLoggersByConstPointer(const LoggerSingleton **pointee0, LoggerSingleton const **pointee1, LoggerSingleton *const *pointer);
+void takeLoggersByConstReference(const LoggerSingleton *&pointee0, LoggerSingleton const *&pointee1, LoggerSingleton *const &pointer);
+
 class SWIFT_UNSAFE_REFERENCE UnsafeNonCopyable {
 public:
     UnsafeNonCopyable(UnsafeNonCopyable &) = delete;
@@ -109,6 +128,26 @@ private:
 // CHECK: class LoggerSingleton {
 // CHECK:   class func getInstance() -> LoggerSingleton!
 // CHECK: }
+
+// CHECK-LABEL: func takeLoggersByPointer(
+// CHECK-SAME: _ ptr: LoggerSingleton!,
+// CHECK-SAME: _ ptr_ptr: UnsafeMutablePointer<LoggerSingleton?>!,
+// CHECK-SAME: _ ptr_ptr_ptr: UnsafeMutablePointer<UnsafeMutablePointer<LoggerSingleton?>?>!)
+
+// CHECK-LABEL: func takeLoggersByReference(
+// CHECK-SAME: _ ref: LoggerSingleton,
+// CHECK-SAME: _ ref_ptr: inout LoggerSingleton!,
+// CHECK-SAME: _ ref_ptr_ptr: inout UnsafeMutablePointer<LoggerSingleton?>!)
+
+// CHECK-LABEL: func takeLoggersByConstPointer(
+// CHECK-SAME: _ pointee0: UnsafeMutablePointer<LoggerSingleton?>!,
+// CHECK-SAME: _ pointee1: UnsafeMutablePointer<LoggerSingleton?>!,
+// CHECK-SAME: _ pointer: UnsafePointer<LoggerSingleton?>!)
+
+// CHECK-LABEL: func takeLoggersByConstReference(
+// CHECK-SAME: _ pointee0: inout LoggerSingleton!,
+// CHECK-SAME: _ pointee1: inout LoggerSingleton!,
+// CHECK-SAME: _ pointer: LoggerSingleton!)
 
 // CHECK: class UnsafeNonCopyable {
 // CHECK: }


### PR DESCRIPTION
- Explanation: Corrects import of doubly-indirect pointers/references to C++ foreign reference types. ClangImporter was previously collapsing away all of the levels of indirection; it should only have removed one. (rdar://123905345)
- Scope: Projects using C++ interop and using the `SWIFT_SHARED_REFERENCE`, `SWIFT_IMMORTAL_REFERENCE`, or `SWIFT_UNSAFE_REFERENCE` macros.
- Risk: Low, and should only affect projects that would have otherwise miscompiled.
- Testing: New tests have been added.
- Reviewer: @zoecarver, @egorzhdan 
- Original PR: apple/swift#73811

> When a C++ type `ForeignTy` is imported as a foreign reference type, Swift should strip a level of indirection from parameters of that type, so e.g. `ForeignTy *` and `ForeignTy &` should be imported to Swift as just `ForeignTy`.  However, it should only strip *one* level of indirection. importType() was instead stripping *all* levels, so things like `ForeignTy **` and `ForeignTy *&` were *also* being incorrectly imported as `ForeignTy`. Narrow this behavior so it only applies to a single level of indirection and add a few test cases to pin down the specifics.