### PR TITLE
[Concurrency] Make UnownedTaskExecutor Hashable for convenience

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -885,6 +885,26 @@ extension UnownedTaskExecutor: Equatable {
   }
 }
 
+@_unavailableInEmbedded
+@available(SwiftStdlib 6.0, *)
+extension UnownedTaskExecutor {
+  /// Hash the executor identity into the given hasher.
+  ///
+  /// This function is available independently from the `Hashable` conformance,
+  /// allowing back-deployment to older runtimes when implementing `Hashable`
+  /// in user code
+  @_alwaysEmitIntoClient
+  public func hash(into hasher: inout Hasher) {
+    let (ident, impl) = unsafe unsafeBitCast(self.executor, to: (Int, Int).self)
+    hasher.combine(ident)
+    hasher.combine(impl)
+  }
+}
+
+@_unavailableInEmbedded
+@available(SwiftStdlib 6.4, *)
+extension UnownedTaskExecutor: Hashable {}
+
 /// Returns either `true` or will CRASH if called from a different executor
 /// than the passed `executor`.
 ///

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -316,6 +316,11 @@ Added: _$sScf13checkIsolatedyyFTj
 // method descriptor for Swift.SerialExecutor.checkIsolated() -> ()
 Added: _$sScf13checkIsolatedyyFTq
 
+// Added Hashable conformance to UnownedTaskExecutor
+Added: _$ss19UnownedTaskExecutorV9hashValueSivg
+Added: _$ss19UnownedTaskExecutorV9hashValueSivpMV
+Added: _$ss19UnownedTaskExecutorVSHsMc
+
 // #isolated adoption in multiple APIs
 // withTaskCancellationHandler gains #isolated
 Added: _$ss27withTaskCancellationHandler9operation8onCancel9isolationxxyYaKXE_yyYbXEScA_pSgYitYaKlF

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -316,7 +316,12 @@ Added: _$sScf13checkIsolatedyyFTj
 // method descriptor for Swift.SerialExecutor.checkIsolated() -> ()
 Added: _$sScf13checkIsolatedyyFTq
 
-// #isolated adoption in multiple APis
+// Added Hashable conformance to UnownedTaskExecutor
+Added: _$ss19UnownedTaskExecutorV9hashValueSivg
+Added: _$ss19UnownedTaskExecutorV9hashValueSivpMV
+Added: _$ss19UnownedTaskExecutorVSHsMc
+
+// #isolated adoption in multiple APIs
 // withTaskCancellationHandler gains #isolated
 Added: _$ss27withTaskCancellationHandler9operation8onCancel9isolationxxyYaKXE_yyYbXEScA_pSgYitYaKlF
 Added: _$ss27withTaskCancellationHandler9operation8onCancel9isolationxxyYaKXE_yyYbXEScA_pSgYitYaKlFTu


### PR DESCRIPTION
**Explanation**: 

`UnownedTaskExecutor` already is equatable -- just by pointer comparison, and tbh there's no harm in making it hashable as well then.

Funnily enough `UnownedSerialExecutor` is not equatable or hashable -- we'd have to take into account complex equality there, which is doable but a bit annoying. Serial executors are not really used in the same way as sticky task executors in with thread pools where we want to "select the right one" like in a connection pool situation... so let's not add more than we need to I think.

This specific conformance makes maps like this possible without wrapper types and unsafe casts in user-code: `[UnownedTaskExecutor: EventLoop]` which is what I think @fabianfett was after here. 


This was accepted in SE review over here: https://forums.swift.org/t/se-0523-hashable-conformance-for-unownedtaskexecutor/85593/3


**Scope**:  Adds always-emit-into-client hash method and an 6.4 gated Hashable availability, very low risk as it is unlikely anyone had implemented it by hand.

**Risk**: Low, unlikely anyone had implemented this conformance as it would use unsafe casts and is uncommon use-case.

**Testing**: CI testing, no additional tests for the hashable though.

**Issues**: 
Resolves rdar://128452304