### PR TITLE
Expand the work from #73491 to support more MPE layouts.

### DIFF
--- a/include/swift/RemoteInspection/BitMask.h
+++ b/include/swift/RemoteInspection/BitMask.h
@@ -74,7 +74,16 @@ public:
 
   BitMask(unsigned sizeInBytes, uint64_t sourceMask): size(sizeInBytes) {
     mask = (uint8_t *)calloc(1, sizeInBytes);
-    memcpy(mask, &sourceMask, sizeInBytes);
+    if (!mask) {
+      assert(false && "Failed to allocate Bitmask");
+      size = 0;
+      return;
+    }
+    size_t toCopy = sizeInBytes;
+    if (toCopy > sizeof(sourceMask)) {
+      toCopy = sizeof(sourceMask);
+    }
+    memcpy(mask, &sourceMask, toCopy);
   }
 
   // Construct a bitmask of the appropriate number of bytes

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -1987,6 +1987,15 @@ public:
     default: Kind = EnumKind::MultiPayloadEnum; break;
     }
 
+    // Sanity:  Ignore any enum that claims to have a size more than 1MiB
+    // This avoids allocating lots of memory for spare bit mask calculations
+    // when clients try to interpret random chunks of memory as type descriptions.
+    if (Size > (1024ULL * 1024)) {
+      unsigned Stride = ((Size + Alignment - 1) & ~(Alignment - 1));
+      return TC.makeTypeInfo<UnsupportedEnumTypeInfo>(
+	Size, Alignment, Stride, NumExtraInhabitants, BitwiseTakable, Kind, Cases);
+    }
+
     if (Cases.size() == 1) {
       if (EffectivePayloadCases == 0) {
         // Zero-sized enum with only one empty case

--- a/validation-test/Reflection/Inputs/reflect_Enum_values_resilient_enums.swift
+++ b/validation-test/Reflection/Inputs/reflect_Enum_values_resilient_enums.swift
@@ -1,0 +1,10 @@
+
+public enum E1_resilient {
+case a
+case b
+}
+
+public enum E2_resilient {
+case c(E1_resilient)
+case d(E1_resilient)
+}

--- a/validation-test/Reflection/reflect_Enum_values_resilient.swift
+++ b/validation-test/Reflection/reflect_Enum_values_resilient.swift
@@ -9,6 +9,7 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_values_resilient | tee /dev/stderr | %FileCheck %s --dump-input=fail
 
 // REQUIRES: executable_test
+// REQUIRES: objc_interop, OS=macosx
 // UNSUPPORTED: use_os_stdlib
 
 import SwiftReflectionTest

--- a/validation-test/Reflection/reflect_Enum_values_resilient.swift
+++ b/validation-test/Reflection/reflect_Enum_values_resilient.swift
@@ -1,0 +1,74 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_enums)) -enable-library-evolution %S/Inputs/reflect_Enum_values_resilient_enums.swift -emit-module -emit-module-path %t/resilient_enums.swiftmodule -module-name resilient_enums
+// RUN: %target-codesign %t/%target-library-name(resilient_enums)
+
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -L %t -I %t -lresilient_enums -o %t/reflect_Enum_values_resilient %target-rpath(%t)
+// RUN: %target-codesign %t/reflect_Enum_values_resilient
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_values_resilient | tee /dev/stderr | %FileCheck %s --dump-input=fail
+
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+
+import resilient_enums
+
+// Non-resilient enum wrapping a resilient enum
+// This doesn't use spare bits of the inner enum
+enum E2 {
+case y(E1_resilient)
+case z(E1_resilient)
+}
+
+// Contrast:
+// E2_resilient is a resilient enum wrapping a resilient enum
+// This does use spare bits of the inner enum
+
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_values_resilient.E2)
+// CHECK-NEXT: Value: .y(.a)
+
+reflect(enumValue: E2.y(.a))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_values_resilient.E2)
+// CHECK-NEXT: Value: .z(.b)
+
+reflect(enumValue: E2.z(.b))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum resilient_enums.E1_resilient)
+// CHECK-NEXT: Value: .a
+
+reflect(enumValue: E1_resilient.a)
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum resilient_enums.E1_resilient)
+// CHECK-NEXT: Value: .b
+
+reflect(enumValue: E1_resilient.b)
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum resilient_enums.E2_resilient)
+// CHECK-NEXT: Value: .c(.a)
+
+reflect(enumValue: E2_resilient.c(.a))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum resilient_enums.E2_resilient)
+// CHECK-NEXT: Value: .d(.b)
+
+reflect(enumValue: E2_resilient.d(.b))
+
+doneReflecting()
+
+// CHECK: Done.


### PR DESCRIPTION
This is also switches the MPE layout code to exclusively use the new approach.  The key observation: existing reflection metadata seems to already provide enough information in all cases, so we can abandon an earlier effort to add spare bitmask data.

There is some risk that the old code may have handled some enums that aren't (yet) fully supported by the new code.  However, I did a bunch of experiments and found that our existing test cases have decent coverage of the major capabilities and I've also added a new test case specifically to exercise enum layouts being accessed resiliently.  So if there are regressions from this change, they should be minor and easily fixed.

Resolves rdar://129281368