### PR TITLE
Remove duplicated comments in String.swift

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -961,7 +961,6 @@ extension String {
     // Lookup if it should be shifted in our ascii table, then we subtract 0x20 if
     // it should, 0x0 if not.
     // This code is equivalent to:
-    // This code is equivalent to:
     // switch sourcex {
     // case let x where (x >= 0x41 && x <= 0x5a):
     //   return x &- 0x20
@@ -984,7 +983,6 @@ extension String {
 
     // Lookup if it should be shifted in our ascii table, then we add 0x20 if
     // it should, 0x0 if not.
-    // This code is equivalent to:
     // This code is equivalent to:
     // switch sourcex {
     // case let x where (x >= 0x41 && x <= 0x5a):


### PR DESCRIPTION
<!-- What's in this pull request? -->
Hello, I found some duplicated comments in String.swift file and removed them to make descriptions for methods clearer.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
