### PR TITLE
Sema: Ban unsound convenience initializer inheritance inside a module

### DIFF
--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -144,7 +144,7 @@ void HasMissingDesignatedInitializersRequest::cacheResult(bool result) const {
 
 bool
 HasMissingDesignatedInitializersRequest::evaluate(Evaluator &evaluator,
-                                           ClassDecl *subject) const {
+                                                  ClassDecl *subject) const {
   // Short-circuit and check for the attribute here.
   if (subject->getAttrs().hasAttribute<HasMissingDesignatedInitializersAttr>())
     return true;

--- a/test/decl/init/private-designated-init.swift
+++ b/test/decl/init/private-designated-init.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+class Base {
+  private init(x: Int) {}
+  convenience init(y: Int) { self.init(x: y) }
+}
+
+class Derived: Base {}
+// expected-error@-1 {{class 'Derived' has no initializers}}
+
+class RequiredBase {
+  private init(x: Int) {}
+  required convenience init(y: Int) { self.init(x: y) }
+  // expected-note@-1 {{'required' initializer is declared in superclass here}}
+}
+
+class RequiredDerived: RequiredBase {}
+// expected-error@-1 {{class 'RequiredDerived' has no initializers}}
+// expected-error@-1 {{'required' initializer 'init(y:)' must be provided by subclass of 'RequiredBase'}}

--- a/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
@@ -120,6 +120,8 @@ class C8 {
     private init?(from: Decoder) {}
 }
 final class C9: C8 {}
+// expected-error@-1 {{class 'C9' has no initializers}}
+
 extension C9: Codable {}
 // expected-error@-1 {{type 'C9' does not conform to protocol 'Decodable'}}
 

--- a/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
@@ -28,8 +28,9 @@ class InaccessibleNonDecodableSuper {
   private init() {} // expected-note {{cannot automatically synthesize 'init(from:)' because implementation would need to call 'init()', which is inaccessible due to 'private' protection level}}
 }
 
-class InaccessibleNonDecodableSub : InaccessibleNonDecodableSuper, Decodable { // expected-error {{type 'InaccessibleNonDecodableSub' does not conform to protocol 'Decodable'}}
-}
+class InaccessibleNonDecodableSub : InaccessibleNonDecodableSuper, Decodable {}
+// expected-error@-1 {{type 'InaccessibleNonDecodableSub' does not conform to protocol 'Decodable'}}
+// expected-error@-2 {{class 'InaccessibleNonDecodableSub' has no initializers}}
 
 // Non-Decodable superclasses of synthesized Decodable classes must have a
 // non-failable init().


### PR DESCRIPTION
We already prevent the user from subclassing a class with an inaccessible
designated initializer from another module,

    open class C {
      private init() {}
      public convenience init(x: Int) { self.init() }
    }

However, we should ban this within a module too:

    class C {
      private init() {}
      convenience init(x: Int) { self.init() }
    }

    class D: C {}

Today, we don't diagnose anything, and we also don't synthesize the
override, so we just miscompile instead.

We can't synthesize the override though, because this would then
allow calling the superclass's private init from the subclass, which
violates access control.

So the only option is to ban this.

Fixes rdar://68220237.
Fixes https://github.com/apple/swift/issues/61508.