### PR TITLE
[Synchronization] Fix Wasm mutex build

### DIFF
--- a/stdlib/public/Synchronization/Mutex/WasmImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/WasmImpl.swift
@@ -23,7 +23,7 @@ internal func _swift_stdlib_wait(
 @_extern(c, "llvm.wasm32.memory.atomic.notify")
 internal func _swift_stdlib_wake(on: UnsafePointer<UInt32>, count: UInt32)
 
-extension Atomic where Value == UInt32 {
+extension Atomic where Value == _MutexHandle.State {
   internal borrowing func _wait(expected: _MutexHandle.State) {
     _swift_stdlib_wait(
       on: .init(_rawAddress),


### PR DESCRIPTION
This change fixes the following build error happening on Wasm:
```
error: referencing instance method '_wait(expected:)' on 'Atomic' requires the types '_MutexHandle.State' and 'UInt32' be equivalent
```
