### PR TITLE
[6.0 - stdlib] remove deprecations added by SE-0426

### DIFF
--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -510,9 +510,6 @@ extension UnsafeRawPointer {
   ///   with the value in the range of memory referenced by this pointer.
   @inlinable
   @_alwaysEmitIntoClient
-  @available(swift, deprecated: 6, message:
-    "Use the BitwiseCopyable-constrained overload"
-  )
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -1344,9 +1341,6 @@ extension UnsafeMutableRawPointer {
   ///   with the value in the range of memory referenced by this pointer.
   @inlinable
   @_alwaysEmitIntoClient
-  @available(swift, deprecated: 6, message:
-    "Use the BitwiseCopyable-constrained overload"
-  )
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -1450,9 +1444,6 @@ extension UnsafeMutableRawPointer {
   @_alwaysEmitIntoClient
   // This custom silgen name is chosen to not interfere with the old ABI
   @_silgen_name("_swift_se0349_UnsafeMutableRawPointer_storeBytes")
-  @available(swift, deprecated: 6, message:
-    "Use the BitwiseCopyable-constrained overload"
-  )
   public func storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {


### PR DESCRIPTION
Remove some deprecations introduced in SE-0426. Amendment to the proposal is here: https://github.com/apple/swift-evolution/pull/2469

Addresses rdar://128709914
Original PR: https://github.com/apple/swift/pull/73947.
Risk: None. This only removes a newly-added deprecation.
Reviewer: @stephentyrone 