### PR TITLE
[6.0][NFC] Fix a distributed actor test failure due to IRGen ptrauth differences.

### DIFF
--- a/test/Distributed/distributed_actor_to_actor.swift
+++ b/test/Distributed/distributed_actor_to_actor.swift
@@ -6,9 +6,6 @@
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
-// rdar://123970272
-// UNSUPPORTED: CPU=arm64e
-
 import Swift
 import _Concurrency
 import Distributed
@@ -38,7 +35,7 @@ func getAnyActor(distributedActor: isolated some DistributedActor) -> any Actor 
 // CHECK-IR: [[CONDITIONAL_REQ_GEP:%[0-9]+]] = getelementptr inbounds [1 x ptr], ptr %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-IR-NEXT: [[SELF_DA_REQ:%.*]] = getelementptr inbounds ptr, ptr [[CONDITIONAL_REQ_GEP]], i32 0
 // CHECK-IR-NEXT: store ptr %"some DistributedActor.DistributedActor", ptr [[SELF_DA_REQ]]
-// CHECK-IR-NEXT: call ptr @swift_getWitnessTable(ptr @"$sxScA11DistributedMc", ptr %"some DistributedActor", ptr [[CONDITIONAL_REQ_GEP]])
+// CHECK-IR-NEXT: call ptr @swift_getWitnessTable(ptr @"$sxScA11DistributedMc{{(.ptrauth)?}}", ptr %"some DistributedActor", ptr [[CONDITIONAL_REQ_GEP]])
 
 distributed actor WorkerPool<Worker, ActorSystem: DistributedActorSystem>: AsyncSequence, AsyncIteratorProtocol {
   var level: Int


### PR DESCRIPTION
* **Explanation**: This distributed actor test has different IRGen output on arm64e; this change just updates the expected text to handle the difference.
* **Scope**: Just a test change.
* **Issue**: rdar://123970272
* **Risk**: None.
* **Testing**: Updated the test.
* **Reviewer**: TBD
* **Main branch PR**: https://github.com/apple/swift/pull/73897