### PR TITLE
5.10: [Mem2Reg] Undef types in empty projection sources.

### DIFF
--- a/test/SILOptimizer/mem2reg.sil
+++ b/test/SILOptimizer/mem2reg.sil
@@ -531,3 +531,19 @@ sil @dont_canonicalize_undef : $@convention(thin) () -> () {
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: sil @undef_for_load_of_empty_type_from_nontrivial_aggregate : {{.*}} {
+// CHECK:         [[EMPTY:%[^,]+]] = tuple ()
+// CHECK:         [[AGGREGATE:%[^,]+]] = tuple (undef : $Builtin.BridgeObject, [[EMPTY]] : $())
+// CHECK:         tuple_extract [[AGGREGATE]] : $(Builtin.BridgeObject, ()), 1
+// CHECK-LABEL: } // end sil function 'undef_for_load_of_empty_type_from_nontrivial_aggregate'
+sil @undef_for_load_of_empty_type_from_nontrivial_aggregate : $@convention(thin) () -> () {
+bb0:
+  %11 = alloc_stack $(Builtin.BridgeObject, ())
+  %12 = tuple_element_addr %11 : $*(Builtin.BridgeObject, ()), 1
+  %13 = load %12 : $*()
+  %empty = tuple ()
+  %14 = tuple (%empty : $(), %13 : $())
+  dealloc_stack %11 : $*(Builtin.BridgeObject, ())
+  return undef : $()
+}


### PR DESCRIPTION
**Explanation**: Fix a crash-on-valid during optimization (Mem2Reg).

Mem2Reg may create the unique instance of empty types when promoting an address of that empty type.

Previously, the code that creates that instance required that the top-most type from which the address was projected was itself empty.  This failed to handle the case where the address' type was empty but the top-most type was not.

Here, this is fixed by allowing the top-most type to be instantiated using `undef` for non-empty fields.
**Scope**: Affects optimization of code involving empty fields of non-empty types.
**Issue**: rdar://122417297
**Original PR**: https://github.com/apple/swift/pull/71521
**Risk**: Low.
**Testing**: Added SIL test.
**Reviewer**: Erik Eckstein ( @eeckstein )
