### PR TITLE
Only set clang linker if it exists

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1653,8 +1653,11 @@ for host in "${ALL_HOSTS[@]}"; do
     else
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
-    export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
-    export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+
+    if [[ -f "${CLANG_BIN}/clang" ]]; then
+      export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
+      export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+    fi
 
     if [[ "${NATIVE_SWIFT_TOOLS_PATH}" ]] ; then
         SWIFTC_BIN="${NATIVE_SWIFT_TOOLS_PATH}/swiftc"
@@ -2722,8 +2725,11 @@ for host in "${ALL_HOSTS[@]}"; do
     else
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
-    export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
-    export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+
+    if [[ -f "${CLANG_BIN}/clang" ]]; then
+      export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
+      export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+    fi
 
     if [[ "${NATIVE_SWIFT_TOOLS_PATH}" ]] ; then
         SWIFTC_BIN="${NATIVE_SWIFT_TOOLS_PATH}/swiftc"
@@ -3082,8 +3088,11 @@ for host in "${ALL_HOSTS[@]}"; do
     else
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
-    export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
-    export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+
+    if [[ -f "${CLANG_BIN}/clang" ]]; then
+      export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
+      export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
+    fi
 
     # Set the build options for this host
     set_build_options_for_host $host


### PR DESCRIPTION
It we're not building clang, the swift driver silently dies and fails to build. While it shouldn't do that, we should also only tell it to use a clang that exists. If we're not building clang or the "native" clang doesn't exist, leave the environment variable unset and let the driver choose something.

rdar://128635969