### PR TITLE
[6.0] [IRGen] Add option for raw layout to move as its like type

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2533,6 +2533,8 @@ class RawLayoutAttr final : public DeclAttribute {
   unsigned SizeOrCount;
   /// If `LikeType` is null, the alignment in bytes to use for the raw storage.
   unsigned Alignment;
+  /// If a value of this raw layout type should move like its `LikeType`.
+  bool MovesAsLike = false;
   /// The resolved like type.
   mutable Type CachedResolvedLikeType = Type();
 
@@ -2540,10 +2542,12 @@ class RawLayoutAttr final : public DeclAttribute {
 
 public:
   /// Construct a `@_rawLayout(like: T)` attribute.
-  RawLayoutAttr(TypeRepr *LikeType, SourceLoc AtLoc, SourceRange Range)
+  RawLayoutAttr(TypeRepr *LikeType, bool movesAsLike, SourceLoc AtLoc,
+                SourceRange Range)
       : DeclAttribute(DeclAttrKind::RawLayout, AtLoc, Range,
                       /*implicit*/ false),
-        LikeType(LikeType), SizeOrCount(0), Alignment(~0u) {}
+        LikeType(LikeType), SizeOrCount(0), Alignment(~0u),
+        MovesAsLike(movesAsLike) {}
 
   /// Construct a `@_rawLayout(likeArrayOf: T, count: N)` attribute.
   RawLayoutAttr(TypeRepr *LikeType, unsigned Count, SourceLoc AtLoc,
@@ -2613,6 +2617,11 @@ public:
     if (Alignment == ~0u)
       return std::nullopt;
     return std::make_pair(getResolvedLikeType(sd), SizeOrCount);
+  }
+
+  /// Whether a value of this raw layout should move like its `LikeType`.
+  bool shouldMoveAsLikeType() const {
+    return MovesAsLike;
   }
 
   static bool classof(const DeclAttribute *DA) {

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -878,6 +878,17 @@ public:
   /// Returns true if this SILType is a differentiable type.
   bool isDifferentiable(SILModule &M) const;
 
+  /// Returns the @_rawLayout attribute on this type if it has one.
+  RawLayoutAttr *getRawLayout() const {
+    auto sd = getStructOrBoundGenericStruct();
+
+    if (!sd) {
+      return nullptr;
+    }
+
+    return sd->getAttrs().getAttribute<RawLayoutAttr>();
+  }
+
   /// If this is a SILBoxType, return getSILBoxFieldType(). Otherwise, return
   /// SILType().
   ///

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -289,7 +289,7 @@ public:
           auto &likeTypeInfo = IGF.IGM.getTypeInfo(loweredLikeType);
 
           likeTypeInfo.initializeWithTake(IGF, dest, src, loweredLikeType,
-                                          isOutlined, zeroizeIfSensitive);
+                                          isOutlined);
         }
       }
     }

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -195,6 +195,25 @@ public:
       return emitAssignWithTakeCall(IGF, T, dest, src);
     }
 
+    if (auto rawLayout = T.getRawLayout()) {
+      // Because we have a rawlayout attribute, we know this has to be a struct.
+      auto structDecl = T.getStructOrBoundGenericStruct();
+
+      if (auto likeType = rawLayout->getResolvedScalarLikeType(structDecl)) {
+        if (rawLayout->shouldMoveAsLikeType()) {
+          auto astT = T.getASTType();
+          auto subs = astT->getContextSubstitutionMap(IGF.IGM.getSwiftModule(),
+                                                      structDecl);
+          auto loweredLikeType = IGF.IGM.getLoweredType(likeType->subst(subs));
+          auto &likeTypeInfo = IGF.IGM.getTypeInfo(loweredLikeType);
+
+          likeTypeInfo.assignWithTake(IGF, dest, src, loweredLikeType,
+                                      isOutlined);
+          return;
+        }
+      }
+    }
+
     if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
@@ -255,6 +274,24 @@ public:
     // If the fields are not ABI-accessible, use the value witness table.
     if (!AreFieldsABIAccessible) {
       return emitInitializeWithTakeCall(IGF, T, dest, src);
+    }
+
+    if (auto rawLayout = T.getRawLayout()) {
+      // Because we have a rawlayout attribute, we know this has to be a struct.
+      auto structDecl = T.getStructOrBoundGenericStruct();
+
+      if (auto likeType = rawLayout->getResolvedScalarLikeType(structDecl)) {
+        if (rawLayout->shouldMoveAsLikeType()) {
+          auto astT = T.getASTType();
+          auto subs = astT->getContextSubstitutionMap(IGF.IGM.getSwiftModule(),
+                                                      structDecl);
+          auto loweredLikeType = IGF.IGM.getLoweredType(likeType->subst(subs));
+          auto &likeTypeInfo = IGF.IGM.getTypeInfo(loweredLikeType);
+
+          likeTypeInfo.initializeWithTake(IGF, dest, src, loweredLikeType,
+                                          isOutlined, zeroizeIfSensitive);
+        }
+      }
     }
 
     if (isOutlined || T.hasParameterizedExistential()) {

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -119,11 +119,26 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
         MinimumAlign = likeFixedType->getFixedAlignment();
         IsFixedLayout = true;
         IsKnownAlwaysFixedSize = IsFixedSize;
+
+        // @_rawLayout(like: T) has an optional `movesAsLike` which enforces that
+        // a value of this raw layout type should have the same move semantics
+        // as the like its like.
+        if (rawLayout->shouldMoveAsLikeType()) {
+          IsKnownTriviallyDestroyable = likeFixedType->isTriviallyDestroyable(ResilienceExpansion::Maximal);
+          IsKnownBitwiseTakable = likeFixedType->isBitwiseTakable(ResilienceExpansion::Maximal);
+        }
       } else {
         MinimumSize = Size(0);
         MinimumAlign = Alignment(1);
         IsFixedLayout = false;
         IsKnownAlwaysFixedSize = IsNotFixedSize;
+
+        // We don't know our like type, so assume we're not known to be bitwise
+        // takable.
+        if (rawLayout->shouldMoveAsLikeType()) {
+          IsKnownTriviallyDestroyable = IsNotTriviallyDestroyable;
+          IsKnownBitwiseTakable = IsNotBitwiseTakable;
+        }
       }
     } else if (auto likeArray = rawLayout->getResolvedArrayLikeTypeAndCount(sd)) {
       auto elementType = likeArray->first;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3989,6 +3989,16 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       if (likeType.isNull()) {
         return makeParserSuccess();
       }
+
+      bool movesAsLike = false;
+
+      // @_rawLayout(like: T, movesAsLike)
+      if (consumeIf(tok::comma) && Tok.isAny(tok::identifier) &&
+          !parseSpecificIdentifier("movesAsLike",
+            diag::attr_rawlayout_expected_label, "movesAsLike")) {
+        movesAsLike = true;
+      }
+
       SourceLoc rParenLoc;
       if (!consumeIf(tok::r_paren, rParenLoc)) {
         diagnose(Tok.getLoc(), diag::attr_expected_rparen,
@@ -3996,7 +4006,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         return makeParserSuccess();
       }
 
-      attr = new (Context) RawLayoutAttr(likeType.get(),
+      attr = new (Context) RawLayoutAttr(likeType.get(), movesAsLike,
                                          AtLoc, SourceRange(Loc, rParenLoc));
     } else if (firstLabel.is("likeArrayOf")) {
       // @_rawLayout(likeArrayOf: T, count: N)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6291,8 +6291,9 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         TypeID typeID;
         uint32_t rawSize;
         uint8_t rawAlign;
+        bool movesAsLike;
         serialization::decls_block::RawLayoutDeclAttrLayout::
-          readRecord(scratch, isImplicit, typeID, rawSize, rawAlign);
+          readRecord(scratch, isImplicit, typeID, rawSize, rawAlign, movesAsLike);
         
         if (typeID) {
           auto type = MF.getTypeChecked(typeID);
@@ -6302,6 +6303,7 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
           auto typeRepr = new (ctx) FixedTypeRepr(type.get(), SourceLoc());
           if (rawAlign == 0) {
             Attr = new (ctx) RawLayoutAttr(typeRepr,
+                                           movesAsLike,
                                            SourceLoc(),
                                            SourceRange());
             break;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2154,7 +2154,8 @@ namespace decls_block {
     BCFixed<1>, // implicit
     TypeIDField, // like type
     BCVBR<32>, // size
-    BCVBR<8> // alignment
+    BCVBR<8>, // alignment
+    BCFixed<1> // movesAsLike
   >;
   
   using SwiftNativeObjCRuntimeBaseDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3305,7 +3305,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       
       RawLayoutDeclAttrLayout::emitRecord(
         S.Out, S.ScratchRecord, abbrCode, attr->isImplicit(),
-        typeID, rawSize, rawAlign);
+        typeID, rawSize, rawAlign, attr->shouldMoveAsLikeType());
     }
     }
   }

--- a/test/IRGen/Inputs/module.modulemap
+++ b/test/IRGen/Inputs/module.modulemap
@@ -39,3 +39,7 @@ module PointerAuth {
 module CFBridgedType {
   header "CFBridgedType.h"
 }
+
+module RawLayoutCXX {
+  header "raw_layout_cxx.h"
+}

--- a/test/IRGen/Inputs/raw_layout_cxx.h
+++ b/test/IRGen/Inputs/raw_layout_cxx.h
@@ -1,0 +1,16 @@
+class NonBitwiseTakableCXXType {
+public:
+  bool state = false;
+
+  NonBitwiseTakableCXXType() {}
+
+  NonBitwiseTakableCXXType(const NonBitwiseTakableCXXType &other) {
+    state = false;
+  }
+
+  NonBitwiseTakableCXXType(NonBitwiseTakableCXXType &&other) {
+    state = !other.state;
+  }
+
+  ~NonBitwiseTakableCXXType() {}
+};

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -1,9 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/raw_layout.sil
-// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-ir -disable-availability-checking %t/raw_layout.sil | %FileCheck %t/raw_layout.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-ir -disable-availability-checking -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %t/raw_layout.sil | %FileCheck %t/raw_layout.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 import Builtin
 import Swift
+import RawLayoutCXX
 
 // CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}4LockVWV" = {{.*}} %swift.vwtable
 // size
@@ -143,6 +144,52 @@ struct BadBuffer: ~Copyable {
     let buffer: SmallVectorOf3<Int64?>
 }
 
+// Raw Layout types that move like their like type
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}19CellThatMovesAsLikeVWV" = {{.*}} %swift.vwtable
+// initializeWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout19CellThatMovesAsLikeVwtk"
+// assignWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout19CellThatMovesAsLikeVwta"
+// size
+// CHECK-SAME:  , {{i64|i32}} 0
+// stride
+// CHECK-SAME:  , {{i64|i32}} 0
+// flags: alignment 0, incomplete
+// CHECK-SAME:  , <i32 0x400000>
+@_rawLayout(like: T, movesAsLike)
+struct CellThatMovesAsLike<T>: ~Copyable {}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}18ConcreteMoveAsLikeVWV" = {{.*}} %swift.vwtable
+// initializeWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"
+// assignWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"
+// size
+// CHECK-SAME:  , {{i64|i32}} 1
+// stride
+// CHECK-SAME:  , {{i64|i32}} 1
+// flags: not copyable, not bitwise takable, not pod, not inline
+// CHECK-SAME:  , <i32 0x930000>
+struct ConcreteMoveAsLike: ~Copyable {
+  let cell: CellThatMovesAsLike<NonBitwiseTakableCXXType>
+}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}21ConcreteIntMoveAsLikeVWV" = {{.*}} %swift.vwtable
+// initializeWithTake
+// CHECK-SAME:  , ptr @__swift_memcpy4_4
+// assignWithTake
+// CHECK-SAME:  , ptr @__swift_memcpy4_4
+// size
+// CHECK-SAME:  , {{i64|i32}} 4
+// stride
+// CHECK-SAME:  , {{i64|i32}} 4
+// flags: alignment 3, not copyable
+// CHECK-SAME:  , <i32 0x800003>
+struct ConcreteIntMoveAsLike: ~Copyable {
+  let cell: CellThatMovesAsLike<Int32>
+}
+
 sil @use_lock : $@convention(thin) (@in_guaranteed Lock) -> () {
 entry(%L: $*Lock):
     return undef : $()
@@ -193,3 +240,33 @@ entry(%0 : $*Cell<T>):
 
 // CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}14SmallVectorBufVMr"(ptr %"SmallVectorBuf<T>", ptr {{.*}}, ptr {{.*}})
 // CHECK: call void @swift_initRawStructMetadata(ptr %"SmallVectorBuf<T>", {{i64|i32}} 0, ptr {{%.*}}, {{i64|i32}} 8)
+
+// Ensure that 'movesAsLike' is correctly calling the underlying type's move constructor
+
+// CellThatMovesAsLike<T> initializeWithTake
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout19CellThatMovesAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %"CellThatMovesAsLike<T>")
+// CHECK: [[T_ADDR:%.*]] = getelementptr inbounds ptr, ptr %"CellThatMovesAsLike<T>", {{i64|i32}} 2
+// CHECK-NEXT: [[T:%.*]] = load ptr, ptr [[T_ADDR]]
+// CHECK: {{%.*}} = call ptr %InitializeWithTake(ptr {{.*}} %dest, ptr {{.*}} %src, ptr [[T]])
+
+// CellThatMovesAsLike<T> assignWithTake
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout19CellThatMovesAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %"CellThatMovesAsLike<T>")
+// CHECK: [[T_ADDR:%.*]] = getelementptr inbounds ptr, ptr %"CellThatMovesAsLike<T>", {{i64|i32}} 2
+// CHECK-NEXT: [[T:%.*]] = load ptr, ptr [[T_ADDR]]
+// CHECK: {{%.*}} = call ptr %AssignWithTake(ptr {{.*}} %dest, ptr {{.*}} %src, ptr [[T]])
+
+// ConcreteMoveAsLike initializeWithTake
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
+// CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
+// CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
+// CHECK: {{invoke void|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+
+// ConcreteMoveAsLike assignWithTake
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
+// CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
+// CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
+// CHECK: {{invoke void|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -262,11 +262,11 @@ entry(%0 : $*Cell<T>):
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: {{invoke void|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
 
 // ConcreteMoveAsLike assignWithTake
 
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-// CHECK: {{invoke void|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+// CHECK: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -148,9 +148,9 @@ struct BadBuffer: ~Copyable {
 
 // CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}19CellThatMovesAsLikeVWV" = {{.*}} %swift.vwtable
 // initializeWithTake
-// CHECK-SAME:  , ptr @"$s10raw_layout19CellThatMovesAsLikeVwtk"
+// CHECK-SAME:  , ptr @"$s10raw_layout19CellThatMovesAsLikeVwtk
 // assignWithTake
-// CHECK-SAME:  , ptr @"$s10raw_layout19CellThatMovesAsLikeVwta"
+// CHECK-SAME:  , ptr @"$s10raw_layout19CellThatMovesAsLikeVwta
 // size
 // CHECK-SAME:  , {{i64|i32}} 0
 // stride
@@ -162,9 +162,9 @@ struct CellThatMovesAsLike<T>: ~Copyable {}
 
 // CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}18ConcreteMoveAsLikeVWV" = {{.*}} %swift.vwtable
 // initializeWithTake
-// CHECK-SAME:  , ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"
+// CHECK-SAME:  , ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk
 // assignWithTake
-// CHECK-SAME:  , ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"
+// CHECK-SAME:  , ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta
 // size
 // CHECK-SAME:  , {{i64|i32}} 1
 // stride

--- a/test/Serialization/Inputs/module.modulemap
+++ b/test/Serialization/Inputs/module.modulemap
@@ -2,3 +2,7 @@
 module CLibrary {
   header "CLibrary.h"
 }
+
+module RawLayoutCXX {
+  header "raw_layout_cxx.h"
+}

--- a/test/Serialization/Inputs/raw_layout.swift
+++ b/test/Serialization/Inputs/raw_layout.swift
@@ -5,3 +5,6 @@ extension Bool: Foo {}
 public struct Fred<T: Foo>: ~Copyable {
   public init() {}
 }
+
+@_rawLayout(like: T, movesAsLike)
+public struct CellThatMovesLike<T>: ~Copyable {}

--- a/test/Serialization/Inputs/raw_layout_cxx.h
+++ b/test/Serialization/Inputs/raw_layout_cxx.h
@@ -1,0 +1,16 @@
+class NonBitwiseTakableCXXType {
+public:
+  bool state = false;
+
+  NonBitwiseTakableCXXType() {}
+
+  NonBitwiseTakableCXXType(const NonBitwiseTakableCXXType &other) {
+    state = false;
+  }
+
+  NonBitwiseTakableCXXType(NonBitwiseTakableCXXType &&other) {
+    state = !other.state;
+  }
+
+  ~NonBitwiseTakableCXXType() {}
+};

--- a/test/Serialization/raw_layout.swift
+++ b/test/Serialization/raw_layout.swift
@@ -1,10 +1,26 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-experimental-feature RawLayout -module-name raw_layout_fred -o %t %S/Inputs/raw_layout.swift
-// RUN: %target-swift-frontend -I %t -emit-ir %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -emit-ir %s -verify | %FileCheck %s
 
 import raw_layout_fred
+import RawLayoutCXX
 
 // CHECK: %T15raw_layout_fred4FredVySbG = type <{ [1 x i8] }>
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}16WeirdCXXTypeCellVWV" = {{.*}} %swift.vwtable
+// initializeWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwtk"
+// assignWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwta"
+// size
+// CHECK-SAME:  , {{i64|i32}} 1
+// stride
+// CHECK-SAME:  , {{i64|i32}} 1
+// flags: not copyable, not bitwise takable, not pod, not inline
+// CHECK-SAME:  , i32 9633792
+struct WeirdCXXTypeCell: ~Copyable {
+  let cell: CellThatMovesLike<NonBitwiseTakableCXXType>
+}
 
 do {
   // CHECK: {{%.*}} = alloca %T15raw_layout_fred4FredVySbG

--- a/test/Serialization/raw_layout.swift
+++ b/test/Serialization/raw_layout.swift
@@ -9,9 +9,9 @@ import RawLayoutCXX
 
 // CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}16WeirdCXXTypeCellVWV" = {{.*}} %swift.vwtable
 // initializeWithTake
-// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwtk"
+// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwtk
 // assignWithTake
-// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwta"
+// CHECK-SAME:  , ptr @"$s10raw_layout16WeirdCXXTypeCellVwta
 // size
 // CHECK-SAME:  , {{i64|i32}} 1
 // stride


### PR DESCRIPTION
This is a cherry pick of https://github.com/apple/swift/pull/73955, https://github.com/apple/swift/pull/74053, and https://github.com/apple/swift/pull/74095

* Explanation: In order for types like Mutex to store arbitrary types, raw layout needs to support moving like the type it's like. Add an option movesAsLike to the attribute to let types opt into this behavior and call into their underlying type to figure out how to move themselves.
* Scope: Types using `@_rawLayout` which should be only the stdlib.
* Main Branch PR: https://github.com/apple/swift/pull/73955
* Risk: Low
* Reviewed By: @jckarter 
* Testing: New tests added to the test suite.