### PR TITLE
[6.0 🍒][Dependency Scanning] Add forgotten '-Xcc' qualifier to modulemap dependency flags

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -270,7 +270,8 @@ static llvm::Error resolveExplicitModuleInputs(
         auto optionalBridgingHeaderDepModuleInfo = cache.findKnownDependency(
             {bridgingHeaderDepName, ModuleDependencyKind::Clang});
         const auto bridgingHeaderDepModuleDetails =
-            optionalBridgingHeaderDepModuleInfo.getAsClangModule();
+          optionalBridgingHeaderDepModuleInfo.getAsClangModule();
+	commandLine.push_back("-Xcc");
         commandLine.push_back(
             "-fmodule-map-file=" +
             remapPath(bridgingHeaderDepModuleDetails->moduleMapFile));

--- a/test/ScanDependencies/bridging_header_dep_module_map.swift
+++ b/test/ScanDependencies/bridging_header_dep_module_map.swift
@@ -49,7 +49,18 @@
 // CHECK-DAG:    "clang": "Dart"
 // CHECK: ],
 // CHECK: "commandLine": [
-// CHECK: "-fmodule-map-file={{.*}}{{/|\\}}CHeaders{{/|\\}}module.modulemap"
+// CHECK: "-Xcc"
+// CHECK-NEXT: "-fno-implicit-modules"
+// CHECK: "-Xcc"
+// CHECK-NEXT: "-fno-implicit-module-maps"
+// CHECK-DAG: "-Xcc",
+// CHECK-NEXT: "-fmodule-file=Dart={{.*}}"
+// CHECK-DAG: "-Xcc"
+// CHECK-NEXT: "-fmodule-map-file={{.*}}{{/|\\}}CHeaders{{/|\\}}module.modulemap"
+// CHECK-DAG: "-Xcc",
+// CHECK-NEXT: "-fmodule-file=SwiftShims={{.*}}"
+// CHECK-DAG: "-Xcc",
+// CHECK-NEXT: "-fmodule-file=X={{.*}}"
 // CHECK-NOT: "-fmodule-map-file={{.*}}{{/|\\}}TestCHeaders{{/|\\}}module.modulemap"
 // CHECK: ]
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/74026
----------------------------------
**Explanation**: A prior change to introduced explicit `.modulemap` inputs to Swift module compilation recipes whose binary Swift module dependencies were built with a bridging header. Added `-fmodule-map-file` flags were missing the required `-Xcc` prefix to correctly get propagated to the underlying Clang invocation.

**Risk**: Low. This change only affects a code-path that previously resulted in malformed compilation commands which would fail to execute. 

**Testing**: Automated test added to the compiler test suite.

Resolves rdar://128945712
