### PR TITLE
[Benchmark] Disable CxxVectorSum and CxxSetToCollection.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -209,10 +209,13 @@ set(SWIFT_BENCH_MODULES
     single-source/WordCount
     single-source/XorLoop
     cxx-source/CreateObjects
-    cxx-source/CxxSetToCollection
+    # Disabled for rdar://128520766
+    # cxx-source/CxxSetToCollection
     cxx-source/CxxStringConversion
-    cxx-source/CxxVectorSum
-    cxx-source/ReadAccessor
+    # Disabled for rdar://128520766
+    # cxx-source/CxxVectorSum
+    # TODO: rdar://92120528
+    # cxx-source/ReadAccessor
 )
 
 set(SWIFT_MULTISOURCE_SWIFT_BENCHES

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -55,9 +55,11 @@ import CodableTest
 import Combos
 import CountAlgo
 import CreateObjects
-import CxxSetToCollection
+// rdar://128520766
+// import CxxSetToCollection
 import CxxStringConversion
-import CxxVectorSum
+// rdar://128520766
+// import CxxVectorSum
 import DataBenchmarks
 import DeadArray
 import DevirtualizeProtocolComposition
@@ -251,9 +253,11 @@ register(Combos.benchmarks)
 register(CountAlgo.benchmarks)
 register(ClassArrayGetter.benchmarks)
 register(CreateObjects.benchmarks)
-register(CxxSetToCollection.benchmarks)
+// rdar://128520766
+// register(CxxSetToCollection.benchmarks)
 register(CxxStringConversion.benchmarks)
-register(CxxVectorSum.benchmarks)
+// rdar://128520766
+// register(CxxVectorSum.benchmarks)
 register(DataBenchmarks.benchmarks)
 register(DeadArray.benchmarks)
 register(DevirtualizeProtocolComposition.benchmarks)


### PR DESCRIPTION
The two benchmarks don't currently build in some configurations.  Also disabled building ReadAccessor whose running had previously been disabled because it doesn't build anymore.

rdar://128520766