### PR TITLE
[test] Add missing memmove definition for wasm tests

### DIFF
--- a/test/embedded/wasm/classes.swift
+++ b/test/embedded/wasm/classes.swift
@@ -15,6 +15,9 @@
 
 int putchar(int c) { return c; }
 void free(void *ptr) {}
+void *memmove(void *dest, const void *src, size_t n) {
+    return __builtin_memmove(dest, src, n);
+}
 
 int posix_memalign(void **memptr, size_t alignment, size_t size) {
     uintptr_t mem = __builtin_wasm_memory_grow(0, (size + 0xffff) / 0x10000);


### PR DESCRIPTION
7ae20b703907bdeeadd519a409bb44e35006c3a3 added a `memmove` dependency to the embedded build, so we need to add a definition for it in the test to satisfy the linker.
