### PR TITLE
[PoC][Concurrency] Typed throws in Task.init and .detached

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -167,21 +167,14 @@ extension Task {
   ///
   /// - Returns: The task's result.
   public var value: Success {
+    // FIXME: This seems wrong that abi test is not freaking out here?
+    //        At the same time, adding a silgen_name compat accessor with old signature results in duplicate definitions -- is mangling of typed throws not done properly on return position?
     get async throws(Failure) {
       do {
-        return try await __abi_value
+        return try await _taskFutureGetThrowing(_task)
       } catch {
         throw error as! Failure
       }
-    }
-  }
-
-  @available(SwiftStdlib 5.1, *)
-  @_silgen_name("$sScT5valuexvg")
-  @usableFromInline
-  internal var __abi_value: Success {
-    get async throws {
-      return try await _taskFutureGetThrowing(_task)
     }
   }
 
@@ -200,7 +193,7 @@ extension Task {
   public var result: Result<Success, Failure> {
     get async {
       do {
-        return .success(try await __abi_value)
+        return .success(try await value)
       } catch {
         return .failure(error as! Failure) // as!-safe, guaranteed to be Failure
       }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -166,15 +166,24 @@ extension Task {
   /// have that error propagated here upon cancellation.
   ///
   /// - Returns: The task's result.
+  @_alwaysEmitIntoClient
   public var value: Success {
-    // FIXME: This seems wrong that abi test is not freaking out here?
-    //        At the same time, adding a silgen_name compat accessor with old signature results in duplicate definitions -- is mangling of typed throws not done properly on return position?
+    @_silgen_name("$sScT7valueTTxvg") // "_t" suffix for the typed throws version
     get async throws(Failure) {
       do {
         return try await _taskFutureGetThrowing(_task)
       } catch {
         throw error as! Failure
       }
+    }
+  }
+
+  // Legacy non-typed throws computed property
+  @usableFromInline
+  internal var __abi_value: Success {
+    @_silgen_name("$sScT5valuexvg")
+    get async throws {
+      return try await _taskFutureGetThrowing(_task)
     }
   }
 
@@ -195,7 +204,7 @@ extension Task {
       do {
         return .success(try await value)
       } catch {
-        return .failure(error as! Failure) // as!-safe, guaranteed to be Failure
+        return .failure(error)
       }
     }
   }

--- a/test/Concurrency/typed_throws.swift
+++ b/test/Concurrency/typed_throws.swift
@@ -21,3 +21,21 @@ func testAsyncFor<S: AsyncSequence>(seq: S) async throws(MyError)
   for try await _ in seq {
   }
 }
+
+@available(SwiftStdlib 6.0, *)
+func testTask() async throws(MyError)  {
+  let t: Task<Int, MyError> = Task { () throws(MyError) -> Int in
+    throw MyError.failed
+  }
+
+  _ = try await t.value
+}
+
+@available(SwiftStdlib 6.0, *)
+func testTaskDetached() async throws(MyError)  {
+  let t: Task<Int, MyError> = Task.detached { () throws(MyError) -> Int in
+    throw MyError.failed
+  }
+
+  _ = try await t.value
+}

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -270,6 +270,10 @@ Added: _swift_task_getPreferredTaskExecutor
 Added: _swift_task_popTaskExecutorPreference
 Added: _swift_task_pushTaskExecutorPreference
 
+// Typed throws Task<Success, Failure>
+// property descriptor for Swift.Task.__abi_value : A
+Added: _$sScT11__abi_valuexvpMV
+
 // Adopt #isolation in with...Continuation APIs
 // Swift.withCheckedThrowingContinuation<A>(isolation: isolated Swift.Actor?, function: Swift.String, _: (Swift.CheckedContinuation<A, Swift.Error>) -> ()) async throws -> A
 Added: _$ss31withCheckedThrowingContinuation9isolation8function_xScA_pSgYi_SSyScCyxs5Error_pGXEtYaKlF
@@ -322,4 +326,3 @@ Added: _$ss9TaskLocalC13withValueImpl_9operation9isolation4file4lineqd__xn_qd__y
 // Swift.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, isolation: isolated Swift.Actor?, file: Swift.String, line: Swift.UInt) async throws -> A1
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlF
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlFTu
-

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -270,6 +270,10 @@ Added: _swift_task_getPreferredTaskExecutor
 Added: _swift_task_popTaskExecutorPreference
 Added: _swift_task_pushTaskExecutorPreference
 
+// Typed throws Task<Success, Failure>
+// property descriptor for Swift.Task.__abi_value : A
+Added: _$sScT11__abi_valuexvpMV
+
 // Adopt #isolation in with...Continuation APIs
 // Swift.withCheckedThrowingContinuation<A>(isolation: isolated Swift.Actor?, function: Swift.String, _: (Swift.CheckedContinuation<A, Swift.Error>) -> ()) async throws -> A
 Added: _$ss31withCheckedThrowingContinuation9isolation8function_xScA_pSgYi_SSyScCyxs5Error_pGXEtYaKlF

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -115,6 +115,12 @@ Func TaskLocal.withValue(_:operation:file:line:) has parameter 1 type change fro
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 2 type change from Swift.String to (any _Concurrency.Actor)?
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 3 type change from Swift.UInt to Swift.String
 
+// Adopt typed throws in Task<> and Task::value
+// (abi compat  was handled but this test does not understand the silgen_name trickery)
+Accessor Task.value.Get() has mangled name changing from 'Swift.Task.value.getter : A' to 'Swift.Task.__abi_value.getter : A'
+Var Task.value has been renamed to Var __abi_value
+Var Task.value has mangled name changing from 'Swift.Task.value : A' to 'Swift.Task.__abi_value : A'
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 
 


### PR DESCRIPTION
PoC of adding typed throws to _just_ Task.init and Task.detached -- we can't do it yet with TaskGroup but it would be perhaps worth doing so where we can, i.e. task initializers.

A bit confused about the ABI of `.value` -- I'm expecting that to need a new ABI entry point but that does not seem to be the case? Adding the typed throw to the accessor does not seem to change the mangling -- see second commit: adding an abi compat function just ends up in duplicate symbols as well -- is this a bug in typed throws mangling?

rdar://129195968

SE proposal: https://github.com/swiftlang/swift-evolution/pull/2990