### PR TITLE
[MoveOnly] Call borrowing methods on existentials.

### DIFF
--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -158,6 +158,12 @@ SubElementOffset::computeForAddress(SILValue projectionDerivedFromRoot,
       continue;
     }
 
+    if (auto *oea =
+            dyn_cast<OpenExistentialAddrInst>(projectionDerivedFromRoot)) {
+      projectionDerivedFromRoot = oea->getOperand();
+      continue;
+    }
+
     if (auto *teai =
             dyn_cast<TupleElementAddrInst>(projectionDerivedFromRoot)) {
       SILType tupleType = teai->getOperand()->getType();

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -190,6 +190,14 @@ bool ExistentialSpecializer::canSpecializeExistentialArgsInFunction(
     if (paramInfo.isIndirectMutating())
       continue;
 
+    // The ExistentialSpecializerCloner copies the incoming generic argument
+    // into an existential if it is non-consuming (if it's consuming, it's
+    // moved into the existential via `copy_addr [take]`).  Introducing a copy
+    // of a move-only value isn't legal.
+    if (!paramInfo.isConsumed() &&
+        paramInfo.getSILStorageInterfaceType().isMoveOnly())
+      continue;
+
     ETAD.AccessType = paramInfo.isConsumed()
                           ? OpenedExistentialAccess::Mutable
                           : OpenedExistentialAccess::Immutable;

--- a/test/Interpreter/rdar125864434.swift
+++ b/test/Interpreter/rdar125864434.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift  %s -o %t/bin
+// RUN: %target-codesign %t/bin
+// RUN: %target-run %t/bin | %FileCheck %s
+
+// REQUIRES: executable_test
+
+protocol Boopable: ~Copyable {
+  func boop()
+}
+
+struct S: ~Copyable, Boopable {
+  func boop() { print("boop") }
+}
+
+func check(_ b: borrowing any Boopable & ~Copyable) {
+  b.boop()
+}
+
+// CHECK: boop
+check(S())


### PR DESCRIPTION
Teach FSPL to look through `open_existential_addr` and teach the `ExistentialSpecializer` not to specialize non-copyable existentials which aren't consumed (doing so would require a copy, which is illegal).

Not fixed here:
- a mangling failure when `-g` is passed
- consuming methods on existentials

rdar://125864434
