### PR TITLE
[Index] Don’t verify mangled names of declarations in invalid decl contexts

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -867,7 +867,16 @@ ASTMangler::mangleAnyDecl(const ValueDecl *Decl,
 
   // We have a custom prefix, so finalize() won't verify for us. If we're not
   // in invalid code (coming from an IDE caller) verify manually.
-  if (!Decl->isInvalid())
+  bool shouldVerify = true;
+  if (Decl->isInvalid()) {
+    shouldVerify = false;
+  }
+  if (auto contextDecl = Decl->getDeclContext()->getAsDecl()) {
+    if (contextDecl->isInvalid()) {
+      shouldVerify = false;
+    }
+  }
+  if (shouldVerify)
     verify(Storage.str());
   return finalize();
 }

--- a/test/Index/enum_case_with_invalid_associated_type.swift
+++ b/test/Index/enum_case_with_invalid_associated_type.swift
@@ -1,0 +1,7 @@
+enum MyEnum {
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+  case test(artifactID: String, hostTriple: Triple)
+// CHECK: enumerator/Swift | test(artifactID:hostTriple:)
+// CHECK: param/Swift | artifactID
+// CHECK: param/Swift | hostTriple
+}


### PR DESCRIPTION
The added test case crashed because we were trying to verify the mangled name of the `artifactID` parameter, because the parameter is not marked as invalid. But the mangled name of that parameter contains the name of the enum case, which is invalid. Thus, the mangled name contained errors and didn’t pass verification.

To fix the crash, don’t verify mangled names in decl contexts that are invalid.

rdar://128092323