### PR TITLE
[embedded] Avoid strip-ing .a embedded libraries

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3345,10 +3345,11 @@ for host in "${ALL_HOSTS[@]}"; do
             printJSONEndTimestamp dsymutil
 
             # Strip executables, shared libraries and static libraries in
-            # `host_install_destdir`. Avoid touching clang builtins .a files.
+            # `host_install_destdir`. Avoid touching .a clang builtins and embedded libraries.
             find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
               '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
               grep_that_allows_no_matches -v "/clang/lib/darwin/" | \
+              grep_that_allows_no_matches -v "/lib/swift/embedded/" | \
               xargs -t -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
 
             # Codesign dylibs and executables in usr/bin after strip tool

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -792,6 +792,15 @@ function set_build_options_for_host() {
                 -DCMAKE_OSX_ARCHITECTURES="${architecture}"
             )
 
+            # Avoid building the embedded stdlib and other embedded libraries when cross-compiling.
+            # Those are already provided by the local host build, and are identical and only cause
+            # trouble when lipo-ing if they are produced in cross-compile builds too.
+            if [[ $(is_cross_tools_host "${host}") ]] ; then
+                swift_cmake_options+=(
+                    -DSWIFT_SHOULD_BUILD_EMBEDDED_STDLIB:BOOL=FALSE
+                )
+            fi
+
             lldb_cmake_options+=(
                 -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING="${cmake_osx_deployment_target}"
                 -DCMAKE_OSX_SYSROOT:PATH="${cmake_os_sysroot}"


### PR DESCRIPTION
Some of the embedded .a libraries are ELF files -- we should avoid strip-ing those. Resolves a CI failure preventing macOS toolchains from being built:
```
LLVM ERROR: malformed uleb128, extends past end
xargs: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip: terminated with signal 6; aborting
```

rdar://128857716