### PR TITLE
[SourceKit] Don’t set `DisableModulesValidateSystemDependencies` to `true`

### DIFF
--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -254,8 +254,6 @@ bool ide::initCompilerInvocation(
                                      std::to_string(sessionTimestamp - 1));
     ImporterOpts.ExtraArgs.push_back(
         "-fmodules-validate-once-per-build-session");
-
-    SearchPathOpts.DisableModulesValidateSystemDependencies = true;
   }
 
   // Disable expensive SIL options to reduce time spent in SILGen.

--- a/test/SourceKit/test-change-modulemap-of-system-module.swift
+++ b/test/SourceKit/test-change-modulemap-of-system-module.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %sourcekitd-test -req=diags %t/test.swift -- %t/test.swift -Xcc -fmodule-map-file=%t/module.modulemap -module-cache-path %t/module-cache | %FileCheck %s
+// Sleep for 1 second so that touching the modulemap modifies its timestamp on the second level.
+// RUN: sleep 1
+// RUN: touch %t/module.modulemap
+// RUN: %sourcekitd-test -req=diags %t/test.swift -- %t/test.swift -Xcc -fmodule-map-file=%t/module.modulemap -module-cache-path %t/module-cache | %FileCheck %s
+
+// CHECK: 'guard' body must not fall through
+
+//--- test.swift
+
+import Lib
+
+func test(value: Bool) {
+  guard value else {
+
+  }
+}
+
+//--- module.modulemap
+
+module Lib [system] {
+  export *
+}


### PR DESCRIPTION
- **Explanation**: It appears that https://github.com/apple/llvm-project/commit/a6ebd3083dbf8aadae58f6f2a2f1071976649d56 changed the behavior of `-fno-modules-validate-system-headers` (aka. `DisableModulesValidateSystemDependencies`) in conjunction with `-fmodules-validate-once-per-build-session`: Before that change, `-fno-modules-validate-system-headers` needed to be passed for `-fmodules-validate-once-per-build-session` to have any effect (we were always validating system dependencies if `-fno-modules-validate-once-per-build-session` was not set). After the change, `-fno-modules-validate-once-per-build-session` causes system dependencies to never be validated, independent of the build session timestamp.
This change should have no effect on Xcode because it adds `-fmodules-validate-system-headers` to the compiler arguments for Swift files, which overrides `SearchPathOpts.DisableModulesValidateSystemDependencies = true;`
- **Scope**: SourceKit for system modules that are modified
- **Risk**: Low
- **Testing**: Added test case
- **Issue**: rdar://129046909
- **Reviewer**:   @bnbarham on https://github.com/apple/swift/pull/74063