### PR TITLE
Remove diagnostic: lifetime_dependence_on_bitwise_copyable

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtilsTest.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtilsTest.swift
@@ -1,0 +1,23 @@
+//===--- AccessUtils.swift - Utilities for analyzing memory accesses ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// TODO: Move this to AccessUtils.swift when FunctionTest is available.
+//
+//===----------------------------------------------------------------------===//
+
+let getAccessBaseTest = FunctionTest("swift_get_access_base") {
+  function, arguments, context in
+  let address = arguments.takeValue()
+  print("Address: \(address)")
+  let base = address.accessBase
+  print("Base: \(base)")
+}

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
@@ -7,6 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 swift_compiler_sources(Optimizer
+  AccessUtilsTest.swift
   AddressUtils.swift
   BorrowedFromUpdater.swift
   BorrowUtils.swift

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -153,6 +153,7 @@ extension BridgedTestArguments {
 public func registerOptimizerTests() {
   // Register each test.
   registerFunctionTests(
+    getAccessBaseTest,
     argumentConventionsTest,
     borrowIntroducersTest,
     enclosingValuesTest,

--- a/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
@@ -777,8 +777,8 @@ extension AddressUseDefWalker {
       } else {
         return walkUp(address: ia.base, path: path.push(.anyIndexedElement, index: 0))
       }
-    case let mdi as MarkDependenceInst:
-      return walkUp(address: mdi.operands[0].value, path: path)
+    case is MarkDependenceInst, is MarkUninitializedInst:
+      return walkUp(address: (def as! Instruction).operands[0].value, path: path)
     case is MoveOnlyWrapperToCopyableAddrInst,
          is CopyableToMoveOnlyWrapperAddrInst:
       return walkUp(address: (def as! Instruction).operands[0].value, path: path)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7985,8 +7985,6 @@ ERROR(lifetime_dependence_cannot_infer_ambiguous_candidate, none,
        "expected nil or self as return values in an initializer with "
        "lifetime dependent specifiers",
        ())
- ERROR(lifetime_dependence_on_bitwise_copyable, none,
-       "invalid lifetime dependence on BitwiseCopyable type", ())
  ERROR(lifetime_dependence_cannot_be_applied_to_tuple_elt, none,
        "lifetime dependence specifiers cannot be applied to tuple elements", ())
  ERROR(lifetime_dependence_method_escapable_bitwisecopyable_self, none,

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2087,13 +2087,14 @@ struct AccessUseTestVisitor : public AccessUseVisitor {
   }
 };
 
-static FunctionTest AccessPathBaseTest("accesspath-base", [](auto &function,
-                                                             auto &arguments,
-                                                             auto &test) {
+static FunctionTest AccessPathBaseTest("accesspath", [](auto &function,
+                                                        auto &arguments,
+                                                        auto &test) {
   auto value = arguments.takeValue();
   function.print(llvm::outs());
-  llvm::outs() << "Access path base: " << value;
+  llvm::outs() << "Access path for: " << value;
   auto accessPathWithBase = AccessPathWithBase::compute(value);
+  llvm::outs() << "  base: " << accessPathWithBase.base;
   AccessUseTestVisitor visitor;
   visitAccessPathBaseUses(visitor, accessPathWithBase, &function);
 });

--- a/test/ModuleInterface/Inputs/lifetime_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_dependence.swift
@@ -1,8 +1,7 @@
 public struct AnotherView : ~Escapable {
   @usableFromInline let _ptr: UnsafeRawBufferPointer
   @usableFromInline let _count: Int
-  @_unsafeNonescapableResult
-  internal init(_ ptr: UnsafeRawBufferPointer, _ count: Int) {
+  internal init(_ ptr: UnsafeRawBufferPointer, _ count: Int) -> dependsOn(ptr) Self {
     self._ptr = ptr
     self._count = count
   }
@@ -11,9 +10,8 @@ public struct AnotherView : ~Escapable {
 public struct BufferView : ~Escapable {
   @usableFromInline let _ptr: UnsafeRawBufferPointer
   @usableFromInline let _count: Int
-  @_unsafeNonescapableResult
   @usableFromInline 
-  internal init(_ ptr: UnsafeRawBufferPointer, _ count: Int) {
+  internal init(_ ptr: UnsafeRawBufferPointer, _ count: Int) -> dependsOn(ptr) Self  {
     self._ptr = ptr
     self._count = count
   }

--- a/test/Parse/explicit_lifetime_dependence_specifiers.swift
+++ b/test/Parse/explicit_lifetime_dependence_specifiers.swift
@@ -5,10 +5,10 @@ import Builtin
 
 struct BufferView : ~Escapable {
   let ptr: UnsafeRawBufferPointer
-  @_unsafeNonescapableResult
-  init(_ ptr: UnsafeRawBufferPointer) {
+  init(_ ptr: UnsafeRawBufferPointer) -> dependsOn(ptr) Self {
     self.ptr = ptr
   }
+  // TODO:  -> dependsOn(ptr) Self
   @_unsafeNonescapableResult
   init?(_ ptr: UnsafeRawBufferPointer, _ i: Int) {
     if (i % 2 == 0) {
@@ -45,8 +45,7 @@ struct BufferView : ~Escapable {
 
 struct MutableBufferView : ~Escapable, ~Copyable {
   let ptr: UnsafeMutableRawBufferPointer
-  @_unsafeNonescapableResult
-  init(_ ptr: UnsafeMutableRawBufferPointer) {
+  init(_ ptr: UnsafeMutableRawBufferPointer) -> dependsOn(ptr) Self {
     self.ptr = ptr
   }
 }

--- a/test/SIL/Parser/lifetime_dependence.sil
+++ b/test/SIL/Parser/lifetime_dependence.sil
@@ -8,7 +8,7 @@ import Swift
 
 struct BufferView : ~Escapable {
   @_hasStorage let ptr: UnsafeRawBufferPointer { get }
-  @_unsafeNonescapableResult @inlinable init(_ ptr: UnsafeRawBufferPointer)
+  @inlinable init(_ ptr: UnsafeRawBufferPointer) -> _scope(ptr) Self
   init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) -> _scope(a) Self
 }
 

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -6,8 +6,12 @@
 struct BufferView : ~Escapable {
   let ptr: UnsafeRawBufferPointer
   let c: Int
+  init(_ ptr: UnsafeRawBufferPointer, _ c: Int) -> dependsOn(ptr) Self {
+    self.ptr = ptr
+    self.c = c
+  }
   @_unsafeNonescapableResult
-  init(_ ptr: UnsafeRawBufferPointer, _ c: Int) {
+  init(independent ptr: UnsafeRawBufferPointer, _ c: Int) {
     self.ptr = ptr
     self.c = c
   }
@@ -31,8 +35,7 @@ struct BufferView : ~Escapable {
 struct MutableBufferView : ~Escapable, ~Copyable {
   let ptr: UnsafeMutableRawBufferPointer
   let c: Int
-  @_unsafeNonescapableResult
-  init(_ ptr: UnsafeMutableRawBufferPointer, _ c: Int) {
+  init(_ ptr: UnsafeMutableRawBufferPointer, _ c: Int) -> dependsOn(ptr) Self {
     self.ptr = ptr
     self.c = c
   }
@@ -54,12 +57,12 @@ func derive(_ x: borrowing BufferView) -> BufferView {
 }
 
 func derive(_ unused: Int, _ x: borrowing BufferView) -> BufferView {
-  return BufferView(x.ptr, x.c)
+  return BufferView(independent: x.ptr, x.c)
 }
 
 // CHECK: sil hidden @$s28implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView {
 func consumeAndCreate(_ x: consuming BufferView) -> BufferView {
-  return BufferView(x.ptr, x.c)
+  return BufferView(independent: x.ptr, x.c)
 }
 
 func use(_ x: borrowing BufferView) {}
@@ -135,8 +138,7 @@ struct GenericBufferView<Element> : ~Escapable {
                                       count: count)
   }
   // unsafe private API
-  @_unsafeNonescapableResult
-  init(baseAddress: Pointer, count: Int) {
+  init(baseAddress: Pointer, count: Int) -> dependsOn(baseAddress) Self {
     precondition(count >= 0, "Count must not be negative")
     self.baseAddress = baseAddress
     self.count = count

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -15,6 +15,7 @@ extension P {
 }
 
 public struct View: ~Escapable {
+  // TODO: dependsOn(immortal)
   @_unsafeNonescapableResult
   init() { }
 }

--- a/test/SIL/type_lowering_unit.sil
+++ b/test/SIL/type_lowering_unit.sil
@@ -248,6 +248,7 @@ extension GSNCInt: Copyable where T: Copyable  {}
 
 struct GSNEInt<T: ~Escapable>: ~Escapable {
     var x: Int
+    // TODO: dependsOn(immortal)
     @_unsafeNonescapableResult
     init() { x = 0 }
 }

--- a/test/SILOptimizer/accessbase_unit.sil
+++ b/test/SILOptimizer/accessbase_unit.sil
@@ -65,3 +65,24 @@ sil @test_access_global : $@convention(thin) () -> () {
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test {{.*}} on test_mark_uninitialized_inst: get_access_base
+// CHECK: Address:  %{{.*}} = mark_uninitialized [var] [[ALLOC:%.*]] : $*C
+// CHECK: Base:     [[ALLOC]] = alloc_stack [var_decl] $C
+// CHECK-LABEL: end running test {{.*}} on test_mark_uninitialized_inst: get_access_base
+// CHECK-LABEL: begin running test {{.*}} on test_mark_uninitialized_inst: swift_get_access_base
+// CHECK: Address:  %{{.*}} = mark_uninitialized [var] [[ALLOC:%.*]] : $*C
+// CHECK: Base: stack - [[ALLOC]] = alloc_stack [var_decl] $C
+// CHECK-LABEL: end running test {{.*}} on test_mark_uninitialized_inst: swift_get_access_base
+sil [ossa] @test_mark_uninitialized_inst : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  %1 = alloc_stack [var_decl] $C, let
+  %2 = mark_uninitialized [var] %1 : $*C
+  specify_test "get_access_base %2"
+  specify_test "swift_get_access_base %2"
+  assign %0 to %2 : $*C
+  destroy_addr %2 : $*C
+  dealloc_stack %1 : $*C
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/accessbase_unit.sil
+++ b/test/SILOptimizer/accessbase_unit.sil
@@ -27,10 +27,10 @@ class C {}
 // CHECK:       Class [[BOX]] = argument of bb0
 // CHECK:         Field: var value: T Index: 0
 // CHECK-LABEL: end running test {{.*}} on test_phi_nested_access: compute_access_storage with
-// CHECK-LABEL: begin running test 3 of 3 on test_phi_nested_access: accesspath-base
-// CHECK:       Access path base: %6 = argument of bb1
+// CHECK-LABEL: begin running test 3 of 3 on test_phi_nested_access: accesspath
+// CHECK:       Access path for: %6 = argument of bb1
 // CHECK:       Exact Use:   end_access %2
-// CHECK-LABEL: end running test 3 of 3 on test_phi_nested_access: accesspath-base
+// CHECK-LABEL: end running test 3 of 3 on test_phi_nested_access: accesspath
 sil @test_phi_nested_access : $@convention(method) (@guaranteed Box<C>) -> () {
 bb1(%box : $Box<C>):         
   %value_addr = ref_element_addr %box : $Box<C>, #Box.value 
@@ -42,7 +42,7 @@ bb1(%box : $Box<C>):
 exit(%phi : $Builtin.RawPointer):                   
   specify_test "get_access_base @argument"
   specify_test "compute_access_storage @argument"
-  specify_test "accesspath-base @argument"
+  specify_test "accesspath @argument"
   %retval = tuple ()
   return %retval : $()
 } 

--- a/test/SILOptimizer/accesspath_unit.sil
+++ b/test/SILOptimizer/accesspath_unit.sil
@@ -20,34 +20,36 @@ struct S2 {
 sil_global hidden @globalKlass : $Klass
 sil_global hidden @globalStruct : $S2
 
-// CHECK-LABEL: begin running test 1 of 2 on testRefElement: accesspath-base with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 2 on testRefElement: accesspath with: @trace[0]
 // CHECK: [[P1:%.*]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]] : $*S
 // CHECK: [[P2:%.*]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]] : $*S
-// CHECK: Access path base:  [[P1]] = ref_element_addr %0 : $Klass, #Klass.f
+// CHECK: Access path for:  [[P1]] = ref_element_addr %0 : $Klass, #Klass.f
+// CHECK-NEXT: base: [[P1]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK-NEXT: Exact Use:   %{{.*}} = load [trivial] [[A1]] : $*S
 // CHECK-NEXT: Exact Use:   end_access [[A1]] : $*S
-// CHECK: end running test 1 of 2 on testRefElement: accesspath-base with: @trace[0]
+// CHECK: end running test 1 of 2 on testRefElement: accesspath with: @trace[0]
 
-// CHECK-LABEL: begin running test 2 of 2 on testRefElement: accesspath-base with: @trace[1]
+// CHECK-LABEL: begin running test 2 of 2 on testRefElement: accesspath with: @trace[1]
 // CHECK: [[P1:%.*]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]] : $*S
 // CHECK: [[P2:%.*]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]] : $*S
-// CHECK: Access path base:  [[P2]] = ref_element_addr %0 : $Klass, #Klass.f
+// CHECK: Access path for:  [[P2]] = ref_element_addr %0 : $Klass, #Klass.f
+// CHECK: base: [[P2]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK-NEXT: Exact Use:   %{{.*}} = load [trivial] [[A2]] : $*S
 // CHECK-NEXT: Exact Use:   end_access [[A2]] : $*S
-// CHECK: end running test 2 of 2 on testRefElement: accesspath-base with: @trace[1]
+// CHECK: end running test 2 of 2 on testRefElement: accesspath with: @trace[1]
 sil hidden [ossa] @testRefElement : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  specify_test "accesspath-base @trace[0]"
+  specify_test "accesspath @trace[0]"
   %p1 = ref_element_addr %0 : $Klass, #Klass.f
   debug_value [trace] %p1 : $*S
   %a1 = begin_access [read] [dynamic] %p1 : $*S
   %l1 = load [trivial] %a1 : $*S
   end_access %a1 : $*S
-  specify_test "accesspath-base @trace[1]"
+  specify_test "accesspath @trace[1]"
   %p2 = ref_element_addr %0 : $Klass, #Klass.f
   debug_value [trace] %p2 : $*S
   %a2 = begin_access [read] [dynamic] %p2 : $*S
@@ -57,28 +59,30 @@ bb0(%0 : @guaranteed $Klass):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 2 on testGlobalAddrKlass: accesspath with: @trace[0]
 // CHECK: [[P1:%.*]] = global_addr @globalKlass : $*Klass
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]] : $*Klass
 // CHECK: [[P2:%.*]] = global_addr @globalKlass : $*Klass
 // CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]] : $*Klass
-// CHECK: Access path base:  [[P1]] = global_addr @globalKlass : $*Klass
+// CHECK: Access path for:  [[P1]] = global_addr @globalKlass : $*Klass
+// CHECK: base:  [[P1]] = global_addr @globalKlass : $*Klass
 // CHECK-NEXT: Exact Use:   %{{.*}} = load_borrow [[A1]]
 // CHECK-NEXT: Exact Use:   end_access [[A1]]
-// CHECK: end running test 1 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[0]
+// CHECK: end running test 1 of 2 on testGlobalAddrKlass: accesspath with: @trace[0]
 
-// CHECK-LABEL: begin running test 2 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[1]
+// CHECK-LABEL: begin running test 2 of 2 on testGlobalAddrKlass: accesspath with: @trace[1]
 // CHECK: [[P1:%.*]] = global_addr @globalKlass : $*Klass
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]] : $*Klass
 // CHECK: [[P2:%.*]] = global_addr @globalKlass : $*Klass
 // CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]] : $*Klass
-// CHECK: Access path base:  [[P2]] = global_addr @globalKlass : $*Klass
+// CHECK: Access path for:  [[P2]] = global_addr @globalKlass : $*Klass
+// CHECK: base:  [[P2]] = global_addr @globalKlass : $*Klass
 // CHECK-NEXT: Exact Use:   %{{.*}} = load_borrow [[A2]]
 // CHECK-NEXT: Exact Use:   end_access [[A2]]
-// CHECK: end running test 2 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[1]
+// CHECK: end running test 2 of 2 on testGlobalAddrKlass: accesspath with: @trace[1]
 sil [ossa] @testGlobalAddrKlass : $@convention(thin) () -> () {
 bb0:
-  specify_test "accesspath-base @trace[0]"
+  specify_test "accesspath @trace[0]"
   %p1 = global_addr @globalKlass : $*Klass
   debug_value [trace] %p1 : $*Klass
   %a1 = begin_access [read] [dynamic] %p1 : $*Klass
@@ -86,7 +90,7 @@ bb0:
   end_borrow %l1 : $Klass
   end_access %a1 : $*Klass
 
-  specify_test "accesspath-base @trace[1]"
+  specify_test "accesspath @trace[1]"
   %p2 = global_addr @globalKlass : $*Klass
   debug_value [trace] %p2 : $*Klass
   %a2 = begin_access [read] [dynamic] %p2 : $*Klass
@@ -98,7 +102,7 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 3 on testGlobalAddrStruct: accesspath with: @trace[0]
 // CHECK: [[P1:%.*]] = global_addr @globalStruct
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]]
 // CHECK: [[P2:%.*]] = global_addr @globalStruct
@@ -107,12 +111,13 @@ bb0:
 // CHECK: [[P3:%.*]] = global_addr @globalStruct
 // CHECK: [[A3:%.*]] = begin_access [read] [dynamic] [[P3]]
 // CHECK: [[GEP3:%.*]] = struct_element_addr [[A3]]
-// CHECK: Access path base:  [[P1]] = global_addr @globalStruct
+// CHECK: Access path for:  [[P1]] = global_addr @globalStruct
+// CHECK: base:  [[P1]] = global_addr @globalStruct
 // CHECK-NEXT: Exact Use:   %{{.*}} = load_borrow [[A1]]
 // CHECK-NEXT: Exact Use:   end_access [[A1]]
-// CHECK: end running test 1 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[0]
+// CHECK: end running test 1 of 3 on testGlobalAddrStruct: accesspath with: @trace[0]
 
-// CHECK-LABEL: begin running test 2 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[1]
+// CHECK-LABEL: begin running test 2 of 3 on testGlobalAddrStruct: accesspath with: @trace[1]
 // CHECK: [[P1:%.*]] = global_addr @globalStruct
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]]
 // CHECK: [[P2:%.*]] = global_addr @globalStruct
@@ -121,12 +126,13 @@ bb0:
 // CHECK: [[P3:%.*]] = global_addr @globalStruct
 // CHECK: [[A3:%.*]] = begin_access [read] [dynamic] [[P3]]
 // CHECK: [[GEP3:%.*]] = struct_element_addr [[A3]]
-// CHECK: Access path base:  [[P2]] = global_addr @globalStruct
+// CHECK: Access path for:  [[P2]] = global_addr @globalStruct
+// CHECK: base:  [[P2]] = global_addr @globalStruct
 // CHECK-NEXT: Inner Use:   %{{.*}} = load_borrow [[GEP2]]
 // CHECK-NEXT: Exact Use:   end_access [[A2]]
-// CHECK: end running test 2 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[1]
+// CHECK: end running test 2 of 3 on testGlobalAddrStruct: accesspath with: @trace[1]
 
-// CHECK-LABEL: begin running test 3 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[2]
+// CHECK-LABEL: begin running test 3 of 3 on testGlobalAddrStruct: accesspath with: @trace[2]
 // CHECK: [[P1:%.*]] = global_addr @globalStruct
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]]
 // CHECK: [[P2:%.*]] = global_addr @globalStruct
@@ -135,13 +141,14 @@ bb0:
 // CHECK: [[P3:%.*]] = global_addr @globalStruct
 // CHECK: [[A3:%.*]] = begin_access [read] [dynamic] [[P3]]
 // CHECK: [[GEP3:%.*]] = struct_element_addr [[A3]]
-// CHECK: Access path base:  [[P3]] = global_addr @globalStruct
+// CHECK: Access path for:  [[P3]] = global_addr @globalStruct
+// CHECK: base:  [[P3]] = global_addr @globalStruct
 // CHECK-NEXT: Inner Use:   %{{.*}} = load_borrow [[GEP3]]
 // CHECK-NEXT: Exact Use:   end_access [[A3]]
-// CHECK: end running test 3 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[2]
+// CHECK: end running test 3 of 3 on testGlobalAddrStruct: accesspath with: @trace[2]
 sil [ossa] @testGlobalAddrStruct : $@convention(thin) () -> () {
 bb0:
-  specify_test "accesspath-base @trace[0]"
+  specify_test "accesspath @trace[0]"
   %p3 = global_addr @globalStruct : $*S2
   debug_value [trace] %p3 : $*S2
   %a3 = begin_access [read] [dynamic] %p3 : $*S2
@@ -149,7 +156,7 @@ bb0:
   end_borrow %l3 : $S2
   end_access %a3 : $*S2
 
-  specify_test "accesspath-base @trace[1]"
+  specify_test "accesspath @trace[1]"
   %p4 = global_addr @globalStruct : $*S2
   debug_value [trace] %p4 : $*S2
   %a4 = begin_access [read] [dynamic] %p4 : $*S2
@@ -158,7 +165,7 @@ bb0:
   end_borrow %l4 : $Klass
   end_access %a4 : $*S2
 
-  specify_test "accesspath-base @trace[2]"
+  specify_test "accesspath @trace[2]"
   %p5 = global_addr @globalStruct : $*S2
   debug_value [trace] %p5 : $*S2
   %a5 = begin_access [read] [dynamic] %p5 : $*S2

--- a/test/SILOptimizer/lifetime_dependence_borrow.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow.swift
@@ -21,8 +21,7 @@ struct BV : ~Escapable {
 
   public var isEmpty: Bool { i == 0 }
 
-  @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ i: Int) {
+  init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
     self.p = p
     self.i = i
   }
@@ -38,8 +37,7 @@ struct MBV : ~Escapable, ~Copyable {
   let p: UnsafeRawPointer
   let i: Int
   
-  @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ i: Int) {
+  init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
     self.p = p
     self.i = i
   }

--- a/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
@@ -13,7 +13,7 @@ struct BV : ~Escapable {
   let i: Int
 
   @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ i: Int) {
+  init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
     self.p = p
     self.i = i
   }
@@ -23,7 +23,6 @@ struct NC : ~Copyable {
   let p: UnsafeRawPointer
   let i: Int
 
-  @_unsafeNonescapableResult
   init(_ p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
@@ -38,7 +37,7 @@ struct NE : ~Escapable {
   let i: Int
 
   @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ i: Int) {
+  init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
     self.p = p
     self.i = i
   }

--- a/test/SILOptimizer/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence_diagnostics.swift
@@ -10,8 +10,7 @@
 struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let c: Int
-  @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ c: Int) {
+  init(_ p: UnsafeRawPointer, _ c: Int) -> dependsOn(p) Self {
     self.p = p
     self.c = c
   }

--- a/test/SILOptimizer/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit.swift
@@ -12,8 +12,13 @@ struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
+  init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
+    self.p = p
+    self.i = i
+  }
+
   @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ i: Int) {
+  init(independent p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
   }
@@ -21,7 +26,7 @@ struct BV : ~Escapable {
   consuming func derive() -> dependsOn(self) BV {
     // Technically, this "new" view does not depend on the 'view' argument.
     // This unsafely creates a new view with no dependence.
-    return BV(self.p, self.i)
+    return BV(independent: self.p, self.i)
   }
 }
 

--- a/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
@@ -12,8 +12,13 @@ struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
+  init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
+    self.p = p
+    self.i = i
+  }
+
   @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ i: Int) {
+  init(independent p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
   }
@@ -21,7 +26,7 @@ struct BV : ~Escapable {
   consuming func derive() -> dependsOn(self) BV {
     // Technically, this "new" view does not depend on the 'view' argument.
     // This unsafely creates a new view with no dependence.
-    return BV(self.p, self.i)
+    return BV(independent: self.p, self.i)
   }
 }
 

--- a/test/SILOptimizer/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence_insertion.swift
@@ -12,8 +12,7 @@ struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
-  @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ i: Int) {
+  init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
     self.p = p
     self.i = i
   }

--- a/test/SILOptimizer/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence_mutate.swift
@@ -12,8 +12,7 @@ struct MBV : ~Escapable, ~Copyable {
   let p: UnsafeMutableRawPointer
   let c: Int
 
-  @_unsafeNonescapableResult
-  init(_ p: UnsafeMutableRawPointer, _ c: Int) {
+  init(_ p: UnsafeMutableRawPointer, _ c: Int) -> dependsOn(p) Self {
     self.p = p
     self.c = c
   }

--- a/test/SILOptimizer/lifetime_dependence_optional.swift
+++ b/test/SILOptimizer/lifetime_dependence_optional.swift
@@ -10,6 +10,7 @@
 // Simply test that it is possible for a module to define a pseudo-Optional type without triggering any compiler errors.
 
 public protocol ExpressibleByNilLiteral: ~Copyable & ~Escapable {
+  // TODO: dependsOn(immortal)
   @_unsafeNonescapableResult
   init(nilLiteral: ())
 }
@@ -29,6 +30,7 @@ extension Nillable: Sendable where Wrapped: ~Copyable & ~Escapable & Sendable { 
 extension Nillable: BitwiseCopyable where Wrapped: BitwiseCopyable { }
 
 extension Nillable: ExpressibleByNilLiteral where Wrapped: ~Copyable & ~Escapable {
+  // TODO: dependsOn(immortal)
   @_transparent
   @_unsafeNonescapableResult
   public init(nilLiteral: ()) {

--- a/test/SILOptimizer/lifetime_dependence_param.swift
+++ b/test/SILOptimizer/lifetime_dependence_param.swift
@@ -12,8 +12,13 @@ struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
+  init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
+    self.p = p
+    self.i = i
+  }
+
   @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ i: Int) {
+  init(independent p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
   }
@@ -25,7 +30,7 @@ struct BV : ~Escapable {
   consuming func derive() -> dependsOn(self) BV {
     // Technically, this "new" view does not depend on the 'view' argument.
     // This unsafely creates a new view with no dependence.
-    return BV(self.p, self.i)
+    return BV(independent: self.p, self.i)
   }
 }
 
@@ -33,8 +38,7 @@ struct BV : ~Escapable {
 struct NE {
   var bv: BV
 
-  @_unsafeNonescapableResult
-  init(_ bv: BV) {
+  init(_ bv: BV) -> dependsOn(bv) Self {
     self.bv = bv
   }
 }

--- a/test/SILOptimizer/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_param_fail.swift
@@ -12,8 +12,7 @@ struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let c: Int
 
-  @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ c: Int) {
+  init(_ p: UnsafeRawPointer, _ c: Int) -> dependsOn(p) Self {
     self.p = p
     self.c = c
   }

--- a/test/SILOptimizer/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope.swift
@@ -15,8 +15,7 @@ struct BV : ~Escapable {
 
   public var isEmpty: Bool { c == 0 }
 
-  @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ c: Int) {
+  init(_ p: UnsafeRawPointer, _ c: Int) -> dependsOn(p) Self {
     self.p = p
     self.c = c
   }

--- a/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
@@ -39,8 +39,7 @@ struct View : ~Escapable {
 struct MutableView : ~Copyable, ~Escapable {
   let ptr: UnsafeRawBufferPointer
   let c: Int
-  @_unsafeNonescapableResult
-  init(_ ptr: UnsafeRawBufferPointer, _ c: Int) {
+  init(_ ptr: UnsafeRawBufferPointer, _ c: Int) -> dependsOn(ptr) Self {
     self.ptr = ptr
     self.c = c
   }

--- a/test/SILOptimizer/lifetime_dependence_todo.swift
+++ b/test/SILOptimizer/lifetime_dependence_todo.swift
@@ -15,7 +15,7 @@ struct BV : ~Escapable {
   let i: Int
 
   @_unsafeNonescapableResult
-  init(_ p: UnsafeRawPointer, _ i: Int) {
+  init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
     self.p = p
     self.i = i
   }

--- a/test/SILOptimizer/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence_util.sil
@@ -15,6 +15,7 @@ import Builtin
 
 struct NCNEInt: ~Copyable, ~Escapable {
   var i: Builtin.Int64
+  // TODO: dependsOn(immortal)
   @_unsafeNonescapableResult
   init() {}
   deinit {}
@@ -49,12 +50,14 @@ sil_vtable D {
 
 struct NE : ~Escapable {
   var d: D
+  // TODO: dependsOn(immortal)
   @_unsafeNonescapableResult
   init() { }
 }
 
 struct NEWrap : ~Escapable {
   var ne: NE
+  // TODO: dependsOn(immortal)
   @_unsafeNonescapableResult
   init() { }
 }

--- a/test/Sema/explicit_lifetime_dependence_specifiers2.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers2.swift
@@ -4,8 +4,7 @@
 
 struct AnotherBufferView : ~Escapable, BitwiseCopyable {
   let ptr: UnsafeRawBufferPointer
-  @_unsafeNonescapableResult
-  init(_ ptr: UnsafeRawBufferPointer) {
+  init(_ ptr: UnsafeRawBufferPointer) -> dependsOn(ptr) Self  {
     self.ptr = ptr
   }
 }

--- a/test/Sema/implicit_lifetime_dependence.swift
+++ b/test/Sema/implicit_lifetime_dependence.swift
@@ -4,8 +4,7 @@
 struct BufferView : ~Escapable, ~Copyable {
   let ptr: UnsafeRawBufferPointer?
   let c: Int
-  @_unsafeNonescapableResult
-  init(_ ptr: UnsafeRawBufferPointer?, _ c: Int) {
+  init(_ ptr: UnsafeRawBufferPointer?, _ c: Int) -> dependsOn(ptr) Self {
     self.ptr = ptr
     self.c = c
   }

--- a/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
+++ b/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
@@ -1,16 +1,14 @@
 public struct AnotherView : ~Escapable {
   let ptr: UnsafeRawBufferPointer
-  @_unsafeNonescapableResult
-  public init(_ ptr: UnsafeRawBufferPointer) {
+  public init(_ ptr: UnsafeRawBufferPointer) -> dependsOn(ptr) Self {
     self.ptr = ptr
   }
 }
 
 public struct BufferView : ~Escapable {
   public let ptr: UnsafeRawBufferPointer
-  @_unsafeNonescapableResult
   @inlinable
-  public init(_ ptr: UnsafeRawBufferPointer) {
+  public init(_ ptr: UnsafeRawBufferPointer) -> dependsOn(ptr) Self {
     self.ptr = ptr
   }
   public init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) -> dependsOn(a) Self {
@@ -29,8 +27,7 @@ public struct BufferView : ~Escapable {
 
 public struct MutableBufferView : ~Escapable, ~Copyable {
   let ptr: UnsafeMutableRawBufferPointer
-  @_unsafeNonescapableResult
-  public init(_ ptr: UnsafeMutableRawBufferPointer) {
+  public init(_ ptr: UnsafeMutableRawBufferPointer) -> dependsOn(ptr) Self {
     self.ptr = ptr
   }
 }

--- a/test/Serialization/Inputs/def_implicit_lifetime_dependence.swift
+++ b/test/Serialization/Inputs/def_implicit_lifetime_dependence.swift
@@ -1,8 +1,7 @@
 public struct BufferView : ~Escapable {
   public let ptr: UnsafeRawBufferPointer
   public let c: Int
-  @_unsafeNonescapableResult
-  public init(_ ptr: UnsafeRawBufferPointer, _ c: Int) {
+  public init(_ ptr: UnsafeRawBufferPointer, _ c: Int) -> dependsOn(ptr) Self {
     self.ptr = ptr
     self.c = c
   }
@@ -16,8 +15,7 @@ public struct BufferView : ~Escapable {
 public struct MutableBufferView : ~Escapable, ~Copyable {
   let ptr: UnsafeMutableRawBufferPointer
   let c: Int
-  @_unsafeNonescapableResult
-  public init(_ ptr: UnsafeMutableRawBufferPointer, _ c: Int) {
+  public init(_ ptr: UnsafeMutableRawBufferPointer, _ c: Int) -> dependsOn(ptr) Self {
     self.ptr = ptr
     self.c = c
   }

--- a/test/attr/attr_nonEscapable.swift
+++ b/test/attr/attr_nonEscapable.swift
@@ -5,11 +5,13 @@
 public struct NES : ~Escapable {
   let x: Int
 
+  // TODO: dependsOn(immortal)
   @_unsafeNonescapableResult
   init() {
     x = 0
   }
 
+  // TODO: dependsOn(immortal)
   @_unsafeNonescapableResult
   static func makeS() -> NES {
     return NES()
@@ -18,6 +20,7 @@ public struct NES : ~Escapable {
 
 struct BC {
   public var nes: NES {
+    // TODO: dependsOn(immortal)
     @_unsafeNonescapableResult
     get {
       NES()


### PR DESCRIPTION
Allow lifetime depenendence on types that are BitwiseCopyable & Escapable.

Single commit PR on top of https://github.com/apple/swift/pull/73621

This is unsafe in the sense that the compiler will not diagnose any use of the
dependent value outside of the lexcial scope of the source value. But, in
practice, dependence on an UnsafePointer is often needed. In that case, the
programmer should have already taken responsibility for ensuring the lifetime of the
pointer over all dependent uses. Typically, an unsafe pointer is valid for the
duration of a closure. Lifetime dependence prevents the dependent value from
being returned by the closure, so common usage is safe by default.

Typical example:

func decode(_ bufferRef: Span<Int>) { /*...*/ }

extension UnsafeBufferPointer {
  // The client must ensure the lifetime of the buffer across the invocation of `body`.
  // The client must ensure that no code modifies the buffer during the invocation of `body`.
  func withUnsafeSpan<Result>(_ body: (Span<Element>) throws -> Result) rethrows -> Result {
    // Construct Span using its internal, unsafe API.
    try body(Span(unsafePointer: baseAddress!, count: count))
  }
}

func decodeArrayAsUBP(array: [Int]) {
  array.withUnsafeBufferPointer { buffer in
    buffer.withUnsafeSpan {
      decode($0)
    }
  }
}

In the future, we may add SILGen support for tracking the lexical scope of
BitwiseCopyable values. That would allow them to have the same dependence
behavior as other source values.