### PR TITLE
[Synchronization] Fix wasm atomic intrinsic declarations

### DIFF
--- a/stdlib/public/Synchronization/Mutex/WasmImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/WasmImpl.swift
@@ -13,19 +13,19 @@
 // Note: All atomic accesses on WASM are sequentially consistent regardless of
 // what ordering we tell LLVM to use.
 
-@_extern(c, "llvm.wasm32.memory.atomic.wait32")
+@_extern(c, "llvm.wasm.memory.atomic.wait32")
 internal func _swift_stdlib_wait(
   on: UnsafePointer<UInt32>,
   expected: UInt32,
   timeout: Int64
 ) -> UInt32
 
-@_extern(c, "llvm.wasm32.memory.atomic.notify")
-internal func _swift_stdlib_wake(on: UnsafePointer<UInt32>, count: UInt32)
+@_extern(c, "llvm.wasm.memory.atomic.notify")
+internal func _swift_stdlib_wake(on: UnsafePointer<UInt32>, count: UInt32) -> UInt32
 
 extension Atomic where Value == _MutexHandle.State {
   internal borrowing func _wait(expected: _MutexHandle.State) {
-    _swift_stdlib_wait(
+    _ = _swift_stdlib_wait(
       on: .init(_rawAddress),
       expected: expected.rawValue,
 
@@ -36,7 +36,7 @@ extension Atomic where Value == _MutexHandle.State {
 
   internal borrowing func _wake() {
     // Only wake up 1 thread
-    _swift_stdlib_wake(on: .init(_rawAddress), count: 1)
+    _ = _swift_stdlib_wake(on: .init(_rawAddress), count: 1)
   }
 }
 

--- a/stdlib/public/Synchronization/Mutex/WasmImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/WasmImpl.swift
@@ -25,6 +25,7 @@ internal func _swift_stdlib_wake(on: UnsafePointer<UInt32>, count: UInt32) -> UI
 
 extension Atomic where Value == _MutexHandle.State {
   internal borrowing func _wait(expected: _MutexHandle.State) {
+    #if _runtime(_multithreaded)
     _ = _swift_stdlib_wait(
       on: .init(_rawAddress),
       expected: expected.rawValue,
@@ -32,11 +33,14 @@ extension Atomic where Value == _MutexHandle.State {
       // A timeout of < 0 means indefinitely.
       timeout: -1
     )
+    #endif
   }
 
   internal borrowing func _wake() {
+    #if _runtime(_multithreaded)
     // Only wake up 1 thread
     _ = _swift_stdlib_wake(on: .init(_rawAddress), count: 1)
+    #endif
   }
 }
 


### PR DESCRIPTION
- 0536c9ac651161b1b2afddfa2d834291be5366f3 Fix wasm atomic intrinsic declarations 
  Otherwise, isel will not be able to select the desired atomic instructions.
- 2dbbbcf64656072d5b43d7a5139c5efd3a4e9296 Skip atomic operations in single-threaded mode on WebAssembly
  Use of atomics instructions requires the explicit support of threads proposal and it's not widely supported yet. So we should enable actual atomic operations only when targeting wasm32-uknown-wasip1-threads.

Those changes repair the current test failure:

```
Command Output (stderr):
--
wasm-ld: error: /home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64/./lib/swift_static/wasi/libswiftSynchronization.a(Synchronization.o): undefined symbol: llvm.wasm32.memory.atomic.wait32
wasm-ld: error: /home/build-user/build/buildbot_linux/wasmstdlib-linux-x86_64/./lib/swift_static/wasi/libswiftSynchronization.a(Synchronization.o): undefined symbol: llvm.wasm32.memory.atomic.notify
clang: error: linker command failed with exit code 1 (use -v to see invocation)
<unknown>:0: error: link command failed with exit code 1 (use -v to see invocation)
```
https://ci.swift.org/job/swift-PR-Linux-crosscompile-wasm/106/console