### PR TITLE
Use toolchain clang on macOS

### DIFF
--- a/test/ScanDependencies/error_path.swift
+++ b/test/ScanDependencies/error_path.swift
@@ -3,6 +3,9 @@
 // REQUIRES: objc_interop
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 2>&1 | %FileCheck %s
 
+// There is a use-after-free in ScanDependencies rdar://131388478
+// XFAIL: asan
+
 import P
 
 // CHECK:      {{.*}}{{/|\\}}Z.swiftinterface:3:8: error: Unable to find module dependency: 'missing_module'

--- a/test/ScanDependencies/error_source_locations.swift
+++ b/test/ScanDependencies/error_source_locations.swift
@@ -6,6 +6,10 @@
 import P
 import FooBar
 
+
+// There is a use-after-free in ScanDependencies rdar://131388478
+// XFAIL: asan
+
 // CHECK:      {{.*}}{{/|\\}}error_source_locations.swift:7:8: error: Unable to find module dependency: 'FooBar'
 // CHECK-NEXT: 5 |
 // CHECK-NEXT: 6 | import P

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1666,7 +1666,7 @@ for host in "${ALL_HOSTS[@]}"; do
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
 
-    if [[ -f "${CLANG_BIN}/clang" ]]; then
+    if [[ -f "${CLANG_BIN}/clang" ]] && [[ -z ${ENABLE_ASAN+x} ]]; then
       export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
       export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
     fi
@@ -2744,7 +2744,7 @@ for host in "${ALL_HOSTS[@]}"; do
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
 
-    if [[ -f "${CLANG_BIN}/clang" ]]; then
+    if [[ -f "${CLANG_BIN}/clang" ]] && [[ -z ${ENABLE_ASAN+x} ]]; then
       export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
       export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
     fi
@@ -3039,7 +3039,7 @@ for host in "${ALL_HOSTS[@]}"; do
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
 
-    if [[ -f "${CLANG_BIN}/clang" ]]; then
+    if [[ -f "${CLANG_BIN}/clang" ]] && [[ -z ${ENABLE_ASAN+x} ]]; then
       export SWIFT_DRIVER_CLANG_EXEC="${CLANG_BIN}/clang"
       export SWIFT_DRIVER_CLANGXX_EXEC="${CLANG_BIN}/clang++"
     fi


### PR DESCRIPTION
Don't use the just-built clang on macOS. macOS does this more "right" than the Linux build. Linux will sometimes use the just-built Swift-driver with the just-built clang, but sometimes would use the system clang instead. macOS uses the toolchain Swift-driver with the toolchain clang. This is correct, but it means that if we force the other clang, we'll get mismatched sanitizer runtimes so the ASAN bot will fail.

rdar://128602427