### PR TITLE
Add dependsOn(immortal)

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7973,6 +7973,8 @@ ERROR(lifetime_dependence_cannot_infer_ambiguous_candidate, none,
        "cannot infer lifetime dependence on a self which is BitwiseCopyable & "
        "Escapable",
        ())
+ERROR(lifetime_dependence_immortal_conflict_name, none,
+      "conflict between the parameter name and immortal keyword", ())
 
 //===----------------------------------------------------------------------===//
 //                             MARK: Transferring

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5122,10 +5122,16 @@ ParserStatus Parser::parseLifetimeDependenceSpecifiers(
             Identifier paramName;
             auto paramLoc =
                 consumeIdentifier(paramName, /*diagnoseDollarPrefix=*/false);
-            specifierList.push_back(
-                LifetimeDependenceSpecifier::
-                    getNamedLifetimeDependenceSpecifier(
-                        paramLoc, lifetimeDependenceKind, paramName));
+            if (paramName.is("immortal")) {
+              specifierList.push_back(
+                  LifetimeDependenceSpecifier::
+                      getImmortalLifetimeDependenceSpecifier(paramLoc));
+            } else {
+              specifierList.push_back(
+                  LifetimeDependenceSpecifier::
+                      getNamedLifetimeDependenceSpecifier(
+                          paramLoc, lifetimeDependenceKind, paramName));
+            }
             break;
           }
           case tok::integer_literal: {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -8864,12 +8864,13 @@ ModuleFile::maybeReadLifetimeDependenceInfo(unsigned numParams) {
     return std::nullopt;
   }
 
+  bool isImmortal;
   bool hasInheritLifetimeParamIndices;
   bool hasScopeLifetimeParamIndices;
   ArrayRef<uint64_t> lifetimeDependenceData;
-  LifetimeDependenceLayout::readRecord(scratch, hasInheritLifetimeParamIndices,
-                                       hasScopeLifetimeParamIndices,
-                                       lifetimeDependenceData);
+  LifetimeDependenceLayout::readRecord(
+      scratch, isImmortal, hasInheritLifetimeParamIndices,
+      hasScopeLifetimeParamIndices, lifetimeDependenceData);
 
   SmallBitVector inheritLifetimeParamIndices(numParams, false);
   SmallBitVector scopeLifetimeParamIndices(numParams, false);
@@ -8898,5 +8899,6 @@ ModuleFile::maybeReadLifetimeDependenceInfo(unsigned numParams) {
           : nullptr,
       hasScopeLifetimeParamIndices
           ? IndexSubset::get(ctx, scopeLifetimeParamIndices)
-          : nullptr);
+          : nullptr,
+      isImmortal);
 }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,8 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 877; // extend_lifetime instruction
+const uint16_t SWIFTMODULE_VERSION_MINOR =
+    878; // immortal bit in LifetimeDependence
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2212,6 +2213,7 @@ namespace decls_block {
 
   using LifetimeDependenceLayout =
       BCRecordLayout<LIFETIME_DEPENDENCE,
+                     BCFixed<1>,         // isImmortal
                      BCFixed<1>,         // hasInheritLifetimeParamIndices
                      BCFixed<1>,         // hasScopeLifetimeParamIndices
                      BCArray<BCFixed<1>> // concatenated param indices

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2579,7 +2579,7 @@ void Serializer::writeLifetimeDependenceInfo(
 
   auto abbrCode = DeclTypeAbbrCodes[LifetimeDependenceLayout::Code];
   LifetimeDependenceLayout::emitRecord(
-      Out, ScratchRecord, abbrCode,
+      Out, ScratchRecord, abbrCode, lifetimeDependenceInfo.isImmortal(),
       lifetimeDependenceInfo.hasInheritLifetimeParamIndices(),
       lifetimeDependenceInfo.hasScopeLifetimeParamIndices(), paramIndices);
 }

--- a/test/Parse/explicit_lifetime_dependence_specifiers.swift
+++ b/test/Parse/explicit_lifetime_dependence_specifiers.swift
@@ -153,3 +153,15 @@ struct Wrapper : ~Escapable {
     return view
   }
 }
+
+enum FakeOptional<Wrapped: ~Escapable>: ~Escapable {
+  case none, some(Wrapped)
+}
+
+extension FakeOptional: Escapable where Wrapped: Escapable {}
+
+extension FakeOptional where Wrapped: ~Escapable {
+  init(nilLiteral: ()) -> dependsOn(immortal) Self {
+    self = .none
+  }
+}

--- a/test/SILOptimizer/lifetime_dependence.sil
+++ b/test/SILOptimizer/lifetime_dependence.sil
@@ -7,7 +7,7 @@
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
-// Test the SIL representation for lifetime depenence.
+// Test the SIL representation for lifetime dependence.
 
 sil_stage raw
 
@@ -18,6 +18,7 @@ class C {}
 struct Nonescapable: ~Escapable {}
 
 sil @c_dependence : $@convention(thin) (@guaranteed C) -> _scope(0) @owned Nonescapable
+sil @immortal_dependence : $@convention(thin) () -> _scope(immortal) @owned Nonescapable
 
 // Test that SILType.isEscpable does not crash on a generic box when NoncopyableGenerics is enabled.
 sil shared [serialized] [ossa] @testLocalFunc : $@convention(thin) <T, U> (@guaranteed <τ_0_0> { var τ_0_0 } <U>) -> () {
@@ -41,4 +42,13 @@ bb0(%0 : @owned $C):
   destroy_value %0 : $C
   %28 = tuple ()
   return %28 : $()
+}
+
+sil [ossa] @test_immortal_dependence : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @immortal_dependence : $@convention(thin) () -> _scope(immortal) @owned Nonescapable
+  %c = apply %f() : $@convention(thin) () -> _scope(immortal) @owned Nonescapable
+  destroy_value %c : $Nonescapable
+  %t = tuple ()
+  return %t : $()
 }

--- a/test/Sema/explicit_lifetime_dependence_specifiers1.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers1.swift
@@ -231,3 +231,8 @@ extension RawBufferView {
     return BufferView(ptr)
   }
 }
+
+func immortalConflict(immortal: UnsafeRawBufferPointer ) -> dependsOn(immortal) BufferView { // expected-error{{conflict between the parameter name and immortal keyword}}
+  return BufferView(immortal)
+}
+

--- a/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
+++ b/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
@@ -68,3 +68,16 @@ public struct Wrapper : ~Escapable {
     }
   }
 }
+
+public enum FakeOptional<Wrapped: ~Escapable>: ~Escapable {
+  case none, some(Wrapped)
+}
+
+extension FakeOptional: Escapable where Wrapped: Escapable {}
+
+extension FakeOptional where Wrapped: ~Escapable {
+  public init(_ nilLiteral: ()) -> dependsOn(immortal) Self {
+    self = .none
+  }
+}
+

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -44,6 +44,10 @@ func testReadAccessor() {
   }
 }
 
+func testFakeOptional() {
+  _ = FakeOptional<Int>(())
+}
+
 // CHECK: sil @$s32def_explicit_lifetime_dependence6deriveyAA10BufferViewVADYlsF : $@convention(thin) (@guaranteed BufferView) -> _scope(0) @owned BufferView
 // CHECK: sil @$s32def_explicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView
 // CHECK: sil @$s32def_explicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADYlsF : $@convention(thin) (@guaranteed BufferView) -> _scope(0) @owned BufferView


### PR DESCRIPTION
Used in cases where a nonescapable value must be constructed without any owner that can stand in as the source of a dependence. See https://gist.github.com/atrick/9ed708431e9a18059c22d37d18759c6d for details

Fixes rdar://129183196