### PR TITLE
Don't delete allocations in DCE

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -81,6 +81,12 @@ static bool seemsUseful(SILInstruction *I) {
   if (isa<DebugValueInst>(I))
     return isa<SILFunctionArgument>(I->getOperand(0))
       || isa<SILUndef>(I->getOperand(0));
+  
+
+  // Don't delete allocation instructions in DCE.
+  if (isa<AllocRefInst>(I) || isa<AllocRefDynamicInst>(I)) {
+    return true;
+  }
 
   return false;
 }

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -1203,3 +1203,20 @@ sil [ossa] @dont_dce_lexical_phi : $() -> () {
    return %retval : $()
 }
 
+class KlassWithDeinit {
+  init()
+  deinit
+}
+
+// DCE should not delete dead allocations, leave it to DOE
+// CHECK-LABEL: sil [ossa] @dont_delete_allocation :
+// CHECK: alloc_ref
+// CHECK-LABEL: } // end sil function 'dont_delete_allocation'
+sil [ossa] @dont_delete_allocation : $@convention(thin) () -> () {
+bb0:
+  %a = alloc_ref $KlassWithDeinit
+  destroy_value %a : $KlassWithDeinit
+  %t = tuple ()
+  return %t : $()
+}
+


### PR DESCRIPTION
DCE was deleting an allocation with only destroy_value users. This isn't correct when the deinit can have a side effect. This should be handled in DeadObjectElimination which does additional analysis on deinit to determine if a dead allocation can be eliminated. 
