### PR TITLE
[LifetimeCompletion] Removed "with leaks" mode.

### DIFF
--- a/include/swift/SIL/OSSALifetimeCompletion.h
+++ b/include/swift/SIL/OSSALifetimeCompletion.h
@@ -57,11 +57,6 @@ public:
   // Availability: "As late as possible."  Consume the value in the last blocks
   //               beyond the non-consuming uses in which the value has been
   //               consumed on no incoming paths.
-  // AvailabilityWithLeaks: "As late as possible or later."  Consume the value
-  //                        in the last blocks beyond the non-consuming uses in
-  //                        which the value has been consumed on no incoming
-  //                        paths, unless that block's terminator isn't an
-  //                        unreachable, in which case, don't consume it there.
   //
   //                        This boundary works around bugs where SILGen emits
   //                        illegal OSSA lifetimes.
@@ -69,7 +64,6 @@ public:
     enum Value : uint8_t {
       Liveness,
       Availability,
-      AvailabilityWithLeaks,
     };
     Value value;
 
@@ -115,11 +109,6 @@ public:
                : LifetimeCompletion::AlreadyComplete;
   }
 
-  enum AllowLeaks_t : bool {
-    AllowLeaks = true,
-    DoNotAllowLeaks = false,
-  };
-
   enum class LifetimeEnd : uint8_t {
     /// The lifetime ends at the boundary.
     Boundary,
@@ -128,8 +117,7 @@ public:
   };
 
   static void visitAvailabilityBoundary(
-      SILValue value, AllowLeaks_t allowLeaks,
-      const SSAPrunedLiveness &liveness,
+      SILValue value, const SSAPrunedLiveness &liveness,
       llvm::function_ref<void(SILInstruction *, LifetimeEnd end)> visit);
 
 protected:
@@ -186,9 +174,6 @@ operator<<(llvm::raw_ostream &OS, OSSALifetimeCompletion::Boundary boundary) {
     break;
   case OSSALifetimeCompletion::Boundary::Availability:
     OS << "availability";
-    break;
-  case OSSALifetimeCompletion::Boundary::AvailabilityWithLeaks:
-    OS << "availability_with_leaks";
     break;
   }
   return OS;

--- a/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
+++ b/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
@@ -118,8 +118,7 @@ bool SILGenCleanup::completeOSSALifetimes(SILFunction *function) {
     for (SILInstruction &inst : reverse(*block)) {
       for (auto result : inst.getResults()) {
         if (completion.completeOSSALifetime(
-                result,
-                OSSALifetimeCompletion::Boundary::AvailabilityWithLeaks) ==
+                result, OSSALifetimeCompletion::Boundary::Availability) ==
             LifetimeCompletion::WasCompleted) {
           changed = true;
         }
@@ -128,7 +127,7 @@ bool SILGenCleanup::completeOSSALifetimes(SILFunction *function) {
     for (SILArgument *arg : block->getArguments()) {
       assert(!arg->isReborrow() && "reborrows not legal at this SIL stage");
       if (completion.completeOSSALifetime(
-              arg, OSSALifetimeCompletion::Boundary::AvailabilityWithLeaks) ==
+              arg, OSSALifetimeCompletion::Boundary::Availability) ==
           LifetimeCompletion::WasCompleted) {
         changed = true;
       }

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -274,8 +274,7 @@ void CanonicalizeOSSALifetime::extendLivenessToDeinitBarriers() {
   }
 
   OSSALifetimeCompletion::visitAvailabilityBoundary(
-      getCurrentDef(), OSSALifetimeCompletion::DoNotAllowLeaks,
-      completeLiveness, [&](auto *unreachable, auto end) {
+      getCurrentDef(), completeLiveness, [&](auto *unreachable, auto end) {
         if (end == OSSALifetimeCompletion::LifetimeEnd::Boundary) {
           recordUnreachableLifetimeEnd(unreachable);
         }


### PR DESCRIPTION
Now that the two known issues which resulted in invalid SIL being provided to lifetime completion have been addressed, tighten up the completion done on the availability boundary not to allow leaks.
