### PR TITLE
Build-script preset: pr-apple-llvm-project-linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1776,6 +1776,8 @@ skip-test-osx
 
 [preset: pr_apple_llvm_project_linux]
 
+llvm-cmake-options=-DCLANG_DEFAULT_LINKER=gold
+
 foundation
 libicu
 libdispatch

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1771,6 +1771,26 @@ skip-test-osx
 
 
 #===------------------------------------------------------------------------===#
+# PR testing presets
+#===------------------------------------------------------------------------===#
+
+[preset: pr_apple_llvm_project_linux]
+
+foundation
+libicu
+libdispatch
+test
+
+release
+
+lldb
+lldb-test-swift-only
+
+skip-test-cmark
+skip-test-swift
+skip-test-foundation
+
+#===------------------------------------------------------------------------===#
 # Mixins for LLBuild, SwiftPM and downstream package project PR tests.
 #===------------------------------------------------------------------------===#
 [preset: mixin_swiftpm_base]


### PR DESCRIPTION
Adding a preset for the pr-apple-llvm-project-linux PR test so that it is configurable without needing to modify CI directly.

Also fixing the linker that clang defaults to in order to avoid using the BFD linker and failing to link (relocations and private symbols).
Related PR: https://github.com/apple/llvm-project/pull/8850