### PR TITLE
6.0: [TypeLowering] Return pseudogeneric @autoreleasing.

### DIFF
--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -1,18 +1,11 @@
 // Please keep this file in alphabetical order!
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-sil-ownership-verifier -emit-module -o %t %s -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-sil-ownership-verifier -parse-as-library %t/extensions.swiftmodule -typecheck -emit-objc-header-path %t/extensions.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/extensions.swiftmodule -typecheck -emit-objc-header-path %t/extensions.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
 // RUN: %FileCheck %s < %t/extensions.h
 // RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/extensions.h
 // RUN: %check-in-clang %t/extensions.h
-
-// This test generates invalid SIL. It will cause a compiler assert in
-// both -Onone and -O builds:
-// Error! Found a leaked owned value that was never consumed.
-// -disable-sil-ownership-verifier is a temporary workaround.
-// rdar://64375208 (Wrong lowering of PrintAsObjC code. Result is
-// unowned instead of autoreleased)
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/Inputs/usr/include/objc_extensions_helper.h
+++ b/test/SILGen/Inputs/usr/include/objc_extensions_helper.h
@@ -4,3 +4,9 @@
 - (void)objCBaseMethod;
 @property (nonatomic, strong) NSString *prop;
 @end
+
+@protocol Pettable
+@end
+
+@interface PettableContainer<T : id<Pettable>> : NSObject
+@end

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -185,3 +185,10 @@ func testStaticVarAccess() {
   // CHECK: [[ADDR:%.*]] = pointer_to_address [[PTR]]
   _ = Base.x
 }
+
+extension PettableContainer {
+  // CHECK-LABEL: sil private [thunk] [ossa] @$sSo17PettableContainerC15objc_extensionsE7extractxyFTo : $@convention(objc_method) @pseudogeneric <T where T : Pettable> (PettableContainer<T>) -> @autoreleased T
+  @objc public func extract() -> T { fatalError() }
+// CHECK-LABEL: sil private [thunk] [ossa] @$sSo17PettableContainerC15objc_extensionsE8extract2xSgyFTo : $@convention(objc_method) @pseudogeneric <T where T : Pettable> (PettableContainer<T>) -> @autoreleased Optional<T>
+  @objc public func extract2() -> T? { fatalError() }
+}


### PR DESCRIPTION
**Explanation**: Fix a leak in certain Swift extensions of pseudogeneric ObjC types.

Given a pseudogeneric Objective-C type
```
@interface PG<T>
@end
```
it's permitted to write an extension in Swift which returns the pseudogeneric parameter
```
extension PG {
  func get() -> T {...}
}
```

which can be called from ObjC.  To match Objective-C conventions, these methods should return values autoreleased.

Previously, these methods returned values unowned.  The result was a memory leak and a corresponding SIL verification error.

Here, this is fixed by using the `@autoreleased` convention in such cases.
**Scope**: Affects extensions of pseudogeneric ObjC types.
**Issue**: rdar://64375208
**Original PR**: https://github.com/apple/swift/pull/74072
**Risk**: Low.
**Testing**: Enabled SIL verification in existing test.
**Reviewer**: Andrew Trick ( @atrick )
