### PR TITLE
[6.0][PackageCMO] Add [serialized_for_package] attribute

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -366,6 +366,10 @@ private:
   /// The function's serialized attribute.
   bool Serialized : 1;
 
+  /// [serialized_for_package] attribute if package serialization
+  /// is enabled.
+  bool SerializedForPackage : 1;
+
   /// Specifies if this function is a thunk or a reabstraction thunk.
   ///
   /// The inliner uses this information to avoid inlining (non-trivial)
@@ -1143,6 +1147,22 @@ public:
     Serialized = isSerialized;
     assert(this->isSerialized() == isSerialized &&
            "too few bits for Serialized storage");
+  }
+
+  /// A [serialized_for_package] attribute is used to indicate that a function
+  /// is [serialized] because of package-cmo optimization.
+  /// Package-cmo allows serializing a function containing a loadable type in
+  /// a resiliently built module, which is normally illegal. During SIL deserialization,
+  /// this attribute can be used to check whether a loaded function that was serialized
+  /// can be allowed to have loadable types. This attribute is also used to determine
+  /// if a callee can be inlined into a caller that's serialized without package-cmo, for
+  /// example, by explicitly annotating the caller decl with `@inlinable`.
+  IsSerializedForPackage_t isSerializedForPackage() const {
+    return IsSerializedForPackage_t(SerializedForPackage);
+  }
+  void
+  setSerializedForPackage(IsSerializedForPackage_t isSerializedForPackage) {
+    SerializedForPackage = isSerializedForPackage;
   }
 
   /// Get this function's thunk attribute.

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -162,6 +162,11 @@ enum IsSerialized_t : unsigned char {
   IsSerialized
 };
 
+enum IsSerializedForPackage_t : unsigned char {
+  IsNotSerializedForPackage,
+  IsSerializedForPackage
+};
+
 /// The scope in which a subclassable class can be subclassed.
 enum class SubclassScope : uint8_t {
   /// This class can be subclassed in other modules.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3060,7 +3060,7 @@ bool AbstractStorageDecl::isResilient(ModuleDecl *M,
   case ResilienceExpansion::Maximal:
     if (M == getModuleContext())
       return false;
-    // Non-resilient if bypass optimization in package is enabled
+    // Access non-resiliently if package optimization is enabled
     if (bypassResilienceInPackage(M))
       return false;
     return isResilient();
@@ -4299,13 +4299,23 @@ bool ValueDecl::hasOpenAccess(const DeclContext *useDC) const {
 }
 
 bool ValueDecl::bypassResilienceInPackage(ModuleDecl *accessingModule) const {
-  // Client needs to opt in to bypass resilience checks at the use site.
-  // Client and the loaded module both need to be in the same package.
-  // The loaded module needs to be built from source and opt in to allow
-  // non-resilient access.
-  return getASTContext().LangOpts.EnableBypassResilienceInPackage &&
-         getModuleContext()->inSamePackage(accessingModule) &&
-         getModuleContext()->allowNonResilientAccess();
+  auto declModule = getModuleContext();
+  if (declModule->inSamePackage(accessingModule) &&
+      declModule->allowNonResilientAccess()) {
+    // If the defining module is built with package-cmo,
+    // allow direct access from the use site that belongs
+    // to accessingModule (client module).
+    if (declModule->isResilient() &&
+        declModule->serializePackageEnabled())
+      return true;
+
+    // If not, check if the client can still opt in to
+    // have a direct access to this decl from the use
+    // site with a flag.
+    // FIXME: serialize this flag to Module and get it via accessingModule.
+    return getASTContext().LangOpts.EnableBypassResilienceInPackage;
+  }
+  return false;
 }
 
 /// Given the formal access level for using \p VD, compute the scope where
@@ -5160,7 +5170,7 @@ bool NominalTypeDecl::isResilient(ModuleDecl *M,
     // non-resiliently in a maximal context.
     if (M == getModuleContext())
       return false;
-    // Non-resilient if bypass optimization in package is enabled
+    // Access non-resiliently if package optimization is enabled
     if (bypassResilienceInPackage(M))
       return false;
 

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -460,8 +460,12 @@ static LinkageLimit getLinkageLimit(SILDeclRef constant) {
   case Kind::EnumElement:
     return Limit::OnDemand;
 
-  case Kind::GlobalAccessor:
-    return cast<VarDecl>(d)->isResilient() ? Limit::NeverPublic : Limit::None;
+  case Kind::GlobalAccessor: {
+    auto varDecl = cast<VarDecl>(d);
+    return varDecl->isResilient() &&
+           !varDecl->getModuleContext()->allowNonResilientAccess() ?
+           Limit::NeverPublic : Limit::None;
+  }
 
   case Kind::DefaultArgGenerator:
     // If the default argument is to be serialized, only use non-ABI public

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3339,6 +3339,14 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   case IsSerialized: OS << "[serialized] "; break;
   }
 
+  switch (isSerializedForPackage()) {
+  case IsNotSerializedForPackage:
+    break;
+  case IsSerializedForPackage:
+    OS << "[serialized_for_package] ";
+    break;
+  }
+
   switch (isThunk()) {
   case IsNotThunk: break;
   case IsThunk: OS << "[thunk] "; break;
@@ -3526,7 +3534,7 @@ void SILGlobalVariable::print(llvm::raw_ostream &OS, bool Verbose) const {
 
   if (isSerialized())
     OS << "[serialized] ";
-  
+
   if (isLet())
     OS << "[let] ";
 
@@ -3838,7 +3846,7 @@ void SILProperty::print(SILPrintContext &Ctx) const {
   OS << "sil_property ";
   if (isSerialized())
     OS << "[serialized] ";
-  
+
   OS << '#';
   printValueDecl(getDecl(), OS);
   if (auto sig = getDecl()->getInnermostDeclContext()
@@ -4017,6 +4025,7 @@ void SILVTable::print(llvm::raw_ostream &OS, bool Verbose) const {
   OS << "sil_vtable ";
   if (isSerialized())
     OS << "[serialized] ";
+
   if (SILType classTy = getClassType()) {
     OS << classTy;
   } else {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -665,7 +665,8 @@ void SILParser::convertRequirements(ArrayRef<RequirementRepr> From,
 }
 
 static bool parseDeclSILOptional(
-    bool *isTransparent, IsSerialized_t *isSerialized, bool *isCanonical,
+    bool *isTransparent, IsSerialized_t *isSerialized,
+    IsSerializedForPackage_t *isSerializedForPackage, bool *isCanonical,
     bool *hasOwnershipSSA, bool *hasResultDependsOnSelf, IsThunk_t *isThunk,
     IsDynamicallyReplaceable_t *isDynamic, IsDistributed_t *isDistributed,
     IsRuntimeAccessible_t *isRuntimeAccessible,
@@ -676,10 +677,9 @@ static bool parseDeclSILOptional(
     SILFunction **usedAdHocRequirementWitness, Identifier *objCReplacementFor,
     SILFunction::Purpose *specialPurpose, Inline_t *inlineStrategy,
     OptimizationMode *optimizationMode, PerformanceConstraints *perfConstraints,
-    bool *isPerformanceConstraint,
-    bool *markedAsUsed, StringRef *section, bool *isLet, bool *isWeakImported,
-    bool *needStackProtection, AvailabilityContext *availability,
-    bool *isWithoutActuallyEscapingThunk,
+    bool *isPerformanceConstraint, bool *markedAsUsed, StringRef *section,
+    bool *isLet, bool *isWeakImported, bool *needStackProtection,
+    AvailabilityContext *availability, bool *isWithoutActuallyEscapingThunk,
     SmallVectorImpl<std::string> *Semantics,
     SmallVectorImpl<ParsedSpecAttr> *SpecAttrs, ValueDecl **ClangDecl,
     EffectsKind *MRK, SILParser &SP, SILModule &M) {
@@ -697,6 +697,9 @@ static bool parseDeclSILOptional(
       *isTransparent = true;
     else if (isSerialized && SP.P.Tok.getText() == "serialized")
       *isSerialized = IsSerialized;
+    else if (isSerializedForPackage &&
+             SP.P.Tok.getText() == "serialized_for_package")
+      *isSerializedForPackage = IsSerializedForPackage;
     else if (isDynamic && SP.P.Tok.getText() == "dynamically_replacable")
       *isDynamic = IsDynamic;
     else if (isDistributed && SP.P.Tok.getText() == "distributed")
@@ -7074,6 +7077,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
 
   bool isTransparent = false;
   IsSerialized_t isSerialized = IsNotSerialized;
+  IsSerializedForPackage_t isSerializedForPackage = IsNotSerializedForPackage;
   bool isCanonical = false;
   IsDynamicallyReplaceable_t isDynamic = IsNotDynamic;
   IsDistributed_t isDistributed = IsNotDistributed;
@@ -7106,17 +7110,17 @@ bool SILParserState::parseDeclSIL(Parser &P) {
   Identifier objCReplacementFor;
   if (parseSILLinkage(FnLinkage, P) ||
       parseDeclSILOptional(
-          &isTransparent, &isSerialized, &isCanonical, &hasOwnershipSSA,
-          &hasResultDependsOnSelf, &isThunk, &isDynamic, &isDistributed,
-          &isRuntimeAccessible, &forceEnableLexicalLifetimes,
+          &isTransparent, &isSerialized, &isSerializedForPackage, &isCanonical,
+          &hasOwnershipSSA, &hasResultDependsOnSelf, &isThunk, &isDynamic,
+          &isDistributed, &isRuntimeAccessible, &forceEnableLexicalLifetimes,
           &useStackForPackMetadata, &hasUnsafeNonEscapableResult,
           &isExactSelfClass, &DynamicallyReplacedFunction,
           &AdHocWitnessFunction, &objCReplacementFor, &specialPurpose,
           &inlineStrategy, &optimizationMode, &perfConstr,
-          &isPerformanceConstraint, &markedAsUsed,
-          &section, nullptr, &isWeakImported, &needStackProtection,
-          &availability, &isWithoutActuallyEscapingThunk, &Semantics,
-          &SpecAttrs, &ClangDecl, &MRK, FunctionState, M) ||
+          &isPerformanceConstraint, &markedAsUsed, &section, nullptr,
+          &isWeakImported, &needStackProtection, &availability,
+          &isWithoutActuallyEscapingThunk, &Semantics, &SpecAttrs, &ClangDecl,
+          &MRK, FunctionState, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_function_name) ||
       P.parseIdentifier(FnName, FnNameLoc, /*diagnoseDollarPrefix=*/false,
                         diag::expected_sil_function_name) ||
@@ -7141,6 +7145,8 @@ bool SILParserState::parseDeclSIL(Parser &P) {
     FunctionState.F->setBare(IsBare);
     FunctionState.F->setTransparent(IsTransparent_t(isTransparent));
     FunctionState.F->setSerialized(IsSerialized_t(isSerialized));
+    FunctionState.F->setSerializedForPackage(
+        IsSerializedForPackage_t(isSerializedForPackage));
     FunctionState.F->setWasDeserializedCanonical(isCanonical);
     if (!hasOwnershipSSA)
       FunctionState.F->setOwnershipEliminated();
@@ -7367,10 +7373,9 @@ bool SILParserState::parseSILGlobal(Parser &P) {
       parseDeclSILOptional(nullptr, &isSerialized, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr,
-                           nullptr, nullptr, nullptr, nullptr, nullptr, &isLet,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, State, M) ||
+                           nullptr, &isLet, nullptr, nullptr, nullptr, nullptr,
+                           nullptr, nullptr, nullptr, nullptr, State, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
       P.parseIdentifier(GlobalName, NameLoc, /*diagnoseDollarPrefix=*/false,
                         diag::expected_sil_value_name) ||
@@ -7422,7 +7427,7 @@ bool SILParserState::parseSILProperty(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, SP, M))
+                           nullptr, nullptr, nullptr, nullptr, SP, M))
     return true;
   
   ValueDecl *VD;
@@ -7492,7 +7497,7 @@ bool SILParserState::parseSILVTable(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, VTableState, M))
+                           nullptr, nullptr, nullptr, nullptr, VTableState, M))
     return true;
 
 
@@ -7615,7 +7620,8 @@ bool SILParserState::parseSILMoveOnlyDeinit(Parser &parser) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, moveOnlyDeinitTableState, M))
+                           nullptr, nullptr, nullptr, nullptr,
+                           moveOnlyDeinitTableState, M))
     return true;
 
   // Parse the class name.
@@ -8102,7 +8108,7 @@ bool SILParserState::parseSILWitnessTable(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, WitnessState, M))
+                           nullptr, nullptr, nullptr, nullptr, WitnessState, M))
     return true;
 
   // Parse the protocol conformance.

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -156,10 +156,35 @@ namespace {
 /// When resilience is bypassed, direct access is legal, but the decls are still
 /// resilient.
 template <typename DeclType>
-bool checkResilience(DeclType *D, ModuleDecl *M,
-                     ResilienceExpansion expansion) {
-  return !D->getModuleContext()->getBypassResilience() &&
-         D->isResilient(M, expansion);
+bool checkResilience(DeclType *D, ModuleDecl *accessingModule,
+                     ResilienceExpansion expansion,
+                     bool isSerializedForPackage) {
+  auto declModule = D->getModuleContext();
+
+  // For DEBUGGING: this check looks up
+  // `bypass-resilience-checks`, which is
+  // an old flag used for debugging, and
+  // has nothing to do with optimizations.
+  if (declModule->getBypassResilience())
+    return false;
+
+  // If the SIL function containing the decl D is
+  // [serialized_for_package], package-cmo had been
+  // enabled in its defining module, so direct access
+  // from a client module should be allowed.
+  if (accessingModule != declModule &&
+      expansion == ResilienceExpansion::Maximal &&
+      isSerializedForPackage)
+      return false;
+
+  return D->isResilient(accessingModule, expansion);
+}
+
+template <typename DeclType>
+bool checkResilience(DeclType *D, const SILFunction &f) {
+  return checkResilience(D, f.getModule().getSwiftModule(),
+                         f.getResilienceExpansion(),
+                         f.isSerializedForPackage());
 }
 
 bool checkTypeABIAccessible(SILFunction const &F, SILType ty) {
@@ -193,6 +218,7 @@ namespace {
 /// Verify invariants on a key path component.
 void verifyKeyPathComponent(SILModule &M,
                             TypeExpansionContext typeExpansionContext,
+                            bool isSerializedForPackage,
                             llvm::function_ref<void(bool, StringRef)> require,
                             CanType &baseTy,
                             CanType leafTy,
@@ -300,7 +326,8 @@ void verifyKeyPathComponent(SILModule &M,
             "property decl should be a member of the base with the same type "
             "as the component");
     require(property->hasStorage(), "property must be stored");
-    require(!checkResilience(property, M.getSwiftModule(), expansion),
+    require(!checkResilience(property, M.getSwiftModule(),
+                             expansion, isSerializedForPackage),
             "cannot access storage of resilient property");
     auto propertyTy =
         loweredBaseTy.getFieldType(property, M, typeExpansionContext);
@@ -2450,8 +2477,7 @@ public:
   void checkAllocGlobalInst(AllocGlobalInst *AGI) {
     SILGlobalVariable *RefG = AGI->getReferencedGlobal();
     if (auto *VD = RefG->getDecl()) {
-      require(!checkResilience(VD, F.getModule().getSwiftModule(),
-                               F.getResilienceExpansion()),
+      require(!checkResilience(VD, F),
               "cannot access storage of resilient global");
     }
     if (F.isSerialized()) {
@@ -2471,8 +2497,7 @@ public:
         RefG->getLoweredTypeInContext(F.getTypeExpansionContext()),
         "global_addr/value must be the type of the variable it references");
     if (auto *VD = RefG->getDecl()) {
-      require(!checkResilience(VD, F.getModule().getSwiftModule(),
-                               F.getResilienceExpansion()),
+      require(!checkResilience(VD, F),
               "cannot access storage of resilient global");
     }
     if (F.isSerialized()) {
@@ -3396,8 +3421,7 @@ public:
     require(!structDecl->hasUnreferenceableStorage(),
             "Cannot build a struct with unreferenceable storage from elements "
             "using StructInst");
-    require(!checkResilience(structDecl, F.getModule().getSwiftModule(),
-                             F.getResilienceExpansion()),
+    require(!checkResilience(structDecl, F),
             "cannot access storage of resilient struct");
     require(SI->getType().isObject(),
             "StructInst must produce an object");
@@ -3633,8 +3657,7 @@ public:
     auto *cd = DI->getOperand()->getType().getClassOrBoundGenericClass();
     require(cd, "Operand of dealloc_ref must be of class type");
 
-    require(!checkResilience(cd, F.getModule().getSwiftModule(),
-                             F.getResilienceExpansion()),
+    require(!checkResilience(cd, F),
             "cannot directly deallocate resilient class");
   }
   void checkDeallocPartialRefInst(DeallocPartialRefInst *DPRI) {
@@ -3761,8 +3784,7 @@ public:
             "result of struct_extract cannot be address");
     StructDecl *sd = operandTy.getStructOrBoundGenericStruct();
     require(sd, "must struct_extract from struct");
-    require(!checkResilience(sd, F.getModule().getSwiftModule(),
-                             F.getResilienceExpansion()),
+    require(!checkResilience(sd, F),
             "cannot access storage of resilient struct");
     require(!EI->getField()->isStatic(),
             "cannot get address of static property with struct_element_addr");
@@ -3817,8 +3839,7 @@ public:
             "must derive struct_element_addr from address");
     StructDecl *sd = operandTy.getStructOrBoundGenericStruct();
     require(sd, "struct_element_addr operand must be struct address");
-    require(!checkResilience(sd, F.getModule().getSwiftModule(),
-                             F.getResilienceExpansion()),
+    require(!checkResilience(sd, F),
             "cannot access storage of resilient struct");
     require(EI->getType().isAddress(),
             "result of struct_element_addr must be address");
@@ -3859,8 +3880,7 @@ public:
     SILType operandTy = EI->getOperand()->getType();
     ClassDecl *cd = operandTy.getClassOrBoundGenericClass();
     require(cd, "ref_element_addr operand must be a class instance");
-    require(!checkResilience(cd, F.getModule().getSwiftModule(),
-                             F.getResilienceExpansion()),
+    require(!checkResilience(cd, F),
             "cannot access storage of resilient class");
 
     require(EI->getField()->getDeclContext() ==
@@ -3885,8 +3905,7 @@ public:
     SILType operandTy = RTAI->getOperand()->getType();
     ClassDecl *cd = operandTy.getClassOrBoundGenericClass();
     require(cd, "ref_tail_addr operand must be a class instance");
-    require(!checkResilience(cd, F.getModule().getSwiftModule(),
-                             F.getResilienceExpansion()),
+    require(!checkResilience(cd, F),
             "cannot access storage of resilient class");
     require(cd, "ref_tail_addr operand must be a class instance");
     checkAddressWalkerCanVisitAllTransitiveUses(RTAI);
@@ -3896,8 +3915,7 @@ public:
     SILType operandTy = DSI->getOperand()->getType();
     StructDecl *sd = operandTy.getStructOrBoundGenericStruct();
     require(sd, "must struct_extract from struct");
-    require(!checkResilience(sd, F.getModule().getSwiftModule(),
-                             F.getResilienceExpansion()),
+    require(!checkResilience(sd, F),
             "cannot access storage of resilient struct");
     if (F.hasOwnership()) {
       // Make sure that all of our destructure results ownership kinds are
@@ -5714,7 +5732,9 @@ public:
           break;
         }
       
-        verifyKeyPathComponent(F.getModule(), F.getTypeExpansionContext(),
+        verifyKeyPathComponent(F.getModule(),
+                               F.getTypeExpansionContext(),
+                               F.isSerializedForPackage(),
           [&](bool reqt, StringRef message) { _require(reqt, message); },
           baseTy,
           leafTy,
@@ -7220,6 +7240,7 @@ void SILProperty::verify(const SILModule &M) const {
             ResilienceExpansion::Maximal);
     verifyKeyPathComponent(const_cast<SILModule&>(M),
                            typeExpansionContext,
+                           /* isSerializedForPackage */ false, // SILProperty doesn't get serialized
                            require,
                            baseTy,
                            leafTy,

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -497,17 +497,37 @@ bool CrossModuleOptimization::shouldSerialize(SILFunction *function) {
   return true;
 }
 
+/// Adds [serialized_for_package] attribute to an already [serialized] function.
+/// It's used to indicate that a function was [serialized] because of package-cmo.
+/// Package-cmo allows serializing a function containing a loadable type in
+/// a resiliently built module, which is normally illegal. During SIL deserialization,
+/// this attribute can be used to check whether a loaded function that was serialized
+/// can be allowed to have loadable types. This attribute is also used to determine
+/// if a callee can be inlined into a caller that's serialized without package-cmo, for
+/// example, by explicitly annotating the caller decl with `@inlinable`, where
+/// the callee was serialized due to package-cmo.
+static void addSerializedForPackageAttrIfEnabled(SILFunction *f,
+                                                 const SILModule &mod) {
+  assert(f->isSerialized());
+  auto shouldSet = mod.getSwiftModule()->serializePackageEnabled() &&
+                   mod.getSwiftModule()->isResilient();
+  f->setSerializedForPackage(shouldSet ? IsSerializedForPackage
+                                       : IsNotSerializedForPackage);
+}
+
 /// Serialize \p function and recursively all referenced functions which are
 /// marked in \p canSerializeFlags.
 void CrossModuleOptimization::serializeFunction(SILFunction *function,
                                        const FunctionFlags &canSerializeFlags) {
-  if (function->isSerialized())
+  if (function->isSerialized()) {
+    addSerializedForPackageAttrIfEnabled(function, M);
     return;
-  
+  }
   if (!canSerializeFlags.lookup(function))
     return;
 
   function->setSerialized(IsSerialized);
+  addSerializedForPackageAttrIfEnabled(function, M);
 
   for (SILBasicBlock &block : *function) {
     for (SILInstruction &inst : block) {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -563,16 +563,16 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
   IdentifierID replacedFunctionID;
   IdentifierID usedAdHocWitnessFunctionID;
   GenericSignatureID genericSigID;
-  unsigned rawLinkage, isTransparent, isSerialized, isThunk,
-      isWithoutActuallyEscapingThunk, specialPurpose, inlineStrategy,
+  unsigned rawLinkage, isTransparent, isSerialized, isSerializedForPackage,
+      isThunk, isWithoutActuallyEscapingThunk, specialPurpose, inlineStrategy,
       optimizationMode, perfConstr, subclassScope, hasCReferences, effect,
       numAttrs, hasQualifiedOwnership, isWeakImported,
       LIST_VER_TUPLE_PIECES(available), isDynamic, isExactSelfClass,
       isDistributed, isRuntimeAccessible, forceEnableLexicalLifetimes;
   ArrayRef<uint64_t> SemanticsIDs;
   SILFunctionLayout::readRecord(
-      scratch, rawLinkage, isTransparent, isSerialized, isThunk,
-      isWithoutActuallyEscapingThunk, specialPurpose, inlineStrategy,
+      scratch, rawLinkage, isTransparent, isSerialized, isSerializedForPackage,
+      isThunk, isWithoutActuallyEscapingThunk, specialPurpose, inlineStrategy,
       optimizationMode, perfConstr, subclassScope, hasCReferences, effect,
       numAttrs, hasQualifiedOwnership, isWeakImported,
       LIST_VER_TUPLE_PIECES(available), isDynamic, isExactSelfClass,
@@ -656,13 +656,26 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
 
     fn->setSerialized(IsSerialized_t(isSerialized));
 
+    // If fn was serialized in a module with package serialization
+    // enabled, a new attribute [serialized_for_package] was added
+    // to its definition. Preserve the attribute here if the current
+    // module is in the same package, and use it to determine the
+    // resilience expansion for this function.
+    auto loadedModule = getFile()->getParentModule();
+    if (isSerializedForPackage == IsSerializedForPackage &&
+        loadedModule->isResilient() &&
+        loadedModule != SILMod.getSwiftModule() &&
+        loadedModule->serializePackageEnabled() &&
+        loadedModule->inSamePackage(SILMod.getSwiftModule()))
+      fn->setSerializedForPackage(IsSerializedForPackage);
+
     // If the serialized function comes from the same module, we're merging
     // modules, and can update the linkage directly. This is needed to
     // correctly update the linkage for forward declarations to entities defined
     // in another file of the same module – we want to ensure the linkage
     // reflects the fact that the entity isn't really external and shouldn't be
     // dropped from the resulting merged module.
-    if (getFile()->getParentModule() == SILMod.getSwiftModule())
+    if (loadedModule == SILMod.getSwiftModule())
       fn->setLinkage(linkage);
 
     // Don't override the transparency or linkage of a function with
@@ -703,6 +716,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     fn->setLinkage(linkage);
     fn->setTransparent(IsTransparent_t(isTransparent == 1));
     fn->setSerialized(IsSerialized_t(isSerialized));
+    fn->setSerializedForPackage(IsSerializedForPackage_t(isSerializedForPackage));
     fn->setThunk(IsThunk_t(isThunk));
     fn->setWithoutActuallyEscapingThunk(bool(isWithoutActuallyEscapingThunk));
     fn->setInlineStrategy(Inline_t(inlineStrategy));
@@ -3514,16 +3528,16 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
   IdentifierID replacedFunctionID;
   IdentifierID usedAdHocWitnessFunctionID;
   GenericSignatureID genericSigID;
-  unsigned rawLinkage, isTransparent, isSerialized, isThunk,
-      isWithoutActuallyEscapingThunk, isGlobal, inlineStrategy,
+  unsigned rawLinkage, isTransparent, isSerialized, isSerializedForPackage,
+      isThunk, isWithoutActuallyEscapingThunk, isGlobal, inlineStrategy,
       optimizationMode, perfConstr, subclassScope, hasCReferences, effect,
       numSpecAttrs, hasQualifiedOwnership, isWeakImported,
       LIST_VER_TUPLE_PIECES(available), isDynamic, isExactSelfClass,
       isDistributed, isRuntimeAccessible, forceEnableLexicalLifetimes;
   ArrayRef<uint64_t> SemanticsIDs;
   SILFunctionLayout::readRecord(
-      scratch, rawLinkage, isTransparent, isSerialized, isThunk,
-      isWithoutActuallyEscapingThunk, isGlobal, inlineStrategy,
+      scratch, rawLinkage, isTransparent, isSerialized, isSerializedForPackage,
+      isThunk, isWithoutActuallyEscapingThunk, isGlobal, inlineStrategy,
       optimizationMode, perfConstr, subclassScope, hasCReferences, effect,
       numSpecAttrs, hasQualifiedOwnership, isWeakImported,
       LIST_VER_TUPLE_PIECES(available), isDynamic, isExactSelfClass,
@@ -3975,7 +3989,7 @@ SILProperty *SILDeserializer::readProperty(DeclID PId) {
   DeclID StorageID;
   ArrayRef<uint64_t> ComponentValues;
   PropertyLayout::readRecord(scratch, StorageID, Serialized, ComponentValues);
-  
+
   auto decl = cast<AbstractStorageDecl>(MF->getDecl(StorageID));
   unsigned ComponentValueIndex = 0;
   auto component = readKeyPathComponent(ComponentValues, ComponentValueIndex);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 869; // ~ for suppression
+const uint16_t SWIFTMODULE_VERSION_MINOR = 871; // [serialized_for_package] for SILFunctionLayout
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -292,6 +292,7 @@ namespace sil_block {
       BCRecordLayout<SIL_FUNCTION, SILLinkageField,
                      BCFixed<1>,  // transparent
                      BCFixed<1>,  // serialized
+                     BCFixed<1>,  // serializedForPackage
                      BCFixed<2>,  // thunks: signature optimized/reabstraction
                      BCFixed<1>,  // without_actually_escaping
                      BCFixed<3>,  // specialPurpose

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -515,7 +515,8 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   SILFunctionLayout::emitRecord(
       Out, ScratchRecord, abbrCode, toStableSILLinkage(Linkage),
       (unsigned)F.isTransparent(), (unsigned)F.isSerialized(),
-      (unsigned)F.isThunk(), (unsigned)F.isWithoutActuallyEscapingThunk(),
+      (unsigned)F.isSerializedForPackage(), (unsigned)F.isThunk(),
+      (unsigned)F.isWithoutActuallyEscapingThunk(),
       (unsigned)F.getSpecialPurpose(), (unsigned)F.getInlineStrategy(),
       (unsigned)F.getOptimizationMode(), (unsigned)F.getPerfConstraints(),
       (unsigned)F.getClassSubclassScope(), (unsigned)F.hasCReferences(),

--- a/test/SILOptimizer/package-cmo-resilient-mode.swift
+++ b/test/SILOptimizer/package-cmo-resilient-mode.swift
@@ -1,0 +1,487 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift %t/Lib.swift \
+// RUN: -module-name=Lib -package-name Pkg \
+// RUN: -parse-as-library -emit-module -emit-module-path %t/Lib.swiftmodule -I%t \
+// RUN: -Xfrontend -experimental-package-cmo -Xfrontend -experimental-allow-non-resilient-access \
+// RUN: -O -wmo
+
+// RUN: %target-sil-opt %t/Lib.swiftmodule -sil-verify-all -o %t/Lib-non-res.sil
+// RUN: %FileCheck %s --check-prefixes=CHECK-COMMON,CHECK-NONRES < %t/Lib-non-res.sil
+
+// RUN: %target-build-swift -module-name=Main -package-name Pkg -I%t -emit-sil -O %t/main.swift -o %t/Main-non-res.sil
+// RUN: %FileCheck %s --check-prefixes=CHECK-MAIN-COMMON,CHECK-MAIN-NONRES < %t/Main-non-res.sil
+
+// RUN: rm -rf %t/Lib.swiftmodule
+
+// RUN: %target-build-swift %t/Lib.swift \
+// RUN: -module-name=Lib -package-name Pkg \
+// RUN: -parse-as-library -emit-module -emit-module-path %t/Lib.swiftmodule -I%t \
+// RUN: -Xfrontend -experimental-package-cmo -Xfrontend -experimental-allow-non-resilient-access \
+// RUN: -O -wmo -enable-library-evolution
+
+// RUN: %target-sil-opt %t/Lib.swiftmodule -sil-verify-all -o %t/Lib-res.sil
+// RUN: %FileCheck %s --check-prefixes=CHECK-COMMON,CHECK-RES < %t/Lib-res.sil
+
+// RUN: %target-build-swift -module-name=Main -package-name Pkg -I%t -emit-sil -O %t/main.swift -o %t/Main-res.sil
+// RUN: %FileCheck %s --check-prefixes=CHECK-MAIN-COMMON,CHECK-MAIN-RES < %t/Main-res.sil
+
+// RUN: llvm-bcanalyzer --dump %t/Lib.swiftmodule | %FileCheck %s --check-prefix=CHECK-BC
+// CHECK-BC: SERIALIZE_PACKAGE_ENABLED
+
+// REQUIRES: swift_in_compiler
+
+//--- main.swift
+
+import Lib
+
+// CHECK-MAIN-COMMON-NOT: s3Lib9PubStructVyACSicfC
+// CHECK-MAIN-COMMON-NOT: s3Lib9PubStructV6fooVarSivg
+// CHECK-MAIN-COMMON-NOT: s3Lib9PubStructV6fooVarSivs
+// CHECK-MAIN-COMMON-NOT: s3Lib6runPubySiAA0C6StructVF
+// CHECK-MAIN-COMMON-NOT: s3Lib9PkgStructVyACSicfC
+// CHECK-MAIN-COMMON-NOT: s3Lib9PkgStructV6fooVarSivg
+// CHECK-MAIN-COMMON-NOT: s3Lib9PkgStructV6fooVarSivs
+// CHECK-MAIN-COMMON-NOT: s3Lib6runPkgySiAA0C6StructVF
+
+// CHECK-MAIN-COMMON: [[PUB_INIT:%.*]] = struct $PubStruct
+// CHECK-MAIN-COMMON: store [[PUB_INIT]] to {{.*}} : $*PubStruct
+// CHECK-MAIN-COMMON: [[PUB_ELEM_ADDR:%.*]] = struct_element_addr {{.*}} : $*PubStruct, #PubStruct.fooVar
+// CHECK-MAIN-COMMON: [[PUB_GET:%.*]] = load [[PUB_ELEM_ADDR]] : $*Int
+// CHECK-MAIN-COMMON: store [[PUB_GET]] to {{.*}} : $*Int
+
+// CHECK-MAIN-COMMON: [[FRPUB_INIT:%.*]] = struct $FrPubStruct
+// CHECK-MAIN-COMMON: store [[FRPUB_INIT]] to {{.*}} : $*FrPubStruct
+// CHECK-MAIN-COMMON: [[FRPUB_ELEM_ADDR:%.*]] = struct_element_addr {{.*}} : $*FrPubStruct, #FrPubStruct.fooVar
+// CHECK-MAIN-COMMON: [[FRPUB_GET:%.*]] = load [[FRPUB_ELEM_ADDR]] : $*Int
+// CHECK-MAIN-COMMON: store [[FRPUB_GET]] to {{.*}} : $*Int
+
+// CHECK-MAIN-COMMON: [[PKG_INIT:%.*]] = struct $PkgStruct
+// CHECK-MAIN-COMMON: store [[PKG_INIT]] to {{.*}} : $*PkgStruct
+// CHECK-MAIN-COMMON: [[PKG_ELEM_ADDR:%.*]] = struct_element_addr {{.*}} : $*PkgStruct, #PkgStruct.fooVar
+// CHECK-MAIN-COMMON: [[PKG_GET:%.*]] = load [[PKG_ELEM_ADDR]] : $*Int
+// CHECK-MAIN-COMMON: store [[PKG_GET]] to {{.*}} : $*Int
+
+// CHECK-MAIN-COMMON: [[PUB_ALLOC:%.*]] = alloc_ref $PubKlass
+// CHECK-MAIN-COMMON-NEXT: [[PUB_INIT:%.*]] = end_init_let_ref [[PUB_ALLOC]] : $PubKlass
+// CHECK-MAIN-COMMON-NEXT: [[PUB_REF_ELEM_ADDR:%.*]] = ref_element_addr [[PUB_INIT]] : $PubKlass, #PubKlass.data
+// CHECK-MAIN-COMMON-NEXT: store {{.*}} to [[PUB_REF_ELEM_ADDR]] : $*Int
+// CHECK-MAIN-COMMON-NEXT: store [[PUB_INIT]] to {{.*}} : $*PubKlass
+  
+// CHECK-MAIN-COMMON: [[PUBK_GET:%.*]] = load {{.*}} : $*PubKlass
+// CHECK-MAIN-COMMON: class_method [[PUBK_GET]] : $PubKlass, #PubKlass.data!getter : (PubKlass) -> () -> Int, $@convention(method) (@guaranteed PubKlass) -> Int
+// CHECK-MAIN-COMMON: [[PUBK_SET:%.*]] = load {{.*}} : $*PubKlass
+// CHECK-MAIN-COMMON: class_method [[PUBK_SET]] : $PubKlass, #PubKlass.data!setter : (PubKlass) -> (Int) -> (), $@convention(method) (Int, @guaranteed PubKlass) -> ()
+  
+// CHECK-MAIN-COMMON: [[PKG_ALLOC:%.*]] = alloc_ref $PkgKlass
+// CHECK-MAIN-COMMON-NEXT: [[PKG_INIT:%.*]] = end_init_let_ref [[PKG_ALLOC]] : $PkgKlass
+// CHECK-MAIN-COMMON-NEXT: [[PKG_REF_ELEM_ADDR:%.*]] = ref_element_addr [[PKG_INIT]] : $PkgKlass, #PkgKlass.data
+// CHECK-MAIN-COMMON-NEXT: store {{.*}} to [[PKG_REF_ELEM_ADDR]] : $*Int
+// CHECK-MAIN-COMMON-NEXT: store [[PKG_INIT]] to {{.*}} : $*PkgKlass
+
+// CHECK-MAIN-COMMON: [[PKGK_GET:%.*]] = load {{.*}} : $*PkgKlass
+// CHECK-MAIN-COMMON: class_method [[PKGK_GET]] : $PkgKlass, #PkgKlass.data!getter : (PkgKlass) -> () -> Int, $@convention(method) (@guaranteed PkgKlass) -> Int
+
+// CHECK-MAIN-COMMON: [[PKGK_SET:%.*]] = load {{.*}} : $*PkgKlass
+// CHECK-MAIN-COMMON: class_method [[PKGK_SET]] : $PkgKlass, #PkgKlass.data!setter : (PkgKlass) -> (Int) -> (), $@convention(method) (Int, @guaranteed PkgKlass) -> ()
+
+// CHECK-MAIN-COMMON: [[FNL_PUB_ALLOC:%.*]] = alloc_ref $FinalPubKlass
+// CHECK-MAIN-COMMON-NEXT: [[FNL_PUB_INIT:%.*]] = end_init_let_ref [[FNL_PUB_ALLOC]] : $FinalPubKlass
+// CHECK-MAIN-COMMON-NEXT: [[FNL_PUB_REF_ELEM_ADDR:%.*]] = ref_element_addr [[FNL_PUB_INIT]] : $FinalPubKlass, #FinalPubKlass.data
+// CHECK-MAIN-COMMON-NEXT: store {{.*}} to [[FNL_PUB_REF_ELEM_ADDR]] : $*Int
+// CHECK-MAIN-COMMON: store [[FNL_PUB_INIT]] to {{.*}} : $*FinalPubKlass
+  
+// CHECK-MAIN-COMMON: [[FNL_PUB_GET:%.*]] = load {{.*}} : $*FinalPubKlass
+// CHECK-MAIN-COMMON: [[FNL_PUB_REF:%.*]] = ref_element_addr [[FNL_PUB_GET]] : $FinalPubKlass, #FinalPubKlass.data
+// CHECK-MAIN-COMMON-NEXT: [[FNL_PUB_ACCESS:%.*]] = begin_access {{.*}} [[FNL_PUB_REF]] : $*Int
+// CHECK-MAIN-COMMON-NEXT: [[FNL_PUB_LOAD:%.*]] = load [[FNL_PUB_ACCESS]] : $*Int
+// CHECK-MAIN-COMMON-NEXT: store [[FNL_PUB_LOAD]] to {{.*}} : $*Int
+  
+// CHECK-MAIN-COMMON: [[FNL_PKG_ALLOC:%.*]] = alloc_ref $FinalPkgKlass
+// CHECK-MAIN-COMMON-NEXT: [[FNL_PKG_INIT:%.*]] = end_init_let_ref [[FNL_PKG_ALLOC]] : $FinalPkgKlass
+// CHECK-MAIN-COMMON-NEXT: [[FNL_PKG_REF_ELEM_ADDR:%.*]] = ref_element_addr [[FNL_PKG_INIT]] : $FinalPkgKlass, #FinalPkgKlass.data
+// CHECK-MAIN-COMMON-NEXT: store {{.*}} to [[FNL_PKG_REF_ELEM_ADDR]] : $*Int
+// CHECK-MAIN-COMMON: store [[FNL_PKG_INIT]] to {{.*}} : $*FinalPkgKlass
+  
+// CHECK-MAIN-COMMON: [[FNL_PKG_GET:%.*]] = load {{.*}} : $*FinalPkgKlass
+// CHECK-MAIN-COMMON: [[FNL_PKG_REF:%.*]] = ref_element_addr [[FNL_PKG_GET]] : $FinalPkgKlass, #FinalPkgKlass.data
+// CHECK-MAIN-COMMON-NEXT: [[FNL_PKG_ACCESS:%.*]] = begin_access {{.*}} [[FNL_PKG_REF]] : $*Int
+// CHECK-MAIN-COMMON-NEXT: [[FNL_PKG_LOAD:%.*]] = load [[FNL_PKG_ACCESS]] : $*Int
+// CHECK-MAIN-COMMON-NEXT: store [[FNL_PKG_LOAD]] to {{.*}} : $*Int
+  
+// CHECK-MAIN-RES-DAG: sil public_external [serialized_for_package] @$s3Lib8PubKlassCyACSicfC : $@convention(method) (Int, @thick PubKlass.Type) -> @owned PubKlass {
+// CHECK-MAIN-NONRES-DAG: sil public_external @$s3Lib8PubKlassCyACSicfC : $@convention(method) (Int, @thick PubKlass.Type) -> @owned PubKlass {
+
+// CHECK-MAIN-RES-DAG: sil package_external [serialized_for_package] @$s3Lib8PkgKlassCyACSicfC : $@convention(method) (Int, @thick PkgKlass.Type) -> @owned PkgKlass {
+// CHECK-MAIN-NONRES-DAG: sil package_external @$s3Lib8PkgKlassCyACSicfC : $@convention(method) (Int, @thick PkgKlass.Type) -> @owned PkgKlass {
+
+// CHECK-MAIN-RES-DAG: sil public_external [serialized_for_package] @$s3Lib13FinalPubKlassCyACSicfC : $@convention(method) (Int, @thick FinalPubKlass.Type) -> @owned FinalPubKlass {
+// CHECK-MAIN-NONRES-DAG: sil public_external @$s3Lib13FinalPubKlassCyACSicfC : $@convention(method) (Int, @thick FinalPubKlass.Type) -> @owned FinalPubKlass {
+
+// CHECK-MAIN-RES-DAG: sil public_external [serialized_for_package] @$s3Lib8PubKlassC4dataSivs : $@convention(method) (Int, @guaranteed PubKlass) -> () {
+// CHECK-MAIN-NONRES-DAG: sil public_external [transparent] @$s3Lib8PubKlassC4dataSivs : $@convention(method) (Int, @guaranteed PubKlass) -> () {
+
+// CHECK-MAIN-RES-DAG: sil package_external [serialized_for_package] @$s3Lib13FinalPkgKlassCyACSicfC : $@convention(method) (Int, @thick FinalPkgKlass.Type) -> @owned FinalPkgKlass {
+// CHECK-MAIN-NONRES-DAG: sil package_external @$s3Lib13FinalPkgKlassCyACSicfC : $@convention(method) (Int, @thick FinalPkgKlass.Type) -> @owned FinalPkgKlass {
+
+// CHECK-MAIN-RES-DAG: sil package_external [serialized_for_package] @$s3Lib8PkgKlassC4dataSivs : $@convention(method) (Int, @guaranteed PkgKlass) -> () {
+// CHECK-MAIN-NONRES-DAG: sil package_external [transparent] @$s3Lib8PkgKlassC4dataSivs : $@convention(method) (Int, @guaranteed PkgKlass) -> () {
+
+// CHECK-MAIN-COMMON: sil_vtable PubKlass {
+// CHECK-MAIN-COMMON: sil_vtable PkgKlass {
+// CHECK-MAIN-COMMON: sil_vtable FinalPubKlass {
+// CHECK-MAIN-COMMON: sil_vtable FinalPkgKlass {
+
+var pub = PubStruct(1)
+let prevPub = pub.fooVar
+pub.fooVar = 3
+let a = runPub(pub)
+
+var frpub = FrPubStruct(1)
+let prevFrPub = frpub.fooVar
+frpub.fooVar = 3
+let b = runFrPub(frpub)
+
+var pkg = PkgStruct(1)
+let prevPkg = pkg.fooVar
+pkg.fooVar = 3
+let c = runPkg(pkg)
+
+var pubKlass = PubKlass(5)
+let prevPubData = pubKlass.data
+pubKlass.data = 7
+let x = runPubKlass(pubKlass)
+
+var pkgKlass = PkgKlass(7)
+let prevPkgData = pkgKlass.data
+pkgKlass.data = 7
+let y = runPkgKlass(pkgKlass)
+
+var fnlPubKlass = FinalPubKlass(9)
+let prevPubDataFnl = fnlPubKlass.data
+fnlPubKlass.data = 11
+
+var fnlPkgKlass = FinalPkgKlass(9)
+let prevPkgDataFnl = fnlPkgKlass.data
+fnlPkgKlass.data = 11
+
+print(a, b, c, x, y, 
+      prevPub, prevFrPub, prevPkg, prevPubData,
+      prevPkgData, prevPubDataFnl, prevPkgDataFnl)
+
+public func mainPub() {
+  print(PubStruct(1))
+}
+
+@inlinable
+public func mainPubInlinable() {
+  print(PubStruct(2))
+}
+
+public func mainPubArgRet(_ arg: PubKlass) -> PubStruct {
+  return PubStruct(arg.data)
+}
+
+@inlinable
+public func mainPubArgRetInlinable(_ arg: PubKlass) -> PubStruct {
+  return PubStruct(arg.data)
+}
+
+//--- Lib.swift
+
+public struct PubStruct {
+  // PubStruct.foovar.getter
+  // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib9PubStructV6fooVarSivg : $@convention(method) (@in_guaranteed PubStruct) -> Int {
+  // CHECK-NONRES-DAG: sil [transparent] [serialized] [canonical] [ossa] @$s3Lib9PubStructV6fooVarSivg : $@convention(method) (PubStruct) -> Int
+  // CHECK-RES-DAG: [[PUB_GET:%.*]] = struct_element_addr {{.*}} : $*PubStruct, #PubStruct.fooVar
+  // CHECK-RES-DAG: load [[PUB_GET]] : $*Int
+  // CHECK-NONRES-DAG = struct_extract {{.*}} : $PubStruct, #PubStruct.fooVar
+
+  // PubStruct.foovar.setter
+  // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib9PubStructV6fooVarSivs : $@convention(method) (Int, @inout PubStruct) -> () {
+  // CHECK-NONRES-DAG: sil [transparent] [serialized] [canonical] [ossa] @$s3Lib9PubStructV6fooVarSivs : $@convention(method) (Int, @inout PubStruct) -> () {
+
+  /// NOTE: `struct $PubStruct` in [serialized] function is legal only if package serialization is enabled.
+  // CHECK-COMMON-DAG:  [[PUB_SET:%.*]] = struct $PubStruct
+  // CHECK-RES-DAG:  store [[PUB_SET]] to {{.*}} : $*PubStruct
+  // CHECK-NONRES-DAG:  store [[PUB_SET]] to [trivial] {{.*}} : $*PubStruct
+
+  // PubStruct.foovar.modify
+  // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib9PubStructV6fooVarSivM : $@yield_once @convention(method) (@inout PubStruct) -> @yields @inout Int {
+  // CHECK-NONRES-DAG: sil [transparent] [serialized] [canonical] [ossa] @$s3Lib9PubStructV6fooVarSivM : $@yield_once @convention(method) (@inout PubStruct) -> @yields @inout Int {
+  // CHECK-COMMON-DAG: [[PUB_MODIFY:%.*]] = struct_element_addr {{.*}} : $*PubStruct, #PubStruct.fooVar
+  // CHECK-COMMON-DAG: yield [[PUB_MODIFY]]
+  public var fooVar: Int
+
+  public init(_ arg: Int) {
+    // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib9PubStructVyACSicfC : $@convention(method) (Int, @thin PubStruct.Type) -> @out PubStruct {
+    // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib9PubStructVyACSicfC : $@convention(method) (Int, @thin PubStruct.Type) -> PubStruct {
+    // CHECK-COMMON-DAG: [[PUB_INIT:%.*]] = struct $PubStruct
+    // CHECK-RES-DAG: store [[PUB_INIT]] to {{.*}} : $*PubStruct
+    // CHECK-NONRES-DAG: return [[PUB_INIT]] : $PubStruct
+    fooVar = arg
+  }
+  public func f() -> Int {
+    // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib9PubStructV1fSiyF : $@convention(method) (@in_guaranteed PubStruct) -> Int {
+    // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib9PubStructV1fSiyF : $@convention(method) (PubStruct) -> Int {
+    return fooVar > 7 ? fooVar : fooVar + 11
+  }
+}
+
+public func runPub(_ arg: PubStruct) -> Int {
+  // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib6runPubySiAA0C6StructVF : $@convention(thin) (@in_guaranteed PubStruct) -> Int {
+  // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib6runPubySiAA0C6StructVF : $@convention(thin) (PubStruct) -> Int {
+  return arg.f() > arg.fooVar ? arg.f() : arg.fooVar
+}
+
+@inlinable
+public func runPubInlinable(_ arg: Int) -> PubStruct {
+  // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib15runPubInlinableyAA0C6StructVSiF : $@convention(thin) (Int) -> @out PubStruct {
+  // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib15runPubInlinableyAA0C6StructVSiF : $@convention(thin) (Int) -> PubStruct {
+  // CHECK-RES-DAG: alloc_stack [var_decl] $PubStruct
+  // CHECK-RES-DAG: function_ref @$s3Lib9PubStructVyACSicfC : $@convention(method) (Int, @thin PubStruct.Type) -> @out PubStruct
+  // CHECK-NONRES-DAG: function_ref @$s3Lib9PubStructVyACSicfC : $@convention(method) (Int, @thin PubStruct.Type) -> PubStruct
+  var x = PubStruct(1)
+  x.fooVar = arg > 11 ? arg + 13 : arg + 17
+  return x
+}
+
+@frozen
+public struct FrPubStruct {
+  // FrPubStruct.fooVar.getter
+  // CHECK-RES-DAG: sil [transparent] [serialized] [serialized_for_package] [canonical] [ossa] @$s3Lib11FrPubStructV6fooVarSivg : $@convention(method) (FrPubStruct) -> Int {
+  // CHECK-NONRES-DAG: sil [transparent] [serialized] [canonical] [ossa] @$s3Lib11FrPubStructV6fooVarSivg : $@convention(method) (FrPubStruct) -> Int {
+  // CHECK-COMMON-DAG: [[FR_GET:%.*]] = struct_extract {{.*}} : $FrPubStruct, #FrPubStruct.fooVar
+  // CHECK-COMMON-DAG: return [[FR_GET]] : $Int
+
+  // FrPubStruct.fooVar.setter
+  // CHECK-RES-DAG: sil [transparent] [serialized] [serialized_for_package] [canonical] [ossa] @$s3Lib11FrPubStructV6fooVarSivs : $@convention(method) (Int, @inout FrPubStruct) -> () {
+  // CHECK-NONRES-DAG: sil [transparent] [serialized] [canonical] [ossa] @$s3Lib11FrPubStructV6fooVarSivs : $@convention(method) (Int, @inout FrPubStruct) -> () {
+  // CHECK-COMMON-DAG:  [[FR_SET:%.*]] = struct $FrPubStruct
+  // CHECK-COMMON-DAG:  store [[FR_SET]] to [trivial] {{.*}} : $*FrPubStruct
+
+  // FrPubStruct.fooVar.modify
+  // CHECK-RES-DAG: sil [transparent] [serialized] [serialized_for_package] [canonical] [ossa] @$s3Lib11FrPubStructV6fooVarSivM : $@yield_once @convention(method) (@inout FrPubStruct) -> @yields @inout Int {
+  // CHECK-NONRES-DAG: sil [transparent] [serialized] [canonical] [ossa] @$s3Lib11FrPubStructV6fooVarSivM : $@yield_once @convention(method) (@inout FrPubStruct) -> @yields @inout Int {
+  // CHECK-COMMON-DAG: [[FIELD:%.*]] = struct_element_addr {{.*}} : $*FrPubStruct, #FrPubStruct.fooVar
+  // CHECK-COMMON-DAG: yield [[FIELD]]
+  public var fooVar: Int
+
+  public init(_ arg: Int) {
+    // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib11FrPubStructVyACSicfC : $@convention(method) (Int, @thin FrPubStruct.Type) -> FrPubStruct {
+    // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib11FrPubStructVyACSicfC : $@convention(method) (Int, @thin FrPubStruct.Type) -> FrPubStruct {
+    // CHECK-COMMON-DAG: [[FR_MODIFY:%.*]] = struct $FrPubStruct
+    // CHECK-COMMON-DAG: return [[FR_MODIFY]] : $FrPubStruct
+    fooVar = arg
+  }
+  public func f() -> Int {
+    // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib11FrPubStructV1fSiyF : $@convention(method) (FrPubStruct) -> Int {
+    // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib11FrPubStructV1fSiyF : $@convention(method) (FrPubStruct) -> Int {
+    return fooVar > 13 ? fooVar : fooVar + 17
+  }
+}
+
+public func runFrPub(_ arg: FrPubStruct) -> Int {
+  // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib8runFrPubySiAA0cD6StructVF : $@convention(thin) (FrPubStruct) -> Int {
+  // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib8runFrPubySiAA0cD6StructVF : $@convention(thin) (FrPubStruct) -> Int {
+  return arg.f() > arg.fooVar ? arg.f() : arg.fooVar
+}
+
+package struct PkgStruct {
+  // PkgStruct.fooVar.getter
+  // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib9PkgStructV6fooVarSivg : $@convention(method) (@in_guaranteed PkgStruct) -> Int {
+  // CHECK-NONRES-DAG: sil package [transparent] [serialized] [canonical] [ossa] @$s3Lib9PkgStructV6fooVarSivg : $@convention(method) (PkgStruct) -> Int {
+  // CHECK-COMMON-DAG: [[PKG_GET:%.*]] = struct_element_addr {{.*}} : $*PkgStruct, #PkgStruct.fooVar
+  // CHECK-RES-DAG: load [[PKG_GET]] : $*Int
+  // CHECK-NONRES-DAG = struct_extract {{.*}} : $PkgStruct, #PkgStruct.fooVar
+
+  // PkgStruct.fooVar.setter
+  // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib9PkgStructV6fooVarSivs : $@convention(method) (Int, @inout PkgStruct) -> () {
+  // CHECK-NONRES-DAG: sil package [transparent] [serialized] [canonical] [ossa] @$s3Lib9PkgStructV6fooVarSivs : $@convention(method) (Int, @inout PkgStruct) -> () {
+  // CHECK-COMMON-DAG:  [[PKG_SET:%.*]] = struct $PkgStruct
+  // CHECK-RES-DAG:  store [[PKG_SET]] to {{.*}} : $*PkgStruct
+  // CHECK-NONRES-DAG:  store [[PKG_SET]] to [trivial] {{.*}} : $*PkgStruct
+
+  // PkgStruct.fooVar.modify
+  // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib9PkgStructV6fooVarSivM : $@yield_once @convention(method) (@inout PkgStruct) -> @yields @inout Int {
+  // CHECK-NONRES-DAG: sil package [transparent] [serialized] [canonical] [ossa] @$s3Lib9PkgStructV6fooVarSivM : $@yield_once @convention(method) (@inout PkgStruct) -> @yields @inout Int {
+  package var fooVar: Int
+
+  package init(_ arg: Int) {
+    // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib9PkgStructVyACSicfC : $@convention(method) (Int, @thin PkgStruct.Type) -> @out PkgStruct {
+    // CHECK-NONRES-DAG: sil package [serialized] [canonical] @$s3Lib9PkgStructVyACSicfC : $@convention(method) (Int, @thin PkgStruct.Type) -> PkgStruct {
+    // CHECK-COMMON-DAG: [[PKG_INIT:%.*]] = struct $PkgStruct
+    // CHECK-RES-DAG: store [[PKG_INIT]] to {{.*}} : $*PkgStruct
+    // CHECK-NONRES-DAG: return [[PKG_INIT]] : $PkgStruct
+    fooVar = arg
+  }
+  package func f() -> Int {
+    // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib9PkgStructV1fSiyF : $@convention(method) (@in_guaranteed PkgStruct) -> Int {
+    // CHECK-NONRES-DAG: sil package [serialized] [canonical] @$s3Lib9PkgStructV1fSiyF : $@convention(method) (PkgStruct) -> Int {
+    return fooVar > 19 ? fooVar : fooVar + 23
+  }
+}
+
+package func runPkg(_ arg: PkgStruct) -> Int {
+  // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib6runPkgySiAA0C6StructVF : $@convention(thin) (@in_guaranteed PkgStruct) -> Int {
+  // CHECK-NONRES-DAG: sil package [serialized] [canonical] @$s3Lib6runPkgySiAA0C6StructVF : $@convention(thin) (PkgStruct) -> Int {
+  return arg.f() > arg.fooVar ? arg.f() : arg.fooVar
+}
+
+public protocol PubProto {
+  var data: Int { get set }
+  func pubfunc(_ arg: Int) -> Int
+}
+
+public class PubKlass: PubProto {
+  // CHECK-RES-DAG: sil shared [transparent] [serialized] [serialized_for_package] [thunk] [canonical] [ossa] @$s3Lib8PubKlassCAA0B5ProtoA2aDP4dataSivgTW : $@convention(witness_method: PubProto) (@in_guaranteed PubKlass) -> Int {
+  // CHECK-RES-DAG: sil shared [transparent] [serialized] [serialized_for_package] [thunk] [canonical] [ossa] @$s3Lib8PubKlassCAA0B5ProtoA2aDP4dataSivMTW : $@yield_once @convention(witness_method: PubProto) @substituted <τ_0_0> (@inout τ_0_0) -> @yields @inout Int for <PubKlass> {
+  // CHECK-RES-DAG: sil shared [transparent] [serialized] [serialized_for_package] [thunk] [canonical] [ossa] @$s3Lib8PubKlassCAA0B5ProtoA2aDP4dataSivsTW : $@convention(witness_method: PubProto) (Int, @inout PubKlass) -> () {
+  // CHECK-NONRES-DAG: sil shared [transparent] [serialized] [thunk] [canonical] [ossa] @$s3Lib8PubKlassCAA0B5ProtoA2aDP4dataSivgTW : $@convention(witness_method: PubProto) (@in_guaranteed PubKlass) -> Int {
+  // CHECK-NONRES-DAG: sil shared [transparent] [serialized] [thunk] [canonical] [ossa] @$s3Lib8PubKlassCAA0B5ProtoA2aDP4dataSivMTW : $@yield_once @convention(witness_method: PubProto) @substituted <τ_0_0> (@inout τ_0_0) -> @yields @inout Int for <PubKlass> {
+  // CHECK-NONRES-DAG: sil shared [transparent] [serialized] [thunk] [canonical] [ossa] @$s3Lib8PubKlassCAA0B5ProtoA2aDP4dataSivsTW : $@convention(witness_method: PubProto) (Int, @inout PubKlass) -> () {
+  // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib8PubKlassC4dataSivg : $@convention(method) (@guaranteed PubKlass) -> Int
+  // CHECK-NONRES-DAG: sil [transparent] [serialized] [canonical] [ossa] @$s3Lib8PubKlassC4dataSivg : $@convention(method) (@guaranteed PubKlass) -> Int {
+  // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib8PubKlassC4dataSivs : $@convention(method) (Int, @guaranteed PubKlass) -> () {
+  // CHECK-NONRES-DAG: sil [transparent] [serialized] [canonical] [ossa] @$s3Lib8PubKlassC4dataSivs : $@convention(method) (Int, @guaranteed PubKlass) -> () {
+  public var data: Int
+  public init(_ arg: Int = 1) {
+    // FIXME: default argument 0 of PubKlass.init(_:) gets non_abi so is not considered
+    // for package serialization, but should it?
+    // sil non_abi [serialized] [canonical] @$s3Lib8PubKlassCyACSicfcfA_ : $@convention(thin) () -> Int {
+    // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib8PubKlassCyACSicfc : $@convention(method) (Int, @owned PubKlass) -> @owned PubKlass {
+    // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [exact_self_class] [canonical] @$s3Lib8PubKlassCyACSicfC : $@convention(method) (Int, @thick PubKlass.Type) -> @owned PubKlass {
+    // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib8PubKlassCfD : $@convention(method) (@owned PubKlass) -> () {
+    // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib8PubKlassCfd : $@convention(method) (@guaranteed PubKlass) -> @owned Builtin.NativeObject {
+    // default argument 0 of PubKlass.init(_:)
+    // CHECK-NONRES-DAG: sil non_abi [serialized] [canonical] @$s3Lib8PubKlassCyACSicfcfA_ : $@convention(thin) () -> Int {
+    // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib8PubKlassCyACSicfc : $@convention(method) (Int, @owned PubKlass) -> @owned PubKlass {
+    // CHECK-NONRES-DAG: sil [serialized] [exact_self_class] [canonical] @$s3Lib8PubKlassCyACSicfC : $@convention(method) (Int, @thick PubKlass.Type) -> @owned PubKlass {
+    // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib8PubKlassCfD : $@convention(method) (@owned PubKlass) -> () {
+    // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib8PubKlassCfd : $@convention(method) (@guaranteed PubKlass) -> @owned Builtin.NativeObject {
+    self.data = arg
+  }
+  public func pubfunc(_ arg: Int) -> Int {
+    // CHECK-RES-DAG: sil shared [transparent] [serialized] [serialized_for_package] [thunk] [canonical] [ossa] @$s3Lib8PubKlassCAA0B5ProtoA2aDP7pubfuncyS2iFTW : $@convention(witness_method: PubProto) (Int, @in_guaranteed PubKlass) -> Int {
+    // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib8PubKlassC7pubfuncyS2iF : $@convention(method) (Int, @guaranteed PubKlass) -> Int {
+    // CHECK-NONRES-DAG: sil shared [transparent] [serialized] [thunk] [canonical] [ossa] @$s3Lib8PubKlassCAA0B5ProtoA2aDP7pubfuncyS2iFTW : $@convention(witness_method: PubProto) (Int, @in_guaranteed PubKlass) -> Int {
+    // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib8PubKlassC7pubfuncyS2iF : $@convention(method) (Int, @guaranteed PubKlass) -> Int {
+    return data + arg
+  }
+}
+
+public func runPubKlass(_ arg: PubKlass) -> Int {
+  // CHECK-RES-DAG: sil [serialized] [serialized_for_package] [canonical] @$s3Lib11runPubKlassySiAA0cD0CF : $@convention(thin) (@guaranteed PubKlass) -> Int
+  // CHECK-NONRES-DAG: sil [serialized] [canonical] @$s3Lib11runPubKlassySiAA0cD0CF : $@convention(thin) (@guaranteed PubKlass) -> Int {
+  arg.data += 29
+  return arg.pubfunc(31)
+}
+
+final public class FinalPubKlass {
+  public var data = 1
+  public init(_ arg: Int) {
+    data = arg
+  }
+  public func fnlPubFunc(_ arg: Int) -> Int {
+    data + arg
+  }
+}
+
+package protocol PkgProto {
+  var data: Int { get set }
+  func pkgfunc(_ arg: Int) -> Int
+}
+
+package class PkgKlass: PkgProto {
+  // CHECK-RES-DAG: sil shared [transparent] [serialized] [serialized_for_package] [thunk] [canonical] [ossa] @$s3Lib8PkgKlassCAA0B5ProtoA2aDP4dataSivgTW : $@convention(witness_method: PkgProto) (@in_guaranteed PkgKlass) -> Int {
+  // CHECK-RES-DAG: sil shared [transparent] [serialized] [serialized_for_package] [thunk] [canonical] [ossa] @$s3Lib8PkgKlassCAA0B5ProtoA2aDP4dataSivsTW : $@convention(witness_method: PkgProto) (Int, @inout PkgKlass) -> () {
+  // CHECK-RES-DAG: sil shared [transparent] [serialized] [serialized_for_package] [thunk] [canonical] [ossa] @$s3Lib8PkgKlassCAA0B5ProtoA2aDP4dataSivMTW : $@yield_once @convention(witness_method: PkgProto) @substituted <τ_0_0> (@inout τ_0_0) -> @yields @inout Int for <PkgKlass> {
+  // CHECK-NONRES-DAG: sil shared [transparent] [serialized] [thunk] [canonical] [ossa] @$s3Lib8PkgKlassCAA0B5ProtoA2aDP4dataSivgTW : $@convention(witness_method: PkgProto) (@in_guaranteed PkgKlass) -> Int {
+  // CHECK-NONRES-DAG: sil shared [transparent] [serialized] [thunk] [canonical] [ossa] @$s3Lib8PkgKlassCAA0B5ProtoA2aDP4dataSivsTW : $@convention(witness_method: PkgProto) (Int, @inout PkgKlass) -> () {
+  // CHECK-NONRES-DAG: sil shared [transparent] [serialized] [thunk] [canonical] [ossa] @$s3Lib8PkgKlassCAA0B5ProtoA2aDP4dataSivMTW : $@yield_once @convention(witness_method: PkgProto) @substituted <τ_0_0> (@inout τ_0_0) -> @yields @inout Int for <PkgKlass> {
+  // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib8PkgKlassC4dataSivM : $@yield_once @convention(method) (@guaranteed PkgKlass) -> @yields @inout Int {
+  // CHECK-NONRES-DAG: sil package [transparent] [serialized] [canonical] [ossa] @$s3Lib8PkgKlassC4dataSivM : $@yield_once @convention(method) (@guaranteed PkgKlass) -> @yields @inout Int {
+  // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib8PkgKlassC4dataSivg : $@convention(method) (@guaranteed PkgKlass) -> Int {
+  // CHECK-NONRES-DAG: sil package [transparent] [serialized] [canonical] [ossa] @$s3Lib8PkgKlassC4dataSivg : $@convention(method) (@guaranteed PkgKlass) -> Int {
+  // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib8PkgKlassC4dataSivs : $@convention(method) (Int, @guaranteed PkgKlass) -> () {
+  // CHECK-NONRES-DAG: sil package [transparent] [serialized] [canonical] [ossa] @$s3Lib8PkgKlassC4dataSivs : $@convention(method) (Int, @guaranteed PkgKlass) -> () {
+  package var data: Int
+
+  package init(_ arg: Int = 1) {
+    // FIXME: package -> package_non_abi for default argument 0 of PkgKlass.init(_:)
+    // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib8PkgKlassCyACSicfcfA_ : $@convention(thin) () -> Int {
+    // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib8PkgKlassCyACSicfc : $@convention(method) (Int, @owned PkgKlass) -> @owned PkgKlass {
+    // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [exact_self_class] [canonical] @$s3Lib8PkgKlassCyACSicfC : $@convention(method) (Int, @thick PkgKlass.Type) -> @owned PkgKlass {
+    // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib8PkgKlassCfd : $@convention(method) (@guaranteed PkgKlass) -> @owned Builtin.NativeObject {
+    // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib8PkgKlassCfD : $@convention(method) (@owned PkgKlass) -> ()
+    // CHECK-NONRES-DAG: sil package [serialized] [canonical] @$s3Lib8PkgKlassCyACSicfcfA_ : $@convention(thin) () -> Int {
+    // CHECK-NONRES-DAG: sil package [serialized] [canonical] @$s3Lib8PkgKlassCyACSicfc : $@convention(method) (Int, @owned PkgKlass) -> @owned PkgKlass {
+    // CHECK-NONRES-DAG: sil package [serialized] [exact_self_class] [canonical] @$s3Lib8PkgKlassCyACSicfC : $@convention(method) (Int, @thick PkgKlass.Type) -> @owned PkgKlass {
+    // CHECK-NONRES-DAG: sil package [serialized] [canonical] @$s3Lib8PkgKlassCfd : $@convention(method) (@guaranteed PkgKlass) -> @owned Builtin.NativeObject {
+    // CHECK-NONRES-DAG: sil package [serialized] [canonical] @$s3Lib8PkgKlassCfD : $@convention(method) (@owned PkgKlass) -> ()
+    self.data = arg
+  }
+
+  package func pkgfunc(_ arg: Int) -> Int {
+    // CHECK-RES-DAG: sil shared [transparent] [serialized] [serialized_for_package] [thunk] [canonical] [ossa] @$s3Lib8PkgKlassCAA0B5ProtoA2aDP7pkgfuncyS2iFTW : $@convention(witness_method: PkgProto) (Int, @in_guaranteed PkgKlass) -> Int {
+    // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib8PkgKlassC7pkgfuncyS2iF : $@convention(method) (Int, @guaranteed PkgKlass) -> Int {
+    // CHECK-NONRES-DAG: sil shared [transparent] [serialized] [thunk] [canonical] [ossa] @$s3Lib8PkgKlassCAA0B5ProtoA2aDP7pkgfuncyS2iFTW : $@convention(witness_method: PkgProto) (Int, @in_guaranteed PkgKlass) -> Int {
+    // CHECK-NONRES-DAG: sil package [serialized] [canonical] @$s3Lib8PkgKlassC7pkgfuncyS2iF : $@convention(method) (Int, @guaranteed PkgKlass) -> Int {
+    return data + arg
+  }
+}
+
+package func runPkgKlass(_ arg: PkgKlass) -> Int {
+  // CHECK-RES-DAG: sil package [serialized] [serialized_for_package] [canonical] @$s3Lib11runPkgKlassySiAA0cD0CF : $@convention(thin) (@guaranteed PkgKlass) -> Int
+  // CHECK-NONRES-DAG: sil package [serialized] [canonical] @$s3Lib11runPkgKlassySiAA0cD0CF : $@convention(thin) (@guaranteed PkgKlass) -> Int {
+  arg.data += 37
+  return arg.pkgfunc(41)
+}
+
+
+final package class FinalPkgKlass {
+  package var data = 1
+  package init(_ arg: Int) {
+    data = arg
+  }
+  package func fnlPkgFunc(_ arg: Int) -> Int {
+    data + arg
+  }
+}
+
+// CHECK-COMMON-LABEL: sil_vtable [serialized] PubKlass {
+// CHECK-COMMON-NEXT:   #PubKlass.data!getter: (PubKlass) -> () -> Int : @$s3Lib8PubKlassC4dataSivg
+// CHECK-COMMON-NEXT:   #PubKlass.data!setter: (PubKlass) -> (Int) -> () : @$s3Lib8PubKlassC4dataSivs
+// CHECK-COMMON-NEXT:   #PubKlass.data!modify: (PubKlass) -> () -> () : @$s3Lib8PubKlassC4dataSivM
+// CHECK-COMMON-NEXT:   #PubKlass.init!allocator: (PubKlass.Type) -> (Int) -> PubKlass : @$s3Lib8PubKlassCyACSicfC
+// CHECK-COMMON-NEXT:   #PubKlass.pubfunc: (PubKlass) -> (Int) -> Int : @$s3Lib8PubKlassC7pubfuncyS2iF
+// CHECK-COMMON-NEXT:   #PubKlass.deinit!deallocator: @$s3Lib8PubKlassCfD
+
+// CHECK-COMMON-LABEL: sil_vtable [serialized] FinalPubKlass {
+// CHECK-COMMON-NEXT:  #FinalPubKlass.init!allocator: (FinalPubKlass.Type) -> (Int) -> FinalPubKlass : @$s3Lib13FinalPubKlassCyACSicfC
+// CHECK-COMMON-NEXT:  #FinalPubKlass.deinit!deallocator: @$s3Lib13FinalPubKlassCfD
+
+// CHECK-COMMON-LABEL: sil_vtable [serialized] PkgKlass {
+// CHECK-COMMON-NEXT:   #PkgKlass.data!getter: (PkgKlass) -> () -> Int : @$s3Lib8PkgKlassC4dataSivg
+// CHECK-COMMON-NEXT:   #PkgKlass.data!setter: (PkgKlass) -> (Int) -> () : @$s3Lib8PkgKlassC4dataSivs
+// CHECK-COMMON-NEXT:   #PkgKlass.data!modify: (PkgKlass) -> () -> () : @$s3Lib8PkgKlassC4dataSivM
+// CHECK-COMMON-NEXT:   #PkgKlass.init!allocator: (PkgKlass.Type) -> (Int) -> PkgKlass : @$s3Lib8PkgKlassCyACSicfC
+// CHECK-COMMON-NEXT:   #PkgKlass.pkgfunc: (PkgKlass) -> (Int) -> Int : @$s3Lib8PkgKlassC7pkgfuncyS2iF
+// CHECK-COMMON-NEXT:   #PkgKlass.deinit!deallocator: @$s3Lib8PkgKlassCfD
+
+// CHECK-COMMON-LABEL: sil_vtable [serialized] FinalPkgKlass {
+// CHECK-COMMON-NEXT:  #FinalPkgKlass.init!allocator: (FinalPkgKlass.Type) -> (Int) -> FinalPkgKlass : @$s3Lib13FinalPkgKlassCyACSicfC
+// CHECK-COMMON-NEXT:  #FinalPkgKlass.deinit!deallocator: @$s3Lib13FinalPkgKlassCfD
+
+// CHECK-COMMON-LABEL: sil_witness_table [serialized] PubKlass: PubProto module Lib {
+// CHECK-COMMON-NEXT:   method #PubProto.data!getter: <Self where Self : PubProto> (Self) -> () -> Int : @$s3Lib8PubKlassCAA0B5ProtoA2aDP4dataSivgTW
+// CHECK-COMMON-NEXT:   method #PubProto.data!setter: <Self where Self : PubProto> (inout Self) -> (Int) -> () : @$s3Lib8PubKlassCAA0B5ProtoA2aDP4dataSivsTW
+// CHECK-COMMON-NEXT:   method #PubProto.data!modify: <Self where Self : PubProto> (inout Self) -> () -> () : @$s3Lib8PubKlassCAA0B5ProtoA2aDP4dataSivMTW
+// CHECK-COMMON-NEXT:   method #PubProto.pubfunc: <Self where Self : PubProto> (Self) -> (Int) -> Int : @$s3Lib8PubKlassCAA0B5ProtoA2aDP7pubfuncyS2iFTW
+
+// CHECK-COMMON-LABEL: sil_witness_table package [serialized] PkgKlass: PkgProto module Lib {
+// CHECK-COMMON-NEXT:   method #PkgProto.data!getter: <Self where Self : PkgProto> (Self) -> () -> Int : @$s3Lib8PkgKlassCAA0B5ProtoA2aDP4dataSivgTW
+// CHECK-COMMON-NEXT:   method #PkgProto.data!setter: <Self where Self : PkgProto> (inout Self) -> (Int) -> () : @$s3Lib8PkgKlassCAA0B5ProtoA2aDP4dataSivsTW
+// CHECK-COMMON-NEXT:   method #PkgProto.data!modify: <Self where Self : PkgProto> (inout Self) -> () -> () : @$s3Lib8PkgKlassCAA0B5ProtoA2aDP4dataSivMTW
+// CHECK-COMMON-NEXT:   method #PkgProto.pkgfunc: <Self where Self : PkgProto> (Self) -> (Int) -> Int : @$s3Lib8PkgKlassCAA0B5ProtoA2aDP7pkgfuncyS2iFTW


### PR DESCRIPTION
- Explanation: Adds a new attribute [serialized_for_package] to SIL functions that are serialized during Package CMO. It indicates that loadable types are allowed in functions serialized due to Package CMO even in resiliently built modules. 
- Scope: Affects Package CMO only.
- Original PR: https://github.com/apple/swift/pull/73566
- Risk: Low. Changes are behind a flag and only affects Package CMO.
- Testing: Added new cases to tests.
- Issue:  rdar://127870822&128647016
- Reviewer: @aschwaighofer