### PR TITLE
Don't check sendability of witnesses for `@preconcurrency` conformances

### DIFF
--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -130,11 +130,15 @@ public:
 
   /// Check that the witness and requirement have compatible actor contexts.
   ///
+  /// \param usesPreconcurrency Will be set true if the conformance is
+  /// @preconcurrency and we made use of that fact.
+  ///
   /// \returns the isolation that needs to be enforced to invoke the witness
   /// from the requirement, used when entering an actor-isolated synchronous
   /// witness from an asynchronous requirement.
   std::optional<ActorIsolation> checkActorIsolation(ValueDecl *requirement,
-                                                    ValueDecl *witness);
+                                                    ValueDecl *witness,
+                                                    bool &usesPreconcurrency);
 
   /// Enforce restrictions on non-final classes witnessing requirements
   /// involving the protocol 'Self' type.


### PR DESCRIPTION
When a witness is part of a `@preconcurrency` conformance, suppress Sendable checking for that witness. The `@preconcurrency` conformance will dynamically verify that the code is actually executed on the right actor, which addresses most data race issues. Suppressing Sendable checking in this case is a compromise: it makes `@preconcurrency` conformances usable, but admits a small possibility of data races that will be addressed when the protocol is updated appropriately.

Fixes https://github.com/apple/swift/issues/74057.
