### PR TITLE
[6.0] [For PackageCMO] Silently drop @_alwaysEmitIntoClient on a package decl inside a non-serialized type.

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -621,7 +621,11 @@ SILLinkage SILDeclRef::getDefinitionLinkage() const {
     case Limit::None:
       return SILLinkage::Package;
     case Limit::AlwaysEmitIntoClient:
-      return SILLinkage::PackageNonABI;
+      // Drop the AEIC if the enclosing decl is not effectively public.
+      // This matches what we do in the `internal` case.
+      if (isSerialized())
+        return SILLinkage::PackageNonABI;
+      else return SILLinkage::Package;
     case Limit::OnDemand:
       return SILLinkage::Shared;
     case Limit::NeverPublic:

--- a/test/SILGen/always_emit_into_client_attribute.swift
+++ b/test/SILGen/always_emit_into_client_attribute.swift
@@ -58,3 +58,21 @@ public final class C {
   @_alwaysEmitIntoClient
   deinit {}
 }
+
+
+// We drop AEIC if the containing context does not have effective public
+// visibility.
+internal struct InternalContext {
+// CHECK-LABEL: sil hidden [ossa] @$s33always_emit_into_client_attribute15InternalContextV1vSivgZ
+  @_alwaysEmitIntoClient
+  internal static var v : Int { 1 }
+}
+
+// We drop AEIC if the containing context does not have effective public
+// visibility.
+package struct PackageContext {
+// CHECK-LABEL: sil package [ossa] @$s33always_emit_into_client_attribute14PackageContextV1vSivgZ
+
+  @_alwaysEmitIntoClient
+  package static var v : Int { 1 }
+}


### PR DESCRIPTION
- Explanation: @_alwaysEmitIntoClient on a package decl inside a non-serialized type is essentially a no-op so silently drop.
- Scope: Used to assert fail but now silently drops on @_alwaysEmitIntoClient package decl inside a non-serialized type.
- Original PR: https://github.com/apple/swift/pull/73708 by @aschwaighofer
- Risk: Low. Used to assert fail but now silently drops.
- Testing: New tests added.
- Issue: rdar://128270848&128647016
- Reviewer: @slavapestov 