### PR TITLE
[6.0][Caching] Temporarily using llvm style diagnostics in caching

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -61,10 +61,10 @@ public:
   CharSourceRange generatedSourceRange;
 
   /// The opaque pointer for an ASTNode for which this buffer was generated.
-  void *astNode;
+  void *astNode = nullptr;
 
   /// The declaration context in which this buffer logically resides.
-  DeclContext *declContext;
+  DeclContext *declContext = nullptr;
 
   /// The custom attribute for an attached macro.
   CustomAttr *attachedMacroCustomAttr = nullptr;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2142,7 +2142,7 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
       Args.hasFlag(OPT_color_diagnostics,
                    OPT_no_color_diagnostics,
                    /*Default=*/llvm::sys::Process::StandardErrHasColors());
-  // If no style options are specified, default to LLVM style.
+  // If no style options are specified, default to Swift style.
   Opts.PrintedFormattingStyle = DiagnosticOptions::FormattingStyle::Swift;
   if (const Arg *arg = Args.getLastArg(OPT_diagnostic_style)) {
     StringRef contents = arg->getValue();
@@ -2156,6 +2156,9 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
       return true;
     }
   }
+  // Swift style is not fully supported in cached mode yet.
+  if (Args.hasArg(OPT_cache_compile_job))
+    Opts.PrintedFormattingStyle = DiagnosticOptions::FormattingStyle::LLVM;
 
   for (const Arg *arg: Args.filtered(OPT_emit_macro_expansion_files)) {
     StringRef contents = arg->getValue();


### PR DESCRIPTION
Explanation: Swift Caching Diagnostics doesn't support swift style diagnostics yet, which can cause crashes. Workaround the issue by only using llvm style diagnostics for now.
Scope: Avoid crashes and wrongly rendered diagnostics when caching is on.
Original PR: https://github.com/apple/swift/pull/73575
Issue: rdar://127530204
Reviewer: @akyrtzi 
Risk: Low.
Test: Unit Tests

