### PR TITLE
Pack expansion closures part 7

### DIFF
--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -41,9 +41,12 @@ template <> struct DenseMapInfo<swift::CapturedValue>;
 namespace swift {
 class ValueDecl;
 class FuncDecl;
+class Expr;
 class OpaqueValueExpr;
+class PackElementExpr;
 class VarDecl;
 class GenericEnvironment;
+class Type;
 
 /// CapturedValue includes both the declaration being captured, along with flags
 /// that indicate how it is captured.
@@ -52,7 +55,7 @@ class CapturedValue {
 
 public:
   using Storage =
-      llvm::PointerIntPair<llvm::PointerUnion<ValueDecl*, OpaqueValueExpr*>, 2,
+      llvm::PointerIntPair<llvm::PointerUnion<ValueDecl *, Expr *>, 2,
                            unsigned>;
 
 private:
@@ -78,15 +81,7 @@ public:
   CapturedValue(ValueDecl *Val, unsigned Flags, SourceLoc Loc)
       : Value(Val, Flags), Loc(Loc) {}
 
-private:
-  // This is only used in TypeLowering when forming Lowered Capture
-  // Info. OpaqueValueExpr captured value should never show up in the AST
-  // itself.
-  //
-  // NOTE: AbstractClosureExpr::getIsolationCrossing relies upon this and
-  // asserts that it never sees one of these.
-  explicit CapturedValue(OpaqueValueExpr *Val, unsigned Flags)
-      : Value(Val, Flags), Loc(SourceLoc()) {}
+  CapturedValue(Expr *Val, unsigned Flags);
 
 public:
   static CapturedValue getDynamicSelfMetadata() {
@@ -97,9 +92,13 @@ public:
   bool isNoEscape() const { return Value.getInt() & IsNoEscape; }
 
   bool isDynamicSelfMetadata() const { return !Value.getPointer(); }
-  bool isOpaqueValue() const {
-    return Value.getPointer().is<OpaqueValueExpr *>();
+
+  bool isExpr() const {
+    return Value.getPointer().dyn_cast<Expr *>();
   }
+
+  bool isPackElement() const;
+  bool isOpaqueValue() const;
 
   /// Returns true if this captured value is a local capture.
   ///
@@ -116,16 +115,18 @@ public:
   }
 
   ValueDecl *getDecl() const {
-    assert(Value.getPointer() && "dynamic Self metadata capture does not "
-           "have a value");
     return Value.getPointer().dyn_cast<ValueDecl *>();
   }
 
-  OpaqueValueExpr *getOpaqueValue() const {
-    assert(Value.getPointer() && "dynamic Self metadata capture does not "
-           "have a value");
-    return Value.getPointer().dyn_cast<OpaqueValueExpr *>();
+  Expr *getExpr() const {
+    return Value.getPointer().dyn_cast<Expr *>();
   }
+
+  OpaqueValueExpr *getOpaqueValue() const;
+
+  PackElementExpr *getPackElement() const;
+
+  Type getPackElementType() const;
 
   SourceLoc getLoc() const { return Loc; }
 

--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -106,12 +106,8 @@ public:
   /// values with decls are the only values that are able to be local captures.
   bool isLocalCapture() const;
 
-  CapturedValue mergeFlags(CapturedValue cv) {
-    assert(Value.getPointer() == cv.Value.getPointer() &&
-           "merging flags on two different value decls");
-    return CapturedValue(
-        Storage(Value.getPointer(), getFlags() & cv.getFlags()),
-        Loc);
+  CapturedValue mergeFlags(unsigned flags) const {
+    return CapturedValue(Storage(Value.getPointer(), getFlags() & flags), Loc);
   }
 
   ValueDecl *getDecl() const {

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4241,7 +4241,10 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
   
   // Recursively collect transitive captures from captured local functions.
   llvm::DenseSet<AnyFunctionRef> visitedFunctions;
-  llvm::MapVector<ValueDecl*,CapturedValue> captures;
+
+  // FIXME: CapturedValue should just be a hash key
+  llvm::MapVector<VarDecl *, CapturedValue> varCaptures;
+  llvm::MapVector<PackElementExpr *, CapturedValue> packElementCaptures;
 
   // If there is a capture of 'self' with dynamic 'Self' type, it goes last so
   // that IRGen can pass dynamic 'Self' metadata.
@@ -4259,12 +4262,23 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
   std::function<void (SILDeclRef)> collectConstantCaptures;
 
   auto recordCapture = [&](CapturedValue capture) {
-    ValueDecl *value = capture.getDecl();
-    auto existing = captures.find(value);
-    if (existing != captures.end()) {
-      existing->second = existing->second.mergeFlags(capture.getFlags());
+    if (auto *expr = capture.getPackElement()) {
+      auto existing = packElementCaptures.find(expr);
+      if (existing != packElementCaptures.end()) {
+        existing->second = existing->second.mergeFlags(capture.getFlags());
+      } else {
+        packElementCaptures.insert(std::pair<PackElementExpr *, CapturedValue>(
+          expr, capture));
+      }
     } else {
-      captures.insert(std::pair<ValueDecl *, CapturedValue>(value, capture));
+      VarDecl *value = cast<VarDecl>(capture.getDecl());
+      auto existing = varCaptures.find(value);
+      if (existing != varCaptures.end()) {
+        existing->second = existing->second.mergeFlags(capture.getFlags());
+      } else {
+        varCaptures.insert(std::pair<VarDecl *, CapturedValue>(
+          value, capture));
+      }
     }
   };
 
@@ -4284,6 +4298,11 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
     }
 
     for (auto capture : captureInfo.getCaptures()) {
+      if (capture.isPackElement()) {
+        recordCapture(capture);
+        continue;
+      }
+
       if (!capture.isLocalCapture())
         continue;
 
@@ -4492,7 +4511,10 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
   collectConstantCaptures(fn);
 
   SmallVector<CapturedValue, 4> resultingCaptures;
-  for (auto capturePair : captures) {
+  for (auto capturePair : varCaptures) {
+    resultingCaptures.push_back(capturePair.second);
+  }
+  for (auto capturePair : packElementCaptures) {
     resultingCaptures.push_back(capturePair.second);
   }
 
@@ -4511,7 +4533,7 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
     resultingCaptures.push_back(*selfCapture);
   }
 
-  // Cache the uniqued set of transitive captures.
+  // Cache the result.
   CaptureInfo info(Context, resultingCaptures,
                    capturesDynamicSelf, capturesOpaqueValue,
                    capturesGenericParams, genericEnv.getArrayRef());

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4262,7 +4262,7 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
     ValueDecl *value = capture.getDecl();
     auto existing = captures.find(value);
     if (existing != captures.end()) {
-      existing->second = existing->second.mergeFlags(capture);
+      existing->second = existing->second.mergeFlags(capture.getFlags());
     } else {
       captures.insert(std::pair<ValueDecl *, CapturedValue>(value, capture));
     }
@@ -4398,7 +4398,7 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
             // If we've already captured the same value already, just merge
             // flags.
             if (selfCapture && selfCapture->getDecl() == capture.getDecl()) {
-              selfCapture = selfCapture->mergeFlags(capture);
+              selfCapture = selfCapture->mergeFlags(capture.getFlags());
               continue;
 
             // Otherwise, record the canonical self capture. It will appear

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -569,10 +569,9 @@ void SILGenFunction::emitCaptures(SILLocation loc,
       continue;
     }
 
-    if (capture.isOpaqueValue()) {
-      OpaqueValueExpr *opaqueValue = capture.getOpaqueValue();
+    if (capture.isOpaqueValue() || capture.isPackElement()) {
       capturedArgs.push_back(
-          emitRValueAsSingleValue(opaqueValue).ensurePlusOne(*this, loc));
+          emitRValueAsSingleValue(capture.getExpr()).ensurePlusOne(*this, loc));
       continue;
     }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2185,9 +2185,8 @@ public:
     emitOpenExistentialExprImpl(e, emitSubExpr);
   }
 
-  /// Mapping from active opaque value expressions to their values.
-  llvm::SmallDenseMap<OpaqueValueExpr *, ManagedValue>
-    OpaqueValues;
+  /// Mapping from OpaqueValueExpr/PackElementExpr to their values.
+  llvm::SmallDenseMap<Expr *, ManagedValue> OpaqueValues;
 
   /// A mapping from opaque value expressions to the open-existential
   /// expression that determines them, used while lowering lvalues.

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -39,17 +39,18 @@ class FindCapturedVars : public ASTWalker {
   SmallVector<CapturedValue, 4> Captures;
   llvm::SmallDenseMap<ValueDecl*, unsigned, 4> captureEntryNumber;
 
-  /// We track the pack expansion expressions in ForEachStmts, because
-  /// their local generics remain in scope until the end of the statement.
-  llvm::DenseSet<PackExpansionExpr *> ForEachPatternSequences;
+  /// Opened element environments introduced by `for ... in repeat`
+  /// statements.
+  llvm::SetVector<GenericEnvironment *> VisitingForEachEnv;
 
-  /// A stack of pack element environments we're currently walking into.
-  /// A reference to an element archetype defined by one of these is not
-  /// a capture.
-  llvm::SetVector<GenericEnvironment *> VisitingEnvironments;
+  /// Opened element environments introduced by `repeat` expressions.
+  llvm::SetVector<GenericEnvironment *> VisitingPackExpansionEnv;
 
-  /// A set of pack element environments we've encountered that were not
+  /// A set of local generic environments we've encountered that were not
   /// in the above stack; those are the captures.
+  ///
+  /// Once we can capture opened existentials, opened existential environments
+  /// can go here too.
   llvm::SetVector<GenericEnvironment *> CapturedEnvironments;
 
   SourceLoc GenericParamCaptureLoc;
@@ -167,7 +168,8 @@ public:
         // outside the body of the current closure.
         if (auto *element = t->getAs<ElementArchetypeType>()) {
           auto *env = element->getGenericEnvironment();
-          if (VisitingEnvironments.count(env) == 0)
+          if (VisitingForEachEnv.count(env) == 0 &&
+              VisitingPackExpansionEnv.count(env) == 0)
             CapturedEnvironments.insert(env);
         }
 
@@ -201,7 +203,11 @@ public:
   /// if invalid.
   void addCapture(CapturedValue capture) {
     auto VD = capture.getDecl();
-    
+    if (!VD) {
+      Captures.push_back(capture);
+      return;
+    }
+
     if (auto var = dyn_cast<VarDecl>(VD)) {
       // `async let` variables cannot currently be captured.
       if (var->isAsyncLet()) {
@@ -243,6 +249,24 @@ public:
 
   MacroWalking getMacroWalkingBehavior() const override {
     return MacroWalking::Expansion;
+  }
+
+  PreWalkResult<Expr *> walkToPackElementExpr(PackElementExpr *PEE) {
+    // A pack element reference expression like `each t` or `each f()`
+    // expands within the innermost pack expansion expression. If there
+    // isn't one, it's from an outer function, so we record the capture.
+    if (!VisitingPackExpansionEnv.empty())
+      return Action::Continue(PEE);
+
+    unsigned Flags = 0;
+
+    // If the closure is noescape, then we can capture the pack element
+    // as noescape.
+    if (NoEscape)
+      Flags |= CapturedValue::IsNoEscape;
+
+    addCapture(CapturedValue(PEE, Flags));
+    return Action::SkipChildren(PEE);
   }
 
   PreWalkResult<Expr *> walkToDeclRefExpr(DeclRefExpr *DRE) {
@@ -378,7 +402,14 @@ public:
   void propagateCaptures(CaptureInfo captureInfo, SourceLoc loc) {
     for (auto capture : captureInfo.getCaptures()) {
       // If the decl was captured from us, it isn't captured *by* us.
-      if (capture.getDecl()->getDeclContext() == CurDC)
+      if (capture.getDecl() &&
+          capture.getDecl()->getDeclContext() == CurDC)
+        continue;
+
+      // If the inner closure is nested in a PackExpansionExpr, it's
+      // PackElementExpr captures are not our captures.
+      if (capture.getPackElement() &&
+          !VisitingPackExpansionEnv.empty())
         continue;
 
       // Compute adjusted flags.
@@ -393,7 +424,7 @@ public:
       if (!NoEscape)
         Flags &= ~CapturedValue::IsNoEscape;
 
-      addCapture(CapturedValue(capture.getDecl(), Flags, capture.getLoc()));
+      addCapture(capture.mergeFlags(Flags));
     }
 
     if (!HasGenericParamCaptures) {
@@ -609,6 +640,9 @@ public:
     if (auto *DRE = dyn_cast<DeclRefExpr>(E))
       return walkToDeclRefExpr(DRE);
 
+    if (auto *PEE = dyn_cast<PackElementExpr>(E))
+      return walkToPackElementExpr(PEE);
+
     // Look into lazy initializers.
     if (auto *LIE = dyn_cast<LazyInitializerExpr>(E)) {
       LIE->getSubExpr()->walk(*this);
@@ -644,8 +678,8 @@ public:
 
     if (auto expansion = dyn_cast<PackExpansionExpr>(E)) {
       if (auto *env = expansion->getGenericEnvironment()) {
-        assert(VisitingEnvironments.count(env) == 0);
-        VisitingEnvironments.insert(env);
+        assert(VisitingPackExpansionEnv.count(env) == 0);
+        VisitingPackExpansionEnv.insert(env);
       }
     }
 
@@ -655,13 +689,10 @@ public:
   PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
     if (auto expansion = dyn_cast<PackExpansionExpr>(E)) {
       if (auto *env = expansion->getGenericEnvironment()) {
-        assert(env == VisitingEnvironments.back());
+        assert(env == VisitingPackExpansionEnv.back());
         (void) env;
 
-        // If this is the pack expansion of a for .. in loop, the generic
-        // environment remains in scope until the end of the loop.
-        if (ForEachPatternSequences.count(expansion) == 0)
-          VisitingEnvironments.pop_back();
+        VisitingPackExpansionEnv.pop_back();
       }
     }
 
@@ -675,8 +706,8 @@ public:
         if (auto *env = expansion->getGenericEnvironment()) {
           // Remember this generic environment, so that it remains on the
           // visited stack until the end of the for .. in loop.
-          assert(ForEachPatternSequences.count(expansion) == 0);
-          ForEachPatternSequences.insert(expansion);
+          assert(VisitingForEachEnv.count(env) == 0);
+          VisitingForEachEnv.insert(env);
         }
       }
     }
@@ -689,13 +720,10 @@ public:
       if (auto *expansion =
               dyn_cast<PackExpansionExpr>(forEachStmt->getParsedSequence())) {
         if (auto *env = expansion->getGenericEnvironment()) {
-          assert(ForEachPatternSequences.count(expansion) != 0);
-          ForEachPatternSequences.erase(expansion);
-
-          // Clean up the generic environment bound by the for loop.
-          assert(env == VisitingEnvironments.back());
-          VisitingEnvironments.pop_back();
+          assert(VisitingForEachEnv.back() == env);
           (void) env;
+
+          VisitingForEachEnv.pop_back();
         }
       }
     }

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -761,3 +761,10 @@ do {
     (repeat takesAutoclosure(each t)) // Ok
   }
 }
+
+// Crash-on-invalid - rdar://110711746
+func butt<T>(x: T) {}
+
+func rump<each T>(x: repeat each T) {
+  let x = (repeat { butt(each x) }()) // expected-error {{missing argument label 'x:' in call}}
+}

--- a/test/Interpreter/variadic_generic_captures_2.swift
+++ b/test/Interpreter/variadic_generic_captures_2.swift
@@ -1,0 +1,72 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-concrete-type-metadata-mangled-name-accessors)
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var captures = TestSuite("VariadicGenericCaptures")
+
+func f1<T>(_ fn: @autoclosure () -> T) {
+  _ = fn()
+}
+
+func f2<T>(_ fn: @autoclosure @escaping () -> T) {
+  _ = fn()
+}
+
+func f3<T>(_ fn: () -> T) {
+  _ = fn()
+}
+
+func f4<T>(_ fn: @escaping () -> T) {
+  _ = fn()
+}
+
+func f5<T: AnyObject>(_ fn: @autoclosure () -> T) {
+  _ = fn()
+}
+
+func f6<T: AnyObject>(_ fn: @autoclosure @escaping () -> T) {
+  _ = fn()
+}
+
+func f7<T: AnyObject>(_ fn: () -> T) {
+  _ = fn()
+}
+
+func f8<T: AnyObject>(_ fn: @escaping () -> T) {
+  _ = fn()
+}
+
+func g1<each T>(_ t: repeat each T) {
+  repeat f1(each t)
+  repeat f2(each t)
+  repeat f3 { each t }
+  repeat f4 { each t }
+  repeat _ = ({ each t }())
+  repeat _ = ({ (each t, each t) }())
+}
+
+func g2<each T: AnyObject>(_ t: repeat each T) {
+  repeat f5(each t)
+  repeat f6(each t)
+  repeat f7 { each t }
+  repeat f8 { each t }
+  repeat _ = ({ (each t, each t) }())
+}
+
+class C {
+  var x = LifetimeTracked(0)
+}
+
+class D: C {}
+
+class E: D {}
+
+captures.test("Test") {
+  g1(C(), D(), E())
+  g2(C(), D(), E())
+}
+
+runAllTests()

--- a/test/SILGen/pack_element_expr_captures.swift
+++ b/test/SILGen/pack_element_expr_captures.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
+
+func callee(_ fn: () -> Any) {}
+
+func caller<each T>(_ t: repeat each T) {
+  repeat callee { each t }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26pack_element_expr_captures6calleryyxxQpRvzlF : $@convention(thin) <each T> (@pack_guaranteed Pack{repeat each T}) -> () {
+// CHECK: [[FN:%.*]] = function_ref @$s26pack_element_expr_captures6calleryyxxQpRvzlFypyXEfU_ : $@convention(thin) <each τ_0_0><τ_1_0> (@in_guaranteed τ_1_0) -> @out Any
+// CHECK: [[ELT_ADDR:%.*]] = pack_element_get {{.*}} of %0 : $*Pack{repeat each T} as $*@pack_element("{{.*}}") each T
+// CHECK: [[ELT_COPY:%.*]] = alloc_stack $@pack_element("{{.*}}") each T
+// CHECK: copy_addr [[ELT_ADDR]] to [init] [[ELT_COPY]] : $*@pack_element("{{.*}}") each T
+// CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FN]]<Pack{repeat each T}, @pack_element("{{.*}}") each T>([[ELT_COPY]])
+// CHECK: [[CONVERTED:%.*]] = convert_escape_to_noescape [not_guaranteed] %15 : $@callee_guaranteed () -> @out Any to $@noescape @callee_guaranteed () -> @out Any
+// CHECK: [[CALLEE:%.*]]  = function_ref @$s26pack_element_expr_captures6calleeyyypyXEF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @out Any) -> ()
+// CHECK: apply [[CALLEE]]([[CONVERTED]]) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @out Any) -> ()
+
+// CHECK-LABEL: sil private [ossa] @$s26pack_element_expr_captures6calleryyxxQpRvzlFypyXEfU_ : $@convention(thin) <each T><τ_1_0> (@in_guaranteed τ_1_0) -> @out Any {
+// CHECK: bb0(%0 : $*Any, %1 : @closureCapture $*τ_1_0):
+// CHECK: [[ADDR:%.*]] = init_existential_addr %0 : $*Any, $τ_1_0
+// CHECK: copy_addr %1 to [init] [[ADDR]] : $*τ_1_0
+// CHECK: return

--- a/validation-test/compiler_crashers_2_fixed/issue-68941.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-68941.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+public struct S<each T> {
+    public var value: (repeat each T)
+
+    public init(_ value: repeat each T) {
+        self.value = (repeat each value)
+        let getters: (repeat () -> each T) = (repeat { each self.value })
+    }
+}

--- a/validation-test/compiler_crashers_2_fixed/issue-73829.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-73829.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public func apply<Input, each Transformed>(
+  _ transform: (repeat (Input) -> each Transformed),
+  _ input: Input
+) -> (repeat each Transformed) {
+  (repeat (each transform)(input))
+}
+
+struct S: Equatable {
+  // MARK: Equatables
+  let eq = "🎛"
+  let u = 1.0 / 1_000_000
+  let al = 13
+
+  let breaksEquatableSynthesis: Void
+
+  static func == (ecuador0: Self, ecuador1: Self) -> Bool {
+    let getProperties = (
+      \.eq as (Self) -> _,
+      \.u as (Self) -> _,
+      \.al as (Self) -> _
+    )
+    return apply(getProperties, ecuador0) == apply(getProperties, ecuador1)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar119212867.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar119212867.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+protocol P {
+    func evaluate(_ item: Int) -> Bool
+}
+
+struct G<each F: P>: P {
+    init(filters: repeat each F) {
+        self.filters = (repeat each filters)
+    }
+
+    var filters: (repeat each F)
+
+    func evaluate(_ item: Int) -> Bool {
+        var result = true
+
+        (repeat result.and((each filters).evaluate(item)))
+
+        return result
+    }
+}
+
+private extension Bool {
+    mutating func and(_ other: @autoclosure () -> Bool) {
+        self = self && other()
+    }
+}
+
+struct S1: P {
+    func evaluate(_ item: Int) -> Bool {
+        print("S1", item)
+        return false
+    }
+}
+struct S2: P {
+    func evaluate(_ item: Int) -> Bool {
+        print("S2", item)
+        return false
+    }
+}
+
+do {
+    let filter = G(filters: S1(), S2())
+    print(filter.evaluate(5))
+}


### PR DESCRIPTION
Follow-up to #73712. This implements support for the case where a PackElementExpr is directly captured by a closure, eg `repeat foo { each t }`.

Fixes https://github.com/apple/swift/issues/68941.
Fixes https://github.com/apple/swift/issues/69282.
Fixes https://github.com/apple/swift/issues/72153.
Fixes rdar://110711746.
Fixes rdar://119212867.
Fixes rdar://124202697.