### PR TITLE
[Completion] Only skip result builder expressions in the same builder

### DIFF
--- a/test/IDE/complete_rdar127154780.swift
+++ b/test/IDE/complete_rdar127154780.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+// rdar://127154780 - Make sure we provide completions on variables that rely
+// on result builders being solved.
+
+@resultBuilder
+enum Builder {
+  static func buildBlock<T>(_ x: T) -> T { x }
+}
+
+struct S {}
+
+struct R<T> {
+  init(@Builder _: () -> T) {}
+}
+
+extension R where T == S {
+  func bar() {}
+}
+
+func foo() {
+  let r = R() {
+    S()
+  }
+  r.#^COMPLETE1?check=COMPLETE^#
+
+  let fn = {
+    let r = R() {
+      S()
+    }
+    r.#^COMPLETE2?check=COMPLETE^#
+  }
+}
+// COMPLETE-DAG: Keyword[self]/CurrNominal:          self[#R<S>#]; name=self
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   bar()[#Void#]; name=bar()


### PR DESCRIPTION
Previously we would skip any expression in a result builder that didn't contain the completion token, but that would cause issues if e.g the result builder was needed to infer the type of a variable that we're completing on. Instead, only skip expressions in a result builder if the completion token is in the same builder and the expression itself doesn't contain the completion.

rdar://127154780
Resolves #72399