### PR TITLE
[SIL][PackageCMO] Allow optimizing [serialized_for_pkg] functions 

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
@@ -281,7 +281,7 @@ private func transitivelyErase(load: LoadInst, _ context: SimplifyContext) {
 
 private extension Value {
   func canBeCopied(into function: Function, _ context: SimplifyContext) -> Bool {
-    if !function.isSerialized {
+    if !function.isAnySerialized {
       return true
     }
 
@@ -297,7 +297,7 @@ private extension Value {
 
     while let value = worklist.pop() {
       if let fri = value as? FunctionRefInst {
-        if !fri.referencedFunction.hasValidLinkageForFragileRef {
+        if !fri.referencedFunction.hasValidLinkageForFragileRef(function.serializedKind) {
           return false
         }
       }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -655,9 +655,8 @@ extension FullApplySite {
       return false
     }
     // Cannot inline a non-inlinable function it an inlinable function.
-    if parentFunction.isSerialized,
-       let calleeFunction = referencedFunction,
-       !calleeFunction.isSerialized {
+    if let calleeFunction = referencedFunction,
+       !calleeFunction.canBeInlinedIntoCaller(parentFunction.serializedKind) {
       return false
     }
 

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -136,7 +136,37 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
   }
   public var isSerialized: Bool { bridged.isSerialized() }
 
-  public var hasValidLinkageForFragileRef: Bool { bridged.hasValidLinkageForFragileRef() }
+  public var isAnySerialized: Bool { bridged.isAnySerialized() }
+
+  public enum SerializedKind {
+    case notSerialized, serialized, serializedForPackage
+  }
+
+  public var serializedKind: SerializedKind {
+    switch bridged.getSerializedKind() {
+    case .IsNotSerialized: return .notSerialized
+    case .IsSerialized: return .serialized
+    case .IsSerializedForPackage: return .serializedForPackage
+    default: fatalError()
+    }
+  }
+
+  private func serializedKindBridged(_ arg: SerializedKind) -> BridgedFunction.SerializedKind {
+    switch arg {
+    case .notSerialized: return .IsNotSerialized
+    case .serialized: return .IsSerialized
+    case .serializedForPackage: return .IsSerializedForPackage
+    default: fatalError()
+    }
+  }
+
+  public func canBeInlinedIntoCaller(_ kind: SerializedKind) -> Bool {
+    bridged.canBeInlinedIntoCaller(serializedKindBridged(kind))
+  }
+
+  public func hasValidLinkageForFragileRef(_ kind: SerializedKind) -> Bool {
+    bridged.hasValidLinkageForFragileRef(serializedKindBridged(kind))
+  }
 
   public enum ThunkKind {
     case noThunk, thunk, reabstractionThunk, signatureOptimizedThunk

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -574,6 +574,12 @@ struct BridgedFunction {
     IsSignatureOptimizedThunk
   };
 
+  enum class SerializedKind {
+    IsNotSerialized,
+    IsSerialized,
+    IsSerializedForPackage
+  };
+
   enum class Linkage {
     Public,
     PublicNonABI,
@@ -621,7 +627,10 @@ struct BridgedFunction {
   BRIDGED_INLINE PerformanceConstraints getPerformanceConstraints() const;
   BRIDGED_INLINE InlineStrategy getInlineStrategy() const;
   BRIDGED_INLINE bool isSerialized() const;
-  BRIDGED_INLINE bool hasValidLinkageForFragileRef() const;
+  BRIDGED_INLINE bool isAnySerialized() const;
+  BRIDGED_INLINE SerializedKind getSerializedKind() const;
+  BRIDGED_INLINE bool canBeInlinedIntoCaller(SerializedKind) const;
+  BRIDGED_INLINE bool hasValidLinkageForFragileRef(SerializedKind) const;
   BRIDGED_INLINE ThunkKind isThunk() const;
   BRIDGED_INLINE void setThunk(ThunkKind) const;
   BRIDGED_INLINE bool needsStackProtection() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -718,7 +718,7 @@ bool BridgedFunction::isSerialized() const {
 }
 
 bool BridgedFunction::hasValidLinkageForFragileRef() const {
-  return getFunction()->hasValidLinkageForFragileRef();
+  return getFunction()->hasValidLinkageForFragileRef(swift::SerializedKind_t::IsSerialized);
 }
 
 bool BridgedFunction::needsStackProtection() const {

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -717,8 +717,20 @@ bool BridgedFunction::isSerialized() const {
   return getFunction()->isSerialized();
 }
 
-bool BridgedFunction::hasValidLinkageForFragileRef() const {
-  return getFunction()->hasValidLinkageForFragileRef(swift::SerializedKind_t::IsSerialized);
+bool BridgedFunction::isAnySerialized() const {
+  return getFunction()->isAnySerialized();
+}
+
+BridgedFunction::SerializedKind BridgedFunction::getSerializedKind() const {
+  return (SerializedKind)getFunction()->getSerializedKind();
+}
+
+bool BridgedFunction::canBeInlinedIntoCaller(SerializedKind kind) const {
+  return getFunction()->canBeInlinedIntoCaller(swift::SerializedKind_t(kind));
+}
+
+bool BridgedFunction::hasValidLinkageForFragileRef(SerializedKind kind) const {
+  return getFunction()->hasValidLinkageForFragileRef(swift::SerializedKind_t(kind));
 }
 
 bool BridgedFunction::needsStackProtection() const {

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -874,10 +874,8 @@ public:
   void setLinkage(SILLinkage linkage) { Linkage = unsigned(linkage); }
 
 ///   Checks if this (callee) function body can be inlined into the caller
-///   by comparing their SerializedKind_t values.
+///   by comparing their `SerializedKind_t` values.
 ///
-///   If the \p assumeFragileCaller is true, the caller must be serialized,
-///   in which case the callee needs to be serialized also to be inlined.
 ///   If both callee and caller are `not_serialized`, the callee can be inlined
 ///   into the caller during SIL inlining passes even if it (and the caller)
 ///   might contain private symbols. If this callee is `serialized_for_pkg`,
@@ -894,21 +892,13 @@ public:
 ///  ```
 ///
 /// \p callerSerializedKind The caller's SerializedKind.
-/// \p assumeFragileCaller True if the call site of this function already
-///                        knows that the caller is serialized.
-  bool canBeInlinedIntoCaller(
-      std::optional<SerializedKind_t> callerSerializedKind = std::nullopt,
-      bool assumeFragileCaller = true) const;
+  bool canBeInlinedIntoCaller(SerializedKind_t callerSerializedKind) const;
 
   /// Returns true if this function can be referenced from a fragile function
   /// body.
   /// \p callerSerializedKind The caller's SerializedKind. Used to be passed to
   ///                         \c canBeInlinedIntoCaller.
-  /// \p assumeFragileCaller Default to true since this function must be called
-  //                         if the caller is [serialized].
-  bool hasValidLinkageForFragileRef(
-      std::optional<SerializedKind_t> callerSerializedKind = std::nullopt,
-      bool assumeFragileCaller = true) const;
+  bool hasValidLinkageForFragileRef(SerializedKind_t callerSerializedKind) const;
 
   /// Get's the effective linkage which is used to derive the llvm linkage.
   /// Usually this is the same as getLinkage(), except in one case: if this
@@ -1165,11 +1155,9 @@ public:
   bool isSerialized() const {
     return SerializedKind_t(SerializedKind) == IsSerialized;
   }
-  bool isSerializedForPackage() const {
-    return SerializedKind_t(SerializedKind) == IsSerializedForPackage;
-  }
-  bool isNotSerialized() const {
-    return SerializedKind_t(SerializedKind) == IsNotSerialized;
+  bool isAnySerialized() const {
+    return SerializedKind_t(SerializedKind) == IsSerialized ||
+           SerializedKind_t(SerializedKind) == IsSerializedForPackage;
   }
 
   /// Get this function's serialized attribute.

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -154,11 +154,10 @@ public:
   /// Check if this global variable is [serialized]. This does not check
   /// if it's [serialized_for_package].
   bool isSerialized() const;
-  /// Check if this global variable is [serialized_for_package].
-  bool isSerializedForPackage() const;
-  /// Checks whether this global var is neither [serialized] nor
-  /// [serialized_for_package].
-  bool isNotSerialized() const;
+
+  /// Check if this global variable is [serialized] or [serialized_for_package].
+  bool isAnySerialized() const;
+
   /// Get this global variable's serialized attribute.
   SerializedKind_t getSerializedKind() const;
   void setSerializedKind(SerializedKind_t isSerialized);

--- a/include/swift/SIL/SILMoveOnlyDeinit.h
+++ b/include/swift/SIL/SILMoveOnlyDeinit.h
@@ -66,8 +66,9 @@ public:
     return funcImpl;
   }
 
-  bool isNotSerialized() const {
-    return SerializedKind_t(serialized) == IsNotSerialized;
+  bool isAnySerialized() const {
+    return SerializedKind_t(serialized) == IsSerialized ||
+           SerializedKind_t(serialized) == IsSerializedForPackage;
   }
   SerializedKind_t getSerializedKind() const {
     return SerializedKind_t(serialized);

--- a/include/swift/SIL/SILProperty.h
+++ b/include/swift/SIL/SILProperty.h
@@ -53,7 +53,10 @@ public:
                              AbstractStorageDecl *Decl,
                              std::optional<KeyPathPatternComponent> Component);
 
-  bool isNotSerialized() const { return SerializedKind_t(Serialized) == IsNotSerialized; }
+  bool isAnySerialized() const {
+    return SerializedKind_t(Serialized) == IsSerialized ||
+           SerializedKind_t(Serialized) == IsSerializedForPackage;
+  }
   SerializedKind_t getSerializedKind() const {
     return SerializedKind_t(Serialized);
   }

--- a/include/swift/SIL/SILVTable.h
+++ b/include/swift/SIL/SILVTable.h
@@ -158,11 +158,10 @@ public:
   bool isSerialized() const {
     return SerializedKind_t(SerializedKind) == IsSerialized;
   }
-  bool isSerializedForPackage() const {
-    return SerializedKind_t(SerializedKind) == IsSerializedForPackage;
-  }
-  bool isNotSerialized() const {
-    return SerializedKind_t(SerializedKind) == IsNotSerialized;
+
+  bool isAnySerialized() const {
+    return SerializedKind_t(SerializedKind) == IsSerialized ||
+           SerializedKind_t(SerializedKind) == IsSerializedForPackage;
   }
 
   SerializedKind_t getSerializedKind() const {

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -255,12 +255,12 @@ public:
   bool isSerialized() const {
     return SerializedKind_t(SerializedKind) == IsSerialized;
   }
-  bool isSerializedForPackage() const {
-    return SerializedKind_t(SerializedKind) == IsSerializedForPackage;
+
+  bool isAnySerialized() const {
+    return SerializedKind_t(SerializedKind) == IsSerialized ||
+           SerializedKind_t(SerializedKind) == IsSerializedForPackage;
   }
-  bool isNotSerialized() const {
-    return SerializedKind_t(SerializedKind) == IsNotSerialized;
-  }
+
   SerializedKind_t getSerializedKind() const {
     return SerializedKind_t(SerializedKind);
   }

--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -87,7 +87,7 @@ void SILLinkerVisitor::deserializeAndPushToWorklist(SILFunction *F) {
     return;
   }
 
-  assert(F->isNotSerialized() == Mod.isSerialized() &&
+  assert(!F->isAnySerialized() == Mod.isSerialized() &&
          "the de-serializer did set the wrong serialized flag");
   
   F->setBare(IsBare);
@@ -186,8 +186,8 @@ void SILLinkerVisitor::linkInVTable(ClassDecl *D) {
   // for processing.
   for (auto &entry : Vtbl->getEntries()) {
     SILFunction *impl = entry.getImplementation();
-    if (!Vtbl->isSerialized() ||
-        impl->hasValidLinkageForFragileRef()) {
+    if (!Vtbl->isAnySerialized() ||
+        impl->hasValidLinkageForFragileRef(Vtbl->getSerializedKind())) {
       // Deserialize and recursively walk any vtable entries that do not have
       // bodies yet.
       maybeAddFunctionToWorklist(impl, 

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -875,7 +875,6 @@ SerializedKind_t SILDeclRef::getSerializedKind() const {
   }
 
   // Anything else that is not public is not serializable.
-  // pcmo TODO: should check if package-cmo is enabled?
   if (d->getEffectiveAccess() < AccessLevel::Public)
     return IsNotSerialized;
 

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -78,11 +78,10 @@ bool SILGlobalVariable::shouldBePreservedForDebugger() const {
 bool SILGlobalVariable::isSerialized() const {
   return SerializedKind_t(Serialized) == IsSerialized;
 }
-bool SILGlobalVariable::isSerializedForPackage() const {
-  return SerializedKind_t(Serialized) == IsSerializedForPackage;
-}
-bool SILGlobalVariable::isNotSerialized() const {
-  return SerializedKind_t(Serialized) == IsNotSerialized;
+
+bool SILGlobalVariable::isAnySerialized() const {
+  return SerializedKind_t(Serialized) == IsSerialized ||
+         SerializedKind_t(Serialized) == IsSerializedForPackage;
 }
 
 /// Get this global variable's fragile attribute.

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1123,7 +1123,7 @@ void SILGenModule::emitNonCopyableTypeDeinitTable(NominalTypeDecl *nom) {
   auto serialized = SerializedKind_t::IsNotSerialized;
   bool nomIsPublic = nom->getEffectiveAccess() >= AccessLevel::Public;
   // We only serialize the deinit if the type is public and not resilient.
-  if (nomIsPublic && !nom->isResilient()) // pcmo TODO: isFragile()?
+  if (nomIsPublic && !nom->isResilient())
     serialized = IsSerialized;
   SILMoveOnlyDeinit::create(f->getModule(), nom, serialized, f);
 }

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -1310,10 +1310,7 @@ bool SILClosureSpecializerTransform::gatherCallSites(
         // Don't specialize non-fragile callees if the caller is fragile;
         // the specialized callee will have shared linkage, and thus cannot
         // be referenced from the fragile caller.
-        // pcmo TODO: remove F->isSerialiezd() and pass its kind to
-        // canBeInlinedIntoCaller instead.
-        if (Caller->isSerialized() &&
-            !ApplyCallee->canBeInlinedIntoCaller())
+        if (!ApplyCallee->canBeInlinedIntoCaller(Caller->getSerializedKind()))
           continue;
 
         // If the callee uses a dynamic Self, we cannot specialize it,

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -753,11 +753,9 @@ getCalleeFunction(SILFunction *F, FullApplySite AI, bool &IsThick,
   if (CalleeFunction->empty())
     return nullptr;
 
-  // pcmo TODO: remove F->isSerialiezd() and pass its kind to
-  // canBeInlinedIntoCaller instead.
-  if (F->isSerialized() &&
-      !CalleeFunction->canBeInlinedIntoCaller()) {
-    if (!CalleeFunction->hasValidLinkageForFragileRef()) {
+  if (!CalleeFunction->canBeInlinedIntoCaller(F->getSerializedKind())) {
+    if (F->isAnySerialized() &&
+        !CalleeFunction->hasValidLinkageForFragileRef(F->getSerializedKind())) {
       llvm::errs() << "caller: " << F->getName() << "\n";
       llvm::errs() << "callee: " << CalleeFunction->getName() << "\n";
       llvm_unreachable("Should never be inlining a resilient function into "

--- a/lib/SILOptimizer/UtilityPasses/SILSkippingChecker.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SILSkippingChecker.cpp
@@ -32,7 +32,7 @@ static bool shouldHaveSkippedFunction(const SILFunction &F) {
   // First, we only care about functions that haven't been marked serialized.
   // If they've been marked serialized, they will end up in the final module
   // and we needed to SILGen them.
-  if (F.isSerialized())
+  if (F.isAnySerialized())
     return false;
 
   // Next, we're looking for functions that shouldn't have a body, but do. If

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -426,7 +426,7 @@ class SerializeSILPass : public SILModuleTransform {
   /// optimizations and for a better dead function elimination.
   void removeSerializedFlagFromAllFunctions(SILModule &M) {
     for (auto &F : M) {
-      bool wasSerialized = !F.isNotSerialized();
+      bool wasSerialized = F.isAnySerialized();
       F.setSerializedKind(IsNotSerialized);
 
       // We are removing [serialized] from the function. This will change how

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -530,8 +530,8 @@ findBridgeToObjCFunc(SILOptFunctionBuilder &functionBuilder,
     bridgedFunc->setParentModule(
         resultDecl->getDeclContext()->getParentModule());
 
-  if (dynamicCast.getFunction()->isSerialized() &&
-      !bridgedFunc->hasValidLinkageForFragileRef())
+  if (dynamicCast.getFunction()->isAnySerialized() &&
+      !bridgedFunc->hasValidLinkageForFragileRef(dynamicCast.getFunction()->getSerializedKind()))
     return std::nullopt;
 
   if (bridgedFunc->getLoweredFunctionType()

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -719,11 +719,11 @@ bool swift::canDevirtualizeClassMethod(FullApplySite applySite, ClassDecl *cd,
     return false;
   }
 
-  // pcmo TODO: check for tri-state serialized kind
-  if (applySite.getFunction()->isSerialized()) {
+  if (applySite.getFunction()->isAnySerialized()) {
     // function_ref inside fragile function cannot reference a private or
     // hidden symbol.
-    if (!f->hasValidLinkageForFragileRef())
+    if (!f->hasValidLinkageForFragileRef(
+      applySite.getFunction()->getSerializedKind()))
       return false;
   }
 
@@ -1168,13 +1168,11 @@ static bool canDevirtualizeWitnessMethod(ApplySite applySite, bool isMandatory) 
   if (!f)
     return false;
 
-  // pcmo TODO: check for tri-state serialized kind
-  if (applySite.getFunction()->isSerialized()) {
-    // function_ref inside fragile function cannot reference a private or
-    // hidden symbol.
-    if (!f->hasValidLinkageForFragileRef())
-      return false;
-  }
+  // function_ref inside fragile function cannot reference a private or
+  // hidden symbol.
+  if (applySite.getFunction()->isAnySerialized() &&
+      !f->hasValidLinkageForFragileRef(applySite.getFunction()->getSerializedKind()))
+    return false;
 
   // devirtualizeWitnessMethod below does not support this case. It currently
   // assumes it can try_apply call the target.

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -559,7 +559,7 @@ TermInst *swift::addArgumentsToBranch(ArrayRef<SILValue> vals,
 }
 
 SILLinkage swift::getSpecializedLinkage(SILFunction *f, SILLinkage linkage) {
-  if (hasPrivateVisibility(linkage) && f->isNotSerialized()) {
+  if (hasPrivateVisibility(linkage) && !f->isAnySerialized()) {
     // Specializations of private symbols should remain so, unless
     // they were serialized, which can only happen when specializing
     // definitions from a standard library built with -sil-serialize-all.

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -846,11 +846,9 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   }
 
   // A non-fragile function may not be inlined into a fragile function.
-  // pcmo TODO: remove Caller->isSerialized() and pass its kind to
-  // canBeInlinedIntoCaller instead.
-  if (Caller->isSerialized() &&
-      !Callee->canBeInlinedIntoCaller()) {
-    if (!Callee->hasValidLinkageForFragileRef()) {
+  if (!Callee->canBeInlinedIntoCaller(Caller->getSerializedKind())) {
+    if (Caller->isAnySerialized() &&
+        !Callee->hasValidLinkageForFragileRef(Caller->getSerializedKind())) {
       llvm::errs() << "caller: " << Caller->getName() << "\n";
       llvm::errs() << "callee: " << Callee->getName() << "\n";
       llvm_unreachable("Should never be inlining a resilient function into "

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -657,27 +657,13 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
 
     fn->setSerializedKind(SerializedKind_t(serializedKind));
 
-    // pcmo TODO: check if this can be deleted
-    // If fn was serialized in a module with package serialization
-    // enabled, a new attribute [serialized_for_package] was added
-    // to its definition. Preserve the attribute here if the current
-    // module is in the same package, and use it to determine the
-    // resilience expansion for this function.
-    auto loadedModule = getFile()->getParentModule();
-    if (SerializedKind_t(serializedKind) == IsSerializedForPackage &&
-        loadedModule->isResilient() &&
-        loadedModule != SILMod.getSwiftModule() &&
-        loadedModule->serializePackageEnabled() &&
-        loadedModule->inSamePackage(SILMod.getSwiftModule()))
-      fn->setSerializedKind(IsSerializedForPackage);
-
     // If the serialized function comes from the same module, we're merging
     // modules, and can update the linkage directly. This is needed to
     // correctly update the linkage for forward declarations to entities defined
     // in another file of the same module – we want to ensure the linkage
     // reflects the fact that the entity isn't really external and shouldn't be
     // dropped from the resulting merged module.
-    if (loadedModule == SILMod.getSwiftModule())
+    if (getFile()->getParentModule() == SILMod.getSwiftModule())
       fn->setLinkage(linkage);
 
     // Don't override the transparency or linkage of a function with
@@ -981,7 +967,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     Callback->didDeserializeFunctionBody(MF->getAssociatedModule(), fn);
 
   if (!MF->isSIB() && !SILMod.isSerialized()) {
-    assert((!fn->isNotSerialized() || fn->empty()) &&
+    assert((fn->isAnySerialized() || fn->empty()) &&
            "deserialized function must have the IsSerialized or IsSerializedForPackage flag set");
   }
   return fn;

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2948,7 +2948,11 @@ void SILSerializer::writeSILMoveOnlyDeinit(const SILMoveOnlyDeinit &deinit) {
     return;
 
   SILFunction *impl = deinit.getImplementation();
-  if (!ShouldSerializeAll && !impl->hasValidLinkageForFragileRef(IsSerialized))
+  if (!ShouldSerializeAll &&
+      // Package CMO for MoveOnlyDeinit is not supported so
+      // pass the IsSerialized argument to keep the behavior
+      // consistent with or without the optimization.
+      !impl->hasValidLinkageForFragileRef(IsSerialized))
     return;
 
   // Use the mangled name of the class as a key to distinguish between classes
@@ -3100,7 +3104,11 @@ writeSILDefaultWitnessTable(const SILDefaultWitnessTable &wt) {
           SILAbbrCodes[DefaultWitnessTableNoEntryLayout::Code]);
       continue;
     }
-    writeSILWitnessTableEntry(entry, IsNotSerialized);
+
+    // Default witness table is not serialized. The IsSerialized
+    // argument is passed here to call hasValidLinkageForFragileRef
+    // to keep the behavior consistent with or without any optimizations.
+    writeSILWitnessTableEntry(entry, IsSerialized);
   }
 }
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -278,7 +278,7 @@ namespace {
     void writeSILGlobalVar(const SILGlobalVariable &g);
     void writeSILWitnessTable(const SILWitnessTable &wt);
     void writeSILWitnessTableEntry(const SILWitnessTable::Entry &entry,
-                                   std::optional<SerializedKind_t> serializedKind = std::nullopt);
+                                   SerializedKind_t serializedKind);
     void writeSILDefaultWitnessTable(const SILDefaultWitnessTable &wt);
     void
     writeSILDifferentiabilityWitness(const SILDifferentiabilityWitness &dw);
@@ -376,8 +376,7 @@ void SILSerializer::addReferencedSILFunction(const SILFunction *F,
   }
 
   if (F->getLinkage() == SILLinkage::Shared) {
-    assert(!F->isNotSerialized() ||
-           F->hasForeignBody());
+    assert(F->isAnySerialized() || F->hasForeignBody());
 
     FuncsToEmit[F] = false;
     functionWorklist.push_back(F);
@@ -495,7 +494,6 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   }
 
   unsigned numAttrs = NoBody ? 0 : F.getSpecializeAttrs().size();
-  // pcmo TODO: check if package-cmo is enabled
   auto resilience = F.getModule().getSwiftModule()->getResilienceStrategy();
   bool serializeDerivedEffects = (resilience != ResilienceStrategy::Resilient) &&
                                  !F.hasSemanticsAttr("optimize.no.crossmodule");
@@ -2879,7 +2877,7 @@ void SILSerializer::writeSILGlobalVar(const SILGlobalVariable &g) {
                                  TyID, dID);
 
   // Don't emit the initializer instructions if not marked as "serialized".
-  if (g.isNotSerialized())
+  if (!g.isAnySerialized())
     return;
 
   ValueIDs.clear();
@@ -2926,8 +2924,8 @@ void SILSerializer::writeSILVTable(const SILVTable &vt) {
     SILFunction *impl = entry.getImplementation();
 
     if (ShouldSerializeAll ||
-        impl->hasValidLinkageForFragileRef(vt.getSerializedKind(),
-                                           /*assumeFragileCaller*/ false)) {
+        (vt.isAnySerialized() &&
+         impl->hasValidLinkageForFragileRef(vt.getSerializedKind()))) {
       handleSILDeclRef(S, entry.getMethod(), ListOfValues);
       addReferencedSILFunction(impl, true);
       // Each entry is a pair of SILDeclRef and SILFunction.
@@ -2950,7 +2948,7 @@ void SILSerializer::writeSILMoveOnlyDeinit(const SILMoveOnlyDeinit &deinit) {
     return;
 
   SILFunction *impl = deinit.getImplementation();
-  if (!ShouldSerializeAll && !impl->hasValidLinkageForFragileRef())
+  if (!ShouldSerializeAll && !impl->hasValidLinkageForFragileRef(IsSerialized))
     return;
 
   // Use the mangled name of the class as a key to distinguish between classes
@@ -3026,7 +3024,7 @@ void SILSerializer::writeSILWitnessTable(const SILWitnessTable &wt) {
 
 void SILSerializer::writeSILWitnessTableEntry(
                                         const SILWitnessTable::Entry &entry,
-                                        std::optional<SerializedKind_t> serializedKind) {
+                                        SerializedKind_t serializedKind) {
   if (entry.getKind() == SILWitnessTable::BaseProtocol) {
     auto &baseWitness = entry.getBaseProtocolWitness();
 
@@ -3068,8 +3066,8 @@ void SILSerializer::writeSILWitnessTableEntry(
   IdentifierID witnessID = 0;
   SILFunction *witness = methodWitness.Witness;
   if (witness &&
-      witness->hasValidLinkageForFragileRef(serializedKind,
-                                            /*assumeFragileCaller*/ false)) {
+      serializedKind != IsNotSerialized &&
+      witness->hasValidLinkageForFragileRef(serializedKind)) {
     addReferencedSILFunction(witness, true);
     witnessID = S.addUniquedStringRef(witness->getName());
   }
@@ -3102,7 +3100,7 @@ writeSILDefaultWitnessTable(const SILDefaultWitnessTable &wt) {
           SILAbbrCodes[DefaultWitnessTableNoEntryLayout::Code]);
       continue;
     }
-    writeSILWitnessTableEntry(entry);
+    writeSILWitnessTableEntry(entry, IsNotSerialized);
   }
 }
 
@@ -3174,8 +3172,7 @@ bool SILSerializer::shouldEmitFunctionBody(const SILFunction *F,
   // If F is serialized, we should always emit its body.
   // Shared functions are only serialized if they are referenced from another
   // serialized function. This is handled in `addReferencedSILFunction`.
-  if (!F->isNotSerialized() &&
-      !hasSharedVisibility(F->getLinkage()))
+  if (F->isAnySerialized() && !hasSharedVisibility(F->getLinkage()))
     return true;
 
   return false;
@@ -3237,13 +3234,13 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   // serialize everything.
   // FIXME: Resilience: could write out vtable for fragile classes.
   for (const auto &vt : SILMod->getVTables()) {
-    if ((ShouldSerializeAll || !vt->isNotSerialized()) &&
+    if ((ShouldSerializeAll || vt->isAnySerialized()) &&
         SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(vt->getClass()))
       writeSILVTable(*vt);
   }
 
   for (const auto &deinit : SILMod->getMoveOnlyDeinits()) {
-    if ((ShouldSerializeAll || !deinit->isNotSerialized()) &&
+    if ((ShouldSerializeAll || deinit->isAnySerialized()) &&
         SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(
             deinit->getNominalDecl()))
       writeSILMoveOnlyDeinit(*deinit);
@@ -3251,7 +3248,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
 
   // Write out property descriptors.
   for (const SILProperty &prop : SILMod->getPropertyList()) {
-    if ((ShouldSerializeAll || !prop.isNotSerialized()) &&
+    if ((ShouldSerializeAll || prop.isAnySerialized()) &&
         SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(
                                      prop.getDecl()->getInnermostDeclContext()))
       writeSILProperty(prop);
@@ -3259,7 +3256,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
 
   // Write out fragile WitnessTables.
   for (const SILWitnessTable &wt : SILMod->getWitnessTables()) {
-    if ((ShouldSerializeAll || !wt.isNotSerialized()) &&
+    if ((ShouldSerializeAll || wt.isAnySerialized()) &&
         SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(
                                          wt.getConformance()->getDeclContext()))
       writeSILWitnessTable(wt);
@@ -3276,7 +3273,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
 
   // Add global variables that must be emitted to the list.
   for (const SILGlobalVariable &g : SILMod->getSILGlobals()) {
-    if (!g.isNotSerialized() || ShouldSerializeAll)
+    if (g.isAnySerialized() || ShouldSerializeAll)
       addReferencedGlobalVariable(&g);
   }
 
@@ -3322,7 +3319,6 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
 
   // Now write function declarations for every function we've
   // emitted a reference to without emitting a function body for.
-  // pcmo TODO: check if package-cmo is enabled
   auto resilience = SILMod->getSwiftModule()->getResilienceStrategy();
   for (const SILFunction &F : *SILMod) {
     auto iter = FuncsToEmit.find(&F);


### PR DESCRIPTION
Allow optimizing `[serialized_for_pkg]` functions during SIL inlining, generic/closure specialization, and devirtualization optimization passes.

`SILFunction::canBeInlinedIntoCaller` now exlicitly requires a caller's `SerializedKind_t` arg. `isAnySerialized()` is added as a convenience function that checks if `[serialized]` or `[serialized_for_pkg]`.

Resolves rdar://128704752
