### PR TITLE
Setting the default linker to gold

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3023,3 +3023,6 @@ skip-test-cmark
 skip-test-swift
 skip-build-benchmarks
 skip-test-foundation
+
+llvm-cmake-options=
+  -DCLANG_DEFAULT_LINKER=gold


### PR DESCRIPTION
Missed another build preset. Setting the default linker to gold on the LLDB linux job.
