### PR TITLE
[6.0][ExplicitModule] Don't pass PCM output path in `-Xcc` option

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -239,6 +239,7 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
     // invocation, not swift invocation.
     depsInvocation.getFrontendOpts().ModuleCacheKeys.clear();
     depsInvocation.getFrontendOpts().PathPrefixMappings.clear();
+    depsInvocation.getFrontendOpts().OutputFile.clear();
 
     // FIXME: workaround for rdar://105684525: find the -ivfsoverlay option
     // from clang scanner and pass to swift.
@@ -351,7 +352,7 @@ void ClangImporter::recordBridgingHeaderOptions(
       clang::frontend::ActionKind::GeneratePCH;
   depsInvocation.getFrontendOpts().ModuleCacheKeys.clear();
   depsInvocation.getFrontendOpts().PathPrefixMappings.clear();
-  depsInvocation.getFrontendOpts().OutputFile = "";
+  depsInvocation.getFrontendOpts().OutputFile.clear();
 
   llvm::BumpPtrAllocator allocator;
   llvm::StringSaver saver(allocator);

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -32,6 +32,11 @@
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:F clangIncludeTree > %t/F_tree.casid
 // RUN: clang-cas-test --cas %t/cas --print-include-tree @%t/F_tree.casid | %FileCheck %s -check-prefix INCLUDE_TREE_F
 
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:F commandLine > %t/F.cmd
+// RUN: %FileCheck %s -check-prefix F_CMD -input-file=%t/F.cmd
+// F_CMD: "-Xcc"
+// F_CMD-NOT: "-o"
+
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json deps commandLine > %t/deps.cmd
 // RUN: %FileCheck %s -check-prefix MAIN_CMD -input-file=%t/deps.cmd
 


### PR DESCRIPTION
Explanation: Don't pass PCM output file path as `-Xcc` flag as it is passed as `-o` swift flag already. This can cause swift cache key computation sensitive to output file path change.
Scope: Drop a `-Xcc` flag from build command constructed dependency scanner that has no real effects.
Original PR: https://github.com/apple/swift/pull/73874
Issue: rdar://128650954
Reviewer: @artemcm 
Risk: Low.
Test: UnitTest.