### PR TITLE
[sending] Fix issues when suppressing SendingArgsAndResults found when adding sending to Swift Concurrency

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -62,6 +62,7 @@
 #include "clang/Lex/MacroInfo.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/SaveAndRestore.h"
@@ -70,6 +71,15 @@
 #include <queue>
 
 using namespace swift;
+
+#ifndef NDEBUG
+static llvm::cl::opt<bool> NumberSuppressionChecks(
+    "swift-ast-printer-number-suppression-checks",
+    llvm::cl::desc("Used to number suppression checks in swift interface files "
+                   "to make it easier to FileCheck them. Only available with "
+                   "asserts enabled and intended for compiler tests."),
+    llvm::cl::init(false), llvm::cl::Hidden);
+#endif
 
 // Defined here to avoid repeatedly paying the price of template instantiation.
 const std::function<bool(const ExtensionDecl *)>
@@ -3199,6 +3209,15 @@ static void printCompatibilityCheckIf(ASTPrinter &printer, bool isElseIf,
     }
     printer << "$" << getFeatureName(feature);
   }
+
+#ifndef NDEBUG
+  if (NumberSuppressionChecks) {
+    static unsigned totalSuppressionChecks = 0;
+    printer << " // Suppression Count: " << totalSuppressionChecks;
+    ++totalSuppressionChecks;
+  }
+#endif
+
   printer.printNewline();
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3289,10 +3289,13 @@ void swift::printWithCompatibilityFeatureChecks(ASTPrinter &printer,
   // features, or else just print the body.
   if (features.hasAnySuppressible()) {
     auto generator = features.generateSuppressibleFeatures();
+
+    // NOTE: We emit the compiler check here as well since that also implicitly
+    // ensures that we ignore parsing errors in the if block. It is harmless
+    // otherwise.
     printWithSuppressibleFeatureChecks(printer, options,
-                             /*first*/ true,
-                    /*compiler check*/ !hasRequiredFeatures,
-                                       generator,
+                                       /*first*/ true,
+                                       /*compiler check*/ true, generator,
                                        printBody);
   } else {
     printBody();

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -647,8 +647,7 @@ UNINTERESTING_FEATURE(GroupActorErrors)
 
 UNINTERESTING_FEATURE(TransferringArgsAndResults)
 static bool usesFeatureSendingArgsAndResults(Decl *decl) {
-  auto functionTypeUsesSending = [](Decl *decl) {
-    return usesTypeMatching(decl, [](Type type) {
+  auto isFunctionTypeWithSending = [](Type type) {
       auto fnType = type->getAs<AnyFunctionType>();
       if (!fnType)
         return false;
@@ -660,7 +659,9 @@ static bool usesFeatureSendingArgsAndResults(Decl *decl) {
                           [](AnyFunctionType::Param param) {
                             return param.getParameterFlags().isSending();
                           });
-    });
+  };
+  auto declUsesFunctionTypesThatUseSending = [&](Decl *decl) {
+    return usesTypeMatching(decl, isFunctionTypeWithSending);
   };
 
   if (auto *pd = dyn_cast<ParamDecl>(decl)) {
@@ -668,7 +669,7 @@ static bool usesFeatureSendingArgsAndResults(Decl *decl) {
       return true;
     }
 
-    if (functionTypeUsesSending(pd))
+    if (declUsesFunctionTypesThatUseSending(pd))
       return true;
   }
 
@@ -678,8 +679,18 @@ static bool usesFeatureSendingArgsAndResults(Decl *decl) {
           return usesFeatureSendingArgsAndResults(pd);
         }))
       return true;
-    if (functionTypeUsesSending(decl))
+    if (declUsesFunctionTypesThatUseSending(decl))
       return true;
+  }
+
+  // Check if we have a pattern binding decl for a function that has sending
+  // parameters and results.
+  if (auto *pbd = dyn_cast<PatternBindingDecl>(decl)) {
+    for (auto index : range(pbd->getNumPatternEntries())) {
+      auto *pattern = pbd->getPattern(index);
+      if (pattern->hasType() && isFunctionTypeWithSending(pattern->getType()))
+        return true;
+    }
   }
 
   return false;

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -673,7 +673,7 @@ static bool usesFeatureSendingArgsAndResults(Decl *decl) {
       return true;
   }
 
-  if (auto *fDecl = dyn_cast<FuncDecl>(decl)) {
+  if (auto *fDecl = dyn_cast<AbstractFunctionDecl>(decl)) {
     // First check for param decl results.
     if (llvm::any_of(fDecl->getParameters()->getArray(), [](ParamDecl *pd) {
           return usesFeatureSendingArgsAndResults(pd);

--- a/test/Concurrency/sending_conditional_suppression.swift
+++ b/test/Concurrency/sending_conditional_suppression.swift
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-upcoming-feature SendingArgsAndResults -swift-version 5 -enable-library-evolution -module-name test -emit-module -o %t/test.swiftmodule -emit-module-interface-path - %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-upcoming-feature SendingArgsAndResults -swift-version 5 -enable-library-evolution -module-name test -emit-module -o %t/test.swiftmodule -emit-module-interface-path - -disable-availability-checking -swift-ast-printer-number-suppression-checks %s | %FileCheck %s
+
+// REQUIRES: asserts
 
 public class NonSendableKlass {}
 

--- a/test/Concurrency/sending_conditional_suppression.swift
+++ b/test/Concurrency/sending_conditional_suppression.swift
@@ -90,6 +90,69 @@ public struct TestInStruct {
   // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: test.NonSendableKlass, z: test.NonSendableKlass) -> test.NonSendableKlass
   // CHECK-NEXT: #endif
   public func testKlassArgAndResult(_ x: NonSendableKlass, _ y: sending NonSendableKlass, z: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: public func testFunctionArg(_ x: () -> sending test.NonSendableKlass)
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: public func testFunctionArg(_ x: () -> test.NonSendableKlass)
+  // CHECK-NEXT: #endif  
+  public func testFunctionArg(_ x: () -> sending NonSendableKlass) { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: public func testFunctionResult() -> (() -> sending test.NonSendableKlass)
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: public func testFunctionResult() -> (() -> test.NonSendableKlass)
+  // CHECK-NEXT: #endif  
+  public func testFunctionResult() -> (() -> sending NonSendableKlass) { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal func testUsableFromInlineKlassArg(_ x: sending test.NonSendableKlass)
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal func testUsableFromInlineKlassArg(_ x: test.NonSendableKlass)
+  // CHECK-NEXT: #endif
+  @usableFromInline func testUsableFromInlineKlassArg(_ x: sending NonSendableKlass) { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal func testUsableFromInlineKlassResult() -> sending test.NonSendableKlass
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal func testUsableFromInlineKlassResult() -> test.NonSendableKlass
+  // CHECK-NEXT: #endif
+  @usableFromInline
+  func testUsableFromInlineKlassResult() -> sending NonSendableKlass { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal func testUsableFromInlineKlassArgAndResult(_ x: test.NonSendableKlass, _ y: sending test.NonSendableKlass, z: test.NonSendableKlass) -> sending test.NonSendableKlass
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal func testUsableFromInlineKlassArgAndResult(_ x: test.NonSendableKlass, _ y: test.NonSendableKlass, z: test.NonSendableKlass) -> test.NonSendableKlass
+  // CHECK-NEXT: #endif
+  @usableFromInline
+  func testUsableFromInlineKlassArgAndResult(_ x: NonSendableKlass, _ y: sending NonSendableKlass, z: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal func testUsableFromInlineFunctionArg(_ x: () -> sending test.NonSendableKlass)
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal func testUsableFromInlineFunctionArg(_ x: () -> test.NonSendableKlass)
+  // CHECK-NEXT: #endif
+  @usableFromInline
+  func testUsableFromInlineFunctionArg(_ x: () -> sending NonSendableKlass) { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal func testUsableFromInlineFunctionResult() -> (() -> sending test.NonSendableKlass)
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal func testUsableFromInlineFunctionResult() -> (() -> test.NonSendableKlass)
+  // CHECK-NEXT: #endif
+  @usableFromInline
+  func testUsableFromInlineFunctionResult() -> (() -> sending NonSendableKlass) { fatalError() }
 }
 
 // Make sure that we emit compiler(>= 5.3) when emitting the suppressing check

--- a/test/Concurrency/sending_conditional_suppression.swift
+++ b/test/Concurrency/sending_conditional_suppression.swift
@@ -153,6 +153,40 @@ public struct TestInStruct {
   // CHECK-NEXT: #endif
   @usableFromInline
   func testUsableFromInlineFunctionResult() -> (() -> sending NonSendableKlass) { fatalError() }
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: public var publicVarFieldFunctionArg: (sending test.NonSendableKlass) -> ()
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: public var publicVarFieldFunctionArg: (test.NonSendableKlass) -> ()
+  // CHECK-NEXT: #endif
+  public var publicVarFieldFunctionArg: (sending NonSendableKlass) -> ()
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal var internalVarFieldFunctionArg: (sending test.NonSendableKlass) -> ()
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal var internalVarFieldFunctionArg: (test.NonSendableKlass) -> ()
+  // CHECK-NEXT: #endif
+  @usableFromInline
+  var internalVarFieldFunctionArg: (sending NonSendableKlass) -> ()
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: public let publicLetFieldFunctionArg: (sending test.NonSendableKlass) -> ()
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: public let publicLetFieldFunctionArg: (test.NonSendableKlass) -> ()
+  // CHECK-NEXT: #endif
+  public let publicLetFieldFunctionArg: (sending NonSendableKlass) -> ()
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal let internalLetFieldFunctionArg: (sending test.NonSendableKlass) -> ()
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal let internalLetFieldFunctionArg: (test.NonSendableKlass) -> ()
+  // CHECK-NEXT: #endif
+  @usableFromInline
+  let internalLetFieldFunctionArg: (sending NonSendableKlass) -> ()
 }
 
 // Make sure that we emit compiler(>= 5.3) when emitting the suppressing check

--- a/test/Concurrency/sending_conditional_suppression.swift
+++ b/test/Concurrency/sending_conditional_suppression.swift
@@ -95,14 +95,14 @@ public struct TestInStruct {
   // CHECK-NEXT: public func testFunctionArg(_ x: () -> sending test.NonSendableKlass)
   // CHECK-NEXT: #else
   // CHECK-NEXT: public func testFunctionArg(_ x: () -> test.NonSendableKlass)
-  // CHECK-NEXT: #endif  
+  // CHECK-NEXT: #endif
   public func testFunctionArg(_ x: () -> sending NonSendableKlass) { fatalError() }
 
   // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
   // CHECK-NEXT: public func testFunctionResult() -> (() -> sending test.NonSendableKlass)
   // CHECK-NEXT: #else
   // CHECK-NEXT: public func testFunctionResult() -> (() -> test.NonSendableKlass)
-  // CHECK-NEXT: #endif  
+  // CHECK-NEXT: #endif
   public func testFunctionResult() -> (() -> sending NonSendableKlass) { fatalError() }
 
   // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
@@ -187,6 +187,16 @@ public struct TestInStruct {
   // CHECK-NEXT: #endif
   @usableFromInline
   let internalLetFieldFunctionArg: (sending NonSendableKlass) -> ()
+
+  // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal init(_ x: Int, transformWithResult: @escaping () async throws -> sending test.NonSendableKlass) { fatalError() }
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal init(_ x: Int, transformWithResult: @escaping () async throws -> test.NonSendableKlass) { fatalError() }
+  // CHECK-NEXT: #endif
+  @usableFromInline
+  internal init(_ x: Int, transformWithResult: @escaping () async throws -> sending NonSendableKlass) { fatalError() }
 }
 
 // Make sure that we emit compiler(>= 5.3) when emitting the suppressing check

--- a/test/Concurrency/sending_conditional_suppression.swift
+++ b/test/Concurrency/sending_conditional_suppression.swift
@@ -192,10 +192,10 @@ public struct TestInStruct {
 
   // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal init(_ x: Int, transformWithResult: @escaping () async throws -> sending test.NonSendableKlass) { fatalError() }
+  // CHECK-NEXT: internal init(_ x: Swift.Int, transformWithResult: @escaping () async throws -> sending test.NonSendableKlass)
   // CHECK-NEXT: #else
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal init(_ x: Int, transformWithResult: @escaping () async throws -> test.NonSendableKlass) { fatalError() }
+  // CHECK-NEXT: internal init(_ x: Swift.Int, transformWithResult: @escaping () async throws -> test.NonSendableKlass)
   // CHECK-NEXT: #endif
   @usableFromInline
   internal init(_ x: Int, transformWithResult: @escaping () async throws -> sending NonSendableKlass) { fatalError() }
@@ -204,19 +204,38 @@ public struct TestInStruct {
 // Make sure that we emit compiler(>= 5.3) when emitting the suppressing check
 // to make sure we do not fail if we fail to parse sending in the if block.
 
-// CHECK: #if compiler(>=5.3) && $OptionalIsolatedParameters && $ExpressionMacroDefaultArguments
-// CHECK-NEXT: #if compiler(>=5.3) && $SendingArgsAndResults
-// CHECK-NEXT: @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-// CHECK-NEXT: @backDeployed(before: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999)
-// CHECK-NEXT: @inlinable public func withCheckedContinuation<T>(isolation:
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-@backDeployed(before: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999)
+// CHECK-LABEL: #if compiler(>=5.3) && $OptionalIsolatedParameters && $ExpressionMacroDefaultArguments // Suppression Count: 24
+// CHECK-NEXT: #if compiler(>=5.3) && $SendingArgsAndResults // Suppression Count: 25
+// CHECK-NEXT: @inlinable public func withCheckedContinuation<T>(isolation: isolated (any _Concurrency.Actor)? = #isolation, function: Swift.String = #function, _ body: (_Concurrency.CheckedContinuation<T, Swift.Never>) -> Swift.Void) async -> sending T {
+// CHECK-NEXT:   fatalError()
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: @inlinable public func withCheckedContinuation<T>(isolation: isolated (any _Concurrency.Actor)? = #isolation, function: Swift.String = #function, _ body: (_Concurrency.CheckedContinuation<T, Swift.Never>) -> Swift.Void) async -> T {
+// CHECK-NEXT:   fatalError()
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+// CHECK-NEXT: #endif
 @inlinable public func withCheckedContinuation<T>(
   isolation: isolated (any _Concurrency.Actor)? = #isolation,
   function: String = #function,
   _ body: (_Concurrency.CheckedContinuation<T, Swift.Never>) -> Swift.Void
 ) async -> sending T {
-  return await withUnsafeContinuation {
-    body(CheckedContinuation(continuation: $0, function: function))
-  }
+  fatalError()
 }
+
+// CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults // Suppression Count: 26
+// CHECK-NEXT: public var publicGlobal: (sending test.NonSendableKlass) -> ()
+// CHECK-NEXT: #else
+// CHECK-NEXT: public var publicGlobal: (test.NonSendableKlass) -> ()
+// CHECK-NEXT: #endif
+public var publicGlobal: (sending NonSendableKlass) -> () = { x in fatalError() }
+
+// CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults // Suppression Count: 27
+// CHECK-NEXT: @usableFromInline
+// CHECK-NEXT: internal var usableFromInlineGlobal: (sending test.NonSendableKlass) -> ()
+// CHECK-NEXT: #else
+// CHECK-NEXT: @usableFromInline
+// CHECK-NEXT: internal var usableFromInlineGlobal: (test.NonSendableKlass) -> ()
+// CHECK-NEXT: #endif
+@usableFromInline
+internal var usableFromInlineGlobal: (sending NonSendableKlass) -> () = { x in fatalError() }

--- a/test/Concurrency/sending_conditional_suppression.swift
+++ b/test/Concurrency/sending_conditional_suppression.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-upcoming-feature SendingArgsAndResults -swift-version 5 -enable-library-evolution -module-name test -emit-module -o %t/test.swiftmodule -emit-module-interface-path - -disable-availability-checking -swift-ast-printer-number-suppression-checks %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-upcoming-feature SendingArgsAndResults -swift-version 5 -enable-library-evolution -module-name test -emit-module -o %t/test.swiftmodule -emit-module-interface-path - -disable-availability-checking -Xllvm -swift-ast-printer-number-suppression-checks %s | %FileCheck %s
 
 // REQUIRES: asserts
 


### PR DESCRIPTION
While working on adding sending to some APIs in the stdlib, I noticed these issues were showing up in the swift interface file produces for Concurrency.

This PR fixes all of the issues I found:

1. The AST Printer if it wanted to print first a required feature and then a suppressible feature would drop compiler(>=5.3) from the inner suppressible check since it thought it wasn't necessary. The problem with doing this is that it ignores that compiler(>=5.3) has a second purpose. It causes the compiler to ignore parsing errors from the if block if the test fails. I added the compiler(>=5.3) check since I need that for sending and I think it is reasonable to not fail if we parse.
2. I found that we were not properly suppression function typed fields of nominal types.
3. I discovered that we did not properly detect sending in function parameters to initializers (i.e. we handled just FuncDecls instead of AbstractFunctionDecls).

rdar://129045783