### PR TITLE
[6.0] IRGen: Rename the section pointing to rodata of generic classest to __objc_clsrolist

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -554,7 +554,7 @@ public:
         EnableGlobalISel(false), VirtualFunctionElimination(false),
         WitnessMethodElimination(false), ConditionalRuntimeRecords(false),
         InternalizeAtLink(false), InternalizeSymbols(false),
-        EmitGenericRODatas(false), NoPreallocatedInstantiationCaches(false),
+        EmitGenericRODatas(true), NoPreallocatedInstantiationCaches(false),
         DisableReadonlyStaticObjects(false), CollocatedMetadataFunctions(false),
         ColocateTypeDescriptors(true), UseRelativeProtocolWitnessTables(false),
         UseFragileResilientProtocolWitnesses(false),

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1167,9 +1167,9 @@ void IRGenModule::emitGlobalLists() {
     if (IRGen.Opts.EmitGenericRODatas) {
       emitGlobalList(
           *this, GenericRODatas, "generic_ro_datas",
-          GetObjCSectionName("__swift_rodatas", "regular"),
+          GetObjCSectionName("__objc_clsrolist", "regular"),
           llvm::GlobalValue::InternalLinkage, Int8PtrTy, /*isConstant*/ false,
-          /*asContiguousArray*/ true, /*canBeStrippedByLinker*/ true);
+          /*asContiguousArray*/ true, /*canBeStrippedByLinker*/ false);
     }
 
     // Objective-C class references go in a variable with a meaningless

--- a/test/IRGen/generic_class_rodata_list.swift
+++ b/test/IRGen/generic_class_rodata_list.swift
@@ -30,7 +30,7 @@
 // CHECK:         .quad   0
 // CHECK:         .quad   __CLASS_METHODS__TtC25generic_class_rodata_list9Somethin
 
-// CHECK:        .section        __DATA,__swift_rodatas
+// CHECK:        .section        __DATA,__objc_clsrolist
 // CHECK:        .p2align        3
 // CHECK:_generic_ro_datas:
 // CHECK:        .quad   ___unnamed_1+40


### PR DESCRIPTION
Also emit it per default.

This is to enable rewriting objective c method lists in generic class' metadata pattern by the linker to the relative format.

Relative method lists are very important for pointer security.

Risk: Very low. We emit an extra section containing pointers. No one currently consumes this section.

rdar://129299739
(cherry picked from commit f063c7e052b8ab4e8608f94d332502d5a383420f)

Original PR: https://github.com/apple/swift/pull/74178