### PR TITLE
NCGenerics: improve diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7811,33 +7811,15 @@ NOTE(noncopyable_parameter_ownership_suggestion, none,
       "add '%0' %1", (StringRef, StringRef))
 ERROR(ownership_specifier_nonescaping_closure,none,
       "'%0' cannot be applied to nonescaping closure", (StringRef))
-ERROR(noncopyable_generics, none,
-      "noncopyable type %0 cannot be used with generics yet",
-      (Type))
 ERROR(noncopyable_generics_variadic, none,
       "noncopyable type %0 cannot be used within a variadic type yet",
       (Type))
-ERROR(noncopyable_generics_specific, none,
-      "noncopyable type %0 cannot be used with generic type %1 yet",
-      (Type, Type))
-ERROR(noncopyable_generics_erasure, none,
-      "noncopyable type %0 cannot be erased to copyable existential type %1",
-      (Type, Type))
-ERROR(noncopyable_generics_metatype_cast, none,
-      "metatype %0 cannot be cast to %1 because %2 is noncopyable",
-      (Type, Type, Type))
-ERROR(noncopyable_generics_generic_param, none,
-      "noncopyable type %0 cannot be substituted for copyable %1 %2 in %3",
-      (Type, DescriptiveDeclKind, Type, DeclName))
-ERROR(noncopyable_generics_generic_param_metatype, none,
-      "metatype %4 of noncopyable type %0 cannot be substituted for copyable %1 %2 in %3",
-      (Type, DescriptiveDeclKind, Type, DeclName, Type))
-NOTE(noncopyable_generics_implicit_copyable, none,
-      "%0 %1 has an implicit Copyable requirement",
-      (DescriptiveDeclKind, Type))
-ERROR(noncopyable_element_of_pack_not_supported,none,
-      "parameter pack containing noncopyable element %0 is not supported",
-      (Type))
+NOTE(noncopyable_generics_implicit_conformance_req, none,
+     "'where %noformat0: %noformat1' is implicit here",
+     (Type, Type))
+NOTE(noncopyable_generics_implicit_composition, none,
+     "'%noformat0 & %noformat1' is implicit here",
+     (Type, Type))
 ERROR(noncopyable_effectful_getter,none,
       "%0 of noncopyable type cannot be 'async' or 'throws'", (DescriptiveDeclKind))
 ERROR(noncopyable_enums_do_not_support_indirect,none,

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -432,9 +432,6 @@ enum class FixKind : uint8_t {
   /// vs.`@OtherActor () -> Void`
   AllowGlobalActorMismatch,
 
-  /// Produce an error about a type that must be Copyable
-  MustBeCopyable,
-
   /// Allow 'each' applied to a non-pack type.
   AllowInvalidPackElement,
 
@@ -2136,32 +2133,6 @@ public:
   static NoncopyableMatchFailure forExistentialCast(Type existential) {
     assert(existential->isAnyExistentialType());
     return NoncopyableMatchFailure(ExistentialCast, existential);
-  }
-};
-
-class MustBeCopyable final : public ConstraintFix {
-  Type noncopyableTy;
-  NoncopyableMatchFailure failure;
-
-  MustBeCopyable(ConstraintSystem &cs,
-                 Type noncopyableTy,
-                 NoncopyableMatchFailure failure,
-                 ConstraintLocator *locator);
-
-public:
-  std::string getName() const override { return "remove move-only from type"; }
-
-  bool diagnose(const Solution &solution, bool asNote = false) const override;
-
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
-
-  static MustBeCopyable *create(ConstraintSystem &cs,
-                             Type noncopyableTy,
-                             NoncopyableMatchFailure failure,
-                             ConstraintLocator *locator);
-
-  static bool classof(const ConstraintFix *fix) {
-    return fix->getKind() == FixKind::MustBeCopyable;
   }
 };
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1861,20 +1861,6 @@ public:
   bool diagnoseAsError() override;
 };
 
-class NotCopyableFailure final : public FailureDiagnostic {
-  Type noncopyableTy;
-  NoncopyableMatchFailure failure;
-public:
-  NotCopyableFailure(const Solution &solution,
-                     Type noncopyableTy,
-                     NoncopyableMatchFailure failure,
-                     ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator),
-        noncopyableTy(noncopyableTy), failure(failure) {}
-
-  bool diagnoseAsError() override;
-};
-
 /// Diagnose \c each applied to an expression that is not a pack type.
 class InvalidPackElement final : public FailureDiagnostic {
   Type packElementType;

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1361,45 +1361,6 @@ bool NotCompileTimeConst::diagnose(const Solution &solution, bool asNote) const 
   return failure.diagnose(asNote);
 }
 
-MustBeCopyable::MustBeCopyable(ConstraintSystem &cs,
-                               Type noncopyableTy,
-                               NoncopyableMatchFailure failure,
-                               ConstraintLocator *locator)
-    : ConstraintFix(cs, FixKind::MustBeCopyable, locator, FixBehavior::Error),
-      noncopyableTy(noncopyableTy), failure(failure) {}
-
-bool MustBeCopyable::diagnose(const Solution &solution, bool asNote) const {
-  NotCopyableFailure failDiag(solution, noncopyableTy, failure, getLocator());
-  return failDiag.diagnose(asNote);
-}
-
-MustBeCopyable* MustBeCopyable::create(ConstraintSystem &cs,
-                                              Type noncopyableTy,
-                                              NoncopyableMatchFailure failure,
-                                              ConstraintLocator *locator) {
-  return new (cs.getAllocator()) MustBeCopyable(cs, noncopyableTy,
-                                                failure, locator);
-}
-
-bool MustBeCopyable::diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
-  // Only diagnose if all solutions agreed on the same errant non-copyable type.
-  Type firstNonCopyable;
-  for (const auto &solutionAndFix : commonFixes) {
-    const auto *solution = solutionAndFix.first;
-    const auto *fix = solutionAndFix.second->getAs<MustBeCopyable>();
-
-    auto otherNonCopyable = solution->simplifyType(fix->noncopyableTy);
-    if (!firstNonCopyable)
-      firstNonCopyable = otherNonCopyable;
-
-    if (firstNonCopyable->getCanonicalType() != otherNonCopyable->getCanonicalType()) {
-      return false; // fixes differed, so decline to emit a tailored diagnostic.
-    }
-  }
-
-  return diagnose(*commonFixes.front().first);
-}
-
 bool AllowInvalidPackElement::diagnose(const Solution &solution,
                                        bool asNote) const {
   InvalidPackElement failure(solution, packElementType, getLocator());

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8850,18 +8850,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
           return SolutionKind::Solved;
       }
     }
-
-    // If this is a failure to conform to Copyable, tailor the error message.
-    if (kind == ConstraintKind::ConformsTo &&
-        protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
-      auto *fix =
-          MustBeCopyable::create(*this,
-                                 type,
-                                 NoncopyableMatchFailure::forCopyableConstraint(),
-                                 getConstraintLocator(locator));
-      if (!recordFix(fix))
-        return SolutionKind::Solved;
-    }
   }
 
   // There's nothing more we can do; fail.
@@ -15158,7 +15146,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowAutoClosurePointerConversion:
   case FixKind::NotCompileTimeConst:
   case FixKind::RenameConflictingPatternVariables:
-  case FixKind::MustBeCopyable:
   case FixKind::AllowInvalidPackElement:
   case FixKind::AllowInvalidPackReference:
   case FixKind::AllowInvalidPackExpansion:

--- a/test/Generics/inverse_copyable_requirement_errors.swift
+++ b/test/Generics/inverse_copyable_requirement_errors.swift
@@ -8,29 +8,29 @@ struct MO: ~Copyable {
 func totallyInvalid<T>(_ t: T) where MO: ~Copyable {}
 // expected-error@-1{{type 'MO' in conformance requirement does not refer to a generic parameter or associated type}}
 
-func packingHeat<each T>(_ t: repeat each T) {} // expected-note {{generic parameter 'each T' has an implicit Copyable requirement}}
+func packingHeat<each T>(_ t: repeat each T) {} // expected-note {{'where each T: Copyable' is implicit here}}
 func packIt() {
-  packingHeat(MO())  // expected-error {{noncopyable type 'MO' cannot be substituted for copyable generic parameter 'each T' in 'packingHeat'}}
+  packingHeat(MO())  // expected-error {{global function 'packingHeat' requires that 'MO' conform to 'Copyable'}}
   packingHeat(10)
 }
 
 func packingUniqueHeat_1<each T: ~Copyable>(_ t: repeat each T) {}
 // expected-error@-1{{cannot suppress '~Copyable' on type 'each T'}}
-// expected-note@-2{{generic parameter 'each T' has an implicit Copyable requirement}}
+// expected-note@-2{{'where each T: Copyable' is implicit here}}
 // expected-error@-3{{'each T' required to be 'Copyable' but is marked with '~Copyable'}}
 
 func packingUniqueHeat_2<each T>(_ t: repeat each T)
    where repeat each T: ~Copyable {}
 // expected-error@-1{{cannot suppress '~Copyable' on type 'each T'}}
-// expected-note@-3{{generic parameter 'each T' has an implicit Copyable requirement}}
+// expected-note@-3{{'where each T: Copyable' is implicit here}}
 // expected-error@-3{{'each T' required to be 'Copyable' but is marked with '~Copyable'}}
 
 func packItUniquely() {
   packingUniqueHeat_1(MO())
-  // expected-error@-1{{noncopyable type 'MO' cannot be substituted for copyable generic parameter 'each T' in 'packingUniqueHeat_1'}}
+  // expected-error@-1{{global function 'packingUniqueHeat_1' requires that 'MO' conform to 'Copyable'}}
 
   packingUniqueHeat_2(MO())
-  // expected-error@-1{{noncopyable type 'MO' cannot be substituted for copyable generic parameter 'each T' in 'packingUniqueHeat_2'}}
+  // expected-error@-1{{global function 'packingUniqueHeat_2' requires that 'MO' conform to 'Copyable'}}
 
   packingUniqueHeat_1(10)
 }

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -13,7 +13,7 @@ extension ExplicitCond: Copyable {}
 public typealias ExplicitCondAlias<T> = ExplicitCond<T> where T: ~Copyable
 public typealias AlwaysCopyable<T> = ExplicitCond<T>
 
-func checkCopyable<T>(_ t: T) {} // expected-note {{generic parameter 'T' has an implicit Copyable requirement}}
+func checkCopyable<T>(_ t: T) {} // expected-note {{'where T: Copyable' is implicit here}}
 
 func test<C, NC: ~Copyable>(
   _ a1: ExplicitCond<C>, _ b1: borrowing ExplicitCond<NC>,
@@ -69,7 +69,7 @@ class ClassContainment<T: ~Copyable> {
     var storage: T
     init(_ t: consuming T) {
         storage = t
-        checkCopyable(t) // expected-error {{noncopyable type 'T' cannot be substituted for copyable generic parameter 'T' in 'checkCopyable'}}
+        checkCopyable(t) // expected-error {{global function 'checkCopyable' requires that 'T' conform to 'Copyable'}}
     }
 
     deinit {}
@@ -184,14 +184,14 @@ extension NeedsCopyable where Self: ~Copyable {}
 
 protocol NoCopyP: ~Copyable {}
 
-func needsCopyable<T>(_ t: T) {} // expected-note 2{{generic parameter 'T' has an implicit Copyable requirement}}
+func needsCopyable<T>(_ t: T) {} // expected-note 2{{'where T: Copyable' is implicit here}}
 func noCopyable(_ t: borrowing some ~Copyable) {}
 func noCopyableAndP(_ t: borrowing some NoCopyP & ~Copyable) {}
 
 func openingExistentials(_ a: borrowing any NoCopyP & ~Copyable,
                          _ b: any NoCopyP,
                          _ nc: borrowing any ~Copyable) {
-  needsCopyable(a) // expected-error {{noncopyable type 'any NoCopyP & ~Copyable' cannot be substituted for copyable generic parameter 'T' in 'needsCopyable'}}
+  needsCopyable(a) // expected-error {{global function 'needsCopyable' requires that 'T' conform to 'Copyable'}}
   noCopyable(a)
   noCopyableAndP(a)
 
@@ -199,7 +199,7 @@ func openingExistentials(_ a: borrowing any NoCopyP & ~Copyable,
   noCopyable(b)
   noCopyableAndP(b)
 
-  needsCopyable(nc) // expected-error {{noncopyable type 'any ~Copyable' cannot be substituted for copyable generic parameter 'T' in 'needsCopyable'}}
+  needsCopyable(nc) // expected-error {{global function 'needsCopyable' requires that 'T' conform to 'Copyable'}}
   noCopyable(nc)
   noCopyableAndP(nc) // expected-error {{global function 'noCopyableAndP' requires that 'some NoCopyP & ~Copyable' conform to 'NoCopyP'}}
 }
@@ -212,13 +212,10 @@ func testSpecial(_ a: Any) {
 /// MARK: non-Escapable types
 
 func requireEscape<T: ~Copyable>(_ t: borrowing T) {} // expected-note {{generic parameters are always considered '@escaping'}}
-// expected-note@-1 {{where 'T' = 'MutableBuggerView<NC>'}}
-// expected-note@-2 {{where 'T' = 'BuggerView<NC>'}}
-// expected-note@-3 {{where 'T' = 'MutableBuggerView<Int>'}}
-// expected-note@-4 {{where 'T' = 'BuggerView<Int>'}}
+// expected-note@-1 4{{'where T: Escapable' is implicit here}}
 
 func genericNoEscape<T: ~Escapable>(_ t: borrowing T) {} // expected-note {{generic parameters are always considered '@escaping'}}
-// expected-note@-1 2{{generic parameter 'T' has an implicit Copyable requirement}}
+// expected-note@-1 2{{'where T: Copyable' is implicit here}}
 
 func genericNoEscapeOrCopy<T: ~Escapable & ~Copyable>(_ t: borrowing T) {}
 
@@ -238,9 +235,9 @@ func checkNominals(_ mutRef: inout MutableBuggerView<NC>,
                    _ intMutRef: borrowing MutableBuggerView<Int>,
                    _ intRef: BuggerView<Int>) {
 
-  genericNoEscape(mutRef) // expected-error {{noncopyable type 'MutableBuggerView<NC>' cannot be substituted for copyable generic parameter 'T' in 'genericNoEscape'}}
+  genericNoEscape(mutRef) // expected-error {{global function 'genericNoEscape' requires that 'MutableBuggerView<NC>' conform to 'Copyable'}}
   genericNoEscape(ref)
-  genericNoEscape(intMutRef) // expected-error {{noncopyable type 'MutableBuggerView<Int>' cannot be substituted for copyable generic parameter 'T' in 'genericNoEscape'}}
+  genericNoEscape(intMutRef) // expected-error {{global function 'genericNoEscape' requires that 'MutableBuggerView<Int>' conform to 'Copyable'}}
   genericNoEscape(intRef)
 
   genericNoEscapeOrCopy(mutRef)
@@ -508,3 +505,12 @@ public enum List<Element: ~Copyable>: ~Copyable {
   case empty
 }
 extension List: Copyable where Element: Copyable {}
+
+
+struct Yapping<T: ~Copyable> {}
+extension Yapping { // expected-note {{'where T: Copyable' is implicit here}}
+  func yap() {}
+}
+func testYap(_ y: Yapping<NC>) {
+  y.yap() // expected-error {{referencing instance method 'yap()' on 'Yapping' requires that 'NC' conform to 'Copyable'}}
+}

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -514,3 +514,9 @@ extension Yapping { // expected-note {{'where T: Copyable' is implicit here}}
 func testYap(_ y: Yapping<NC>) {
   y.yap() // expected-error {{referencing instance method 'yap()' on 'Yapping' requires that 'NC' conform to 'Copyable'}}
 }
+
+protocol Veggie: ~Copyable {}
+func generalized(_ x: Any.Type) {}
+func testMetatypes(_ t: (any Veggie & ~Copyable).Type) {
+  generalized(t) // expected-error {{cannot convert value of type '(any Veggie & ~Copyable).Type' to expected argument type 'any Any.Type'}}
+}

--- a/test/SILOptimizer/moveonly_builtins.swift
+++ b/test/SILOptimizer/moveonly_builtins.swift
@@ -20,17 +20,17 @@ func checkArrayBuiltins(_ dest: Builtin.RawPointer, src: Builtin.RawPointer, cou
   Builtin.destroyArray(NC.self, dest, count)
 
 #if ILLEGAL
-  Builtin.copyArray(NC.self, dest, src, count) // expected-illegal-error {{noncopyable type 'NC' cannot be substituted for copyable generic parameter 'T' in 'copyArray'}}
-  Builtin.assignCopyArrayNoAlias(NC.self, dest, src, count) // expected-illegal-error {{noncopyable type 'NC' cannot be substituted for copyable generic parameter 'T' in 'assignCopyArrayNoAlias'}}
-  Builtin.assignCopyArrayFrontToBack(NC.self, dest, src, count) // expected-illegal-error {{noncopyable type 'NC' cannot be substituted for copyable generic parameter 'T' in 'assignCopyArrayFrontToBack'}}
-  Builtin.assignCopyArrayBackToFront(NC.self, dest, src, count) // expected-illegal-error {{noncopyable type 'NC' cannot be substituted for copyable generic parameter 'T' in 'assignCopyArrayBackToFront'}}
+  Builtin.copyArray(NC.self, dest, src, count) // expected-illegal-error {{global function 'copyArray' requires that 'NC' conform to 'Copyable'}}
+  Builtin.assignCopyArrayNoAlias(NC.self, dest, src, count) // expected-illegal-error {{global function 'assignCopyArrayNoAlias' requires that 'NC' conform to 'Copyable'}}
+  Builtin.assignCopyArrayFrontToBack(NC.self, dest, src, count) // expected-illegal-error {{global function 'assignCopyArrayFrontToBack' requires that 'NC' conform to 'Copyable'}}
+  Builtin.assignCopyArrayBackToFront(NC.self, dest, src, count) // expected-illegal-error {{global function 'assignCopyArrayBackToFront' requires that 'NC' conform to 'Copyable'}}
 #endif
 }
 
 public func checkIllegal() {
 #if ILLEGAL
   _ = Builtin.unsafeCastToNativeObject(NC())
-  _ = Builtin.castToNativeObject(NC()) // expected-illegal-error {{noncopyable type 'NC' cannot be substituted for copyable generic parameter 'T' in 'castToNativeObject'}}
+  _ = Builtin.castToNativeObject(NC()) // expected-illegal-error {{global function 'castToNativeObject' requires that 'NC' conform to 'Copyable'}}
   let _: NC = Builtin.zeroInitializer()
 #endif
 }

--- a/test/Sema/copyable_constraint.swift
+++ b/test/Sema/copyable_constraint.swift
@@ -7,8 +7,9 @@
 
 @_marker public protocol Copyable {}
 
-func nextTime<T>(_ t: T) {} // expected-note {{generic parameter 'T' has an implicit Copyable requirement}}
+func nextTime<T>(_ t: T) {} // expected-note {{Copyable' is implicit here}}
 
 @_moveOnly struct MO {}
 
-nextTime(MO()) // expected-error {{noncopyable type 'MO' cannot be substituted for copyable generic parameter 'T' in 'nextTime'}}
+// NOTE: when building without being the stdlib, we get a Builtin.Copyable
+nextTime(MO()) // expected-error {{global function 'nextTime' requires that 'MO' conform to}}

--- a/test/Sema/invertible_no_stdlib.swift
+++ b/test/Sema/invertible_no_stdlib.swift
@@ -8,8 +8,8 @@
 
 import Builtin
 
-func reqCopy1<T>(_ t: T) {} // expected-note {{generic parameter 'T' has an implicit Copyable requirement}}
-func reqCopy2<T: Builtin.Copyable>(_ t: T) {} // expected-note {{generic parameter 'T' has an implicit Copyable requirement}}
+func reqCopy1<T>(_ t: T) {} // expected-note {{'where T: Builtin.Copyable' is implicit here}}
+func reqCopy2<T: Builtin.Copyable>(_ t: T) {} // expected-note {{'where T: Builtin.Copyable' is implicit here}}
 
 protocol P {}
 
@@ -17,8 +17,8 @@ struct DataType: P, Builtin.Escapable {} // expected-error {{type 'Escapable' re
 struct DataTypeNC: ~Builtin.Copyable {}
 
 func main() {
-    reqCopy1(DataTypeNC()) // expected-error {{noncopyable type 'DataTypeNC' cannot be substituted for copyable generic parameter 'T' in 'reqCopy1'}}
-    reqCopy2(DataTypeNC()) // expected-error {{noncopyable type 'DataTypeNC' cannot be substituted for copyable generic parameter 'T' in 'reqCopy2'}}
+    reqCopy1(DataTypeNC()) // expected-error {{global function 'reqCopy1' requires that 'DataTypeNC' conform to 'Builtin.Copyable'}}
+    reqCopy2(DataTypeNC()) // expected-error {{global function 'reqCopy2' requires that 'DataTypeNC' conform to 'Builtin.Copyable'}}
     reqCopy1(DataType())
     reqCopy2(DataType())
 }

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -94,7 +94,11 @@ enum Wrong_NoncopyableOption<T> : Sendable { // expected-note {{consider making 
 }
 
 func takeAnySendable(_ s: any Sendable) {}
-func takeSomeSendable(_ s: some Sendable) {} // expected-note {{generic parameter 'some Sendable' has an implicit Copyable requirement}}
+func takeSomeSendable(_ s: some Sendable) {} // expected-note {{'some Sendable & Copyable' is implicit here}}
+
+protocol Munchable: ~Copyable {}
+struct Chips: ~Copyable, Sendable, Munchable {}
+func takeSomeMunchySendable(_ s: some Sendable & Munchable) {} // expected-note {{'some Sendable & Munchable & Copyable' is implicit here}}
 
 // expected-error@+1 {{return expression of type 'FileDescriptor' does not conform to 'Copyable'}}
 func mkSendable() -> Sendable { return FileDescriptor(id: 0) }
@@ -104,7 +108,8 @@ func tryToCastIt(_ fd: borrowing FileDescriptor) {
   let _: Sendable = fd // expected-error {{value of type 'FileDescriptor' does not conform to specified type 'Copyable'}}
 
   takeAnySendable(fd) // expected-error {{argument type 'FileDescriptor' does not conform to expected type 'Copyable'}}
-  takeSomeSendable(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be substituted for copyable generic parameter 'some Sendable' in 'takeSomeSendable'}}
+  takeSomeSendable(fd) // expected-error {{global function 'takeSomeSendable' requires that 'FileDescriptor' conform to 'Copyable'}}
+  takeSomeMunchySendable(Chips()) // expected-error {{global function 'takeSomeMunchySendable' requires that 'Chips' conform to 'Copyable'}}
 
   let _ = fd as Sendable // expected-error {{cannot convert value of type 'FileDescriptor' to type 'any Sendable' in coercion}}
 

--- a/test/Serialization/noncopyable_generics.swift
+++ b/test/Serialization/noncopyable_generics.swift
@@ -35,7 +35,7 @@ struct NC: ~Copyable {}
 struct RegularStruct {}
 
 func isItCopyable<T: Copyable>(_ t: T) {}
-// expected-note@-1 {{generic parameter 'T' has an implicit Copyable requirement}}
+// expected-note@-1 {{'where T: Copyable' is implicit here}}
 
 func check() {
     var tr = TestRequirements()
@@ -43,7 +43,7 @@ func check() {
 
     isItCopyable(TestRequirements())
     isItCopyable(RegularStruct())
-    isItCopyable(NC()) // expected-error {{noncopyable type 'NC' cannot be substituted for copyable generic parameter 'T' in 'isItCopyable'}}
+    isItCopyable(NC()) // expected-error {{global function 'isItCopyable' requires that 'NC' conform to 'Copyable'}}
 
     let x: Maybe<NC> = .none
 }


### PR DESCRIPTION
Removing the old, ad-hoc diagnostics code improves the diagnostics we
emit, since the existing diagnostics for missing conformances is already
pretty good.

rdar://127369509