### PR TITLE
[6.0] [IRGen] Add Builtin.addressOfRawLayout

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -1107,6 +1107,19 @@ BUILTIN_MISC_OPERATION_WITH_SILGEN(InjectEnumTag, "injectEnumTag", "", Special)
 /// `any Actor` existential that refers to the local actor.
 BUILTIN_MISC_OPERATION_WITH_SILGEN(DistributedActorAsAnyActor, "distributedActorAsAnyActor", "n", Special)
 
+/// addressOfRawLayout: <T: ~Copyable>(_: borrowing T) -> Builtin.RawPointer
+///
+/// Returns a raw pointer to the address of the raw layout type. This address is
+/// only valid during a borrow access of the raw layout type or until the value
+/// is either moved or consumed.
+///
+/// Note: The purpose of this builtin is to get an opaque pointer to the address
+/// of the raw layout type. We explicitly do not want the optimizer looking into
+/// this pointer or address thereof to start assuming things about mutability or
+/// immutability. This builtin _must_ persist throughout all of SIL and must be
+/// lowered away at IRGen, no sooner.
+BUILTIN_MISC_OPERATION_WITH_SILGEN(AddressOfRawLayout, "addressOfRawLayout", "n", Special)
+
 /// Builtins for instrumentation added by sanitizers during SILGen.
 #ifndef BUILTIN_SANITIZER_OPERATION
 #define BUILTIN_SANITIZER_OPERATION(Id, Name, Attrs) BUILTIN(Id, Name, Attrs)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -196,6 +196,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(NoncopyableGenerics, 427, "Noncopyable generics")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ConformanceSuppression, 426, "Suppressible inferred conformances")
 SUPPRESSIBLE_LANGUAGE_FEATURE(BitwiseCopyable2, 426, "BitwiseCopyable feature")
 LANGUAGE_FEATURE(BodyMacros, 415, "Function body macros")
+LANGUAGE_FEATURE(BuiltinAddressOfRawLayout, 0, "Builtin.addressOfRawLayout")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)

--- a/include/swift/SIL/AddressWalker.h
+++ b/include/swift/SIL/AddressWalker.h
@@ -276,6 +276,7 @@ TransitiveAddressWalker<Impl>::walk(SILValue projectedAddress) && {
         case BuiltinValueKind::ZeroInitializer:
         case BuiltinValueKind::GetEnumTag:
         case BuiltinValueKind::InjectEnumTag:
+        case BuiltinValueKind::AddressOfRawLayout:
           callVisitUse(op);
           continue;
         default:

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2141,6 +2141,15 @@ static ValueDecl *getInjectEnumTag(ASTContext &ctx, Identifier id) {
   return builder.build(id);
 }
 
+static ValueDecl *getAddressOfRawLayout(ASTContext &ctx, Identifier id) {
+  BuiltinFunctionBuilder builder(ctx, /* genericParamCount */ 1);
+
+  builder.addParameter(makeGenericParam(), ParamSpecifier::Borrowing);
+  builder.setResult(makeConcrete(ctx.TheRawPointerType));
+
+  return builder.build(id);
+}
+
 /// An array of the overloaded builtin kinds.
 static const OverloadedBuiltinKind OverloadedBuiltinKinds[] = {
   OverloadedBuiltinKind::None,
@@ -3214,6 +3223,9 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
 
   case BuiltinValueKind::DistributedActorAsAnyActor:
     return getDistributedActorAsAnyActor(Context, Id);
+
+  case BuiltinValueKind::AddressOfRawLayout:
+    return getAddressOfRawLayout(Context, Id);
   }
 
   llvm_unreachable("bad builtin value!");

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -359,6 +359,7 @@ static bool usesFeatureExpressionMacroDefaultArguments(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(BuiltinStoreRaw)
+UNINTERESTING_FEATURE(BuiltinAddressOfRawLayout)
 
 // ----------------------------------------------------------------------------
 // MARK: - Upcoming Features

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1498,5 +1498,15 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     return;
   }
 
+  // LLVM must not see the address generated here as 'invariant' or immutable
+  // ever. A raw layout's address defies all formal access, so immutable looking
+  // uses may actually mutate the underlying value!
+  if (Builtin.ID == BuiltinValueKind::AddressOfRawLayout) {
+    auto addr = args.claimNext();
+    auto value = IGF.Builder.CreateBitCast(addr, IGF.IGM.Int8PtrTy);
+    out.add(value);
+    return;
+  }
+
   llvm_unreachable("IRGen unimplemented for this builtin!");
 }

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -892,6 +892,7 @@ BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TargetOSVersionAtLeast)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GetEnumTag)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, InjectEnumTag)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, DistributedActorAsAnyActor)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AddressOfRawLayout)
 OperandOwnership OperandOwnershipBuiltinClassifier::visitCopy(BuiltinInst *bi,
                                                               StringRef) {
   if (bi->getFunction()->getConventions().useLoweredAddresses()) {

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -620,6 +620,7 @@ CONSTANT_OWNERSHIP_BUILTIN(None, GetEnumTag)
 CONSTANT_OWNERSHIP_BUILTIN(None, InjectEnumTag)
 CONSTANT_OWNERSHIP_BUILTIN(Owned, DistributedActorAsAnyActor)
 CONSTANT_OWNERSHIP_BUILTIN(Guaranteed, ExtractFunctionIsolation) // unreachable
+CONSTANT_OWNERSHIP_BUILTIN(None, AddressOfRawLayout)
 
 #undef CONSTANT_OWNERSHIP_BUILTIN
 

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2667,6 +2667,7 @@ static void visitBuiltinAddress(BuiltinInst *builtin,
     // These builtins take a generic 'T' as their operand.
     case BuiltinValueKind::GetEnumTag:
     case BuiltinValueKind::InjectEnumTag:
+    case BuiltinValueKind::AddressOfRawLayout:
       visitor(&builtin->getAllOperands()[0]);
       return;
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -611,6 +611,12 @@ struct ImmutableAddressUseVerifier {
           if (builtinKind == BuiltinValueKind::GetEnumTag) {
             return false;
           }
+
+          // The optimizer cannot reason about a raw layout type's address due
+          // to it not respecting formal access scopes.
+          if (builtinKind == BuiltinValueKind::AddressOfRawLayout) {
+            return false;
+          }
         }
 
         // Otherwise this is a builtin that we are not expecting to see, so bail

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -2006,6 +2006,21 @@ static ManagedValue emitBuiltinDistributedActorAsAnyActor(
   return SGF.emitDistributedActorAsAnyActor(loc, subs, args[0]);
 }
 
+static ManagedValue emitBuiltinAddressOfRawLayout(SILGenFunction &SGF,
+                                                  SILLocation loc,
+                                                  SubstitutionMap subs,
+                                                  ArrayRef<ManagedValue> args,
+                                                  SGFContext C) {
+  auto &ctx = SGF.getASTContext();
+
+  auto bi = SGF.B.createBuiltin(
+    loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::AddressOfRawLayout)),
+    SILType::getRawPointerType(ctx), subs,
+    { args[0].getValue() });
+
+  return ManagedValue::forObjectRValueWithoutOwnership(bi);
+}
+
 std::optional<SpecializedEmitter>
 SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   // Only consider standalone declarations in the Builtin module.

--- a/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
@@ -159,6 +159,7 @@ static bool isBarrier(SILInstruction *inst) {
     case BuiltinValueKind::GetEnumTag:
     case BuiltinValueKind::InjectEnumTag:
     case BuiltinValueKind::ExtractFunctionIsolation:
+    case BuiltinValueKind::AddressOfRawLayout:
       return false;
 
     // Handle some rare builtins that may be sensitive to object lifetime

--- a/test/SILGen/raw_layout.swift
+++ b/test/SILGen/raw_layout.swift
@@ -1,10 +1,12 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature RawLayout %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature RawLayout -enable-builtin-module %s | %FileCheck %s
 
 
 
 // CHECK: @_rawLayout(size: 4, alignment: 4) struct Lock : ~Copyable
 // CHECK: @_rawLayout(like: T) struct Cell<T> : ~Copyable
 // CHECK: @_rawLayout(likeArrayOf: T, count: 8) struct SmallVectorBuf<T> : ~Copyable
+
+import Builtin
 
 @_rawLayout(size: 4, alignment: 4)
 struct Lock: ~Copyable {
@@ -22,7 +24,18 @@ struct Lock: ~Copyable {
 }
 
 @_rawLayout(like: T)
-struct Cell<T>: ~Copyable {}
+struct Cell<T>: ~Copyable {
+    // CHECK-LABEL: sil {{.*}} @$s10raw_layout4CellV7addressSpyxGvg : $@convention(method) <T> (@in_guaranteed Cell<T>) -> UnsafeMutablePointer<T> {
+    // CHECK:         {{%.*}} = builtin "addressOfRawLayout"<Cell<T>>({{%.*}} : $*Cell<T>) : $Builtin.RawPointer
+    // CHECK-LABEL: } // end sil function '$s10raw_layout4CellV7addressSpyxGvg'
+    var address: UnsafeMutablePointer<T> {
+        .init(Builtin.addressOfRawLayout(self))
+    }
+
+    init(_ value: consuming T) {
+        address.initialize(to: value)
+    }
+}
 
 @_rawLayout(likeArrayOf: T, count: 8)
 struct SmallVectorBuf<T>: ~Copyable {}

--- a/test/SILOptimizer/stdlib/Cell.swift
+++ b/test/SILOptimizer/stdlib/Cell.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -O -emit-sil -disable-availability-checking %s -enable-builtin-module -enable-experimental-feature RawLayout -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+
+import Builtin
+
+@frozen
+@_rawLayout(like: T)
+public struct Cell<T: ~Copyable>: ~Copyable {
+  // CHECK-LABEL: sil {{.*}} @$s4CellAAVAARiczrlE7addressSpyxGvg : $@convention(method) <T where T : ~Copyable> (@in_guaranteed Cell<T>) -> UnsafeMutablePointer<T> {
+  // CHECK:       bb0([[SELF:%.*]] : $*Cell<T>):
+  // CHECK:         [[RAW_LAYOUT_ADDR:%.*]] = builtin "addressOfRawLayout"<Cell<T>>([[SELF]] : $*Cell<T>) : $Builtin.RawPointer
+  // CHECK-NEXT:    [[POINTER:%.*]] = struct $UnsafeMutablePointer<T> ([[RAW_LAYOUT_ADDR]] : $Builtin.RawPointer)
+  // CHECK-NEXT:    return [[POINTER]] : $UnsafeMutablePointer<T>
+  // CHECK-LABEL: } // end sil function '$s4CellAAVAARiczrlE7addressSpyxGvg'
+  @_transparent
+  public var address: UnsafeMutablePointer<T> {
+    .init(Builtin.addressOfRawLayout(self))
+  }
+
+  // CHECK-LABEL: sil {{.*}} @$s4CellAAVAARiczrlEyAByxGxcfC : $@convention(method) <T where T : ~Copyable> (@in T, @thin Cell<T>.Type) -> @out Cell<T> {
+  // CHECK:       bb0({{%.*}} : $*Cell<T>, [[VALUE:%.*]] : $*T, {{%.*}} : $@thin Cell<T>.Type):
+  // CHECK:         {{%.*}} = builtin "zeroInitializer"<Cell<T>>([[SELF:%.*]] : $*Cell<T>) : $()
+  // CHECK-NEXT:    [[RAW_LAYOUT_ADDR:%.*]] = builtin "addressOfRawLayout"<Cell<T>>([[SELF]] : $*Cell<T>) : $Builtin.RawPointer
+  // CHECK-NEXT:    [[POINTER:%.*]] = struct $UnsafeMutablePointer<T> ([[RAW_LAYOUT_ADDR]] : $Builtin.RawPointer)
+  //                Calling 'UnsafeMutablePointer<T>.initialize(to:)'
+  // CHECK:         {{%.*}} = apply {{%.*}}<T>([[VALUE]], [[POINTER]])
+  // CHECK-LABEL: } // end sil function '$s4CellAAVAARiczrlEyAByxGxcfC'
+  @_transparent
+  public init(_ value: consuming T) {
+    address.initialize(to: value)
+  }
+
+  @inlinable
+  deinit {
+    address.deinitialize(count: 1)
+  }
+}

--- a/test/SILOptimizer/stdlib/Cell.swift
+++ b/test/SILOptimizer/stdlib/Cell.swift
@@ -5,25 +5,25 @@ import Builtin
 @frozen
 @_rawLayout(like: T)
 public struct Cell<T: ~Copyable>: ~Copyable {
-  // CHECK-LABEL: sil {{.*}} @$s4CellAAVAARiczrlE7addressSpyxGvg : $@convention(method) <T where T : ~Copyable> (@in_guaranteed Cell<T>) -> UnsafeMutablePointer<T> {
+  // CHECK-LABEL: sil {{.*}} @$s4CellAAVAARi_zrlE7addressSpyxGvg : $@convention(method) <T where T : ~Copyable> (@in_guaranteed Cell<T>) -> UnsafeMutablePointer<T> {
   // CHECK:       bb0([[SELF:%.*]] : $*Cell<T>):
   // CHECK:         [[RAW_LAYOUT_ADDR:%.*]] = builtin "addressOfRawLayout"<Cell<T>>([[SELF]] : $*Cell<T>) : $Builtin.RawPointer
   // CHECK-NEXT:    [[POINTER:%.*]] = struct $UnsafeMutablePointer<T> ([[RAW_LAYOUT_ADDR]] : $Builtin.RawPointer)
   // CHECK-NEXT:    return [[POINTER]] : $UnsafeMutablePointer<T>
-  // CHECK-LABEL: } // end sil function '$s4CellAAVAARiczrlE7addressSpyxGvg'
+  // CHECK-LABEL: } // end sil function '$s4CellAAVAARi_zrlE7addressSpyxGvg'
   @_transparent
   public var address: UnsafeMutablePointer<T> {
     .init(Builtin.addressOfRawLayout(self))
   }
 
-  // CHECK-LABEL: sil {{.*}} @$s4CellAAVAARiczrlEyAByxGxcfC : $@convention(method) <T where T : ~Copyable> (@in T, @thin Cell<T>.Type) -> @out Cell<T> {
+  // CHECK-LABEL: sil {{.*}} @$s4CellAAVAARi_zrlEyAByxGxcfC : $@convention(method) <T where T : ~Copyable> (@in T, @thin Cell<T>.Type) -> @out Cell<T> {
   // CHECK:       bb0({{%.*}} : $*Cell<T>, [[VALUE:%.*]] : $*T, {{%.*}} : $@thin Cell<T>.Type):
   // CHECK:         {{%.*}} = builtin "zeroInitializer"<Cell<T>>([[SELF:%.*]] : $*Cell<T>) : $()
   // CHECK-NEXT:    [[RAW_LAYOUT_ADDR:%.*]] = builtin "addressOfRawLayout"<Cell<T>>([[SELF]] : $*Cell<T>) : $Builtin.RawPointer
   // CHECK-NEXT:    [[POINTER:%.*]] = struct $UnsafeMutablePointer<T> ([[RAW_LAYOUT_ADDR]] : $Builtin.RawPointer)
   //                Calling 'UnsafeMutablePointer<T>.initialize(to:)'
   // CHECK:         {{%.*}} = apply {{%.*}}<T>([[VALUE]], [[POINTER]])
-  // CHECK-LABEL: } // end sil function '$s4CellAAVAARiczrlEyAByxGxcfC'
+  // CHECK-LABEL: } // end sil function '$s4CellAAVAARi_zrlEyAByxGxcfC'
   @_transparent
   public init(_ value: consuming T) {
     address.initialize(to: value)


### PR DESCRIPTION
This is a cherry pick of https://github.com/apple/swift/pull/72592

Explanation: Adds a new builtin that gets the stable address of a `@_rawLayout` type.
Scope: Compiler
Issue: None.
Original PR: https://github.com/apple/swift/pull/72592
Risk: Low, this adds a new builtin and has related functionality to support this builtin.
Testing: CI
Reviewer: @atrick 