### PR TITLE
🍒[cxx-interop] Re-enable a test for borrowing const ref

### DIFF
--- a/test/Interop/Cxx/class/safe-use-of-returned-reference-with-borrowing.swift
+++ b/test/Interop/Cxx/class/safe-use-of-returned-reference-with-borrowing.swift
@@ -8,7 +8,7 @@
 // aborrowed value.
 // RUN: %target-swift-frontend -DBORROW_PASS_TO_VALUE_PARAM -emit-ir -o /dev/null -I %t %t/test.swift -enable-experimental-cxx-interop -verify
 
-// REQUIRES: rdar111065819
+// REQUIRES: executable_test
 
 //--- Inputs/module.modulemap
 module CxxTest {


### PR DESCRIPTION
**Explanation**: This enables a test that previously got disabled. It was failing in non-executable CI job because it was missing `// REQUIRES: executable_test`.
**Scope**: Only changes a test.
**Risk**: Low.
**Issue**: rdar://111065819

Original PR: https://github.com/apple/swift/pull/73942