### PR TITLE
[6.0] Frontend: Lift restrictions on lazy type checking options

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1150,11 +1150,6 @@ def experimental_skip_all_function_bodies:
   Flag<["-"], "experimental-skip-all-function-bodies">,
   HelpText<"Skip type-checking function bodies and all SIL generation">;
 
-def experimental_skip_non_inlinable_function_bodies_is_lazy
-  : Flag<["-"], "experimental-skip-non-inlinable-function-bodies-is-lazy">,
-  HelpText<"Infer lazy typechecking for "
-           "-experimental-skip-non-inlinable-function-bodies">;
-
 def experimental_allow_module_with_compiler_errors:
   Flag<["-"], "experimental-allow-module-with-compiler-errors">,
   Flags<[HelpHidden]>,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1162,11 +1162,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_enable_library_evolution)) {
     Opts.SkipNonExportableDecls |=
         Args.hasArg(OPT_experimental_skip_non_exportable_decls);
-
-    Opts.SkipNonExportableDecls |=
-        Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) &&
-        Args.hasArg(
-            OPT_experimental_skip_non_inlinable_function_bodies_is_lazy);
   } else {
     if (Args.hasArg(OPT_experimental_skip_non_exportable_decls))
       Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
@@ -1692,20 +1687,10 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
 
   if (Args.hasArg(OPT_enable_library_evolution)) {
     Opts.EnableLazyTypecheck |= Args.hasArg(OPT_experimental_lazy_typecheck);
-    Opts.EnableLazyTypecheck |=
-        Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) &&
-        Args.hasArg(
-            OPT_experimental_skip_non_inlinable_function_bodies_is_lazy);
   } else {
     if (Args.hasArg(OPT_experimental_lazy_typecheck))
       Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
                      "-experimental-lazy-typecheck",
-                     "-enable-library-evolution");
-
-    if (Args.hasArg(
-            OPT_experimental_skip_non_inlinable_function_bodies_is_lazy))
-      Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
-                     "-experimental-skip-non-inlinable-function-bodies-is-lazy",
                      "-enable-library-evolution");
   }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1159,14 +1159,20 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableSkipExplicitInterfaceModuleBuildRemarks = Args.hasArg(OPT_remark_skip_explicit_interface_build);
 
-  if (Args.hasArg(OPT_enable_library_evolution)) {
-    Opts.SkipNonExportableDecls |=
-        Args.hasArg(OPT_experimental_skip_non_exportable_decls);
-  } else {
-    if (Args.hasArg(OPT_experimental_skip_non_exportable_decls))
+  if (Args.hasArg(OPT_experimental_skip_non_exportable_decls)) {
+    // Only allow -experimental-skip-non-exportable-decls if either library
+    // evolution is enabled (in which case the module's ABI is independent of
+    // internal declarations) or when -experimental-skip-all-function-bodies is
+    // present. The latter implies the module will not be used for code
+    // generation, so omitting details needed for ABI should be safe.
+    if (Args.hasArg(OPT_enable_library_evolution) ||
+        Args.hasArg(OPT_experimental_skip_all_function_bodies)) {
+      Opts.SkipNonExportableDecls |= true;
+    } else {
       Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
                      "-experimental-skip-non-exportable-decls",
                      "-enable-library-evolution");
+    }
   }
 
   Opts.AllowNonResilientAccess =
@@ -1685,13 +1691,18 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   Opts.DebugGenericSignatures |= Args.hasArg(OPT_debug_generic_signatures);
   Opts.DebugInverseRequirements |= Args.hasArg(OPT_debug_inverse_requirements);
 
-  if (Args.hasArg(OPT_enable_library_evolution)) {
-    Opts.EnableLazyTypecheck |= Args.hasArg(OPT_experimental_lazy_typecheck);
-  } else {
-    if (Args.hasArg(OPT_experimental_lazy_typecheck))
+  if (Args.hasArg(OPT_experimental_lazy_typecheck)) {
+    // Same restrictions as -experimental-skip-non-exportable-decls. These
+    // could be relaxed in the future, since lazy typechecking is probably not
+    // inherently unsafe without these options.
+    if (Args.hasArg(OPT_enable_library_evolution) ||
+        Args.hasArg(OPT_experimental_skip_all_function_bodies)) {
+      Opts.EnableLazyTypecheck |= Args.hasArg(OPT_experimental_lazy_typecheck);
+    } else {
       Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
                      "-experimental-lazy-typecheck",
                      "-enable-library-evolution");
+    }
   }
 
   // HACK: The driver currently erroneously passes all flags to module interface

--- a/test/Serialization/lazy-typecheck.swift
+++ b/test/Serialization/lazy-typecheck.swift
@@ -11,6 +11,11 @@
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-all/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
 // RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-all
 
+// (2a) Verify that -experimental-lazy-typecheck and -experimental-skip-non-exportable-decls do not require
+// -enable-library-evolution if -experimental-skip-all-function-bodies is specified.
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-all-non-resilient/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
+// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-all-non-resilient
+
 // (3) Verify that a module built with -experimental-lazy-typecheck, -experimental-skip-non-inlinable-function-bodies,
 //     and -experimental-skip-non-exportable-decls can be used by the same client as in (1).
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-non-inlinable/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-exportable-decls

--- a/test/Serialization/lazy-typecheck.swift
+++ b/test/Serialization/lazy-typecheck.swift
@@ -15,8 +15,3 @@
 //     and -experimental-skip-non-exportable-decls can be used by the same client as in (1).
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-non-inlinable/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-exportable-decls
 // RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-non-inlinable
-
-// (4) Verify that a module built with -experimental-skip-non-inlinable-function-bodies-is-lazy implies
-//     -experimental-lazy-typecheck and -experimental-skip-non-exportable-decls.
-// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-non-inlinable-is-lazy/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-inlinable-function-bodies-is-lazy
-// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-non-inlinable-is-lazy


### PR DESCRIPTION
- **Explanation:** The `-experimental-skip-all-function-bodies` flag is specified when producing modules for indexing. These modules are not used for compilation, so it should be safe to allow `-experimental-lazy-typecheck` and `-experimental-skip-non-exportable-decls` as well without `-enable-library-evolution`.
- **Scope:** Unblocks experimentation with lazy type checking during indexing.
- **Issue/Radar:** rdar://128706306
- **Original PR:** https://github.com/apple/swift/pull/73905
- **Risk:** Low. `-experimental-skip-all-function-bodies` is only specified during indexing, and existing build systems only pass the lazy type checking flags when a module has library evolution enabled.
- **Testing:** Added a regression test.