### PR TITLE
[embedded] Make Mirror present but unavailable

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -98,7 +98,7 @@ split_embedded_sources(
   EMBEDDED Integers.swift
     NORMAL Join.swift
   EMBEDDED KeyPath.swift
-    NORMAL KeyValuePairs.swift
+  EMBEDDED KeyValuePairs.swift
   EMBEDDED LazyCollection.swift
   EMBEDDED LazySequence.swift
     NORMAL LegacyABI.swift
@@ -227,7 +227,7 @@ split_embedded_sources(
   EMBEDDED FloatingPointRandom.swift
   EMBEDDED Instant.swift
   EMBEDDED Int128.swift
-    NORMAL Mirror.swift
+  EMBEDDED Mirror.swift
     NORMAL PlaygroundDisplay.swift
     NORMAL CommandLine.swift
   EMBEDDED SliceBuffer.swift

--- a/stdlib/public/core/EmbeddedStubs.swift
+++ b/stdlib/public/core/EmbeddedStubs.swift
@@ -15,10 +15,9 @@ import SwiftShims
 /// String
 
 @_unavailableInEmbedded
-extension String {
-  public init<Subject>(describing instance: Subject) { fatalError() }
-  public init<Subject>(reflecting instance: Subject) { fatalError() }
-}
+internal func _print_unlocked<T>(_ value: T, _ target: inout String) { fatalError() }
+@_unavailableInEmbedded
+public func _debugPrint_unlocked<T>(_ value: T, _ target: inout String) { fatalError() }
 
 /// Codable
 

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -125,6 +125,7 @@ extension KeyValuePairs: RandomAccessCollection {
   }
 }
 
+@_unavailableInEmbedded
 extension KeyValuePairs: CustomStringConvertible {
   /// A string that represents the contents of the dictionary.
   public var description: String {
@@ -132,6 +133,7 @@ extension KeyValuePairs: CustomStringConvertible {
   }
 }
 
+@_unavailableInEmbedded
 extension KeyValuePairs: CustomDebugStringConvertible {
   /// A string that represents the contents of the dictionary, suitable for
   /// debugging.

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -538,6 +538,7 @@ extension Mirror {
 
 //===--- General Utilities ------------------------------------------------===//
 
+@_unavailableInEmbedded
 extension String {
   /// Creates a string representing the given value.
   ///

--- a/test/embedded/mirror.swift
+++ b/test/embedded/mirror.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-ir -verify %s -enable-experimental-feature Embedded -wmo
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public struct MyStruct {
+  var a, b, c: Int
+}
+
+public func foo(s: MyStruct) {
+  let mirror = Mirror(reflecting: s) // expected-error {{'Mirror' is unavailable}}
+  _ = mirror.children
+}


### PR DESCRIPTION
Currently, we just have Mirror completely removed from the embedded stdlib. A nicer user experience would be to have the APIs be present but unavailable so attempts to use them error out with "Mirror not available" instead of "Cannot find Mirror in scope".