### PR TITLE
6.0: [Features] Move NoncopyableGenerics up.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -192,9 +192,9 @@ LANGUAGE_FEATURE(BuiltinCreateTask, 0, "Builtin.createTask and Builtin.createDis
 SUPPRESSIBLE_LANGUAGE_FEATURE(AssociatedTypeImplements, 0, "@_implements on associated types")
 LANGUAGE_FEATURE(MoveOnlyPartialConsumption, 429, "Partial consumption of noncopyable values")
 LANGUAGE_FEATURE(BitwiseCopyable, 426, "BitwiseCopyable protocol")
+SUPPRESSIBLE_LANGUAGE_FEATURE(NoncopyableGenerics, 427, "Noncopyable generics")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ConformanceSuppression, 426, "Suppressible inferred conformances")
 SUPPRESSIBLE_LANGUAGE_FEATURE(BitwiseCopyable2, 426, "BitwiseCopyable feature")
-SUPPRESSIBLE_LANGUAGE_FEATURE(NoncopyableGenerics, 427, "Noncopyable generics")
 LANGUAGE_FEATURE(BodyMacros, 415, "Function body macros")
 
 // Swift 6

--- a/test/ModuleInterface/conformance_suppression.swift
+++ b/test/ModuleInterface/conformance_suppression.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Mojuel
+// RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface -module-name Mojuel)
+
+// CHECK:      #if compiler(>=5.3) && $ConformanceSuppression
+// CHECK-NEXT: public enum RecollectionOrganization<T> : ~Swift.BitwiseCopyable, Swift.Copyable where T : ~Copyable {
+// CHECK-NEXT: }
+// CHECK-NEXT: #elseif compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: public enum RecollectionOrganization<T> : Swift.Copyable where T : ~Copyable {
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: public enum RecollectionOrganization<T> {
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+public enum RecollectionOrganization<T : ~Copyable> : ~BitwiseCopyable, Copyable {}


### PR DESCRIPTION
**Explanation**: Fix a condfail on MemoryLayout in the stdlib.

The `MemoryLayout` declaration involves both `NoncopyableGenerics` (its generic paramter need not conform to `Copyable`) and `ConformanceSuppression` (inference of conformance to `BitwiseCopyable` is repressed).  

Some compilers have `NoncopyableGenerics` but not `ConformanceSuppression`.  The declarations in Features.def need to match the order in which features appeared in compilers.  This is necesary because ASTPrinting assumes that if a compiler has a declared-later feature, it has all declared-earlier features.

Previously, `NoncopyableGenerics` was declared _after_ `ConformanceSuppression`.  That resulted in `ASTPrinting` assuming that all compilers which had `NoncopyableGenerics` also had `ConformanceSuppression`.  That isn't the case, however--as mentioned, some compilers have `NoncopyableGenerics` but not `ConformanceSuppression`.

Here, this is fixed by declaring the `NoncopyableGenerics` feature earlier than `ConformanceSuppression` in Features.def.  The result is that ASTPrinting correctly assumes that if a compiler has `ConformanceSuppression` it also has `NoncopyableGenerics`, but not the reverse.
caused by NoncopyableGenerics being newer than ConformanceSuppression.
**Scope**: Very narrow.  Affects declarations of types involving both `NoncopyableGenerics` and `ConformanceSuppression` in swiftinterfaces.
**Issue**: rdar://128611158
**Original PR**: https://github.com/apple/swift/pull/73843
**Risk**: Very low.
**Testing**: Added a test which demonstrates the interface being printed as desired.
**Reviewer**: Allan Shortlidge ( @tshortli )
