### PR TITLE
🍒[5.10] Build-script preset: pr-apple-llvm-project-linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1752,6 +1752,26 @@ skip-test-osx
 
 
 #===------------------------------------------------------------------------===#
+# PR testing presets
+#===------------------------------------------------------------------------===#
+
+[preset: pr_apple_llvm_project_linux]
+
+foundation
+libicu
+libdispatch
+test
+
+release
+
+lldb
+lldb-test-swift-only
+
+skip-test-cmark
+skip-test-swift
+skip-test-foundation
+
+#===------------------------------------------------------------------------===#
 # Mixins for LLBuild, SwiftPM and downstream package project PR tests.
 #===------------------------------------------------------------------------===#
 [preset: mixin_swiftpm_base]

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1757,6 +1757,8 @@ skip-test-osx
 
 [preset: pr_apple_llvm_project_linux]
 
+llvm-cmake-options=-DCLANG_DEFAULT_LINKER=gold
+
 foundation
 libicu
 libdispatch


### PR DESCRIPTION
Cherry picking: https://github.com/apple/swift/pull/74156

> Adding a preset for the pr-apple-llvm-project-linux PR test so that it is configurable without needing to modify CI directly.
>
> Also fixing the linker that clang defaults to in order to avoid using the BFD linker and failing to link (relocations and private symbols).