### PR TITLE
[Windows] Prepare for swift-foundation in the toolchain

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1414,6 +1414,7 @@ function Build-Dispatch([Platform]$Platform, $Arch, [switch]$Test = $false) {
 
 function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
   $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch
+  $SwiftSyntaxBinaryCache = Get-TargetProjectBinaryCache $Arch SwiftSyntax
   $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch Foundation
   $ShortArch = $Arch.LLVMName
 
@@ -1458,6 +1459,10 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
         ZLIB_LIBRARY = "$LibraryRoot\zlib-1.3.1\usr\lib\$Platform\$ShortArch\zlibstatic.lib";
         ZLIB_INCLUDE_DIR = "$LibraryRoot\zlib-1.3.1\usr\include";
         dispatch_DIR = "$DispatchBinaryCache\cmake\modules";
+        SwiftSyntax_DIR = "$SwiftSyntaxBinaryCache\cmake\modules";
+        _SwiftFoundation_SourceDIR = "$SourceCache\swift-foundation";
+        _SwiftFoundationICU_SourceDIR = "$SourceCache\swift-foundation-icu";
+        _SwiftCollections_SourceDIR = "$SourceCache\swift-collections"
       } + $TestingDefines)
   }
 }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1414,7 +1414,7 @@ function Build-Dispatch([Platform]$Platform, $Arch, [switch]$Test = $false) {
 
 function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
   $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch
-  $SwiftSyntaxBinaryCache = Get-TargetProjectBinaryCache $Arch SwiftSyntax
+  $SwiftSyntaxDir = Get-HostProjectCMakeModules Compilers
   $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch Foundation
   $ShortArch = $Arch.LLVMName
 
@@ -1459,7 +1459,7 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
         ZLIB_LIBRARY = "$LibraryRoot\zlib-1.3.1\usr\lib\$Platform\$ShortArch\zlibstatic.lib";
         ZLIB_INCLUDE_DIR = "$LibraryRoot\zlib-1.3.1\usr\include";
         dispatch_DIR = "$DispatchBinaryCache\cmake\modules";
-        SwiftSyntax_DIR = "$SwiftSyntaxBinaryCache\cmake\modules";
+        SwiftSyntax_DIR = "$SwiftSyntaxDir";
         _SwiftFoundation_SourceDIR = "$SourceCache\swift-foundation";
         _SwiftFoundationICU_SourceDIR = "$SourceCache\swift-foundation-icu";
         _SwiftCollections_SourceDIR = "$SourceCache\swift-collections"


### PR DESCRIPTION
This PR is the same effective change as https://github.com/apple/swift/pull/74019 but for the Windows build via `build.ps1`