### PR TITLE
[6.0] Add missing OpenExistentialAddr no-changes-needed case to MoveOnlyWrappedTypeEliminator

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -193,6 +193,7 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   NO_UPDATE_NEEDED(CheckedCastBranch)
   NO_UPDATE_NEEDED(Object)
   NO_UPDATE_NEEDED(OpenExistentialRef)
+  NO_UPDATE_NEEDED(OpenExistentialAddr)
   NO_UPDATE_NEEDED(ConvertFunction)
   NO_UPDATE_NEEDED(RefToBridgeObject)
   NO_UPDATE_NEEDED(BridgeObjectToRef)

--- a/test/SILOptimizer/moveonly_wrapped_type_eliminator_consumed_existential.swift
+++ b/test/SILOptimizer/moveonly_wrapped_type_eliminator_consumed_existential.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+protocol Foo {
+    var foo: String { get }
+} 
+ 
+func identity(_ a: consuming any Foo) -> String {
+    return a.foo
+}


### PR DESCRIPTION
Explanation: Fixes a crash when performing certain operations on an existential value that was marked `borrowing` or `consuming`.
Scope: Bug fix.
Issue: rdar://126875325
Original PR: https://github.com/apple/swift/pull/74187
Risk: Low. Removes an unnecessary assertion.
Testing: Swift CI, test case from bug report
Reviewer: @nate-chandler 