### PR TITLE
[Sema] Have operator diagnostics get types from solutions where those exprs have no fixes.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15276,6 +15276,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
       }
     }
 
+    // Mismatches where param has type variable but arg does not means a poor
+    // generic argument match, overload is less viable.
+    if (!type1->hasTypeVariable() && type2->hasTypeVariable()) {
+      impact += 6;
+    }
+
     // De-prioritize `Builtin.RawPointer` and `OpaquePointer` parameters
     // because they usually clash with generic parameter mismatches e.g.
     //

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2726,7 +2726,7 @@ assessRequirementFailureImpact(ConstraintSystem &cs, Type requirementType,
                                ConstraintLocatorBuilder locator) {
   assert(requirementType);
 
-  unsigned impact = 1;
+  unsigned impact = 2;
   auto anchor = locator.getAnchor();
   if (!anchor)
     return impact;

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -276,7 +276,7 @@ func rdar19831698() {
   var v71 = true + 1.0 // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and 'Double'}}
 // expected-note@-1{{overloads for '+'}}
   var v72 = true + true // expected-error{{binary operator '+' cannot be applied to two 'Bool' operands}}
-  var v73 = true + [] // expected-error@:13 {{cannot convert value of type 'Bool' to expected argument type 'Array<Bool>'}}
+  var v73 = true + [] // expected-error@:13 {{cannot convert value of type 'Bool' to expected argument type 'IndexPath'}}
   var v75 = true + "str" // expected-error@:13 {{cannot convert value of type 'Bool' to expected argument type 'String'}}
 }
 

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -77,8 +77,8 @@ class MoviesViewController {
 // https://github.com/apple/swift/issues/57380
 
 func f1_57380<T : Numeric>(_ a: T, _ b: T) -> T {
-  (a + b) / 2 // expected-note {{overloads for '/' exist with these partially matching parameter lists: (Int, Int)}}
-  // expected-error@-1 {{binary operator '/' cannot be applied to operands of type 'T' and 'Int'}}
+  (a + b) / 2 // expected-error {{cannot convert value of type 'T' to expected argument type 'Int'}}
+  // expected-error@-1 {{cannot convert return expression of type 'Int' to return type 'T'}}
 }
 
 infix operator %%

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1580,3 +1580,14 @@ func testAddMemberVsRemoveCall() {
   let b = Foo_74617()
   let c = (a + b).bar() // expected-error {{cannot call value of non-function type 'Float'}} {{22-24=}}
 }
+
+// https://github.com/apple/swift/issues/73029
+func testBinaryOpWrongTypesFix() {
+  struct S<T> {
+    static func ==(lhs: S, rhs: S) -> Bool {
+      true
+    }
+  }
+  func getS<T>(value: T) -> S<T> {}
+  let _ = getS(value: "") == getS(value: 0) // expected-error {{binary operator '==' cannot be applied to operands of type 'S<String>' and 'S<Int>'}}
+}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1124,10 +1124,13 @@ func rdar17170728() {
     // expected-error@-1 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
   }
 
-  let _ = [i, j, k].reduce(0 as Int?) { // expected-error {{missing argument label 'into:' in call}}
-    // expected-error@-1 {{cannot convert value of type 'Int?' to expected argument type '(inout @escaping (Bool, Bool) -> Bool?, Int?) throws -> ()'}}
+  let _ = [i, j, k].reduce(0 as Int?) { // expected-error 3 {{cannot convert value of type 'Int?' to expected element type 'Int'}}
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
-    // expected-error@-1 {{binary operator '+' cannot be applied to two 'Bool' operands}}
+    // expected-error@-1 2 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    // expected-error@-2 2 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
+    // expected-error@-3 {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
+    // expected-note@-4 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+    // expected-note@-5 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
   }
 }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1148,7 +1148,7 @@ func badTypes() {
   let sequence:AnySequence<[Int]> = AnySequence() { AnyIterator() { [3] }}
   // Notes, attached to declarations, explain that there is a difference between Array.init(_:) and
   // RangeReplaceableCollection.init(_:) which are both applicable in this case.
-  let array = [Int](sequence)
+  let array = [Int](sequence) // expected-note {{candidate expects value of type 'AnyObject' for parameter #1 (got 'AnySequence<[Int]>')}}
   // expected-error@-1 {{no exact matches in call to initializer}}
 }
 
@@ -1555,19 +1555,19 @@ func testNilCoalescingOperatorRemoveFix() {
   let _ = "" /* This is a comment */ ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{13-43=}}
 
   let _ = "" // This is a comment
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1554:13-1555:10=}}
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{-1:13-+0:10=}}
 
   let _ = "" // This is a comment
-    /*
-     * The blank line below is part of the test case, do not delete it
-     */
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1557:13-1561:10=}}
+  /*
+   * The blank line below is part of the test case, do not delete it
+   */
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{-4:13-+0:10=}}
 
-  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-1564:9=}}
+  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-+1:9=}}
       "").isEmpty {}
 
   if ("" // This is a comment
-      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1566:9-1567:12=}}
+      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{-1:9-+0:12=}}
 }
 
 // https://github.com/apple/swift/issues/74617

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -182,15 +182,11 @@ enum CompassPoint {
 }
 
 func isNorth(c : CompassPoint) -> Bool {
-  // expected-error@+1{{member 'North' expects argument of type 'Int'}}
-  return c == .North // expected-error {{binary operator '==' cannot be applied to two 'CompassPoint' operands}}
-  // expected-note@-1 {{binary operator '==' cannot be synthesized for enums with associated values}}
+  return c == .North // expected-error {{member 'North' expects argument of type 'Int'}}
 }
 
 func isNorth2(c : CompassPoint) -> Bool {
-  // expected-error@+1{{member 'North' expects argument of type 'Int'}}
-  return .North == c // expected-error {{binary operator '==' cannot be applied to two 'CompassPoint' operands}}
-  // expected-note@-1 {{binary operator '==' cannot be synthesized for enums with associated values}}
+  return .North == c // expected-error {{member 'North' expects argument of type 'Int'}}
 }
 
 func isSouth(c : CompassPoint) -> Bool {

--- a/test/Constraints/issue-74700.swift
+++ b/test/Constraints/issue-74700.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Idable<ID> {
+  associatedtype ID
+  var id: ID { get }
+}
+func test74700() {
+  @dynamicMemberLookup struct Binding<C> {
+    subscript(dynamicMember member: String) -> String { "" }
+  }
+  struct ForEach<Data, ID, Content> where Data : RandomAccessCollection, ID: Hashable {
+    init(_ data: Data, content: (Data.Element) -> Content) where ID == Data.Element.ID, Data.Element : Idable {}
+    // expected-note@-1 {{where 'Data.Element' = 'User'}}
+    init<C>(_ data: Binding<C>, content: (Binding<C.Element>) -> Content) where Data == Array<C>, ID == C.Element.ID, C : MutableCollection, C : RandomAccessCollection, C.Element : Idable, C.Index : Hashable {}
+  }
+
+  struct User {
+    let name: String // expected-note {{'name' declared here}}
+  }
+
+  struct ContentView {
+    let users: [User] = []
+    func body() -> Void {
+      ForEach(users) { user in // expected-error {{initializer 'init(_:content:)' requires that 'User' conform to 'Idable'}}
+        return user.nam // expected-error {{value of type 'User' has no member 'nam'; did you mean 'name'?}}
+      }
+    }
+  }
+}

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -277,7 +277,7 @@ func rdar_60185506() {
 func rdar60727310() {
   func myAssertion<T>(_ a: T, _ op: ((T,T)->Bool), _ b: T) {}
   var e: Error? = nil
-  myAssertion(e, ==, nil) // expected-error {{binary operator '==' cannot be applied to two '(any Error)?' operands}}
+  myAssertion(e, ==, nil) // expected-error {{type of expression is ambiguous without a type annotation}}
 }
 
 // https://github.com/apple/swift/issues/54877
@@ -295,7 +295,6 @@ func rdar_62054241() {
 
   func test(_ arr: [Foo]) -> [Foo] {
     return arr.sorted(by: <) // expected-error {{no exact matches in reference to operator function '<'}}
-    // expected-note@-1 {{found candidate with type '(Foo, Foo) -> Bool'}}
   }
 }
 

--- a/test/Constraints/rdar40002266.swift
+++ b/test/Constraints/rdar40002266.swift
@@ -4,8 +4,7 @@
 import Foundation
 
 struct S {
-  init<T: NSNumber>(_ num: T) { // expected-note {{where 'T' = 'Bool'}}
-    self.init(num != 0) // expected-error {{initializer 'init(_:)' requires that 'Bool' inherit from 'NSNumber'}}
-    // expected-error@-1 {{cannot convert value of type 'T' to expected argument type 'Int'}}
+  init<T: NSNumber>(_ num: T) {
+    self.init(num != 0) // expected-error {{cannot convert value of type 'T' to expected argument type 'Int'}}
   }
 }

--- a/test/Constraints/rdar85263844_swift6.swift
+++ b/test/Constraints/rdar85263844_swift6.swift
@@ -2,8 +2,8 @@
 
 // rdar://85263844 - initializer 'init(_:)' requires the types be equivalent
 func rdar85263844(arr: [(q: String, a: Int)]) -> AnySequence<(question: String, answer: Int)> {
-  AnySequence(arr.map { $0 })
-  // expected-error@-1 {{initializer 'init(_:)' requires the types '(question: String, answer: Int)' and '(q: String, a: Int)' be equivalent}}
+  AnySequence(arr.map { $0 }) // expected-note {{arguments to generic parameter 'Element' ('(q: String, a: Int)' and '(question: String, answer: Int)') are expected to be equal}}
+  // expected-error@-1 {{cannot convert value of type '[(q: String, a: Int)]' to expected argument type '[(question: String, answer: Int)]'}}
 }
 
 // Another case for rdar://85263844
@@ -28,6 +28,6 @@ extension S4 where T == (outer: Int, y: Int) {
 }
 
 public func rdar85263844_2(_ x: [Int]) -> S4<(outer: Int, y: Int)> {
-  // FIXME: Bad error message.
-  S4(x.map { (inner: $0, y: $0) }) // expected-error {{type of expression is ambiguous without a type annotation}}
+  S4(x.map { (inner: $0, y: $0) }) // expected-error {{cannot convert value of type '[(inner: Int, y: Int)]' to expected argument type '[(outer: Int, y: Int)]'}}
+  // expected-note@-1 {{arguments to generic parameter 'Element' ('(inner: Int, y: Int)' and '(outer: Int, y: Int)') are expected to be equal}}
 }

--- a/test/Generics/conditional_conformances_literals.swift
+++ b/test/Generics/conditional_conformances_literals.swift
@@ -10,14 +10,11 @@ protocol Conforms {}
 struct Works: Hashable, Conforms {}
 struct Fails: Hashable {}
 
-extension Array: SameType where Element == Works {}
-// expected-note@-1 3 {{requirement from conditional conformance of '[Fails]' to 'SameType'}}
-extension Dictionary: SameType where Value == Works {}
-// expected-note@-1 3 {{requirement from conditional conformance of '[Int : Fails]' to 'SameType'}}
-extension Array: Conforms where Element: Conforms {}
-// expected-note@-1 7 {{requirement from conditional conformance of '[Fails]' to 'Conforms'}}
+extension Array: SameType where Element == Works {} // expected-note 2 {{requirement from conditional conformance of '[Fails]' to 'SameType'}}
+extension Dictionary: SameType where Value == Works {} // expected-note 2 {{requirement from conditional conformance of '[Int : Fails]' to 'SameType'}}
+extension Array: Conforms where Element: Conforms {} // expected-note 6 {{requirement from conditional conformance of '[Fails]' to 'Conforms'}}
 extension Dictionary: Conforms where Value: Conforms {}
-// expected-note@-1 5 {{requirement from conditional conformance of '[Int : Fails]' to 'Conforms'}}
+// expected-note@-1 4 {{requirement from conditional conformance of '[Int : Fails]' to 'Conforms'}}
 // expected-note@-2 2 {{requirement from conditional conformance of '[Int : any Conforms]' to 'Conforms'}}
 
 let works = Works()
@@ -44,8 +41,8 @@ func arraySameType() {
     // expected-error@-1 {{cannot convert value of type 'Fails' to expected element type 'Works'}}
 
     let _: SameType = arrayWorks as SameType
-    let _: SameType = arrayFails as SameType
-    // expected-error@-1 {{generic struct 'Array' requires the types 'Fails' and 'Works' be equivalent}}
+    let _: SameType = arrayFails as SameType // expected-note {{did you mean to use 'as!' to force downcast?}}
+    // expected-error@-1 {{'[Fails]' is not convertible to 'any SameType'}}
 }
 
 func dictionarySameType() {
@@ -69,8 +66,8 @@ func dictionarySameType() {
     // expected-error@-1 {{cannot convert value of type 'Fails' to expected dictionary value type 'Works'}}
 
     let _: SameType = dictWorks as SameType
-    let _: SameType = dictFails as SameType
-    // expected-error@-1 {{generic struct 'Dictionary' requires the types 'Fails' and 'Works' be equivalent}}
+    let _: SameType = dictFails as SameType // expected-note {{did you mean to use 'as!' to force downcast?}}
+    // expected-error@-1 {{'[Int : Fails]' is not convertible to 'any SameType'}}
 }
 
 func arrayConforms() {
@@ -94,8 +91,8 @@ func arrayConforms() {
     // expected-error@-1 {{generic struct 'Array' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = arrayWorks as Conforms
-    let _: Conforms = arrayFails as Conforms
-    // expected-error@-1 {{generic struct 'Array' requires that 'Fails' conform to 'Conforms'}}
+    let _: Conforms = arrayFails as Conforms // expected-note {{did you mean to use 'as!' to force downcast?}}
+    // expected-error@-1 {{'[Fails]' is not convertible to 'any Conforms'}}
 }
 
 func dictionaryConforms() {
@@ -119,8 +116,8 @@ func dictionaryConforms() {
     // expected-error@-1 {{generic struct 'Dictionary' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = dictWorks as Conforms
-    let _: Conforms = dictFails as Conforms
-    // expected-error@-1 {{generic struct 'Dictionary' requires that 'Fails' conform to 'Conforms'}}
+    let _: Conforms = dictFails as Conforms // expected-note {{did you mean to use 'as!' to force downcast?}}
+    // expected-error@-1 {{'[Int : Fails]' is not convertible to 'any Conforms'}}
 }
 
 func combined() {

--- a/test/Generics/inheritance.swift
+++ b/test/Generics/inheritance.swift
@@ -12,7 +12,7 @@ class Other { }
 
 func acceptA(_ a: A) { }
 
-func f0<T : A>(_ obji: T, _ ai: A, _ bi: B) { // expected-note {{where 'T' = 'Other'}}
+func f0<T : A>(_ obji: T, _ ai: A, _ bi: B) {
   var obj = obji, a = ai, b = bi
   // Method access
   obj.foo()
@@ -39,7 +39,7 @@ func f0<T : A>(_ obji: T, _ ai: A, _ bi: B) { // expected-note {{where 'T' = 'Ot
 func call_f0(_ a: A, b: B, other: Other) {
   f0(a, a, b)
   f0(b, a, b)
-  f0(other, a, b) // expected-error{{global function 'f0' requires that 'Other' inherit from 'A'}}
+  f0(other, a, b) // expected-error{{type of expression is ambiguous without a type annotation}}
 }
 
 class X<T> {

--- a/test/Generics/inverse_copyable_requirement.swift
+++ b/test/Generics/inverse_copyable_requirement.swift
@@ -231,7 +231,7 @@ func checkCasting(_ b: any Box, _ mo: borrowing MO, _ a: Any) {
 // FIXME: rdar://115752211 (deal with existing Swift modules that lack Copyable requirements)
 // the stdlib right now is not yet being compiled with NoncopyableGenerics
 func checkStdlibTypes(_ mo: borrowing MO) {
-  _ = "\(mo)" // expected-error {{no exact matches in call to instance method 'appendInterpolation'}}
+  _ = "\(mo)" // expected-error {{cannot convert value of type 'MO' to expected argument type 'any Any.Type'}}
   let _: String = String(describing: mo) // expected-error {{no exact matches in call to initializer}}
 
   let _: [MO] = // expected-error {{type 'MO' does not conform to protocol 'Copyable'}}
@@ -241,12 +241,12 @@ func checkStdlibTypes(_ mo: borrowing MO) {
   let _: [String: MO] = // expected-error {{type 'MO' does not conform to protocol 'Copyable'}}
       ["hello" : MO()]  // expected-error{{type '(String, MO)' containing noncopyable element is not supported}}
 
-  _ = [MO()] // expected-error {{generic struct 'Array' requires that 'MO' conform to 'Copyable'}}
+  _ = [MO()] // expected-error {{type of expression is ambiguous without a type annotation}}
 
   let _: Array<MO> = .init() // expected-error {{type 'MO' does not conform to protocol 'Copyable'}}
   _ = [MO]() // expected-error {{type 'MO' does not conform to protocol 'Copyable'}}
 
-  let _: String = "hello \(mo)" // expected-error {{no exact matches in call to instance method 'appendInterpolation'}}
+  let _: String = "hello \(mo)" // expected-error {{cannot convert value of type 'MO' to expected argument type 'any Any.Type'}}
 }
 
 func copyableExistentials(_ a: Any, _ e1: Error, _ e2: any Error, _ ah: AnyHashable) {

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -536,7 +536,7 @@ struct HasEqualsSelf3 {
 struct HasEqualsSelf4 {
 }
 
-protocol SelfEqualsBoolProto { // expected-note 4{{where 'Self' =}}
+protocol SelfEqualsBoolProto {
   static func ==(lhs: Self, rhs: Bool) -> Bool
 }
 
@@ -563,10 +563,10 @@ func testHasEqualsSelf(
 ) {
 #if TEST_DIAGNOSTICS
   // Global operator lookup doesn't find member operators introduced by macros.
-  _ = (x == true) // expected-error{{referencing operator function '=='}}
-  _ = (y == true) // expected-error{{referencing operator function '=='}}
-  _ = (z == true) // expected-error{{referencing operator function '=='}}
-  _ = (w == true) // expected-error{{referencing operator function '=='}}
+  _ = (x == true) // expected-error{{cannot convert value of type 'HasEqualsSelf' to expected argument type 'Bool'}}
+  _ = (y == true) // expected-error{{cannot convert value of type 'HasEqualsSelf2' to expected argument type 'Bool'}}
+  _ = (z == true) // expected-error{{cannot convert value of type 'HasEqualsSelf3' to expected argument type 'Bool'}}
+  _ = (w == true) // expected-error{{cannot convert value of type 'HasEqualsSelf4' to expected argument type 'Bool'}}
 #endif
 
   // These should be found through the protocol.

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -56,8 +56,7 @@ class A {
     var a: MyArray<Int>
     init() {
         a = MyArray<Int // expected-error {{generic parameter 'Element' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
-       // expected-error@-1 {{binary operator '<' cannot be applied to operands of type 'MyArray<_>.Type' and 'Int.Type'}}
-       // expected-error@-2 {{cannot assign value of type 'Bool' to type 'MyArray<Int>'}}
+       // expected-error@-1 {{cannot assign value of type 'Bool' to type 'MyArray<Int>'}}
     }
 }
 

--- a/test/Parse/confusables.swift
+++ b/test/Parse/confusables.swift
@@ -20,6 +20,7 @@ if (true ꝸꝸꝸ false) {} // expected-note {{identifier 'ꝸꝸꝸ' contains 
 // expected-error @+2 {{expected ',' separator}}
 // expected-error @+1 {{binary operator '==' cannot be applied to operands of type '(Int, Int)' and 'Int'}}
 if (5 ‒ 5) == 0 {} // expected-note {{unicode character '‒' (Figure Dash) looks similar to '-' (Hyphen Minus); did you mean to use '-' (Hyphen Minus)?}} {{7-10=-}}
+// expected-note@-1 {{overloads for '==' exist with these partially matching parameter lists: (Int, Int)}}
 
 // GREEK QUESTION MARK (which looks like a semicolon) 
 print("A"); print("B")

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -130,7 +130,7 @@ _ = /x/.../y/
 // expected-error@-2 {{'/' is not a postfix unary operator}}
 
 _ = /x/...
-// expected-error@-1 {{unary operator '...' cannot be applied to an operand of type 'Regex<Substring>'}}
+// expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type 'UnboundedRange_'}}
 
 do {
   _ = /x /...
@@ -191,10 +191,10 @@ do {
   _ = [/abc /: /abc /]
   // expected-error@-1:14 {{expected expression after operator}}
 }
-_ = [/abc/:/abc/] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
-_ = [/abc/ : /abc/] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
-_ = [/abc/:/abc/] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
-_ = [/abc/: /abc/] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = [/abc/:/abc/] // expected-error {{type of expression is ambiguous without a type annotation}}
+_ = [/abc/ : /abc/] // expected-error {{type of expression is ambiguous without a type annotation}}
+_ = [/abc/:/abc/] // expected-error {{type of expression is ambiguous without a type annotation}}
+_ = [/abc/: /abc/] // expected-error {{type of expression is ambiguous without a type annotation}}
 _ = (/abc/, /abc/)
 _ = ((/abc/))
 

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -618,7 +618,6 @@ extension UnfulfillableGenericRequirements {
   func method2() where A: Sequence, A.Element == Self {}
   func method3<U>(_: U) -> U {}
   func method4<U>(_: U) where U : Class<Self.A> {}
-  // expected-note@-1 3 {{where 'U' = 'Bool'}}
   func method5<U>(_: U) where U: Sequence, Self == U.Element {}
   // expected-note@-1 {{where 'U' = 'Bool'}}
 
@@ -639,8 +638,7 @@ do {
   // expected-error@-2 {{instance method 'method2()' requires that 'Self.A' conform to 'Sequence'}}
   _ = exist.method3(false) // ok
   exist.method4(false)
-  // expected-error@-1 {{instance method 'method4' requires that 'Bool' inherit from 'Class<Self.A>'}}
-  // expected-error@-2 {{member 'method4' cannot be used on value of type 'any UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
+  // expected-error@-1 {{member 'method4' cannot be used on value of type 'any UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
   exist.method5(false)
   // expected-error@-1 {{instance method 'method5' requires that 'Bool' conform to 'Sequence'}}
   // expected-error@-2 {{member 'method5' cannot be used on value of type 'any UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
@@ -670,10 +668,9 @@ do {
   let exist2: any UnfulfillableGenericRequirementsDerived2
 
   exist1.method4(false)
-  // expected-error@-1 {{instance method 'method4' requires that 'Bool' inherit from 'Class<Self.A>}}
+  // expected-error@-1 {{type of expression is ambiguous without a type annotation}}
   exist2.method4(false)
   // expected-error@-1 {{member 'method4' cannot be used on value of type 'any UnfulfillableGenericRequirementsDerived2'; consider using a generic constraint instead}}
-  // expected-error@-2 {{instance method 'method4' requires that 'Bool' inherit from 'Class<Self.A>'}}
 }
 protocol UnfulfillableGenericRequirementsDerived3: UnfulfillableGenericRequirements where A: Sequence, A.Element: Sequence {}
 do {

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -785,8 +785,8 @@ func testNilCoalescePrecedence(cond: Bool, a: Int?, r: ClosedRange<Int>?) {
   // ?? should have higher precedence than logical operators like || and comparisons.
   if cond || (a ?? 42 > 0) {}  // Ok.
   if (cond || a) ?? 42 > 0 {}  // expected-error {{cannot be used as a boolean}} {{15-15=(}} {{16-16= != nil)}}
-  // expected-error@-1 {{binary operator '>' cannot be applied to operands of type 'Bool' and 'Int'}}  expected-note@-1 {{overloads for '>' exist with these partially matching parameter list}}
-  // expected-error@-2 {{binary operator '??' cannot be applied to operands of type 'Bool' and 'Int'}}
+  // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
+  // expected-error@-2 {{cannot convert value of type 'Bool' to expected argument type 'Int'}}
   if (cond || a) ?? (42 > 0) {}  // expected-error {{cannot be used as a boolean}} {{15-15=(}} {{16-16= != nil)}}
 
   if cond || a ?? 42 > 0 {}    // Parses as the first one, not the others.
@@ -794,7 +794,8 @@ func testNilCoalescePrecedence(cond: Bool, a: Int?, r: ClosedRange<Int>?) {
 
   // ?? should have lower precedence than range and arithmetic operators.
   let r1 = r ?? (0...42) // ok
-  let r2 = (r ?? 0)...42 // not ok: expected-error {{binary operator '??' cannot be applied to operands of type 'ClosedRange<Int>?' and 'Int'}}
+  let r2 = (r ?? 0)...42 // not ok: expected-error {{cannot convert value of type 'Int' to expected argument type 'ClosedRange<Int>'}}
+  // expected-error@-1 {{cannot convert value of type 'ClosedRange<Int>' to expected argument type 'Int'}}
   let r3 = r ?? 0...42 // parses as the first one, not the second.
   
   

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -747,9 +747,8 @@ func invalidDictionaryLiteral() {
 }
 
 
-[4].joined(separator: [1])
-// expected-error@-1 {{no exact matches in call to instance method 'joined'}}
-// There is one more note here - candidate requires that 'Int' conform to 'Sequence' (requirement specified as 'Self.Element' : 'Sequence') pointing to Sequence extension
+[4].joined(separator: [1]) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'String'}}
+// expected-error@-1 {{cannot convert value of type 'Int' to expected element type 'String'}}
 
 [4].joined(separator: [[[1]]])
 // expected-error@-1 {{cannot convert value of type 'Int' to expected element type 'String'}}

--- a/test/stdlib/UnicodeScalarDiagnostics.swift
+++ b/test/stdlib/UnicodeScalarDiagnostics.swift
@@ -21,10 +21,8 @@ func test_UnicodeScalarDoesNotImplementArithmetic(_ us: UnicodeScalar, i: Int) {
 
   let c1 = us + i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
   let c2 = us - i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
-  let c3 = us * i // expected-note {{overloads for '*' exist with these partially matching parameter lists: (Int, Int)}}
-  // expected-error@-1 {{binary operator '*' cannot be applied to operands of type 'UnicodeScalar' (aka 'Unicode.Scalar') and 'Int'}}
-  let c4 = us / i // expected-note {{overloads for '/' exist with these partially matching parameter lists: (Int, Int)}}
-  // expected-error@-1 {{binary operator '/' cannot be applied to operands of type 'UnicodeScalar' (aka 'Unicode.Scalar') and 'Int'}}
+  let c3 = us * i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
+  let c4 = us / i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
 
   let d1 = i + us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
   let d2 = i - us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}

--- a/test/type/builtin_types.swift
+++ b/test/type/builtin_types.swift
@@ -4,5 +4,6 @@ import Swift
 
 func testBuiltinModulePrint(_ builtin: Builtin.Int64) -> Bool {
   let x = 35
-  return x == builtin // expected-error {{operator function '==' requires that 'Builtin.Int64' conform to 'BinaryInteger'}}
+  return x == builtin // expected-error {{binary operator '==' cannot be applied to operands of type 'Int' and 'Builtin.Int64'}}
+  // expected-note@-1 {{overloads for '==' exist with these partially matching parameter lists: (Int, Int)}}
 }

--- a/test/type/implicit_some/opaque_parameters.swift
+++ b/test/type/implicit_some/opaque_parameters.swift
@@ -86,5 +86,8 @@ func testPrimaries(
   takePrimaryCollections(setOfStrings, setOfInts)
   takePrimaryCollections(setOfStrings, arrayOfInts)
   _ = takeMatchedPrimaryCollections(arrayOfInts, setOfInts)
-  _ = takeMatchedPrimaryCollections(arrayOfInts, setOfStrings) // expected-error{{type of expression is ambiguous without a type annotation}}
+  _ = takeMatchedPrimaryCollections(arrayOfInts, setOfStrings) // expected-error {{conflicting arguments to generic parameter 'Collection<T>' ('Set<Int>' vs. 'Set<String>')}}
+  // expected-error@-1 {{conflicting arguments to generic parameter 'Element' ('String' vs. 'Int')}}
+  // expected-error@-2 {{conflicting arguments to generic parameter 'Collection<T>' ('[Int]' vs. '[String]')}}
+  // expected-error@-3 {{conflicting arguments to generic parameter 'T' ('Int' vs. 'String')}}
 }

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -106,7 +106,10 @@ func testPrimaries(
   takePrimaryCollections(setOfStrings, setOfInts)
   takePrimaryCollections(setOfStrings, arrayOfInts)
   _ = takeMatchedPrimaryCollections(arrayOfInts, setOfInts)
-  _ = takeMatchedPrimaryCollections(arrayOfInts, setOfStrings) // expected-error{{type of expression is ambiguous without a type annotation}}
+  _ = takeMatchedPrimaryCollections(arrayOfInts, setOfStrings) // expected-error{{conflicting arguments to generic parameter 'Element' ('String' vs. 'Int')}}
+    // expected-error@-1 {{conflicting arguments to generic parameter 'some PrimaryCollection<T>' ('Set<Int>' vs. 'Set<String>')}}
+    // expected-error@-2 {{conflicting arguments to generic parameter 'T' ('Int' vs. 'String')}}
+    // expected-error@-3 {{conflicting arguments to generic parameter 'some PrimaryCollection<T>' ('[Int]' vs. '[String]')}}
 }
 
 

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -189,15 +189,9 @@ takesP1AndP2([Swift.AnyObject & P1 & P2]())
 takesP1AndP2([AnyObject & protocol_composition.P1 & P2]())
 takesP1AndP2([AnyObject & P1 & protocol_composition.P2]())
 takesP1AndP2([DoesNotExist & P1 & P2]()) // expected-error {{cannot find 'DoesNotExist' in scope}}
-// expected-error@-1 {{binary operator '&' cannot be applied to operands of type 'UInt8' and '(any P2).Type'}}
-// expected-error@-2 {{binary operator '&' cannot be applied to operands of type 'UInt8' and '(any P1).Type'}}
-// expected-note@-3 2 {{overloads for '&' exist with these partially matching parameter lists}}
-// expected-error@-4 {{cannot call value of non-function type '[UInt8]'}}
+// expected-error@-1 {{cannot call value of non-function type '[UInt8]'}}
 takesP1AndP2([Swift.DoesNotExist & P1 & P2]()) // expected-error {{module 'Swift' has no member named 'DoesNotExist'}}
-// expected-error@-1 {{binary operator '&' cannot be applied to operands of type 'UInt8' and '(any P2).Type'}}
-// expected-error@-2 {{binary operator '&' cannot be applied to operands of type 'UInt8' and '(any P1).Type'}}
-// expected-note@-3 2 {{overloads for '&' exist with these partially matching parameter lists}}
-// expected-error@-4 {{cannot call value of non-function type '[UInt8]'}}
+// expected-error@-1 {{cannot call value of non-function type '[UInt8]'}}
 
 typealias T08 = P1 & inout P2 // expected-error {{'inout' may only be used on parameters}}
 typealias T09 = P1 & __shared P2 // expected-error {{'__shared' may only be used on parameters}}

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -331,12 +331,12 @@ func conformsToAnyObject<T : AnyObject>(_: T) {}
 func conformsToP1<T : P1>(_: T) {}
 func conformsToP2<T : P2>(_: T) {}
 func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {}
-// expected-note@-1 {{where 'T' = 'FakeDerived'}}
+// expected-note@-1 {{where 'T' = 'Base<String>'}}
 // expected-note@-2 {{where 'T' = 'T1'}}
 // expected-note@-3 2 {{where 'T' = 'Base<Int>'}}
 
 func conformsToBaseIntAndP2WithWhereClause<T>(_: T) where T : Base<Int> & P2 {}
-// expected-note@-1 {{where 'T' = 'FakeDerived'}}
+// expected-note@-1 {{where 'T' = 'Base<String>'}}
 // expected-note@-2 {{where 'T' = 'T1'}}
 
 class FakeDerived : Base<String>, P2 {
@@ -454,10 +454,10 @@ func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
   // expected-error@-2 {{cannot convert value of type 'Base<String>' to expected argument type 'Base<Int>'}}
 
   conformsToBaseIntAndP2(fakeDerived)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'FakeDerived' inherit from 'Base<Int>'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<String>' inherit from 'Base<Int>'}}
 
   conformsToBaseIntAndP2WithWhereClause(fakeDerived)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'FakeDerived' inherit from 'Base<Int>'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'Base<String>' inherit from 'Base<Int>'}}
 
   conformsToBaseIntAndP2(p2Archetype)
   // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'T1' inherit from 'Base<Int>'}}

--- a/test/type/subclass_composition_objc.swift
+++ b/test/type/subclass_composition_objc.swift
@@ -24,13 +24,13 @@ class SomeMethods {
 
 // Test self-conformance
 
-func takesObjCClass<T : ObjCClass>(_: T) {} // expected-note {{where 'T' = 'any ObjCProtocol'}}
+func takesObjCClass<T : ObjCClass>(_: T) {}
 func takesObjCProtocol<T : ObjCProtocol>(_: T) {} // expected-note {{where 'T' = 'ObjCClass'}}
 func takesObjCClassAndProtocol<T : ObjCClass & ObjCProtocol>(_: T) {} // expected-note {{where 'T' = 'any ObjCProtocol'}} expected-note {{where 'T' = 'ObjCClass'}}
 
 func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProtocol) {
   takesObjCClass(c)
-  takesObjCClass(p) // expected-error {{global function 'takesObjCClass' requires that 'any ObjCProtocol' inherit from 'ObjCClass'}}
+  takesObjCClass(p) // expected-error {{type of expression is ambiguous without a type annotation}}
   takesObjCClass(cp)
 
   takesObjCProtocol(c) // expected-error {{global function 'takesObjCProtocol' requires that 'ObjCClass' conform to 'ObjCProtocol'}}


### PR DESCRIPTION
`diagnoseOperatorAmbiguity()` was previously only looking at the first solution in the set, and thus in the reported issue there was a fix being applied to the LHS in that solution and so the type of the LHS expression was forced to be wrong.

The code now looks through all solutions, and pulls type info from the LHS and RHS expressions only if there isn't a fix anchored to that expression. This resolves the reported issue.

It also lets us skip reporting any diagnostic at all from here if all of the possible solutions contain fixes for one or the other of the args. See the rest of the test expected-error changes, which are all places where the operator ambiguity diagnostic was applied inappropriately and a more targeted diagnostic is already emitted. 

Fixes #73029 
