### PR TITLE
6.0: [ConsumeObjectChecker] End lifetimes at consumes.

### DIFF
--- a/include/swift/SIL/ParseTestSpecification.h
+++ b/include/swift/SIL/ParseTestSpecification.h
@@ -186,7 +186,15 @@ public:
   }
   Operand *takeOperand() { return takeInstance<OperandArgument>("operand"); }
   SILInstruction *takeInstruction() {
-    return takeInstance<InstructionArgument>("instruction");
+    auto argument = takeArgument();
+    if (isa<ValueArgument>(argument)) {
+      auto value = cast<ValueArgument>(argument).getValue();
+      auto *definingInstruction = value.getDefiningInstruction();
+      assert(definingInstruction &&
+             "selected instruction via argument value!?");
+      return definingInstruction;
+    }
+    return getInstance<InstructionArgument>("instruction", argument);
   }
   SILArgument *takeBlockArgument() {
     return takeInstance<BlockArgumentArgument>("block argument");

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -613,9 +613,10 @@ protected:
                                            ValueSet &visited,
                                            SILValue value);
 
-  void updateForUse(SILInstruction *user, LifetimeEnding lifetimeEnding);
-
 public:
+  /// Add \p inst to liveness which uses the def as indicated by \p usage.
+  void updateForUse(SILInstruction *inst, LifetimeEnding usage);
+
   /// For flexibility, \p lifetimeEnding is provided by the
   /// caller. PrunedLiveness makes no assumptions about the def-use
   /// relationships that generate liveness. For example, use->isLifetimeEnding()

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -185,6 +185,11 @@ enum PruneDebugInsts_t : bool {
   PruneDebugInsts = true,
 };
 
+enum MaximizeLifetime_t : bool {
+  DontMaximizeLifetime = false,
+  MaximizeLifetime = true,
+};
+
 /// Canonicalize OSSA lifetimes.
 ///
 /// Allows the allocation of analysis state to be reused across calls to
@@ -230,7 +235,7 @@ private:
 
   /// If true, lifetimes will not be shortened except when necessary to avoid
   /// copies.
-  bool maximizeLifetime;
+  const MaximizeLifetime_t maximizeLifetime;
 
   // If present, will be used to ensure that the lifetime is not shortened to
   // end inside an access scope which it previously enclosed.  (Note that ending
@@ -318,7 +323,8 @@ public:
   };
 
   CanonicalizeOSSALifetime(PruneDebugInsts_t pruneDebugMode,
-                           bool maximizeLifetime, SILFunction *function,
+                           MaximizeLifetime_t maximizeLifetime,
+                           SILFunction *function,
                            NonLocalAccessBlockAnalysis *accessBlockAnalysis,
                            DominanceInfo *domTree,
                            BasicCalleeAnalysis *calleeAnalysis,

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -180,6 +180,11 @@ public:
   SWIFT_ASSERT_ONLY_DECL(void dump() const LLVM_ATTRIBUTE_USED);
 };
 
+enum PruneDebugInsts_t : bool {
+  DontPruneDebugInsts = false,
+  PruneDebugInsts = true,
+};
+
 /// Canonicalize OSSA lifetimes.
 ///
 /// Allows the allocation of analysis state to be reused across calls to
@@ -221,7 +226,7 @@ public:
 private:
   /// If true, then debug_value instructions outside of non-debug
   /// liveness may be pruned during canonicalization.
-  bool pruneDebugMode;
+  const PruneDebugInsts_t pruneDebugMode;
 
   /// If true, lifetimes will not be shortened except when necessary to avoid
   /// copies.
@@ -312,8 +317,8 @@ public:
     }
   };
 
-  CanonicalizeOSSALifetime(bool pruneDebugMode, bool maximizeLifetime,
-                           SILFunction *function,
+  CanonicalizeOSSALifetime(PruneDebugInsts_t pruneDebugMode,
+                           bool maximizeLifetime, SILFunction *function,
                            NonLocalAccessBlockAnalysis *accessBlockAnalysis,
                            DominanceInfo *domTree,
                            BasicCalleeAnalysis *calleeAnalysis,

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -459,6 +459,10 @@ private:
   void extendLivenessToDeinitBarriers();
 
   void extendUnconsumedLiveness(PrunedLivenessBoundary const &boundary);
+  void visitExtendedUnconsumedBoundary(
+      ArrayRef<SILInstruction *> ends,
+      llvm::function_ref<void(SILInstruction *, PrunedLiveness::LifetimeEnding)>
+          visitor);
 
   void insertDestroysOnBoundary(PrunedLivenessBoundary const &boundary);
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
@@ -48,7 +48,7 @@ struct OSSACanonicalizer {
 
   OSSACanonicalizer(SILFunction *fn, DominanceInfo *domTree,
                     InstructionDeleter &deleter)
-      : canonicalizer(false /*pruneDebugMode*/,
+      : canonicalizer(DontPruneDebugInsts,
                       !fn->shouldOptimize() /*maximizeLifetime*/, fn,
                       nullptr /*accessBlockAnalysis*/, domTree,
                       nullptr /*calleeAnalysis*/, deleter) {}

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
@@ -64,7 +64,7 @@ struct OSSACanonicalizer {
     CanonicalizeOSSALifetime::LivenessState canonicalizerState;
 
     LivenessState(OSSACanonicalizer &parent, SILValue def)
-        : parent(parent), canonicalizerState(parent.canonicalizer, def) {}
+        : parent(parent), canonicalizerState(parent.canonicalizer, def, {}) {}
 
     ~LivenessState() { parent.clear(); }
   };

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
@@ -49,7 +49,7 @@ struct OSSACanonicalizer {
   OSSACanonicalizer(SILFunction *fn, DominanceInfo *domTree,
                     InstructionDeleter &deleter)
       : canonicalizer(DontPruneDebugInsts,
-                      !fn->shouldOptimize() /*maximizeLifetime*/, fn,
+                      MaximizeLifetime_t(!fn->shouldOptimize()), fn,
                       nullptr /*accessBlockAnalysis*/, domTree,
                       nullptr /*calleeAnalysis*/, deleter) {}
 

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -351,7 +351,7 @@ void SILCombiner::canonicalizeOSSALifetimes(SILInstruction *currentInst) {
 
   DominanceInfo *domTree = DA->get(&Builder.getFunction());
   CanonicalizeOSSALifetime canonicalizer(
-      false /*prune debug*/,
+      DontPruneDebugInsts,
       !parentTransform->getFunction()->shouldOptimize() /*maximize lifetime*/,
       parentTransform->getFunction(), NLABA, domTree, CA, deleter);
   CanonicalizeBorrowScope borrowCanonicalizer(parentTransform->getFunction(),

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -352,7 +352,7 @@ void SILCombiner::canonicalizeOSSALifetimes(SILInstruction *currentInst) {
   DominanceInfo *domTree = DA->get(&Builder.getFunction());
   CanonicalizeOSSALifetime canonicalizer(
       DontPruneDebugInsts,
-      !parentTransform->getFunction()->shouldOptimize() /*maximize lifetime*/,
+      MaximizeLifetime_t(!parentTransform->getFunction()->shouldOptimize()),
       parentTransform->getFunction(), NLABA, domTree, CA, deleter);
   CanonicalizeBorrowScope borrowCanonicalizer(parentTransform->getFunction(),
                                               deleter);

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -493,7 +493,7 @@ void CopyPropagation::run() {
   // canonicalizer performs all modifications through deleter's callbacks, so we
   // don't need to explicitly check for changes.
   CanonicalizeOSSALifetime canonicalizer(
-      pruneDebug, /*maximizeLifetime=*/!getFunction()->shouldOptimize(),
+      pruneDebug, MaximizeLifetime_t(!getFunction()->shouldOptimize()),
       getFunction(), accessBlockAnalysis, domTree, calleeAnalysis, deleter);
   // NOTE: We assume that the function is in reverse post order so visiting the
   //       blocks and pushing begin_borrows as we see them and then popping them

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -425,7 +425,7 @@ namespace {
 
 class CopyPropagation : public SILFunctionTransform {
   /// If true, debug_value instructions should be pruned.
-  bool pruneDebug;
+  PruneDebugInsts_t pruneDebug;
   /// If true, all values will be canonicalized.
   bool canonicalizeAll;
   /// If true, then borrow scopes will be canonicalized, allowing copies of
@@ -433,7 +433,7 @@ class CopyPropagation : public SILFunctionTransform {
   bool canonicalizeBorrows;
 
 public:
-  CopyPropagation(bool pruneDebug, bool canonicalizeAll,
+  CopyPropagation(PruneDebugInsts_t pruneDebug, bool canonicalizeAll,
                   bool canonicalizeBorrows)
       : pruneDebug(pruneDebug), canonicalizeAll(canonicalizeAll),
         canonicalizeBorrows(canonicalizeBorrows) {}
@@ -643,11 +643,11 @@ void CopyPropagation::run() {
 // MandatoryCopyPropagation is not currently enabled in the -Onone pipeline
 // because it may negatively affect the debugging experience.
 SILTransform *swift::createMandatoryCopyPropagation() {
-  return new CopyPropagation(/*pruneDebug*/ true, /*canonicalizeAll*/ true,
+  return new CopyPropagation(PruneDebugInsts, /*canonicalizeAll*/ true,
                              /*canonicalizeBorrows*/ false);
 }
 
 SILTransform *swift::createCopyPropagation() {
-  return new CopyPropagation(/*pruneDebug*/ true, /*canonicalizeAll*/ true,
+  return new CopyPropagation(PruneDebugInsts, /*canonicalizeAll*/ true,
                              /*canonicalizeBorrows*/ EnableRewriteBorrows);
 }

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -2070,7 +2070,7 @@ void MemoryToRegisters::canonicalizeValueLifetimes(
     }
   }
   CanonicalizeOSSALifetime canonicalizer(
-      PruneDebugInsts, /*maximizeLifetime=*/!f.shouldOptimize(), &f,
+      PruneDebugInsts, MaximizeLifetime_t(!f.shouldOptimize()), &f,
       accessBlockAnalysis, domInfo, calleeAnalysis, deleter);
   for (auto value : owned) {
     if (isa<SILUndef>(value) || value->isMarkedAsDeleted())

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -2070,7 +2070,7 @@ void MemoryToRegisters::canonicalizeValueLifetimes(
     }
   }
   CanonicalizeOSSALifetime canonicalizer(
-      /*pruneDebug=*/true, /*maximizeLifetime=*/!f.shouldOptimize(), &f,
+      PruneDebugInsts, /*maximizeLifetime=*/!f.shouldOptimize(), &f,
       accessBlockAnalysis, domInfo, calleeAnalysis, deleter);
   for (auto value : owned) {
     if (isa<SILUndef>(value) || value->isMarkedAsDeleted())

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -568,8 +568,10 @@ void CanonicalizeOSSALifetime::findOriginalBoundary(
 ///   with consumedAtExitBlocks, liveness should be extended to its original
 ///   extent.
 ///   [Extend liveness down to the boundary between green blocks and uncolored.]
-void CanonicalizeOSSALifetime::extendUnconsumedLiveness(
-    PrunedLivenessBoundary const &boundary) {
+void CanonicalizeOSSALifetime::visitExtendedUnconsumedBoundary(
+    ArrayRef<SILInstruction *> ends,
+    llvm::function_ref<void(SILInstruction *, PrunedLiveness::LifetimeEnding)>
+        visitor) {
   auto currentDef = getCurrentDef();
 
   // First, collect the blocks that were _originally_ live.  We can't use
@@ -617,7 +619,7 @@ void CanonicalizeOSSALifetime::extendUnconsumedLiveness(
     // consumes. These are just the instructions on the boundary which aren't
     // destroys.
     BasicBlockWorklist worklist(currentDef->getFunction());
-    for (auto *instruction : boundary.lastUsers) {
+    for (auto *instruction : ends) {
       if (destroys.contains(instruction))
         continue;
       if (liveness->isInterestingUser(instruction)
@@ -646,7 +648,7 @@ void CanonicalizeOSSALifetime::extendUnconsumedLiveness(
       // Add "the instruction(s) before the terminator" of the predecessor to
       // liveness.
       predecessor->getTerminator()->visitPriorInstructions([&](auto *inst) {
-        liveness->extendToNonUse(inst);
+        visitor(inst, PrunedLiveness::LifetimeEnding::NonUse());
         return true;
       });
     }
@@ -660,8 +662,16 @@ void CanonicalizeOSSALifetime::extendUnconsumedLiveness(
     // hoisting it would avoid a copy.
     if (consumedAtExitBlocks.contains(block))
       continue;
-    liveness->updateForUse(destroy, /*lifetimeEnding*/ true);
+    visitor(destroy, PrunedLiveness::LifetimeEnding::Ending());
   }
+}
+
+void CanonicalizeOSSALifetime::extendUnconsumedLiveness(
+    PrunedLivenessBoundary const &boundary) {
+  visitExtendedUnconsumedBoundary(
+      boundary.lastUsers, [&](auto *instruction, auto lifetimeEnding) {
+        liveness->updateForUse(instruction, lifetimeEnding);
+      });
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -1252,7 +1252,7 @@ static FunctionTest CanonicalizeOSSALifetimeTest(
       auto *dominanceAnalysis = test.template getAnalysis<DominanceAnalysis>();
       DominanceInfo *domTree = dominanceAnalysis->get(&function);
       auto *calleeAnalysis = test.template getAnalysis<BasicCalleeAnalysis>();
-      auto pruneDebug = arguments.takeBool();
+      auto pruneDebug = PruneDebugInsts_t(arguments.takeBool());
       auto maximizeLifetimes = arguments.takeBool();
       auto respectAccessScopes = arguments.takeBool();
       InstructionDeleter deleter;

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -1253,7 +1253,7 @@ static FunctionTest CanonicalizeOSSALifetimeTest(
       DominanceInfo *domTree = dominanceAnalysis->get(&function);
       auto *calleeAnalysis = test.template getAnalysis<BasicCalleeAnalysis>();
       auto pruneDebug = PruneDebugInsts_t(arguments.takeBool());
-      auto maximizeLifetimes = arguments.takeBool();
+      auto maximizeLifetimes = MaximizeLifetime_t(arguments.takeBool());
       auto respectAccessScopes = arguments.takeBool();
       InstructionDeleter deleter;
       CanonicalizeOSSALifetime canonicalizer(

--- a/test/Interpreter/consume_operator_kills_copyable_values.swift.gyb
+++ b/test/Interpreter/consume_operator_kills_copyable_values.swift.gyb
@@ -1,0 +1,196 @@
+// RUN: %target-run-simple-swiftgyb(-Xfrontend -sil-verify-all) | %FileCheck %t/main.swift
+// RUN: %target-run-simple-swiftgyb(-O -Xfrontend -sil-verify-all) | %FileCheck %t/main.swift
+
+// This test uses gyb substitute let and var in as the introducers for the
+// vardecls that are consumed.  This guarantees that the same ordering results
+// from checking the consume operator when applied to lets as when applied to
+// lets.
+
+// REQUIRES: executable_test
+
+class X {
+  let number: Int
+  let function: StaticString
+  let line: UInt
+  init(_ number: Int, function: StaticString = #function, line: UInt = #line) {
+    self.number = number
+    self.function = function
+    self.line = line
+    print("hi - \(function) - \(number) - \(line)")
+  }
+  deinit {
+    print("adios - \(function) - \(number) - \(line)")
+  }
+}
+
+func barrier(_ name: String = "", function: StaticString = #function, line: UInt = #line) {
+  print("barrier - \(name) - \(function) - \(line)")
+}
+
+func endcap(name: String, _ args: [Any], function: StaticString = #function, line: UInt = #line) {
+  print("\(name) \(function)(", terminator: "")
+  for (index, arg) in args.enumerated() {
+    print(arg, terminator: "")
+    if index != args.count - 1 {
+      print(", ", terminator: "")
+    }
+  }
+   print(") - \(line)")
+}
+
+func begin(_ args: [Any], function: StaticString = #function, line: UInt = #line) {
+  endcap(name: "begin", args, function: function, line: line)
+}
+
+func end(_ args: [Any], function: StaticString = #function, line: UInt = #line) {
+  endcap(name: "end", args, function: function, line: line)
+}
+
+func takeX(_ x: consuming X) {}
+
+% for introducer in ["let", "var"]:
+
+func simple_${introducer}() {
+  // CHECK-LABEL: begin simple_{{let|var}}
+  begin([])
+  do {
+  // CHECK: hi
+  ${introducer} x = X(0)
+  // CHECK: adios
+  takeX(consume x)
+  // CHECK: barrier
+  barrier()
+  }
+  // CHECK-LABEL: end simple_{{let|var}}
+  end([])
+}
+
+// CHECK-LABEL: begin testLeft_{{let|var}}(_:)(true)
+// CHECK:       hi
+// CHECK:       adios
+// CHECK:       barrier - left
+// CHECK:       barrier - end
+// CHECK-LABEL: end testLeft_{{let|var}}(_:)(true)
+// CHECK-LABEL: begin testLeft_{{let|var}}(_:)(false)
+// CHECK:       hi
+// CHECK:       barrier - right
+// CHECK:       adios
+// CHECK:       barrier - end
+// CHECK-LABEL: end testLeft_{{let|var}}(_:)(false)
+func testLeft_${introducer}(_ condition: Bool) {
+  begin([condition])
+  do {
+  ${introducer} x = X(0)
+  if condition {
+    takeX(consume x)
+    barrier("left")
+  } else {
+    barrier("right")
+  }
+  barrier("end")
+  }
+  end([condition])
+}
+
+// CHECK-LABEL: begin testNested1_{{let|var}}(_:_:)(false, false)
+// CHECK:       hi
+// CHECK:       barrier - not c1, not c2
+// CHECK:       barrier - not c1
+// CHECK:       adios
+// CHECK-LABEL: end testNested1_{{let|var}}(_:_:)(false, false)
+// CHECK-LABEL: begin testNested1_{{let|var}}(_:_:)(false, true)
+// CHECK:       hi
+// CHECK:       barrier - not c1, c2
+// CHECK:       barrier - not c1
+// CHECK:       adios
+// CHECK-LABEL: end testNested1_{{let|var}}(_:_:)(false, true)
+// CHECK-LABEL: begin testNested1_{{let|var}}(_:_:)(true, false)
+// CHECK:       hi
+// CHECK:       adios
+// CHECK:       barrier - c2
+// CHECK-LABEL: end testNested1_{{let|var}}(_:_:)(true, false)
+// CHECK-LABEL: begin testNested1_{{let|var}}(_:_:)(true, true)
+// CHECK:       hi
+// CHECK:       adios
+// CHECK:       barrier - c2
+// CHECK-LABEL: end testNested1_{{let|var}}(_:_:)(true, true)
+func testNested1_${introducer}(_ c1: Bool, _ c2: Bool) {
+  begin([c1, c2])
+  do {
+  ${introducer} x = X(0)
+  if c1 {
+    takeX(consume x)
+    barrier("c2")
+  } else {
+    if c2 {
+      takeX(x)
+      barrier("not c1, c2")
+    } else {
+      barrier("not c1, not c2")
+    }
+    barrier("not c1")
+  }
+  }
+  end([c1, c2])
+}
+
+// CHECK-LABEL: begin testNested2_{{let|var}}(_:_:)(false, false)
+// CHECK:       hi
+// CHECK:       barrier - not c1, not c2
+// CHECK:       adios
+// CHECK:       barrier - not c1
+// CHECK-LABEL: end testNested2_{{let|var}}(_:_:)(false, false)
+// CHECK-LABEL: begin testNested2_{{let|var}}(_:_:)(false, true)
+// CHECK:       hi
+// CHECK:       adios
+// CHECK:       barrier - not c1, c2
+// CHECK:       barrier - not c1
+// CHECK-LABEL: end testNested2_{{let|var}}(_:_:)(false, true)
+// CHECK-LABEL: begin testNested2_{{let|var}}(_:_:)(true, false)
+// CHECK:       hi
+// CHECK:       adios
+// CHECK:       barrier - c1
+// CHECK-LABEL: end testNested2_{{let|var}}(_:_:)(true, false)
+// CHECK-LABEL: begin testNested2_{{let|var}}(_:_:)(true, true)
+// CHECK:       hi
+// CHECK:       adios
+// CHECK:       barrier - c1
+// CHECK-LABEL: end testNested2_{{let|var}}(_:_:)(true, true)
+func testNested2_${introducer}(_ c1: Bool, _ c2: Bool) {
+  begin([c1, c2])
+  do {
+  ${introducer} x = X(0)
+  if c1 {
+    takeX(consume x)
+    barrier("c1")
+  } else {
+    if c2 {
+      takeX(consume x)
+      barrier("not c1, c2")
+    } else {
+      barrier("not c1, not c2")
+    }
+    barrier("not c1")
+  }
+  }
+  end([c1, c2])
+}
+
+func main_${introducer}() {
+  simple_${introducer}()
+  testLeft_${introducer}(true)
+  testLeft_${introducer}(false)
+  testNested1_${introducer}(false, false)
+  testNested1_${introducer}(false, true)
+  testNested1_${introducer}(true, false)
+  testNested1_${introducer}(true, true)
+  testNested2_${introducer}(false, false)
+  testNested2_${introducer}(false, true)
+  testNested2_${introducer}(true, false)
+  testNested2_${introducer}(true, true)
+}
+
+% end
+
+main_let()
+main_var()

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -119,8 +119,8 @@ bb0(%0 : $*C, %instance : @owned $C):
 // CHECK-LABEL: sil [ossa] @store_arg_to_out_addr_with_barrier : $@convention(thin) (@owned C) -> @out C {
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] : $*C, [[INSTANCE:%[^,]+]] :
 // CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
-// CHECK:         [[REGISTER_3:%[^,]+]] = copy_value [[INSTANCE]]
-// CHECK:         store [[REGISTER_3]] to [init] [[ADDR]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:         store [[COPY]] to [init] [[ADDR]]
 // CHECK:         apply [[BARRIER]]()
 // CHECK:         destroy_value [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'store_arg_to_out_addr_with_barrier'

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -5,6 +5,7 @@ sil @getOwned : $@convention(thin) () -> @owned C
 sil @barrier : $@convention(thin) () -> ()
 sil [ossa] @getC : $@convention(thin) () -> @owned C
 sil [ossa] @borrowC : $@convention(thin) (@guaranteed C) -> ()
+sil [ossa] @takeC : $@convention(thin) (@owned C) -> ()
 struct S {}
 
 @_moveOnly struct MoS {}
@@ -317,6 +318,283 @@ die:
 
 destroy:
   destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// (1) When no end is specified, the lifetime ends after the barrier.
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_1: canonicalize-ossa-lifetime
+// CHECK-LABEL: sil [ossa] @lexical_end_at_end_1 : {{.*}} {
+// CHECK:       bb0([[C1:%[^,]+]] :
+// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
+// CHECK:         [[C2:%[^,]+]] = copy_value [[C1]]
+// CHECK:         [[M:%[^,]+]] = move_value [[C2]]
+// CHECK:         apply [[TAKE_C]]([[M]])
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[C1]]
+// CHECK-LABEL: } // end sil function 'lexical_end_at_end_1'
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_1: canonicalize-ossa-lifetime
+// (2) When the move_value is specified as a lexical-lifetime-end, the lifetime doesn't extend to the destroy.
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_1: canonicalize-ossa-lifetime
+// CHECK-LABEL: sil [ossa] @lexical_end_at_end_1 : {{.*}} {
+// CHECK:       bb0([[C1:%[^,]+]] :
+// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
+// CHECK:         [[M:%[^,]+]] = move_value [[C1]]
+// CHECK:         apply [[TAKE_C]]([[M]])
+// CHECK:         apply [[BARRIER]]()
+// CHECK-LABEL: } // end sil function 'lexical_end_at_end_1'
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_1: canonicalize-ossa-lifetime
+sil [ossa] @lexical_end_at_end_1 : $@convention(thin) (@owned C) -> () {
+entry(%c1 : @owned $C):
+  specify_test "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize-ossa-lifetime true false true @argument %m"
+  %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  %c2 = copy_value %c1 : $C
+  %m = move_value %c2 : $C
+  apply %takeC(%m) : $@convention(thin) (@owned C) -> ()
+  apply %barrier() : $@convention(thin) () -> ()
+  destroy_value %c1 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// (1) When no end is specified, the lifetime ends after the barrier.
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_2: canonicalize-ossa-lifetime
+// CHECK-LABEL: sil [ossa] @lexical_end_at_end_2 : {{.*}} {
+// CHECK:       bb0([[C1:%[^,]+]] :
+// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[C2:%[^,]+]] = copy_value [[C1]]
+// CHECK:         [[M:%[^,]+]] = move_value [[C2]]
+// CHECK:         apply [[TAKE_C]]([[M]])
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[C1]]
+// CHECK-LABEL: } // end sil function 'lexical_end_at_end_2'
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_2: canonicalize-ossa-lifetime
+// (2) When the move_value is specified as a lexical-lifetime-end, the lifetime
+//     doesn't extend to the destroy.  But it DOES extend beyond barriers in
+//     blocks where unaffected by the move_value.
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_2: canonicalize-ossa-lifetime
+// CHECK-LABEL: sil [ossa] @lexical_end_at_end_2 : {{.*}} {
+// CHECK:       bb0([[C1:%[^,]+]] : @owned $C):
+// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
+// CHECK:         cond_br undef, [[LEFT]], [[RIGHT]]                         
+// CHECK:       [[LEFT]]:                                              
+// CHECK:         [[M:%[^,]+]] = move_value [[C1]]
+// CHECK:         apply [[TAKE_C]]([[M]])
+// CHECK:         br [[EXIT]]                                          
+// CHECK:       [[RIGHT]]:                                              
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[C1]]
+// CHECK:         br [[EXIT]]                                          
+// CHECK:       [[EXIT]]:                                              
+// CHECK:         apply [[BARRIER]]()
+// CHECK-LABEL: } // end sil function 'lexical_end_at_end_2'
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_2: canonicalize-ossa-lifetime
+sil [ossa] @lexical_end_at_end_2 : $@convention(thin) (@owned C) -> () {
+entry(%c1 : @owned $C):
+  specify_test "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize-ossa-lifetime true false true @argument %m"
+  %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  cond_br undef, left, right
+left:
+  %c2 = copy_value %c1 : $C
+  %m = move_value %c2 : $C
+  apply %takeC(%m) : $@convention(thin) (@owned C) -> ()
+  br exit
+right:
+  apply %barrier() : $@convention(thin) () -> ()
+  br exit
+exit:
+  apply %barrier() : $@convention(thin) () -> ()
+  destroy_value %c1 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Check barriers on branching unconsumed paths are respected.
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_3: canonicalize-ossa-lifetime
+// CHECK-LABEL: sil [ossa] @lexical_end_at_end_3 : {{.*}} {
+// CHECK:       bb0([[C1:%[^,]+]] :
+// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT_TOP:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[C2:%[^,]+]] = copy_value [[C1]]
+// CHECK:         [[M:%[^,]+]] = move_value [[C2]]
+// CHECK:         apply [[TAKE_C]]([[M]])
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT_TOP]]:
+// CHECK:         cond_br undef, [[RIGHT_LEFT:bb[0-9]+]], [[RIGHT_RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT_LEFT]]:
+// CHECK:         [[C2P:%[^,]+]] = copy_value [[C1]]
+// CHECK:         apply [[TAKE_C]]([[C2P]])
+// CHECK:         br [[RIGHT_BOTTOM:bb[0-9]+]]
+// CHECK:       [[RIGHT_RIGHT]]:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         br [[RIGHT_BOTTOM]]
+// CHECK:       [[RIGHT_BOTTOM]]:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[C1]]
+// CHECK-LABEL: } // end sil function 'lexical_end_at_end_3'
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_3: canonicalize-ossa-lifetime
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_3: canonicalize-ossa-lifetime
+// CHECK-LABEL: sil [ossa] @lexical_end_at_end_3 : {{.*}} {
+// CHECK:       bb0([[C1:%[^,]+]] :
+// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
+// CHECK:         cond_br undef, bb1, bb2
+// CHECK:       bb1:
+// CHECK:         [[M:%[^,]+]] = move_value [[C1]]
+// CHECK:         apply [[TAKE_C]]([[M]])
+// CHECK:         br bb6
+// CHECK:       bb2:
+// CHECK:         cond_br undef, bb3, bb4
+// CHECK:       bb3:
+// CHECK:         [[C2P:%[^,]+]] = copy_value [[C1]]
+// CHECK:         apply [[TAKE_C]]([[C2P]])
+// CHECK:         br bb5
+// CHECK:       bb4:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         br bb5
+// CHECK:       bb5:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[C1]]
+// CHECK:         br bb6
+// CHECK:       bb6:
+// CHECK:         apply [[BARRIER]]()
+// CHECK-LABEL: } // end sil function 'lexical_end_at_end_3'
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_3: canonicalize-ossa-lifetime
+sil [ossa] @lexical_end_at_end_3 : $@convention(thin) (@owned C) -> () {
+entry(%c1 : @owned $C):
+  specify_test "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize-ossa-lifetime true false true @argument %m"
+  %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  cond_br undef, left, right_top
+left:
+  %c2 = copy_value %c1 : $C
+  %m = move_value %c2 : $C
+  apply %takeC(%m) : $@convention(thin) (@owned C) -> ()
+  br exit
+right_top:
+  cond_br undef, right_left, right_right
+right_left:
+  %c2p = copy_value %c1 : $C
+  apply %takeC(%c2p) : $@convention(thin) (@owned C) -> ()
+  br right_bottom
+right_right:
+  apply %barrier() : $@convention(thin) () -> ()
+  br right_bottom
+right_bottom:
+  apply %barrier() : $@convention(thin) () -> ()
+  br exit
+exit:
+  apply %barrier() : $@convention(thin) () -> ()
+  destroy_value %c1 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_4: canonicalize-ossa-lifetime
+// CHECK-LABEL: sil [ossa] @lexical_end_at_end_4 : {{.*}} {
+// CHECK:       bb0([[C1:%[^,]+]] :
+// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT_TOP:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[C2:%[^,]+]] = copy_value [[C1]]
+// CHECK:         [[M:%[^,]+]] = move_value [[C2]]
+// CHECK:         apply [[TAKE_C]]([[M]])
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT_TOP]]:
+// CHECK:         cond_br undef, [[RIGHT_LEFT:bb[0-9]+]], [[RIGHT_RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT_LEFT]]:
+// CHECK:         [[C2P:%[^,]+]] = copy_value [[C1]]
+// CHECK:         [[M2:%[^,]+]] = move_value [[C2P]]
+// CHECK:         apply [[TAKE_C]]([[M2]])
+// CHECK:         br [[RIGHT_BOTTOM:bb[0-9]+]]
+// CHECK:       [[RIGHT_RIGHT]]:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         br [[RIGHT_BOTTOM]]
+// CHECK:       [[RIGHT_BOTTOM]]:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[C1]]
+// CHECK-LABEL: } // end sil function 'lexical_end_at_end_4'
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_4: canonicalize-ossa-lifetime
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_4: canonicalize-ossa-lifetime
+// CHECK-LABEL: sil [ossa] @lexical_end_at_end_4 : {{.*}} {
+// CHECK:       bb0([[C1:%[^,]+]] :
+// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC : $@convention(thin) (@owned C) -> ()
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier : $@convention(thin) () -> ()
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT_TOP:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[M:%[^,]+]] = move_value [[C1]]
+// CHECK:         apply [[TAKE_C]]([[M]])
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT_TOP]]:
+// CHECK:         cond_br undef, [[RIGHT_LEFT:bb[0-9]+]], [[RIGHT_RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT_LEFT]]:
+// CHECK:         [[M2:%[^,]+]] = move_value [[C1]]
+// CHECK:         apply [[TAKE_C]]([[M2]])
+// CHECK:         br [[RIGHT_BOTTOM:bb[0-9]+]]
+// CHECK:       [[RIGHT_RIGHT]]:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[C1]]
+// CHECK:         br [[RIGHT_BOTTOM]]
+// CHECK:       [[RIGHT_BOTTOM]]:
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         apply [[BARRIER]]()
+// CHECK-LABEL: } // end sil function 'lexical_end_at_end_4'
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_4: canonicalize-ossa-lifetime
+sil [ossa] @lexical_end_at_end_4 : $@convention(thin) (@owned C) -> () {
+entry(%c1 : @owned $C):
+  specify_test "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize-ossa-lifetime true false true @argument %m %m2"
+  %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  cond_br undef, left, right_top
+left:
+  %c2 = copy_value %c1 : $C
+  %m = move_value %c2 : $C
+  apply %takeC(%m) : $@convention(thin) (@owned C) -> ()
+  br exit
+right_top:
+  cond_br undef, right_left, right_right
+right_left:
+  %c2p = copy_value %c1 : $C
+  %m2 = move_value %c2p : $C
+  apply %takeC(%m2) : $@convention(thin) (@owned C) -> ()
+  br right_bottom
+right_right:
+  apply %barrier() : $@convention(thin) () -> ()
+  br right_bottom
+right_bottom:
+  apply %barrier() : $@convention(thin) () -> ()
+  br exit
+exit:
+  apply %barrier() : $@convention(thin) () -> ()
+  destroy_value %c1 : $C
   %retval = tuple ()
   return %retval : $()
 }

--- a/validation-test/SILOptimizer/rdar113142446.sil
+++ b/validation-test/SILOptimizer/rdar113142446.sil
@@ -1,0 +1,31 @@
+// RUN: %target-sil-opt -opt-mode=none  -enable-sil-verify-all %s -sil-consume-operator-copyable-values-checker | %FileCheck %s
+// RUN: %target-sil-opt -opt-mode=speed -enable-sil-verify-all %s -sil-consume-operator-copyable-values-checker | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+class X {}
+
+struct S {}
+
+sil @getX : $@convention(thin) () -> @owned X
+sil @takeX : $@convention(thin) (@owned X) -> S
+
+// CHECK-LABEL: sil [ossa] @testit : {{.*}} {
+// CHECK-NOT:     copy_value
+// CHECK-LABEL: } // end sil function 'testit'
+sil [ossa] @testit : $@convention(thin) () -> () {
+  %getX = function_ref @getX : $@convention(thin) () -> @owned X
+  %x = apply %getX() : $@convention(thin) () -> @owned X
+  %begin = move_value [lexical] [var_decl] %x : $X
+  debug_value %begin : $X, let, name "x"
+  %copy = copy_value %begin : $X
+  %consume = move_value [allows_diagnostics] %copy : $X
+  %takeX = function_ref @takeX : $@convention(thin) (@owned X) -> S
+  apply %takeX(%consume) : $@convention(thin) (@owned X) -> S
+  destroy_value %begin : $X
+  %retval = tuple ()
+  return %retval : $()
+}
+


### PR DESCRIPTION
**Explanation**: Fixed `let` consume checker to end lifetimes at `consume`s.

The consume checker verifies that there are no _non-destroy_ users after a `consume`.  When there are, it issues diagnostics.  There may, however, be _destroy_ users after a `consume`--these correspond to the value's original lifetime.

Previously, the checker did not shorten the lifetime to end at the `consume`.  The result was that the object would remain alive despite the use of the `consume` operator.

Here, this is fixed by trimming the lifetime of the value to end at the uses of the `consume` operator and to otherwise be as long as possible (while staying within the original lifetime).
**Scope**: Affects consume checking.
**Issue**: rdar://113142446
**Original PR**: https://github.com/apple/swift/pull/74109
**Risk**: Low.
**Testing**: Added new execution and SIL level tests.
**Reviewer**: Andrew Trick ( @atrick )
