### PR TITLE
[Concurrency] Relax task-local mis-use prevention in task groups

### DIFF
--- a/include/swift/ABI/TaskLocal.h
+++ b/include/swift/ABI/TaskLocal.h
@@ -44,6 +44,10 @@ public:
     /// lookups by skipping empty parent tasks during get(), and explained
     /// in depth in `createParentLink`.
     IsParent = 0b01,
+    /// The task local binding was created inside the body of a `withTaskGroup`,
+    /// and therefore must either copy it, or crash when a child task is created
+    /// using 'group.addTask' and it would refer to this task local.
+    IsNextCreatedInTaskGroupBody = 0b10,
   };
 
   class Item {
@@ -103,7 +107,17 @@ public:
 
     static Item *createLink(AsyncTask *task,
                             const HeapObject *key,
+                            const Metadata *valueType,
+                            bool inTaskGroupBody);
+
+    static Item *createLink(AsyncTask *task,
+                            const HeapObject *key,
                             const Metadata *valueType);
+
+    static Item *createLinkInTaskGroup(
+        AsyncTask *task,
+        const HeapObject *key,
+        const Metadata *valueType);
 
     void destroy(AsyncTask *task);
 
@@ -113,6 +127,16 @@ public:
 
     NextLinkType getNextLinkType() const {
       return static_cast<NextLinkType>(next & statusMask);
+    }
+
+    bool isNextLinkPointer() const {
+      return static_cast<NextLinkType>(next & statusMask) ==
+             NextLinkType::IsNext;
+    }
+
+    bool IsNextCreatedInTaskGroupBody() const {
+      return static_cast<NextLinkType>(next & statusMask) ==
+             NextLinkType::IsNextCreatedInTaskGroupBody;
     }
 
     /// Item does not contain any actual value, and is only used to point at
@@ -136,9 +160,9 @@ public:
       if (valueType) {
         size_t alignment = valueType->vw_alignment();
         return (offset + alignment - 1) & ~(alignment - 1);
-      } else {
-        return offset;
       }
+
+      return offset;
     }
 
     /// Determine the size of the item given a particular value type.
@@ -199,6 +223,8 @@ public:
     /// and `false` if the just popped value was the last one and the storage
     /// can be safely disposed of.
     bool popValue(AsyncTask *task);
+
+    std::optional<NextLinkType> peekHeadLinkType() const;
 
     /// Copy all task-local bindings to the target task.
     ///

--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -254,7 +254,7 @@ static void swift_task_reportIllegalTaskLocalBindingWithinWithTaskGroupImpl(
     const unsigned char *_unused_file, uintptr_t _unused_fileLength,
     bool _unused_fileIsASCII, uintptr_t _unused_line) {
 
-  char *message =
+  char const *message =
       "error: task-local: detected illegal task-local value binding.\n"
       "Task-local values must only be set in a structured-context, such as: "
       "around any (synchronous or asynchronous function invocation), "

--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -317,7 +317,6 @@ static void swift_task_reportIllegalTaskLocalBindingWithinWithTaskGroupImpl(
   __android_log_print(ANDROID_LOG_FATAL, "SwiftRuntime", "%s", message);
 #endif
 
-  free(message);
   abort();
 }
 

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -252,9 +252,6 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
                                  operation: () async throws -> R,
                                  isolation: isolated (any Actor)?,
                                  file: String = #fileID, line: UInt = #line) async rethrows -> R {
-    // check if we're not trying to bind a value from an illegal context; this may crash
-    _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
-
     _taskLocalValuePush(key: key, value: consume valueDuringOperation)
     defer { _taskLocalValuePop() }
 
@@ -269,9 +266,6 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   internal func withValueImpl<R>(_ valueDuringOperation: __owned Value,
                                  operation: () async throws -> R,
                                  file: String = #fileID, line: UInt = #line) async rethrows -> R {
-    // check if we're not trying to bind a value from an illegal context; this may crash
-    _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
-
     _taskLocalValuePush(key: key, value: consume valueDuringOperation)
     defer { _taskLocalValuePop() }
 
@@ -296,9 +290,6 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   @discardableResult
   public func withValue<R>(_ valueDuringOperation: Value, operation: () throws -> R,
                            file: String = #fileID, line: UInt = #line) rethrows -> R {
-    // check if we're not trying to bind a value from an illegal context; this may crash
-    _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
-
     _taskLocalValuePush(key: key, value: valueDuringOperation)
     defer { _taskLocalValuePop() }
 

--- a/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use_but_specific_case_is_ok.swift
+++ b/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use_but_specific_case_is_ok.swift
@@ -1,0 +1,39 @@
+// RUN: %target-run-simple-swift( -plugin-path %swift-plugin-dir -Xfrontend -disable-availability-checking -parse-as-library %import-libdispatch) 2>&1 | %FileCheck %s --dump-input=always
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+@available(SwiftStdlib 5.1, *)
+enum TL {
+  @TaskLocal
+  static var number: Int = 2
+}
+
+// ==== ------------------------------------------------------------------------
+
+func bindAroundGroupAddTask() async {
+  await TL.$number.withValue(1111) { // ok
+    await withTaskGroup(of: Int.self) { group in
+      // CHECK-NOT: error: task-local: detected illegal
+
+      TL.$number.withValue(2222) { // this is OK, there's no addTask being wrapped
+        print("Survived, inside withValue, value: \(TL.number)") // CHECK: Survived, inside withValue, value: 2222
+      }
+
+      group.addTask {
+        print("Survived, inside addTask, value: \(TL.number)") // CHECK: Survived, inside addTask, value: 1111
+        return TL.number
+      }
+    }
+    print("Survived, done") // CHECK: Survived, done
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    await bindAroundGroupAddTask()
+  }
+}

--- a/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use_discarding_taskgroup.swift
+++ b/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use_discarding_taskgroup.swift
@@ -22,11 +22,11 @@ enum TL {
 func bindAroundGroupAddTask() async {
   await TL.$number.withValue(1111) { // ok
     await withTaskGroup(of: Int.self) { group in
-      // CHECK: error: task-local: detected illegal task-local value binding at {{.*}}illegal_use_discarding_taskgroup.swift:[[# @LINE + 1]]
+      // CHECK: error: task-local: detected illegal task-local value binding
       TL.$number.withValue(2222) { // bad!
-        print("Survived, inside withValue!") // CHECK-NOT: Survived, inside withValue!
         group.addTask {
-          0 // don't actually perform the read, it would be unsafe.
+          print("Survived, inside withValue!") // CHECK-NOT: Survived, inside withValue!
+          return 0 // don't actually perform the read, it would be unsafe.
         }
       }
 

--- a/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use_taskgroup.swift
+++ b/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use_taskgroup.swift
@@ -21,11 +21,11 @@ enum TL {
 func bindAroundDiscardingGroupAddTask() async {
   await TL.$number.withValue(1111) { // ok
     await withTaskGroup(of: Int.self) { group in
-      // CHECK: error: task-local: detected illegal task-local value binding at {{.*}}illegal_use_taskgroup.swift:[[# @LINE + 1]]
+      // CHECK: error: task-local: detected illegal task-local value binding
       TL.$number.withValue(2222) { // bad!
-        print("Survived, inside withValue!") // CHECK-NOT: Survived, inside withValue!
         group.addTask {
-          0 // don't actually perform the read, it would be unsafe.
+          print("Survived, inside withValue!") // CHECK-NOT: Survived, inside withValue!
+          return 0 // don't actually perform the read, it would be unsafe.
         }
       }
 


### PR DESCRIPTION
We have a mechanism protecting task group child tasks from accessing values in "outer scope"  if they are defined like this:

```swift
await withTaskGroup { group in 
  await $local.withValue(value) {  // push "value"
    group.addTask {} // would refer to "value" by "direct pointer" to parent task
  } // pop value ---- if we allowed the above "direct pointer" the child task now refers to trash memory
}  
```

So to prevent this, today, we crash eagerly when we detect this. 

The problem: 

We crash to aggresively, also falsely triggering on this:
```swift
await withTaskGroup { group in 
  await $local.withValue(value) {  // does crash, but shouldn't
  }
  group.addTask {} 
}  
```

This patch solves this behavior by more precise runtime detecting of the specific problem situation -- we now crash inside the `addTask` and NOT inside the `withValue`.

**Future direction:** We could start copying defensively when we notice the "bad situation" rather than just crash. @FranzBusch was arguing that behavior would be preferable -- because we cannot always control the shapes of APIs, and if someone were to offer a synchronous callback API and they had set a task local value inside a task group "by accident" without even knowing about it, today we would crash - causing weird non-local interactions.

I'll see if I can pull off the copying "only when we have to in the bad-bad and rare case".

resolves rdar://127156303 