### PR TITLE
Copy over EarlySwiftDriver executables on Debug builds by specifying the correct driver build directory

### DIFF
--- a/cmake/modules/SwiftUtils.cmake
+++ b/cmake/modules/SwiftUtils.cmake
@@ -191,11 +191,17 @@ endfunction()
 # to ensure that `swiftc` forwards to the standalone driver when invoked.
 function(swift_create_early_driver_copies target)
   # Early swift-driver is built adjacent to the compiler (swift build dir)
-  set(driver_bin_dir "${CMAKE_BINARY_DIR}/../earlyswiftdriver-${SWIFT_HOST_VARIANT}-${SWIFT_HOST_VARIANT_ARCH}/release/bin")
+  if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    set(driver_package_configuration_dir "release")
+  else()
+    set(driver_package_configuration_dir "debug")
+  endif()
+  
+  set(driver_bin_dir "${CMAKE_BINARY_DIR}/../earlyswiftdriver-${SWIFT_HOST_VARIANT}-${SWIFT_HOST_VARIANT_ARCH}/${driver_package_configuration_dir}/bin")
   set(swift_bin_dir "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
   # If early swift-driver wasn't built, nothing to do here.
   if(NOT EXISTS "${driver_bin_dir}/swift-driver" OR NOT EXISTS "${driver_bin_dir}/swift-help")
-      message(STATUS "Skipping creating early SwiftDriver symlinks - no early SwiftDriver build found.")
+      message(STATUS "Skipping creating early SwiftDriver symlinks - no early SwiftDriver build found at: ${driver_bin_dir}.")
       return()
   endif()
 


### PR DESCRIPTION
Following the same logic as `EarlySwiftDriver.py` product's `is_release` method which determines its configuration.