### PR TITLE
[6.0] [Sema] Preserve compatibility for `weak self` with `@_implicitSelfCapture`

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2415,6 +2415,13 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
         return true;
       }
 
+      // Implicit self was also permitted for weak self captures in closures
+      // passed to @_implicitSelfCapture parameters in Swift 5.7.
+      if (auto *CE = dyn_cast<ClosureExpr>(ACE)) {
+        if (CE->allowsImplicitSelfCapture())
+          return true;
+      }
+
       // Invalid captures like `[weak self = somethingElse]`
       // were permitted in Swift 5.8, so we must only warn.
       if (!isSimpleSelfCapture(weakSelfDecl)) {

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -756,6 +756,8 @@ public class TestImplicitCaptureOfExplicitCaptureOfSelfInEscapingClosure {
     }
 }
 
+func takesEscapingWithAllowedImplicitSelf(@_implicitSelfCapture _ fn: @escaping () -> Void) {}
+
 public class TestImplicitSelfForWeakSelfCapture {
   static let staticOptional: TestImplicitSelfForWeakSelfCapture? = nil
   func method() { }
@@ -817,7 +819,13 @@ public class TestImplicitSelfForWeakSelfCapture {
         method()
       }
     }
-    
+
+    takesEscapingWithAllowedImplicitSelf { [weak self] in
+      method() // expected-warning {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+      guard let self = self else { return }
+      method()
+    }
+
     doVoidStuff { [weak self] in
       let `self`: TestImplicitSelfForWeakSelfCapture? = self ?? TestImplicitSelfForWeakSelfCapture.staticOptional
       guard let self = self else { return }

--- a/test/expr/closure/closures_swift6.swift
+++ b/test/expr/closure/closures_swift6.swift
@@ -81,6 +81,8 @@ class C_56501 {
   }
 }
 
+func takesEscapingWithAllowedImplicitSelf(@_implicitSelfCapture _ fn: @escaping () -> Void) {}
+
 public final class TestImplicitSelfForWeakSelfCapture: Sendable {
   static let staticOptional: TestImplicitSelfForWeakSelfCapture? = .init()
   func method() { }
@@ -128,6 +130,12 @@ public final class TestImplicitSelfForWeakSelfCapture: Sendable {
       if let self = self {
         method()
       }
+    }
+
+    takesEscapingWithAllowedImplicitSelf { [weak self] in
+      method() // expected-error {{explicit use of 'self' is required when 'self' is optional, to make control flow explicit}} expected-note {{reference 'self?.' explicitly}}
+      guard let self = self else { return }
+      method()
     }
 
     doVoidStuff { [weak self] in


### PR DESCRIPTION
*6.0 cherry-pick of #73976*

- Explanation: Fixes a regression that would cause us to error on an implicit use of `self` in a `weak self` captured closure passed to an `@_implicitSelfCapture` parameter, e.g `Task`'s initializer.
- Scope: Adds a missed case to the warning downgrade logic for the invalid implicit self diagnostic.
- Issue: rdar://128941797
- Risk: Low, this strictly causes us to warn in more cases
- Testing: Added tests to test suite
- Reviewer: Cal Stephens