### PR TITLE
[cxx-interop][IRGen] Emit type metadata accessors correctly

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1102,9 +1102,6 @@ MetadataAccessStrategy irgen::getTypeMetadataAccessStrategy(CanType type) {
       assert(type->hasUnboundGenericType());
     }
 
-    if (type->isForeignReferenceType())
-      return MetadataAccessStrategy::PublicUniqueAccessor;
-
     if (requiresForeignTypeMetadata(nominal))
       return MetadataAccessStrategy::ForeignAccessor;
 

--- a/test/Interop/Cxx/foreign-reference/multiple-protocol-conformances.swift
+++ b/test/Interop/Cxx/foreign-reference/multiple-protocol-conformances.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-build-swift -I %S/Inputs %t/main.swift %t/second.swift -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking
+
+// XFAIL: OS=windows-msvc
+
+//--- main.swift
+import ReferenceCounted
+
+protocol P1 {}
+extension GlobalCount : P1 {}
+
+//--- second.swift
+import ReferenceCounted
+
+protocol P2 {}
+extension GlobalCount : P2 {}


### PR DESCRIPTION
This change makes sure we correctly emit IR for type metadata accessors for C++ reference types.

This fixes linker errors when a type metadata of a C++ reference type is used in multiple object files that are later linked together, for instance, if a C++ reference type is conformed to different Swift protocols in different Swift source files:
```
duplicate symbol 'type metadata accessor for __C.SharedObject' in:
  main.o
  second.o
ld: 1 duplicate symbols
```

rdar://129027705