### PR TITLE
Create two versions (for caller and callee) of the functions that answer questions about parameter convention

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4114,7 +4114,9 @@ inline bool isIndirectFormalParameter(ParameterConvention conv) {
   }
   llvm_unreachable("covered switch isn't covered?!");
 }
-inline bool isConsumedParameter(ParameterConvention conv) {
+
+template <bool InCallee>
+bool isConsumedParameter(ParameterConvention conv) {
   switch (conv) {
   case ParameterConvention::Indirect_In:
   case ParameterConvention::Direct_Owned:
@@ -4133,10 +4135,19 @@ inline bool isConsumedParameter(ParameterConvention conv) {
   llvm_unreachable("bad convention kind");
 }
 
+inline bool isConsumedParameterInCallee(ParameterConvention conv) {
+  return isConsumedParameter<true>(conv);
+}
+
+inline bool isConsumedParameterInCaller(ParameterConvention conv) {
+  return isConsumedParameter<false>(conv);
+}
+
 /// Returns true if conv is a guaranteed parameter. This may look unnecessary
 /// but this will allow code to generalize to handle Indirect_Guaranteed
 /// parameters when they are added.
-inline bool isGuaranteedParameter(ParameterConvention conv) {
+template <bool InCallee>
+bool isGuaranteedParameter(ParameterConvention conv) {
   switch (conv) {
   case ParameterConvention::Direct_Guaranteed:
   case ParameterConvention::Indirect_In_Guaranteed:
@@ -4153,6 +4164,14 @@ inline bool isGuaranteedParameter(ParameterConvention conv) {
     return false;
   }
   llvm_unreachable("bad convention kind");
+}
+
+inline bool isGuaranteedParameterInCallee(ParameterConvention conv) {
+  return isGuaranteedParameter<true>(conv);
+}
+
+inline bool isGuaranteedParameterInCaller(ParameterConvention conv) {
+  return isGuaranteedParameter<false>(conv);
 }
 
 inline bool isMutatingParameter(ParameterConvention conv) {
@@ -4282,14 +4301,22 @@ public:
 
   /// True if this parameter is consumed by the callee, either
   /// indirectly or directly.
-  bool isConsumed() const {
-    return isConsumedParameter(getConvention());
+  bool isConsumedInCallee() const {
+    return isConsumedParameterInCallee(getConvention());
+  }
+
+  bool isConsumedInCaller() const {
+    return isConsumedParameterInCaller(getConvention());
   }
 
   /// Returns true if this parameter is guaranteed, either indirectly or
   /// directly.
-  bool isGuaranteed() const {
-    return isGuaranteedParameter(getConvention());
+  bool isGuaranteedInCallee() const {
+    return isGuaranteedParameterInCallee(getConvention());
+  }
+
+  bool isGuaranteedInCaller() const {
+    return isGuaranteedParameterInCaller(getConvention());
   }
 
   bool hasOption(Flag flag) const { return options.contains(flag); }

--- a/include/swift/SIL/SILArgumentConvention.h
+++ b/include/swift/SIL/SILArgumentConvention.h
@@ -103,6 +103,7 @@ struct SILArgumentConvention {
     llvm_unreachable("covered switch isn't covered?!");
   }
 
+  template <bool InCallee>
   bool isOwnedConvention() const {
     switch (Value) {
     case SILArgumentConvention::Indirect_In:
@@ -123,6 +124,11 @@ struct SILArgumentConvention {
     llvm_unreachable("covered switch isn't covered?!");
   }
 
+  bool isOwnedConventionInCallee() const { return isOwnedConvention<true>(); }
+
+  bool isOwnedConventionInCaller() const { return isOwnedConvention<false>(); }
+
+  template <bool InCallee>
   bool isGuaranteedConvention() const {
     switch (Value) {
     case SILArgumentConvention::Indirect_In_Guaranteed:
@@ -141,6 +147,14 @@ struct SILArgumentConvention {
       return false;
     }
     llvm_unreachable("covered switch isn't covered?!");
+  }
+
+  bool isGuaranteedConventionInCallee() const {
+    return isGuaranteedConvention<true>();
+  }
+
+  bool isGuaranteedConventionInCaller() const {
+    return isGuaranteedConvention<false>();
   }
 
   /// Returns true if \p Value is a non-aliasing indirect parameter.

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -811,7 +811,7 @@ public:
   // callee.
   bool hasOwnedParameters() const {
     for (auto &ParamInfo : getLoweredFunctionType()->getParameters()) {
-      if (ParamInfo.isConsumed())
+      if (ParamInfo.isConsumedInCallee())
         return true;
     }
     return false;

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -178,7 +178,7 @@ ClangTypeConverter::getFunctionType(ArrayRef<SILParameterInfo> params,
     if (pc.isNull())
       return nullptr;
     clang::FunctionProtoType::ExtParameterInfo extParamInfo;
-    if (p.isConsumed()) {
+    if (p.isConsumedInCallee()) {
       someParamIsConsumed = true;
       extParamInfo = extParamInfo.withIsConsumed(true);
     }

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -353,7 +353,7 @@ std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromTypeRepr(
     auto kind = specifier.getParsedLifetimeDependenceKind();
 
     if (kind == ParsedLifetimeDependenceKind::Scope &&
-        (!isGuaranteedParameter(paramConvention) &&
+        (!isGuaranteedParameterInCallee(paramConvention) &&
          !isMutatingParameter(paramConvention))) {
       diags.diagnose(loc, diag::lifetime_dependence_cannot_use_kind, "_scope",
                      getStringForParameterConvention(paramConvention));

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2612,7 +2612,7 @@ void LoadableByAddress::recreateSingleApply(
         } else if (newValue->getType().isTrivial(*F)) {
           ownership = LoadOwnershipQualifier::Trivial;
         } else {
-          assert(oldYields[i].isConsumed() &&
+          assert(oldYields[i].isConsumedInCaller() &&
                  "borrowed yields not yet supported here");
           ownership = LoadOwnershipQualifier::Take;
         }

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1256,12 +1256,12 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   signature.visitParameterList(
       [&](const LoweredFunctionSignature::IndirectResultValue &) {},
       [&](const LoweredFunctionSignature::DirectParameter &param) {
-        if (isConsumedParameter(param.getConvention()))
+        if (isConsumedParameterInCaller(param.getConvention()))
           emitParamCopyForConsume(param.getParamDecl());
         ++paramIndex;
       },
       [&](const LoweredFunctionSignature::IndirectParameter &param) {
-        if (isConsumedParameter(param.getConvention()))
+        if (isConsumedParameterInCaller(param.getConvention()))
           emitParamCopyForConsume(param.getParamDecl());
         ++paramIndex;
       },
@@ -1325,12 +1325,12 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
         },
         [&](const LoweredFunctionSignature::DirectParameter &param) {
           printParamUse(param.getParamDecl(), /*isIndirect=*/false,
-                        isConsumedParameter(param.getConvention()),
+                        isConsumedParameterInCaller(param.getConvention()),
                         encodeTypeInfo(param, moduleContext, typeMapping));
         },
         [&](const LoweredFunctionSignature::IndirectParameter &param) {
           printParamUse(param.getParamDecl(), /*isIndirect=*/true,
-                        isConsumedParameter(param.getConvention()),
+                        isConsumedParameterInCaller(param.getConvention()),
                         /*directTypeEncoding=*/"");
         },
         [&](const LoweredFunctionSignature::GenericRequirementParameter

--- a/lib/SIL/Verifier/LoadBorrowImmutabilityChecker.cpp
+++ b/lib/SIL/Verifier/LoadBorrowImmutabilityChecker.cpp
@@ -226,7 +226,7 @@ bool GatherWritesVisitor::visitUse(Operand *op, AccessUseType useTy) {
     if (info.isIndirectInGuaranteed()) {
       return true;
     }
-    if (info.isIndirectMutating() || info.isConsumed()) {
+    if (info.isIndirectMutating() || info.isConsumedInCaller()) {
       writeAccumulator.push_back(op);
       return true;
     }
@@ -259,7 +259,7 @@ bool GatherWritesVisitor::visitUse(Operand *op, AccessUseType useTy) {
       writeAccumulator.push_back(op);
       return true;
     }
-    if (argConv.isOwnedConvention()) {
+    if (argConv.isOwnedConventionInCaller()) {
       writeAccumulator.push_back(op);
       return true;
     }

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -849,10 +849,10 @@ void MemoryLifetimeVerifier::checkBlock(SILBasicBlock *block, Bits &bits) {
               fnType->getYields()[index].getConvention());
           if (argConv.isIndirectConvention()) {
             if (argConv.isInoutConvention() ||
-                argConv.isGuaranteedConvention()) {
+                argConv.isGuaranteedConventionInCaller()) {
               requireBitsSet(bits | ~nonTrivialLocations, yieldedValues[index],
                              &I);
-            } else if (argConv.isOwnedConvention()) {
+            } else if (argConv.isOwnedConventionInCaller()) {
               requireBitsClear(bits & nonTrivialLocations, yieldedValues[index],
                                &I);
             }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2194,8 +2194,9 @@ public:
           "applied argument types do not match suffix of function type's "
           "inputs");
       if (PAI->isOnStack()) {
-        require(!substConv.getSILArgumentConvention(argIdx).isOwnedConvention(),
-          "on-stack closures do not support owned arguments");
+        require(!substConv.getSILArgumentConvention(argIdx)
+                     .isOwnedConventionInCaller(),
+                "on-stack closures do not support owned arguments");
       }
     }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6872,7 +6872,7 @@ ArgumentSource AccessorBaseArgPreparer::prepareAccessorAddressBaseArg() {
       // The load can only be a take if the base is a +1 rvalue.
       auto shouldTake = IsTake_t(base.hasCleanup());
 
-      auto isGuaranteed = selfParam.isGuaranteed();
+      auto isGuaranteed = selfParam.isGuaranteedInCaller();
 
       auto context =
           isGuaranteed ? SGFContext::AllowImmediatePlusZero : SGFContext();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -258,7 +258,7 @@ static ManagedValue convertOwnershipConventionGivenParamInfo(
     }
   }
 
-  if (param.isConsumed() &&
+  if (param.isConsumedInCaller() &&
       value.getOwnershipKind() == OwnershipKind::Guaranteed) {
     return value.copyUnmanaged(SGF, loc);
   }
@@ -1926,7 +1926,7 @@ static void emitRawApply(SILGenFunction &SGF,
     auto inputTy =
         substFnConv.getSILType(inputParams[i], SGF.getTypeExpansionContext());
 
-    if (inputParams[i].isConsumed()) {
+    if (inputParams[i].isConsumedInCaller()) {
       argValue = args[i].forward(SGF);
       if (argValue->getType().isMoveOnlyWrapped() &&
           !inputTy.isMoveOnlyWrapped()) {
@@ -3539,7 +3539,7 @@ private:
     }
 
     // If we have a guaranteed +0 parameter...
-    if (param.isGuaranteed() || isShared) {
+    if (param.isGuaranteedInCaller() || isShared) {
       // And this is a yield, emit a borrowed r-value.
       if (IsYield) {
         if (tryEmitBorrowed(std::move(arg), loweredSubstArgType,
@@ -3561,7 +3561,7 @@ private:
         return;
     }
 
-    if (param.isConsumed() || isOwned) {
+    if (param.isConsumedInCaller() || isOwned) {
       if (tryEmitConsumedMoveOnly(std::move(arg), loweredSubstArgType,
                                   loweredSubstParamType, origParamType,
                                   paramSlice))
@@ -3762,7 +3762,7 @@ private:
                     ClaimedParamsRef claimedParams) {
     auto emissionKind = SGFAccessKind::BorrowedObjectRead;
     for (auto param : claimedParams) {
-      assert(!param.isConsumed());
+      assert(!param.isConsumedInCaller());
       if (param.isIndirectInGuaranteed() && SGF.silConv.useLoweredAddresses()) {
         emissionKind = SGFAccessKind::BorrowedAddressRead;
         break;
@@ -3886,7 +3886,7 @@ private:
       // happen outside of the formal-evaluation scope we pushed for the
       // expression evaluation, but any copies to be done inside of it.
       // Copies are only done if the parameter is consumed.
-      if (!param.isConsumed())
+      if (!param.isConsumedInCaller())
         S.pop();
 
       Args.push_back(convertOwnershipConvention(value));
@@ -4359,7 +4359,7 @@ private:
     bool requiresReabstraction = loweredArgType.getASTType()
       != param.getInterfaceType();
     // If the parameter is consumed, we have to emit at +1.
-    if (param.isConsumed()) {
+    if (param.isConsumedInCaller()) {
       return {SGFContext(), requiresReabstraction};
     }
 
@@ -5053,7 +5053,7 @@ SILGenFunction::emitBeginApply(SILLocation loc, ManagedValue fn,
          MarkUnresolvedNonCopyableValueInst::CheckKind::ConsumableAndAssignable);
       }
       yields.push_back(ManagedValue::forLValue(value));
-    } else if (info.isConsumed()) {
+    } else if (info.isConsumedInCaller()) {
       if (value->getType().isMoveOnly()) {
         value = B.createMarkUnresolvedNonCopyableValueInst(loc, value,
          MarkUnresolvedNonCopyableValueInst::CheckKind::ConsumableAndAssignable);
@@ -5061,7 +5061,7 @@ SILGenFunction::emitBeginApply(SILLocation loc, ManagedValue fn,
       !useLoweredAddresses && value->getType().isTrivial(getFunction())
           ? yields.push_back(ManagedValue::forRValueWithoutOwnership(value))
           : yields.push_back(emitManagedRValueWithCleanup(value));
-    } else if (info.isGuaranteed()) {
+    } else if (info.isGuaranteedInCaller()) {
       if (value->getType().isMoveOnly()) {
         if (!value->getType().isAddress()) {
           // The move checker uses the lifetime of the "copy" for borrow checking.
@@ -6868,7 +6868,7 @@ bool AccessorBaseArgPreparer::shouldLoadBaseAddress() const {
 ArgumentSource AccessorBaseArgPreparer::prepareAccessorAddressBaseArg() {
   // If the base is currently an address, we may have to copy it.
   if (shouldLoadBaseAddress()) {
-    if (selfParam.isConsumed() || base.getType().isAddressOnly(SGF.F)) {
+    if (selfParam.isConsumedInCaller() || base.getType().isAddressOnly(SGF.F)) {
       // The load can only be a take if the base is a +1 rvalue.
       auto shouldTake = IsTake_t(base.hasCleanup());
 
@@ -6921,7 +6921,7 @@ ArgumentSource AccessorBaseArgPreparer::prepareAccessorObjectBaseArg() {
   assert(!base.isLValue());
 
   // We need to produce the value at +1 if it's going to be consumed.
-  if (selfParam.isConsumed() && !base.hasCleanup()) {
+  if (selfParam.isConsumedInCaller() && !base.hasCleanup()) {
     base = base.copyUnmanaged(SGF, loc);
   }
   // If the parameter is indirect, we'll need to drop the value into

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -189,7 +189,7 @@ static RValue emitImplicitValueConstructorArg(SILGenFunction &SGF,
   auto argType = loweredParamTypes.claimNext();
 
   auto *arg = SGF.F.begin()->createFunctionArgument(argType, VD);
-  bool argIsConsumed = origParamInfo.isConsumed();
+  bool argIsConsumed = origParamInfo.isConsumedInCallee();
 
   // If the lowered parameter is a pack expansion, copy/move the pack
   // into the initialization, which we assume is there.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2010,7 +2010,7 @@ private:
     auto convention = innerSlot.getConvention();
     assert(!isPackParameter(convention));
     assert(innerSlot.shouldProduceAddress(SGF) == innerValue.getType().isAddress());
-    if (innerValue.hasCleanup() && !isConsumedParameter(convention)) {
+    if (innerValue.hasCleanup() && !isConsumedParameterInCaller(convention)) {
       return innerValue.borrow(SGF, Loc);
     }
     return innerValue;
@@ -2047,7 +2047,7 @@ private:
 
     // Easy case: we want to pass exactly this value.
     if (outer.getType() == innerParam.getType()) {
-      if (isConsumedParameter(innerParam.getConvention()) &&
+      if (isConsumedParameterInCaller(innerParam.getConvention()) &&
           !outer.isPlusOne(SGF)) {
         outer = outer.copyUnmanaged(SGF, Loc);
       }
@@ -2792,12 +2792,12 @@ static void forwardFunctionArguments(SILGenFunction &SGF,
     arg = applyTrivialConversions(SGF, loc, arg,
                                   SILType::getPrimitiveObjectType(argSubstTy));
 
-    if (argTy.isConsumed()) {
+    if (argTy.isConsumedInCaller()) {
       forwardedArgs.push_back(arg.ensurePlusOne(SGF, loc).forward(SGF));
       continue;
     }
 
-    if (isGuaranteedParameter(argTy.getConvention())) {
+    if (isGuaranteedParameterInCallee(argTy.getConvention())) {
       forwardedArgs.push_back(
           SGF.emitManagedBeginBorrow(loc, arg.getValue()).getValue());
       continue;
@@ -3932,7 +3932,7 @@ ManagedValue TranslateArguments::expandPackExpansion(
     // Note that we need to force *trivial* packs/tuples to be copied, in
     // case the inner context wants to mutate the memory, even though we might
     // have ownership of that memory (e.g. if it's a consuming parameter).
-    needsInnerTemporary = (isConsumedParameter(innerConvention) &&
+    needsInnerTemporary = (isConsumedParameterInCaller(innerConvention) &&
                            !outerTupleOrPackMV.isPlusOne(SGF));
   }
 
@@ -3960,7 +3960,7 @@ ManagedValue TranslateArguments::expandPackExpansion(
   // This doesn't apply if we're translating into a tuple because we
   // always need to copy/move into the tuple.
   if (!innerIsTuple && !needsInnerTemporary &&
-      !isConsumedParameter(innerConvention)) {
+      !isConsumedParameterInCaller(innerConvention)) {
     outerTupleOrPackMV =
       ManagedValue::forBorrowedAddressRValue(outerTupleOrPackMV.getValue());
   }
@@ -3970,7 +3970,7 @@ ManagedValue TranslateArguments::expandPackExpansion(
   SILValue outerTupleOrPackAddr = outerTupleOrPackMV.forward(SGF);
 
   bool innerIsOwned = (innerIsTuple || needsInnerTemporary ||
-                       isConsumedParameter(innerConvention));
+                       isConsumedParameterInCaller(innerConvention));
 
   // Perform a pack loop to translate the components and set the element
   // addresses for this pack expansion in the inner pack (if it's a pack).
@@ -4085,7 +4085,7 @@ ManagedValue TranslateArguments::expandPackExpansion(
     // We only associate this cleanup with what we return from this function
     // if we're generating an owned value; otherwise we just leave it active
     // so that we destroy the values later.
-    if (isConsumedParameter(innerConvention)) {
+    if (isConsumedParameterInCaller(innerConvention)) {
       return ManagedValue::forOwnedAddressRValue(innerTupleOrPackAddr,
                                                  innerExpansionCleanup);
     }

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -496,7 +496,7 @@ mayGuaranteedUseValue(SILInstruction *User, SILValue Ptr, AliasAnalysis *AA) {
   // Ptr. If we fail, return true.
   auto Params = FType->getParameters();
   for (unsigned i : indices(Params)) {    
-    if (!Params[i].isGuaranteed())
+    if (!Params[i].isGuaranteedInCaller())
       continue;
     SILValue Op = FAS.getArgumentsWithoutIndirectResults()[i];
     if (!AA->isNoAlias(Op, Ptr))

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -815,7 +815,8 @@ bool swift::ArraySemanticsCall::replaceByAppendingValues(
     SILValue Args[] = {AllocStackInst, ArrRef};
     Builder.createApply(Loc, FnRef, Subs, Args);
     Builder.createDeallocStack(Loc, AllocStackInst);
-    if (!isConsumedParameter(AppendFnTy->getParameters()[0].getConvention())) {
+    if (!isConsumedParameterInCaller(
+            AppendFnTy->getParameters()[0].getConvention())) {
       ValLowering.emitDestroyValue(Builder, Loc, CopiedVal);
     }
   }

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -445,7 +445,7 @@ static SILValue getBeginScopeInst(SILValue V) {
     // guaranteed argument.
     SILValue root = findOwnershipReferenceAggregate(object);
     if (auto *funcArg = dyn_cast<SILFunctionArgument>(root)) {
-      if (funcArg->getArgumentConvention().isGuaranteedConvention())
+      if (funcArg->getArgumentConvention().isGuaranteedConventionInCallee())
         return funcArg;
     }
   }
@@ -529,7 +529,7 @@ bool AliasAnalysis::isInImmutableScope(SILInstruction *inst, SILValue V) {
   if (auto *funcArg = dyn_cast<SILFunctionArgument>(beginScope)) {
     // The immutable scope (= an guaranteed argument) spans over the whole
     // function. We don't need to do any scope computation in this case.
-    assert(funcArg->getArgumentConvention().isGuaranteedConvention());
+    assert(funcArg->getArgumentConvention().isGuaranteedConventionInCallee());
     return true;
   }
 

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -75,7 +75,7 @@ static void forwardFunctionArgumentsConvertingOwnership(
     auto fromParam = fromParameters[index];
     auto toParam = toParameters[index];
     // To convert guaranteed argument to be owned, create a copy.
-    if (fromParam.isConsumed() && !toParam.isConsumed()) {
+    if (fromParam.isConsumedInCaller() && !toParam.isConsumedInCallee()) {
       // If the argument has an object type, create a `copy_value`.
       if (arg->getType().isObject()) {
         auto argCopy = builder.emitCopyValueOperation(loc, arg);
@@ -91,7 +91,7 @@ static void forwardFunctionArgumentsConvertingOwnership(
       continue;
     }
     // To convert owned argument to be guaranteed, borrow the argument.
-    if (fromParam.isGuaranteed() && !toParam.isGuaranteed()) {
+    if (fromParam.isGuaranteedInCaller() && !toParam.isGuaranteedInCaller()) {
       auto bbi = builder.emitBeginBorrowOperation(loc, arg);
       forwardedArgs.push_back(bbi);
       valuesToCleanup.push_back(bbi);
@@ -465,14 +465,14 @@ getOrCreateSubsetParametersThunkForLinearMap(
       builder.emitZeroIntoBuffer(loc, buf, IsInitialization);
       if (zeroSILType.isAddress()) {
         arguments.push_back(buf);
-        if (zeroSILParameter.isGuaranteed()) {
+        if (zeroSILParameter.isGuaranteedInCaller()) {
           valuesToCleanup.push_back(buf);
         }
       } else {
         auto arg = builder.emitLoadValueOperation(loc, buf,
                                                   LoadOwnershipQualifier::Take);
         arguments.push_back(arg);
-        if (zeroSILParameter.isGuaranteed()) {
+        if (zeroSILParameter.isGuaranteedInCaller()) {
           valuesToCleanup.push_back(arg);
         }
       }

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -194,14 +194,14 @@ bool ExistentialSpecializer::canSpecializeExistentialArgsInFunction(
     // into an existential if it is non-consuming (if it's consuming, it's
     // moved into the existential via `copy_addr [take]`).  Introducing a copy
     // of a move-only value isn't legal.
-    if (!paramInfo.isConsumed() &&
+    if (!paramInfo.isConsumedInCallee() &&
         paramInfo.getSILStorageInterfaceType().isMoveOnly())
       continue;
 
-    ETAD.AccessType = paramInfo.isConsumed()
+    ETAD.AccessType = paramInfo.isConsumedInCallee()
                           ? OpenedExistentialAccess::Mutable
                           : OpenedExistentialAccess::Immutable;
-    ETAD.isConsumed = paramInfo.isConsumed();
+    ETAD.isConsumed = paramInfo.isConsumedInCallee();
 
     /// Save the attributes
     ExistentialArgDescriptor[Idx] = ETAD;

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -378,11 +378,11 @@ public:
   }
 
   bool isClosureGuaranteed() const {
-    return getClosureParameterInfo().isGuaranteed();
+    return getClosureParameterInfo().isGuaranteedInCaller();
   }
 
   bool isClosureConsumed() const {
-    return getClosureParameterInfo().isConsumed();
+    return getClosureParameterInfo().isConsumedInCaller();
   }
 
   bool isClosureOnStack() const {
@@ -1371,7 +1371,8 @@ bool SILClosureSpecializerTransform::gatherCallSites(
             isa<ThinToThickFunctionInst>(ClosureInst) && !HaveUsedReabstraction;
 
         llvm::TinyPtrVector<SILBasicBlock *> NonFailureExitBBs;
-        if ((ClosureParamInfo.isGuaranteed() || IsClosurePassedTrivially) &&
+        if ((ClosureParamInfo.isGuaranteedInCaller() ||
+             IsClosurePassedTrivially) &&
             !OnlyHaveThinToThickClosure &&
             !findAllNonFailureExitBBs(ApplyCallee, NonFailureExitBBs)) {
           continue;

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -650,7 +650,7 @@ static void convertDirectToIndirectFunctionArgs(AddressLoweringState &pass) {
       if (addrType.isTrivial(*pass.function)) {
         load = argBuilder.createLoad(loc, undefAddress,
                                      LoadOwnershipQualifier::Trivial);
-      } else if (param.isConsumed()) {
+      } else if (param.isConsumedInCallee()) {
         load = argBuilder.createLoad(loc, undefAddress,
                                      LoadOwnershipQualifier::Take);
       } else {
@@ -2269,7 +2269,7 @@ void CallArgRewriter::rewriteIndirectArgument(Operand *operand) {
   // Allocate temporary storage for a loadable operand.
   AllocStackInst *allocInst =
       argBuilder.createAllocStack(callLoc, argValue->getType());
-  if (apply.getCaptureConvention(*operand).isOwnedConvention()) {
+  if (apply.getCaptureConvention(*operand).isOwnedConventionInCaller()) {
     argBuilder.createTrivialStoreOr(apply.getLoc(), argValue, allocInst,
                                     StoreOwnershipQualifier::Init);
     apply.insertAfterApplication([&](SILBuilder &callBuilder) {
@@ -2648,7 +2648,7 @@ void ApplyRewriter::convertBeginApplyWithOpaqueYield() {
     if (oldResult.getType().isAddressOnly(*pass.function)) {
       auto info = newCall->getSubstCalleeConv().getYieldInfoForOperandIndex(i);
       assert(info.isFormalIndirect());
-      if (info.isConsumed()) {
+      if (info.isConsumedInCaller()) {
         // Because it is legal to have uses of an owned value produced by a
         // begin_apply after a coroutine's range, AddressLowering must move the
         // value into local storage so that such out-of-coroutine-range uses can
@@ -2660,9 +2660,9 @@ void ApplyRewriter::convertBeginApplyWithOpaqueYield() {
         auto destAddr = addrMat.materializeAddress(&oldResult);
         storage.storageAddress = destAddr;
         storage.markRewritten();
-        resultBuilder.createCopyAddr(callLoc, &newResult, destAddr,
-                                     info.isConsumed() ? IsTake : IsNotTake,
-                                     IsInitialization);
+        resultBuilder.createCopyAddr(
+            callLoc, &newResult, destAddr,
+            info.isConsumedInCaller() ? IsTake : IsNotTake, IsInitialization);
       } else {
         // [in_guaranteed_begin_apply_results] Because OSSA ensures that all
         // uses of a guaranteed value produced by a begin_apply are used within

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -402,8 +402,9 @@ computeNewArgInterfaceTypes(SILFunction *f, IndicesSet &promotableIndices,
     } else if (paramTL.isTrivial()) {
       convention = ParameterConvention::Direct_Unowned;
     } else {
-      convention = param.isGuaranteed() ? ParameterConvention::Direct_Guaranteed
-                                        : ParameterConvention::Direct_Owned;
+      convention = param.isGuaranteedInCallee()
+                       ? ParameterConvention::Direct_Guaranteed
+                       : ParameterConvention::Direct_Owned;
     }
     outTys.push_back(SILParameterInfo(paramBoxedTy.getASTType(), convention,
                                       param.getOptions()));

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
@@ -2125,7 +2125,7 @@ static MoveConstraint getMoveConstraint(SILValue addr) {
     // An indirect argument is guaranteed if it's @in_guaranteed.
     auto *arg = base.getArgument();
     return MoveConstraint::forGuaranteed(
-        arg->getArgumentConvention().isGuaranteedConvention());
+        arg->getArgumentConvention().isGuaranteedConventionInCaller());
   }
   case AccessRepresentation::Kind::Yield: {
     auto baseAddr = base.getBaseAddress();
@@ -2133,7 +2133,7 @@ static MoveConstraint getMoveConstraint(SILValue addr) {
         cast<MultipleValueInstructionResult>(baseAddr)->getParent());
     auto index = *bai->getIndexOfResult(baseAddr);
     auto info = bai->getSubstCalleeConv().getYieldInfoForOperandIndex(index);
-    return MoveConstraint::forGuaranteed(!info.isConsumed());
+    return MoveConstraint::forGuaranteed(!info.isConsumedInCaller());
   }
   case AccessRepresentation::Kind::Nested: {
     auto *bai = cast<BeginAccessInst>(base.getBaseAddress());

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -312,7 +312,7 @@ static void copyParameterArgumentsForApply(
     auto argConv = applySite.getArgumentConvention(argOperand);
     auto collectNewArg = [&](SILValue newArg) {
       copiedArgs.push_back(newArg);
-      if (argConv.isGuaranteedConvention() &&
+      if (argConv.isGuaranteedConventionInCaller() &&
           argConv != SILArgumentConvention::Indirect_InoutAliasable)
         newArgsToDestroy.push_back(newArg);
     };

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2566,7 +2566,7 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
   }
 
   if (auto *yi = dyn_cast<YieldInst>(user)) {
-    if (yi->getYieldInfoForOperand(*op).isGuaranteed()) {
+    if (yi->getYieldInfoForOperand(*op).isGuaranteedInCaller()) {
       LLVM_DEBUG(llvm::dbgs() << "coroutine yield\n");
       SmallVector<TypeTreeLeafTypeRange, 2> leafRanges;
       TypeTreeLeafTypeRange::get(op, getRootAddress(), leafRanges);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
@@ -285,7 +285,7 @@ bool noncopyable::memInstMustConsume(Operand *memOper) {
   case SILInstructionKind::BeginApplyInst:
   case SILInstructionKind::TryApplyInst: {
     FullApplySite applySite(memInst);
-    return applySite.getCaptureConvention(*memOper).isOwnedConvention();
+    return applySite.getCaptureConvention(*memOper).isOwnedConventionInCaller();
   }
   case SILInstructionKind::BeginAccessInst:
     return cast<BeginAccessInst>(memInst)->getAccessKind() ==

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1031,7 +1031,7 @@ struct ConcreteArgumentCopy {
     assert(!paramInfo.isIndirectMutating()
            && "A mutated opened existential value can't be replaced");
 
-    if (!paramInfo.isConsumed())
+    if (!paramInfo.isConsumedInCaller())
       return std::nullopt;
 
     SILValue origArg = apply.getArgument(argIdx);

--- a/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
@@ -734,7 +734,7 @@ SILValue EagerDispatch::emitArgumentConversion(
     // loadable on the caller's side?
     auto argConv = substConv.getSILArgumentConvention(ArgIdx);
     SILValue Val;
-    if (!argConv.isGuaranteedConvention()) {
+    if (!argConv.isGuaranteedConventionInCaller()) {
       Val = Builder.emitLoadValueOperation(Loc, CastArg,
                                            LoadOwnershipQualifier::Take);
     } else {

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -201,7 +201,7 @@ collectLoads(Operand *addressUse, CopyAddrInst *originalCopy,
   case SILInstructionKind::TryApplyInst:
   case SILInstructionKind::BeginApplyInst: {
     auto convention = ApplySite(user).getArgumentConvention(*addressUse);
-    if (!convention.isGuaranteedConvention())
+    if (!convention.isGuaranteedConventionInCaller())
       return false;
 
     loadInsts.insert(user);
@@ -221,7 +221,7 @@ collectLoads(Operand *addressUse, CopyAddrInst *originalCopy,
   case SILInstructionKind::YieldInst: {
     auto *yield = cast<YieldInst>(user);
     auto convention = yield->getArgumentConventionForOperand(*addressUse);
-    if (!convention.isGuaranteedConvention())
+    if (!convention.isGuaranteedConventionInCaller())
       return false;
 
     loadInsts.insert(user);

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -806,7 +806,7 @@ swift::devirtualizeClassMethod(SILPassManager *pm, FullApplySite applySite,
     SILValue arg = *paramArgIter;
     if (builder.hasOwnership() && arg->getType().isObject() &&
         arg->getOwnershipKind() == OwnershipKind::Owned &&
-        param.isGuaranteed()) {
+        param.isGuaranteedInCaller()) {
       SILBuilderWithScope borrowBuilder(applySite.getInstruction(), builder);
       arg = borrowBuilder.createBeginBorrow(loc, arg);
       newArgBorrows.push_back(arg);
@@ -1089,7 +1089,7 @@ devirtualizeWitnessMethod(SILPassManager *pm, ApplySite applySite, SILFunction *
           applySite.getKind() != ApplySiteKind::PartialApplyInst &&
           arg->getType().isObject() &&
           arg->getOwnershipKind() == OwnershipKind::Owned &&
-          paramInfo.isGuaranteedConvention()) {
+          paramInfo.isGuaranteedConventionInCaller()) {
         SILBuilderWithScope borrowBuilder(applySite.getInstruction(),
                                           argBuilder);
         arg = borrowBuilder.createBeginBorrow(applySite.getLoc(), arg);

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -143,7 +143,8 @@ void GenericCloner::populateCloned() {
           // Store the new direct parameter to an alloc_stack.
           createAllocStack();
           SILValue addr;
-          if (NewArg->getArgumentConvention().isGuaranteedConvention() &&
+          if (NewArg->getArgumentConvention()
+                  .isGuaranteedConventionInCallee() &&
               NewArg->getFunction()->hasOwnership()) {
             auto *sbi = getBuilder().createStoreBorrow(Loc, NewArg, ASI);
             StoreBorrowsToCleanup.push_back(sbi);

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -983,7 +983,7 @@ createSpecializedType(CanSILFunctionType SubstFTy, SILModule &M) const {
     // owned/guaranteed (except it's a trivial type).
     auto C = ParameterConvention::Direct_Unowned;
     if (!isTrivial) {
-      if (PI.isGuaranteed()) {
+      if (PI.isGuaranteedInCallee()) {
         C = ParameterConvention::Direct_Guaranteed;
       } else {
         C = ParameterConvention::Direct_Owned;
@@ -2265,7 +2265,7 @@ prepareCallArguments(ApplySite AI, SILBuilder &Builder,
       argConv = substConv.getSILArgumentConvention(ArgIdx);
     }
     SILValue Val;
-    if (!argConv.isGuaranteedConvention()) {
+    if (!argConv.isGuaranteedConventionInCaller()) {
       Val = Builder.emitLoadValueOperation(Loc, InputValue,
                                            LoadOwnershipQualifier::Take);
     } else {
@@ -2748,7 +2748,7 @@ ReabstractionThunkGenerator::convertReabstractionThunkArguments(
                                Builder.getTypeExpansionContext()));
       assert(ParamTy.isAddress());
       SILFunctionArgument *NewArg = addFunctionArgument(Thunk, ParamTy, specArg);
-      if (!NewArg->getArgumentConvention().isGuaranteedConvention()) {
+      if (!NewArg->getArgumentConvention().isGuaranteedConventionInCallee()) {
         SILValue argVal = Builder.emitLoadValueOperation(
             Loc, NewArg, LoadOwnershipQualifier::Take);
         Arguments.push_back(argVal);

--- a/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
+++ b/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
@@ -766,7 +766,7 @@ bool FilterCandidates::rewritableArgumentIndicesForApply(
       if (apply.isArgumentOperand(operand)) {
         auto convention = apply.getArgumentConvention(operand);
         if (isSimpleExtendedIntroducerDef(operand.get()) &&
-            convention.isOwnedConvention()) {
+            convention.isOwnedConventionInCaller()) {
           indices.push_back(apply.getCalleeArgIndex(operand));
         } else {
           // This argument is a use of %lifetime but not an owned use that we

--- a/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
+++ b/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
@@ -181,7 +181,7 @@ void PartialApplyCombiner::processSingleApply(FullApplySite paiAI) {
       arg = argToTmpCopy.lookup(arg);
 
     if (paramInfo[paramInfo.size() - partialApplyArgs.size() + i]
-            .isConsumed()) {
+            .isConsumedInCaller()) {
       // Copy the argument as the callee may consume it.
       if (arg->getType().isAddress()) {
         auto *ASI = builder.createAllocStack(pai->getLoc(), arg->getType());

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -499,12 +499,12 @@ void SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
             asi->setIsLexical();
         } else {
           // Insert begin/end borrow for guaranteed arguments.
-          if (paramInfo.isGuaranteed()) {
+          if (paramInfo.isGuaranteedInCaller()) {
             if (SILValue newValue = borrowFunctionArgument(callArg, idx)) {
               callArg = newValue;
               borrowedArgs[idx] = true;
             }
-          } else if (paramInfo.isConsumed()) {
+          } else if (paramInfo.isConsumedInCaller()) {
             if (SILValue newValue = moveFunctionArgument(callArg, idx)) {
               callArg = newValue;
             }


### PR DESCRIPTION
Create two versions of the following functions:

isConsumedParameter
isGuaranteedParameter
SILParameterInfo::isConsumed
SILParameterInfo::isGuaranteed
SILArgumentConvention::isOwnedConvention
SILArgumentConvention::isGuaranteedConvention

This commit doesn't change any functionality as the caller and callee versions are functionally the same at present.

These changes will be needed when we add a new convention for non-trivial C++ types as the functions will return different answers depending on whether they are called for the caller or the callee.