### PR TITLE
Tweak "initializable values" logic slightly to address source incompatibilities

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7404,6 +7404,11 @@ VarDecl::mutability(const DeclContext *UseDC,
   if (!isLet()) {
     if (hasInitAccessor()) {
       if (auto *ctor = dyn_cast_or_null<ConstructorDecl>(UseDC)) {
+        // If we're referencing 'self.', it's mutable.
+        if (!base ||
+            (*base && ctor->getImplicitSelfDecl() == (*base)->getDecl()))
+          return StorageMutability::Mutable;
+
         return storageIsMutable(supportsMutation());
       }
     }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1614,3 +1614,36 @@ class DerivedWrappedProperty : SomeClass {
   }  // expected-error {{'super.init' isn't called on all paths before returning from initializer}}
 
 }
+
+// rdar://129031705 ([error: ... used before being initialized)
+// Related to treating 'let's as immutable RValues.
+struct S {
+  let rotation: (Int, Int)
+
+  init() {
+    rotation.0 = 0
+    rotation.1 = rotation.0
+  }
+}
+
+// rdar://128890586: Init accessors
+final class HasInitAccessors {
+  private var _ints: [Int] = []
+
+  private var ints: [Int] {
+    @storageRestrictions(initializes: _ints)
+    init(initialValue) {
+        _ints = initialValue
+    }
+    get {
+        return _ints
+    }
+    set {
+      _ints = newValue
+    }
+  }
+
+  init() {
+    ints.append(0)
+  }
+}


### PR DESCRIPTION
Back of slightly on when we treat a "let" instance property as immutable within an initializer, to deal with two newly-introduced source incompatibilities.

Fixes rdar://129253556.