### PR TITLE
6.0: [MoveOnly] Call borrowing methods on existentials.

### DIFF
--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -158,6 +158,12 @@ SubElementOffset::computeForAddress(SILValue projectionDerivedFromRoot,
       continue;
     }
 
+    if (auto *oea =
+            dyn_cast<OpenExistentialAddrInst>(projectionDerivedFromRoot)) {
+      projectionDerivedFromRoot = oea->getOperand();
+      continue;
+    }
+
     if (auto *teai =
             dyn_cast<TupleElementAddrInst>(projectionDerivedFromRoot)) {
       SILType tupleType = teai->getOperand()->getType();

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -190,6 +190,14 @@ bool ExistentialSpecializer::canSpecializeExistentialArgsInFunction(
     if (paramInfo.isIndirectMutating())
       continue;
 
+    // The ExistentialSpecializerCloner copies the incoming generic argument
+    // into an existential if it is non-consuming (if it's consuming, it's
+    // moved into the existential via `copy_addr [take]`).  Introducing a copy
+    // of a move-only value isn't legal.
+    if (!paramInfo.isConsumed() &&
+        paramInfo.getSILStorageInterfaceType().isMoveOnly())
+      continue;
+
     ETAD.AccessType = paramInfo.isConsumed()
                           ? OpenedExistentialAccess::Mutable
                           : OpenedExistentialAccess::Immutable;

--- a/test/Interpreter/rdar125864434.swift
+++ b/test/Interpreter/rdar125864434.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift  %s -o %t/bin
+// RUN: %target-codesign %t/bin
+// RUN: %target-run %t/bin | %FileCheck %s
+
+// REQUIRES: executable_test
+
+protocol Boopable: ~Copyable {
+  func boop()
+}
+
+struct S: ~Copyable, Boopable {
+  func boop() { print("boop") }
+}
+
+func check(_ b: borrowing any Boopable & ~Copyable) {
+  b.boop()
+}
+
+// CHECK: boop
+check(S())


### PR DESCRIPTION
**Explanation**: Fix a diagnostic-on-valid in the move-checker.

Previously, calling a borrowing method on a non-copyable existential failed with `error: usage of a noncopyable type that compiler can't verify`.  Here, this is fixed.

The move-only address-checker relies on switching on opcodes to determine what part of a value is used by an instruction.  It uses a bitmap consisting of atoms which can each be consumed at most once.  An existential is a single "atom" from that perspective.  Here, the `open_existential_addr` opcode is treated as a pass-through.  This makes sense because it produces an instance of an archetype which is also an "atom", and it's "the same" "atom".

Fixing the diagnostic exposed an issue in the existential specializer where it would create copies of non-copyable values when the argument was `@in_guaranteed`.  The existential specializer is fixed to bail out to avoid such illegal copies.
**Scope**: Affects non-copyable code.
**Issue**: rdar://125864434
**Original PR**: https://github.com/apple/swift/pull/73857
**Risk**: Low.  The fix is small and targeted.
**Testing**: Added regression test.
**Reviewer**: Andrew Trick ( @atrick )
