### PR TITLE
[stdlib] Use broader fast-path for Unicode.Scalar.Properties.canonicalCombiningClass

### DIFF
--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -790,10 +790,8 @@ extension _GraphemeBreakingState {
       // we continue being in one and may check if this extend is a Virama.
       if self.isInIndicSequence || scalar1._isLinkingConsonant {
         if y == .extend {
-          let extendNormData = Unicode._NormData(scalar2, fastUpperbound: 0x300)
-
           // If our extend's CCC is 0, then this rule does not apply.
-          guard extendNormData.ccc != 0 else {
+          guard scalar2.properties.canonicalCombiningClass != .notReordered else {
             return false
           }
         }
@@ -931,12 +929,9 @@ extension _StringGuts {
       // GB9c
       switch (x, scalar2._isLinkingConsonant) {
       case (.extend, true):
-        let extendNormData = Unicode._NormData(scalar1, fastUpperbound: 0x300)
-
-        guard extendNormData.ccc != 0 else {
+        guard scalar1.properties.canonicalCombiningClass != .notReordered else {
           return true
         }
-
         return !checkIfInIndicSequence(at: index, with: previousScalar)
 
       case (.zwj, true):
@@ -1055,9 +1050,7 @@ extension _StringGuts {
 
       switch (gbp, scalar._isLinkingConsonant) {
       case (.extend, false):
-        let extendNormData = Unicode._NormData(scalar, fastUpperbound: 0x300)
-
-        guard extendNormData.ccc != 0 else {
+        guard scalar.properties.canonicalCombiningClass != .notReordered else {
           return false
         }
 

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -1427,8 +1427,7 @@ extension Unicode.Scalar.Properties {
   /// This property corresponds to the "Canonical_Combining_Class" property in
   /// the [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var canonicalCombiningClass: Unicode.CanonicalCombiningClass {
-    let normData = Unicode._NormData(_scalar)
-    return Unicode.CanonicalCombiningClass(rawValue: normData.ccc)
+    Unicode._NormData(_scalar, fastUpperbound: 0x300).canonicalCombiningClass
   }
 }
 


### PR DESCRIPTION
1. We can add the U+0300 fast-path to `Unicode.Scalar.Properties.canonicalCombiningClass`. The reason we use that fast-path in other places is because, even though it gives us inaccurate NFD_QC values, we don't care about that if all we need is the CCC (and/or NFC_QC value).
2. Since the scalar property now includes all the fast-paths, there is no reason _not_ to use it in GraphemeBreaking when all we need is the CCC. It's nicer and clearer if we can reduce the number of places where we hard-code magic numbers.