### PR TITLE
[cxx-interop][SwiftCompilerSources] Remove a workaround

### DIFF
--- a/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
@@ -37,7 +37,7 @@ public:
   BasicCalleeAnalysis(SILModule *M)
       : SILAnalysis(SILAnalysisKind::BasicCallee), M(*M), Cache(nullptr) {}
 
-  ~BasicCalleeAnalysis();
+  ~BasicCalleeAnalysis() {}
 
   static bool classof(const SILAnalysis *S) {
     return S->getKind() == SILAnalysisKind::BasicCallee;

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -30,10 +30,6 @@
 
 using namespace swift;
 
-// TODO: can't be inlined to work around https://github.com/apple/swift/issues/64502
-BasicCalleeAnalysis::~BasicCalleeAnalysis() {
-}
-
 void BasicCalleeAnalysis::dump() const {
   print(llvm::errs());
 }


### PR DESCRIPTION
The definition of `~BasicCalleeAnalysis` can now be inlined.

rdar://127152872 / resolves https://github.com/apple/swift/issues/64502