### PR TITLE
Turn mishandled reinitialize-in-`defer`-after-`consume` cases into errors.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -399,6 +399,8 @@ EXPERIMENTAL_FEATURE(Sensitive, true)
 // Enable the stdlib @DebugDescription macro.
 EXPERIMENTAL_FEATURE(DebugDescriptionMacro, true)
 
+EXPERIMENTAL_FEATURE(ReinitializeConsumeInMultiBlockDefer, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -767,6 +767,7 @@ static bool usesFeatureSensitive(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(DebugDescriptionMacro)
+UNINTERESTING_FEATURE(ReinitializeConsumeInMultiBlockDefer)
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet

--- a/test/SILOptimizer/consume_operator_reinit_in_defer.swift
+++ b/test/SILOptimizer/consume_operator_reinit_in_defer.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+func consume<T>(_: consuming T) {}
+
+func testSingleBlock<T>(x: inout T, y: T) {
+    defer { x = y }
+    consume(consume x)
+}
+
+func cond() -> Bool { fatalError() }
+
+// TODO: should be accepted
+func testAlwaysReinitAfterConditional<T>(x: inout T, y: T) { // not-really expected-error{{used after consume}}
+    defer {
+        if cond() { }
+        x = y // not-really expected-note{{}}
+    }
+    consume(consume x) // not-really expected-note{{}}
+}
+
+// TODO: should be accepted
+func testAlwaysReinitBeforeConditional<T>(x: inout T, y: T) { // not-really expected-error{{used after consume}}
+    defer {
+        x = y // not-really expected-note{{}}
+        if cond() { }
+    }
+    consume(consume x) // not-really expected-note{{}}
+}
+
+// TODO: should be accepted
+func testAlwaysReinitInBothBranchesOfConditional<T>(x: inout T, y: T) { // not-really expected-error{{used after consume}}
+    defer {
+        if cond() {
+            x = y // not-really expected-note{{}}
+        } else {
+            x = y
+        }
+    }
+    consume(consume x) // not-really expected-note{{}}
+}
+
+// TODO: should raise an error about inout not being reinitialized on all paths
+func testSometimesReinitInConditional<T>(x: inout T, y: T) { // not-really expected-error{{used after consume}}
+    defer {
+        if cond() {
+            x = y // not-really expected-note{{}}
+        } else {
+            // ex/pected-note {{not initialized on this path}}
+        }
+    }
+    consume(consume x) // not-really expected-note{{}}
+}


### PR DESCRIPTION
The handling of multi-basic-block control flow in `defer` blocks looks like it was left incomplete and completely untested; I fixed a few obvious problems but it still completely lacks any analysis of conditional reinitializations. For now, change it to treat attempted reinitializations as uses-after-consumes so we raise reliable errors now instead of emitting code that causes memory corruption at runtime. Fixes rdar://129303198.
