### PR TITLE
Be smarter about how we compute and inline isASCII and asciiValue

### DIFF
--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -81,7 +81,6 @@ extension Character {
   internal func _invariantCheck() {
     _internalInvariant(_str.count == 1)
     _internalInvariant(_str._guts.isFastUTF8)
-
     _internalInvariant(_str._guts._object.isPreferredRepresentation)
   }
   #endif // INTERNAL_CHECKS_ENABLED


### PR DESCRIPTION
The existing implementation of these properties uses string equality, as well as _isSingleScalar and _firstScalar which have to dispatch through the underlying String's encoding checks; this results in several calls and a few tens of instructions inlined at the call site. However, it is an invariant of Character that the underlying String must be either small or large and native, so most of this extra work is wasted. This change moves the entire SmallString path inline (with no calls to the stdlib binary) and moves the entire large-native path out-of-line. We have to make the out-of-line path continue handling SmallString for bincompat purposes (this could be eliminated on platforms that are not ABI stable, or which are made ABI stable after this change), but it is quite cheap to do so--the resulting library function is still much smaller than what we used to have.

This nets us 2x (single-Unicode.Scalar Character) to 4x (Characters that need to use the large-native representation) speedups when iterating through a string and checking these properties (the actual speedup to the properties is much larger; the measurement after this change is almost entirely the iteration overhead--we'll have to look at that next). Codesize comes down significantly as well.