### PR TITLE
[6.0] [stdlib] Enforce that atomic representations are BitwiseCopyable

### DIFF
--- a/stdlib/public/Synchronization/AtomicOptional.swift
+++ b/stdlib/public/Synchronization/AtomicOptional.swift
@@ -18,7 +18,7 @@ public protocol AtomicOptionalRepresentable: AtomicRepresentable {
   /// The storage representation type that encodes to and decodes from
   /// `Optional<Self>` which is a suitable type when used in atomic operations
   /// on `Optional`.
-  associatedtype AtomicOptionalRepresentation
+  associatedtype AtomicOptionalRepresentation: BitwiseCopyable
 
   /// Destroys a value of `Self` and prepares an `AtomicOptionalRepresentation`
   /// storage type to be used for atomic operations on `Optional`.

--- a/stdlib/public/Synchronization/AtomicRepresentable.swift
+++ b/stdlib/public/Synchronization/AtomicRepresentable.swift
@@ -163,7 +163,7 @@
 public protocol AtomicRepresentable {
   /// The storage representation type that `Self` encodes to and decodes from
   /// which is a suitable type when used in atomic operations.
-  associatedtype AtomicRepresentation
+  associatedtype AtomicRepresentation: BitwiseCopyable
 
   /// Destroys a value of `Self` and prepares an `AtomicRepresentation` storage
   /// type to be used for atomic operations.

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -61,7 +61,9 @@
 @frozen
 public enum Never {}
 
-extension Never: Sendable { }
+extension Never: BitwiseCopyable {}
+
+extension Never: Sendable {}
 
 extension Never: Error {}
 


### PR DESCRIPTION
This is a cherry pick of https://github.com/apple/swift/pull/73734

Explanation: Marks `AtomicRepresentable.AtomicRepresentation` and `AtomicOptionalRepresentable.AtomicOptionalRepresentation` as `BitwiseCopyable`.
Scope: Synchronization module
Issue: rdar://128296144.
Original PR: https://github.com/apple/swift/pull/73734
Risk: Very Low, atomics are always expected to store bitwise copyable values.
Testing: Ci
Reviewer: @nate-chandler and @lorentey 