### PR TITLE
[Basic] Fix return type of FixedBitSet::chunkMask()

### DIFF
--- a/include/swift/Basic/FixedBitSet.h
+++ b/include/swift/Basic/FixedBitSet.h
@@ -78,7 +78,7 @@ class FixedBitSet {
   static size_t chunkIndex(ValueType i) {
     return size_t(i) / chunkSize;
   }
-  static size_t chunkMask(ValueType i) {
+  static ChunkType chunkMask(ValueType i) {
     return ChunkType(1) << (size_t(i) % chunkSize);
   }
 


### PR DESCRIPTION
Fix a warning in msvc compiler:
e.g. https://ci-external.swift.org/job/swift-PR-windows/25634/console
```
C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift\include\swift/Basic/FixedBitSet.h(82): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift\include\swift/Basic/FixedBitSet.h(81): note: while compiling class template member function 'size_t swift::FixedBitSet<147,swift::Feature>::chunkMask(ValueType)'
        with
        [
            ValueType=swift::Feature
        ]
C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift\include\swift/Basic/FixedBitSet.h(132): note: see reference to function template instantiation 'size_t swift::FixedBitSet<147,swift::Feature>::chunkMask(ValueType)' being compiled
        with
        [
            ValueType=swift::Feature
        ]
C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift\include\swift/Basic/LangOptions.h(792): note: see reference to class template instantiation 'swift::FixedBitSet<147,swift::Feature>' being compiled
```