### PR TITLE
[cxx-interop] Re-enable a test for borrowing const ref

### DIFF
--- a/test/Interop/Cxx/class/safe-use-of-returned-reference-with-borrowing.swift
+++ b/test/Interop/Cxx/class/safe-use-of-returned-reference-with-borrowing.swift
@@ -8,7 +8,7 @@
 // aborrowed value.
 // RUN: %target-swift-frontend -DBORROW_PASS_TO_VALUE_PARAM -emit-ir -o /dev/null -I %t %t/test.swift -enable-experimental-cxx-interop -verify
 
-// REQUIRES: rdar111065819
+// REQUIRES: executable_test
 
 //--- Inputs/module.modulemap
 module CxxTest {


### PR DESCRIPTION
We were trying to run an execution test in a non-executable CI job.

rdar://111065819