### PR TITLE
[sending] Do not allow for sending to be used together with borrowing.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2211,7 +2211,8 @@ ERROR(sending_and_transferring_used_together,none,
 WARNING(transferring_is_now_sendable,none,
         "'transferring' has been renamed to 'sending' and the 'transferring' spelling will be removed shortly",
         ())
-
+ERROR(sending_cannot_be_used_with_borrowing,none,
+      "'%0' cannot be used together with 'borrowing'", (StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5520,6 +5520,14 @@ ParserStatus Parser::ParsedTypeAttributeList::slowParse(Parser &P) {
             .fixItRemove(TransferringLoc);
       }
 
+      // If we already saw a specifier, check if we have borrowing. In such a
+      // case, emit an error.
+      if (SpecifierLoc.isValid() &&
+          Specifier == ParamDecl::Specifier::Borrowing) {
+        P.diagnose(Tok, diag::sending_cannot_be_used_with_borrowing,
+                   "sending");
+      }
+
       SendingLoc = P.consumeToken();
       continue;
     }
@@ -5557,6 +5565,13 @@ ParserStatus Parser::ParsedTypeAttributeList::slowParse(Parser &P) {
       if (bool(Specifier) && SendingLoc.isValid()) {
         P.diagnose(Tok, diag::sending_before_parameter_specifier,
                    getNameForParamSpecifier(Specifier));
+      }
+
+      // We cannot use transferring with borrowing.
+      if (TransferringLoc.isValid() &&
+          Specifier == ParamDecl::Specifier::Borrowing) {
+        P.diagnose(TransferringLoc, diag::sending_cannot_be_used_with_borrowing,
+                   "transferring");
       }
     }
     Tok.setKind(tok::contextual_keyword);

--- a/test/Parse/sending.swift
+++ b/test/Parse/sending.swift
@@ -28,3 +28,6 @@ func testArgWithConsumingWrongOrder(_ x: sending consuming String, _ y: sending 
 func testArgWithConsumingWrongOrderType(_ x: (sending consuming String, sending inout String) -> ()) {}
 // expected-error @-1 {{'sending' must be placed after specifier 'consuming'}}
 // expected-error @-2 {{'sending' must be placed after specifier 'inout'}}
+
+func testBorrowSending(_ x: borrowing sending String) {}
+// expected-error @-1 {{'sending' cannot be used together with 'borrowing'}}

--- a/test/Parse/transferring.swift
+++ b/test/Parse/transferring.swift
@@ -27,3 +27,7 @@ func testVarDeclTuple2(_ x: (transferring String)) {}
   // expected-warning @-1 {{'transferring' has been renamed to 'sending' and the 'transferring' spelling will be removed shortly}}
 func testVarDeclTuple2(_ x: (transferring String, String)) {} // expected-error {{'transferring' cannot be applied to tuple elements}}
   // expected-warning @-1 {{'transferring' has been renamed to 'sending' and the 'transferring' spelling will be removed shortly}}
+
+func testBorrowSending(_ x: transferring borrowing String) {}
+// expected-warning @-1 {{'transferring' has been renamed to 'sending' and the 'transferring' spelling will be removed shortly}}
+// expected-error @-2 {{'transferring' cannot be used together with 'borrowing'}}

--- a/test/SIL/Parser/sending.sil
+++ b/test/SIL/Parser/sending.sil
@@ -4,8 +4,8 @@ sil_stage raw
 
 // CHECK-LABEL: func transferValueDefault<T>(_ t: sending T)
 func transferValueDefault<T>(_ t: sending T)
-// CHECK-LABEL: func transferValueBorrowing<T>(_ t: borrowing sending T)
-func transferValueBorrowing<T>(_ t: borrowing sending T)
+// CHECK-LABEL: func transferValueBorrowing<T>(_ t: __shared sending T)
+func transferValueBorrowing<T>(_ t: __shared sending T)
 // CHECK-LABEL: func transferValueConsuming<T>(_ t: consuming sending T)
 func transferValueConsuming<T>(_ t: consuming sending T)
 

--- a/test/SIL/Parser/transferring.sil
+++ b/test/SIL/Parser/transferring.sil
@@ -4,8 +4,8 @@ sil_stage raw
 
 // CHECK-LABEL: func transferValueDefault<T>(_ t: sending T)
 func transferValueDefault<T>(_ t: transferring T)
-// CHECK-LABEL: func transferValueBorrowing<T>(_ t: borrowing sending T)
-func transferValueBorrowing<T>(_ t: transferring borrowing T)
+// CHECK-LABEL: func transferValueBorrowing<T>(_ t: __shared sending T)
+func transferValueBorrowing<T>(_ t: transferring __shared T)
 // CHECK-LABEL: func transferValueConsuming<T>(_ t: consuming sending T)
 func transferValueConsuming<T>(_ t: transferring consuming T)
 

--- a/test/SIL/Serialization/sending.sil
+++ b/test/SIL/Serialization/sending.sil
@@ -9,15 +9,15 @@ sil_stage raw
 
 // CHECK-LABEL: func transferValueDefault<T>(_ t: sending T)
 func transferValueDefault<T>(_ t: transferring T)
-// CHECK-LABEL: func transferValueBorrowing<T>(_ t: borrowing sending T)
-func transferValueBorrowing<T>(_ t: transferring borrowing T)
+// CHECK-LABEL: func transferValue__shared<T>(_ t: __shared sending T)
+func transferValue__shared<T>(_ t: transferring __shared T)
 // CHECK-LABEL: func transferValueConsuming<T>(_ t: consuming sending T)
 func transferValueConsuming<T>(_ t: transferring consuming T)
 
 // CHECK-LABEL: func sendingValueDefault<T>(_ t: sending T)
 func sendingValueDefault<T>(_ t: sending T)
-// CHECK-LABEL: func sendingValueBorrowing<T>(_ t: borrowing sending T)
-func sendingValueBorrowing<T>(_ t: borrowing sending T)
+// CHECK-LABEL: func sendingValue__shared<T>(_ t: __shared sending T)
+func sendingValue__shared<T>(_ t: __shared sending T)
 // CHECK-LABEL: func sendingValueConsuming<T>(_ t: consuming sending T)
 func sendingValueConsuming<T>(_ t: consuming sending T)
 

--- a/test/Sema/sending.swift
+++ b/test/Sema/sending.swift
@@ -10,14 +10,12 @@ func test_good(_ x: sending Int) {}
 
 func test_consuming_after_sending(_ x: sending consuming Int) {} // expected-error {{'sending' must be placed after specifier 'consuming'}}
 
-func test_borrowing_after_sending(_ x: sending borrowing Int) {} // expected-error {{'sending' must be placed after specifier 'borrowing'}}
-
 func test_inout_after_sending(_ x: sending inout Int) {} // expected-error {{'sending' must be placed after specifier 'inout'}}
 
 func test_repeated_sending(_ x: sending sending Int) {} // expected-error {{parameter may have at most one 'sending' specifier}}
 
-func test_repeated_sending_mixed(_ x: sending borrowing sending inout Int) {}
-// expected-error @-1 {{'sending' must be placed after specifier 'borrowing'}}
+func test_repeated_sending_mixed(_ x: sending consuming sending inout Int) {}
+// expected-error @-1 {{'sending' must be placed after specifier 'consuming'}}
 // expected-error @-2 {{parameter may have at most one 'sending' specifier}}
 // expected-error @-3 {{parameter may have at most one of the 'inout', 'borrowing', or 'consuming' specifiers}}
 

--- a/test/Sema/transferring.swift
+++ b/test/Sema/transferring.swift
@@ -28,6 +28,7 @@ func test_repeated_transferring_mixed(_ x: transferring borrowing transferring i
 // expected-error @-3 {{parameter may have at most one of the 'inout', 'borrowing', or 'consuming' specifiers}}
 // expected-warning @-4 {{'transferring' has been renamed to 'sending' and the 'transferring' spelling will be removed shortly}}
 // expected-warning @-5 {{'transferring' has been renamed to 'sending' and the 'transferring' spelling will be removed shortly}}
+// expected-error @-6 {{'transferring' cannot be used together with 'borrowing'}}
 
 // Just until we get the results setup.
 func test_transferring_result_in_tuple() -> (transferring Int, Int) {}


### PR DESCRIPTION
We are leaving this as an open part of the design space. In the mean time if people need a +0 parameter, they can use __shared with sending.

rdar://129116182
