### PR TITLE
[Features] Move NoncopyableGenerics up.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -192,9 +192,9 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(AssociatedTypeImplements, 0, "@_implements on asso
 LANGUAGE_FEATURE(BuiltinAddressOfRawLayout, 0, "Builtin.addressOfRawLayout")
 LANGUAGE_FEATURE(MoveOnlyPartialConsumption, 429, "Partial consumption of noncopyable values")
 LANGUAGE_FEATURE(BitwiseCopyable, 426, "BitwiseCopyable protocol")
+SUPPRESSIBLE_LANGUAGE_FEATURE(NoncopyableGenerics, 427, "Noncopyable generics")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ConformanceSuppression, 426, "Suppressible inferred conformances")
 SUPPRESSIBLE_LANGUAGE_FEATURE(BitwiseCopyable2, 426, "BitwiseCopyable feature")
-SUPPRESSIBLE_LANGUAGE_FEATURE(NoncopyableGenerics, 427, "Noncopyable generics")
 LANGUAGE_FEATURE(BodyMacros, 415, "Function body macros")
 
 // Swift 6

--- a/test/ModuleInterface/conformance_suppression.swift
+++ b/test/ModuleInterface/conformance_suppression.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Mojuel
+// RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface -module-name Mojuel)
+
+// CHECK:      #if compiler(>=5.3) && $ConformanceSuppression
+// CHECK-NEXT: public enum RecollectionOrganization<T> : ~Swift.BitwiseCopyable, Swift.Copyable where T : ~Copyable {
+// CHECK-NEXT: }
+// CHECK-NEXT: #elseif compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: public enum RecollectionOrganization<T> : Swift.Copyable where T : ~Copyable {
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: public enum RecollectionOrganization<T> {
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+public enum RecollectionOrganization<T : ~Copyable> : ~BitwiseCopyable, Copyable {}


### PR DESCRIPTION
Some compilers have the `NoncopyableGenerics` feature enabled via interesting mechanisms but do not have `ConformanceSuppression`.  To support such compilers, the `NoncopyableGenerics` feature must appear before `ConformanceSuppression` in the list of features.  Otherwise, when parsing the portion of the swiftinterface corresponding to an entity which involves both features, the first check will be for `NoncopyableGenerics` (which that old compiler has) and the code inside will involve `ConformanceSuppression` (which that old compiler does not have).

rdar://128611158
