### PR TITLE
[MoveOnly] Call mutating methods on existentials.

### DIFF
--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -164,6 +164,12 @@ SubElementOffset::computeForAddress(SILValue projectionDerivedFromRoot,
       continue;
     }
 
+    if (auto *iea =
+            dyn_cast<InitExistentialAddrInst>(projectionDerivedFromRoot)) {
+      projectionDerivedFromRoot = iea->getOperand();
+      continue;
+    }
+
     if (auto *teai =
             dyn_cast<TupleElementAddrInst>(projectionDerivedFromRoot)) {
       SILType tupleType = teai->getOperand()->getType();

--- a/test/Interpreter/moveonly_existentials.swift
+++ b/test/Interpreter/moveonly_existentials.swift
@@ -7,15 +7,24 @@
 
 protocol Boopable: ~Copyable {
   func boop()
+  mutating func bonk()
 }
 
 struct S: ~Copyable, Boopable {
   func boop() { print("boop") }
+  mutating func bonk() { print("hmm") }
 }
 
-func check(_ b: borrowing any Boopable & ~Copyable) {
+func borrow(_ b: borrowing any Boopable & ~Copyable) {
   b.boop()
 }
 
+func mutate(_ b: inout any Boopable & ~Copyable) {
+  b.bonk()
+}
+
 // CHECK: boop
-check(S())
+// CHECK: hmm
+borrow(S())
+var s = S() as any Boopable & ~Copyable
+mutate(&s)


### PR DESCRIPTION
Teach FSPL to look through `init_existential_addr`.

rdar://128900124