### PR TITLE
[IRGen] Assign layout strings for static layout generic types in meta…

### DIFF
--- a/validation-test/IRGen/rdar127535274.swift
+++ b/validation-test/IRGen/rdar127535274.swift
@@ -1,0 +1,11 @@
+// RUN: %target-build-swift -g -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnessesInstantiation -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -enable-layout-string-value-witnesses-instantiation -Xfrontend -enable-library-evolution -c -parse-as-library -emit-ir %s | %FileCheck %s
+
+// CHECK: define internal ptr @"$s13rdar1275352744TestVMi"
+// CHECK:  [[METADATA:%.*]] = call ptr @swift_allocateGenericValueMetadataWithLayoutString
+// CHECK:  call void @swift_generic_instantiateLayoutString(ptr @"type_layout_string l13rdar1275352744TestVyxG", ptr [[METADATA]])
+// CHECK:  ret ptr [[METADATA]]
+// CHECK: }
+public struct Test<T> {
+    let x: [T]
+    let y: [T]
+}


### PR DESCRIPTION
…data initialization function

rdar://127535274

The layout string needs to be assigned before completion, to make it available in recursive metadata initialization. Setting it in the completion function causes a race between other metadata initializers using it and the completion function running.

