### PR TITLE
ConstraintSystem: clarify consuming conversions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7848,10 +7848,10 @@ ERROR(noncopyable_objc_enum, none,
       "noncopyable enums cannot be marked '@objc'", ())
 ERROR(moveOnly_not_allowed_here,none,
       "'@_moveOnly' attribute is only valid on structs or enums", ())
-WARNING(consume_expression_needed_for_cast,none,
+ERROR(consume_expression_needed_for_cast,none,
       "implicit conversion to %0 is consuming", (Type))
-NOTE(add_consume_to_silence_warning,none,
-     "add 'consume' to silence this warning", ())
+NOTE(add_consume_to_silence,none,
+     "add 'consume' to make consumption explicit", ())
 ERROR(consume_expression_not_passed_lvalue,none,
       "'consume' can only be applied to a local binding ('let', 'var', or parameter)", ())
 ERROR(consume_expression_partial_copyable,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7848,6 +7848,10 @@ ERROR(noncopyable_objc_enum, none,
       "noncopyable enums cannot be marked '@objc'", ())
 ERROR(moveOnly_not_allowed_here,none,
       "'@_moveOnly' attribute is only valid on structs or enums", ())
+WARNING(consume_expression_needed_for_cast,none,
+      "implicit conversion to %0 is consuming", (Type))
+NOTE(add_consume_to_silence_warning,none,
+     "add 'consume' to silence this warning", ())
 ERROR(consume_expression_not_passed_lvalue,none,
       "'consume' can only be applied to a local binding ('let', 'var', or parameter)", ())
 ERROR(consume_expression_partial_copyable,none,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6582,6 +6582,13 @@ TypeVariableType *TypeVariableType::getNew(const ASTContext &C, unsigned ID,
 /// underlying forced downcast expression.
 ForcedCheckedCastExpr *findForcedDowncast(ASTContext &ctx, Expr *expr);
 
+/// Assuming the expression appears in a consuming context,
+/// if it does not already have an explicit `consume`,
+/// can I add `consume` around this expression?
+///
+/// \param module represents the module in which the expr appears
+bool canAddExplicitConsume(ModuleDecl *module, Expr *expr);
+
 // Count the number of overload sets present
 // in the expression and all of the children.
 class OverloadSetCounter : public ASTWalker {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5590,7 +5590,7 @@ namespace {
                       cs.getType(coercion));
         ctx.Diags
             .diagnose(coercion->getLoc(),
-                      diag::add_consume_to_silence_warning)
+                      diag::add_consume_to_silence)
             .fixItInsert(coercion->getStartLoc(), "consume ");
       }
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -355,6 +355,45 @@ static bool buildObjCKeyPathString(KeyPathExpr *E,
   return true;
 }
 
+/// Since a cast to an optional will consume a noncopyable type, check to see
+/// if injecting the value into an optional here will potentially be confusing.
+static bool willHaveConfusingConsumption(Type type,
+                                         ConstraintLocatorBuilder locator,
+                                         ConstraintSystem &cs) {
+  assert(type);
+  if (!type->isNoncopyable())
+    return false; /// If it's a copyable type, there's no confusion.
+
+  auto loc = cs.getConstraintLocator(locator);
+  if (!loc)
+    return true;
+
+  auto path = loc->getPath();
+  if (path.empty())
+    return true;
+
+  switch (loc->getPath().back().getKind()) {
+  case ConstraintLocator::FunctionResult:
+  case ConstraintLocator::ClosureResult:
+  case ConstraintLocator::ClosureBody:
+  case ConstraintLocator::ContextualType:
+  case ConstraintLocator::CoercionOperand:
+    return false; // These last-uses won't be confused for borrowing.
+
+  case ConstraintLocator::ApplyArgToParam: {
+    auto argLoc = loc->castLastElementTo<LocatorPathElt::ApplyArgToParam>();
+    auto paramFlags = argLoc.getParameterFlags();
+    if (paramFlags.getOwnershipSpecifier() == ParamSpecifier::Consuming)
+      return false; // Parameter already declares 'consuming'.
+
+    return true;
+  }
+
+  default:
+    return true;
+  }
+}
+
 namespace {
 
   /// Rewrites an expression by applying the solution of a constraint
@@ -3241,9 +3280,11 @@ namespace {
     }
 
   private:
-    /// A list of "suspicious" optional injections that come from
-    /// forced downcasts.
+    /// A list of "suspicious" optional injections.
     SmallVector<InjectIntoOptionalExpr *, 4> SuspiciousOptionalInjections;
+
+    /// A list of implicit coercions of noncopyable types.
+    SmallVector<Expr *, 4> ConsumingCoercions;
 
     /// Create a member reference to the given constructor.
     Expr *applyCtorRefExpr(Expr *expr, Expr *base, SourceLoc dotLoc,
@@ -4466,9 +4507,9 @@ namespace {
       if (choice == 0) {
         // Convert the subexpression.
         Expr *sub = expr->getSubExpr();
-
-        sub = solution.coerceToType(sub, expr->getCastType(),
-                                    cs.getConstraintLocator(sub));
+        auto subLoc =
+            cs.getConstraintLocator(sub, ConstraintLocator::CoercionOperand);
+        sub = solution.coerceToType(sub, expr->getCastType(), subLoc);
         if (!sub)
           return nullptr;
 
@@ -5516,41 +5557,69 @@ namespace {
       assert(OpenedExistentials.empty());
 
       auto &ctx = cs.getASTContext();
+      auto *module = dc->getParentModule();
 
       // Look at all of the suspicious optional injections
       for (auto injection : SuspiciousOptionalInjections) {
-        auto *cast = findForcedDowncast(ctx, injection->getSubExpr());
-        if (!cast)
-          continue;
+        if (auto *cast = findForcedDowncast(ctx, injection->getSubExpr())) {
+          if (!isa<ParenExpr>(injection->getSubExpr())) {
+            ctx.Diags.diagnose(
+                injection->getLoc(), diag::inject_forced_downcast,
+                cs.getType(injection->getSubExpr())->getRValueType());
+            auto exclaimLoc = cast->getExclaimLoc();
+            ctx.Diags
+                .diagnose(exclaimLoc, diag::forced_to_conditional_downcast,
+                          cs.getType(injection)->getOptionalObjectType())
+                .fixItReplace(exclaimLoc, "?");
+            ctx.Diags
+                .diagnose(cast->getStartLoc(),
+                          diag::silence_inject_forced_downcast)
+                .fixItInsert(cast->getStartLoc(), "(")
+                .fixItInsertAfter(cast->getEndLoc(), ")");
+          }
+        }
+      }
 
-        if (isa<ParenExpr>(injection->getSubExpr()))
-          continue;
-
-        ctx.Diags.diagnose(
-            injection->getLoc(), diag::inject_forced_downcast,
-            cs.getType(injection->getSubExpr())->getRValueType());
-        auto exclaimLoc = cast->getExclaimLoc();
+      // Diagnose the implicit coercions of noncopyable values that happen in
+      // a context where it isn't "obviously" consuming already.
+      for (auto *coercion : ConsumingCoercions) {
+        assert(coercion->isImplicit());
         ctx.Diags
-            .diagnose(exclaimLoc, diag::forced_to_conditional_downcast,
-                      cs.getType(injection)->getOptionalObjectType())
-            .fixItReplace(exclaimLoc, "?");
+            .diagnose(coercion->getLoc(),
+                      diag::consume_expression_needed_for_cast,
+                      cs.getType(coercion));
         ctx.Diags
-            .diagnose(cast->getStartLoc(), diag::silence_inject_forced_downcast)
-            .fixItInsert(cast->getStartLoc(), "(")
-            .fixItInsertAfter(cast->getEndLoc(), ")");
+            .diagnose(coercion->getLoc(),
+                      diag::add_consume_to_silence_warning)
+            .fixItInsert(coercion->getStartLoc(), "consume ");
       }
     }
 
     /// Diagnose an optional injection that is probably not what the
-    /// user wanted, because it comes from a forced downcast.
-    void diagnoseOptionalInjection(InjectIntoOptionalExpr *injection) {
+    /// user wanted, because it comes from a forced downcast, or from an
+    /// implicitly consumed noncopyable type.
+    void diagnoseOptionalInjection(InjectIntoOptionalExpr *injection,
+                                   ConstraintLocatorBuilder locator) {
       // Check whether we have a forced downcast.
-      auto *cast =
-          findForcedDowncast(cs.getASTContext(), injection->getSubExpr());
-      if (!cast)
-        return;
-      
-      SuspiciousOptionalInjections.push_back(injection);
+      if (findForcedDowncast(cs.getASTContext(), injection->getSubExpr()))
+        SuspiciousOptionalInjections.push_back(injection);
+
+      /// Check if it needs an explicit consume, due to this being a cast.
+      auto *module = dc->getParentModule();
+      auto origType = cs.getType(injection->getSubExpr());
+      if (willHaveConfusingConsumption(origType, locator, cs) &&
+          canAddExplicitConsume(module, injection->getSubExpr()))
+        ConsumingCoercions.push_back(injection);
+    }
+
+    void diagnoseExistentialErasureOf(Expr *fromExpr, Expr *toExpr,
+                                      ConstraintLocatorBuilder locator) {
+      auto *module = dc->getParentModule();
+      auto fromType = cs.getType(fromExpr);
+      if (willHaveConfusingConsumption(fromType, locator, cs) &&
+          canAddExplicitConsume(module, fromExpr)) {
+        ConsumingCoercions.push_back(toExpr);
+      }
     }
   };
 } // end anonymous namespace
@@ -5821,7 +5890,7 @@ Expr *ExprRewriter::coerceOptionalToOptional(Expr *expr, Type toType,
     while (diff--) {
       Type type = toOptionals[diff];
       expr = cs.cacheType(new (ctx) InjectIntoOptionalExpr(expr, type));
-      diagnoseOptionalInjection(cast<InjectIntoOptionalExpr>(expr));
+      diagnoseOptionalInjection(cast<InjectIntoOptionalExpr>(expr), locator);
     }
 
     return expr;
@@ -6950,8 +7019,11 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       return coerceSuperclass(expr, toType);
 
     case ConversionRestrictionKind::Existential:
-    case ConversionRestrictionKind::MetatypeToExistentialMetatype:
-      return coerceExistential(expr, toType, locator);
+    case ConversionRestrictionKind::MetatypeToExistentialMetatype: {
+      auto coerced = coerceExistential(expr, toType, locator);
+      diagnoseExistentialErasureOf(expr, coerced, locator);
+      return coerced;
+    }
 
     case ConversionRestrictionKind::ClassMetatypeToAnyObject: {
       assert(ctx.LangOpts.EnableObjCInterop &&
@@ -6980,7 +7052,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
       auto *result =
           cs.cacheType(new (ctx) InjectIntoOptionalExpr(expr, toType));
-      diagnoseOptionalInjection(result);
+      diagnoseOptionalInjection(result, locator);
       return result;
     }
 
@@ -7674,7 +7746,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     if (!expr) return nullptr;
 
     auto *result = cs.cacheType(new (ctx) InjectIntoOptionalExpr(expr, toType));
-    diagnoseOptionalInjection(result);
+    diagnoseOptionalInjection(result, locator);
     return result;
   }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -422,87 +422,11 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
     }
 
     void checkConsumeExpr(ConsumeExpr *consumeExpr) {
-      auto *subExpr = consumeExpr->getSubExpr();
-      bool noncopyable =
-          subExpr->getType()->getCanonicalType()->isNoncopyable();
-
-      bool partial = false;
-      Expr *current = subExpr;
-      while (current) {
-        if (auto *dre = dyn_cast<DeclRefExpr>(current)) {
-          if (partial & !noncopyable) {
-            Ctx.Diags.diagnose(consumeExpr->getLoc(),
-                               diag::consume_expression_partial_copyable);
-            return;
-          }
-          // The chain of member_ref_exprs and load_exprs terminates at a
-          // declref_expr.  This is legal.
-          return;
-        }
-        // Look through loads.
-        if (auto *le = dyn_cast<LoadExpr>(current)) {
-          current = le->getSubExpr();
-          continue;
-        }
-        auto *mre = dyn_cast<MemberRefExpr>(current);
-        if (mre) {
-          auto *vd = dyn_cast<VarDecl>(mre->getMember().getDecl());
-          if (!vd) {
-            Ctx.Diags.diagnose(consumeExpr->getLoc(),
-                               diag::consume_expression_non_storage);
-            return;
-          }
-          partial = true;
-          AccessStrategy strategy = vd->getAccessStrategy(
-              mre->getAccessSemantics(), AccessKind::Read,
-              DC->getParentModule(), ResilienceExpansion::Minimal);
-          if (strategy.getKind() != AccessStrategy::Storage) {
-            if (noncopyable) {
-              Ctx.Diags.diagnose(consumeExpr->getLoc(),
-                                 diag::consume_expression_non_storage);
-              Ctx.Diags.diagnose(
-                  mre->getLoc(),
-                  diag::note_consume_expression_non_storage_property);
-            } else {
-              Ctx.Diags.diagnose(consumeExpr->getLoc(),
-                                 diag::consume_expression_partial_copyable);
-            }
-            return;
-          }
-          current = mre->getBase();
-          continue;
-        }
-        auto *ce = dyn_cast<CallExpr>(current);
-        if (ce) {
-          if (noncopyable) {
-            Ctx.Diags.diagnose(consumeExpr->getLoc(),
-                               diag::consume_expression_non_storage);
-            Ctx.Diags.diagnose(ce->getLoc(),
-                               diag::note_consume_expression_non_storage_call);
-          } else {
-            Ctx.Diags.diagnose(consumeExpr->getLoc(),
-                               diag::consume_expression_partial_copyable);
-          }
-          return;
-        }
-        auto *se = dyn_cast<SubscriptExpr>(current);
-        if (se) {
-          if (noncopyable) {
-            Ctx.Diags.diagnose(consumeExpr->getLoc(),
-                               diag::consume_expression_non_storage);
-            Ctx.Diags.diagnose(
-                se->getLoc(),
-                diag::note_consume_expression_non_storage_subscript);
-          } else {
-            Ctx.Diags.diagnose(consumeExpr->getLoc(),
-                               diag::consume_expression_partial_copyable);
-          }
-          return;
-        }
-        Ctx.Diags.diagnose(consumeExpr->getLoc(),
-                           diag::consume_expression_not_passed_lvalue);
-        return;
-      }
+      auto diags = findSyntacticErrorForConsume(DC->getParentModule(),
+                                                consumeExpr->getLoc(),
+                                                consumeExpr->getSubExpr());
+      for (auto &diag : diags)
+        diag.emit(Ctx);
     }
 
     void checkCopyExpr(CopyExpr *copyExpr) {
@@ -1519,6 +1443,82 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           const_cast<CollectionExpr *>(collection));
     }
   }
+}
+
+DeferredDiags swift::findSyntacticErrorForConsume(
+    ModuleDecl *module, SourceLoc loc, Expr *subExpr) {
+  assert(!isa<ConsumeExpr>(subExpr) && "operates on the sub-expr of a consume");
+
+  DeferredDiags result;
+  const bool noncopyable =
+      subExpr->getType()->getCanonicalType()->isNoncopyable();
+
+  bool partial = false;
+  Expr *current = subExpr;
+  while (current) {
+    if (auto *dre = dyn_cast<DeclRefExpr>(current)) {
+      if (partial & !noncopyable)
+        result.emplace_back(loc, diag::consume_expression_partial_copyable);
+
+      // The chain of member_ref_exprs and load_exprs terminates at a
+      // declref_expr.  This is legal.
+      break;
+    }
+    // Look through loads.
+    if (auto *le = dyn_cast<LoadExpr>(current)) {
+      current = le->getSubExpr();
+      continue;
+    }
+    auto *mre = dyn_cast<MemberRefExpr>(current);
+    if (mre) {
+      auto *vd = dyn_cast<VarDecl>(mre->getMember().getDecl());
+      if (!vd) {
+        result.emplace_back(loc, diag::consume_expression_non_storage);
+        break;
+      }
+      partial = true;
+      AccessStrategy strategy = vd->getAccessStrategy(
+          mre->getAccessSemantics(), AccessKind::Read,
+          module, ResilienceExpansion::Minimal);
+      if (strategy.getKind() != AccessStrategy::Storage) {
+        if (noncopyable) {
+          result.emplace_back(loc, diag::consume_expression_non_storage);
+          result.emplace_back(mre->getLoc(),
+                            diag::note_consume_expression_non_storage_property);
+          break;
+        }
+        result.emplace_back(loc, diag::consume_expression_partial_copyable);
+        break;
+      }
+      current = mre->getBase();
+      continue;
+    }
+    auto *ce = dyn_cast<CallExpr>(current);
+    if (ce) {
+      if (noncopyable) {
+        result.emplace_back(loc, diag::consume_expression_non_storage);
+        result.emplace_back(ce->getLoc(),
+                            diag::note_consume_expression_non_storage_call);
+        break;
+      }
+      result.emplace_back(loc, diag::consume_expression_partial_copyable);
+      break;
+    }
+    auto *se = dyn_cast<SubscriptExpr>(current);
+    if (se) {
+      if (noncopyable) {
+        result.emplace_back(loc, diag::consume_expression_non_storage);
+        result.emplace_back(se->getLoc(),
+                          diag::note_consume_expression_non_storage_subscript);
+        break;
+      }
+      result.emplace_back(loc, diag::consume_expression_partial_copyable);
+      break;
+    }
+    result.emplace_back(loc, diag::consume_expression_not_passed_lvalue);
+    break;
+  }
+  return result;
 }
 
 
@@ -6722,4 +6722,10 @@ bool swift::diagnoseUnhandledThrowsInAsyncContext(DeclContext *dc,
   }
 
   return false;
+}
+
+void DeferredDiag::emit(swift::ASTContext &ctx) {
+  assert(loc && "no loc... already emitted?");
+  ctx.Diags.diagnose(loc, diag);
+  loc = SourceLoc();
 }

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -161,6 +161,29 @@ namespace swift {
     static bool shouldWalkIntoDeclInClosureContext(Decl *D);
   };
 
+  // A simple, deferred diagnostic container.
+  struct DeferredDiag {
+    SourceLoc loc;
+    ZeroArgDiagnostic diag;
+    DeferredDiag(SourceLoc loc, ZeroArgDiagnostic diag)
+      : loc(loc), diag(diag) {}
+
+    // Emits this diagnostic.
+    void emit(ASTContext &ctx);
+  };
+
+  using DeferredDiags = SmallVector<DeferredDiag, 2>;
+
+  /// Search for syntactic errors in the given sub-expression of a ConsumeExpr,
+  /// collecting them without actually emitting them.
+  ///
+  /// \param loc corresponds to the location of the 'consume' for which
+  ///            diagnostics should be collected, if any.
+  ///
+  /// \returns an empty collection if there are no errors.
+  DeferredDiags findSyntacticErrorForConsume(ModuleDecl *module,
+                                             SourceLoc loc,
+                                             Expr *subExpr);
 } // namespace swift
 
 #endif // SWIFT_SEMA_MISC_DIAGNOSTICS_H

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2317,6 +2317,10 @@ static Expr *lookThroughBridgeFromObjCCall(ASTContext &ctx, Expr *expr) {
 /// underlying forced downcast expression.
 ForcedCheckedCastExpr *swift::findForcedDowncast(ASTContext &ctx, Expr *expr) {
   expr = expr->getSemanticsProvidingExpr();
+
+  // Look through a consume, just in case.
+  if (auto consume = dyn_cast<ConsumeExpr>(expr))
+    expr = consume->getSubExpr();
   
   // Simple case: forced checked cast.
   if (auto forced = dyn_cast<ForcedCheckedCastExpr>(expr)) {
@@ -2366,6 +2370,18 @@ ForcedCheckedCastExpr *swift::findForcedDowncast(ASTContext &ctx, Expr *expr) {
   }
 
   return nullptr;
+}
+
+bool swift::canAddExplicitConsume(ModuleDecl *module, Expr *expr) {
+  expr = expr->getSemanticsProvidingExpr();
+
+  // Is it already wrapped in a `consume`?
+  if (isa<ConsumeExpr>(expr))
+    return false;
+
+  // Is this expression valid to wrap inside a `consume`?
+  auto diags = findSyntacticErrorForConsume(module, SourceLoc(), expr);
+  return diags.empty();
 }
 
 void ConstraintSystem::forEachExpr(

--- a/test/Sema/moveonly_casts.swift
+++ b/test/Sema/moveonly_casts.swift
@@ -1,0 +1,126 @@
+// RUN: %target-typecheck-verify-swift
+
+struct NC: ~Copyable {}
+
+func testBorrowing(_ v: borrowing NC?) {}
+func testConsuming(_ v: consuming NC?) {}
+func testInout(_ v: inout NC?) {}
+
+class MethodSir {
+  func borrow(_ v: borrowing NC?) {}
+  func consume(_ v: consuming NC?) {}
+}
+
+func testExplicitCasts() {
+  let nc = NC()
+  _ = nc as NC?
+}
+
+func testCalls() {
+  let method = MethodSir()
+  let foo = NC()
+  testBorrowing(foo) // expected-warning {{implicit conversion to 'NC?' is consuming}}
+                     // expected-note@-1 {{add 'consume' to silence this warning}} {{17-17=consume }}
+  testBorrowing(consume foo)
+  testBorrowing(foo as NC?)
+
+  method.borrow(foo) // expected-warning {{implicit conversion to 'NC?' is consuming}}
+                     // expected-note@-1 {{add 'consume' to silence this warning}} {{17-17=consume }}
+  method.borrow(consume foo)
+
+  testConsuming(foo)
+  testConsuming(consume foo)
+
+  var optNC: NC? = NC() // ConstraintLocator::ContextualType
+  testInout(&optNC)
+}
+
+func testReturn() -> NC? {
+    let foo = NC()
+    return foo // ConstraintLocator::ContextualType
+}
+
+func higherOrder(_ f: () -> NC?) -> NC? {
+  if let nc = f() {
+    nc // ConstraintLocator::ContextualType
+  } else {
+    nil
+  }
+}
+func callHigherOrder() {
+  let nc = NC()
+  let _ = higherOrder { nc } // ConstraintLocator::ClosureBody
+
+  let _ = higherOrder { return nc } // ConstraintLocator::ClosureBody
+}
+
+
+func delay(_ f: @autoclosure () -> NC?) -> NC? { f() }
+
+func testDelay() {
+  let nc = NC()
+  let _ = delay(nc) // expected-warning {{implicit conversion to 'NC?' is consuming}}
+                    // expected-note@-1 {{add 'consume' to silence this warning}} {{17-17=consume }}
+}
+
+struct PropCity {
+  var harmless1: NC? { NC() }
+  var harmless2: NC? {
+    get { return NC() }
+  }
+
+  subscript(_ i: Int) -> NC? { return NC() }
+
+  func chk(_ t: borrowing NC!) {}
+  func chkWithDefaultArg(_ oath: borrowing NC? = NC()) {}
+  func test(_ nc: consuming NC) {
+    chk(nc) // expected-warning {{implicit conversion to 'NC?' is consuming}}
+            // expected-note@-1 {{add 'consume' to silence this warning}} {{9-9=consume }}
+
+    chk(consume nc)
+
+    chkWithDefaultArg()
+    chkWithDefaultArg(nc) // expected-warning {{implicit conversion to 'NC?' is consuming}}
+                          // expected-note@-1 {{add 'consume' to silence this warning}} {{23-23=consume }}
+  }
+}
+
+protocol Veggie: ~Copyable {}
+struct Carrot: ~Copyable, Veggie {}
+
+func restockBorrow(_ x: borrowing any Veggie & ~Copyable) {}
+func restockConsume(_ x: consuming any Veggie & ~Copyable) {}
+
+func checkExistential() {
+  let carrot = Carrot()
+  restockBorrow(carrot) // expected-warning {{implicit conversion to 'any Veggie & ~Copyable' is consuming}}
+                        // expected-note@-1 {{add 'consume' to silence this warning}} {{17-17=consume }}
+  restockBorrow(consume carrot)
+
+  restockConsume(carrot)
+}
+
+func genericErasure<T: Veggie & ~Copyable>(_ veg: consuming T) {
+  restockBorrow(veg) // expected-warning {{implicit conversion to 'any Veggie & ~Copyable' is consuming}}
+                     // expected-note@-1 {{add 'consume' to silence this warning}} {{17-17=consume }}
+  restockBorrow(consume veg)
+  restockBorrow(veg as any Veggie & ~Copyable)
+  restockConsume(veg)
+
+  let _ = veg as any Veggie & ~Copyable
+}
+
+extension Veggie where Self: ~Copyable {
+  func inspect(_ b: borrowing any Veggie & ~Copyable) {}
+}
+extension Carrot {
+  consuming func check() {
+    inspect(self) // expected-warning {{implicit conversion to 'any Veggie & ~Copyable' is consuming}}
+                  // expected-note@-1 {{add 'consume' to silence this warning}} {{13-13=consume }}
+    inspect(consume self)
+    inspect(self as any Veggie & ~Copyable)
+
+    let _: any Veggie & ~Copyable = self
+  }
+}
+

--- a/test/Sema/moveonly_casts.swift
+++ b/test/Sema/moveonly_casts.swift
@@ -19,13 +19,13 @@ func testExplicitCasts() {
 func testCalls() {
   let method = MethodSir()
   let foo = NC()
-  testBorrowing(foo) // expected-warning {{implicit conversion to 'NC?' is consuming}}
-                     // expected-note@-1 {{add 'consume' to silence this warning}} {{17-17=consume }}
+  testBorrowing(foo) // expected-error {{implicit conversion to 'NC?' is consuming}}
+                     // expected-note@-1 {{add 'consume' to make consumption explicit}} {{17-17=consume }}
   testBorrowing(consume foo)
   testBorrowing(foo as NC?)
 
-  method.borrow(foo) // expected-warning {{implicit conversion to 'NC?' is consuming}}
-                     // expected-note@-1 {{add 'consume' to silence this warning}} {{17-17=consume }}
+  method.borrow(foo) // expected-error {{implicit conversion to 'NC?' is consuming}}
+                     // expected-note@-1 {{add 'consume' to make consumption explicit}} {{17-17=consume }}
   method.borrow(consume foo)
 
   testConsuming(foo)
@@ -59,8 +59,8 @@ func delay(_ f: @autoclosure () -> NC?) -> NC? { f() }
 
 func testDelay() {
   let nc = NC()
-  let _ = delay(nc) // expected-warning {{implicit conversion to 'NC?' is consuming}}
-                    // expected-note@-1 {{add 'consume' to silence this warning}} {{17-17=consume }}
+  let _ = delay(nc) // expected-error {{implicit conversion to 'NC?' is consuming}}
+                    // expected-note@-1 {{add 'consume' to make consumption explicit}} {{17-17=consume }}
 }
 
 struct PropCity {
@@ -74,14 +74,14 @@ struct PropCity {
   func chk(_ t: borrowing NC!) {}
   func chkWithDefaultArg(_ oath: borrowing NC? = NC()) {}
   func test(_ nc: consuming NC) {
-    chk(nc) // expected-warning {{implicit conversion to 'NC?' is consuming}}
-            // expected-note@-1 {{add 'consume' to silence this warning}} {{9-9=consume }}
+    chk(nc) // expected-error {{implicit conversion to 'NC?' is consuming}}
+            // expected-note@-1 {{add 'consume' to make consumption explicit}} {{9-9=consume }}
 
     chk(consume nc)
 
     chkWithDefaultArg()
-    chkWithDefaultArg(nc) // expected-warning {{implicit conversion to 'NC?' is consuming}}
-                          // expected-note@-1 {{add 'consume' to silence this warning}} {{23-23=consume }}
+    chkWithDefaultArg(nc) // expected-error {{implicit conversion to 'NC?' is consuming}}
+                          // expected-note@-1 {{add 'consume' to make consumption explicit}} {{23-23=consume }}
   }
 }
 
@@ -93,16 +93,16 @@ func restockConsume(_ x: consuming any Veggie & ~Copyable) {}
 
 func checkExistential() {
   let carrot = Carrot()
-  restockBorrow(carrot) // expected-warning {{implicit conversion to 'any Veggie & ~Copyable' is consuming}}
-                        // expected-note@-1 {{add 'consume' to silence this warning}} {{17-17=consume }}
+  restockBorrow(carrot) // expected-error {{implicit conversion to 'any Veggie & ~Copyable' is consuming}}
+                        // expected-note@-1 {{add 'consume' to make consumption explicit}} {{17-17=consume }}
   restockBorrow(consume carrot)
 
   restockConsume(carrot)
 }
 
 func genericErasure<T: Veggie & ~Copyable>(_ veg: consuming T) {
-  restockBorrow(veg) // expected-warning {{implicit conversion to 'any Veggie & ~Copyable' is consuming}}
-                     // expected-note@-1 {{add 'consume' to silence this warning}} {{17-17=consume }}
+  restockBorrow(veg) // expected-error {{implicit conversion to 'any Veggie & ~Copyable' is consuming}}
+                     // expected-note@-1 {{add 'consume' to make consumption explicit}} {{17-17=consume }}
   restockBorrow(consume veg)
   restockBorrow(veg as any Veggie & ~Copyable)
   restockConsume(veg)
@@ -115,12 +115,11 @@ extension Veggie where Self: ~Copyable {
 }
 extension Carrot {
   consuming func check() {
-    inspect(self) // expected-warning {{implicit conversion to 'any Veggie & ~Copyable' is consuming}}
-                  // expected-note@-1 {{add 'consume' to silence this warning}} {{13-13=consume }}
+    inspect(self) // expected-error {{implicit conversion to 'any Veggie & ~Copyable' is consuming}}
+                  // expected-note@-1 {{add 'consume' to make consumption explicit}} {{13-13=consume }}
     inspect(consume self)
     inspect(self as any Veggie & ~Copyable)
 
     let _: any Veggie & ~Copyable = self
   }
 }
-


### PR DESCRIPTION
There are a number of implicit conversions in Swift, such as to Optional
and to an existential, which are now possible for noncopyable types.
 
But all type casts are consuming operations for noncopyable types. So 
it's confusing when a function that takes a borrowed argument of 
optional type appears to be consuming:

```
func f(_ x: borrowing NC?) { ... }

let x = NC()
f(x)
f(x) // error!
```
 
So, rather than for people to write `x as T?` around all implicit 
conversions, require them to write `consume x` around expressions 
that will consume some lvalue. Since that makes it much more clear what 
the consequences will be.

Expressions like `f(g())`, where you're passing an rvalue to the callee,
are not confusing. And those are exactly the expressions you're not 
allowed to write `consume` for, anyway.

fixes rdar://127450418