### PR TITLE
Add a definite initialization test case for 'let' tuples.

### DIFF
--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1614,3 +1614,14 @@ class DerivedWrappedProperty : SomeClass {
   }  // expected-error {{'super.init' isn't called on all paths before returning from initializer}}
 
 }
+
+// rdar://129031705 ([error: ... used before being initialized)
+// Related to treating 'let's as immutable RValues.
+struct S {
+  let rotation: (Int, Int)
+
+  init() {
+    rotation.0 = 0
+    rotation.1 = rotation.0
+  }
+}


### PR DESCRIPTION
We should be able to merge this test after @DougGregor reverts

commit 2ffe9d556c9cd29da9d5ec053a69426930c89d1c
Author: Doug Gregor <dgregor@apple.com>
Date:   Wed May 15 10:33:54 2024

    [Type checker] Represent "initializable" let instance property references as lvalues