### PR TITLE
[wasm] Enable Observation module build for Wasm target

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -110,6 +110,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
                                                'swift-experimental-string-processing'))
         self.cmake_options.define('SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_ENABLE_SYNCHRONIZATION:BOOL', 'TRUE')
+        self.cmake_options.define('SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION:BOOL', 'TRUE')
 
         self.add_extra_cmake_options()
 


### PR DESCRIPTION
There is no reason not to enable it :)