### PR TITLE
[embedded] Allow disabling embedded stdlib, but still test compiler

### DIFF
--- a/test/DebugInfo/embedded.swift
+++ b/test/DebugInfo/embedded.swift
@@ -6,5 +6,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib
 
 // CHECK:          !DICompileUnit({{.*}}flags: "-enable-embedded-swift"

--- a/test/IDE/complete_embedded_linux.swift
+++ b/test/IDE/complete_embedded_linux.swift
@@ -1,6 +1,7 @@
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 // REQUIRES: OS=linux-gnu
+// REQUIRES: embedded_stdlib
 // RUN: %batch-code-completion -enable-experimental-feature Embedded
 
 func test() {

--- a/test/IDE/complete_embedded_macos.swift
+++ b/test/IDE/complete_embedded_macos.swift
@@ -1,6 +1,7 @@
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 // REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib
 // RUN: %batch-code-completion -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded
 
 func test() {

--- a/test/SILOptimizer/devirt_deinits.swift
+++ b/test/SILOptimizer/devirt_deinits.swift
@@ -18,6 +18,7 @@
 // REQUIRES: OS=macosx
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: embedded_stdlib
 
 @inline(never)
 func log(_ s: StaticString) {

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -10,3 +10,7 @@ if config.target_sdk_name == 'macosx':
     return (key, value)
 
   config.substitutions = [do_fixup(a, b) for (a, b) in config.substitutions]
+
+if 'embedded_stdlib' not in config.available_features:
+  config.unsupported = True
+

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -157,6 +157,8 @@ if "@SWIFT_STDLIB_ENABLE_DEBUG_PRECONDITIONS_IN_RELEASE@" == "TRUE":
     config.available_features.add('swift_stdlib_debug_preconditions_in_release')
 if "@SWIFT_ENABLE_SYNCHRONIZATION@" == "TRUE":
     config.available_features.add('synchronization')
+if "@SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB@" == "TRUE":
+    config.available_features.add('embedded_stdlib')
 
 config.swift_freestanding_is_darwin = "@SWIFT_FREESTANDING_IS_DARWIN@" == "TRUE"
 config.swift_stdlib_use_relative_protocol_witness_tables = "@SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES@" == "TRUE"


### PR DESCRIPTION
While one can disable building the embedded stdlib, the tests for that feature were unconditionally added. If one wants to just build the compiler without any stdlib (except target), a bunch of embedded tests would have failed.

Inject the value of `SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB` into the Lit test system as a feature `embedded_stdlib` and add `REQUIRES:` to a couple of tests outside the `embedded/` directory that seems to use the experimental feature. Make the tests in `embedded/` unsupported in the local Lit configuration file.
