### PR TITLE
[cxx-interop] C++ reference types are not `AnyObject`s

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7580,6 +7580,10 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     // Class and protocol metatypes are interoperable with certain Objective-C
     // runtime classes, but only when ObjC interop is enabled.
 
+    // Foreign reference types do *not* conform to AnyObject.
+    if (type1->isForeignReferenceType() && type2->isAnyObject())
+      return getTypeMatchFailure(locator);
+
     if (getASTContext().LangOpts.EnableObjCInterop) {
       // These conversions are between concrete types that don't need further
       // resolution, so we can consider them immediately solved.
@@ -7589,10 +7593,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                                   type1, type2, locator);
           return getTypeMatchSuccess();
         };
-
-      // Foreign reference types do *not* conform to AnyObject.
-      if (type1->isForeignReferenceType() && type2->isAnyObject())
-        return getTypeMatchFailure(locator);
       
       if (auto meta1 = type1->getAs<MetatypeType>()) {
         if (meta1->getInstanceType()->mayHaveSuperclass()

--- a/test/Interop/Cxx/foreign-reference/not-any-object.swift
+++ b/test/Interop/Cxx/foreign-reference/not-any-object.swift
@@ -2,8 +2,6 @@
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop
 
-// REQUIRES: objc_interop
-
 //--- Inputs/module.modulemap
 module Test {
   header "test.h"
@@ -11,14 +9,10 @@ module Test {
 }
 
 //--- Inputs/test.h
-#include <stdlib.h>
-
-inline void* operator new(unsigned long, void* p) { return p; }
-
 struct __attribute__((swift_attr("import_reference")))
        __attribute__((swift_attr("retain:immortal")))
        __attribute__((swift_attr("release:immortal"))) Empty {
-  static Empty *create() { return new (malloc(sizeof(Empty))) Empty(); }
+  static Empty *create() { return new Empty(); }
 };
 
 //--- test.swift


### PR DESCRIPTION
C++ foreign reference types have custom reference counting mechanisms, so they cannot conform to `AnyObject`.

Currently Swift's type system treats C++ FRTs as `AnyObject`s on non-Darwin platforms, which is incorrect. This change makes sure the behavior is consistent with Darwin platform, i.e. a cast of C++ FRT to `AnyObject` is rejected by the typechecker.

rdar://136664617