### PR TITLE
tests: fix embedded/static-object.swift

### DIFF
--- a/test/embedded/static-object.swift
+++ b/test/embedded/static-object.swift
@@ -6,6 +6,7 @@
 // RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
 
 // REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
 
 // Check if the optimizer is able to convert array literals to constant statically initialized arrays.
 


### PR DESCRIPTION
A REQUIRES for embedded tests was missing

rdar://128611737
