### PR TITLE
[Concurrency] Remove SWIFT_ENABLE_ASYNC_JOB_DISPATCH_INTEGRATION environment variable.

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -45,10 +45,6 @@ using string = const char *;
 // Concurrency library can call.
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableCooperativeQueues();
 
-// Wrapper around SWIFT_ENABLE_ASYNC_JOB_DISPATCH_INTEGRATION that the
-// Concurrency library can call.
-SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableJobDispatchIntegration();
-
 // Wrapper around SWIFT_DEBUG_VALIDATE_UNCHECKED_CONTINUATIONS that the
 // Concurrency library can call.
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations();

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -93,18 +93,16 @@ static void initializeDispatchEnqueueFunc(dispatch_queue_t queue, void *obj,
 
   // Always fall back to plain dispatch_async_f for back-deployed concurrency.
 #if !defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT)
-  if (runtime::environment::concurrencyEnableJobDispatchIntegration())
 #if SWIFT_CONCURRENCY_HAS_DISPATCH_PRIVATE
-    if (SWIFT_RUNTIME_WEAK_CHECK(dispatch_async_swift_job))
-      func = SWIFT_RUNTIME_WEAK_USE(dispatch_async_swift_job);
+  if (SWIFT_RUNTIME_WEAK_CHECK(dispatch_async_swift_job))
+    func = SWIFT_RUNTIME_WEAK_USE(dispatch_async_swift_job);
 #elif defined(_WIN32)
-    func = reinterpret_cast<dispatchEnqueueFuncType>(
-        GetProcAddress(LoadLibraryW(L"dispatch.dll"),
-        "dispatch_async_swift_job"));
+  func = reinterpret_cast<dispatchEnqueueFuncType>(
+      GetProcAddress(LoadLibraryW(L"dispatch.dll"),
+      "dispatch_async_swift_job"));
 #else
-    func = reinterpret_cast<dispatchEnqueueFuncType>(
-        dlsym(RTLD_NEXT, "dispatch_async_swift_job"));
-
+  func = reinterpret_cast<dispatchEnqueueFuncType>(
+      dlsym(RTLD_NEXT, "dispatch_async_swift_job"));
 #endif
 #endif
 

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -263,12 +263,6 @@ SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableCooperativeQueues() {
       SWIFT_DEBUG_CONCURRENCY_ENABLE_COOPERATIVE_QUEUES();
 }
 
-
-SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableJobDispatchIntegration() {
-  return runtime::environment::
-      SWIFT_ENABLE_ASYNC_JOB_DISPATCH_INTEGRATION();
-}
-
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations() {
   return runtime::environment::SWIFT_DEBUG_VALIDATE_UNCHECKED_CONTINUATIONS();
 }

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -47,9 +47,6 @@ VARIABLE(SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE, bool, false,
 VARIABLE(SWIFT_DEBUG_ENABLE_COW_CHECKS, bool, false,
          "Enable internal checks for copy-on-write operations.")
 
-VARIABLE(SWIFT_ENABLE_ASYNC_JOB_DISPATCH_INTEGRATION, bool, true,
-         "Enable use of dispatch_async_swift_job when available.")
-
 VARIABLE(SWIFT_DEBUG_VALIDATE_UNCHECKED_CONTINUATIONS, bool, false,
          "Check for and error on double-calls of unchecked continuations.")
 

--- a/test/abi/Inputs/macOS/arm64/stdlib/baseline
+++ b/test/abi/Inputs/macOS/arm64/stdlib/baseline
@@ -13463,7 +13463,6 @@ __swift_tsan_enabled
 __swift_tsan_release
 __swift_willThrow
 _concurrencyEnableCooperativeQueues
-_concurrencyEnableJobDispatchIntegration
 _concurrencyValidateUncheckedContinuations
 _swift_COWChecksEnabled
 _swift_EnumCaseName

--- a/test/abi/Inputs/macOS/arm64/stdlib/baseline-asserts
+++ b/test/abi/Inputs/macOS/arm64/stdlib/baseline-asserts
@@ -13558,7 +13558,6 @@ __swift_tsan_enabled
 __swift_tsan_release
 __swift_willThrow
 _concurrencyEnableCooperativeQueues
-_concurrencyEnableJobDispatchIntegration
 _concurrencyValidateUncheckedContinuations
 _swift_COWChecksEnabled
 _swift_EnumCaseName

--- a/test/abi/Inputs/macOS/x86_64/stdlib/baseline
+++ b/test/abi/Inputs/macOS/x86_64/stdlib/baseline
@@ -13421,7 +13421,6 @@ __swift_tsan_enabled
 __swift_tsan_release
 __swift_willThrow
 _concurrencyEnableCooperativeQueues
-_concurrencyEnableJobDispatchIntegration
 _concurrencyValidateUncheckedContinuations
 _swift_COWChecksEnabled
 _swift_EnumCaseName

--- a/test/abi/Inputs/macOS/x86_64/stdlib/baseline-asserts
+++ b/test/abi/Inputs/macOS/x86_64/stdlib/baseline-asserts
@@ -13516,7 +13516,6 @@ __swift_tsan_enabled
 __swift_tsan_release
 __swift_willThrow
 _concurrencyEnableCooperativeQueues
-_concurrencyEnableJobDispatchIntegration
 _concurrencyValidateUncheckedContinuations
 _swift_COWChecksEnabled
 _swift_EnumCaseName


### PR DESCRIPTION
This option serves no purpose anymore and this dispatch integration should always be enabled.