### PR TITLE
Frontend: Lift restrictions on lazy type checking options

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1158,11 +1158,6 @@ def experimental_skip_all_function_bodies:
   Flag<["-"], "experimental-skip-all-function-bodies">,
   HelpText<"Skip type-checking function bodies and all SIL generation">;
 
-def experimental_skip_non_inlinable_function_bodies_is_lazy
-  : Flag<["-"], "experimental-skip-non-inlinable-function-bodies-is-lazy">,
-  HelpText<"Infer lazy typechecking for "
-           "-experimental-skip-non-inlinable-function-bodies">;
-
 def experimental_allow_module_with_compiler_errors:
   Flag<["-"], "experimental-allow-module-with-compiler-errors">,
   Flags<[HelpHidden]>,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4423,7 +4423,7 @@ public:
   /// \param UseDC The context of the access.  Some variables have different
   ///   types depending on where they are used.
   ///
-  /// \param memberLocator The locator anchored at this value reference, when
+  /// \param locator The locator anchored at this value reference, when
   /// it is a member reference.
   ///
   /// \param wantInterfaceType Whether we want the interface type, if available.
@@ -4441,7 +4441,7 @@ public:
   /// \param UseDC The context of the access.  Some variables have different
   ///   types depending on where they are used.
   ///
-  /// \param memberLocator The locator anchored at this value reference, when
+  /// \param locator The locator anchored at this value reference, when
   /// it is a member reference.
   ///
   /// \param wantInterfaceType Whether we want the interface type, if available.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1157,11 +1157,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_enable_library_evolution)) {
     Opts.SkipNonExportableDecls |=
         Args.hasArg(OPT_experimental_skip_non_exportable_decls);
-
-    Opts.SkipNonExportableDecls |=
-        Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) &&
-        Args.hasArg(
-            OPT_experimental_skip_non_inlinable_function_bodies_is_lazy);
   } else {
     if (Args.hasArg(OPT_experimental_skip_non_exportable_decls))
       Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
@@ -1714,20 +1709,10 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
 
   if (Args.hasArg(OPT_enable_library_evolution)) {
     Opts.EnableLazyTypecheck |= Args.hasArg(OPT_experimental_lazy_typecheck);
-    Opts.EnableLazyTypecheck |=
-        Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) &&
-        Args.hasArg(
-            OPT_experimental_skip_non_inlinable_function_bodies_is_lazy);
   } else {
     if (Args.hasArg(OPT_experimental_lazy_typecheck))
       Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
                      "-experimental-lazy-typecheck",
-                     "-enable-library-evolution");
-
-    if (Args.hasArg(
-            OPT_experimental_skip_non_inlinable_function_bodies_is_lazy))
-      Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
-                     "-experimental-skip-non-inlinable-function-bodies-is-lazy",
                      "-enable-library-evolution");
   }
 

--- a/test/Serialization/lazy-typecheck.swift
+++ b/test/Serialization/lazy-typecheck.swift
@@ -11,6 +11,11 @@
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-all/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
 // RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-all
 
+// (2a) Verify that -experimental-lazy-typecheck and -experimental-skip-non-exportable-decls do not require
+// -enable-library-evolution if -experimental-skip-all-function-bodies is specified.
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-all-non-resilient/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
+// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-all-non-resilient
+
 // (3) Verify that a module built with -experimental-lazy-typecheck, -experimental-skip-non-inlinable-function-bodies,
 //     and -experimental-skip-non-exportable-decls can be used by the same client as in (1).
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-non-inlinable/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-exportable-decls

--- a/test/Serialization/lazy-typecheck.swift
+++ b/test/Serialization/lazy-typecheck.swift
@@ -15,8 +15,3 @@
 //     and -experimental-skip-non-exportable-decls can be used by the same client as in (1).
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-non-inlinable/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-exportable-decls
 // RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-non-inlinable
-
-// (4) Verify that a module built with -experimental-skip-non-inlinable-function-bodies-is-lazy implies
-//     -experimental-lazy-typecheck and -experimental-skip-non-exportable-decls.
-// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-non-inlinable-is-lazy/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-inlinable-function-bodies-is-lazy
-// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-non-inlinable-is-lazy


### PR DESCRIPTION
The `-experimental-skip-all-function-bodies` flag is specified when producing modules for indexing. These modules are not used for compilation, so it should be safe to allow `-experimental-lazy-typecheck` and `-experimental-skip-non-exportable-decls` as well without `-enable-library-evolution`.

Resolves rdar://128706306