### PR TITLE
Don't pass foundation build path to swift-driver/swift-package-manager

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdriver.py
@@ -92,10 +92,6 @@ def run_build_script_helper(action, host_target, product, args):
     dispatch_build_dir = os.path.join(
         build_root, '%s-%s' % ('libdispatch', host_target))
 
-    # Pass Foundation directory down if we built it
-    foundation_build_dir = os.path.join(
-        build_root, '%s-%s' % ('foundation', host_target))
-
     # Pass the swift lit tests if we're testing and the Swift tests were built
     swift_build_dir = os.path.join(
         build_root, 'swift-{}'.format(host_target))
@@ -117,10 +113,6 @@ def run_build_script_helper(action, host_target, product, args):
     if os.path.exists(dispatch_build_dir):
         helper_cmd += [
             '--dispatch-build-dir', dispatch_build_dir
-        ]
-    if os.path.exists(foundation_build_dir):
-        helper_cmd += [
-            '--foundation-build-dir', foundation_build_dir
         ]
     if os.path.exists(lit_test_dir) and action == 'test':
         helper_cmd += [

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -84,15 +84,6 @@ class SwiftPM(product.Product):
                 "--dispatch-build-dir", dispatch_build_dir
             ]
 
-        # Pass Foundation directory down if we built it
-        foundation_build_dir = os.path.join(
-            build_root, '%s-%s' % ("foundation", host_target))
-
-        if os.path.exists(foundation_build_dir):
-            helper_cmd += [
-                "--foundation-build-dir", foundation_build_dir
-            ]
-
         # Pass Cross compile host info
         if self.has_cross_compile_hosts():
             if self.is_darwin_host(host_target):


### PR DESCRIPTION
Both the swift-driver and swift-package-manager get the Foundation cmake build dir from the build script and pass it along to the Yams build. However, in the case where Foundation has been built via cmake, the Yams build ends up seeing duplicate modules in its search paths - one in the cmake build folder (search path added via the cmake target) and one in the installed toolchain directory (search path added implicitly by the compiler). This results in build failures due to the duplicate clang modules. Previously this was not an issue because all clang modules built by Foundation were private dependencies in cmake, but with the swift-foundation recore we need to make these public dependencies in the cmake graph because we are using `internal import` and not `@_implementationOnly` import (since library evolution is not enabled).

This should not affect behavior - in all of the cases where Foundation had been built via cmake, Foundation is also already installed into the toolchain and is still in the provided search paths.