### PR TITLE
[IRGen] Strip marker protocols in a few more places

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -186,6 +186,9 @@ IRGenMangler::mangleTypeForFlatUniqueTypeRef(CanGenericSignature sig,
   // mangled name.
   configureForSymbolicMangling();
 
+  llvm::SaveAndRestore<bool> savedAllowMarkerProtocols(
+      AllowMarkerProtocols, false);
+
   // We don't make the substitution adjustments above because they're
   // target-specific and so would break the goal of getting a unique
   // string.

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -706,9 +706,6 @@ protected:
                          llvm::function_ref<void ()> body);
 
   std::string mangleTypeSymbol(Type type, const char *Op) {
-    llvm::SaveAndRestore<bool> savedAllowMarkerProtocols(AllowMarkerProtocols,
-                                                         false);
-
     beginMangling();
     appendType(type, nullptr);
     appendOperator(Op);

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1979,6 +1979,16 @@ namespace {
       
     MetadataResponse visitExistentialType(CanExistentialType type,
                                           DynamicMetadataRequest request) {
+      if (auto *PCT =
+              type->getConstraintType()->getAs<ProtocolCompositionType>()) {
+        auto constraintTy = PCT->withoutMarkerProtocols();
+        if (constraintTy->getClassOrBoundGenericClass()) {
+          auto response = IGF.emitTypeMetadataRef(
+              constraintTy->getCanonicalType(), request);
+          return setLocal(type, response);
+        }
+      }
+
       if (auto metadata = tryGetLocal(type, request))
         return metadata;
 

--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -14,7 +14,7 @@ extension Int: P { }
 extension Array: P where Element: P { }
 
 // No mention of the marker protocol for runtime type instantiation.
-// CHECK-LABEL: @"$sSS_yptMD" =
+// CHECK-LABEL: @"$sSS_15marker_protocol1P_ptMD" =
 // CHECK-SAME: @"symbolic SS_ypt"
 
 // CHECK-LABEL: @"$s15marker_protocol1QMp" = {{(dllexport |protected )?}}constant
@@ -47,7 +47,7 @@ struct HasMarkers {
 
 // Note: no mention of marker protocols when forming a dictionary.
 // CHECK-LABEL: define{{.*}}@"$s15marker_protocol0A12InDictionaryypyF"
-// CHECK: call ptr @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$sSS_yptMD")
+// CHECK: call ptr @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$sSS_15marker_protocol1P_ptMD")
 public func markerInDictionary() -> Any {
   let dict: [String: P] = ["answer" : 42]
   return dict
@@ -92,7 +92,7 @@ let v1 = (any C & P).self
 let v2 = C.self
 
 // CHECK-LABEL: define hidden swiftcc void @"$s15marker_protocol23testProtocolCompositionyyF"()
-// CHECK: [[V1:%.*]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s15marker_protocol1CCMD")
+// CHECK: [[V1:%.*]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s15marker_protocol1P_AA1CCXcMD")
 // CHECK: [[V2:%.*]] = load ptr, ptr @"$s15marker_protocol2v2AA1CCmvp"
 func testProtocolComposition() {
   print(v1 == v2)

--- a/test/IRGen/marker_protocol_backdeploy.swift
+++ b/test/IRGen/marker_protocol_backdeploy.swift
@@ -20,8 +20,8 @@ protocol R { }
 // Suppress marker protocols when forming existentials at runtime
 public func takeAnyType<T>(_: T.Type) { }
 
-// CHECK-LABEL: define {{.*}}@"$s26marker_protocol_backdeploy1Q_AA1RpMa"
-// CHECK: $s26marker_protocol_backdeploy1Q_AA1RpML
+// CHECK-LABEL: define {{.*}}@"$ss8Sendable_26marker_protocol_backdeploy1QAB1RpMa"
+// CHECK: ss8Sendable_26marker_protocol_backdeploy1QAB1RpML
 // CHECK-NOT: Sendable
 // CHECK: s26marker_protocol_backdeploy1QMp
 // CHECK-NOT: Sendable

--- a/test/Interpreter/protocol_composition_with_markers.swift
+++ b/test/Interpreter/protocol_composition_with_markers.swift
@@ -27,3 +27,27 @@ do {
   print(v1 == v2)
   // CHECK: true
 }
+
+@_marker
+protocol Marker {
+}
+
+do {
+  print(G<any (C & Sendable)>.self)
+  // CHECK: G<C>
+
+  class D<T> {
+  }
+
+  print((D<Int> & Sendable).self)
+  // CHECK: D<Int>
+
+  print((D<C & Marker> & Sendable).self)
+  // CHECK: D<C>
+
+  print((any Marker & Sendable).self)
+  // CHECK: Any
+
+  print((AnyObject & Sendable & Marker).self)
+  // CHECK: AnyObject
+}

--- a/test/Interpreter/protocol_composition_with_markers.swift
+++ b/test/Interpreter/protocol_composition_with_markers.swift
@@ -50,4 +50,11 @@ do {
 
   print((AnyObject & Sendable & Marker).self)
   // CHECK: AnyObject
+
+  func generic<T>(_: T.Type) {
+    print((D<T> & Sendable).self)
+  }
+
+  generic(Int.self)
+  // CHECK: D<Int>
 }

--- a/test/Interpreter/rdar128667580.swift
+++ b/test/Interpreter/rdar128667580.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-clang %t/Impl.m -c -o %t/Test.o
+// RUN: %target-build-swift %t/main.swift -import-objc-header %t/Test.h %t/Test.o -Xfrontend -disable-concrete-type-metadata-mangled-name-accessors -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+//--- Test.h
+#import "Foundation/Foundation.h"
+
+@interface Test : NSObject { }
+@end
+
+//--- Impl.m
+#import "Test.h"
+
+@implementation Test
+@end
+
+//--- main.swift
+print((any Test & Sendable).self)
+// CHECK: Test


### PR DESCRIPTION
- Strip marker protocols when forming generic metadata requests

   Without this might might end up with a single element protocol compositions
   which are invalid.

- Move marker protocol stripping from `mangleTypeSymbol` to `mangleTypeForFlatUniqueTypeRef`

  The original check introduced by https://github.com/apple/swift/pull/71855
  is too broad. For concrete metadata we call the runtime demangler so
  we need to strip off marker protocols when mangling that string and
  `mangleTypeForReflection` already does that.

Resolves: rdar://128667580

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
