### PR TITLE
[6.0] Fix SILCombine to delete dead end_access instructions.

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -107,8 +107,16 @@ SILValue stripBorrow(SILValue V);
 /// type may be changed by a cast.
 SingleValueInstruction *getSingleValueCopyOrCast(SILInstruction *I);
 
+// Return true if this instruction begins a SIL-level scope. If so, it must have
+// a single result. That result must have an isEndOfScopeMarker direct use on
+// all reachable paths. This instruction along with its scope-ending
+// instructions are considered a single operation. They must be inserted and
+// deleted together.
+bool isBeginScopeMarker(SILInstruction *user);
+
 /// Return true if this instruction terminates a SIL-level scope. Scope end
-/// instructions do not produce a result.
+/// instructions do not produce a result. Their single operand must be an
+/// isBeginScopeMarker and cannot be 'undef'.
 bool isEndOfScopeMarker(SILInstruction *user);
 
 /// Return true if the given instruction has no effect on it's operand values

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -295,7 +295,16 @@ SingleValueInstruction *swift::getSingleValueCopyOrCast(SILInstruction *I) {
   }
 }
 
-// Does this instruction terminate a SIL-level scope?
+bool swift::isBeginScopeMarker(SILInstruction *user) {
+  switch (user->getKind()) {
+  default:
+    return false;
+  case SILInstructionKind::BeginAccessInst:
+  case SILInstructionKind::BeginBorrowInst:
+    return true;
+  }
+}
+
 bool swift::isEndOfScopeMarker(SILInstruction *user) {
   switch (user->getKind()) {
   default:

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -587,6 +587,35 @@ bb0(%0 : $Builtin.Int1):
   return %2 : $()
 }
 
+// rdar://121599876 (SILCombine should delete instructions in blocks dominated by cond_fail -1)
+// CHECK-LABEL: sil @cond_fail_end_scope : $@convention(thin) (@inout Builtin.Int32, Builtin.Int1) -> () {
+// CHECK: cond_fail
+// CHECK-NEXT:   unreachable
+// CHECK:      bb1:
+// CHECK-NEXT:   br bb3
+// CHECK:      bb2:
+// CHECK-NEXT:   br bb3
+// CHECK-LABEL: } // end sil function 'cond_fail_end_scope'
+sil @cond_fail_end_scope : $@convention(thin) (@inout Builtin.Int32, Builtin.Int1) -> () {
+entry(%0 : $*Builtin.Int32, %1 : $Builtin.Int1):
+  %true = integer_literal $Builtin.Int1, -1
+  cond_fail %true : $Builtin.Int1
+  %access = begin_access [read] [static] %0 : $*Builtin.Int32
+  cond_br %1, left, right
+
+left:
+  end_access %access : $*Builtin.Int32
+  br end
+
+right:
+  end_access %access : $*Builtin.Int32
+  br end
+
+end:
+  %99 = tuple ()
+  return %99 : $()
+}
+
 // CHECK-LABEL: sil @release_then_retain_peephole
 // CHECK: bb0
 // CHECK-NOT: strong_release
@@ -3688,7 +3717,7 @@ bb3(%16 : $Int32):                                  // Preds: bb1 bb2
   return %16 : $Int32                               // id: %17
 }
 
-protocol Prot0 : class {
+protocol Prot0 : AnyObject {
   static func newWithConfig() throws -> Builtin.Int32
 }
 


### PR DESCRIPTION
Otherwise, the SILVerifier will raise an error.

Fixes rdar://121599876 (SILCombine should delete instructions in blocks dominated by cond_fail -1)

(cherry picked from commit e06fc9966711ed6f2322b91963fa522eb579c42e)

--- CCC ---

Explanation: Fix SILCombine to delete dead end_access instructions.

Scope: SILVerifier raises an error in the asserts compiler.

Radar/SR Issue: rdar://121599876 (SILCombine should delete instructions in blocks dominated by cond_fail -1)

main PR: https://github.com/apple/swift/pull/74073

Risk: The fix adds a few lines of self-contained code to delete more dead instructions.

Testing: Unit test added.

Reviewer: @nate-chandler 