### PR TITLE
[stdlib] Mark some UnsafePointer APIs as transparent

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -262,8 +262,8 @@ extension UnsafePointer where Pointee: ~Copyable {
   /// This pointer must be a pointer to the start of a previously allocated
   /// memory block. The memory must not be initialized or `Pointee` must be a
   /// trivial type.
-  @inlinable
   @_preInverseGenerics
+  @_transparent
   public func deallocate() {
     // Passing zero alignment to the runtime forces "aligned
     // deallocation". Since allocation via `UnsafeMutable[Raw][Buffer]Pointer`
@@ -777,8 +777,8 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   ///
   /// - Parameter count: The amount of memory to allocate, counted in instances
   ///   of `Pointee`.
-  @inlinable
   @_preInverseGenerics
+  @_transparent
   public static func allocate(
     capacity count: Int
   ) -> UnsafeMutablePointer<Pointee> {
@@ -810,8 +810,8 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   /// This pointer must be a pointer to the start of a previously allocated
   /// memory block. The memory must not be initialized or `Pointee` must be a
   /// trivial type.
-  @inlinable
   @_preInverseGenerics
+  @_transparent
   public func deallocate() {
     // Passing zero alignment to the runtime forces "aligned
     // deallocation". Since allocation via `UnsafeMutable[Raw][Buffer]Pointer`
@@ -898,6 +898,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   /// - Parameters:
   ///   - value: The instance to initialize this pointer's pointee to.
   @_alwaysEmitIntoClient
+  @_transparent
   public func initialize(to value: consuming Pointee) {
     Builtin.initialize(value, self._rawValue)
   }
@@ -928,8 +929,8 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   /// `move()`, the memory is uninitialized.
   ///
   /// - Returns: The instance referenced by this pointer.
-  @inlinable
   @_preInverseGenerics
+  @_transparent
   public func move() -> Pointee {
     return Builtin.take(_rawValue)
   }
@@ -1162,9 +1163,9 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   ///   not be negative.
   /// - Returns: A raw pointer to the same address as this pointer. The memory
   ///   referenced by the returned raw pointer is still bound to `Pointee`.
-  @inlinable
-  @_preInverseGenerics
   @discardableResult
+  @_preInverseGenerics
+  @_transparent
   public func deinitialize(count: Int) -> UnsafeMutableRawPointer {
     _debugPrecondition(count >= 0, "UnsafeMutablePointer.deinitialize with negative count")
     // Note: When count is statically known to be 1 the compiler will optimize

--- a/test/SILOptimizer/stdlib/Cell.swift
+++ b/test/SILOptimizer/stdlib/Cell.swift
@@ -20,9 +20,6 @@ public struct Cell<T: ~Copyable>: ~Copyable {
   // CHECK:       bb0({{%.*}} : $*Cell<T>, [[VALUE:%.*]] : $*T, {{%.*}} : $@thin Cell<T>.Type):
   // CHECK:         {{%.*}} = builtin "zeroInitializer"<Cell<T>>([[SELF:%.*]] : $*Cell<T>) : $()
   // CHECK-NEXT:    [[RAW_LAYOUT_ADDR:%.*]] = builtin "addressOfRawLayout"<Cell<T>>([[SELF]] : $*Cell<T>) : $Builtin.RawPointer
-  // CHECK-NEXT:    [[POINTER:%.*]] = struct $UnsafeMutablePointer<T> ([[RAW_LAYOUT_ADDR]] : $Builtin.RawPointer)
-  //                Calling 'UnsafeMutablePointer<T>.initialize(to:)'
-  // CHECK:         {{%.*}} = apply {{%.*}}<T>([[VALUE]], [[POINTER]])
   // CHECK-LABEL: } // end sil function '$s4CellAAVAARi_zrlEyAByxGxcfC'
   @_transparent
   public init(_ value: consuming T) {


### PR DESCRIPTION
This marks a few functions on the typed pointers as transparent. These functions aren't really generic and are calling out to a builtin to do a runtime call to alloc/dealloc, so we can avoid an intermediate function call in generic contexts because that's all these really are.