### PR TITLE
6.0 CMake: do not assume target SDKs are provided when evaluting `NOT`

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1934,11 +1934,14 @@ function(add_swift_target_library name)
   list_replace(SWIFTLIB_TARGET_SDKS ALL_APPLE_PLATFORMS "${SWIFT_DARWIN_PLATFORMS}")
 
   # Support adding a "NOT" on the front to mean all SDKs except the following
-  list(GET SWIFTLIB_TARGET_SDKS 0 first_sdk)
-  if("${first_sdk}" STREQUAL "NOT")
-    list(REMOVE_AT SWIFTLIB_TARGET_SDKS 0)
-    list_subtract("${SWIFT_SDKS}" "${SWIFTLIB_TARGET_SDKS}"
-      "SWIFTLIB_TARGET_SDKS")
+  list(LENGTH SWIFTLIB_TARGET_SDKS number_of_target_sdks)
+  if(number_of_target_sdks GREATER_EQUAL "1")
+    list(GET SWIFTLIB_TARGET_SDKS 0 first_sdk)
+    if("${first_sdk}" STREQUAL "NOT")
+        list(REMOVE_AT SWIFTLIB_TARGET_SDKS 0)
+        list_subtract("${SWIFT_SDKS}" "${SWIFTLIB_TARGET_SDKS}"
+        "SWIFTLIB_TARGET_SDKS")
+    endif()
   endif()
 
   list_intersect(
@@ -2974,11 +2977,14 @@ function(add_swift_target_executable name)
   list_replace(SWIFTEXE_TARGET_TARGET_SDKS ALL_APPLE_PLATFORMS "${SWIFT_DARWIN_PLATFORMS}")
 
   # Support adding a "NOT" on the front to mean all SDKs except the following
-  list(GET SWIFTEXE_TARGET_TARGET_SDKS 0 first_sdk)
-  if("${first_sdk}" STREQUAL "NOT")
-    list(REMOVE_AT SWIFTEXE_TARGET_TARGET_SDKS 0)
-    list_subtract("${SWIFT_SDKS}" "${SWIFTEXE_TARGET_TARGET_SDKS}"
-      "SWIFTEXE_TARGET_TARGET_SDKS")
+  list(LENGTH SWIFTEXE_TARGET_TARGET_SDKS number_of_target_sdks)
+  if(number_of_target_sdks GREATER_EQUAL "1")
+    list(GET SWIFTEXE_TARGET_TARGET_SDKS 0 first_sdk)
+    if("${first_sdk}" STREQUAL "NOT")
+        list(REMOVE_AT SWIFTEXE_TARGET_TARGET_SDKS 0)
+        list_subtract("${SWIFT_SDKS}" "${SWIFTEXE_TARGET_TARGET_SDKS}"
+        "SWIFTEXE_TARGET_TARGET_SDKS")
+    endif()
   endif()
 
   list_intersect(


### PR DESCRIPTION
... operator in `add_swift_target_library` and `add_swift_target_executable`

**Explanation**: address a regression introduce with the addition of the Static Linux SDK (rdar://123503470) that causes the CMake configuration to fail when building the standard library for Swift Embedded on its own (i.e. without the compiler or stdlib for other platforms)
**Radar**: rdar://128819523
**Scope**: CMake logic that builds target libraries and executables (more specifically, the support for the "NOT" operator when specifying target SDKs)
**Risk**: low
* the fix is additive and addresses a narrow scenario (namely adding a guard to prevent the affected logic to run when no target SDK is specified)
* in the worst case, any regression would affect only the Static Linux SDK and building the standard library for Swift Embedded on its own

**Testing**: PR testing to ensure that we are still able to build the standard library across all platforms

**Reviewed By**: @al45tair in https://github.com/apple/swift/pull/73939