### PR TITLE
[Concurrency] Deprecate `AnyActor`.

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -77,7 +77,6 @@
     BUILTIN_EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME(name, "_" #name)
 
 PROTOCOL(Actor)
-PROTOCOL(AnyActor)
 PROTOCOL(Sequence)
 PROTOCOL(Identifiable)
 PROTOCOL(IteratorProtocol)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1308,7 +1308,6 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
     M = getLoadedModule(Id_Differentiation);
     break;
   case KnownProtocolKind::Actor:
-  case KnownProtocolKind::AnyActor:
   case KnownProtocolKind::GlobalActor:
   case KnownProtocolKind::AsyncSequence:
   case KnownProtocolKind::AsyncIteratorProtocol:

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6803,7 +6803,6 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::Differentiable:
   case KnownProtocolKind::FloatingPoint:
   case KnownProtocolKind::Identifiable:
-  case KnownProtocolKind::AnyActor:
   case KnownProtocolKind::Actor:
   case KnownProtocolKind::DistributedActor:
   case KnownProtocolKind::DistributedActorSystem:

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -7016,10 +7016,10 @@ public:
         auto genericSig = FTy->getInvocationGenericSignature();
         auto &ctx = F.getASTContext();
         auto *actorProtocol = ctx.getProtocol(KnownProtocolKind::Actor);
-        auto *anyActorProtocol = ctx.getProtocol(KnownProtocolKind::AnyActor);
+        auto *distributedProtocol = ctx.getProtocol(KnownProtocolKind::DistributedActor);
         require(argType->isAnyActorType() ||
-                    genericSig->requiresProtocol(argType, actorProtocol) ||
-                    genericSig->requiresProtocol(argType, anyActorProtocol),
+                genericSig->requiresProtocol(argType, actorProtocol) ||
+                genericSig->requiresProtocol(argType, distributedProtocol),
                 "Only any actor types can be isolated");
         require(!foundIsolatedParameter, "Two isolated parameters");
         foundIsolatedParameter = true;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -317,7 +317,7 @@ static void checkInheritanceClause(
         continue;
 
       // AnyObject is not allowed except on protocols.
-      if (layout.hasExplicitAnyObject) {
+      if (layout.hasExplicitAnyObject && !isa<ClassDecl>(decl)) {
         decl->diagnose(diag::inheritance_from_anyobject);
         continue;
       }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6094,19 +6094,6 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
         }
         break;
       }
-      case KnownProtocolKind::AnyActor: {
-        if (auto classDecl = dyn_cast<ClassDecl>(nominal)) {
-          if (!classDecl->isExplicitActor() &&
-              !classDecl->isExplicitDistributedActor()) {
-            dc->getSelfNominalTypeDecl()
-                ->diagnose(diag::actor_protocol_illegal_inheritance,
-                           dc->getSelfNominalTypeDecl()->getName(),
-                           proto->getName())
-                .fixItReplace(nominal->getStartLoc(), "actor");
-          }
-        }
-        break;
-      }
       case KnownProtocolKind::UnsafeSendable: {
         hasDeprecatedUnsafeSendable = true;
         break;

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -28,6 +28,8 @@ import Swift
 /// impossible for one to refine the other.
 @_marker
 @available(SwiftStdlib 5.1, *)
+@available(*, deprecated, message: "Use 'any Actor' with 'DistributedActor.asLocalActor' instead")
+@available(swift, obsoleted: 6.0, message: "Use 'any Actor' with 'DistributedActor.asLocalActor' instead")
 public protocol AnyActor: AnyObject, Sendable {}
 
 /// Common protocol to which all actors conform.

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -29,7 +29,6 @@ import Swift
 @_marker
 @available(SwiftStdlib 5.1, *)
 @available(*, deprecated, message: "Use 'any Actor' with 'DistributedActor.asLocalActor' instead")
-@available(swift, obsoleted: 6.0, message: "Use 'any Actor' with 'DistributedActor.asLocalActor' instead")
 public protocol AnyActor: AnyObject, Sendable {}
 
 /// Common protocol to which all actors conform.

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -26,17 +26,17 @@ import Swift
 /// While both local and distributed actors are conceptually "actors", there are
 /// some important isolation model differences between the two, which make it
 /// impossible for one to refine the other.
-@_marker
 @available(SwiftStdlib 5.1, *)
 @available(*, deprecated, message: "Use 'any Actor' with 'DistributedActor.asLocalActor' instead")
-public protocol AnyActor: AnyObject, Sendable {}
+@available(swift, obsoleted: 6.0, message: "Use 'any Actor' with 'DistributedActor.asLocalActor' instead")
+public typealias AnyActor = AnyObject & Sendable
 
 /// Common protocol to which all actors conform.
 ///
 /// The `Actor` protocol generalizes over all `actor` types. Actor types
 /// implicitly conform to this protocol.
 @available(SwiftStdlib 5.1, *)
-public protocol Actor: AnyActor {
+public protocol Actor: AnyObject, Sendable {
 
   /// Retrieve the executor for this actor as an optimized, unowned
   /// reference.

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -197,7 +197,7 @@ import _Concurrency
 /// - SeeAlso: ``Actor``
 /// - SeeAlso: ``AnyActor``
 @available(SwiftStdlib 5.7, *)
-public protocol DistributedActor: AnyActor, Identifiable, Hashable
+public protocol DistributedActor: AnyObject, Sendable, Identifiable, Hashable
   where ID == ActorSystem.ActorID,
         SerializationRequirement == ActorSystem.SerializationRequirement {
   

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -147,11 +147,14 @@
 ///
 ///     struct MyStructure: @unchecked Sendable { ... }
 @available(*, deprecated, message: "Use @unchecked Sendable instead")
+@available(swift, obsoleted: 6.0, message: "Use @unchecked Sendable instead")
 @_marker public protocol UnsafeSendable: Sendable { }
 
 // Historical names
 @available(*, deprecated, renamed: "Sendable")
+@available(swift, obsoleted: 6.0, renamed: "Sendable")
 public typealias ConcurrentValue = Sendable
 
 @available(*, deprecated, renamed: "Sendable")
+@available(swift, obsoleted: 6.0, renamed: "Sendable")
 public typealias UnsafeConcurrentValue = UnsafeSendable

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1105,8 +1105,7 @@ actor A: Actor { // ok
 @available(SwiftStdlib 5.1, *)
 class C: Actor, UnsafeSendable {
   // expected-error@-1{{non-actor type 'C' cannot conform to the 'Actor' protocol}}
-  // expected-error@-2{{non-actor type 'C' cannot conform to the 'AnyActor' protocol}}
-  // expected-warning@-3{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
+  // expected-warning@-2{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError()
   }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -356,6 +356,7 @@ func isolated_generic_bad_2<T: Equatable>(_ t: isolated T) {}
 // expected-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
 func isolated_generic_bad_3<T: AnyActor>(_ t: isolated T) {}
 // expected-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
+// expected-warning@-2 {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
 
 func isolated_generic_bad_4<T>(_ t: isolated Array<T>) {}
 // expected-error@-1 {{'isolated' parameter type 'Array<T>' does not conform to 'Actor' or 'DistributedActor'}}
@@ -475,7 +476,7 @@ nonisolated func fromNonisolated(ns: NotSendable) async -> NotSendable {
   await pass(value: ns, isolation: nil)
 }
 
-func invalidIsolatedClosureParam<A: AnyActor> (
+func invalidIsolatedClosureParam<A: AnyActor> ( // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
   _: (isolated A) async throws -> Void // expected-error {{'isolated' parameter type 'A' does not conform to 'Actor' or 'DistributedActor'}}
 ) {}
 

--- a/test/Distributed/actor_protocols.swift
+++ b/test/Distributed/actor_protocols.swift
@@ -93,17 +93,17 @@ struct S2: DistributedActor {
 
 // ==== -----------------------------------------------------------------------
 
-actor A3: AnyActor {} // ok
-distributed actor DA3: AnyActor {} // ok
+actor A3: AnyActor {} // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
+distributed actor DA3: AnyActor {} // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
 
-class C3: AnyActor, @unchecked Sendable {
+class C3: AnyActor, @unchecked Sendable { // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
   // expected-error@-1{{non-actor type 'C3' cannot conform to the 'AnyActor' protocol}} {{1-6=actor}}
 }
 
-struct S3: AnyActor {
+struct S3: AnyActor { // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
   // expected-error@-1{{non-class type 'S3' cannot conform to class protocol 'AnyActor'}}
 }
 
-enum E3: AnyActor {
+enum E3: AnyActor { // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
   // expected-error@-1{{non-class type 'E3' cannot conform to class protocol 'AnyActor'}}
 }

--- a/test/Distributed/actor_protocols.swift
+++ b/test/Distributed/actor_protocols.swift
@@ -14,25 +14,22 @@ typealias DefaultDistributedActorSystem = FakeActorSystem
 actor A: Actor {} // ok
 
 class C: Actor, UnsafeSendable {
-  // expected-error@-1{{non-actor type 'C' cannot conform to the 'AnyActor' protocol}} {{1-6=actor}}
-  // expected-error@-2{{non-actor type 'C' cannot conform to the 'Actor' protocol}} {{1-6=actor}}
-  // expected-warning@-3{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
+  // expected-error@-1{{non-actor type 'C' cannot conform to the 'Actor' protocol}} {{1-6=actor}}
+  // expected-warning@-2{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError()
   }
 }
 
 struct S: Actor {
-  // expected-error@-1{{non-class type 'S' cannot conform to class protocol 'AnyActor'}}
-  // expected-error@-2{{non-class type 'S' cannot conform to class protocol 'Actor'}}
+  // expected-error@-1{{non-class type 'S' cannot conform to class protocol 'Actor'}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError()
   }
 }
 
 struct E: Actor {
-  // expected-error@-1{{non-class type 'E' cannot conform to class protocol 'AnyActor'}}
-  // expected-error@-2{{non-class type 'E' cannot conform to class protocol 'Actor'}}
+  // expected-error@-1{{non-class type 'E' cannot conform to class protocol 'Actor'}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError()
   }
@@ -65,8 +62,7 @@ actor A2: DistributedActor {
 }
 
 final class DA2: DistributedActor {
-// expected-error@-1{{non-actor type 'DA2' cannot conform to the 'AnyActor' protocol}}
-// expected-error@-2{{non-distributed actor type 'DA2' cannot conform to the 'DistributedActor' protocol}}
+// expected-error@-1{{non-distributed actor type 'DA2' cannot conform to the 'DistributedActor' protocol}}
   nonisolated var id: ID {
     fatalError()
   }
@@ -87,8 +83,7 @@ final class DA2: DistributedActor {
 
 struct S2: DistributedActor {
   // expected-error@-1{{non-class type 'S2' cannot conform to class protocol 'DistributedActor'}}
-  // expected-error@-2{{non-class type 'S2' cannot conform to class protocol 'AnyActor'}}
-  // expected-error@-3{{type 'S2' does not conform to protocol 'Identifiable'}}
+  // expected-error@-2{{type 'S2' does not conform to protocol 'Identifiable'}}
 }
 
 // ==== -----------------------------------------------------------------------
@@ -96,14 +91,14 @@ struct S2: DistributedActor {
 actor A3: AnyActor {} // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
 distributed actor DA3: AnyActor {} // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
 
-class C3: AnyActor, @unchecked Sendable { // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
-  // expected-error@-1{{non-actor type 'C3' cannot conform to the 'AnyActor' protocol}} {{1-6=actor}}
+class C3: AnyActor { // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
+  // expected-warning@-1 {{non-final class 'C3' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
 }
 
 struct S3: AnyActor { // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
-  // expected-error@-1{{non-class type 'S3' cannot conform to class protocol 'AnyActor'}}
+  // expected-error@-1{{only protocols can inherit from 'AnyObject'}}
 }
 
 enum E3: AnyActor { // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
-  // expected-error@-1{{non-class type 'E3' cannot conform to class protocol 'AnyActor'}}
+  // expected-error@-1{{only protocols can inherit from 'AnyObject'}}
 }

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -58,10 +58,8 @@ Func _asyncLet_get(_:_:) has mangled name changing from '_Concurrency._asyncLet_
 Func _asyncLet_get(_:_:) has return type change from Builtin.RawPointer to ()
 Func _asyncLet_get_throwing(_:_:) has mangled name changing from '_Concurrency._asyncLet_get_throwing(Builtin.RawPointer, Builtin.RawPointer) async throws -> Builtin.RawPointer' to '_Concurrency._asyncLet_get_throwing(Builtin.RawPointer, Builtin.RawPointer) async throws -> ()'
 Func _asyncLet_get_throwing(_:_:) has return type change from Builtin.RawPointer to ()
-Protocol Actor has added inherited protocol AnyActor
 Protocol Actor has added inherited protocol Copyable
 Protocol Actor has added inherited protocol Escapable
-Protocol Actor has generic signature change from <Self : AnyObject, Self : Swift.Sendable> to <Self : _Concurrency.AnyActor>
 Protocol AsyncIteratorProtocol has generic signature change from to <Self.Failure : Swift.Error>
 Protocol AsyncIteratorProtocol has added inherited protocol Copyable
 Protocol AsyncIteratorProtocol has added inherited protocol Escapable

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -7,8 +7,7 @@ actor MyActor { }
 class MyActorSubclass1: MyActor { }
 // expected-error@-1{{actor types do not support inheritance}}
 // expected-error@-2{{type 'MyActorSubclass1' cannot conform to the 'Actor' protocol}}
-// expected-error@-3{{non-actor type 'MyActorSubclass1' cannot conform to the 'AnyActor' protocol}}
-// expected-warning@-4 {{non-final class 'MyActorSubclass1' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in the Swift 6 language mode}}
+// expected-warning@-3 {{non-final class 'MyActorSubclass1' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in the Swift 6 language mode}}
 
 actor MyActorSubclass2: MyActor { } // expected-error{{actor types do not support inheritance}}
 

--- a/test/decl/protocol/conforms/placement.swift
+++ b/test/decl/protocol/conforms/placement.swift
@@ -105,7 +105,7 @@ extension ExplicitSub1 : P1 { } // expected-error{{redundant conformance of 'Exp
 // ---------------------------------------------------------------------------
 // Suppression of synthesized conformances
 // ---------------------------------------------------------------------------
-class SynthesizedClass1 : AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}
+class SynthesizedClass1 : AnyObject { }
 
 class SynthesizedClass2 { }
 extension SynthesizedClass2 : AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}
@@ -115,7 +115,7 @@ class SynthesizedClass3 : AnyObjectRefinement { }
 class SynthesizedClass4 { }
 extension SynthesizedClass4 : AnyObjectRefinement { }
 
-class SynthesizedSubClass1 : SynthesizedClass1, AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}
+class SynthesizedSubClass1 : SynthesizedClass1, AnyObject { }
 
 class SynthesizedSubClass2 : SynthesizedClass2 { }
 extension SynthesizedSubClass2 : AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -44,8 +44,7 @@ actor A7 {
 @available(SwiftStdlib 5.1, *)
 class C1: Actor {
   // expected-error@-1{{non-actor type 'C1' cannot conform to the 'Actor' protocol}}
-  // expected-error@-2{{non-actor type 'C1' cannot conform to the 'AnyActor' protocol}}
-  // expected-warning@-3{{non-final class 'C1' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
+  // expected-warning@-2{{non-final class 'C1' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
   }
@@ -54,8 +53,7 @@ class C1: Actor {
 @available(SwiftStdlib 5.1, *)
 class C2: Actor {
   // expected-error@-1{{non-actor type 'C2' cannot conform to the 'Actor' protocol}}
-  // expected-error@-2{{non-actor type 'C2' cannot conform to the 'AnyActor' protocol}}
-// expected-warning@-3{{non-final class 'C2' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
+// expected-warning@-2{{non-final class 'C2' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   // FIXME: this should be an isolation violation
   var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
@@ -66,8 +64,7 @@ class C2: Actor {
 class C3: Actor {
   // expected-error@-1{{type 'C3' does not conform to protocol 'Actor'}}
   // expected-error@-2{{non-actor type 'C3' cannot conform to the 'Actor' protocol}}
-  // expected-error@-3{{non-actor type 'C3' cannot conform to the 'AnyActor' protocol}}
-  // expected-warning@-4{{non-final class 'C3' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
+  // expected-warning@-3{{non-final class 'C3' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   nonisolated func enqueue(_ job: UnownedJob) { }
 }
 

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -68,7 +68,7 @@ distributed actor D5: P1 {
 
 // Make sure the conformances have been added implicitly.
 func acceptDistributedActor<Act: DistributedActor>(_: Act.Type) { }
-func acceptAnyActor<Act: AnyActor>(_: Act.Type) { }
+func acceptAnyActor<Act: AnyActor>(_: Act.Type) { } // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
 
 func testConformance() {
   acceptDistributedActor(D1.self)


### PR DESCRIPTION
This marker protocol isn't useful for abstracting over actors and distributed actors because it doesn't have any runtime requirements, so there's no way to switch to the given actor. Instead, you should use `isolated (any Actor)?` parameters, and the compiler will compute a local actor value from a distributed actor using `DistributedActor.asLocalActor`.

Also, obsolete a few deprecated typealiases to `Sendable` in Swift 6.
