### PR TITLE
[6.0] [DebugInfo] [SILGen] Remove all invalid debug info from intermediates

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1549,18 +1549,19 @@ uint16_t SILGenFunction::emitBasicProlog(
     B.createDebugValue(loc, undef.getValue(), dbgVar);
   }
 
-  for (auto &i : *B.getInsertionBB()) {
-    auto *alloc = dyn_cast<AllocStackInst>(&i);
-    if (!alloc)
-      continue;
-    auto varInfo = alloc->getVarInfo();
-    if (!varInfo || varInfo->ArgNo)
-      continue;
-    // The allocation has a varinfo but no argument number, which should not
-    // happen in the prolog. Unfortunately, some copies can generate wrong
-    // debug info, so we have to fix it here, by invalidating it.
-    alloc->invalidateVarInfo();
-  }
+  for (auto &bb : B.getFunction())
+    for (auto &i : bb) {
+      auto *alloc = dyn_cast<AllocStackInst>(&i);
+      if (!alloc)
+        continue;
+      auto varInfo = alloc->getVarInfo();
+      if (!varInfo || varInfo->ArgNo)
+        continue;
+      // The allocation has a varinfo but no argument number, which should not
+      // happen in the prolog. Unfortunately, some copies can generate wrong
+      // debug info, so we have to fix it here, by invalidating it.
+      alloc->invalidateVarInfo();
+    }
 
   return ArgNo;
 }

--- a/test/DebugInfo/parameter-pack.swift
+++ b/test/DebugInfo/parameter-pack.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+// https://github.com/apple/swift/issues/73030
+
+// CHECK-LABEL: sil {{.+}} @$s4main1f1t1cxxQp_q_t_q0_txxQp_t_q_t_q0_tRvzr1_lF
+func f<each A, B, C>(t: ((repeat each A), B), c: C) -> ((repeat each A, B), C) {
+  // CHECK-NOT: let, name "t"
+  // CHECK: alloc_stack [lexical] [var_decl] $((repeat each A), B), let, name "t", argno 1
+  // CHECK: debug_value %{{[0-9]+}} : $*C, let, name "c", argno 2, expr op_deref
+  ((repeat each t.0, t.1), c)
+}


### PR DESCRIPTION
* **Explanation**: The debug info on temporary allocations in SILGen were not removed if the function used parameter packs.
* **Scope**: Affects debug info at the SILGen level
* **Original PR**: #73995
* **Risk**: Very low, only touches debug info when using parameter packs
* **Testing**: A new test has been added
* **Issue**: #73030 (rdar://126556557)
* **Reviewer**:  @adrian-prantl 