### PR TITLE
[Concurrency] Don't add new task locals copy runtime func

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -668,18 +668,6 @@ void swift_task_localValuePop();
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_localsCopyTo(AsyncTask* target);
 
-/// Some task local bindings must be copied defensively when a child task is
-/// created in a task group. See task creation (swift_task_create_common) for
-/// a detailed discussion how and when this is used.
-///
-/// Its Swift signature is
-///
-/// \code
-/// func swift_task_localsCopyToTaskGroupChildTaskDefensively<Key>(AsyncTask* task)
-/// \endcode
-SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-void swift_task_localsCopyToTaskGroupChildTaskDefensively(AsyncTask* target);
-
 /// Switch the current task to a new executor if we aren't already
 /// running on a compatible executor.
 ///

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -378,12 +378,6 @@ OVERRIDE_TASK_LOCAL(task_localsCopyTo, void,
                     (AsyncTask *target),
                     (target))
 
-OVERRIDE_TASK_LOCAL(task_localsCopyToTaskGroupChildTaskDefensively, void,
-                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
-                    swift::,
-                    (AsyncTask *target),
-                    (target))
-
 OVERRIDE_TASK_STATUS(task_hasTaskGroupStatusRecord, bool,
                      SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                      swift::, , )

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1017,7 +1017,7 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
       if (auto taskLocalHeadLinkType = ParentLocal.peekHeadLinkType()) {
         if (taskLocalHeadLinkType ==
             swift::TaskLocal::NextLinkType::IsNextCreatedInTaskGroupBody) {
-          swift_task_localsCopyToTaskGroupChildTaskDefensively(task);
+          ParentLocal.copyToOnlyOnlyFromCurrentGroup(task);
           taskLocalStorageInitialized = true;
         }
       }

--- a/test/Concurrency/Runtime/async_task_locals_in_task_group_may_need_to_copy.swift
+++ b/test/Concurrency/Runtime/async_task_locals_in_task_group_may_need_to_copy.swift
@@ -13,6 +13,8 @@ enum TL {
   static var two: Int = 2
   @TaskLocal
   static var three: Int = 3
+  @TaskLocal
+  static var four: Int = 4
 }
 
 // ==== ------------------------------------------------------------------------
@@ -96,6 +98,7 @@ func test() async {
     print("--")
   }
 
+  // Multiple nested task groups *in the same task*
   await TL.$one.withValue(11) {
     await withTaskGroup(of: Void.self) { group in
       await TL.$three.withValue(33) {
@@ -109,10 +112,52 @@ func test() async {
           }
         }
       }
-
-      print("Survived, done") // CHECK: Survived, done
+      print("--")
     }
   }
+
+  // Multiple "nested" task groups, however in different child tasks
+  await withTaskGroup(of: Void.self) { outer in
+    // Child task inside  'outer':
+    await TL.$one.withValue(11) { // DOES NOT have to be copied by the 'inner.addTask' (!)
+      outer.addTask {
+        await TL.$two.withValue(2222) {
+          await withTaskGroup(of: Void.self) { inner in
+            TL.$three.withValue(3333) { // MUST be copied by 'inner.addTask'
+              inner.addTask {
+                print("Survived, one: \(TL.one) @ \(#fileID):\(#line)") // CHECK: Survived, one: 11
+                print("Survived, two: \(TL.two) @ \(#fileID):\(#line)") // CHECK: Survived, two: 2222
+                print("Survived, three: \(TL.three) @ \(#fileID):\(#line)") // CHECK: Survived, three: 3333
+              }
+            }
+          }
+        }
+        print("--")
+      }
+    }
+  }
+
+  // Multiple "safe" task locals around a withTaskGroup, check if relinking works ok then
+  await TL.$one.withValue(11) {
+    await TL.$two.withValue(22) {
+      await TL.$three.withValue(33) {
+        await withTaskGroup(of: Void.self) { group in
+          await TL.$four.withValue(44) { // must copy
+            group.addTask {
+              print("Survived, one: \(TL.one) @ \(#fileID):\(#line)") // CHECK: Survived, one: 11
+              print("Survived, two: \(TL.two) @ \(#fileID):\(#line)") // CHECK: Survived, two: 22
+              print("Survived, three: \(TL.three) @ \(#fileID):\(#line)") // CHECK: Survived, three: 33
+              print("Survived, four: \(TL.four) @ \(#fileID):\(#line)") // CHECK: Survived, four: 44
+            }
+          }
+        }
+      }
+    }
+    print("--")
+  }
+
+
+  print("Survived, done") // CHECK: Survived, done
 }
 
 @main struct Main {

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -284,9 +284,6 @@ Added: _$ss26withTaskExecutorPreference_9isolation9operationxSch_pSg_ScA_pSgYixy
 // async function pointer to Swift.withTaskExecutorPreference<A, B where B: Swift.Error>(_: Swift.TaskExecutor?, isolation: isolated Swift.Actor?, operation: () async throws(B) -> A) async throws(B) -> A
 Added: _$ss26withTaskExecutorPreference_9isolation9operationxSch_pSg_ScA_pSgYixyYaq_YKXEtYaq_YKs5ErrorR_r0_lFTu
 
-// === Task groups can now handle (copy) task locals set directly around an addTask
-Added: _swift_task_localsCopyToTaskGroupChildTaskDefensively
-
 // === Add #isolation to next() and waitForAll() in task groups
 // Swift.TaskGroup.awaitAllRemainingTasks(isolation: isolated Swift.Actor?) async -> ()
 Added: _$sScG22awaitAllRemainingTasks9isolationyScA_pSgYi_tYaF

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -284,9 +284,6 @@ Added: _$ss26withTaskExecutorPreference_9isolation9operationxSch_pSg_ScA_pSgYixy
 // async function pointer to Swift.withTaskExecutorPreference<A, B where B: Swift.Error>(_: Swift.TaskExecutor?, isolation: isolated Swift.Actor?, operation: () async throws(B) -> A) async throws(B) -> A
 Added: _$ss26withTaskExecutorPreference_9isolation9operationxSch_pSg_ScA_pSgYixyYaq_YKXEtYaq_YKs5ErrorR_r0_lFTu
 
-// === Task groups can now handle (copy) task locals set directly around an addTask
-Added: _swift_task_localsCopyToTaskGroupChildTaskDefensively
-
 // === Add #isolation to next() and waitForAll() in task groups
 // Swift.TaskGroup.awaitAllRemainingTasks(isolation: isolated Swift.Actor?) async -> ()
 Added: _$sScG22awaitAllRemainingTasks9isolationyScA_pSgYi_tYaF


### PR DESCRIPTION
Review follow up to https://github.com/apple/swift/pull/73978/

We don't need a new runtime entry point to implement this optimization (the swift_task_localsCopyToTaskGroupChildTaskDefensively never shipped anywhere, so removing it right away like this); and a few other cleanups and added a TODO for optimization chances.