### PR TITLE
[6.0] Disable and fix some failing tests in CI

### DIFF
--- a/test/Concurrency/Runtime/async_task_executor_structured_concurrency.swift
+++ b/test/Concurrency/Runtime/async_task_executor_structured_concurrency.swift
@@ -6,6 +6,8 @@
 
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
+// rdar://126118749
+// UNSUPPORTED: CPU=arm64e
 
 import Dispatch
 import StdlibUnittest

--- a/test/Concurrency/isolation_macro_availability.swift
+++ b/test/Concurrency/isolation_macro_availability.swift
@@ -4,6 +4,9 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: VENDOR=apple
 
+// rdar://126118470
+// UNSUPPORTED: CPU=arm64e
+
 @available(SwiftStdlib 5.1, *)
 func isolatedFunc(isolation: isolated (any Actor)? = #isolation) {}
 

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
@@ -14,6 +14,9 @@
 // rdar://90373022
 // UNSUPPORTED: OS=watchos
 
+// rdar://125628060
+// UNSUPPORTED: CPU=arm64e
+ 
 import Distributed
 
 @Resolvable

--- a/test/Distributed/Runtime/distributed_actor_localSystem_manual_conformance.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_manual_conformance.swift
@@ -14,6 +14,9 @@
 // rdar://90373022
 // UNSUPPORTED: OS=watchos
 
+// rdar://125628060
+// UNSUPPORTED: CPU=arm64e
+
 import Distributed
 
 @available(SwiftStdlib 6.0, *)

--- a/validation-test/Runtime/issue-51181.swift
+++ b/validation-test/Runtime/issue-51181.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// REQUIRES: rdar126151157
 
 // https://github.com/apple/swift/issues/51181
 

--- a/validation-test/stdlib/StringGraphemeBreaking.swift
+++ b/validation-test/stdlib/StringGraphemeBreaking.swift
@@ -6,7 +6,7 @@
 // REQUIRES: optimized_stdlib
 
 // rdar://124539686
-// UNSUPPORTED: CPU=arm64e
+// UNSUPPORTED: CPU=arm64e, CPU=arm64
 
 import StdlibUnittest
 import StdlibUnicodeUnittest


### PR DESCRIPTION
Cherry-pick some parts of https://github.com/apple/swift/pull/72922 to 6.0