### PR TITLE
[IRGen] Fix `SyncCallEmission::emitCallToUnmappedExplosion` crash

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2615,10 +2615,13 @@ public:
             == ResultConvention::Autoreleased)) {
       if (IGF.IGM.Context.LangOpts.EnableObjCInterop) {
         auto ty = fnConv.getSILResultType(IGF.IGM.getMaximalTypeExpansionContext());
-        auto *classTypeInfo = dyn_cast<ClassTypeInfo>(&IGF.IGM.getTypeInfo(ty));
-        if (classTypeInfo && classTypeInfo->getReferenceCounting() == ReferenceCounting::Custom) {
+        // NOTE: We cannot dyn_cast directly to ClassTypeInfo since it does not
+        // implement 'classof', so will succeed for any ReferenceTypeInfo.
+        auto *refTypeInfo = dyn_cast<ReferenceTypeInfo>(&IGF.IGM.getTypeInfo(ty));
+        if (refTypeInfo && 
+            refTypeInfo->getReferenceCountingType() == ReferenceCounting::Custom) {
           Explosion e(result);
-          classTypeInfo->strongCustomRetain(IGF, e, true);
+          refTypeInfo->as<ClassTypeInfo>().strongCustomRetain(IGF, e, true);
         } else {
           result = emitObjCRetainAutoreleasedReturnValue(IGF, result);
         }


### PR DESCRIPTION
We cannot `dyn_cast` directly to `ClassTypeInfo` since it does not implement `classof`, so will succeed for any `ReferenceTypeInfo`. Instead, `dyn_cast` to `ReferenceTypeInfo`, and then cast to `ClassTypeInfo` if custom reference counting is being used. This could probably be designed better, this patch is just aiming to resolve the crashes we're seeing in CI.

rdar://128735092
