### PR TITLE
[6.0][Macros] Add '-plugin-path' the the toolchain's plugins in Info.plist

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3375,6 +3375,7 @@ function build_and_test_installable_package() {
           COMPATIBILITY_VERSION=2
           COMPATIBILITY_VERSION_DISPLAY_STRING="Xcode 8.0"
           DARWIN_TOOLCHAIN_CREATED_DATE="$(date -u +'%a %b %d %T GMT %Y')"
+          TOOLCHAIN_PLUGIN_PATH_DESCRIPTOR='$(TOOLCHAIN_DIR)/usr/lib/swift/host/plugins'
 
           SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME="YES"
           if [[ "${DARWIN_TOOLCHAIN_REQUIRE_USE_OS_RUNTIME}" -eq "1" ]]; then
@@ -3409,6 +3410,7 @@ function build_and_test_installable_package() {
           call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_LINK_OBJC_RUNTIME string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
           call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_DEVELOPMENT_TOOLCHAIN string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
           call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME string '${SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:OTHER_SWIFT_FLAGS string '\$(inherited) -plugin-path ${TOOLCHAIN_PLUGIN_PATH_DESCRIPTOR}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
 
           call chmod a+r "${DARWIN_TOOLCHAIN_INFO_PLIST}"
 


### PR DESCRIPTION
Cherry-pick #74018 into release/6.0

* **Explanation**: Since `@TaskLocal` has been changed to a macro, swift.org toolchains are not usable with build-systems with a swift-driver that doesn't include https://github.com/apple/swift-driver/pull/1592,  because the SDK's plugins precede the toolchain's. This PR avoid it by adding `-plugin-path $(TOOLCHAIN_DIR)/usr/lib/swift/host/plugins` to the `OTHER_SWIFT_FLAGS`.
* **Scope**: Macro plugin discovery
* **Risk**: Low, This only affects swift.org toolchains.
* **Testing**: Tested locally with a toolchain built with this change
* **Issues**: rdar://129066769
* **Reviewer**: Ben Barham (@bnbarham) Owen Voorhees (@owenv)