### PR TITLE
[6.0] Make BorrowingSwitch a LANGUAGE_FEATURE.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -199,6 +199,7 @@ LANGUAGE_FEATURE(BodyMacros, 415, "Function body macros")
 LANGUAGE_FEATURE(BuiltinAddressOfRawLayout, 0, "Builtin.addressOfRawLayout")
 LANGUAGE_FEATURE(TransferringArgsAndResults, 430, "Transferring args and results")
 SUPPRESSIBLE_LANGUAGE_FEATURE(SendingArgsAndResults, 430, "Sending arg and results")
+LANGUAGE_FEATURE(BorrowingSwitch, 432, "Noncopyable type pattern matching")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
@@ -216,7 +217,6 @@ UPCOMING_FEATURE(RegionBasedIsolation, 414, 6)
 UPCOMING_FEATURE(DynamicActorIsolation, 423, 6)
 UPCOMING_FEATURE(NonfrozenEnumExhaustivity, 192, 6)
 UPCOMING_FEATURE(GlobalActorIsolatedTypesUsability, 0434, 6)
-UPCOMING_FEATURE(BorrowingSwitch, 432, 6)
 
 // Swift 7
 UPCOMING_FEATURE(ExistentialAny, 335, 7)


### PR DESCRIPTION
Explanation: Changes the compiler's classification of `$BorrowingSwitch` to be a regular language feature rather than an "upcoming feature", since the feature flag doesn't change any source-breaking behavior.
Scope: Should be no change for most Swift developers.
Issue: rdar://129417451
Original PR: https://github.com/apple/swift/pull/74223
Risk: Low. Only affects the behavior of a feature flag used for bringup of a feature.
Testing: N/A
Reviewer: @atrick 
