### PR TITLE
[6.0] Sema: Relax feature check for non-escapable types in swiftinterfaces 

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4406,7 +4406,7 @@ public:
   /// \param UseDC The context of the access.  Some variables have different
   ///   types depending on where they are used.
   ///
-  /// \param memberLocator The locator anchored at this value reference, when
+  /// \param locator The locator anchored at this value reference, when
   /// it is a member reference.
   ///
   /// \param wantInterfaceType Whether we want the interface type, if available.
@@ -4424,7 +4424,7 @@ public:
   /// \param UseDC The context of the access.  Some variables have different
   ///   types depending on where they are used.
   ///
-  /// \param memberLocator The locator anchored at this value reference, when
+  /// \param locator The locator anchored at this value reference, when
   /// it is a member reference.
   ///
   /// \param wantInterfaceType Whether we want the interface type, if available.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2071,6 +2071,11 @@ namespace {
       return (SF && SF->Kind == SourceFileKind::SIL);
     }
 
+    bool isInterfaceFile() const {
+      auto SF = getDeclContext()->getParentSourceFile();
+      return (SF && SF->Kind == SourceFileKind::Interface);
+    }
+
     /// Short-hand to query the current stage of type resolution.
     bool inStage(TypeResolutionStage stage) const {
       return resolution.getStage() == stage;
@@ -4782,6 +4787,7 @@ TypeResolver::resolveDeclRefTypeRepr(DeclRefTypeRepr *repr,
       if (auto known = proto->getKnownProtocol()) {
         if (*known == KnownProtocolKind::Escapable
             && !isSILSourceFile()
+            && !isInterfaceFile()
             && !ctx.LangOpts.hasFeature(Feature::NonescapableTypes)) {
           diagnoseInvalid(repr, repr->getLoc(),
                           diag::escapable_requires_feature_flag);

--- a/test/ModuleInterface/escapable.swiftinterface
+++ b/test/ModuleInterface/escapable.swiftinterface
@@ -1,0 +1,14 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Swift version 6.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name Library
+
+// RUN: %target-swift-typecheck-module-from-interface(%s) -module-name Library
+
+import Swift
+import _Concurrency
+import _StringProcessing
+import _SwiftConcurrencyShims
+
+// Allow Escapable to appear without -enable-experimental-feature NonescapableTypes
+public struct S : Swift.Escapable {
+}

--- a/validation-test/ParseableInterface/rdar128577611.swift
+++ b/validation-test/ParseableInterface/rdar128577611.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s < %t/Library.swiftinterface
+
+struct InternalStruct {}
+extension [Int: InternalStruct]: Sendable {}
+
+// CHECK: @available(*, unavailable)
+// CHECK: extension Swift.Dictionary : Swift.Copyable, Swift.Escapable, Swift.Sendable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}


### PR DESCRIPTION
- **Explanation:** There's a way in which `Escapable` is escaping into interfaces without having been written source. That may be a bug on its own, but regardless we should not enforce the feature flag restriction when checking interfaces. Checking for the presence of a feature flag in order to allow syntax tends to result in condfails when applied to `.swiftinterfaces`, since older compilers that have this restriction may be used to compile newer interfaces where the restriction has been lifted. Remove this restriction for non-escapable types when typechecking an interface.
- **Scope:** Affects libraries with library evolution enabled that contain extensions on some standard library types. 
- **Issue/Radar:** rdar://128577611
- **Original PR:** https://github.com/apple/swift/pull/73898
- **Risk:** Low. This just relaxes a diagnostic to accept more `.swiftinterfaces`. The restriction on `Escapable` types is a policy regarding use of experimental features, rather than a fundamental restriction.
- **Testing:** Added regression tests.