### PR TITLE
[DNM] [stdlib] Atomic is expressible by literals when value is

### DIFF
--- a/stdlib/public/Synchronization/Atomic.swift
+++ b/stdlib/public/Synchronization/Atomic.swift
@@ -57,3 +57,55 @@ public struct Atomic<Value: AtomicRepresentable>: ~Copyable {
 
 @available(SwiftStdlib 6.0, *)
 extension Atomic: @unchecked Sendable where Value: Sendable {}
+
+@available(SwiftStdlib 6.0, *)
+extension Atomic: ExpressibleByNilLiteral where Value: ExpressibleByNilLiteral {
+  @available(SwiftStdlib 6.0, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public init(nilLiteral: ()) {
+    self.init(Value(nilLiteral: ()))
+  }
+}
+
+@available(SwiftStdlib 6.0, *)
+extension Atomic: ExpressibleByBooleanLiteral where Value: ExpressibleByBooleanLiteral {
+  @available(SwiftStdlib 6.0, *)
+  public typealias BooleanLiteralType = Value.BooleanLiteralType
+
+  @available(SwiftStdlib 6.0, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public init(booleanLiteral value: BooleanLiteralType) {
+    let initialValue = Value(booleanLiteral: value)
+    address.initialize(to: Value.encodeAtomicRepresentation(initialValue))
+  }
+}
+
+@available(SwiftStdlib 6.0, *)
+extension Atomic: ExpressibleByIntegerLiteral where Value: ExpressibleByIntegerLiteral {
+  @available(SwiftStdlib 6.0, *)
+  public typealias IntegerLiteralType = Value.IntegerLiteralType
+
+  @available(SwiftStdlib 6.0, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public init(integerLiteral value: IntegerLiteralType) {
+    let initialValue = Value(integerLiteral: value)
+    address.initialize(to: Value.encodeAtomicRepresentation(initialValue))
+  }
+}
+
+@available(SwiftStdlib 6.0, *)
+extension Atomic: ExpressibleByFloatLiteral where Value: ExpressibleByFloatLiteral {
+  @available(SwiftStdlib 6.0, *)
+  public typealias FloatLiteralType = Value.FloatLiteralType
+
+  @available(SwiftStdlib 6.0, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public init(floatLiteral value: FloatLiteralType) {
+    let initialValue = Value(floatLiteral: value)
+    address.initialize(to: Value.encodeAtomicRepresentation(initialValue))
+  }
+}

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -297,7 +297,7 @@ public protocol _ExpressibleByBuiltinIntegerLiteral {
 ///
 /// To add `ExpressibleByIntegerLiteral` conformance to your custom type,
 /// implement the required initializer.
-public protocol ExpressibleByIntegerLiteral {
+public protocol ExpressibleByIntegerLiteral: ~Copyable {
   /// A type that represents an integer literal.
   ///
   /// The standard library integer and floating-point types are all valid types
@@ -340,7 +340,7 @@ public protocol _ExpressibleByBuiltinFloatLiteral {
 ///
 /// To add `ExpressibleByFloatLiteral` conformance to your custom type,
 /// implement the required initializer.
-public protocol ExpressibleByFloatLiteral {
+public protocol ExpressibleByFloatLiteral: ~Copyable {
   /// A type that represents a floating-point literal.
   ///
   /// Valid types for `FloatLiteralType` are `Float`, `Double`, and `Float80`
@@ -375,7 +375,7 @@ public protocol _ExpressibleByBuiltinBooleanLiteral {
 /// To add `ExpressibleByBooleanLiteral` conformance to your custom type,
 /// implement the `init(booleanLiteral:)` initializer that creates an instance
 /// of your type with the given Boolean value.
-public protocol ExpressibleByBooleanLiteral {
+public protocol ExpressibleByBooleanLiteral: ~Copyable {
   /// A type that represents a Boolean literal, such as `Bool`.
   associatedtype BooleanLiteralType: _ExpressibleByBuiltinBooleanLiteral
 


### PR DESCRIPTION
When the underlying value type is expressible by X literal, then atomic can be too.