### PR TITLE
[ChangeLog] Updated entry for SE-0423

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ And the module structure to support such applications looks like this:
 
   ```swift
   @MainActor
-  class MyViewController: ViewDelegateProtocol {
+  class MyViewController: @preconcurrency ViewDelegateProtocol {
     func respondToUIEvent() {
       // implementation...
     }


### PR DESCRIPTION
Fixed the usage of `@preconcurrency` conformance in the CHANGELOG.md example code based on the feature's proposal document introduced in [SE-0423](https://github.com/apple/swift-evolution/blob/main/proposals/0423-dynamic-actor-isolation.md).

The entry was added here: https://github.com/apple/swift/pull/73989