### PR TITLE
Revert "[Sema] Warn about 'Any' to 'any Sendable' override"

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -898,26 +898,6 @@ unsigned int TypeBase::getOptionalityDepth() {
 }
 
 Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {
-
-  if (auto *arrayTy = dyn_cast<ArraySliceType>(this)) {
-    auto newBaseTy =
-        arrayTy->getBaseType()->stripConcurrency(recurse, dropGlobalActor);
-    return newBaseTy->isEqual(arrayTy->getBaseType())
-               ? Type(this)
-               : ArraySliceType::get(newBaseTy);
-  }
-
-  if (auto *dictTy = dyn_cast<DictionaryType>(this)) {
-    auto keyTy = dictTy->getKeyType();
-    auto strippedKeyTy = keyTy->stripConcurrency(recurse, dropGlobalActor);
-    auto valueTy = dictTy->getValueType();
-    auto strippedValueTy = valueTy->stripConcurrency(recurse, dropGlobalActor);
-
-    return keyTy->isEqual(strippedKeyTy) && valueTy->isEqual(strippedValueTy)
-               ? Type(this)
-               : DictionaryType::get(strippedKeyTy, strippedValueTy);
-  }
-
   // Look through optionals.
   if (Type optionalObject = getOptionalObjectType()) {
     Type newOptionalObject =
@@ -1101,6 +1081,25 @@ Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {
         });
 
     return anyChanged ? TupleType::get(elts, getASTContext()) : Type(this);
+  }
+
+  if (auto *arrayTy = dyn_cast<ArraySliceType>(this)) {
+    auto newBaseTy =
+        arrayTy->getBaseType()->stripConcurrency(recurse, dropGlobalActor);
+    return newBaseTy->isEqual(arrayTy->getBaseType())
+               ? Type(this)
+               : ArraySliceType::get(newBaseTy);
+  }
+
+  if (auto *dictTy = dyn_cast<DictionaryType>(this)) {
+    auto keyTy = dictTy->getKeyType();
+    auto strippedKeyTy = keyTy->stripConcurrency(recurse, dropGlobalActor);
+    auto valueTy = dictTy->getValueType();
+    auto strippedValueTy = valueTy->stripConcurrency(recurse, dropGlobalActor);
+
+    return keyTy->isEqual(strippedKeyTy) && valueTy->isEqual(strippedValueTy)
+               ? Type(this)
+               : DictionaryType::get(strippedKeyTy, strippedValueTy);
   }
 
   return Type(this);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1260,16 +1260,9 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
     auto propertyTy = property->getInterfaceType();
     auto parentPropertyTy = getSuperMemberDeclType(baseDecl);
 
-    // If @preconcurrency, strip concurrency from decl before matching
-    if (baseDecl->preconcurrency() && !baseDecl->isObjC()){
-        attempt = OverrideCheckingAttempt::MismatchedSendability;
-        propertyTy = propertyTy->stripConcurrency(true, true);
-        parentPropertyTy = parentPropertyTy->stripConcurrency(true, true);
-    }
     CanType parentPropertyCanTy =
       parentPropertyTy->getReducedType(
         decl->getInnermostDeclContext()->getGenericSignatureOfContext());
-
     if (!propertyTy->matches(parentPropertyCanTy,
                              TypeMatchFlags::AllowOverride)) {
       diags.diagnose(property, diag::override_property_type_mismatch,
@@ -1289,7 +1282,6 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
 
     // The overridden property must not be mutable.
     if (cast<AbstractStorageDecl>(baseDecl)->supportsMutation() &&
-        attempt != OverrideCheckingAttempt::MismatchedSendability &&
         !IsSilentDifference) {
       diags.diagnose(property, diag::override_mutable_covariant_property,
                   property->getName(), parentPropertyTy, propertyTy);

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -252,20 +252,3 @@ extension MainActorPreconcurrency: NotIsolated {
     }
   }
 }
-
-open class Parent {
-    init(userInfo: [String : Any]) {
-        self.userInfo = userInfo
-    }
-
-  @preconcurrency open var userInfo : [String : any Sendable] // expected-note {{overridden declaration is here}}
-}
-
-class Child : Parent {
-    override var userInfo: [String : Any] { // expected-warning {{declaration 'userInfo' has a type with different sendability from any potential overrides; this is an error in the Swift 6 language mode}}
-        get {
-            [:]
-        }
-        set {}
-    }
-}


### PR DESCRIPTION
Reverts apple/swift#73158

I am not sure why this was merged since there is another PR with further discussion about approaches to fix this - https://github.com/apple/swift/pull/73543, specifically https://github.com/apple/swift/pull/73543#discussion_r1596035386. Comments have been marked resolved although they are not even when it comes to test coverage.