### PR TITLE
6.0: [DCE] Insts that define lexical values seem useful

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -63,6 +63,11 @@ static bool seemsUseful(SILInstruction *I) {
   if (I->mayHaveSideEffects())
     return true;
 
+  if (llvm::any_of(I->getResults(),
+                   [](auto result) { return result->isLexical(); })) {
+    return true;
+  }
+
   if (auto *BI = dyn_cast<BuiltinInst>(I)) {
     // Although the onFastPath builtin has no side-effects we don't want to
     // remove it.

--- a/test/SILOptimizer/dead_code_elimination_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_ossa.sil
@@ -13,6 +13,9 @@ typealias Int1 = Builtin.Int1
 
 class C {}
 
+sil @getC : $@convention(thin) () -> @owned C
+sil @barrier : $@convention(thin) () -> ()
+
 struct CAndBit {
     var c: C
     var bit: Int1
@@ -467,4 +470,21 @@ bb6:
 bb3:
   %22 = tuple ()
   return %22 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_delete_move_value_lexical : {{.*}} {
+// CHECK:         [[LEXICAL:%[^,]+]] = move_value [lexical]
+// CHECK:         [[DUMMY:%[^,]+]] = function_ref @dummy
+// CHECK:         apply [[DUMMY]]()
+// CHECK:         destroy_value [[LEXICAL]]
+// CHECK-LABEL: } // end sil function 'dont_delete_move_value_lexical'
+sil [ossa] @dont_delete_move_value_lexical : $@convention(thin) () -> () {
+  %getC = function_ref @getC : $@convention(thin) () -> @owned C
+  %c = apply %getC() : $@convention(thin) () -> @owned C
+  %m = move_value [lexical] %c : $C
+  %dummy = function_ref @dummy : $@convention(thin) () -> ()
+  apply %dummy() : $@convention(thin) () -> ()
+  destroy_value %m : $C
+  %retval = tuple ()
+  return %retval : $()
 }


### PR DESCRIPTION
**Explanation**: Fixed DCE not to delete instructions that define lexical values.

Lexical values, such as those corresponding to source-level `let`s, cannot be deleted as dead, even when they have no uses.  Previously, DCE could delete such values if they had no non-destroy users.  Here this is fixed by preventing instructions which introduce lexical values from being deleted.
**Scope**: Bug fix.
**Issue**: rdar://129299803
**Original PR**: https://github.com/apple/swift/pull/74152
**Risk**: Low.
**Testing**: Added SIL test case.
**Reviewer**: Meghana Gupta ( @meg-gupta )
