### PR TITLE
[Macros] Check external macro defintiion only if warnings are enabled

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2437,19 +2437,20 @@ public:
       break;
 
     case MacroDefinition::Kind::External: {
+      if (!MD->getDiags().getSuppressWarnings()) {
         // Retrieve the external definition of the macro.
-      auto external = macroDef.getExternalMacro();
-      ExternalMacroDefinitionRequest request{
-        &Ctx, external.moduleName, external.macroTypeName
-      };
-      auto externalDef =
-          evaluateOrDefault(Ctx.evaluator, request,
-                            ExternalMacroDefinition::error("unknown error"));
-      if (externalDef.isError()) {
-        MD->diagnose(diag::external_macro_not_found, external.moduleName.str(),
-                     external.macroTypeName.str(), MD->getName(),
-                     externalDef.getErrorMessage())
-            .limitBehavior(DiagnosticBehavior::Warning);
+        auto external = macroDef.getExternalMacro();
+        ExternalMacroDefinitionRequest request{&Ctx, external.moduleName,
+                                               external.macroTypeName};
+        auto externalDef =
+            evaluateOrDefault(Ctx.evaluator, request,
+                              ExternalMacroDefinition::error("unknown error"));
+        if (externalDef.isError()) {
+          MD->diagnose(diag::external_macro_not_found,
+                       external.moduleName.str(), external.macroTypeName.str(),
+                       MD->getName(), externalDef.getErrorMessage())
+              .limitBehavior(DiagnosticBehavior::Warning);
+        }
       }
 
       break;


### PR DESCRIPTION
No observable behavior change.
Avoid checking 'macro' definitions in .swiftinterface files for nothing.
