### PR TITLE
[Coverage] Avoid recording regions from macro expansions

### DIFF
--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -258,9 +258,12 @@ bool shouldSkipExpr(Expr *E) {
 /// Whether the children of a decl that isn't explicitly handled should be
 /// walked.
 static bool shouldWalkIntoUnhandledDecl(const Decl *D) {
-  // We want to walk into the initializer for a pattern binding decl. This
-  // allows us to map LazyInitializerExprs.
-  return isa<PatternBindingDecl>(D);
+  // We want to walk into initializers for bindings, and the expansions of
+  // MacroExpansionDecls, which will be nested within MacroExpansionExprs in
+  // local contexts. We won't record any regions within the macro expansion,
+  // but still need to walk to get accurate counter information in case e.g
+  // there's a throwing function call in the expansion.
+  return isa<PatternBindingDecl>(D) || isa<MacroExpansionDecl>(D);
 }
 
 /// Whether the expression \c E could potentially throw an error.

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2351,6 +2351,20 @@ public struct RemoteBodyMacro: BodyMacro {
 }
 
 @_spi(ExperimentalLanguageFeature)
+public struct BodyMacroWithControlFlow: BodyMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [CodeBlockItemSyntax] {
+    [
+      "guard .random() else { return }",
+      "_ = try throwingFn()"
+    ]
+  }
+}
+
+@_spi(ExperimentalLanguageFeature)
 public struct TracedPreambleMacro: PreambleMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2218,6 +2218,15 @@ public struct SingleMemberStubMacro: DeclarationMacro {
   }
 }
 
+public struct DeclMacroWithControlFlow: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["let _ = .random() ? try throwingFn() : 0"]
+  }
+}
+
 public struct GenerateStubsForProtocolRequirementsMacro: PeerMacro, ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -212,6 +212,25 @@ public class NestedDeclInExprMacro: ExpressionMacro {
   }
 }
 
+public class NullaryFunctionCallMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    let calls = macro.arguments.compactMap(\.expression).map { "\($0)()" }
+    return "(\(raw: calls.joined(separator: ", ")))"
+  }
+}
+
+public class TupleMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return "(\(raw: macro.arguments.map { "\($0)" }.joined()))"
+  }
+}
+
 enum CustomError: Error, CustomStringConvertible {
   case message(String)
 

--- a/test/Profiler/coverage_macros.swift
+++ b/test/Profiler/coverage_macros.swift
@@ -31,6 +31,9 @@ macro id<T>(_: T) -> T = #externalMacro(module: "MacroDefinition", type: "TupleM
 @attached(body)
 macro BodyMacroWithControlFlow() = #externalMacro(module: "MacroDefinition", type: "BodyMacroWithControlFlow")
 
+@freestanding(declaration, names: arbitrary)
+macro declMacroWithControlFlow() = #externalMacro(module: "MacroDefinition", type: "DeclMacroWithControlFlow")
+
 // This needs to be matched up here due to the sorting of the SIL; just make
 // sure the counter '2' is for the initialization.
 // CHECK-LABEL: sil hidden [lazy_getter] [noinline] @$s15coverage_macros2S1V2z3SiSgvg : $@convention(method) (@inout S1) -> Optional<Int>
@@ -144,4 +147,11 @@ func test6() throws
 func test7() throws {
   guard .random() else { return }
   print("hello")
+}
+
+// CHECK-LABEL: sil_coverage_map{{.*}}s15coverage_macros5test8yyKF
+func test8() throws {             // CHECK-NEXT: [[@LINE]]:21   -> [[@LINE+4]]:2 : 0
+  guard .random() else { return } // CHECK-NEXT: [[@LINE]]:24   -> [[@LINE]]:34  : 1
+                                  // CHECK-NEXT: [[@LINE-1]]:34 -> [[@LINE+2]]:2 : (0 - 1)
+  #declMacroWithControlFlow       // CHECK-NEXT: [[@LINE]]:28   -> [[@LINE+1]]:2 : ((0 - 1) - 3)
 }

--- a/test/Profiler/coverage_macros.swift
+++ b/test/Profiler/coverage_macros.swift
@@ -19,20 +19,61 @@ macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers
 @freestanding(expression)
 macro nestedDeclInExpr() -> () -> Void = #externalMacro(module: "MacroDefinition", type: "NestedDeclInExprMacro")
 
+@freestanding(expression)
+macro fnCall<T>(_: () throws -> T) -> T = #externalMacro(module: "MacroDefinition", type: "NullaryFunctionCallMacro")
+
+@freestanding(expression)
+macro fnCall<T>(_: () throws -> T, _: () throws -> T) -> (T, T) = #externalMacro(module: "MacroDefinition", type: "NullaryFunctionCallMacro")
+
+@freestanding(expression)
+macro id<T>(_: T) -> T = #externalMacro(module: "MacroDefinition", type: "TupleMacro")
+
+// This needs to be matched up here due to the sorting of the SIL; just make
+// sure the counter '2' is for the initialization.
+// CHECK-LABEL: sil hidden [lazy_getter] [noinline] @$s15coverage_macros2S1V2z3SiSgvg : $@convention(method) (@inout S1) -> Optional<Int>
+// CHECK:       switch_enum {{%[0-9]+}} : $Optional<Optional<Int>>, case #Optional.some!enumelt: {{bb[0-9]}}, case #Optional.none!enumelt: [[INITBB:bb[0-9]]]
+// CHECK:       [[INITBB]]
+// CHECK-NEXT:  increment_profiler_counter 2
+
+// This needs to be matched up here due to the sorting of the SIL; just make
+// sure we emit the counter increments for the error branches.
+// CHECK-LABEL: sil hidden @$s15coverage_macros5test2Si_SityKF
+// CHECK:       increment_profiler_counter 0,{{.*}}s15coverage_macros5test2Si_SityKF
+// CHECK:       {{bb[0-9]+}}({{%[0-9]+}} : $any Error):
+// CHECK-NEXT:    increment_profiler_counter 1,{{.*}}s15coverage_macros5test2Si_SityKF
+// CHECK:       {{bb[0-9]+}}({{%[0-9]+}} : $any Error):
+// CHECK-NEXT:    increment_profiler_counter 2,{{.*}}s15coverage_macros5test2Si_SityKF
+
 // Note we use implicit-check-not, so this test ensures we don't emit
 // coverage maps for the macro expansions.
 
+// CHECK-LABEL: sil_coverage_map{{.*}}s15coverage_macros10throwingFnSiyKF
+func throwingFn() throws -> Int { 0 }
+
 struct S1 {
-  // CHECK: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S1.x
+  // CHECK-LABEL: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S1.x
   var x: Int = 0
 
-  // CHECK: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S1.y
+  // CHECK-LABEL: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S1.y
   var y: Int = 0
+
+  // CHECK-LABEL: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S1.z
+  var z: Int = #id(.random() ? 3 : 4) // CHECK-NEXT: [[@LINE]]:16 -> [[@LINE]]:38 : 0
+
+  // CHECK-LABEL: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S1.z1
+  var z1: Int? = try? #id(throwingFn()) // CHECK-NEXT: [[@LINE]]:18 -> [[@LINE]]:40 : 0
+
+  // CHECK-LABEL: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S1.z2
+  var z2: Int? = #id(try? throwingFn()) // CHECK-NEXT: [[@LINE]]:18 -> [[@LINE]]:40 : 0
+
+  // The counter for the initialization region is '2', see the match of s15coverage_macros2S1V2z3SiSgvg above.
+  // CHECK-LABEL: sil_coverage_map{{.*}}coverage_macros.S1.z3.getter
+  lazy var z3: Int? = #id(try? throwingFn()) // CHECK-NEXT: [[@LINE]]:23 -> [[@LINE]]:45 : 2
 }
 
 @addMembers
 struct S2 {
-  // CHECK: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S2.(_storage
+  // CHECK-LABEL: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S2.(_storage
   private var _storage = S1()
 
   @accessViaStorage
@@ -43,7 +84,49 @@ struct S2 {
   var y: Int = 17
 }
 
-// CHECK: sil_coverage_map{{.*}}s15coverage_macros3fooyyF
+// CHECK-LABEL: sil_coverage_map{{.*}}s15coverage_macros3fooyyF
 func foo() {
   _ = #nestedDeclInExpr()
+}
+
+// For cases where control flow happens in the macro expansion, we drop
+// all the regions that occur within the expansion, but account for any
+// control flow changes when exiting the expansion.
+//
+// CHECK-LABEL: sil_coverage_map{{.*}}s15coverage_macros5test1yyKF
+func test1() throws {         // CHECK-NEXT: [[@LINE]]:21 -> [[@LINE+2]]:2 : 0
+  _ = try #fnCall(throwingFn) // CHECK-NEXT: [[@LINE]]:30 -> [[@LINE+1]]:2 : (0 - 1)
+}                             // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map{{.*}}s15coverage_macros5test2Si_SityKF
+func test2() throws -> (Int, Int) {            // CHECK-NEXT: [[@LINE]]:35 -> [[@LINE+3]]:2  : 0
+  let x = try #fnCall(throwingFn, throwingFn)  // CHECK-NEXT: [[@LINE]]:46 -> [[@LINE+1]]:11 : ((0 - 1) - 2)
+  return x                                     // CHECK-NEXT: }
+}
+
+// In this case the control flow is entirely contained within the macro, with
+// the same exit count, so no change.
+//
+// CHECK-LABEL: sil_coverage_map{{.*}}s15coverage_macros5test3SiyF
+func test3() -> Int {            // CHECK-NEXT: [[@LINE]]:21 -> [[@LINE+3]]:2 : 0
+  let x = #id(.random() ? 3 : 4) // CHECK-NEXT: }
+  return x
+}
+
+// CHECK-LABEL: sil_coverage_map{{.*}}s15coverage_macros5test4Si_SityKF
+func test4() throws -> (Int, Int) {                // CHECK-NEXT: [[@LINE]]:35 -> [[@LINE+3]]:2  : 0
+  let x = try #id(#fnCall(throwingFn, throwingFn)) // CHECK-NEXT: [[@LINE]]:51 -> [[@LINE+1]]:11 : ((0 - 1) - 2)
+  return x                                         // CHECK-NEXT: }
+}
+
+// 0: entry, 1: first else, 2: first error branch, 3: second else,
+// 4: second error branch, 5: third else, 6: third error branch,
+// 7: fourth error branch
+// CHECK-LABEL: sil_coverage_map{{.*}}s15coverage_macros5test5Si_S2ityKF
+func test5() throws -> (Int, Int, Int) {        // CHECK-NEXT: [[@LINE]]:40 -> [[@LINE+6]]:2  : 0
+  let x = #id(.random() ? try throwingFn() : 4) // CHECK-NEXT: [[@LINE]]:48 -> [[@LINE+4]]:19 : (0 - 2)
+  let y = #id(.random() ? 5 : try throwingFn()) // CHECK-NEXT: [[@LINE]]:48 -> [[@LINE+3]]:19 : ((0 - 2) - 4)
+  let z = #id(.random() ? try throwingFn()
+                        : try throwingFn())     // CHECK-NEXT: [[@LINE]]:44 -> [[@LINE+1]]:19 : ((((0 - 2) - 4) - 6) - 7)
+  return (x, y, z)                              // CHECK-NEXT: }
 }

--- a/test/Profiler/coverage_macros.swift
+++ b/test/Profiler/coverage_macros.swift
@@ -28,6 +28,9 @@ macro fnCall<T>(_: () throws -> T, _: () throws -> T) -> (T, T) = #externalMacro
 @freestanding(expression)
 macro id<T>(_: T) -> T = #externalMacro(module: "MacroDefinition", type: "TupleMacro")
 
+@attached(body)
+macro BodyMacroWithControlFlow() = #externalMacro(module: "MacroDefinition", type: "BodyMacroWithControlFlow")
+
 // This needs to be matched up here due to the sorting of the SIL; just make
 // sure the counter '2' is for the initialization.
 // CHECK-LABEL: sil hidden [lazy_getter] [noinline] @$s15coverage_macros2S1V2z3SiSgvg : $@convention(method) (@inout S1) -> Optional<Int>
@@ -129,4 +132,16 @@ func test5() throws -> (Int, Int, Int) {        // CHECK-NEXT: [[@LINE]]:40 -> [
   let z = #id(.random() ? try throwingFn()
                         : try throwingFn())     // CHECK-NEXT: [[@LINE]]:44 -> [[@LINE+1]]:19 : ((((0 - 2) - 4) - 6) - 7)
   return (x, y, z)                              // CHECK-NEXT: }
+}
+
+// Not profiled.
+@BodyMacroWithControlFlow
+func test6() throws
+
+
+// Not profiled.
+@BodyMacroWithControlFlow
+func test7() throws {
+  guard .random() else { return }
+  print("hello")
 }


### PR DESCRIPTION
Ignore any regions recorded while inside a macro expansion, but account for any control flow that may have happened such that the exit count is correctly adjusted. This allows e.g throwing function calls to behave correctly within the expansion.

Additionally, make sure we avoid profiling functions with function body macros.

rdar://129081384