### PR TITLE
Handle generic self types as the isolation parameters.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4441,6 +4441,12 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
           if (auto *var = actorIsolation.getActorInstance()) {
             assert(isa<ParamDecl>(var));
             recordCapture(CapturedValue(var, 0, afd->getLoc()));
+	    if (var->getInterfaceType()->hasTypeParameter()) {
+	      // If the isolated parameter is of a generic (actor)
+	      // type, we need to treat as if the local function is
+	      // generic.
+	      capturesGenericParams = true;
+	    }
           }
         }
       }

--- a/test/SILGen/local_function_isolation.swift
+++ b/test/SILGen/local_function_isolation.swift
@@ -53,3 +53,17 @@ func f(isolation: isolated MyActor, ns: NotSendable) {
 }
 
 func test() async {}
+
+// A generic actor type, which causes the generic self parameter
+// (actor isolation parameter) to be added to captures of the
+// local/nested function.
+actor GenericActor<K> {
+  var i: Int = 0
+  private func outerFunc() {
+    func accessSelf() -> Int {
+      // CHECK-LABEL: sil private [ossa] @$s24local_function_isolation12GenericActorC9outerFunc33_7B9E2B75110B8600A136A469D51CAF2BLLyyF10accessSelfL_SiylF : $@convention(thin) <K> (@sil_isolated @guaranteed GenericActor<K>) -> Int {
+      return 0
+    }
+    print(accessSelf())
+  }
+}


### PR DESCRIPTION
This PR builds on https://github.com/apple/swift/pull/73129 and fixes https://github.com/apple/swift/issues/73345.

Co-authored with @hyp.

