### PR TITLE
Check if decl context returned by importDeclContextOf is null

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -3429,7 +3429,9 @@ ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
   // FIXME: Duplicated from importMethodParamsAndReturnType.
   DeclContext *origDC = importDeclContextOf(property,
                                             property->getDeclContext());
-  assert(origDC);
+  if (!origDC)
+    return {Type(), false};
+
   auto fieldType = isGetter ? clangDecl->getReturnType()
                             : clangDecl->getParamDecl(0)->getType();
 


### PR DESCRIPTION
I've seen a crash due to `importDeclContextOf` returning a null decl context in `importAccessorParamsAndReturnType`. Most other call sites of `importDeclContextOf` check the returned value, so add a check in `importAccessorParamsAndReturnType` too.

rdar://127847162