### PR TITLE
[Parse] Add diagnostic for extraneous case keyword when multiple patterns.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1222,6 +1222,8 @@ ERROR(expected_case_where_expr,PointsToFirstBadToken,
       "expected expression for 'where' guard of 'case'", ())
 ERROR(expected_case_colon,PointsToFirstBadToken,
       "expected ':' after '%0'", (StringRef))
+ERROR(extra_case_keyword,none,
+      "extraneous 'case' keyword in pattern", ())
 ERROR(default_with_where,none,
       "'default' cannot be used with a 'where' guard expression",
       ())

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2633,6 +2633,12 @@ static ParserStatus parseStmtCase(Parser &P, SourceLoc &CaseLoc,
       isFirst = false;
       if (!P.consumeIf(tok::comma))
         break;
+
+      if (P.Tok.is(tok::kw_case)) {
+        P.diagnose(P.Tok, diag::extra_case_keyword)
+          .fixItRemove(SourceRange(P.Tok.getLoc()));
+        P.consumeToken(tok::kw_case);
+      }
     }
   }
 

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -73,7 +73,7 @@ default:
 // Multiple cases per case block
 switch x { // expected-error {{switch must be exhaustive}} expected-note{{add a default clause}}
 case 0: // expected-error {{'case' label in a 'switch' must have at least one executable statement}} {{8-8= break}}
-case 1:
+case 1, case 2: // expected-error {{extraneous 'case' keyword in pattern}} {{9-14=}}
   x = 0
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This change adds a diagnostic for code that tries to use a second `case` keyword when writing a case statement with multiple patterns. E.g. `case .a, case .b:` instead of `case .a, .b:`. I've seen several people do this while pair programming and a recent question in the iOS-dev Slack on how to do this made me realize the current diagnostics for this (IMHO) common error are pretty terrible:

```
test.swift:8:12: error: expected pattern
  case .a, case .b:
           ^
test.swift:8:12: error: expected ':' after 'case'
  case .a, case .b:
           ^
test.swift:8:17: warning: case is already handled by previous patterns; consider removing it
  case .a, case .b:
                ^~
```
(This is because the second `case` causes pattern parsing to fail and the recovery inserts a match-anything pattern - thus the confusing warning.)

With this change, you get a single error, and a fix-it to remove the offending token:
```
test.swift:8:12: error: extraneous 'case' keyword in pattern
```
