### PR TITLE
[6.0][Distributed] Distributed thunks take parameters as 'sending'

### DIFF
--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -692,7 +692,8 @@ static FuncDecl *createSameSignatureDistributedThunkDecl(DeclContext *DC,
                   /*argumentNameLoc=*/SourceLoc(), funcParam->getArgumentName(),
                   /*parameterNameLoc=*/SourceLoc(), paramName, DC);
 
-    paramDecl->setImplicit(true);
+    paramDecl->setImplicit();
+    paramDecl->setSending();
     paramDecl->setSpecifier(funcParam->getSpecifier());
     paramDecl->setInterfaceType(funcParam->getInterfaceType());
 

--- a/test/Distributed/distributed_actor_accessor_section_coff.swift
+++ b/test/Distributed/distributed_actor_accessor_section_coff.swift
@@ -93,43 +93,43 @@ public distributed actor MyOtherActor {
 
 /// -> `MyActor.simple1`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic Si___________pIetMHygzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic Si___________pIetMHyTgzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section ".sw5acfn$B", {{.*}}
 
 /// -> `MyActor.simple2`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic Si_____SS______pIetMHygozo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic Si_____SS______pIetMHyTgozo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section ".sw5acfn$B", {{.*}}
 
 /// -> `MyActor.simple3`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic SS_____Si______pIetMHggdzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic SS_____Si______pIetMHgTgdzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section ".sw5acfn$B", {{.*}}
 
 /// -> `MyActor.single_case_enum`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic __________AA______pIetMHygdzo_ 27distributed_actor_accessors7SimpleEO AA7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic __________AA______pIetMHyTgdzo_ 27distributed_actor_accessors7SimpleEO AA7MyActorC s5ErrorP"
 // CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section ".sw5acfn$B", {{.*}}
 
 /// -> `MyActor.with_indirect_enums`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic _____Si_____AA______pIetMHgygozo_ 27distributed_actor_accessors9IndirectEO AA7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic _____Si_____AA______pIetMHgTyTgozo_ 27distributed_actor_accessors9IndirectEO AA7MyActorC s5ErrorP"
 // CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section ".sw5acfn$B", {{.*}}
 
 /// -> `MyActor.complex`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic SaySiG_____SSSg__________AD______pIetMHgggngrzo_ 27distributed_actor_accessors3ObjC AA11LargeStructV AA7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic SaySiG_____SSSg__________AD______pIetMHgTgTgTnTgrzo_ 27distributed_actor_accessors3ObjC AA11LargeStructV AA7MyActorC s5ErrorP"
 // CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section ".sw5acfn$B", {{.*}}
 
 /// -> `MyActor.generic`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTEHF" = private constant
-// CHECK-SAME: @"symbolic x___________pSeRzSERzlIetMHngzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic x___________pSeRzSERzlIetMHnTgzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section ".sw5acfn$B", {{.*}}
 

--- a/test/Distributed/distributed_actor_accessor_section_elf.swift
+++ b/test/Distributed/distributed_actor_accessor_section_elf.swift
@@ -91,43 +91,43 @@ public distributed actor MyOtherActor {
 
 /// -> `MyActor.simple1`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic Si___________pIetMHygzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic Si___________pIetMHyTgzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
 
 /// -> `MyActor.simple2`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic Si_____SS______pIetMHygozo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic Si_____SS______pIetMHyTgozo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
 
 /// -> `MyActor.simple3`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic SS_____Si______pIetMHggdzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic SS_____Si______pIetMHgTgdzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
 
 /// -> `MyActor.single_case_enum`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic __________AA______pIetMHygdzo_ 27distributed_actor_accessors7SimpleEO AA7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic __________AA______pIetMHyTgdzo_ 27distributed_actor_accessors7SimpleEO AA7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
 
 /// -> `MyActor.with_indirect_enums`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic _____Si_____AA______pIetMHgygozo_ 27distributed_actor_accessors9IndirectEO AA7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic _____Si_____AA______pIetMHgTyTgozo_ 27distributed_actor_accessors9IndirectEO AA7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
 
 /// -> `MyActor.complex`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic SaySiG_____SSSg__________AD______pIetMHgggngrzo_ 27distributed_actor_accessors3ObjC AA11LargeStructV AA7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic SaySiG_____SSSg__________AD______pIetMHgTgTgTnTgrzo_ 27distributed_actor_accessors3ObjC AA11LargeStructV AA7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
 
 /// -> `MyActor.generic`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTEHF" = private constant
-// CHECK-SAME: @"symbolic x___________pSeRzSERzlIetMHngzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic x___________pSeRzSERzlIetMHnTgzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
 

--- a/test/Distributed/distributed_actor_accessor_section_macho.swift
+++ b/test/Distributed/distributed_actor_accessor_section_macho.swift
@@ -91,43 +91,43 @@ public distributed actor MyOtherActor {
 
 /// -> `MyActor.simple1`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic Si___________pIetMHygzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic Si___________pIetMHyTgzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section {{"swift5_accessible_functions"|".sw5acfn$B"|"__TEXT, __swift5_acfuncs, regular"}}
 
 /// -> `MyActor.simple2`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic Si_____SS______pIetMHygozo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic Si_____SS______pIetMHyTgozo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section {{"swift5_accessible_functions"|".sw5acfn$B"|"__TEXT, __swift5_acfuncs, regular"}}
 
 /// -> `MyActor.simple3`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic SS_____Si______pIetMHggdzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic SS_____Si______pIetMHgTgdzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section {{"swift5_accessible_functions"|".sw5acfn$B"|"__TEXT, __swift5_acfuncs, regular"}}
 
 /// -> `MyActor.single_case_enum`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic __________AA______pIetMHygdzo_ 27distributed_actor_accessors7SimpleEO AA7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic __________AA______pIetMHyTgdzo_ 27distributed_actor_accessors7SimpleEO AA7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section {{"swift5_accessible_functions"|".sw5acfn$B"|"__TEXT, __swift5_acfuncs, regular"}}
 
 /// -> `MyActor.with_indirect_enums`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic _____Si_____AA______pIetMHgygozo_ 27distributed_actor_accessors9IndirectEO AA7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic _____Si_____AA______pIetMHgTyTgozo_ 27distributed_actor_accessors9IndirectEO AA7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section {{"swift5_accessible_functions"|".sw5acfn$B"|"__TEXT, __swift5_acfuncs, regular"}}
 
 /// -> `MyActor.complex`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTEHF" = private constant
-// CHECK-SAME: @"symbolic SaySiG_____SSSg__________AD______pIetMHgggngrzo_ 27distributed_actor_accessors3ObjC AA11LargeStructV AA7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic SaySiG_____SSSg__________AD______pIetMHgTgTgTnTgrzo_ 27distributed_actor_accessors3ObjC AA11LargeStructV AA7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section {{"swift5_accessible_functions"|".sw5acfn$B"|"__TEXT, __swift5_acfuncs, regular"}}
 
 /// -> `MyActor.generic`
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTEHF" = private constant
-// CHECK-SAME: @"symbolic x___________pSeRzSERzlIetMHngzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: @"symbolic x___________pSeRzSERzlIetMHnTgzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section {{"swift5_accessible_functions"|".sw5acfn$B"|"__TEXT, __swift5_acfuncs, regular"}}
 

--- a/test/Distributed/distributed_actor_sending_thunks.swift
+++ b/test/Distributed/distributed_actor_sending_thunks.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+
+// RUN: %target-swift-frontend -I %t -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+// REQUIRES: distributed
+
+
+import Distributed
+import FakeDistributedActorSystems
+
+
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+final class NonSendableKlass {}
+
+extension NonSendableKlass : Codable {}
+
+@MainActor func transferToMain<T>(_ t: T) async {}
+
+// ==== ------------------------------------------------------------------------
+
+distributed actor MyDistributedActor {
+  let x = NonSendableKlass()
+
+  distributed func transferActorIsolatedArgIntoClosure(
+    _ notSendableParamToDistributedFunc: NonSendableKlass) async {}
+}


### PR DESCRIPTION
**Description**: 
This is in order to avoid errors in complete concurrency checking mnode in distributed funcs, or rather their thunks, as there is isolation boundary crossing happening when we pass a value to a distributed func.

This is because as we do this, we pass it to a nonisolated thunk:

```
nonisolated func THUNK(param: Thing) {
  if remote {
    ...
  } else {
    await self.realFunc(param)
  }
}
```

So what happens here is that the Thing would become isolated to the task and we get a bad isolation crossing as we pass it along to the "real func".

Sending values into the distributed thunk is the right thing to do to resolve this problem: `nonisolated func THUNK(param: sending Thing) {}`


**Scope/Impact**: Allows using distributed actors with region isolation and complete concurrency checking.
**Risk:** Low, should not have any impact on existing users
**Testing**: CI testing
**Reviewed by**: @gottesmm 
**Original PR:** https://github.com/apple/swift/pull/74166
**ABI / Distributed func identifier safety:** This is safe to change because the `sending` is not mangled in method parameters, as we cannot overload on it, so this change should not break remote calls between swift versions AFAICS.
**Radar:** rdar://126577527

