### PR TITLE
[stdlib] Update Mutex unavailable attribute for minimal toolchains

### DIFF
--- a/stdlib/public/Synchronization/Mutex/MutexUnavailable.swift
+++ b/stdlib/public/Synchronization/Mutex/MutexUnavailable.swift
@@ -31,7 +31,7 @@
 ///       }
 ///     }
 ///
-@available(unavailable, *, message: "Mutex is not available on this platform")
+@available(*, unavailable, message: "Mutex is not available on this platform")
 @frozen
 @_staticExclusiveOnly
 public struct Mutex<Value: ~Copyable>: ~Copyable {}


### PR DESCRIPTION
I messed up the availability syntax for minimal platforms.

Resolves: rdar://129345303