### PR TITLE
[6.0] Correctly apply @isolated(any) even when converting to an optional type

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5494,19 +5494,18 @@ synthesizeBaseClassFieldGetterOrAddressGetterBody(AbstractFunctionDecl *afd,
   auto *baseMemberCallExpr =
       CallExpr::createImplicit(ctx, baseMemberDotCallExpr, argumentList);
   Type resultType = baseGetterMethod->getResultInterfaceType();
-  if (kind == AccessorKind::Address && resultType->isUnsafeMutablePointer()) {
-    resultType = getterDecl->getResultInterfaceType();
-  }
   baseMemberCallExpr->setType(resultType);
   baseMemberCallExpr->setThrows(nullptr);
 
   Expr *returnExpr = baseMemberCallExpr;
   // Cast an 'address' result from a mutable pointer if needed.
   if (kind == AccessorKind::Address &&
-      baseGetterMethod->getResultInterfaceType()->isUnsafeMutablePointer())
+      baseGetterMethod->getResultInterfaceType()->isUnsafeMutablePointer()) {
+    auto finalResultType = getterDecl->getResultInterfaceType();
     returnExpr = SwiftDeclSynthesizer::synthesizeReturnReinterpretCast(
-        ctx, baseGetterMethod->getResultInterfaceType(), resultType,
+        ctx, baseGetterMethod->getResultInterfaceType(), finalResultType,
         returnExpr);
+  }
 
   auto *returnStmt = ReturnStmt::createImplicit(ctx, returnExpr);
 

--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -81,8 +81,10 @@ ManagedValue ArgumentSource::getAsSingleValue(SILGenFunction &SGF,
                                               SILType loweredTy,
                                               SGFContext C) && {
   auto substFormalType = getSubstRValueType();
+  auto loweredFormalTy = SGF.getLoweredType(substFormalType);
   auto conversion =
-    Conversion::getSubstToOrig(origFormalType, substFormalType, loweredTy);
+    Conversion::getSubstToOrig(origFormalType, substFormalType,
+                               loweredFormalTy, loweredTy);
   return std::move(*this).getConverted(SGF, conversion, C);
 }
 

--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -319,6 +319,21 @@ public:
     return getReabstractionOutputLoweredType();
   }
 
+  /// Given that this conversion is not one of the specialized bridging
+  /// conversion (i.e. it is either a reabstraction or a subtype conversion),
+  /// rebuild it with the given source type.
+  Conversion withSourceType(AbstractionPattern origSourceType,
+                            CanType sourceType,
+                            SILType loweredSourceTy) const;
+  Conversion withSourceType(SILGenFunction &SGF, CanType sourceType) const;
+
+  /// Given that this conversion is not one of the specialized bridging
+  /// conversion (i.e. it is either a reabstraction or a subtype conversion),
+  /// rebuild it with the given result type.
+  Conversion withResultType(AbstractionPattern origResultType,
+                            CanType sourceType,
+                            SILType loweredSourceTy) const;
+
   ManagedValue emit(SILGenFunction &SGF, SILLocation loc,
                     ManagedValue source, SGFContext ctxt) const;
 

--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -37,6 +37,9 @@ public:
     /// implicit force cast.
     ForceAndBridgeToObjC,
 
+    /// Force an optional value.
+    ForceOptional,
+
     /// A bridging conversion from a foreign type.
     BridgeFromObjC,
 
@@ -61,6 +64,7 @@ public:
     switch (kind) {
     case BridgeToObjC:
     case ForceAndBridgeToObjC:
+    case ForceOptional:
     case BridgeFromObjC:
     case BridgeResultFromObjC:
     case AnyErasure:
@@ -80,6 +84,7 @@ public:
 
     case BridgeToObjC:
     case ForceAndBridgeToObjC:
+    case ForceOptional:
     case BridgeFromObjC:
     case BridgeResultFromObjC:
     case AnyErasure:
@@ -114,6 +119,7 @@ private:
     switch (kind) {
     case BridgeToObjC:
     case ForceAndBridgeToObjC:
+    case ForceOptional:
     case BridgeFromObjC:
     case BridgeResultFromObjC:
     case AnyErasure:
@@ -236,6 +242,24 @@ public:
 
   SILType getBridgingLoweredResultType() const {
     return Types.get<BridgingTypes>(Kind).LoweredResultType;
+  }
+
+  CanType getSourceType() const {
+    if (isBridging())
+      return getBridgingSourceType();
+    return getReabstractionInputSubstType();
+  }
+
+  CanType getResultType() const {
+    if (isBridging())
+      return getBridgingResultType();
+    return getReabstractionOutputSubstType();
+  }
+
+  SILType getLoweredResultType() const {
+    if (isBridging())
+      return getBridgingLoweredResultType();
+    return getReabstractionOutputLoweredType();
   }
 
   ManagedValue emit(SILGenFunction &SGF, SILLocation loc,

--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -294,9 +294,9 @@ public:
   bool isForced() const { return Forced; }
 };
 
-std::optional<ConversionPeepholeHint>
-canPeepholeConversions(SILGenFunction &SGF, const Conversion &outerConversion,
-                       const Conversion &innerConversion);
+bool canPeepholeConversions(SILGenFunction &SGF,
+                            const Conversion &outer,
+                            const Conversion &inner);
 
 /// An initialization where we ultimately want to apply a conversion to
 /// the value before completing the initialization.

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -234,6 +234,11 @@ public:
   /// The values must not require any cleanups.
   SILValue getUnmanagedSingleValue(SILGenFunction &SGF, SILLocation l) const &;
 
+  SILType getTypeOfSingleValue() const & {
+    assert(isComplete() && values.size() == 1);
+    return values[0].getType();
+  }
+
   ManagedValue getScalarValue() && {
     if (isInContext()) {
       makeUsed();

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -306,7 +306,7 @@ public:
                                          loweredResultTy);
         } else {
           return Conversion::getOrigToSubst(origType, substType,
-                                            loweredResultTy);
+                                            value.getType(), loweredResultTy);
         }
       }();
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3909,6 +3909,7 @@ private:
         case SILFunctionLanguage::Swift:
           return Conversion::getSubstToOrig(origParamType,
                                             arg.getSubstRValueType(),
+                                            loweredSubstArgType,
                                             param.getSILStorageInterfaceType());
         case SILFunctionLanguage::C:
           return Conversion::getBridging(Conversion::BridgeToObjC,
@@ -4134,7 +4135,9 @@ private:
         convertingInit.emplace(
             Conversion::getSubstToOrig(
                 origExpansionType.getPackExpansionPatternType(),
-                substPatternType, expectedElementType),
+                substPatternType,
+                SILType::getPrimitiveObjectType(loweredPatternTy),
+                expectedElementType),
             SGFContext(innermostInit));
         innermostInit = &*convertingInit;
       }
@@ -7361,6 +7364,7 @@ ManagedValue SILGenFunction::emitAsyncLetStart(
       origParamType);
   
   auto conversion = Conversion::getSubstToOrig(origParam, substParamType,
+                                     getLoweredType(asyncLetEntryPoint->getType()),
                                      getLoweredType(origParam, substParamType));
   auto taskFunction = emitConvertedRValue(asyncLetEntryPoint, conversion);
 

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1637,8 +1637,18 @@ static ManagedValue emitCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
     CanType substParamType = fnArg.getSubstRValueType();
     auto loweredParamTy = SGF.getLoweredType(origParamType, substParamType);
 
+    // The main actor path doesn't give us a value that actually matches the
+    // formal type at all, so this is the best we can do.
+    SILType loweredSubstParamTy;
+    if (fnArg.isRValue()) {
+      loweredSubstParamTy = fnArg.peekRValue().getTypeOfSingleValue();
+    } else {
+      loweredSubstParamTy = SGF.getLoweredType(substParamType);
+    }
+
     auto conversion =
-      Conversion::getSubstToOrig(origParamType, substParamType, loweredParamTy);
+      Conversion::getSubstToOrig(origParamType, substParamType,
+                                 loweredSubstParamTy, loweredParamTy);
     return std::move(fnArg).getConverted(SGF, conversion);
   }();
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1649,7 +1649,8 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
 
     if (needsConvertingInit) {
       Conversion conversion =
-          Conversion::getSubstToOrig(origType, substType, loweredResultTy);
+          Conversion::getSubstToOrig(origType, substType,
+                                     loweredSubstTy, loweredResultTy);
 
       ConvertingInitialization convertingInit(conversion,
                                               SGFContext(memberInit.get()));

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -325,20 +325,40 @@ ManagedValue
 SILGenFunction::emitOptionalSome(SILLocation loc, SILType optTy,
                                  ValueProducerRef produceValue,
                                  SGFContext C) {
-  // If the conversion is a bridging conversion from an optional type,
-  // do a bridging conversion from the non-optional type instead.
-  // TODO: should this be a general thing for all conversions?
+  // If we're emitting into a conversion, try to peephole the
+  // injection into it.
   if (auto optInit = C.getAsConversion()) {
     const auto &optConversion = optInit->getConversion();
-    if (optConversion.isBridging()) {
-      auto sourceValueType =
-          optConversion.getBridgingSourceType().getOptionalObjectType();
-      assert(sourceValueType);
-      if (auto valueConversion =
-            optConversion.adjustForInitialOptionalConversions(sourceValueType)){
-        return optInit->emitWithAdjustedConversion(*this, loc, *valueConversion,
-                                                   produceValue);
-      }
+
+    auto adjustment = optConversion.adjustForInitialOptionalInjection();
+
+    // If the adjustment gives us a conversion that produces an optional
+    // value, that completely takes over emission.  This generally happens
+    // only because of bridging.
+    if (adjustment.isInjection()) {
+      return optInit->emitWithAdjustedConversion(*this, loc,
+                                      adjustment.getInjectionConversion(),
+                                                 produceValue);
+
+    // If the adjustment gives us a conversion that produces a non-optional
+    // value, we need to produce the value under that conversion and then
+    // inject that into an optional.  We can do that by recursing.  This
+    // will terminate because the recursive call to emitOptionalSome gets
+    // passed a strictly "smaller" context: the parent context of the
+    // converting context we were passed.
+    } else if (adjustment.isValue()) {
+      auto produceConvertedValue = [&](SILGenFunction &SGF,
+                                       SILLocation loc,
+                                       SGFContext C) {
+        return SGF.emitConvertedRValue(loc, adjustment.getValueConversion(),
+                                       C, produceValue);
+      };
+      auto result = emitOptionalSome(loc, optConversion.getLoweredResultType(),
+                                     produceConvertedValue,
+                                     optInit->getFinalContext());
+      optInit->initWithConvertedValue(*this, loc, result);
+      optInit->finishInitialization(*this);
+      return ManagedValue::forInContext();
     }
   }
 
@@ -1141,20 +1161,6 @@ void ConvertingInitialization::
   });
 }
 
-namespace {
-struct CombinedConversions {
-  std::optional<Conversion> first;
-  std::optional<Conversion> second;
-
-  explicit CombinedConversions() {}
-  explicit CombinedConversions(const Conversion &first)
-    : first(first) {}
-  explicit CombinedConversions(const Conversion &first,
-                               const Conversion &second)
-    : first(first), second(second) {}
-  };
-}
-
 static std::optional<CombinedConversions>
 combineConversions(SILGenFunction &SGF, const Conversion &outer,
                    const Conversion &inner);
@@ -1258,6 +1264,7 @@ ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
                               ManagedValue value, SGFContext C) const {
   switch (getKind()) {
   case AnyErasure:
+  case BridgingSubtype:
   case Subtype:
     return SGF.emitTransformedValue(loc, value, getBridgingSourceType(),
                                     getBridgingResultType(), C);
@@ -1312,6 +1319,48 @@ ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
   llvm_unreachable("bad kind");
 }
 
+OptionalInjectionConversion
+Conversion::adjustForInitialOptionalInjection() const {
+  switch (getKind()) {
+  case Reabstract:
+    return OptionalInjectionConversion::forValue(
+      getReabstract(
+        getReabstractionInputOrigType().getOptionalObjectType(),
+        getReabstractionInputSubstType().getOptionalObjectType(),
+        getReabstractionInputLoweredType().getOptionalObjectType(),
+        getReabstractionOutputOrigType().getOptionalObjectType(),
+        getReabstractionOutputSubstType().getOptionalObjectType(),
+        getReabstractionOutputLoweredType().getOptionalObjectType())
+    );
+
+  case Subtype:
+    return OptionalInjectionConversion::forValue(
+      getSubtype(
+        getBridgingSourceType().getOptionalObjectType(),
+        getBridgingResultType().getOptionalObjectType(),
+        getBridgingLoweredResultType().getOptionalObjectType())
+    );
+
+  // TODO: can these actually happen?
+  case ForceOptional:
+  case ForceAndBridgeToObjC:
+  case BridgingSubtype:
+    return OptionalInjectionConversion();
+
+  case AnyErasure:
+  case BridgeToObjC:
+  case BridgeFromObjC:
+  case BridgeResultFromObjC:
+    return OptionalInjectionConversion::forInjection(
+      getBridging(getKind(), getBridgingSourceType().getOptionalObjectType(),
+                  getBridgingResultType(),
+                  getBridgingLoweredResultType(),
+                  isBridgingExplicit())
+    );
+  }
+  llvm_unreachable("bad kind");
+}
+
 std::optional<Conversion>
 Conversion::adjustForInitialOptionalConversions(CanType newSourceType) const {
   switch (getKind()) {
@@ -1323,6 +1372,7 @@ Conversion::adjustForInitialOptionalConversions(CanType newSourceType) const {
   case ForceAndBridgeToObjC:
     return std::nullopt;
 
+  case BridgingSubtype:
   case Subtype:
   case AnyErasure:
   case BridgeToObjC:
@@ -1344,6 +1394,7 @@ std::optional<Conversion> Conversion::adjustForInitialForceValue() const {
   case BridgeResultFromObjC:
   case ForceOptional:
   case ForceAndBridgeToObjC:
+  case BridgingSubtype:
   case Subtype:
     return std::nullopt;
 
@@ -1397,6 +1448,8 @@ void Conversion::print(llvm::raw_ostream &out) const {
     return printReabstraction(*this, out, "Reabstract");
   case AnyErasure:
     return printBridging(*this, out, "AnyErasure");
+  case BridgingSubtype:
+    return printBridging(*this, out, "BridgingSubtype");
   case Subtype:
     return printBridging(*this, out, "Subtype");
   case ForceOptional:
@@ -1749,7 +1802,8 @@ combineBridging(SILGenFunction &SGF,
                                 sourceType, resultType, loweredResultTy));
     } else {
       return applyPeephole(
-        Conversion::getSubtype(sourceType, resultType, loweredResultTy));
+        Conversion::getBridging(Conversion::BridgingSubtype,
+                                sourceType, resultType, loweredResultTy));
     }
   }
 
@@ -1777,7 +1831,8 @@ combineBridging(SILGenFunction &SGF,
   // Look for a subtype relationship between the source and destination.
   if (areRelatedTypesForBridgingPeephole(sourceType, resultType)) {
     return applyPeephole(
-      Conversion::getSubtype(sourceType, resultType, loweredResultTy));
+      Conversion::getBridging(Conversion::BridgingSubtype,
+                              sourceType, resultType, loweredResultTy));
   }
 
   // If the inner conversion is a result conversion that removes
@@ -1792,7 +1847,8 @@ combineBridging(SILGenFunction &SGF,
         sourceType = sourceValueType;
         loweredSourceTy = loweredSourceTy.getOptionalObjectType();
         return applyPeephole(
-          Conversion::getSubtype(sourceValueType, resultType, loweredResultTy));
+          Conversion::getBridging(Conversion::BridgingSubtype,
+                                  sourceValueType, resultType, loweredResultTy));
       }
     }
   }
@@ -1824,6 +1880,7 @@ combineConversions(SILGenFunction &SGF, const Conversion &outer,
     return std::nullopt;
 
   case Conversion::AnyErasure:
+  case Conversion::BridgingSubtype:
   case Conversion::BridgeFromObjC:
   case Conversion::BridgeResultFromObjC:
     // TODO: maybe peephole bridging through a Swift type?

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -679,7 +679,7 @@ static BridgingConversion getBridgingConversion(Expr *E) {
 
   // If we peeked through an opening, and we didn't recognize a specific
   // pattern above involving the opaque value, make sure we use the opening
-  // as the final expression instead of accidentally look through it.
+  // as the final expression instead of accidentally looking through it.
   if (open)
     return {open, std::nullopt, 0};
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2853,9 +2853,6 @@ wrappedValueAutoclosurePlaceholder(const AbstractClosureExpr *e) {
 static std::optional<FunctionTypeInfo>
 tryGetSpecializedClosureTypeFromContext(CanAnyFunctionType closureType,
                                         const Conversion &conv) {
-  // NOTE: if you support new kinds of conversion here, make sure you can
-  // rewrite them in narrowClosureConvention below
-
   if (conv.getKind() == Conversion::Reabstract) {
     // We don't care about the input type here; we'll be emitting that
     // based on the closure.
@@ -2879,33 +2876,6 @@ tryGetSpecializedClosureTypeFromContext(CanAnyFunctionType closureType,
 
   // No other kinds of conversion.
   return std::nullopt;
-}
-
-/// Given that tryGetSpecializedClosureTypeFromContext was able to return
-/// specialized closure type information from the given contextual conversion,
-/// construct a new conversion that starts from the given type, which is a
-/// supertype of the previous closure type but a subtype of the final type.
-/// The conversion should end with the same type.
-static Conversion narrowClosureConversion(SILGenFunction &SGF,
-                                          CanAnyFunctionType newClosureType,
-                                          const Conversion &conv) {
-  if (conv.getKind() == Conversion::Reabstract) {
-    auto inputOrigType = conv.getReabstractionInputOrigType();
-    auto inputLoweredTy = SGF.getLoweredType(inputOrigType, newClosureType);
-    return Conversion::getReabstract(inputOrigType, newClosureType,
-                                     inputLoweredTy,
-                                     conv.getReabstractionOutputOrigType(),
-                                     conv.getReabstractionOutputSubstType(),
-                                     conv.getReabstractionOutputLoweredType());
-  }
-
-  if (conv.getKind() == Conversion::Subtype) {
-    return Conversion::getSubtype(newClosureType,
-                                  conv.getBridgingResultType(),
-                                  conv.getBridgingLoweredResultType());
-  }
-
-  llvm_unreachable("mismatch with tryGetSpecializedClosureTypeFromContext");
 }
 
 /// Whether the given abstraction pattern as an opaque thrown error.
@@ -3020,7 +2990,7 @@ RValueEmitter::tryEmitConvertedClosure(AbstractClosureExpr *e,
     auto erasedResult = emitClosureReference(e, erasureInfo);
 
     // Narrow the original conversion to start from the erased closure type.
-    auto convAfterErasure = narrowClosureConversion(SGF, erasedClosureType, conv);
+    auto convAfterErasure = conv.withSourceType(SGF, erasedClosureType);
 
     // Apply the narrowed conversion.
     return convAfterErasure.emit(SGF, e, erasedResult, SGFContext());

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -4635,7 +4635,8 @@ ManagedValue SILGenFunction::emitLoad(SILLocation loc, SILValue addr,
                                 origFormalType.getType(),
                                 substFormalType, rvalueTL.getLoweredType())
       : Conversion::getOrigToSubst(origFormalType, substFormalType,
-                                   rvalueTL.getLoweredType());
+                                   /*input*/addrRValueType,
+                                   /*output*/rvalueTL.getLoweredType());
 
   return emitConvertedRValue(loc, conversion, C,
       [&](SILGenFunction &SGF, SILLocation loc, SGFContext C) {

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -461,9 +461,12 @@ static void wrapInSubstToOrigInitialization(SILGenFunction &SGF,
                                     AbstractionPattern origType,
                                     CanType substType,
                                     SILType expectedTy) {
-  if (expectedTy.getASTType() != SGF.getLoweredRValueType(substType)) {
+  auto loweredSubstTy = SGF.getLoweredRValueType(substType);
+  if (expectedTy.getASTType() != loweredSubstTy) {
     auto conversion =
-      Conversion::getSubstToOrig(origType, substType, expectedTy);
+      Conversion::getSubstToOrig(origType, substType,
+                                 SILType::getPrimitiveObjectType(loweredSubstTy),
+                                 expectedTy);
     auto convertingInit = new ConvertingInitialization(conversion,
                                                        std::move(init));
     init.reset(convertingInit);
@@ -733,10 +736,11 @@ void SILGenFunction::emitReturnExpr(SILLocation branchLoc,
     // Does the return context require reabstraction?
     RValue RV;
     
-    auto loweredRetTy = getLoweredType(origRetTy, retTy);
-    if (loweredRetTy != getLoweredType(retTy)) {
+    auto loweredRetTy = getLoweredType(retTy);
+    auto loweredResultTy = getLoweredType(origRetTy, retTy);
+    if (loweredResultTy != loweredRetTy) {
       auto conversion = Conversion::getSubstToOrig(origRetTy, retTy,
-                                                   loweredRetTy);
+                                                   loweredRetTy, loweredResultTy);
       RV = RValue(*this, ret, emitConvertedRValue(ret, conversion));
     } else {
       RV = emitRValue(ret);

--- a/test/SILGen/isolated_any.swift
+++ b/test/SILGen/isolated_any.swift
@@ -383,6 +383,29 @@ extension MyActor {
   func asyncAction() async {}
 }
 
+func takeInheritingOptionalAsyncIsolatedAny(@_inheritActorContext fn: Optional<@isolated(any) () async -> ()>) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC0a20EraseInheritingAsyncC19ClosureIntoOptionalyyF
+// CHECK:         // function_ref closure #1
+// CHECK-NEXT:    [[CLOSURE_FN:%.*]] = function_ref @$s4test7MyActorC0a20EraseInheritingAsyncC19ClosureIntoOptionalyyFyyYaYbcfU_ : $@convention(thin) @Sendable @async (@guaranteed Optional<any Actor>, @sil_isolated @guaranteed MyActor) -> ()
+// CHECK-NEXT:    [[CAPTURE:%.*]] = copy_value %0 : $MyActor
+// CHECK-NEXT:    [[CAPTURE_FOR_ISOLATION:%.*]] = copy_value [[CAPTURE]] : $MyActor
+// CHECK-NEXT:    [[ISOLATION_OBJECT:%.*]] = init_existential_ref [[CAPTURE_FOR_ISOLATION]] : $MyActor : $MyActor, $any Actor
+// CHECK-NEXT:    [[ISOLATION:%.*]] = enum $Optional<any Actor>, #Optional.some!enumelt, [[ISOLATION_OBJECT]] : $any Actor
+// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [isolated_any] [[CLOSURE_FN]]([[ISOLATION]], [[CAPTURE]])
+// CHECK-NEXT:    [[OPT_CLOSURE:%.*]] = enum $Optional<@isolated(any) @Sendable @async @callee_guaranteed () -> ()>, #Optional.some!enumelt, [[CLOSURE]] :
+// CHECK-NEXT:    // function_ref
+// CHECK-NEXT:    [[TAKE_FN:%.*]] = function_ref @$s4test38takeInheritingOptionalAsyncIsolatedAny2fnyyyYaYbYAcSg_tF
+// CHECK-NEXT:    apply [[TAKE_FN]]([[OPT_CLOSURE]])
+// CHECK-NEXT:    destroy_value [[OPT_CLOSURE]]
+extension MyActor {
+  func testEraseInheritingAsyncActorClosureIntoOptional() {
+    takeInheritingOptionalAsyncIsolatedAny {
+      await self.asyncAction()
+    }
+  }
+}
+
 func takeInheritingAsyncIsolatedAny_optionalResult(@_inheritActorContext fn: @escaping @isolated(any) () async -> Int?) {}
 
 // Test that we correctly handle isolation erasure from closures even when


### PR DESCRIPTION
Explanation: We weren't correctly applying `@isolated(any)` through various optional conversions.  This PR apparently just barely missed the release/6.0 branch point, and we didn't notice until now.
Scope: Affects code-generation paths for many kinds of optional fuctions 
Issue/Radar: rdar://128763372
Original PR: https://github.com/apple/swift/pull/72514
Risk: Low. The most important `@isolated(any)` functions currently in the SDK are related to task construction and are not optional.
Testing: New regression tests