### PR TITLE
[FixIt]: Diagnostic for use of plain protocol name in type position suggests some or any

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5842,6 +5842,15 @@ ERROR(incorrect_optional_any,none,
 ERROR(existential_requires_any,none,
       "use of %select{protocol |}2%0 as a type must be written %1",
       (Type, Type, bool))
+ERROR(existential_requires_any_or_some,none,
+      "use of %select{protocol |}3%0 as a type must be written %1 or %2",
+      (Type, Type, StringRef, bool))
+NOTE(replace_with_any,none,
+     "replace %0 with %1",
+     (Type, Type))
+NOTE(replace_with_some,none,
+     "replace %0 with %1",
+     (Type, StringRef))
 ERROR(inverse_requires_any,none,
       "constraint that suppresses conformance requires 'any'", ())
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6402,11 +6402,22 @@ private:
 
     if (auto *proto = dyn_cast<ProtocolDecl>(decl)) {
       if (proto->existentialRequiresAny() && isAnyOrSomeMissing()) {
+        //Emit fixit to add any keyword
+        Ctx.Diags.diagnose(T->getNameLoc(), diag::replace_with_any,
+                            proto->getDeclaredInterfaceType(),
+                            proto->getDeclaredExistentialType())
+        .fixItReplace(T->getSourceRange(), "any " + proto->getDeclaredInterfaceType()->getString());
+        //Emit fixit to add some keyword
+        Ctx.Diags.diagnose(T->getNameLoc(), diag::replace_with_some,
+                            proto->getDeclaredInterfaceType(),
+                            ("'some " + proto->getDeclaredInterfaceType()->getString() + "'"))
+        .fixItReplace(T->getSourceRange(), "some " + proto->getDeclaredInterfaceType()->getString());
         auto diag =
-            Ctx.Diags.diagnose(T->getNameLoc(), diag::existential_requires_any,
-                               proto->getDeclaredInterfaceType(),
-                               proto->getDeclaredExistentialType(),
-                               /*isAlias=*/false);
+        Ctx.Diags.diagnose(T->getNameLoc(), diag::existential_requires_any_or_some,
+                            proto->getDeclaredInterfaceType(),
+                            proto->getDeclaredExistentialType(),
+                            ("'some " + proto->getDeclaredInterfaceType()->getString() + "'"),
+                            /*isAlias=*/false);
         diag.warnUntilSwiftVersionIf(warnUntilSwift7, 7);
         emitInsertAnyFixit(diag, T);
       }

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -575,3 +575,11 @@ struct S0_53813 {
     c0.foo3 = self // expected-error {{cannot assign value of type 'S0_53813' to type '(any P4_53813)?'}}
   }
 }
+
+// https://github.com/apple/swift/issues/68284
+protocol P {
+  associatedtype A
+}
+func generic(value: P) {}   // expected-error {{use of protocol 'P' as a type must be written 'any P' or 'some P'}}
+                            // expected-note@-1 {{replace 'P' with 'any P'}} {{21-22=any P}}
+                            // expected-note@-2 {{replace 'P' with 'some P'}} {{21-22=some P}}


### PR DESCRIPTION
Changes Made

- Logic added to add two new `fixits` when appropriate
- Updated existing error message to add the `some` keyword
- Added two new notes recommending replacements
- Updated test files

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #68284 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
