### PR TITLE
[stdlib] Use -plugin-path for building the standard library

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -325,8 +325,7 @@ else()
   set(swift_lib_dir "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib")
 endif()
 
-list(APPEND swift_stdlib_compile_flags "-external-plugin-path"
-  "${swift_lib_dir}/swift/host/plugins#${swift_bin_dir}/swift-plugin-server")
+list(APPEND swift_stdlib_compile_flags "-plugin-path" "${swift_lib_dir}/swift/host/plugins")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "DebugDescriptionMacro")
 
 set(swift_core_incorporate_object_libraries)


### PR DESCRIPTION
`-external-plugin-path` requires `swift-plugin-server` exectuable, but there was no CMake dependency. Instead of adding the dependency, use `-plugin-path` that doesn't require the plugin-server.

Fixes a _rare_ build failure caused by the missing dependency. e.g. https://ci.swift.org/job/apple-llvm-project-pr-macos/5439/console