### PR TITLE
AST: Don't skip function bodies that follow a top-level guard [6.0]

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9495,6 +9495,12 @@ bool IsFunctionBodySkippedRequest::evaluate(
       skippingMode == FunctionBodySkipping::NonInlinableWithoutTypes)
     return false;
 
+  // Don't skip functions that follow a top-level guard statement.
+  if (afd->getDeclContext()->isModuleScopeContext() &&
+      isa<FuncDecl>(afd) &&
+      cast<FuncDecl>(afd)->hasTopLevelLocalContextCaptures())
+    return false;
+
   // Skip functions that don't need to be serialized.
   return afd->getResilienceExpansion() != ResilienceExpansion::Minimal;
 }

--- a/test/SILGen/skip_function_bodies_guard.swift
+++ b/test/SILGen/skip_function_bodies_guard.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -experimental-skip-non-inlinable-function-bodies-without-types -emit-module %s
+
+let s: Int? = nil
+guard let m = s else { fatalError() }
+
+let x = m
+
+public func f(_: Int = m, _: String = "") {}
+
+f()

--- a/test/SILGen/top_level_captures.swift
+++ b/test/SILGen/top_level_captures.swift
@@ -5,15 +5,15 @@
 guard let x: Int = nil else { while true { } }
 
 // CHECK-LABEL: sil hidden [ossa] @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> () {
-// SKIPPED-FUNC-EMITTED-LABEL-NOT: sil hidden [ossa] @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> () {
+// SKIPPED-FUNC-EMITTED-LABEL: sil hidden [ossa] @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> () {
 func capturesX() {
   _ = x
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s18top_level_captures17transitiveCaptureyyF : $@convention(thin) (Int) -> () {
 // CHECK: [[FUNC:%.*]] = function_ref @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> ()
-// SKIPPED-FUNC-EMITTED-LABEL-NOT: sil hidden [ossa] @$s18top_level_captures17transitiveCaptureyyF : $@convention(thin) (Int) -> () {
-// SKIPPED-FUNC-EMITTED-NOT: [[FUNC:%.*]] = function_ref @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> ()
+// SKIPPED-FUNC-EMITTED-LABEL: sil hidden [ossa] @$s18top_level_captures17transitiveCaptureyyF : $@convention(thin) (Int) -> () {
+// SKIPPED-FUNC-EMITTED: [[FUNC:%.*]] = function_ref @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> ()
 func transitiveCapture() {
   capturesX()
 }


### PR DESCRIPTION
* **Description:** This is a narrow 6.0-only fix for a crash when using `-experimental-skip-non-inlinable-function-bodies-without-types` with top-level code that contains a local function following a guard statement. This was already fixed on main by e342a38b87af, when the computation of default argument expression captures was request-ified.

* **Origination:** Never worked.

* **Tested:** The test case here is identical to one I already checked in on main.

* **Reviewed by:** @DougGregor 

* **Radar:** Fixes rdar://129255744.