### PR TITLE
[Sema]: improve noasync diagnostics in defer statement bodies

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -397,6 +397,18 @@ static bool shouldAllowReferenceToUnavailableInSwiftDeclaration(
   return false;
 }
 
+// Utility function to help determine if noasync diagnostics are still
+// appropriate even if a `DeclContext` returns `false` from `isAsyncContext()`.
+static bool shouldTreatDeclContextAsAsyncForDiagnostics(const DeclContext *DC) {
+  if (auto *D = DC->getAsDecl())
+    if (auto *FD = dyn_cast<FuncDecl>(D))
+      if (FD->isDeferBody())
+        // If this is a defer body, we should delegate to its parent.
+        return shouldTreatDeclContextAsAsyncForDiagnostics(DC->getParent());
+
+  return DC->isAsyncContext();
+}
+
 namespace {
 
 /// A class to walk the AST to build the type refinement context hierarchy.
@@ -3781,17 +3793,20 @@ bool ExprAvailabilityWalker::diagnoseDeclRefAvailability(
 static bool
 diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
                               const Expr *call, const ExportContext &Where) {
-  // If we are in a synchronous context, don't check it
-  if (!Where.getDeclContext()->isAsyncContext())
+  // If we are not in an (effective) async context, don't check it
+  if (!shouldTreatDeclContextAsAsyncForDiagnostics(Where.getDeclContext()))
     return false;
 
   ASTContext &ctx = Where.getDeclContext()->getASTContext();
 
-  if (const AbstractFunctionDecl *afd = dyn_cast<AbstractFunctionDecl>(D)) {
-    if (const AbstractFunctionDecl *asyncAlt = afd->getAsyncAlternative()) {
-      SourceLoc diagLoc = call ? call->getLoc() : R.Start;
-      ctx.Diags.diagnose(diagLoc, diag::warn_use_async_alternative);
-      asyncAlt->diagnose(diag::decl_declared_here, asyncAlt);
+  // Only suggest async alternatives if the DeclContext is truly async
+  if (Where.getDeclContext()->isAsyncContext()) {
+    if (const AbstractFunctionDecl *afd = dyn_cast<AbstractFunctionDecl>(D)) {
+      if (const AbstractFunctionDecl *asyncAlt = afd->getAsyncAlternative()) {
+        SourceLoc diagLoc = call ? call->getLoc() : R.Start;
+        ctx.Diags.diagnose(diagLoc, diag::warn_use_async_alternative);
+        asyncAlt->diagnose(diag::decl_declared_here, asyncAlt);
+      }
     }
   }
 

--- a/test/attr/attr_availability_noasync.swift
+++ b/test/attr/attr_availability_noasync.swift
@@ -62,3 +62,96 @@ class TestClass {
     @available(*, noasync)
     deinit { }
 }
+
+@available(SwiftStdlib 5.5, *)
+func test_defers_sync() {
+    defer {
+        defer { basicNoAsync() }
+        basicNoAsync()
+    }
+
+    func local_sync_func() {
+        defer { basicNoAsync() }
+        _ = ()
+    }
+
+    func local_async_func() async {
+        // expected-warning@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts; this is an error in the Swift 6 language mode}}
+        defer { basicNoAsync() }
+        _ = ()
+    }
+
+    let local_sync_closure = { () -> Void in
+        defer { basicNoAsync() }
+        _ = ()
+    }
+    _ = local_sync_closure
+
+    // local async closure
+    let local_async_closure = { () async -> Void in
+        // expected-warning@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts; this is an error in the Swift 6 language mode}}
+        defer { basicNoAsync() }
+        _ = ()
+    }
+    _ = local_async_closure
+
+    var local_sync_var: Void {
+        defer { basicNoAsync() }
+        return ()
+    }
+
+    var local_async_var: Void {
+        get async {
+            // expected-warning@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts; this is an error in the Swift 6 language mode}}
+            defer { basicNoAsync() }
+            return ()
+        }
+    }
+}
+
+@available(SwiftStdlib 5.5, *)
+func test_defer_async() async {
+    defer {
+        // expected-warning@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts; this is an error in the Swift 6 language mode}}
+        defer { basicNoAsync() }
+        // expected-warning@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts; this is an error in the Swift 6 language mode}}
+        basicNoAsync()
+    }
+
+    func local_sync_func() {
+        defer { basicNoAsync() }
+        _ = ()
+    }
+
+    func local_async_func() async {
+        // expected-warning@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts; this is an error in the Swift 6 language mode}}
+        defer { basicNoAsync() }
+        _ = ()
+    }
+
+    let local_sync_closure = { () -> Void in
+        defer { basicNoAsync() }
+        _ = ()
+    }
+    _ = local_sync_closure
+
+    let local_async_closure = { () async -> Void in
+        // expected-warning@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts; this is an error in the Swift 6 language mode}}
+        defer { basicNoAsync() }
+        _ = ()
+    }
+    _ = local_async_closure
+
+    var local_sync_var: Void {
+        defer { basicNoAsync() }
+        return ()
+    }
+
+    var local_async_var: Void {
+        get async {
+            // expected-warning@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts; this is an error in the Swift 6 language mode}}
+            defer { basicNoAsync() }
+            return ()
+        }
+    }
+}


### PR DESCRIPTION
updates noasync diagnostics in TypeCheckAvailability.cpp to diagnose defer bodies as if they had the same `isAsyncContext()` value as their nearest non-defer parent scope.

resolves: https://github.com/apple/swift/issues/73614 and rdar://128102432