### PR TITLE
AST: Fix request cycle with local lazy properties

### DIFF
--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -352,6 +352,15 @@ static bool implicitSelfReferenceIsUnwrapped(const ValueDecl *selfDecl) {
 }
 
 ValueDecl *UnqualifiedLookupFactory::lookupBaseDecl(const DeclContext *baseDC) const {
+  // If the member was not in local context, we're not going to need the
+  // 'self' declaration, so skip all this work to avoid request cycles.
+  if (!baseDC->isLocalContext())
+    return nullptr;
+
+  // If we're only interested in type declarations, we can also skip everything.
+  if (isOriginallyTypeLookup)
+    return nullptr;
+
   // Perform an unqualified lookup for the base decl of this result. This
   // handles cases where self was rebound (e.g. `guard let self = self`)
   // earlier in this closure or some outer closure.

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -219,3 +219,15 @@ struct PropertyWrapperContainer {
     _ = $__lazy_storage_$_foo  // This is okay.
   }
 }
+
+// rdar://problem/129255769
+struct X {
+  struct Y { }
+
+  func f() {
+    _ = {
+      lazy var x: [Y] = []
+      _ = Y()
+    }
+  }
+}


### PR DESCRIPTION
This fixes a regression from https://github.com/apple/swift/pull/73482.

Fixes rdar://problem/129255769.