### PR TITLE
Inspect class to determine if its a class, actor, or distributed actor

### DIFF
--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -189,9 +189,17 @@ void DeclarationFragmentPrinter::printAbridgedType(const GenericTypeDecl *TD,
       case DeclKind::Protocol:
         printText(getTokenText(tok::kw_protocol));
         break;
-      case DeclKind::Class:
-        printText(getTokenText(tok::kw_class));
-        break;
+      case DeclKind::Class: {
+        auto *refDecl = cast<ClassDecl>(TD);
+        if (refDecl->isExplicitDistributedActor()) {
+          printText("distributed actor");
+        } else if (refDecl->isExplicitActor()) {
+          printText("actor");
+        } else {
+          printText(getTokenText(tok::kw_class));
+        }
+      break;
+      }
       case DeclKind::TypeAlias:
         printText(getTokenText(tok::kw_typealias));
         break;

--- a/test/SymbolGraph/Symbols/Kinds/Actor.swift
+++ b/test/SymbolGraph/Symbols/Kinds/Actor.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name Actor -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name Actor -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Actor.symbols.json
+
+// CHECK: "identifier": "swift.class"
+// CHECK-NEXT: "displayName": "Class"
+// CHECK: pathComponents
+// CHECK-NEXT: "Q"
+// CHECK: "kind": "keyword"
+// CHECK-NEXT: "spelling": "actor"
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+public actor Q {}

--- a/test/SymbolGraph/Symbols/Kinds/DistributedActor.swift
+++ b/test/SymbolGraph/Symbols/Kinds/DistributedActor.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name DistributedActor -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract %windows_vfs_overlay_opt -module-name DistributedActor -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/DistributedActor.symbols.json
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+import Distributed
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public distributed actor DA {
+  public typealias ActorSystem = LocalTestingDistributedActorSystem
+}
+
+// CHECK: "identifier": "swift.class"
+// CHECK-NEXT: "displayName": "Class"
+// CHECK: pathComponents
+// CHECK-NEXT: "DA"
+// CHECK: "kind": "keyword"
+// CHECK-NEXT: "spelling": "distributed actor"
+

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -378,15 +378,22 @@ else:
     test_resource_dir = make_path(config.swift_lib_dir, 'swift')
 config.swift_system_overlay_opt = ""
 config.clang_system_overlay_opt = ""
+config.windows_vfs_overlay_opt = ""
 if kIsWindows:
     # ucrt.modulemap currently requires -fbuiltin-headers-in-system-modules. -strict-implicit-module-context
     # is necessary for -Xcc arguments to be passed through ModuleInterfaceLoader.
     config.swift_system_overlay_opt = "-vfsoverlay {} -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
         os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
     )
+    # this variant is for extract-symbolgraph which doesn't accept all the same arugments as swiftc
+    # so the extra ceremony lets us pass in the relevant pieces needed for Windows SDK access.
+    config.windows_vfs_overlay_opt = "-Xcc -vfsoverlay -Xcc {} -Xcc -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
+        os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
+    )
     config.clang_system_overlay_opt = "-Xcc -ivfsoverlay -Xcc {} -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
         os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
     )
+config.substitutions.append( ('%windows_vfs_overlay_opt', config.windows_vfs_overlay_opt) )
 stdlib_resource_dir_opt = config.resource_dir_opt
 sourcekitd_framework_dir = config.swift_lib_dir
 config.substitutions.append( ('%test-resource-dir', test_resource_dir) )
@@ -1341,7 +1348,7 @@ if run_vendor == 'apple':
             "-Xlinker -rpath -Xlinker %r " +
             "-Xlinker -rpath -Xlinker /usr/lib/swift " +
             # This ensures LC_LOAD_DYLIB rewrite will succeed in %target-codesign (rdar://7885126):
-            "-Xlinker -headerpad_max_install_names " +  
+            "-Xlinker -headerpad_max_install_names " +
             "%s %s %s %s") %
            (xcrun_prefix, config.swiftc, target_options,
             extra_frameworks_dir,
@@ -1389,7 +1396,7 @@ if run_vendor == 'apple':
             ("%s %s %s -F %r -toolchain-stdlib-rpath %s " +
              "-Xlinker -rpath -Xlinker /usr/lib/swift " +
              # This ensures LC_LOAD_DYLIB rewrite will succeed in %target-codesign (rdar://7885126):
-             "-Xlinker -headerpad_max_install_names " + 
+             "-Xlinker -headerpad_max_install_names " +
              " %s %s %s") %
             (xcrun_prefix, config.swiftc, target_options,
              extra_frameworks_dir,
@@ -1538,7 +1545,7 @@ if run_vendor == 'apple':
     config.target_swiftc_driver = (
         ("%s %s -toolchain-stdlib-rpath %s " +
          # This ensures LC_LOAD_DYLIB rewrite will succeed in %target-codesign (rdar://7885126):
-         "-Xlinker -headerpad_max_install_names " +  
+         "-Xlinker -headerpad_max_install_names " +
          "-Xlinker -rpath -Xlinker /usr/lib/swift %s %s ")%
         (xcrun_prefix, config.swiftc, target_options, config.swift_driver_test_options, swiftc_platform_remap_config))
     config.target_stdlib_swiftc_driver = config.target_swiftc_driver
@@ -2226,7 +2233,7 @@ def configure_remote_run():
         "--input-prefix '{0}' ".format(config.swift_src_root) +
         "--output-prefix %t " +
         "--remote-dir '{0}'%t ".format(remote_tmp_dir) +
-        "{0} ".format(' '.join(remote_run_extra_args)) + 
+        "{0} ".format(' '.join(remote_run_extra_args)) +
         "{0}".format(remote_run_host))
     config.target_swift_reflection_test = os.path.join(
         remote_tmp_dir, 'bin', swift_reflection_test_name)


### PR DESCRIPTION
For the purposes of symbol graph generation

Updates the function printAbridgedType to inspect the declaration to determine if its a class, actor, or distributed actor in order to present "actor" or "distributed actor" into the symbol graph so that DocC (documentation) can represent the type correctly.

resolves https://github.com/apple/swift-docc/issues/212