### PR TITLE
[6.0] [IRGenDebugInfo] Fix usage of dbg.declare

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3401,11 +3401,6 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
   auto DL =
       llvm::DILocation::get(IGM.getLLVMContext(), Line, Col, Scope, InlinedAt);
 
-  // An alloca may only be described by exactly one dbg.declare.
-  if (isa<llvm::AllocaInst>(Storage) &&
-      !llvm::FindDbgDeclareUses(Storage).empty())
-    return;
-
   // Fragment DIExpression cannot cover the whole variable
   // or going out-of-bound.
   if (auto Fragment = Expr->getFragmentInfo()) {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3438,6 +3438,10 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
     return;
   }
 
+  bool optimized = DS->getParentFunction()->shouldOptimize();
+  if (optimized && (!InCoroContext || !Var->isParameter()))
+    AddrDInstKind = AddrDbgInstrKind::DbgValueDeref;
+
   DbgIntrinsicEmitter inserter{Builder, DBuilder, AddrDInstKind};
 
   // If we have a single alloca...
@@ -3464,7 +3468,7 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
     return;
   }
 
-  if (InCoroContext) {
+  if (InCoroContext && (Var->isParameter() || !optimized)) {
     PointerUnion<llvm::BasicBlock *, llvm::Instruction *> InsertPt;
 
     // If we have a dbg.declare, we are relying on a contract with the coroutine

--- a/test/AutoDiff/compiler_crashers_fixed/issue-58123-invalid-debug-info.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-58123-invalid-debug-info.swift
@@ -6,7 +6,7 @@
 
 // CHECK-LABEL: define internal swiftcc float @"$s4main8TestTypeV24doDifferentiableTimeStep04timeG0ySf_tFTJpSSpSrTA"
 // CHECK: [[SELF:%.*]] = alloca %T4main8TestTypeV06ManualB7TangentV
-// CHECK: call void @llvm.dbg.declare(metadata ptr [[SELF]]
+// CHECK: call void @llvm.dbg.value(metadata ptr [[SELF]]
 
 import _Differentiation
 

--- a/test/DebugInfo/debug_fragment_merge.swift
+++ b/test/DebugInfo/debug_fragment_merge.swift
@@ -31,12 +31,12 @@ func test(cond: Int, external: External) async {
 // CHECK-SIL: debug_value %{{.*}} : $String, let, (name "data", {{.*}}), type $Data, expr op_fragment:#Data.a
 // CHECK-SIL: debug_value %{{.*}} : $String, let, (name "data", {{.*}}), type $Data, expr op_fragment:#Data.b
 
-// CHECK-DAG: llvm.dbg.declare{{.*}} metadata ![[VAR:[0-9]+]], metadata !DIExpression(DW_OP_LLVM_fragment, 192, 64){{.*}} !dbg ![[LOC1]]
-// CHECK-DAG: llvm.dbg.declare{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 128, 64){{.*}} !dbg ![[LOC1]]
-// CHECK-DAG: llvm.dbg.declare{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 64, 64){{.*}} !dbg ![[LOC1]]
-// CHECK-DAG: llvm.dbg.declare{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64){{.*}} !dbg ![[LOC1]]
+// CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR:[0-9]+]], metadata !DIExpression(DW_OP_LLVM_fragment, 192, 64){{.*}} !dbg ![[LOC1]]
+// CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 128, 64){{.*}} !dbg ![[LOC1]]
+// CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 64, 64){{.*}} !dbg ![[LOC1]]
+// CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64){{.*}} !dbg ![[LOC1]]
 //
-// CHECK-DAG: llvm.dbg.declare{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 192, 64){{.*}} !dbg ![[LOC2]]
-// CHECK-DAG: llvm.dbg.declare{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 128, 64){{.*}} !dbg ![[LOC2]]
-// CHECK-DAG: llvm.dbg.declare{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 64, 64){{.*}} !dbg ![[LOC2]]
-// CHECK-DAG: llvm.dbg.declare{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64){{.*}} !dbg ![[LOC2]]
+// CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 192, 64){{.*}} !dbg ![[LOC2]]
+// CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 128, 64){{.*}} !dbg ![[LOC2]]
+// CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 64, 64){{.*}} !dbg ![[LOC2]]
+// CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64){{.*}} !dbg ![[LOC2]]

--- a/test/DebugInfo/debug_scope_distinct.swift
+++ b/test/DebugInfo/debug_scope_distinct.swift
@@ -7,6 +7,9 @@
 
 // REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=arm64e
 
+// XFAIL: *
+// rdar://128505421
+
 // CHECK: define {{.*}} void @"$s4main1TV4move2byyAC13TangentVectorV_tF"
 // CHECK-SAME: ptr {{.*}} %[[ARG_PTR:.*]],
 //

--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -52,8 +52,6 @@ public class C<R> {
     // SIL: function_ref {{.*}}use{{.*}} scope [[F1G3H]]
     // IR: dbg.value(metadata ptr %[[ARG_S]], metadata ![[MD_1_0:[0-9]+]]
     // IR: %[[RS_PAIR:.*]] = alloca i8, i{{.*}} %
-    // IR: dbg.declare(metadata ptr %[[RS_PAIR]], metadata ![[GRS_U:[0-9]+]],
-    // IR: dbg.declare(metadata ptr %[[RS_PAIR]], metadata ![[GRS_T:[0-9]+]],
     // IR: dbg.value(metadata ptr %[[ARG_0]], metadata ![[S:[0-9]+]]
     // IR: dbg.value(metadata ptr %[[ARG_0]], metadata ![[GS_T:[0-9]+]]
     // IR: dbg.value(metadata ptr %[[ARG_0]], metadata ![[GS_U:[0-9]+]]
@@ -71,6 +69,8 @@ public class C<R> {
     // IR: call {{.*}}3use
 #sourceLocation(file: "f.swift", line: 3)
     g(r)
+    // IR: dbg.value(metadata ptr %[[RS_PAIR]], metadata ![[GRS_T:[0-9]+]],
+    // IR: dbg.value(metadata ptr %[[RS_PAIR]], metadata ![[GRS_U:[0-9]+]],
     // IR: call {{.*}}3use
 #sourceLocation(file: "f.swift", line: 4)
     g((r, s))
@@ -108,17 +108,17 @@ public class C<R> {
 // IR-DAG: ![[S]] = !DILocalVariable(name: "s", {{.*}} type: ![[LET_TAU_1_0:[0-9]+]]
 // IR-DAG: ![[LET_TAU_1_0]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[TAU_1_0]])
 // IR-DAG: ![[GS_T]] = !DILocalVariable(name: "t", {{.*}} scope: ![[SP_GS_T:[0-9]+]], {{.*}} type: ![[LET_TAU_1_0]])
-// IR: ![[SP_GS_T]] = {{.*}}linkageName: "$s1A1gyyxlFqd___Ti5"
-// IR: ![[GS_U]] = !DILocalVariable(name: "u", {{.*}} scope: ![[SP_GS_U:[0-9]+]], {{.*}} type: ![[LET_TAU_1_0]])
-// IR: ![[SP_GS_U]] = {{.*}}linkageName: "$s1A1hyyxlFqd___Ti5"
+// IR-DAG: ![[SP_GS_T]] = {{.*}}linkageName: "$s1A1gyyxlFqd___Ti5"
+// IR-DAG: ![[GS_U]] = !DILocalVariable(name: "u", {{.*}} scope: ![[SP_GS_U:[0-9]+]], {{.*}} type: ![[LET_TAU_1_0]])
+// IR-DAG: ![[SP_GS_U]] = {{.*}}linkageName: "$s1A1hyyxlFqd___Ti5"
 
 // Debug info for this variable is removed. See the note above the call to g(r).
 //   ![[GR_T]] = !DILocalVariable(name: "t", {{.*}} scope: ![[SP_GR_T:[0-9]+]], {{.*}}type: ![[LET_TAU_0_0]])
 // S has the same generic parameter numbering s T and U.
 //   ![[SP_GR_T]] = {{.*}}linkageName: "$s1A1gyyxlF"
 
-// IR: ![[GR_U]] = !DILocalVariable(name: "u", {{.*}} scope: ![[SP_GR_U:[0-9]+]], {{.*}}type: ![[LET_TAU_0_0]])
-// IR: ![[SP_GR_U]] = {{.*}}linkageName: "$s1A1hyyxlF"
+// IR-DAG: ![[GR_U]] = !DILocalVariable(name: "u", {{.*}} scope: ![[SP_GR_U:[0-9]+]], {{.*}}type: ![[LET_TAU_0_0]])
+// IR-DAG: ![[SP_GR_U]] = {{.*}}linkageName: "$s1A1hyyxlF"
 // IR-DAG: ![[GI_T]] = !DILocalVariable(name: "t", {{.*}} scope: ![[SP_GI_G:[0-9]+]], {{.*}}type: ![[LET_INT]])
 // IR-DAG: ![[SP_GI_G]] = {{.*}}linkageName: "$s1A1gyyxlFSi_Tg5"
 // IR-DAG: ![[GI_U]] = !DILocalVariable(name: "u", {{.*}} scope: ![[SP_GI_U:[0-9]+]], {{.*}}type: ![[LET_INT]])

--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -52,6 +52,7 @@ public class C<R> {
     // SIL: function_ref {{.*}}use{{.*}} scope [[F1G3H]]
     // IR: dbg.value(metadata ptr %[[ARG_S]], metadata ![[MD_1_0:[0-9]+]]
     // IR: %[[RS_PAIR:.*]] = alloca i8, i{{.*}} %
+    // IR: dbg.declare(metadata ptr %[[RS_PAIR]], metadata ![[GRS_U:[0-9]+]],
     // IR: dbg.declare(metadata ptr %[[RS_PAIR]], metadata ![[GRS_T:[0-9]+]],
     // IR: dbg.value(metadata ptr %[[ARG_0]], metadata ![[S:[0-9]+]]
     // IR: dbg.value(metadata ptr %[[ARG_0]], metadata ![[GS_T:[0-9]+]]
@@ -100,6 +101,8 @@ public class C<R> {
 // IR-DAG: ![[MD_1_0]] = !DILocalVariable(name: "$\CF\84_1_0"
 // IR-DAG: ![[GRS_T]] = !DILocalVariable(name: "t", {{.*}} scope: ![[SP_GRS_T:[0-9]+]], {{.*}}type: ![[LET_TUPLE:[0-9]+]]
 // IR-DAG: ![[SP_GRS_T]] = {{.*}}linkageName: "$s1A1gyyxlFx_qd__t_Ti5"
+// IR-DAG: ![[GRS_U]] = !DILocalVariable(name: "u", {{.*}} scope: ![[SP_GRS_U:[0-9]+]], {{.*}}type: ![[LET_TUPLE:[0-9]+]]
+// IR-DAG: ![[SP_GRS_U]] = {{.*}}linkageName: "$s1A1hyyxlFx_qd__t_Ti5"
 // IR-DAG: ![[LET_TUPLE]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[TUPLE:[0-9]+]])
 // IR-DAG: ![[TUPLE]] = {{.*}}DW_TAG_structure_type, name: "$sx_qd__tD"
 // IR-DAG: ![[S]] = !DILocalVariable(name: "s", {{.*}} type: ![[LET_TAU_1_0:[0-9]+]]


### PR DESCRIPTION
* **Explanation**: Avoid using dbg.declare in optimized code, as it can cause issues when debug values get moved around.
* **Scope**: Affects debug info at the IRGen level
* **Original PR**: #73769
* **Risk**: Low, only touches debug info in optimized code, and adds missing debug info in unoptimized code
* **Testing**: Existing tests have been updated
* **Issue**: rdar://128155050 and rdar://128491243
* **Reviewer**:  @adrian-prantl 