### PR TITLE
6.0: [Test] Fix uniqueness check line for 32 bit.

### DIFF
--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift(-Onone -parse-stdlib -Xfrontend -enable-copy-propagation -target %target-swift-abi-5.6-triple) | %FileCheck %s --check-prefixes=CHECK,CHECK-DBG
 // RUN: %target-run-simple-swift(-O -parse-stdlib -Xfrontend -enable-copy-propagation -target %target-swift-abi-5.6-triple) | %FileCheck --check-prefixes=CHECK,CHECK-OPT %s
 
+// rdar://125628293
+// UNSUPPORTED: CPU=arm64_32
+
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // rdar://124700033

--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -1,8 +1,5 @@
-// RUN: %target-run-simple-swift(-Onone -parse-stdlib -Xfrontend -enable-copy-propagation -target %target-swift-abi-5.6-triple) | %FileCheck %s --check-prefixes=CHECK,CHECK-DBG
-// RUN: %target-run-simple-swift(-O -parse-stdlib -Xfrontend -enable-copy-propagation -target %target-swift-abi-5.6-triple) | %FileCheck --check-prefixes=CHECK,CHECK-OPT %s
-
-// rdar://125628293
-// UNSUPPORTED: CPU=arm64_32
+// RUN: %target-run-simple-swift(-Onone -parse-stdlib -Xfrontend -enable-copy-propagation -target %target-swift-abi-5.6-triple) | %FileCheck %s --check-prefixes=CHECK,CHECK-DBG,CHECK-%target-ptrsize
+// RUN: %target-run-simple-swift(-O -parse-stdlib -Xfrontend -enable-copy-propagation -target %target-swift-abi-5.6-triple) | %FileCheck %s --check-prefixes=CHECK,CHECK-OPT,CHECK-%target-ptrsize
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -143,7 +140,16 @@ if true {
 
   var bo3 = nonNativeBridgeObject(NSNumber(value: 22))
   print(Bool(_builtinBooleanLiteral: Builtin.isUnique(&bo3)))
-  // CHECK-NEXT: false
+  // On 64-bit*, this will be an objc tagged pointer.  On 32-bit, there are no
+  // objc tagged pointers.  If it's an objc tagged pointer, it will never be
+  // unique. Otherwise, it will be unique--subject to any intering of NSNumbers
+  // that Foundation does.
+  // * Whether it's a tagged pointer doesn't actually depend on bit width--see
+  //   OBJC_TAGGED_POINTER_BITS for the various architectures at the top of the
+  //   file.  If those other architectures ever start being used in CI, this
+  //   test will need more involved updating.
+  // CHECK-32-NEXT: true
+  // CHECK-64-NEXT: false
   _fixLifetime(bo3)
 }
 


### PR DESCRIPTION
**Explanation**: Update the run and check lines of a test to account for 32 vs 64 bit runtime difference.
**Scope**: None.  Updates a test's run and check lines.
**Issue**: rdar://128682096
**Original PR**: https://github.com/apple/swift/pull/72836
**Risk**: None.
**Testing**: Yes, this is a test fix.
**Reviewer**: Mike Ash ( @mikeash )

