### PR TITLE
🍒[cxx-interop] Adjust tests for new search path mechanism

### DIFF
--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
@@ -3,7 +3,7 @@
 
 // Verify that symbolic interfaces are emitted.
 //
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>%t/remarks
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>%t/remarks
 // RUN: echo "EOF" >> %t/remarks
 // RUN: cat %t/remarks | %FileCheck --check-prefix=REMARK_NEW %s
 // RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
@@ -11,7 +11,7 @@
 
 // Verify that symbolic interfaces are not emitted when PCM doesn't change.
 //
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NO_UPDATE %s
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NO_UPDATE %s
 // RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
 
 // REQUIRES: OS=macosx

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-no-symbolic-module-interface-no-clang-module-index.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-no-symbolic-module-interface-no-clang-module-index.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 //
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-ignore-clang-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -c -index-system-modules -index-ignore-clang-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck %s
 // RUN: not ls %t/store/interfaces
 
 //--- Inputs/module.modulemap

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-objcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-objcxx-symbolic-module-interface.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
 // RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
 // RUN: cat %t/store/interfaces/ObjCxxModule* | %FileCheck --check-prefix=CHECK %s
 
@@ -9,7 +9,7 @@
 // Verify that symbolic interface is not emitted without interop.
 //
 // RUN: rm -r %t/store/interfaces
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -Rindexing-system-module 2>&1 > %t/out
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -c -index-system-modules -index-store-path %t/store -Rindexing-system-module 2>&1 > %t/out
 // RUN: echo "non-empty-file-check" >> %t/out
 // RUN: cat %t/out | %FileCheck --check-prefix=REMARK_NONE %s
 // RUN: not ls %t/store/interfaces

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface-used-decls.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface-used-decls.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop 2>&1
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop 2>&1
 // RUN: cat %t/store/interfaces/CxxModule* | %FileCheck --check-prefix=CHECK %s
 
 //--- Inputs/module.modulemap

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
@@ -3,7 +3,7 @@
 
 // Verify that symbolic interfaces are emitted.
 //
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>%t/remarks
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>%t/remarks
 // RUN: echo "EOF" >> %t/remarks
 // RUN: cat %t/remarks | %FileCheck --check-prefixes=REMARK_NEW,REMARK_INITIAL %s
 // RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
@@ -11,21 +11,21 @@
 
 // Verify that symbolic interfaces are not emitted when PCM doesn't change.
 //
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NO_UPDATE %s
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NO_UPDATE %s
 // RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
 // RUN: cat %t/store/interfaces/CxxModule* | %FileCheck --check-prefix=CHECK %s
 
 // Verify that symbolic interface is re-emitted when the interface is removed.
 //
 // RUN: rm -r %t/store/interfaces
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
 // RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
 // RUN: cat %t/store/interfaces/CxxModule* | %FileCheck --check-prefixes=CHECK %s
 
 // Verify that symbolic interface is re-emitted when PCM changes.
 //
 // RUN: echo "using AdditionalAlias = int;" >> %t/Inputs/headerA.h
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
+// RUN: %target-swift-frontend %t/test.swift -I %t/Inputs -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
 // RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
 // RUN: cat %t/store/interfaces/CxxModule* | %FileCheck --check-prefixes=CHECK,CHECK-UPDATED %s
 


### PR DESCRIPTION
**Explanation**: This fixes a few tests after a Clang change. Previously passing `-I %t` would mean that `%t/Inputs` is also indexed, but that is not the case anymore in certain scenarios.
**Scope**: Only changes tests.
**Risk**: Low.
**Issue**: rdar://128490765

Original PR: https://github.com/apple/swift/pull/74116