### PR TITLE
[SILGen] Fix a crash when a closure is converted to a block returning a value indirectly

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2330,7 +2330,9 @@ static void emitEntryPointArgumentsCOrObjC(IRGenSILFunction &IGF,
   // First, claim all the indirect results.
   ArrayRef<SILArgument *> args = emitEntryPointIndirectReturn(
       *emission, IGF, entry, funcTy, [&](SILType directResultType) -> bool {
-        return FI.getReturnInfo().isIndirect();
+        // Indirect at the IR level but direct at the SIL level.
+        return FI.getReturnInfo().isIndirect() &&
+               !funcTy->hasIndirectFormalResults();
       });
 
   unsigned nextArgTyIdx = 0;

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -392,7 +392,8 @@ static void buildFuncToBlockInvokeBody(SILGenFunction &SGF,
   if (blockTy->getNumResults() != 0) {
     auto result = blockTy->getSingleResult();
     if (result.getConvention() == ResultConvention::Indirect) {
-      indirectResult = entry->createFunctionArgument(blockResultTy);
+      indirectResult =
+          entry->createFunctionArgument(blockResultTy.getAddressType());
     }
   }
 

--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -20,4 +20,6 @@ struct ARCStrong {
 void cfuncARCStrong(void (*_Nonnull)(ARCStrong));
 #endif
 
+void cfuncReturnNonTrivial(NonTrivial (^_Nonnull)()) noexcept;
+
 #endif // __CLOSURE__

--- a/test/Interop/Cxx/class/closure-thunk-macosx-irgen.swift
+++ b/test/Interop/Cxx/class/closure-thunk-macosx-irgen.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swiftxx-frontend -I %S/Inputs -emit-irgen %s | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+import Closure
+
+// CHECK: define internal swiftcc void @"$s4main34testClosureToBlockReturnNonTrivialyyFSo0gH0VycfU_"(ptr noalias sret(%{{.*}}) %[[V0:.*]])
+// CHECK: call {{void|ptr}} @__swift_cxx_ctor_ZN10NonTrivialC1Ev(ptr %[[V0]])
+// CHECK: ret void
+
+// CHECK: define linkonce_odr hidden void @"$sSo10NonTrivialVIegr_ABIeyBr_TR"(ptr noalias sret(%{{.*}}) %[[V0:.*]], ptr %[[V1:.*]])
+// CHECK: %[[V2:.*]] = getelementptr inbounds { %{{.*}}, %{{.*}} }, ptr %[[V1]], i32 0, i32 1
+// CHECK: %[[_FN:.*]] = getelementptr inbounds %{{.*}}, ptr %[[V2]], i32 0, i32 0
+// CHECK: %[[V3:.*]] = load ptr, ptr %[[_FN]], align 8
+// CHECK: %[[_DATA:.*]] = getelementptr inbounds %{{.*}}, ptr %[[V2]], i32 0, i32 1
+// CHECK: %[[V4:.*]] = load ptr, ptr %[[_DATA]], align 8
+// CHECK: call ptr @swift_retain(ptr returned %[[V4]])
+// CHECK: call swiftcc void %[[V3]](ptr noalias sret(%{{.*}}) %[[V0]], ptr swiftself %[[V4]])
+// CHECK: call void @swift_release(ptr %[[V4]])
+// CHECK: ret void
+
+public func testClosureToBlockReturnNonTrivial() {
+  cfuncReturnNonTrivial({() -> NonTrivial in return NonTrivial() })
+}

--- a/test/Interop/Cxx/class/closure-thunk-macosx.swift
+++ b/test/Interop/Cxx/class/closure-thunk-macosx.swift
@@ -20,3 +20,18 @@ import Closure
 public func testClosureToFuncPtr() {
  cfuncARCStrong({N in})
 }
+
+// CHECK: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSo10NonTrivialVIegr_ABIeyBr_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed () -> @out NonTrivial) -> @out NonTrivial {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial, %[[V1:.*]] : $*@block_storage @callee_guaranteed () -> @out NonTrivial):
+// CHECK: %[[V2:.*]] = project_block_storage %[[V1]] : $*@block_storage @callee_guaranteed () -> @out NonTrivial
+// CHECK: %[[V3:.*]] = load [copy] %[[V2]] : $*@callee_guaranteed () -> @out NonTrivial
+// CHECK: %[[V4:.*]] = begin_borrow %[[V3]] : $@callee_guaranteed () -> @out NonTrivial
+// CHECK: apply %[[V4]](%[[V0]]) : $@callee_guaranteed () -> @out NonTrivial
+// CHECK: end_borrow %[[V4]] : $@callee_guaranteed () -> @out NonTrivial
+// CHECK: %[[V8:.*]] = tuple ()
+// CHECK: destroy_value %[[V3]] : $@callee_guaranteed () -> @out NonTrivial
+// CHECK: return %[[V8]] : $()
+
+public func testClosureToBlockReturnNonTrivial() {
+  cfuncReturnNonTrivial({() -> NonTrivial in return NonTrivial() })
+}


### PR DESCRIPTION
Fix the type of the function argument added to the entry basic block.

Also, fix the predicate passed to emitEntryPointIndirectReturn so that it returns true only when the result is returned indirectly at the IR level but directly at the SIL level.

rdar://127745392