### PR TITLE
[6.0] Fix source location info to address availability error with `next(isolation:)`

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4638,7 +4638,7 @@ generateForEachStmtConstraints(ConstraintSystem &cs, DeclContext *dc,
     // `next` is always async but witness might not be throwing
     if (isAsync) {
       nextCall =
-          AwaitExpr::createImplicit(ctx, /*awaitLoc=*/SourceLoc(), nextCall);
+          AwaitExpr::createImplicit(ctx, nextCall->getLoc(), nextCall);
     }
 
     // The iterator type must conform to IteratorProtocol.

--- a/test/Concurrency/async_sequence_macosx.swift
+++ b/test/Concurrency/async_sequence_macosx.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14.0 %s -emit-sil -o /dev/null -verify
+
+// REQUIRES: concurrency, OS=macosx
+
+func acceptClosure(_: () async throws -> Void) { }
+  
+@available(macOS 13.0, *)
+func f<S: AsyncSequence>(s: S) async throws {
+  acceptClosure {
+    if #available(SwiftStdlib 6.0, *) {
+      for try await x in s {
+        print(x)
+      }
+    }
+  }
+}
+
+


### PR DESCRIPTION
**Explanation**: Due to a missing source location in the implicitly-generated `await` in the async for loop, we misdiagnosed availability within an `if #available`.
**Original PR**: https://github.com/apple/swift/pull/73912
**Radar/issue**:  rdar://128560745
**Risk**:  Low. Adds a source location to generated code.