### PR TITLE
[6.0] Start building and including lld even in Darwin toolchains

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -19,7 +19,7 @@ swift-install-components=back-deployment;compiler;clang-builtin-headers;libexec;
 [preset: mixin_buildbot_install_components_with_clang]
 
 swift-install-components=autolink-driver;back-deployment;compiler;clang-resource-dir-symlink;libexec;stdlib;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers;swift-external-generic-metadata-builder;swift-external-generic-metadata-builder-headers
-llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil;LTO;clang-features-file
+llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil;LTO;clang-features-file;lld
 
 [preset: mixin_buildbot_trunk_base]
 # Build standard library and SDK overlay for iOS device and simulator.

--- a/utils/build_swift/build_swift/defaults.py
+++ b/utils/build_swift/build_swift/defaults.py
@@ -121,11 +121,10 @@ def llvm_install_components():
     platforms.
     """
     components = ['llvm-ar', 'llvm-cov', 'llvm-profdata', 'IndexStore', 'clang',
-                  'clang-resource-headers', 'compiler-rt', 'clangd', 'LTO']
+                  'clang-resource-headers', 'compiler-rt', 'clangd', 'LTO',
+                  'lld']
     if os.sys.platform == 'darwin':
         components.extend(['dsymutil'])
-    else:
-        components.extend(['lld'])
     return ';'.join(components)
 
 

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -295,17 +295,13 @@ class LLVM(cmake_product.CMakeProduct):
         if self.args.build_clang_tools_extra:
             llvm_enable_projects.append('clang-tools-extra')
 
-        # On non-Darwin platforms, build lld so we can always have a
+        # Always build lld -- on non-Darwin so we can always have a
         # linker that is compatible with the swift we are using to
-        # compile the stdlib.
+        # compile the stdlib, but on Darwin too for Embedded Swift use cases.
         #
         # This makes it easier to build target stdlibs on systems that
         # have old toolchains without more modern linker features.
-
-        target = targets.StdlibDeploymentTarget.get_target_for_name(host_target)
-
-        if not target.platform.is_darwin or self.args.build_lld:
-            llvm_enable_projects.append('lld')
+        llvm_enable_projects.append('lld')
 
         llvm_cmake_options.define('LLVM_ENABLE_PROJECTS',
                                   ';'.join(llvm_enable_projects))


### PR DESCRIPTION
We want `lld` to land in the toolchain everywhere; this is useful for embedded and also for cross-compilation.

rdar://128925574