### PR TITLE
[concurrency] Mark the global _emptyDequeStorage as nonisolated(unsafe).

### DIFF
--- a/stdlib/public/Concurrency/Deque/_DequeBuffer.swift
+++ b/stdlib/public/Concurrency/Deque/_DequeBuffer.swift
@@ -41,7 +41,7 @@ extension _DequeBuffer: CustomStringConvertible {
 }
 
 /// The type-punned empty singleton storage instance.
-internal let _emptyDequeStorage = _DequeBuffer<Void>.create(
+nonisolated(unsafe) internal let _emptyDequeStorage = _DequeBuffer<Void>.create(
   minimumCapacity: 0,
   makingHeaderWith: { _ in
     _DequeBufferHeader(capacity: 0, count: 0, startSlot: .init(at: 0))


### PR DESCRIPTION
We just use it as a way to initialize values. We will always just read from it and copy from it.
