### PR TITLE
[ExplicitModule] Don't pass PCM output path in `-Xcc` option

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -239,6 +239,7 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
     // invocation, not swift invocation.
     depsInvocation.getFrontendOpts().ModuleCacheKeys.clear();
     depsInvocation.getFrontendOpts().PathPrefixMappings.clear();
+    depsInvocation.getFrontendOpts().OutputFile.clear();
 
     // FIXME: workaround for rdar://105684525: find the -ivfsoverlay option
     // from clang scanner and pass to swift.
@@ -351,7 +352,7 @@ void ClangImporter::recordBridgingHeaderOptions(
       clang::frontend::ActionKind::GeneratePCH;
   depsInvocation.getFrontendOpts().ModuleCacheKeys.clear();
   depsInvocation.getFrontendOpts().PathPrefixMappings.clear();
-  depsInvocation.getFrontendOpts().OutputFile = "";
+  depsInvocation.getFrontendOpts().OutputFile.clear();
 
   llvm::BumpPtrAllocator allocator;
   llvm::StringSaver saver(allocator);

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -32,6 +32,11 @@
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:F clangIncludeTree > %t/F_tree.casid
 // RUN: clang-cas-test --cas %t/cas --print-include-tree @%t/F_tree.casid | %FileCheck %s -check-prefix INCLUDE_TREE_F
 
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:F commandLine > %t/F.cmd
+// RUN: %FileCheck %s -check-prefix F_CMD -input-file=%t/F.cmd
+// F_CMD: "-Xcc"
+// F_CMD-NOT: "-o"
+
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json deps commandLine > %t/deps.cmd
 // RUN: %FileCheck %s -check-prefix MAIN_CMD -input-file=%t/deps.cmd
 


### PR DESCRIPTION
There is no need to pass output path of the PCM compilation twice, once as swift `-o` flag and other time as `-Xcc -o` flag to clang importer. This can also cause swift caching to miss when output path is different because `-Xcc` options are not modeled in caching model to understand `-o` output path doesn't affect compilation output content.

rdar://128650954