### PR TITLE
[Concurrency] Disable test on simulators; unexpected env behavior

### DIFF
--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_main_customExecutorOnMain_swift6_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_main_customExecutorOnMain_swift6_mode.swift
@@ -15,8 +15,11 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: freestanding
 
-// Temporarily disable for now rdar://128862814
-// REQUIRES: rdar128862814
+// Disable this test on simulators
+// UNSUPPORTED: DARWIN_SIMULATOR=watchos
+// UNSUPPORTED: DARWIN_SIMULATOR=ios
+// UNSUPPORTED: DARWIN_SIMULATOR=tvos
+// UNSUPPORTED: single_threaded_concurrency
 
 import Dispatch
 


### PR DESCRIPTION
Instead of disabling the test, only mark simulator env as not supported. Something's off with the env on them.

Undoes: https://github.com/apple/swift/pull/73938
Resolves rdar://128862814