### PR TITLE
Check if decl context returned by importDeclContextOf is null

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -3429,7 +3429,9 @@ ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
   // FIXME: Duplicated from importMethodParamsAndReturnType.
   DeclContext *origDC = importDeclContextOf(property,
                                             property->getDeclContext());
-  assert(origDC);
+  if (!origDC)
+    return {Type(), false};
+
   auto fieldType = isGetter ? clangDecl->getReturnType()
                             : clangDecl->getParamDecl(0)->getType();
 


### PR DESCRIPTION
(cherry picked from commit fedf24c1a7d375f7296b3634b7cb8bace9e49fbe)

Explanation: I've seen a crash due to importDeclContextOf returning a null decl context in importAccessorParamsAndReturnType. Most other call sites of importDeclContextOf check the returned value, so I added a check in importAccessorParamsAndReturnType too.
Risk: Low. This just adds a nullptr check.
Testing: No new tests were added (as I've only seen this on an lldb crash report I'm not sure in what situation this would arise).
Issue: rdar://127847162
Reviewer: @beccadax
Original PR: https://github.com/apple/swift/pull/74188