### PR TITLE
[6.0] Sema: Fix request cycle with isolation inference

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4433,6 +4433,11 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
 /// Infer isolation from witnessed protocol requirements.
 static std::optional<ActorIsolation>
 getIsolationFromWitnessedRequirements(ValueDecl *value) {
+  // Associated types cannot have isolation, so there's no such inference for
+  // type witnesses.
+  if (isa<TypeDecl>(value))
+    return std::nullopt;
+
   auto dc = value->getDeclContext();
   auto idc = dyn_cast_or_null<IterableDeclContext>(dc->getAsDecl());
   if (!idc)

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -481,3 +481,13 @@ func checkOpaqueType() -> some Sendable {
   UnavailableSendable()
   // expected-warning@-1 {{conformance of 'UnavailableSendable' to 'Sendable' is unavailable; this is an error in the Swift 6 language mode}}
 }
+
+// rdar://129024926
+
+@available(SwiftStdlib 5.1, *)
+@MainActor class MainActorSuper<T: Sendable> {}
+
+@available(SwiftStdlib 5.1, *)
+class MainActorSub: MainActorSuper<MainActorSub.Nested> {
+  struct Nested {}  // no cycle
+}


### PR DESCRIPTION
6.0 cherry-pick of https://github.com/apple/swift/pull/74100/.

- **Description:** Fixes a request cycle with global actor inference. We were doing too much work computing isolation of nested types, by looking up conformances on the parent type unnecessarily. Nested types cannot inherit `@MainActor` etc from the same attribute on an associated type, so skipping this has no semantic effect.
- **Origination:** Existing issue exposed by dd1a85cdf9496a113269197a4bba30c885c5090b. 
- **Radar:** rdar://129024926.
- **Risk:** Very low.
- **Reviewed by:** @hborla