### PR TITLE
[6.0] test/Interpreter/element_archetype_captures.swift requires executable_test

### DIFF
--- a/test/Interpreter/element_archetype_captures.swift
+++ b/test/Interpreter/element_archetype_captures.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift
 
+// REQUIRES: executable_test
+
 func callee<X: P1, T: P2, U: P3, V: P4>(x: X, t: T, u: U, v: V)
     -> (any P1, any P2, any P3, any P4) {
   return (x, t, u, v)


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/73800 to 6.0 to unblock CI