### PR TITLE
[IRGen] Add option for raw layout to move as its like type

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -962,7 +962,9 @@ the memory of the annotated type:
   implemented in C as always requiring a fixed address. However, you can provide
   `movesAsLike` to the `like:` version of this attribute to enforce that moving
   the value will defer its move semantics to the type it's like. This makes it
-  suitable for storing such values that are not bitwise-movable.
+  suitable for storing such values that are not bitwise-movable. Note that the
+  raw storage for this variant must always be properly initialized after
+  initialization because foreign moves will assume an initialized state.
 
 Using the `@_rawLayout` attribute will suppress the annotated type from
 being implicitly `Sendable`. If the type is safe to access across threads, it

--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -955,12 +955,14 @@ the memory of the annotated type:
   threads, writes don't overlap with reads or writes coming from the same
   thread, and that the pointer is not used after the value is moved or
   consumed.
-- When the value is moved, a bitwise copy of its memory is performed to the new
-  address of the value in its new owner. As currently implemented, raw storage
-  types are not suitable for storing values which are not bitwise-movable, such
-  as nontrivial C++ types, Objective-C weak references, and data structures
-  such as `pthread_mutex_t` which are implemented in C as always requiring a
-  fixed address.
+- By default, when the value is moved a bitwise copy of its memory is performed
+  to the new address of the value in its new owner. This makes it unsuitable to
+  store not bitwise-movable types such as nontrivial C++ types, Objective-C weak
+  references, and data structures such as `pthread_mutex_t` which are
+  implemented in C as always requiring a fixed address. However, you can provide
+  `movesAsLike` to the `like:` version of this attribute to enforce that moving
+  the value will defer its move semantics to the type it's like. This makes it
+  suitable for storing such values that are not bitwise-movable.
 
 Using the `@_rawLayout` attribute will suppress the annotated type from
 being implicitly `Sendable`. If the type is safe to access across threads, it
@@ -987,6 +989,11 @@ forms are currently accepted:
 - `@_rawLayout(likeArrayOf: T, count: N)` specifies the type's size should be
   `MemoryLayout<T>.stride * N` and alignment should match `T`'s, like an
   array of N contiguous elements of `T` in memory.
+- `@_rawLayout(like: T, movesAsLike)` specifies the type's size and alignment
+  should be equal to the type `T`'s. It also guarantees that moving a value of
+  this raw layout type will have the same move semantics as the type it's like.
+  This is important for things like ObjC weak references and non-trivial move
+  constructors in C++.
 
 A notable difference between `@_rawLayout(like: T)` and
 `@_rawLayout(likeArrayOf: T, count: 1)` is that the latter will pad out the

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -891,6 +891,17 @@ public:
   /// Returns true if this SILType is a differentiable type.
   bool isDifferentiable(SILModule &M) const;
 
+  /// Returns the @_rawLayout attribute on this type if it has one.
+  RawLayoutAttr *getRawLayout() const {
+    auto sd = getStructOrBoundGenericStruct();
+
+    if (!sd) {
+      return nullptr;
+    }
+
+    return sd->getAttrs().getAttribute<RawLayoutAttr>();
+  }
+
   /// If this is a SILBoxType, return getSILBoxFieldType(). Otherwise, return
   /// SILType().
   ///

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3989,6 +3989,16 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       if (likeType.isNull()) {
         return makeParserSuccess();
       }
+
+      bool movesAsLike = false;
+
+      // @_rawLayout(like: T, movesAsLike)
+      if (consumeIf(tok::comma) && Tok.isAny(tok::identifier) &&
+          !parseSpecificIdentifier("movesAsLike",
+            diag::attr_rawlayout_expected_label, "movesAsLike")) {
+        movesAsLike = true;
+      }
+
       SourceLoc rParenLoc;
       if (!consumeIf(tok::r_paren, rParenLoc)) {
         diagnose(Tok.getLoc(), diag::attr_expected_rparen,
@@ -3996,7 +4006,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         return makeParserSuccess();
       }
 
-      attr = new (Context) RawLayoutAttr(likeType.get(),
+      attr = new (Context) RawLayoutAttr(likeType.get(), movesAsLike,
                                          AtLoc, SourceRange(Loc, rParenLoc));
     } else if (firstLabel.is("likeArrayOf")) {
       // @_rawLayout(likeArrayOf: T, count: N)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6292,8 +6292,9 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         TypeID typeID;
         uint32_t rawSize;
         uint8_t rawAlign;
+        bool movesAsLike;
         serialization::decls_block::RawLayoutDeclAttrLayout::
-          readRecord(scratch, isImplicit, typeID, rawSize, rawAlign);
+          readRecord(scratch, isImplicit, typeID, rawSize, rawAlign, movesAsLike);
         
         if (typeID) {
           auto type = MF.getTypeChecked(typeID);
@@ -6303,6 +6304,7 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
           auto typeRepr = new (ctx) FixedTypeRepr(type.get(), SourceLoc());
           if (rawAlign == 0) {
             Attr = new (ctx) RawLayoutAttr(typeRepr,
+                                           movesAsLike,
                                            SourceLoc(),
                                            SourceRange());
             break;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2165,7 +2165,8 @@ namespace decls_block {
     BCFixed<1>, // implicit
     TypeIDField, // like type
     BCVBR<32>, // size
-    BCVBR<8> // alignment
+    BCVBR<8>, // alignment
+    BCFixed<1> // movesAsLike
   >;
   
   using SwiftNativeObjCRuntimeBaseDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3345,7 +3345,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       
       RawLayoutDeclAttrLayout::emitRecord(
         S.Out, S.ScratchRecord, abbrCode, attr->isImplicit(),
-        typeID, rawSize, rawAlign);
+        typeID, rawSize, rawAlign, attr->shouldMoveAsLikeType());
     }
     }
   }

--- a/test/IRGen/Inputs/module.modulemap
+++ b/test/IRGen/Inputs/module.modulemap
@@ -39,3 +39,7 @@ module PointerAuth {
 module CFBridgedType {
   header "CFBridgedType.h"
 }
+
+module RawLayoutCXX {
+  header "raw_layout_cxx.h"
+}

--- a/test/IRGen/Inputs/raw_layout_cxx.h
+++ b/test/IRGen/Inputs/raw_layout_cxx.h
@@ -1,0 +1,16 @@
+class NonBitwiseTakableCXXType {
+public:
+  bool state = false;
+
+  NonBitwiseTakableCXXType() {}
+
+  NonBitwiseTakableCXXType(const NonBitwiseTakableCXXType &other) {
+    state = false;
+  }
+
+  NonBitwiseTakableCXXType(NonBitwiseTakableCXXType &&other) {
+    state = !other.state;
+  }
+
+  ~NonBitwiseTakableCXXType() {}
+};

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -262,11 +262,11 @@ entry(%0 : $*Cell<T>):
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: invoke void @_Z{{.*}}_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: {{invoke void|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
 
 // ConcreteMoveAsLike assignWithTake
 
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: invoke void @_Z{{.*}}_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: {{invoke void|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -262,11 +262,11 @@ entry(%0 : $*Cell<T>):
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: invoke void @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: invoke void @_Z{{.*}}_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
 
 // ConcreteMoveAsLike assignWithTake
 
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: invoke void @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: invoke void @_Z{{.*}}_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -1,9 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/raw_layout.sil
-// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-ir -disable-availability-checking %t/raw_layout.sil | %FileCheck %t/raw_layout.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-ir -disable-availability-checking -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %t/raw_layout.sil | %FileCheck %t/raw_layout.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 import Builtin
 import Swift
+import RawLayoutCXX
 
 // CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}4LockVWV" = {{.*}} %swift.vwtable
 // size
@@ -143,6 +144,52 @@ struct BadBuffer: ~Copyable {
     let buffer: SmallVectorOf3<Int64?>
 }
 
+// Raw Layout types that move like their like type
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}19CellThatMovesAsLikeVWV" = {{.*}} %swift.vwtable
+// initializeWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout19CellThatMovesAsLikeVwtk"
+// assignWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout19CellThatMovesAsLikeVwta"
+// size
+// CHECK-SAME:  , {{i64|i32}} 0
+// stride
+// CHECK-SAME:  , {{i64|i32}} 0
+// flags: alignment 0, incomplete
+// CHECK-SAME:  , <i32 0x400000>
+@_rawLayout(like: T, movesAsLike)
+struct CellThatMovesAsLike<T>: ~Copyable {}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}18ConcreteMoveAsLikeVWV" = {{.*}} %swift.vwtable
+// initializeWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"
+// assignWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"
+// size
+// CHECK-SAME:  , {{i64|i32}} 1
+// stride
+// CHECK-SAME:  , {{i64|i32}} 1
+// flags: not copyable, not bitwise takable, not pod, not inline
+// CHECK-SAME:  , <i32 0x930000>
+struct ConcreteMoveAsLike: ~Copyable {
+  let cell: CellThatMovesAsLike<NonBitwiseTakableCXXType>
+}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}21ConcreteIntMoveAsLikeVWV" = {{.*}} %swift.vwtable
+// initializeWithTake
+// CHECK-SAME:  , ptr @__swift_memcpy4_4
+// assignWithTake
+// CHECK-SAME:  , ptr @__swift_memcpy4_4
+// size
+// CHECK-SAME:  , {{i64|i32}} 4
+// stride
+// CHECK-SAME:  , {{i64|i32}} 4
+// flags: alignment 3, not copyable
+// CHECK-SAME:  , <i32 0x800003>
+struct ConcreteIntMoveAsLike: ~Copyable {
+  let cell: CellThatMovesAsLike<Int32>
+}
+
 sil @use_lock : $@convention(thin) (@in_guaranteed Lock) -> () {
 entry(%L: $*Lock):
     return undef : $()
@@ -193,3 +240,33 @@ entry(%0 : $*Cell<T>):
 
 // CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}14SmallVectorBufVMr"(ptr %"SmallVectorBuf<T>", ptr {{.*}}, ptr {{.*}})
 // CHECK: call void @swift_initRawStructMetadata(ptr %"SmallVectorBuf<T>", {{i64|i32}} 0, ptr {{%.*}}, {{i64|i32}} 8)
+
+// Ensure that 'movesAsLike' is correctly calling the underlying type's move constructor
+
+// CellThatMovesAsLike<T> initializeWithTake
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout19CellThatMovesAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %"CellThatMovesAsLike<T>")
+// CHECK: [[T_ADDR:%.*]] = getelementptr inbounds ptr, ptr %"CellThatMovesAsLike<T>", {{i64|i32}} 2
+// CHECK-NEXT: [[T:%.*]] = load ptr, ptr [[T_ADDR]]
+// CHECK: {{%.*}} = call ptr %InitializeWithTake(ptr {{.*}} %dest, ptr {{.*}} %src, ptr [[T]])
+
+// CellThatMovesAsLike<T> assignWithTake
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout19CellThatMovesAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %"CellThatMovesAsLike<T>")
+// CHECK: [[T_ADDR:%.*]] = getelementptr inbounds ptr, ptr %"CellThatMovesAsLike<T>", {{i64|i32}} 2
+// CHECK-NEXT: [[T:%.*]] = load ptr, ptr [[T_ADDR]]
+// CHECK: {{%.*}} = call ptr %AssignWithTake(ptr {{.*}} %dest, ptr {{.*}} %src, ptr [[T]])
+
+// ConcreteMoveAsLike initializeWithTake
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
+// CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
+// CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
+// CHECK: {{%.*}} = invoke ptr @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+
+// ConcreteMoveAsLike assignWithTake
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
+// CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
+// CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
+// CHECK: {{%.*}} = invoke ptr @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -262,11 +262,11 @@ entry(%0 : $*Cell<T>):
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: {{%.*}} = invoke ptr @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: {{%.*}} = invoke void @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
 
 // ConcreteMoveAsLike assignWithTake
 
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: {{%.*}} = invoke ptr @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: {{%.*}} = invoke void @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -262,11 +262,11 @@ entry(%0 : $*Cell<T>):
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: {{%.*}} = invoke void @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: invoke void @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
 
 // ConcreteMoveAsLike assignWithTake
 
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: {{%.*}} = invoke void @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: invoke void @_ZN24NonBitwiseTakableCXXTypeC1EOS_(ptr [[DEST_CELL]], ptr [[SRC_CELL]])

--- a/test/Serialization/Inputs/module.modulemap
+++ b/test/Serialization/Inputs/module.modulemap
@@ -2,3 +2,7 @@
 module CLibrary {
   header "CLibrary.h"
 }
+
+module RawLayoutCXX {
+  header "raw_layout_cxx.h"
+}

--- a/test/Serialization/Inputs/raw_layout.swift
+++ b/test/Serialization/Inputs/raw_layout.swift
@@ -5,3 +5,6 @@ extension Bool: Foo {}
 public struct Fred<T: Foo>: ~Copyable {
   public init() {}
 }
+
+@_rawLayout(like: T, movesAsLike)
+public struct CellThatMovesLike<T>: ~Copyable {}

--- a/test/Serialization/Inputs/raw_layout_cxx.h
+++ b/test/Serialization/Inputs/raw_layout_cxx.h
@@ -1,0 +1,16 @@
+class NonBitwiseTakableCXXType {
+public:
+  bool state = false;
+
+  NonBitwiseTakableCXXType() {}
+
+  NonBitwiseTakableCXXType(const NonBitwiseTakableCXXType &other) {
+    state = false;
+  }
+
+  NonBitwiseTakableCXXType(NonBitwiseTakableCXXType &&other) {
+    state = !other.state;
+  }
+
+  ~NonBitwiseTakableCXXType() {}
+};

--- a/test/Serialization/raw_layout.swift
+++ b/test/Serialization/raw_layout.swift
@@ -1,10 +1,26 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-experimental-feature RawLayout -module-name raw_layout_fred -o %t %S/Inputs/raw_layout.swift
-// RUN: %target-swift-frontend -I %t -emit-ir %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -emit-ir %s -verify | %FileCheck %s
 
 import raw_layout_fred
+import RawLayoutCXX
 
 // CHECK: %T15raw_layout_fred4FredVySbG = type <{ [1 x i8] }>
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}16WeirdCXXTypeCellVWV" = {{.*}} %swift.vwtable
+// initializeWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwtk"
+// assignWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwta"
+// size
+// CHECK-SAME:  , {{i64|i32}} 1
+// stride
+// CHECK-SAME:  , {{i64|i32}} 1
+// flags: not copyable, not bitwise takable, not pod, not inline
+// CHECK-SAME:  , i32 9633792
+struct WeirdCXXTypeCell: ~Copyable {
+  let cell: CellThatMovesLike<NonBitwiseTakableCXXType>
+}
 
 do {
   // CHECK: {{%.*}} = alloca %T15raw_layout_fred4FredVySbG


### PR DESCRIPTION
In order for types like `Mutex` to store arbitrary types, raw layout needs to support moving like the type it's like. Add an option `movesAsLike` to the attribute to let types opt into this behavior and call into their underlying type to figure out how to move themselves.

Resolves: rdar://128291306