### PR TITLE
[test] Update raw_layout.swift

### DIFF
--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -262,11 +262,11 @@ entry(%0 : $*Cell<T>):
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: {{invoke void|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
 
 // ConcreteMoveAsLike assignWithTake
 
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: {{invoke void|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])

--- a/test/Serialization/raw_layout.swift
+++ b/test/Serialization/raw_layout.swift
@@ -9,9 +9,9 @@ import RawLayoutCXX
 
 // CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}16WeirdCXXTypeCellVWV" = {{.*}} %swift.vwtable
 // initializeWithTake
-// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwtk"
+// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwtk{{.*}}"
 // assignWithTake
-// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwta"
+// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwta{{.*}}"
 // size
 // CHECK-SAME:  , {{i64|i32}} 1
 // stride

--- a/test/Serialization/raw_layout.swift
+++ b/test/Serialization/raw_layout.swift
@@ -9,9 +9,9 @@ import RawLayoutCXX
 
 // CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}16WeirdCXXTypeCellVWV" = {{.*}} %swift.vwtable
 // initializeWithTake
-// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwtk{{.*}}"
+// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwtk
 // assignWithTake
-// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwta{{.*}}"
+// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwta
 // size
 // CHECK-SAME:  , {{i64|i32}} 1
 // stride


### PR DESCRIPTION
There are a few CI jobs that generate an `invoke ptr` in LLVM for C++ move constructor, so check against that as well.

Resolves: rdar://129065473 and rdar://129069454