### PR TITLE
[6.0][Concurrency] Don't ignore mismatching isolation for overrides of Clang-imported superclass methods.

### DIFF
--- a/test/ClangImporter/objc_isolation_complete.swift
+++ b/test/ClangImporter/objc_isolation_complete.swift
@@ -15,3 +15,19 @@ func unsatisfiedPreconcurrencyIsolation(view: MyView) {
   // expected-warning@+1 {{main actor-isolated property 'isVisible' can not be referenced from a non-isolated context}}
   _ = view.isVisible
 }
+
+@preconcurrency @MainActor
+class IsolatedSub: NXSender {
+  var mainActorState = 0 // expected-note {{property declared here}}
+  override func sendAny(_: any Sendable) -> any Sendable {
+    return mainActorState
+    // expected-warning@-1 {{main actor-isolated property 'mainActorState' can not be referenced from a non-isolated context}}
+  }
+
+  @MainActor
+  override func sendOptionalAny(_: (any Sendable)?) -> (any Sendable)? {
+    // expected-warning@-1 {{main actor-isolated instance method 'sendOptionalAny' has different actor isolation from nonisolated overridden declaration; this is an error in the Swift 6 language mode}}
+
+    return mainActorState
+  }
+}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1466,9 +1466,6 @@ class None {
 // try to add inferred isolation while overriding
 @MainActor
 class MA_None1: None {
-
-  // FIXME: bad note, since the problem is a mismatch in overridden vs inferred isolation; this wont help.
-  // expected-note@+1 {{add '@MainActor' to make instance method 'method()' part of global actor 'MainActor'}}
   override func method() {
     beets_ma() // expected-error {{call to main actor-isolated global function 'beets_ma()' in a synchronous nonisolated context}}
   }


### PR DESCRIPTION
* **Explanation**: The actor isolation checker was ignoring mismatching isolation for overrides if the superclass is imported from ObjC. However, mismatching isolation for overrides is invalid, and there's no reason to ignore this mistake for ObjC-imported superclasses. This change is staged in behind complete concurrency checking. This change also removes a bogus fix-it to add global actor isolation to an override if it synchronously calls a global actor isolated method, which won't work. 
* **Scope**: Only impacts overrides where the superclass is imported from ObjC, where the override is isolated to a global actor and the superclass method is not.
* **Issue**: rdar://124409467, https://github.com/apple/swift/issues/72238
* **Risk**: Low; the change is staged in as a warning under `-strict-concurrency=complete`.
* **Testing**: Added a new test.
* **Reviewer**: TBD 
* **Main branch PR**: https://github.com/apple/swift/pull/74237