### PR TITLE
[Test] Remove -disable-sil-ownership-verifier use.

### DIFF
--- a/test/SILOptimizer/definite_init_inout_super_init.swift
+++ b/test/SILOptimizer/definite_init_inout_super_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -Xfrontend -disable-sil-ownership-verifier -emit-sil %s -o /dev/null -Xfrontend -verify
+// RUN: %target-swiftc_driver -emit-sil %s -o /dev/null -Xfrontend -verify
 
 // TODO: Change this back to using target-swift-frontend once we move errors to
 // type checker and SILGen.


### PR DESCRIPTION
The flag had been used in `test/SILOptimizer/definite_init_inout_super_init.swift` because SILGen generated invalid SIL which would only be diagnosed during DI.  Thanks to https://github.com/apple/swift/pull/73664 , this is diagnosed before SILGen.

One other test case use (`test/PrintAsObjC/extensions.swift`) remains.
