### PR TITLE
[6.0] SILGen: Diagnose unsupported shared case blocks for noncopyable switch subjects.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1034,5 +1034,8 @@ NOTE(lifetime_outside_scope_use, none,
 NOTE(lifetime_outside_scope_escape, none,
      "this use causes the lifetime-dependent value to escape", ())
 
+ERROR(noncopyable_shared_case_block_unimplemented, none,
+      "matching a non-'Copyable' value using a case label that has multiple patterns is not implemented", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/test/SILGen/borrowing_switch_multiple_patterns.swift
+++ b/test/SILGen/borrowing_switch_multiple_patterns.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+struct Inner: ~Copyable {}
+enum Outer: ~Copyable { case value(Inner, Int) }
+
+func borrow(_: borrowing Inner) {}
+func consume(_: consuming Inner) {}
+
+func foo(x: borrowing Outer) {
+    switch x {
+    case .value(let y, 0), // expected-error{{not implemented}}
+         .value(let y, _):
+        borrow(y)
+    }
+
+}
+
+func bar(x: borrowing Outer) {
+    switch x {
+    case .value(let y, 0):
+        borrow(y)
+        fallthrough
+
+    case .value(let y, _): // expected-error{{not implemented}}
+        borrow(y)
+    }
+
+}
+
+func zim(x: consuming Outer) {
+    switch consume x {
+    case .value(let y, 0), // expected-error{{not implemented}}
+         .value(let y, _):
+        consume(y)
+    }
+
+}
+
+func zang(x: consuming Outer) {
+    switch consume x {
+    case .value(let y, 0):
+        // should eventually test that this gets diagnosed as a double-consume
+        //consume(y)
+        fallthrough
+
+    case .value(let y, _): // expected-error{{not implemented}}
+        consume(y)
+    }
+
+}


### PR DESCRIPTION
Explanation: Diagnoses currently-unimplemented noncopyable switches involving `fallthrough` or multiple patterns in a single case label.
Scope: Replaces a "not implemented" assertion failure with a proper diagnostic.
Issue: rdar://129034189
Original PR: https://github.com/apple/swift/pull/74041
Risk: Low. Replaces a "not implemented" assertion failure with a proper diagnostic.
Testing: Swift CI
Reviewer: @kavon 