### PR TITLE
Revert remove cplusplus requirement on XAudio29

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -219,6 +219,8 @@ module WinSDK [system] {
       export *
 
       link "xaudio2.lib"
+
+      requires cplusplus
     }
 
     // XInput 1.4 (Windows 10, XBox) is newer than the XInput 9.1.0 which was


### PR DESCRIPTION
Reverts: #70195
Discussion: #73502

XAudio2 seemed like it might be usable with C, this does not appear to be the case.
Microsoft also explicitly states XAudio2 is C++ only, so even if C worked now it could potentially break with any Windows SDK update.