### PR TITLE
[Concurrency] Don't ignore mismatching isolation for overrides of Clang-imported superclass methods.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2152,7 +2152,11 @@ namespace {
                   .limitBehaviorUntilSwiftVersion(behavior, 6);
             }
 
-            // Always emit the note with fix-it.
+            // Overrides cannot be isolated to a global actor; the isolation
+            // must match the overridden decl.
+            if (fn->getOverriddenDecl())
+              return false;
+
             fn->diagnose(diag::add_globalactor_to_function,
                          globalActor->getWithoutParens().getString(),
                          fn, globalActor)
@@ -4941,6 +4945,7 @@ static OverrideIsolationResult validOverrideIsolation(
     ValueDecl *overridden, ActorIsolation overriddenIsolation) {
   ConcreteDeclRef valueRef = getDeclRefInContext(value);
   auto declContext = value->getInnermostDeclContext();
+  auto &ctx = declContext->getASTContext();
 
   auto refResult = ActorReferenceResult::forReference(
       valueRef, SourceLoc(), declContext, std::nullopt, std::nullopt, isolation,
@@ -4964,8 +4969,10 @@ static OverrideIsolationResult validOverrideIsolation(
 
     // If the overridden declaration is from Objective-C with no actor
     // annotation, allow it.
-    if (overridden->hasClangNode() && !overriddenIsolation)
+    if (ctx.LangOpts.StrictConcurrencyLevel != StrictConcurrency::Complete &&
+        overridden->hasClangNode() && !overriddenIsolation) {
       return OverrideIsolationResult::Allowed;
+    }
 
     return OverrideIsolationResult::Disallowed;
   }

--- a/test/ClangImporter/objc_isolation_complete.swift
+++ b/test/ClangImporter/objc_isolation_complete.swift
@@ -15,3 +15,19 @@ func unsatisfiedPreconcurrencyIsolation(view: MyView) {
   // expected-warning@+1 {{main actor-isolated property 'isVisible' can not be referenced from a non-isolated context}}
   _ = view.isVisible
 }
+
+@preconcurrency @MainActor
+class IsolatedSub: NXSender {
+  var mainActorState = 0 // expected-note {{property declared here}}
+  override func sendAny(_: any Sendable) -> any Sendable {
+    return mainActorState
+    // expected-warning@-1 {{main actor-isolated property 'mainActorState' can not be referenced from a non-isolated context}}
+  }
+
+  @MainActor
+  override func sendOptionalAny(_: (any Sendable)?) -> (any Sendable)? {
+    // expected-warning@-1 {{main actor-isolated instance method 'sendOptionalAny' has different actor isolation from nonisolated overridden declaration; this is an error in the Swift 6 language mode}}
+
+    return mainActorState
+  }
+}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1492,9 +1492,6 @@ class None {
 // try to add inferred isolation while overriding
 @MainActor
 class MA_None1: None {
-
-  // FIXME: bad note, since the problem is a mismatch in overridden vs inferred isolation; this wont help.
-  // expected-note@+1 {{add '@MainActor' to make instance method 'method()' part of global actor 'MainActor'}}
   override func method() {
     beets_ma() // expected-error {{call to main actor-isolated global function 'beets_ma()' in a synchronous nonisolated context}}
   }


### PR DESCRIPTION
Mismatching isolation for overrides is invalid, and there's no reason to ignore this mistake for clang-imported superclasses. This change is staged in behind complete concurrency checking.

This change also removes a bogus fix-it to add global actor isolation to an override if it synchronously calls a global actor isolated method, which won't work.

Resolves: rdar://124409467, https://github.com/apple/swift/issues/72238