### PR TITLE
[stdlib] Guard for empty singleton in dictionary builder

### DIFF
--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -106,6 +106,10 @@ extension _NativeDictionary {
     // If the capacity is 0, then our storage is the empty singleton. Those are
     // read only, so we shouldn't attempt to write to them.
     if capacity == 0 {
+      let c = initializer(
+        UnsafeMutableBufferPointer(start: nil, count: 0), 
+        UnsafeMutableBufferPointer(start: nil, count: 0))
+      _precondition(c == 0)
       return
     }
 

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -102,6 +102,13 @@ extension _NativeDictionary {
     ) -> Int
   ) {
     self.init(capacity: capacity)
+
+    // If the capacity is 0, then our storage is the empty singleton. Those are
+    // read only, so we shouldn't attempt to write to them.
+    if capacity == 0 {
+      return
+    }
+
     let initializedCount = initializer(
       UnsafeMutableBufferPointer(start: _keys, count: capacity),
       UnsafeMutableBufferPointer(start: _values, count: capacity))

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -5735,8 +5735,10 @@ DictionaryTestSuite.test("BulkLoadingInitializer.Unique") {
       _unsafeUninitializedCapacity: c,
       allowingDuplicates: false
     ) { keys, values in
-      let k = keys.baseAddress!
-      let v = values.baseAddress!
+      guard let k = keys.baseAddress, let v = values.baseAddress else {
+        return 0
+      }
+
       for i in 0 ..< c {
         (k + i).initialize(to: TestKeyTy(i))
         (v + i).initialize(to: TestEquatableValueTy(i))
@@ -5762,8 +5764,10 @@ DictionaryTestSuite.test("BulkLoadingInitializer.Nonunique") {
       _unsafeUninitializedCapacity: c,
       allowingDuplicates: true
     ) { keys, values in
-      let k = keys.baseAddress!
-      let v = values.baseAddress!
+      guard let k = keys.baseAddress, let v = values.baseAddress else {
+        return 0
+      }
+
       for i in 0 ..< c {
         (k + i).initialize(to: TestKeyTy(i / 2))
         (v + i).initialize(to: TestEquatableValueTy(i / 2))


### PR DESCRIPTION
In preparation of making the empty singletons read only, we need to guard against attempts to write to values in this object. This dictionary builder used by Foundation unconditionally writes to the count based on the initialized count returned from the closure. If the capacity is 0, then we should just skip building the dictionary.