### PR TITLE
[6.0][IRGen] Assign layout strings for static layout generic types in meta…

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3519,16 +3519,6 @@ namespace {
 
         if (HasDependentMetadata)
           asImpl().emitInitializeMetadata(IGF, metadata, false, collector);
-
-        if (layoutStringsEnabled(IGM)) {
-          if (auto *layoutString = getLayoutString()) {
-            auto layoutStringCast = IGF.Builder.CreateBitCast(layoutString,
-                                                              IGM.Int8PtrTy);
-            IGF.Builder.CreateCall(
-              IGM.getGenericInstantiateLayoutStringFunctionPointer(),
-              {layoutStringCast, metadata});
-          }
-        }
       });
     }
 
@@ -5641,11 +5631,24 @@ namespace {
         descriptor = emitPointerAuthSign(IGF, descriptor, authInfo);
       }
 
-      return IGF.Builder.CreateCall(
-          getLayoutString() ?
-          IGM.getAllocateGenericValueMetadataWithLayoutStringFunctionPointer() :
-          IGM.getAllocateGenericValueMetadataFunctionPointer(),
-          {descriptor, arguments, templatePointer, extraSizeV});
+      if (layoutStringsEnabled(IGM)) {
+        auto *call = IGF.Builder.CreateCall(
+            IGM.getAllocateGenericValueMetadataWithLayoutStringFunctionPointer(),
+            {descriptor, arguments, templatePointer, extraSizeV});
+
+        if (auto *layoutString = getLayoutString()) {
+          auto layoutStringCast =
+              IGF.Builder.CreateBitCast(layoutString, IGM.Int8PtrTy);
+          IGF.Builder.CreateCall(
+              IGM.getGenericInstantiateLayoutStringFunctionPointer(),
+              {layoutStringCast, call});
+        }
+        return call;
+      } else {
+        return IGF.Builder.CreateCall(
+            IGM.getAllocateGenericValueMetadataFunctionPointer(),
+            {descriptor, arguments, templatePointer, extraSizeV});
+      }
     }
 
     void flagUnfilledFieldOffset() {
@@ -6113,11 +6116,24 @@ namespace {
         descriptor = emitPointerAuthSign(IGF, descriptor, authInfo);
       }
 
-      return IGF.Builder.CreateCall(
-          getLayoutString() ?
-            IGM.getAllocateGenericValueMetadataWithLayoutStringFunctionPointer() :
+      if (layoutStringsEnabled(IGM)) {
+        auto *call = IGF.Builder.CreateCall(
+            IGM.getAllocateGenericValueMetadataWithLayoutStringFunctionPointer(),
+            {descriptor, arguments, templatePointer, extraSizeV});
+
+        if (auto *layoutString = getLayoutString()) {
+          auto layoutStringCast =
+              IGF.Builder.CreateBitCast(layoutString, IGM.Int8PtrTy);
+          IGF.Builder.CreateCall(
+              IGM.getGenericInstantiateLayoutStringFunctionPointer(),
+              {layoutStringCast, call});
+        }
+        return call;
+      } else {
+        return IGF.Builder.CreateCall(
             IGM.getAllocateGenericValueMetadataFunctionPointer(),
-          {descriptor, arguments, templatePointer, extraSizeV});
+            {descriptor, arguments, templatePointer, extraSizeV});
+      }
     }
 
     bool hasTrailingFlags() {

--- a/validation-test/IRGen/rdar127535274.swift
+++ b/validation-test/IRGen/rdar127535274.swift
@@ -1,0 +1,11 @@
+// RUN: %target-build-swift -g -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnessesInstantiation -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -enable-layout-string-value-witnesses-instantiation -Xfrontend -enable-library-evolution -c -parse-as-library -emit-ir %s | %FileCheck %s
+
+// CHECK: define internal ptr @"$s13rdar1275352744TestVMi"
+// CHECK:  [[METADATA:%.*]] = call ptr @swift_allocateGenericValueMetadataWithLayoutString
+// CHECK:  call void @swift_generic_instantiateLayoutString(ptr @"type_layout_string l13rdar1275352744TestVyxG", ptr [[METADATA]])
+// CHECK:  ret ptr [[METADATA]]
+// CHECK: }
+public struct Test<T> {
+    let x: [T]
+    let y: [T]
+}


### PR DESCRIPTION
…data initialization function

**Explanation:** The layout string needs to be assigned before completion, to make it available in recursive metadata initialization. Setting it in the completion function causes a race between other metadata initializers using it and the completion function running.
**Scope:** Compact Value Witnesses only
**Issue:** rdar://127535274
**Original PR:** https://github.com/apple/swift/pull/74058
**Risk:** Low. Only affects Compact Value Witnesses.
**Testing:** Added a validation test
**Reviewer:** @mikeash @aschwaighofer 
