### PR TITLE
[RelatedIdents] Don’t collect related identifiers if decl is a nullptr

### DIFF
--- a/lib/Refactoring/LocalRename.cpp
+++ b/lib/Refactoring/LocalRename.cpp
@@ -200,7 +200,9 @@ class RenameRangeCollector : public IndexDataConsumer {
 
 public:
   RenameRangeCollector(const ValueDecl *declToRename)
-      : declToRename(declToRename), stringStorage(new StringScratchSpace()) {}
+      : declToRename(declToRename), stringStorage(new StringScratchSpace()) {
+    assert(declToRename != nullptr);
+  }
 
   RenameRangeCollector(RenameRangeCollector &&collector) = default;
 
@@ -363,6 +365,10 @@ RenameLocs swift::ide::localRenameLocs(SourceFile *SF,
     if (DeclarationScope->isChildContextOf(SF)) {
       RenameScope = DeclarationScope;
     }
+  }
+
+  if (valueDecl == nullptr) {
+    return RenameLocs();
   }
 
   RenameRangeCollector rangeCollector(valueDecl);


### PR DESCRIPTION
I don’t have a reproducer, unfortunately but it appears that we could get into a situation where the decl that we want to get related identifiers for is a `nullptr`, at which point we would collect all other references to `nullptr` decls, which was non-sensical.

rdar://128702037
