### PR TITLE
Soften min version for objcImpl early adopters

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1674,10 +1674,13 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
     // supported.
     auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(Ctx);
     if (!deploymentAvailability.isContainedIn(Ctx.getSwift50Availability())) {
-      diagnose(attr->getLocation(),
+      auto diag = diagnose(attr->getLocation(),
                diag::attr_objc_implementation_raise_minimum_deployment_target,
                prettyPlatformString(targetPlatform(Ctx.LangOpts)),
                Ctx.getSwift50Availability().getOSVersion().getLowerEndpoint());
+      if (attr->isEarlyAdopter()) {
+        diag.wrapIn(diag::wrap_objc_implementation_will_become_error);
+      }
     }
   }
   else if (auto AFD = dyn_cast<AbstractFunctionDecl>(D)) {

--- a/test/decl/ext/objc_implementation_deployment_target.swift
+++ b/test/decl/ext/objc_implementation_deployment_target.swift
@@ -1,14 +1,19 @@
 // Hardcode x86_64 macOS because Apple Silicon was born ABI-stable
-// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/objc_implementation.h -target x86_64-apple-macosx10.14.3
+// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/objc_implementation.h -target x86_64-apple-macosx10.14.3 -enable-experimental-feature ObjCImplementation
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 
-@_objcImplementation extension ObjCImplSubclass {
+@objc @implementation extension ObjCImplSubclass {
   // expected-error@-1 {{'@implementation' of an Objective-C class requires a minimum deployment target of at least macOS 10.14.4}}
 }
 
-@_objcImplementation(Conformance) extension ObjCClass {
+@objc(Conformance) @implementation extension ObjCClass {
   // expected-error@-1 {{'@implementation' of an Objective-C class requires a minimum deployment target of at least macOS 10.14.4}}
   func requiredMethod1() {}
   func requiredMethod2() {}
+}
+
+@_objcImplementation(EmptyCategory) extension ObjCClass {
+  // expected-warning@-1 {{'@implementation' of an Objective-C class requires a minimum deployment target of at least macOS 10.14.4; this will become an error after adopting '@implementation'}}
+  // expected-warning@-2 {{'@_objcImplementation' is deprecated; use '@implementation' instead}}
 }


### PR DESCRIPTION
Weaken the minimum deployment target error to a warning for objcImpl adopters using the legacy `@_objcImplementation` syntax until we determine exactly how far back it can be safely used.

Fixes rdar://129225596.