### PR TITLE
[6.0][CSBindings] Optional object type variable should be connected to the optional

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1650,6 +1650,16 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
       break;
     }
 
+    case ConstraintKind::OptionalObject: {
+      // Type variable that represents an object type of
+      // an un-inferred optional is adjacent to a type
+      // variable that presents such optional (`bindingTypeVar`
+      // in this case).
+      if (kind == AllowedBindingKind::Supertypes)
+        AdjacentVars.insert({bindingTypeVar, constraint});
+      break;
+    }
+
     default:
       break;
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5425,8 +5425,14 @@ bool ConstraintSystem::repairFailures(
       auto contextualTy = simplifyType(rhs)->getOptionalObjectType();
       if (!lhs->getOptionalObjectType() && !lhs->hasTypeVariable() &&
           contextualTy && !contextualTy->isTypeVariableOrMember()) {
-        conversionsOrFixes.push_back(IgnoreContextualType::create(
-            *this, lhs, rhs, getConstraintLocator(OEE->getSubExpr())));
+        auto *fixLocator = getConstraintLocator(OEE->getSubExpr());
+        // If inner expression already has a fix, consider this two-way
+        // mismatch as un-salvageable.
+        if (hasFixFor(fixLocator))
+          return false;
+
+        conversionsOrFixes.push_back(
+              IgnoreContextualType::create(*this, lhs, rhs, fixLocator));
         return true;
       }
     }

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -341,3 +341,13 @@ do {
     }
   }
 }
+
+// https://github.com/apple/swift/issues/73207
+do {
+  func test(_ levels: [Range<Int>]) {
+    for (i, leaves): (Int, Range<Int>) in levels[8 ..< 15].enumerated() { // Ok
+      _ = i
+      _ = leaves
+    }
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/73960

---

- Explanation:

  Fixes a recent regression in for-in lookup type-checking.

  If both sides of an `OptionalObject` constraint are un-inferred, their
  binding sets need to correctly reflect adjacency - a type variable
  that represents optional would get "object" as an adjacency through
  its potential binding (the binding is - "object" wrapped in a single
  level of optional) and "object" type variable needs to get its parent
  optional type variable added to its adjacency list explicitly.

  Without this it would be possible to prematurely pick "object" before
  its parent optional type variable.


- Scope: One known situation where this comes up is for-in loop where the pattern has an explicit contextual type.

- Main Branch PRs: https://github.com/apple/swift/pull/73960

- Resolves: https://github.com/apple/swift/issues/73207
- Resolves: rdar://126960579

- Risk: Low

- Reviewed By: @hborla     

- Testing: Added new test-cases to the test suite

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
