### PR TITLE
[Macros] Ignore the `@TaskLocal` macro attached to vars with projected value vars.

### DIFF
--- a/test/ModuleInterface/task_local_attr.swiftinterface
+++ b/test/ModuleInterface/task_local_attr.swiftinterface
@@ -1,0 +1,20 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Swift version 6.0
+// swift-module-flags: -swift-version 5 -disable-availability-checking
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-typecheck-module-from-interface(%s)
+
+import Swift
+import _Concurrency
+
+@_hasMissingDesignatedInitializers final public class C {
+  @_Concurrency.TaskLocal @_projectedValueProperty($x) public static var x: Swift.Int? {
+    get
+  }
+  public static var $x: _Concurrency.TaskLocal<Swift.Int?> {
+    get
+    @available(*, unavailable, message: "use '$myTaskLocal.withValue(_:do:)' instead")
+    set
+  }
+}


### PR DESCRIPTION
VarDecls with `@_projectedValueProperty` have already had the property wrapper transform applied. This only impacts swiftinterfaces, and if a swiftinterface was produced against a Concurrency library that does not declare `TaskLocal` as a macro, we need to ignore the macro to avoid producing duplicate declarations. This is only needed temporarily until all swiftinterfaces have been built against the Concurrency library containing the new macro declaration.

Note that all of the property wrapper requests will not consider these declarations to have an attached property wrapper because the macro declaration always wins when resolving the custom attribute. I think this is okay, because the property wrapper transform has already been applied. As far as I can tell, the purpose of `@_projectedValueProperty` is to avoid synthesizing another projected value in the case where one has already been created.

Resolves: rdar://128542258