### PR TITLE
Prepare for introducing swift-foundation into the toolchain

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1236,10 +1236,13 @@ STRESSTEST_PACKAGE_DIR="${WORKSPACE}/swift-stress-tester"
 XCTEST_SOURCE_DIR="${WORKSPACE}/swift-corelibs-xctest"
 FOUNDATION_SOURCE_DIR="${WORKSPACE}/swift-corelibs-foundation"
 FOUNDATION_STATIC_SOURCE_DIR="${WORKSPACE}/swift-corelibs-foundation"
+FOUNDATION_SWIFTFOUNDATION_SOURCE_DIR="${WORKSPACE}/swift-foundation"
+FOUNDATION_SWIFTFOUNDATIONICU_SOURCE_DIR="${WORKSPACE}/swift-foundation-icu"
 LIBDISPATCH_SOURCE_DIR="${WORKSPACE}/swift-corelibs-libdispatch"
 LIBDISPATCH_STATIC_SOURCE_DIR="${WORKSPACE}/swift-corelibs-libdispatch"
 LIBICU_SOURCE_DIR="${WORKSPACE}/icu"
 LIBCXX_SOURCE_DIR="${WORKSPACE}/llvm-project/runtimes"
+SWIFT_COLLECTIONS_SOURCE_DIR="${WORKSPACE}/swift-collections"
 SWIFT_PATH_TO_STRING_PROCESSING_SOURCE="${WORKSPACE}/swift-experimental-string-processing"
 SWIFTSYNTAX_SOURCE_DIR="${WORKSPACE}/swift-syntax"
 SWIFT_SYNTAX_SOURCE_DIR="${WORKSPACE}/swift-syntax"
@@ -2518,6 +2521,12 @@ for host in "${ALL_HOSTS[@]}"; do
                   -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE=${LIBDISPATCH_SOURCE_DIR}
                   -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=$(build_directory ${host} libdispatch)
                   -Ddispatch_DIR=$(build_directory ${host} libdispatch)/cmake/modules
+
+                  -DSwiftSyntax_DIR=$(build_directory ${host} swift)/cmake/modules
+
+                  -D_SwiftFoundation_SourceDIR=${FOUNDATION_SWIFTFOUNDATION_SOURCE_DIR}
+                  -D_SwiftFoundationICU_SourceDIR=${FOUNDATION_SWIFTFOUNDATIONICU_SOURCE_DIR}
+                  -D_SwiftCollections_SourceDIR=${SWIFT_COLLECTIONS_SOURCE_DIR}
 
                   # NOTE(compnerd) we disable tests because XCTest is not ready
                   # yet, but we will reconfigure when the time comes.

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -41,7 +41,11 @@
         "swift-corelibs-xctest": {
             "remote": { "id": "apple/swift-corelibs-xctest" } },
         "swift-corelibs-foundation": {
-            "remote": { "id": "apple/swift-corelibs-foundation" } },
+            "remote": { "id": "apple/swift-corelibs-foundation" } },  
+        "swift-foundation-icu": {
+            "remote": { "id": "apple/swift-foundation-icu" } },  
+        "swift-foundation": {
+            "remote": { "id": "apple/swift-foundation" } },
         "swift-corelibs-libdispatch": {
             "remote": { "id": "apple/swift-corelibs-libdispatch" } },
         "swift-integration-tests": {
@@ -134,6 +138,8 @@
                 "swift-stress-tester": "main",
                 "swift-corelibs-xctest": "main",
                 "swift-corelibs-foundation": "main",
+                "swift-foundation-icu": "main",
+                "swift-foundation": "main",
                 "swift-corelibs-libdispatch": "main",
                 "swift-integration-tests": "main",
                 "swift-xcode-playground-support": "main",


### PR DESCRIPTION
Per @parkera's update [here](https://forums.swift.org/t/migration-plan-swift-corelibs-foundation-to-swift-foundation/70943/23), we will be adding swift-foundation to the toolchain and updating the swift-corelibs-foundation in the toolchain to be "re-cored" on this new implementation. This adds the initial steps to landing these changes:

1. Update the list of checkouts to include the swift-foundation and swift-foundation icu repos
2. Passing extra variables down to the cmake invocation of swift-corelibs-foundation so that it can appropriately find the new dependencies it will have (swift-collections, swift-syntax, swift-foundation-icu, and swift-foundation)

This change shouldn't affect the build itself today, but will allow us to introduce changes into swift-corelibs-foundation that utilize these new libraries.
