### PR TITLE
IRGen: Put the section pointing to rodata of generic classes into the __LD segment

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -554,7 +554,7 @@ public:
         EnableGlobalISel(false), VirtualFunctionElimination(false),
         WitnessMethodElimination(false), ConditionalRuntimeRecords(false),
         InternalizeAtLink(false), InternalizeSymbols(false),
-        EmitGenericRODatas(false), NoPreallocatedInstantiationCaches(false),
+        EmitGenericRODatas(true), NoPreallocatedInstantiationCaches(false),
         DisableReadonlyStaticObjects(false), CollocatedMetadataFunctions(false),
         ColocateTypeDescriptors(true), UseRelativeProtocolWitnessTables(false),
         UseFragileResilientProtocolWitnesses(false),

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -989,6 +989,7 @@ public:
   };
 
   std::string GetObjCSectionName(StringRef Section, StringRef MachOAttributes);
+  std::string GetLinkerSectionName(StringRef Section, StringRef MachOAttributes);
   void SetCStringLiteralSection(llvm::GlobalVariable *GV, ObjCLabelType Type);
 
   void addAsyncCoroIDMapping(llvm::GlobalVariable *asyncFunctionPointer,

--- a/test/IRGen/generic_class_rodata_list.swift
+++ b/test/IRGen/generic_class_rodata_list.swift
@@ -30,7 +30,7 @@
 // CHECK:         .quad   0
 // CHECK:         .quad   __CLASS_METHODS__TtC25generic_class_rodata_list9Somethin
 
-// CHECK:        .section        __DATA,__swift_rodatas
+// CHECK:        .section        __LD,__swift_rodatas
 // CHECK:        .p2align        3
 // CHECK:_generic_ro_datas:
 // CHECK:        .quad   ___unnamed_1+40


### PR DESCRIPTION
This way the linker knows to drop it.

Also emit it per default.

rdar://129299739