### PR TITLE
[Index] Write empty record files

### DIFF
--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -285,11 +285,6 @@ StringRef StdlibGroupsIndexRecordingConsumer::findGroupForSymbol(const IndexSymb
 static bool writeRecord(SymbolTracker &record, std::string Filename,
                         std::string indexStorePath, DiagnosticEngine *diags,
                         std::string &outRecordFile) {
-  if (record.getOccurrences().empty()) {
-    outRecordFile = std::string();
-    return false;
-  }
-
   IndexRecordWriter recordWriter(indexStorePath);
   std::string error;
   auto result = recordWriter.beginRecord(

--- a/test/Index/Store/record-empty.swift
+++ b/test/Index/Store/record-empty.swift
@@ -2,4 +2,4 @@
 // RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck -primary-file %s
 // RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck %s
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s
-// CHECK-NOT: Record{{.*}}record-empty
+// CHECK: Record | user | {{.*}}{{/|\\}}record-empty.swift

--- a/test/Index/Store/unit-from-compile.swift
+++ b/test/Index/Store/unit-from-compile.swift
@@ -16,6 +16,7 @@
 
 // CHECK: DEPEND START
 // CHECK: Unit | system | {{.*}}{{/|\\}}Swift.swiftmodule
-// CHECK: DEPEND END (1)
+// CHECK: Record | user | {{.*}}{{/|\\}}unit-from-compile.swift
+// CHECK: DEPEND END (2)
 
 // OPT: is-debug: 1


### PR DESCRIPTION
When indexing an empty Swift file, we get a unit file that doesn’t have any record dependency declared on the source file. Because of this, we always assume that the empty file has an out of date index store entry and re-index it on project open. Write empty record files to fix this.

rdar://128711594