### PR TITLE
[Macros] Don't allow macros to add accessors to `let` variables.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7618,6 +7618,9 @@ ERROR(external_macro_arg_not_type_name,none,
 ERROR(invalid_decl_in_macro_expansion,none,
       "macro expansion cannot introduce %0",
       (DescriptiveDeclKind))
+ERROR(let_accessor_expansion,none,
+      "cannot expand accessors on variable declared with 'let'",
+      ())
 ERROR(invalid_main_type_in_macro_expansion,none,
       "macro expansion cannot introduce '@main' type",
       ())

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2482,3 +2482,12 @@ public struct AllLexicalContextsMacro: DeclarationMacro {
   }
 }
 
+public struct AddGetterMacro: AccessorMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    return ["get { 0 }"]
+  }
+}

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -163,3 +163,14 @@ struct MultipleVars {
   // expected-error@-1 2{{accessor macro 'AddWillSet()' can only apply to a single variable}}
 }
 #endif
+
+@attached(accessor)
+macro addGetterMacro() =
+    #externalMacro(module: "MacroDefinition", type: "AddGetterMacro")
+
+#if TEST_DIAGNOSTICS
+struct S {
+  @addGetterMacro let x: Int
+  // expected-warning@-1 {{cannot expand accessors on variable declared with 'let'; this is an error in the Swift 6 language mode}}
+}
+#endif


### PR DESCRIPTION
`let` declarations cannot be computed properties, and accessor macros are currently allowed to bypass this rule. This was accidental, so this change diagnoses expanded accessors on a `let` variable as an invalid macro expansion.

Resolves: rdar://122690037, https://github.com/apple/swift-syntax/issues/2491