### PR TITLE
[sending] Mark Task.init, Task.detached and friends as taking a sending closure instead of a __owned @Sendable

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -591,11 +591,14 @@ class C {
 
 (Note that it is "inherit", not "inherits", unlike below.)
 
-Marks that a `@Sendable async` closure argument should inherit the actor
-context (i.e. what actor it should be run on) based on the declaration site
-of the closure. This is different from the typical behavior, where the closure
-may be runnable anywhere unless its type specifically declares that it will
-run on a specific actor.
+Marks that a `@Sendable async` or `sendable async` closure argument should
+inherit the actor context (i.e. what actor it should be run on) based on the
+declaration site of the closure rather than be non-Sendable. This does not do
+anything if the closure is synchronous.
+
+DISCUSSION: The reason why this does nothing when the closure is synchronous is
+since it does not have the ability to hop to the appropriate executor before it
+is run, so we may create concurrency errors.
 
 ## `@_inheritsConvenienceInitializers`
 

--- a/include/swift/AST/ASTSynthesis.h
+++ b/include/swift/AST/ASTSynthesis.h
@@ -372,6 +372,27 @@ ParamDecl *synthesizeParamDecl(SynthesisContext &SC,
   param->setSpecifier(s.specifier);
   return param;
 }
+
+template <class S>
+struct SendingParamSynthesizer {
+  S sub;
+};
+
+template <class S>
+constexpr SendingParamSynthesizer<S> _sending(S sub) {
+  return {sub};
+}
+
+template <class S>
+ParamDecl *synthesizeParamDecl(SynthesisContext &SC,
+                               const SendingParamSynthesizer<S> &s,
+                               const char *label = nullptr) {
+  auto param = synthesizeParamDecl(SC, s.sub, label);
+  if (SC.Context.LangOpts.hasFeature(Feature::SendingArgsAndResults))
+    param->setSending();
+  return param;
+}
+
 template <class S>
 FunctionType::Param synthesizeParamType(SynthesisContext &SC,
                                         const SpecifiedParamSynthesizer<S> &s) {

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -959,7 +959,7 @@ BUILTIN_MISC_OPERATION(UnprotectedAddressOfBorrowOpaque, "unprotectedAddressOfBo
 ///               initialSerialExecutor: (Builtin.Executor)? = nil,
 ///               taskGroup: Builtin.RawPointer? = nil,
 ///               initialTaskExecutor: (Builtin.Executor)? = nil,
-///               operation: @escaping () async throws -> T)
+///               operation: sending @escaping () async throws -> T)
 ///  -> Builtin.NativeObject, Builtin.RawPointer)
 ///
 /// Create a new task.
@@ -969,7 +969,7 @@ BUILTIN_SIL_OPERATION(CreateTask, "createTask", Special)
 ///                      initialSerialExecutor: (Builtin.Executor)? = nil,
 ///                      taskGroup: Builtin.RawPointer? = nil,
 ///                      initialTaskExecutor: (Builtin.Executor)? = nil,
-///                      operation: @escaping () async throws -> ())
+///                      operation: sending @escaping () async throws -> ())
 ///  -> (Builtin.NativeObject, Builtin.RawPointer)
 ///
 /// Create a new discarding task.
@@ -977,7 +977,7 @@ BUILTIN_SIL_OPERATION(CreateDiscardingTask, "createDiscardingTask", Special)
 
 /// createAsyncTask(): (
 ///     Int,                            // task-creation flags
-///     @escaping () async throws -> T  // function
+///     sending @escaping () async throws -> T  // function
 /// ) -> Builtin.NativeObject
 ///
 /// Legacy spelling of:
@@ -988,7 +988,7 @@ BUILTIN_MISC_OPERATION_WITH_SILGEN(CreateAsyncTask,
 /// createAsyncTaskInGroup(): (
 ///     Int,                            // flags
 ///     Builtin.RawPointer,             // group
-///     @escaping () async throws -> T  // function
+///     sending @escaping () async throws -> T  // function
 /// ) -> Builtin.NativeObject
 ///
 /// Legacy spelling of:
@@ -999,7 +999,7 @@ BUILTIN_SIL_OPERATION(CreateAsyncTaskInGroup,
 /// createAsyncDiscardingTaskInGroup(): (
 ///     Int,                               // flags
 ///     Builtin.RawPointer,                // group
-///     @escaping () async throws -> Void  // function
+///     sending @escaping () async throws -> Void  // function
 /// ) -> Builtin.NativeObject
 ///
 /// Legacy spelling of:
@@ -1010,7 +1010,7 @@ BUILTIN_SIL_OPERATION(CreateAsyncDiscardingTaskInGroup,
 /// createAsyncTaskWithExecutor(): (
 ///     Int,                            // flags
 ///     Builtin.Executor,               // executor
-///     @escaping () async throws -> T  // function
+///     sending @escaping () async throws -> T  // function
 /// ) -> Builtin.NativeObject
 ///
 /// Legacy spelling of:
@@ -1022,7 +1022,7 @@ BUILTIN_SIL_OPERATION(CreateAsyncTaskWithExecutor,
 ///     Int,                            // flags
 ///     Builtin.RawPointer,             // group
 ///     Builtin.Executor,               // executor
-///     @escaping () async throws -> T  // function
+///     sending @escaping () async throws -> T  // function
 /// ) -> Builtin.NativeObject
 ///
 /// Legacy spelling of:
@@ -1034,7 +1034,7 @@ BUILTIN_SIL_OPERATION(CreateAsyncTaskInGroupWithExecutor,
 ///     Int,                               // flags
 ///     Builtin.RawPointer,                // group
 ///     Builtin.Executor,                  // executor
-///     @escaping () async throws -> Void  // function
+///     sending @escaping () async throws -> Void  // function
 /// ) -> Builtin.NativeObject
 ///
 /// Legacy spelling of:

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -283,8 +283,8 @@ protected:
     /// \c \@preconcurrency declaration.
     IsolatedByPreconcurrency : 1,
 
-    /// True if this is a closure literal that is passed as a sending parameter.
-    IsSendingParameter : 1
+    /// True if this is a closure literal that is passed to a sending parameter.
+    IsPassedToSendingParameter : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(BindOptionalExpr, Expr, 16,
@@ -4142,7 +4142,7 @@ public:
     Bits.ClosureExpr.HasAnonymousClosureVars = false;
     Bits.ClosureExpr.ImplicitSelfCapture = false;
     Bits.ClosureExpr.InheritActorContext = false;
-    Bits.ClosureExpr.IsSendingParameter = false;
+    Bits.ClosureExpr.IsPassedToSendingParameter = false;
   }
 
   SourceRange getSourceRange() const;
@@ -4198,14 +4198,14 @@ public:
     Bits.ClosureExpr.IsolatedByPreconcurrency = value;
   }
 
-  /// Whether the closure is a closure literal that is passed as a sending
+  /// Whether the closure is a closure literal that is passed to a sending
   /// parameter.
-  bool isSendingParameter() const {
-    return Bits.ClosureExpr.IsSendingParameter;
+  bool isPassedToSendingParameter() const {
+    return Bits.ClosureExpr.IsPassedToSendingParameter;
   }
 
-  void setSendingParameter(bool value = true) {
-    Bits.ClosureExpr.IsSendingParameter = value;
+  void setIsPassedToSendingParameter(bool value = true) {
+    Bits.ClosureExpr.IsPassedToSendingParameter = value;
   }
 
   /// Determine whether this closure expression has an

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -266,7 +266,7 @@ protected:
     Kind : 2
   );
 
-  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1,
     /// True if closure parameters were synthesized from anonymous closure
     /// variables.
     HasAnonymousClosureVars : 1,
@@ -281,7 +281,10 @@ protected:
 
     /// True if this closure's actor isolation behavior was determined by an
     /// \c \@preconcurrency declaration.
-    IsolatedByPreconcurrency : 1
+    IsolatedByPreconcurrency : 1,
+
+    /// True if this is a closure literal that is passed as a sending parameter.
+    IsSendingParameter : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(BindOptionalExpr, Expr, 16,
@@ -4139,6 +4142,7 @@ public:
     Bits.ClosureExpr.HasAnonymousClosureVars = false;
     Bits.ClosureExpr.ImplicitSelfCapture = false;
     Bits.ClosureExpr.InheritActorContext = false;
+    Bits.ClosureExpr.IsSendingParameter = false;
   }
 
   SourceRange getSourceRange() const;
@@ -4192,6 +4196,16 @@ public:
 
   void setIsolatedByPreconcurrency(bool value = true) {
     Bits.ClosureExpr.IsolatedByPreconcurrency = value;
+  }
+
+  /// Whether the closure is a closure literal that is passed as a sending
+  /// parameter.
+  bool isSendingParameter() const {
+    return Bits.ClosureExpr.IsSendingParameter;
+  }
+
+  void setSendingParameter(bool value = true) {
+    Bits.ClosureExpr.IsSendingParameter = value;
   }
 
   /// Determine whether this closure expression has an

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3832,6 +3832,7 @@ struct ParameterListInfo {
   SmallBitVector implicitSelfCapture;
   SmallBitVector inheritActorContext;
   SmallBitVector variadicGenerics;
+  SmallBitVector isSending;
 
 public:
   ParameterListInfo() { }
@@ -3862,6 +3863,9 @@ public:
   bool anyContextualInfo() const;
 
   bool isVariadicGenericParameter(unsigned paramIdx) const;
+
+  /// Returns true if this is a sending parameter.
+  bool isSendingParameter(unsigned paramIdx) const;
 
   /// Retrieve the number of non-defaulted parameters.
   unsigned numNonDefaultedParameters() const {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3832,7 +3832,7 @@ struct ParameterListInfo {
   SmallBitVector implicitSelfCapture;
   SmallBitVector inheritActorContext;
   SmallBitVector variadicGenerics;
-  SmallBitVector isSending;
+  SmallBitVector isPassedToSending;
 
 public:
   ParameterListInfo() { }
@@ -3865,7 +3865,7 @@ public:
   bool isVariadicGenericParameter(unsigned paramIdx) const;
 
   /// Returns true if this is a sending parameter.
-  bool isSendingParameter(unsigned paramIdx) const;
+  bool isPassedToSendingParameter(unsigned paramIdx) const;
 
   /// Retrieve the number of non-defaulted parameters.
   unsigned numNonDefaultedParameters() const {

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1154,6 +1154,28 @@ public:
   }
 
 private:
+  bool isConvertFunctionFromSendableType(SILValue equivalenceClassRep) const {
+    SILValue valueToTest = equivalenceClassRep;
+    while (true) {
+      if (auto *i = dyn_cast<ThinToThickFunctionInst>(valueToTest)) {
+        valueToTest = i->getOperand();
+        continue;
+      }
+      if (auto *i = dyn_cast<ConvertEscapeToNoEscapeInst>(valueToTest)) {
+        valueToTest = i->getOperand();
+        continue;
+      }
+      break;
+    }
+
+    auto *cvi = dyn_cast<ConvertFunctionInst>(valueToTest);
+    if (!cvi)
+      return false;
+
+    return cvi->getOperand()->getType().isSendable(
+        equivalenceClassRep->getFunction());
+  }
+
   // Private helper that squelches the error if our transfer instruction and our
   // use have the same isolation.
   void handleLocalUseAfterTransferHelper(const PartitionOp &op, Element elt,
@@ -1166,12 +1188,13 @@ private:
           return;
       }
 
-      // If we have a temporary that is initialized with an unsafe nonisolated
-      // value... squelch the error like if we were that value.
-      //
-      // TODO: This goes away with opaque values.
       if (SILValue equivalenceClassRep =
               getRepresentative(transferringOp->get())) {
+
+        // If we have a temporary that is initialized with an unsafe nonisolated
+        // value... squelch the error like if we were that value.
+        //
+        // TODO: This goes away with opaque values.
         if (auto *asi = dyn_cast<AllocStackInst>(equivalenceClassRep)) {
           if (SILValue value = getInitOfTemporaryAllocStack(asi)) {
             if (auto elt = getElement(value)) {
@@ -1182,6 +1205,11 @@ private:
             }
           }
         }
+
+        // See if we have a convert function from a `@Sendable` type. In this
+        // case, we want to squelch the error.
+        if (isConvertFunctionFromSendableType(equivalenceClassRep))
+          return;
       }
 
       // If our instruction does not have any isolation info associated with it,
@@ -1206,12 +1234,12 @@ private:
       const PartitionOp &op, Element elt,
       SILDynamicMergedIsolationInfo dynamicMergedIsolationInfo) const {
     if (shouldTryToSquelchErrors()) {
-      // If we have a temporary that is initialized with an unsafe nonisolated
-      // value... squelch the error like if we were that value.
-      //
-      // TODO: This goes away with opaque values.
       if (SILValue equivalenceClassRep =
               getRepresentative(op.getSourceOp()->get())) {
+        // If we have a temporary that is initialized with an unsafe nonisolated
+        // value... squelch the error like if we were that value.
+        //
+        // TODO: This goes away with opaque values.
         if (auto *asi = dyn_cast<AllocStackInst>(equivalenceClassRep)) {
           if (SILValue value = getInitOfTemporaryAllocStack(asi)) {
             if (auto elt = getElement(value)) {
@@ -1222,6 +1250,11 @@ private:
             }
           }
         }
+
+        // See if we have a convert function from a `@Sendable` type. In this
+        // case, we want to squelch the error.
+        if (isConvertFunctionFromSendableType(equivalenceClassRep))
+          return;
       }
     }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1302,6 +1302,7 @@ ParameterListInfo::ParameterListInfo(
   implicitSelfCapture.resize(params.size());
   inheritActorContext.resize(params.size());
   variadicGenerics.resize(params.size());
+  isSending.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
@@ -1365,6 +1366,10 @@ ParameterListInfo::ParameterListInfo(
     if (param->getInterfaceType()->is<PackExpansionType>()) {
       variadicGenerics.set(i);
     }
+
+    if (param->isSending()) {
+      isSending.set(i);
+    }
   }
 }
 
@@ -1405,6 +1410,9 @@ bool ParameterListInfo::isVariadicGenericParameter(unsigned paramIdx) const {
       : false;
 }
 
+bool ParameterListInfo::isSendingParameter(unsigned paramIdx) const {
+  return paramIdx < isSending.size() ? isSending[paramIdx] : false;
+}
 
 /// Turn a param list into a symbolic and printable representation that does not
 /// include the types, something like (_:, b:, c:)

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1302,7 +1302,7 @@ ParameterListInfo::ParameterListInfo(
   implicitSelfCapture.resize(params.size());
   inheritActorContext.resize(params.size());
   variadicGenerics.resize(params.size());
-  isSending.resize(params.size());
+  isPassedToSending.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
@@ -1368,7 +1368,7 @@ ParameterListInfo::ParameterListInfo(
     }
 
     if (param->isSending()) {
-      isSending.set(i);
+      isPassedToSending.set(i);
     }
   }
 }
@@ -1410,8 +1410,9 @@ bool ParameterListInfo::isVariadicGenericParameter(unsigned paramIdx) const {
       : false;
 }
 
-bool ParameterListInfo::isSendingParameter(unsigned paramIdx) const {
-  return paramIdx < isSending.size() ? isSending[paramIdx] : false;
+bool ParameterListInfo::isPassedToSendingParameter(unsigned paramIdx) const {
+  return paramIdx < isPassedToSending.size() ? isPassedToSending[paramIdx]
+                                             : false;
 }
 
 /// Turn a param list into a symbolic and printable representation that does not

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -722,14 +722,14 @@ bool SILDeclRef::hasFuncDecl() const {
 }
 
 ClosureExpr *SILDeclRef::getClosureExpr() const {
-  return dyn_cast<ClosureExpr>(getAbstractClosureExpr());
+  return dyn_cast_or_null<ClosureExpr>(getAbstractClosureExpr());
 }
 AutoClosureExpr *SILDeclRef::getAutoClosureExpr() const {
-  return dyn_cast<AutoClosureExpr>(getAbstractClosureExpr());
+  return dyn_cast_or_null<AutoClosureExpr>(getAbstractClosureExpr());
 }
 
 FuncDecl *SILDeclRef::getFuncDecl() const {
-  return dyn_cast<FuncDecl>(getDecl());
+  return dyn_cast_or_null<FuncDecl>(getDecl());
 }
 
 ModuleDecl *SILDeclRef::getModuleContext() const {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2408,8 +2408,12 @@ public:
       }
       auto fnType = requireObjectType(SILFunctionType, arguments[5],
                                       "result of createAsyncTask");
-      auto expectedExtInfo =
-        SILExtInfoBuilder().withAsync(true).withSendable(true).build();
+      bool haveSending =
+          F.getASTContext().LangOpts.hasFeature(Feature::SendingArgsAndResults);
+      auto expectedExtInfo = SILExtInfoBuilder()
+                                 .withAsync(true)
+                                 .withSendable(!haveSending)
+                                 .build();
       require(fnType->getExtInfo().isEqualTo(expectedExtInfo, /*clang types*/true),
               "function argument to createAsyncTask has incorrect ext info");
       // FIXME: it'd be better if we took a consuming closure here

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1631,11 +1631,13 @@ static ManagedValue emitCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
 
     auto &&fnArg = nextArg();
 
+    bool hasSending = ctx.LangOpts.hasFeature(Feature::SendingArgsAndResults);
+
     auto extInfo =
         ASTExtInfoBuilder()
             .withAsync()
             .withThrows()
-            .withSendable(true)
+            .withSendable(!hasSending)
             .withRepresentation(GenericFunctionType::Representation::Swift)
             .build();
 
@@ -1757,10 +1759,12 @@ SILGenFunction::emitCreateAsyncMainTask(SILLocation loc, SubstitutionMap subs,
                                         ManagedValue mainFunctionRef) {
   auto &ctx = getASTContext();
   CanType flagsType = ctx.getIntType()->getCanonicalType();
+  bool hasSending = ctx.LangOpts.hasFeature(Feature::SendingArgsAndResults);
   CanType functionType =
-    FunctionType::get({}, ctx.TheEmptyTupleType,
-                      ASTExtInfo().withAsync().withThrows().withSendable(true))
-      ->getCanonicalType();
+      FunctionType::get(
+          {}, ctx.TheEmptyTupleType,
+          ASTExtInfo().withAsync().withThrows().withSendable(!hasSending))
+          ->getCanonicalType();
 
   using Param = FunctionType::Param;
   PreparedArguments args({Param(flagsType), Param(functionType)});

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -521,7 +521,6 @@ namespace {
     RValue visitCaptureListExpr(CaptureListExpr *E, SGFContext C);
     RValue visitAbstractClosureExpr(AbstractClosureExpr *E, SGFContext C);
     ManagedValue tryEmitConvertedClosure(AbstractClosureExpr *e,
-                                         CanAnyFunctionType closureType,
                                          const Conversion &conv);
     ManagedValue emitClosureReference(AbstractClosureExpr *e,
                                       const FunctionTypeInfo &contextInfo);
@@ -1809,9 +1808,7 @@ ManagedValue emitCFunctionPointer(SILGenFunction &SGF,
     (void) emitAnyClosureExpr(SGF, semanticExpr,
                               [&](AbstractClosureExpr *closure) {
       // Emit the closure body.
-      auto closureType =
-        cast<AnyFunctionType>(closure->getType()->getCanonicalType());
-      SGF.SGM.emitClosure(closure, SGF.getFunctionTypeInfo(closureType));
+      SGF.SGM.emitClosure(closure, SGF.getClosureTypeInfo(closure));
 
       loc = closure;
       return ManagedValue();
@@ -2960,10 +2957,10 @@ static bool canEmitSpecializedClosureFunction(CanAnyFunctionType closureType,
 
 /// Try to emit the given closure under the given conversion.
 /// Returns an invalid ManagedValue if this fails.
-ManagedValue
-RValueEmitter::tryEmitConvertedClosure(AbstractClosureExpr *e,
-                                       CanAnyFunctionType closureType,
-                                       const Conversion &conv) {
+ManagedValue RValueEmitter::tryEmitConvertedClosure(AbstractClosureExpr *e,
+                                                    const Conversion &conv) {
+  auto closureType = cast<AnyFunctionType>(e->getType()->getCanonicalType());
+
   // Bail out if we don't have specialized type information from context.
   auto info = tryGetSpecializedClosureTypeFromContext(closureType, conv);
   if (!info) return ManagedValue();
@@ -3012,13 +3009,11 @@ RValue RValueEmitter::visitAbstractClosureExpr(AbstractClosureExpr *e,
   if (auto *placeholder = wrappedValueAutoclosurePlaceholder(e))
     return visitPropertyWrapperValuePlaceholderExpr(placeholder, C);
 
-  auto closureType = cast<AnyFunctionType>(e->getType()->getCanonicalType());
-
   // If we're emitting into a converting context, try to combine the
   // conversion into the emission of the closure function.
   if (auto *convertingInit = C.getAsConversion()) {
-    ManagedValue closure = tryEmitConvertedClosure(e, closureType,
-                                              convertingInit->getConversion());
+    ManagedValue closure =
+        tryEmitConvertedClosure(e, convertingInit->getConversion());
     if (closure.isValid()) {
       convertingInit->initWithConvertedValue(SGF, e, closure);
       convertingInit->finishInitialization(SGF);
@@ -3027,9 +3022,10 @@ RValue RValueEmitter::visitAbstractClosureExpr(AbstractClosureExpr *e,
   }
 
   // Otherwise, emit the expression using the simple type of the expression.
-  auto info = SGF.getFunctionTypeInfo(closureType);
+  auto info = SGF.getClosureTypeInfo(e);
   auto closure = emitClosureReference(e, info);
-  return RValue(SGF, e, closureType, closure);
+
+  return RValue(SGF, e, e->getType()->getCanonicalType(), closure);
 }
 
 ManagedValue

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1038,10 +1038,9 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
 
     auto calleeConvention = ParameterConvention::Direct_Guaranteed;
 
-    auto resultIsolation = (hasErasedIsolation
-                              ? SILFunctionTypeIsolation::Erased
-                              : SILFunctionTypeIsolation::Unknown);
-
+    auto resultIsolation =
+        (hasErasedIsolation ? SILFunctionTypeIsolation::Erased
+                            : SILFunctionTypeIsolation::Unknown);
     auto toClosure =
       B.createPartialApply(loc, functionRef, subs, forwardedArgs,
                            calleeConvention, resultIsolation);
@@ -1056,6 +1055,26 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
                                   typeContext.OrigType,
                                   typeContext.FormalType,
               SILType::getPrimitiveObjectType(typeContext.ExpectedLoweredType));
+
+    auto resultType = cast<SILFunctionType>(result.getType().getASTType());
+
+    // Check if we performed Sendable/sending type compensation in
+    // emitTransformedValue for a closure. If we did, insert some fixup code to
+    // convert from an @Sendable to a not-@Sendable value.
+    //
+    // DISCUSSION: We cannot do this internally to emitTransformedValue since it
+    // does not have access to our SILDeclRef.
+    if (auto *e = constant.getClosureExpr()) {
+      auto actualType = cast<AnyFunctionType>(e->getType()->getCanonicalType());
+      if (e->inheritsActorContext() &&
+          e->getActorIsolation().isActorIsolated() && actualType->isAsync() &&
+          !actualType->isSendable() && resultType->isSendable()) {
+        auto extInfo = resultType->getExtInfo().withSendable(false);
+        resultType = resultType->getWithExtInfo(extInfo);
+        result = B.createConvertFunction(
+            loc, result, SILType::getPrimitiveObjectType(resultType));
+      }
+    }
   }
 
   return result;

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -729,6 +729,10 @@ public:
   /// without any contextual overrides.
   FunctionTypeInfo getFunctionTypeInfo(CanAnyFunctionType fnType);
 
+  /// A helper method that calls getFunctionTypeInfo that also marks global
+  /// actor isolated async closures that are not sendable as sendable.
+  FunctionTypeInfo getClosureTypeInfo(AbstractClosureExpr *expr);
+
   bool isEmittingTopLevelCode() { return IsEmittingTopLevelCode; }
   void stopEmittingTopLevelCode() { IsEmittingTopLevelCode = false; }
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -6530,6 +6530,7 @@ ManagedValue Transform::transformFunction(ManagedValue fn,
     SILType resTy = SILType::getPrimitiveObjectType(expectedFnType);
     fn = SGF.emitManagedRValueWithCleanup(
         SGF.B.createThinToThickFunction(Loc, fn.forward(SGF), resTy));
+
   } else if (newFnType != expectedFnType) {
     // Escaping to noescape conversion.
     SILType resTy = SILType::getPrimitiveObjectType(expectedFnType);

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1859,10 +1859,22 @@ public:
     translateSILMultiAssign(applyResults, pai->getOperandValues());
   }
 
+  void translateCreateAsyncTask(BuiltinInst *bi) {
+    if (auto value = tryToTrackValue(bi->getOperand(1))) {
+      builder.addRequire(value->getRepresentative().getValue());
+      builder.addTransfer(value->getRepresentative().getValue(),
+                          &bi->getAllOperands()[1]);
+    }
+  }
+
   void translateSILBuiltin(BuiltinInst *bi) {
     if (auto kind = bi->getBuiltinKind()) {
       if (kind == BuiltinValueKind::StartAsyncLetWithLocalBuffer) {
         return translateAsyncLetStart(bi);
+      }
+
+      if (kind == BuiltinValueKind::CreateAsyncTask) {
+        return translateCreateAsyncTask(bi);
       }
     }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5963,23 +5963,25 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
 }
 
 /// Apply the contextually Sendable flag to the given expression,
-static void applyContextualClosureFlags(
-      Expr *expr, bool implicitSelfCapture, bool inheritActorContext) {
+static void applyContextualClosureFlags(Expr *expr, bool implicitSelfCapture,
+                                        bool inheritActorContext,
+                                        bool isSendingParameter) {
   if (auto closure = dyn_cast<ClosureExpr>(expr)) {
     closure->setAllowsImplicitSelfCapture(implicitSelfCapture);
     closure->setInheritsActorContext(inheritActorContext);
+    closure->setSendingParameter(isSendingParameter);
     return;
   }
 
   if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
-    applyContextualClosureFlags(
-        captureList->getClosureBody(), implicitSelfCapture,
-        inheritActorContext);
+    applyContextualClosureFlags(captureList->getClosureBody(),
+                                implicitSelfCapture, inheritActorContext,
+                                isSendingParameter);
   }
 
   if (auto identity = dyn_cast<IdentityExpr>(expr)) {
-    applyContextualClosureFlags(
-        identity->getSubExpr(), implicitSelfCapture, inheritActorContext);
+    applyContextualClosureFlags(identity->getSubExpr(), implicitSelfCapture,
+                                inheritActorContext, isSendingParameter);
   }
 }
 
@@ -6207,8 +6209,10 @@ ArgumentList *ExprRewriter::coerceCallArguments(
     // implicit self capture or inheriting actor context.
     bool isImplicitSelfCapture = paramInfo.isImplicitSelfCapture(paramIdx);
     bool inheritsActorContext = paramInfo.inheritsActorContext(paramIdx);
-    applyContextualClosureFlags(
-        argExpr, isImplicitSelfCapture, inheritsActorContext);
+    bool isSendingParameter = paramInfo.isSendingParameter(paramIdx);
+
+    applyContextualClosureFlags(argExpr, isImplicitSelfCapture,
+                                inheritsActorContext, isSendingParameter);
 
     // If the types exactly match, this is easy.
     auto paramType = param.getOldType();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1625,12 +1625,37 @@ bool ReferencedActor::isKnownToBeLocal() const {
   }
 }
 
-static AbstractFunctionDecl const *
-isActorInitOrDeInitContext(const DeclContext *dc) {
-  return swift::isActorInitOrDeInitContext(
-      dc, [](const AbstractClosureExpr *closure) {
-        return isSendableClosure(closure, /*forActorIsolation=*/false);
-      });
+const AbstractFunctionDecl *
+swift::isActorInitOrDeInitContext(const DeclContext *dc) {
+  while (true) {
+    // Non-Sendable closures are considered part of the enclosing context.
+    if (auto *closure = dyn_cast<AbstractClosureExpr>(dc)) {
+      if (isSendableClosure(closure, /*for actor isolation*/ false))
+        return nullptr;
+
+      dc = dc->getParent();
+      continue;
+    }
+
+    if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
+      // If this is an initializer or deinitializer of an actor, we're done.
+      if ((isa<ConstructorDecl>(func) || isa<DestructorDecl>(func)) &&
+          getSelfActorDecl(dc->getParent()))
+        return func;
+
+      // Non-Sendable local functions are considered part of the enclosing
+      // context.
+      if (func->getDeclContext()->isLocalContext()) {
+        if (func->isSendable())
+          return nullptr;
+
+        dc = dc->getParent();
+        continue;
+      }
+    }
+
+    return nullptr;
+  }
 }
 
 static bool isStoredProperty(ValueDecl const *member) {
@@ -6465,40 +6490,6 @@ bool swift::completionContextUsesConcurrencyFeatures(const DeclContext *dc) {
     [](const ClosureExpr *closure) {
       return closure->isIsolatedByPreconcurrency();
     });
-}
-
-AbstractFunctionDecl const *swift::isActorInitOrDeInitContext(
-    const DeclContext *dc,
-    llvm::function_ref<bool(const AbstractClosureExpr *)> isSendable) {
-  while (true) {
-    // Non-Sendable closures are considered part of the enclosing context.
-    if (auto *closure = dyn_cast<AbstractClosureExpr>(dc)) {
-      if (isSendable(closure))
-        return nullptr;
-
-      dc = dc->getParent();
-      continue;
-    }
-
-    if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
-      // If this is an initializer or deinitializer of an actor, we're done.
-      if ((isa<ConstructorDecl>(func) || isa<DestructorDecl>(func)) &&
-          getSelfActorDecl(dc->getParent()))
-        return func;
-
-      // Non-Sendable local functions are considered part of the enclosing
-      // context.
-      if (func->getDeclContext()->isLocalContext()) {
-        if (func->isSendable())
-          return nullptr;
-
-        dc = dc->getParent();
-        continue;
-      }
-    }
-
-    return nullptr;
-  }
 }
 
 /// Find the directly-referenced parameter or capture of a parameter for

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4188,7 +4188,7 @@ namespace {
       // the context.
       if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure)) {
         if (!explicitClosure->inheritsActorContext() &&
-            explicitClosure->isSendingParameter())
+            explicitClosure->isPassedToSendingParameter())
           return ActorIsolation::forNonisolated(/*unsafe=*/false)
               .withPreconcurrency(preconcurrency);
       }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4183,6 +4183,16 @@ namespace {
         return ActorIsolation::forNonisolated(/*unsafe=*/false)
             .withPreconcurrency(preconcurrency);
 
+      // If the explicit closure is used as a non-Sendable sending parameter,
+      // make it nonisolated by default instead of inferring its isolation from
+      // the context.
+      if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure)) {
+        if (!explicitClosure->inheritsActorContext() &&
+            explicitClosure->isSendingParameter())
+          return ActorIsolation::forNonisolated(/*unsafe=*/false)
+              .withPreconcurrency(preconcurrency);
+      }
+
       // A non-Sendable closure gets its isolation from its context.
       auto parentIsolation = getActorIsolationOfContext(
           closure->getParent(), getClosureActorIsolation);

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -591,9 +591,7 @@ ProtocolConformance *deriveImplicitSendableConformance(Evaluator &evaluator,
 /// Check whether we are in an actor's initializer or deinitializer.
 /// \returns nullptr iff we are not in such a declaration. Otherwise,
 ///          returns a pointer to the declaration.
-AbstractFunctionDecl const *isActorInitOrDeInitContext(
-    const DeclContext *dc,
-    llvm::function_ref<bool(const AbstractClosureExpr *)> isSendable);
+const AbstractFunctionDecl *isActorInitOrDeInitContext(const DeclContext *dc);
 
 /// Determine whether this declaration is always accessed asynchronously.
 bool isAsyncDecl(ConcreteDeclRef declRef);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2261,16 +2261,19 @@ ParamSpecifierRequest::evaluate(Evaluator &evaluator,
   if (auto transferring = dyn_cast<TransferringTypeRepr>(nestedRepr)) {
     // If we do not have an Ownership Repr, return implicit copyable consuming.
     auto *base = transferring->getBase();
-    if (!isa<OwnershipTypeRepr>(base)) {
+    if (!param->getInterfaceType()->isNoEscape() &&
+        !isa<OwnershipTypeRepr>(base)) {
       return ParamSpecifier::ImplicitlyCopyableConsuming;
     }
     nestedRepr = base;
   }
 
   if (auto sending = dyn_cast<SendingTypeRepr>(nestedRepr)) {
-    // If we do not have an Ownership Repr, return implicit copyable consuming.
+    // If we do not have an Ownership Repr and do not have a no escape type,
+    // return implicit copyable consuming.
     auto *base = sending->getBase();
-    if (!isa<OwnershipTypeRepr>(base)) {
+    if (!param->getInterfaceType()->isNoEscape() &&
+        !isa<OwnershipTypeRepr>(base)) {
       return ParamSpecifier::ImplicitlyCopyableConsuming;
     }
     nestedRepr = base;

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -178,7 +178,7 @@ public struct DiscardingTaskGroup {
   #endif
   public mutating func addTask(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async -> Void
+    operation: sending @escaping @isolated(any) () async -> Void
   ) {
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
     let flags = taskCreateFlags(
@@ -235,7 +235,7 @@ public struct DiscardingTaskGroup {
   #endif
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async -> Void
+    operation: sending @escaping @isolated(any) () async -> Void
   ) -> Bool {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
 
@@ -287,7 +287,7 @@ public struct DiscardingTaskGroup {
   @_alwaysEmitIntoClient
   @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
-    operation: __owned @Sendable @escaping @isolated(any) () async -> Void
+    operation: sending @escaping @isolated(any) () async -> Void
   ) {
     let flags = taskCreateFlags(
       priority: nil, isChildTask: true, copyTaskLocals: false,
@@ -332,7 +332,7 @@ public struct DiscardingTaskGroup {
   @_allowFeatureSuppression(IsolatedAny)
   @_alwaysEmitIntoClient
   public mutating func addTaskUnlessCancelled(
-    operation: __owned @Sendable @escaping @isolated(any) () async -> Void
+    operation: sending @escaping @isolated(any) () async -> Void
   ) -> Bool {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -394,7 +394,7 @@ public struct DiscardingTaskGroup {
   #endif
   public mutating func addTask(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async -> Void
+    operation: sending @escaping () async -> Void
   ) {
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
     let flags = taskCreateFlags(
@@ -442,7 +442,7 @@ public struct DiscardingTaskGroup {
   #endif
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async -> Void
+    operation: sending @escaping () async -> Void
   ) -> Bool {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
 
@@ -485,7 +485,7 @@ public struct DiscardingTaskGroup {
 
   @_alwaysEmitIntoClient
   public mutating func addTask(
-    operation: __owned @Sendable @escaping () async -> Void
+    operation: sending @escaping () async -> Void
   ) {
     let flags = taskCreateFlags(
       priority: nil, isChildTask: true, copyTaskLocals: false,
@@ -521,7 +521,7 @@ public struct DiscardingTaskGroup {
 #endif
   @_alwaysEmitIntoClient
   public mutating func addTaskUnlessCancelled(
-    operation: __owned @Sendable @escaping () async -> Void
+    operation: sending @escaping () async -> Void
   ) -> Bool {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -830,7 +830,7 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
   @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async throws -> Void
+    operation: sending @escaping @isolated(any) () async throws -> Void
   ) {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let flags = taskCreateFlags(
@@ -874,7 +874,7 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
   @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async throws -> Void
+    operation: sending @escaping @isolated(any) () async throws -> Void
   ) -> Bool {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)

--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -223,7 +223,7 @@ extension Task where Failure == Never {
   public init(
     executorPreference taskExecutor: consuming (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async -> Success
+    operation: sending @escaping () async -> Success
   ) {
     guard let taskExecutor else {
       self = Self.init(priority: priority, operation: operation)
@@ -283,7 +283,7 @@ extension Task where Failure == Error {
   public init(
     executorPreference taskExecutor: consuming (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async throws -> Success
+    operation: sending @escaping () async throws -> Success
   ) {
     guard let taskExecutor else {
       self = Self.init(priority: priority, operation: operation)
@@ -342,7 +342,7 @@ extension Task where Failure == Never {
   public static func detached(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async -> Success
+    operation: sending @escaping () async -> Success
   ) -> Task<Success, Failure> {
     guard let taskExecutor else {
       return Self.detached(priority: priority, operation: operation)
@@ -401,7 +401,7 @@ extension Task where Failure == Error {
   public static func detached(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async throws -> Success
+    operation: sending @escaping () async throws -> Success
   ) -> Task<Success, Failure> {
     guard let taskExecutor else {
       return Self.detached(priority: priority, operation: operation)

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -608,7 +608,7 @@ extension Task where Failure == Never {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public init(
     priority: TaskPriority? = nil,
-    @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping @isolated(any) () async -> Success
+    @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async -> Success
   ) {
     fatalError("Unavailable in task-to-thread concurrency model.")
   }
@@ -617,7 +617,7 @@ extension Task where Failure == Never {
   @_alwaysEmitIntoClient
   public init(
     priority: TaskPriority? = nil,
-    @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> Success
+    @_inheritActorContext @_implicitSelfCapture operation: sending @escaping () async -> Success
   ) {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     // Set up the job flags for a new task.
@@ -664,7 +664,7 @@ extension Task where Failure == Never {
   @_allowFeatureSuppression(IsolatedAny)
   public init(
     priority: TaskPriority? = nil,
-    @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping @isolated(any) () async -> Success
+    @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async -> Success
   ) {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     // Set up the job flags for a new task.
@@ -704,7 +704,7 @@ extension Task where Failure == Error {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public init(
     priority: TaskPriority? = nil,
-    @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping @isolated(any) () async throws -> Success
+    @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async throws -> Success
   ) {
     fatalError("Unavailable in task-to-thread concurrency model")
   }
@@ -713,7 +713,7 @@ extension Task where Failure == Error {
   @_alwaysEmitIntoClient
   public init(
     priority: TaskPriority? = nil,
-    @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> Success
+    @_inheritActorContext @_implicitSelfCapture operation: sending @escaping () async throws -> Success
   ) {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     // Set up the task flags for a new task.
@@ -760,7 +760,7 @@ extension Task where Failure == Error {
   @_allowFeatureSuppression(IsolatedAny)
   public init(
     priority: TaskPriority? = nil,
-    @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping @isolated(any) () async throws -> Success
+    @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async throws -> Success
   ) {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     // Set up the task flags for a new task.
@@ -802,7 +802,7 @@ extension Task where Failure == Never {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public static func detached(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async -> Success
+    operation: sending @escaping @isolated(any) () async -> Success
   ) -> Task<Success, Failure> {
     fatalError("Unavailable in task-to-thread concurrency model")
   }
@@ -811,7 +811,7 @@ extension Task where Failure == Never {
   @_alwaysEmitIntoClient
   public static func detached(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async -> Success
+    operation: sending @escaping () async -> Success
   ) -> Task<Success, Failure> {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     // Set up the job flags for a new task.
@@ -855,7 +855,7 @@ extension Task where Failure == Never {
   @_allowFeatureSuppression(IsolatedAny)
   public static func detached(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async -> Success
+    operation: sending @escaping @isolated(any) () async -> Success
   ) -> Task<Success, Failure> {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     // Set up the job flags for a new task.
@@ -895,7 +895,7 @@ extension Task where Failure == Error {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public static func detached(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async throws -> Success
+    operation: sending @escaping @isolated(any) () async throws -> Success
   ) -> Task<Success, Failure> {
     fatalError("Unavailable in task-to-thread concurrency model")
   }
@@ -904,7 +904,7 @@ extension Task where Failure == Error {
   @_alwaysEmitIntoClient
   public static func detached(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async throws -> Success
+    operation: sending @escaping () async throws -> Success
   ) -> Task<Success, Failure> {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     // Set up the job flags for a new task.
@@ -950,7 +950,7 @@ extension Task where Failure == Error {
   @_allowFeatureSuppression(IsolatedAny)
   public static func detached(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async throws -> Success
+    operation: sending @escaping @isolated(any) () async throws -> Success
   ) -> Task<Success, Failure> {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     // Set up the job flags for a new task.
@@ -1353,7 +1353,7 @@ extension Task where Failure == Error {
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 @usableFromInline
-internal func _runTaskForBridgedAsyncMethod(@_inheritActorContext _ body: __owned @Sendable @escaping () async -> Void) {
+internal func _runTaskForBridgedAsyncMethod(@_inheritActorContext _ body: sending @escaping () async -> Void) {
 #if compiler(>=5.6)
   Task(operation: body)
 #else

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -1357,7 +1357,7 @@ extension Task where Failure == Error {
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 @usableFromInline
-internal func _runTaskForBridgedAsyncMethod(@_inheritActorContext _ body: sending @escaping () async -> Void) {
+internal func _runTaskForBridgedAsyncMethod(@_inheritActorContext _ body: __owned @Sendable @escaping () async -> Void) {
 #if compiler(>=5.6)
   Task(operation: body)
 #else

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -255,6 +255,8 @@ extension Task where Failure == Error {
     @_spi(MainActorUtilities)
     @MainActor
     @available(SwiftStdlib 5.9, *)
+    @available(*, deprecated, message: "Use Task.init with a main actor isolated closure instead")
+    @available(swift, obsoleted: 6.0, message: "Use Task.init with a main actor isolated closure instead")
     @discardableResult
     public static func startOnMainActor(
         priority: TaskPriority? = nil,
@@ -278,6 +280,8 @@ extension Task where Failure == Never {
     @_spi(MainActorUtilities)
     @MainActor
     @available(SwiftStdlib 5.9, *)
+    @available(*, deprecated, message: "Use Task.init with a main actor isolated closure instead")
+    @available(swift, obsoleted: 6.0, message: "Use Task.init with a main actor isolated closure instead")
     @discardableResult
     public static func startOnMainActor(
         priority: TaskPriority? = nil,

--- a/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
@@ -35,7 +35,7 @@ extension TaskGroup {
   public mutating func addTask(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async -> ChildTaskResult
+    operation: sending @escaping @isolated(any) () async -> ChildTaskResult
   ) {
     guard let taskExecutor else {
       return self.addTask(priority: priority, operation: operation)
@@ -84,7 +84,7 @@ extension TaskGroup {
   public mutating func addTaskUnlessCancelled(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async -> ChildTaskResult
+    operation: sending @escaping @isolated(any) () async -> ChildTaskResult
   ) -> Bool {
     guard let taskExecutor else {
       return self.addTaskUnlessCancelled(priority: priority, operation: operation)
@@ -144,7 +144,7 @@ extension ThrowingTaskGroup {
   public mutating func addTask(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async throws -> ChildTaskResult
+    operation: sending @escaping @isolated(any) () async throws -> ChildTaskResult
   ) {
     guard let taskExecutor else {
       return self.addTask(priority: priority, operation: operation)
@@ -189,7 +189,7 @@ extension ThrowingTaskGroup {
   public mutating func addTaskUnlessCancelled(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async throws -> ChildTaskResult
+    operation: sending @escaping @isolated(any) () async throws -> ChildTaskResult
   ) -> Bool {
     guard let taskExecutor else {
       return self.addTaskUnlessCancelled(priority: priority, operation: operation)
@@ -249,7 +249,7 @@ extension DiscardingTaskGroup {
   public mutating func addTask(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async -> Void
+    operation: sending @escaping @isolated(any) () async -> Void
   ) {
     guard let taskExecutor else {
       return self.addTask(priority: priority, operation: operation)
@@ -299,7 +299,7 @@ extension DiscardingTaskGroup {
   public mutating func addTaskUnlessCancelled(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async -> Void
+    operation: sending @escaping @isolated(any) () async -> Void
   ) -> Bool {
     guard let taskExecutor else {
       return self.addTaskUnlessCancelled(priority: priority, operation: operation)
@@ -359,7 +359,7 @@ extension ThrowingDiscardingTaskGroup {
   public mutating func addTask(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async throws -> Void
+    operation: sending @escaping @isolated(any) () async throws -> Void
   ) {
     guard let taskExecutor else {
       return self.addTask(priority: priority, operation: operation)
@@ -409,7 +409,7 @@ extension ThrowingDiscardingTaskGroup {
   public mutating func addTaskUnlessCancelled(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async throws -> Void
+    operation: sending @escaping @isolated(any) () async throws -> Void
   ) -> Bool {
     guard let taskExecutor else {
       return self.addTaskUnlessCancelled(priority: priority, operation: operation)

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -269,7 +269,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async -> ChildTaskResult
+    operation: sending @escaping @isolated(any) () async -> ChildTaskResult
   ) {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
@@ -316,7 +316,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async -> ChildTaskResult
+    operation: sending @escaping @isolated(any) () async -> ChildTaskResult
   ) -> Bool {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -362,7 +362,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   @_alwaysEmitIntoClient
   public mutating func addTask(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+    operation: sending @escaping () async -> ChildTaskResult
   ) {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
@@ -390,7 +390,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   @_alwaysEmitIntoClient
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+    operation: sending @escaping () async -> ChildTaskResult
   ) -> Bool {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -428,7 +428,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async -> ChildTaskResult
+    operation: sending @escaping @isolated(any) () async -> ChildTaskResult
   ) {
     fatalError("Unavailable in task-to-thread concurrency model")
   }
@@ -440,7 +440,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   @_alwaysEmitIntoClient
   @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
-    operation: __owned @Sendable @escaping @isolated(any) () async -> ChildTaskResult
+    operation: sending @escaping @isolated(any) () async -> ChildTaskResult
   ) {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let flags = taskCreateFlags(
@@ -469,7 +469,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTaskUnlessCancelled(operation:)")
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+    operation: sending @escaping () async -> ChildTaskResult
   ) -> Bool {
     fatalError("Unavailable in task-to-thread concurrency model")
   }
@@ -483,7 +483,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   @_alwaysEmitIntoClient
   @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
-    operation: __owned @Sendable @escaping @isolated(any) () async -> ChildTaskResult
+    operation: sending @escaping @isolated(any) () async -> ChildTaskResult
   ) -> Bool {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -814,7 +814,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async throws -> ChildTaskResult
+    operation: sending @escaping @isolated(any) () async throws -> ChildTaskResult
   ) {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let flags = taskCreateFlags(
@@ -856,7 +856,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping @isolated(any) () async throws -> ChildTaskResult
+    operation: sending @escaping @isolated(any) () async throws -> ChildTaskResult
   ) -> Bool {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -894,7 +894,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
   public mutating func addTask(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+    operation: sending @escaping () async throws -> ChildTaskResult
   ) {
     fatalError("Unavailable in task-to-thread concurrency model")
   }
@@ -908,7 +908,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func addTask(
-    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+    operation: sending @escaping () async throws -> ChildTaskResult
   ) {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let flags = taskCreateFlags(
@@ -928,7 +928,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTaskUnlessCancelled(operation:)")
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+    operation: sending @escaping () async throws -> ChildTaskResult
   ) -> Bool {
     fatalError("Unavailable in task-to-thread concurrency model")
   }
@@ -944,7 +944,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func addTaskUnlessCancelled(
-    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+    operation: sending @escaping () async throws -> ChildTaskResult
   ) -> Bool {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)

--- a/test/Backtracing/CrashAsync.swift
+++ b/test/Backtracing/CrashAsync.swift
@@ -51,8 +51,8 @@ struct CrashAsync {
 // CHECK-NEXT:  6 [async]          0x{{[0-9a-f]+}} {{_?}}$s10CrashAsyncAAV4mainyyYaFZ{{TQ0_| \+ [0-9]+}} in CrashAsync at {{.*}}/CrashAsync.swift:37
 // CHECK-NEXT:  7 [async] [system] 0x{{[0-9a-f]+}} {{_?}}$s10CrashAsyncAAV5$mainyyYaFZ{{TQ0_| \+ [0-9]+}} in CrashAsync at {{.*}}/<compiler-generated>
 // CHECK-NEXT:  8 [async] [system] 0x{{[0-9a-f]+}} {{_?}}async_Main{{TQ0_| \+ [0-9]+}} in CrashAsync at {{.*}}/<compiler-generated>
-// CHECK-NEXT:  9 [async] [thunk]  0x{{[0-9a-f]+}} {{_?}}$sIetH_yts5Error_pIeghHrzo_TR{{TQ0_| \+ [0-9]+}} in CrashAsync at {{.*}}/<compiler-generated>
-// CHECK-NEXT: 10 [async] [thunk]  0x{{[0-9a-f]+}} {{_?}}$sIetH_yts5Error_pIeghHrzo_TRTA{{TQ0_| \+ [0-9]+}} in CrashAsync at {{.*}}/<compiler-generated>
+// CHECK-NEXT:  9 [async] [thunk]  0x{{[0-9a-f]+}} {{_?}}$sIetH_yts5Error_pIegHrzo_TR{{TQ0_| \+ [0-9]+}} in CrashAsync at {{.*}}/<compiler-generated>
+// CHECK-NEXT: 10 [async] [thunk]  0x{{[0-9a-f]+}} {{_?}}$sIetH_yts5Error_pIegHrzo_TRTA{{TQ0_| \+ [0-9]+}} in CrashAsync at {{.*}}/<compiler-generated>
 // CHECK-NEXT: 11 [async] [system] 0x{{[0-9a-f]+}} {{_?}}_ZL23completeTaskWithClosurePN5swift12AsyncContextEPNS_10SwiftErrorE in libswift_Concurrency.{{dylib|so}}
 
 // FRIENDLY: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -72,10 +72,10 @@ func asyncFunc() async {
 // CHECK-SIL-NEXT:  [[TASK_EXECUTOR_UNOWNED:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK-SIL-NEXT:  [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<any TaskExecutor>, #Optional.none
 // CHECK-SIL-NEXT:  // function_ref thunk for @escaping @convention(thin) @async () -> ()
-// CHECK-SIL-NEXT:  [[THUNK_FN:%.*]] = function_ref @$sIetH_yts5Error_pIeghHrzo_TR : $@convention(thin) @Sendable @async (@convention(thin) @async () -> ()) -> (@out (), @error any Error)
-// CHECK-SIL-NEXT:  [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]([[ASYNC_MAIN_FN]]) : $@convention(thin) @Sendable @async (@convention(thin) @async () -> ()) -> (@out (), @error any Error)
-// CHECK-SIL-NEXT:  [[CONVERTED_THUNK:%.*]] = convert_function [[THUNK]] : $@Sendable @async @callee_guaranteed () -> (@out (), @error any Error) to $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <()>
-// CHECK-SIL-NEXT:  [[TASK_RESULT:%.*]] = builtin "createAsyncTask"<()>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR_UNOWNED]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<any TaskExecutor>, [[CONVERTED_THUNK]] : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <()>) : $(Builtin.NativeObject, Builtin.RawPointer)
+// CHECK-SIL-NEXT:  [[THUNK_FN:%.*]] = function_ref @$sIetH_yts5Error_pIegHrzo_TR : $@convention(thin) @async (@convention(thin) @async () -> ()) -> (@out (), @error any Error)
+// CHECK-SIL-NEXT:  [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]([[ASYNC_MAIN_FN]]) : $@convention(thin) @async (@convention(thin) @async () -> ()) -> (@out (), @error any Error)
+// CHECK-SIL-NEXT:  [[CONVERTED_THUNK:%.*]] = convert_function [[THUNK]] : $@async @callee_guaranteed () -> (@out (), @error any Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <()>
+// CHECK-SIL-NEXT:  [[TASK_RESULT:%.*]] = builtin "createAsyncTask"<()>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR_UNOWNED]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<any TaskExecutor>, [[CONVERTED_THUNK]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <()>) : $(Builtin.NativeObject, Builtin.RawPointer)
 // CHECK-SIL-NEXT:  [[TASK:%.*]] = tuple_extract [[TASK_RESULT]] : $(Builtin.NativeObject, Builtin.RawPointer), 0
 // CHECK-SIL-NEXT:  // function_ref swift_job_run
 // CHECK-SIL-NEXT:  [[RUN_FN:%.*]] = function_ref @swift_job_run : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking %s -o /dev/null -verify -emit-sil
-// RUN: %target-swift-frontend -strict-concurrency=strict -disable-availability-checking %s -o /dev/null -verify -emit-sil
-// RUN: %target-swift-frontend -strict-concurrency=strict -disable-availability-checking %s -o /dev/null -verify -emit-sil -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking %s -o /dev/null -verify -emit-sil  -DALLOW_TYPECHECKER_ERRORS -verify-additional-prefix typechecker-
+// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking %s -o /dev/null -verify -emit-sil -DALLOW_TYPECHECKER_ERRORS -verify-additional-prefix typechecker-
+// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking %s -o /dev/null -verify -emit-sil -verify-additional-prefix tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -51,21 +51,25 @@ func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
 func test_unsafeContinuations() async {
   // the closure should not allow async operations;
   // after all: if you have async code, just call it directly, without the unsafe continuation
-  let _: String = withUnsafeContinuation { continuation in // expected-error{{cannot pass function of type '(UnsafeContinuation<String, Never>) async -> Void' to parameter expecting synchronous function type}}
-    let s = await someAsyncFunc() // expected-note {{'async' inferred from asynchronous operation used here}}
+#if ALLOW_TYPECHECKER_ERRORS
+  let _: String = withUnsafeContinuation { continuation in // expected-typechecker-error{{cannot pass function of type '(UnsafeContinuation<String, Never>) async -> Void' to parameter expecting synchronous function type}}
+    let s = await someAsyncFunc() // expected-typechecker-note {{'async' inferred from asynchronous operation used here}}
     continuation.resume(returning: s)
   }
+#endif
 
   let _: String = await withUnsafeContinuation { continuation in
     continuation.resume(returning: "")
   }
 
   // rdar://76475495 - suppress warnings for invalid expressions
+#if ALLOW_TYPECHECKER_ERRORS
   func test_invalid_async_no_warnings() async -> Int {
 	  return await withUnsafeContinuation {
-		  $0.resume(throwing: 1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Never'}}
+		  $0.resume(throwing: 1) // expected-typechecker-error {{cannot convert value of type 'Int' to expected argument type 'Never'}}
 	  }
   }
+#endif
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -130,13 +134,15 @@ func test_detached_throwing() async -> String {
   } catch {
     print("caught: \(error)")
   }
+
+  return ""
 }
 
 // ==== Detached Tasks with inout Params---------------------------------------
 @available(SwiftStdlib 5.1, *)
-func printOrderNumber(n: inout Int) async {
-  Task.detached {
-      n+=1 //expected-error {{mutable capture of 'inout' parameter 'n' is not allowed in concurrently-executing code}}
-      print(n) //expected-error {{mutable capture of 'inout' parameter 'n' is not allowed in concurrently-executing code}}
+func printOrderNumber(n: inout Int) async { // expected-tns-note {{parameter 'n' is declared 'inout'}}
+  Task.detached { // expected-tns-error {{escaping closure captures 'inout' parameter 'n'}}
+      n+=1 // expected-tns-note {{captured here}}
+      print(n) // expected-tns-note {{captured here}}
   }
 }

--- a/test/Concurrency/builtin_silgen.swift
+++ b/test/Concurrency/builtin_silgen.swift
@@ -10,7 +10,7 @@ func suspend() async {}
 // Builtin.hopToActor should generate a mandatory hop_to_executor
 // before releasing the actor and reaching a suspend.
 //
-// CHECK-LABEL: sil private @$s14builtin_silgen11runDetachedyyFyyYaYbcfU_ : $@convention(thin) @Sendable @async @substituted <τ_0_0> (@guaranteed Optional<any Actor>) -> @out τ_0_0 for <()>
+// CHECK-LABEL: sil private @$s14builtin_silgen11runDetachedyyFyyYacfU_ : $@convention(thin) @async @substituted <τ_0_0> (@guaranteed Optional<any Actor>) -> @out τ_0_0 for <()> {
 // CHECK:   [[ACTOR:%.*]] = apply {{%.*}}({{%.*}}) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
 // CHECK:   hop_to_executor [mandatory] [[ACTOR]] : $MainActor
 // CHECK:   strong_release [[ACTOR]] : $MainActor

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -1,10 +1,13 @@
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -DALLOW_TYPECHECKER_ERRORS -verify-additional-prefix typechecker- -verify-additional-prefix tns-allow-typechecker-
+
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
-class NotConcurrent { } // expected-note 18{{class 'NotConcurrent' does not conform to the 'Sendable' protocol}}
-// expected-complete-note @-1 12{{class 'NotConcurrent' does not conform to the 'Sendable' protocol}}
+class NotConcurrent { } // expected-note 13{{class 'NotConcurrent' does not conform to the 'Sendable' protocol}}
+// expected-complete-note @-1 13{{class 'NotConcurrent' does not conform to the 'Sendable' protocol}}
+// expected-tns-allow-typechecker-note @-2 {{class 'NotConcurrent' does not conform to the 'Sendable' protocol}}
 
 // ----------------------------------------------------------------------
 // Sendable restriction on actor operations
@@ -15,6 +18,8 @@ actor A1 {
   func synchronous() -> NotConcurrent? { nil }
   func asynchronous(_: NotConcurrent?) async { }
 }
+
+@MainActor var booleanValue: Bool { false }
 
 // Actor initializers and Sendable
 actor A2 {
@@ -63,14 +68,24 @@ actor A2 {
 
 func testActorCreation(value: NotConcurrent) async {
   _ = A2(value: value) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-1 {{sending 'value' risks causing data races}}
+  // expected-tns-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(value:)' risks causing data races between actor-isolated and task-isolated uses}}
 
   _ = await A2(valueAsync: value) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-1 {{sending 'value' risks causing data races}}
+  // expected-tns-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(valueAsync:)' risks causing data races between actor-isolated and task-isolated uses}}
 
   _ = A2(delegatingSync: value) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-1 {{sending 'value' risks causing data races}}
+  // expected-tns-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(delegatingSync:)' risks causing data races between actor-isolated and task-isolated uses}}
 
   _ = await A2(delegatingAsync: value, 9) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-1 {{sending 'value' risks causing data races}}
+  // expected-tns-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(delegatingAsync:_:)' risks causing data races between actor-isolated and task-isolated uses}}
 
   _ = await A2(nonisoAsync: value, 3) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-1 {{sending 'value' risks causing data races}}
+  // expected-tns-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(nonisoAsync:_:)' risks causing data races between actor-isolated and task-isolated uses}}
 }
 
 extension A1 {
@@ -112,6 +127,9 @@ func globalSync(_: NotConcurrent?) {
 
 @SomeGlobalActor
 func globalAsync(_: NotConcurrent?) async {
+  if await booleanValue {
+    return
+  }
   await globalAsync(globalValue) // both okay because we're in the actor
   globalSync(nil)
 }
@@ -131,12 +149,14 @@ func globalTest() async {
   // expected-note@+1 {{property access is 'async'}}
   let _ = E.notSafe // expected-warning{{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated static property 'notSafe' cannot cross actor boundary}}
 
-  // expected-error@+3 {{expression is 'async' but is not marked with 'await'}}
-  // expected-note@+2 {{call is 'async'}}
-  // expected-note@+1 {{property access is 'async'}}
+#if ALLOW_TYPECHECKER_ERRORS
+  // expected-typechecker-error@+3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-typechecker-note@+2 {{call is 'async'}}
+  // expected-typechecker-note@+1 {{property access is 'async'}}
   globalAsync(E.notSafe)
   // expected-complete-warning@-1 {{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
-  // expected-warning@-2 {{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated static property 'notSafe' cannot cross actor boundary}}
+  // expected-typechecker-warning@-2 {{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated static property 'notSafe' cannot cross actor boundary}}
+#endif
 }
 
 struct HasSubscript {
@@ -157,11 +177,13 @@ class ClassWithGlobalActorInits { // expected-note 2{{class 'ClassWithGlobalActo
 func globalTestMain(nc: NotConcurrent) async {
   // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@+1 {{property access is 'async'}}
-  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
-  await globalAsync(a) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
-  await globalSync(a)  // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
-  _ = await ClassWithGlobalActorInits(nc) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
-  // expected-warning@-1{{non-sendable type 'ClassWithGlobalActorInits' returned by call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
+  let a = globalValue // expected-warning {{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
+  await globalAsync(a) // expected-complete-warning {{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
+  await globalSync(a)  // expected-complete-warning {{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
+  _ = await ClassWithGlobalActorInits(nc) // expected-complete-warning {{passing argument of non-sendable type 'NotConcurrent' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
+  // expected-warning @-1 {{non-sendable type 'ClassWithGlobalActorInits' returned by call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
+  // expected-tns-warning @-2 {{sending 'nc' risks causing data races}}
+  // expected-tns-note @-3 {{sending main actor-isolated 'nc' to global actor 'SomeGlobalActor'-isolated initializer 'init(_:)' risks causing data races between global actor 'SomeGlobalActor'-isolated and main actor-isolated uses}}
   _ = await ClassWithGlobalActorInits() // expected-warning{{non-sendable type 'ClassWithGlobalActorInits' returned by call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
 }
 
@@ -286,6 +308,8 @@ func concurrentClosures<T>(_: T) { // expected-note{{consider making generic par
   acceptConcurrentUnary { (x: T) in
     _ = x // ok
     acceptConcurrentUnary { _ in x } // expected-warning{{capture of 'x' with non-sendable type 'T' in a `@Sendable` closure}}
+    let y: T? = nil
+    return y!
   }
 }
 
@@ -380,20 +404,20 @@ extension NotConcurrent {
   func f() { }
 
   func test() {
-    Task {
-      f() // expected-warning{{capture of 'self' with non-sendable type 'NotConcurrent' in a `@Sendable` closure}}
+    Task { // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+      f()
     }
 
-    Task {
-      self.f()  // expected-warning{{capture of 'self' with non-sendable type 'NotConcurrent' in a `@Sendable` closure}}
+    Task { // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+      self.f()
     }
 
-    Task { [self] in
-      f()  // expected-warning{{capture of 'self' with non-sendable type 'NotConcurrent' in a `@Sendable` closure}}
+    Task { [self] in // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+      f()
     }
 
-    Task { [self] in
-      self.f()  // expected-warning{{capture of 'self' with non-sendable type 'NotConcurrent' in a `@Sendable` closure}}
+    Task { [self] in // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+      self.f()
     }
   }
 }
@@ -414,16 +438,19 @@ enum E11<T>: @unchecked Sendable {
   case other(T) // okay
 }
 
+#if ALLOW_TYPECHECKER_ERRORS
+
 class C11 { }
 
-class C12: @unchecked C11 { } // expected-error{{'unchecked' attribute cannot apply to non-protocol type 'C11'}}
+class C12: @unchecked C11 { } // expected-typechecker-error{{'unchecked' attribute cannot apply to non-protocol type 'C11'}}
 
 protocol P { }
 
-protocol Q: @unchecked Sendable { } // expected-error{{'unchecked' attribute only applies in inheritance clauses}}
+protocol Q: @unchecked Sendable { } // expected-typechecker-error{{'unchecked' attribute only applies in inheritance clauses}}
 
-typealias TypeAlias1 = @unchecked P // expected-error{{'unchecked' attribute only applies in inheritance clauses}}
+typealias TypeAlias1 = @unchecked P // expected-typechecker-error{{'unchecked' attribute only applies in inheritance clauses}}
 
+#endif
 
 // ----------------------------------------------------------------------
 // UnsafeSendable historical name

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -DALLOW_TYPECHECKER_ERRORS -verify-additional-prefix typechecker-
+
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix tns-
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
@@ -6,7 +8,7 @@
 
 @available(SwiftStdlib 5.1, *)
 actor A {
-  func f() { } // expected-note 5{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  func f() { } // expected-typechecker-note 5{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -14,18 +16,22 @@ extension Actor {
   func g() { }
 }
 
-@MainActor func mainActorFn() {} // expected-note {{calls to global function 'mainActorFn()' from outside of its actor context are implicitly asynchronous}}
+@MainActor func mainActorFn() {} // expected-typechecker-note {{calls to global function 'mainActorFn()' from outside of its actor context are implicitly asynchronous}}
+
+#if ALLOW_TYPECHECKER_ERRORS
 
 @available(SwiftStdlib 5.1, *)
 func testA<T: Actor>(
-  a: isolated A,  // expected-note{{previous 'isolated' parameter 'a'}}
-  b: isolated T,  // expected-warning{{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-  c: isolated Int // expected-error {{'isolated' parameter type 'Int' does not conform to 'Actor' or 'DistributedActor'}}
+  a: isolated A,  // expected-typechecker-note {{previous 'isolated' parameter 'a'}}
+  b: isolated T,  // expected-typechecker-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  c: isolated Int // expected-typechecker-error {{'isolated' parameter type 'Int' does not conform to 'Actor' or 'DistributedActor'}}
 ) {
   a.f()
   a.g()
   b.g()
 }
+
+#endif
 
 actor Other {
   func inc() {}
@@ -36,9 +42,13 @@ actor Counter {
   func pass(_ f: @Sendable  (Self) async -> Void) {}
 }
 
+#if ALLOW_TYPECHECKER_ERRORS
+
+// This is illegal at the SIL level so even though we could ignore this
+// note/warning, we will get a crash otherwise.
 @available(SwiftStdlib 5.1, *)
-// expected-note@+2 {{previous 'isolated' parameter 'a'}}
-// expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+// expected-typechecker-note@+2 {{previous 'isolated' parameter 'a'}}
+// expected-typechecker-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
 func testDoubleIsolatedParams(a: isolated Counter, b: isolated Other) async {
   a.inc()
   b.inc()
@@ -52,65 +62,79 @@ func taaaa() async {
   }
 }
 
+#endif
+
 @available(SwiftStdlib 5.1, *)
 typealias Fn = (isolated A) -> Void
 
 @available(SwiftStdlib 5.1, *)
 func globalFunc(_ a: A) { }
 
+#if ALLOW_TYPECHECKER_ERRORS
+
 @available(SwiftStdlib 5.1, *)
-func globalFuncIsolated(_: isolated A) { // expected-note{{calls to global function 'globalFuncIsolated' from outside of its actor context are implicitly asynchronous}}
-  let _: Int = globalFuncIsolated // expected-error{{cannot convert value of type '(isolated A) -> ()' to specified type 'Int'}}
-  let _: (A) -> Void = globalFuncIsolated // expected-error{{cannot convert value of type '(isolated A) -> ()' to specified type '(A) -> Void'}}
+func globalFuncIsolated(_: isolated A) { // expected-typechecker-note{{calls to global function 'globalFuncIsolated' from outside of its actor context are implicitly asynchronous}}
+  let _: Int = globalFuncIsolated // expected-typechecker-error{{cannot convert value of type '(isolated A) -> ()' to specified type 'Int'}}
+  let _: (A) -> Void = globalFuncIsolated // expected-typechecker-error{{cannot convert value of type '(isolated A) -> ()' to specified type '(A) -> Void'}}
   let _: Fn = globalFunc // okay
 }
 
 @available(SwiftStdlib 5.1, *)
-// expected-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in the Swift 6 language mode}}{{1-12=}}
+// expected-typechecker-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in the Swift 6 language mode}}{{1-12=}}
 @MainActor func testIsolatedParamCalls(a: isolated A, b: A) {
   globalFunc(a)
   globalFunc(b)
 
   globalFuncIsolated(a)
-  globalFuncIsolated(b) // expected-error{{call to actor-isolated global function 'globalFuncIsolated' in a synchronous actor-isolated context}}
+  globalFuncIsolated(b) // expected-typechecker-error{{call to actor-isolated global function 'globalFuncIsolated' in a synchronous actor-isolated context}}
 }
+
+#endif
 
 @available(SwiftStdlib 5.1, *)
 func testIsolatedParamCallsAsync(a: isolated A, b: A) async {
   globalFunc(a)
   globalFunc(b)
 
+  #if ALLOW_TYPECHECKER_ERRORS
   globalFuncIsolated(a)
-  globalFuncIsolated(b) // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to global function 'globalFuncIsolated' from outside of its actor context are implicitly asynchronous}}
+  globalFuncIsolated(b) // expected-typechecker-error{{expression is 'async' but is not marked with 'await'}}
+  // expected-typechecker-note@-1{{calls to global function 'globalFuncIsolated' from outside of its actor context are implicitly asynchronous}}
   await globalFuncIsolated(b)
+  #endif
 }
 
 @available(SwiftStdlib 5.1, *)
 func testIsolatedParamCaptures(a: isolated A) async {
+#if ALLOW_TYPECHECKER_ERRORS
   let _ = { @MainActor in
-    a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous main actor-isolated context}}
+    a.f() // expected-typechecker-error {{call to actor-isolated instance method 'f()' in a synchronous main actor-isolated context}}
   }
 
   let _: @MainActor () -> () = {
-    a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous main actor-isolated context}}
+    a.f() // expected-typechecker-error {{call to actor-isolated instance method 'f()' in a synchronous main actor-isolated context}}
   }
+#endif
 
   let _ = {
     a.f()
   }
 
+#if ALLOW_TYPECHECKER_ERRORS
   let _ = { @Sendable in
-    a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+    a.f() // expected-typechecker-error {{call to actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   }
-
+#endif
 }
 
 actor MyActor {
-  func hello() {} // expected-note {{calls to instance method 'hello()' from outside of its actor context are implicitly asynchronous}}
+  func hello() {} // expected-typechecker-note {{calls to instance method 'hello()' from outside of its actor context are implicitly asynchronous}}
 }
 
-typealias MyFn = (isolated: Int) -> Void // expected-error {{function types cannot have argument labels; use '_' before 'isolated'}}
+// Compiler >= 5.3 is eneded to suppress the parser error
+#if compiler(>=5.3) && ALLOW_TYPECHECKER_ERRORS
+typealias MyFn = (isolated: Int) -> Void // expected-typechecker-error {{function types cannot have argument labels; use '_' before 'isolated'}}
+#endif
 typealias MyFnFixed = (_: isolated MyActor) -> Void
 
 func standalone(_: isolated MyActor) {}
@@ -142,38 +166,53 @@ struct S: P {
   func j(isolated: Int) -> Int { return isolated }
   func k(isolated y: Int) -> Int { return j(isolated: y) }
   func l(isolated _: Int) -> Int { return k(isolated: 0) }
-  func m(thing: MyActor) { thing.hello() } // expected-error {{call to actor-isolated instance method 'hello()' in a synchronous nonisolated context}}
+  #if ALLOW_TYPECHECKER_ERRORS
+  func m(thing: MyActor) { thing.hello() } // expected-typechecker-error {{call to actor-isolated instance method 'hello()' in a synchronous nonisolated context}}
+  #else
+  func m(thing: MyActor) { }
+  #endif
 }
 
 func checkConformer(_ s: S, _ p: any P, _ ma: MyActor) async {
   s.m(thing: ma)
   await p.m(thing: ma)
   // expected-complete-warning@-1 {{passing argument of non-sendable type 'any P' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-2 {{sending 'p' risks causing data races}}
+  // expected-tns-note @-3 {{sending task-isolated 'p' to actor-isolated instance method 'm(thing:)' risks causing data races between actor-isolated and task-isolated uses}}
 }
-
 
 // Redeclaration checking
 actor TestActor {
-  func test() { // expected-note{{'test()' previously declared here}}
+  func test() { // expected-typechecker-note{{'test()' previously declared here}}
   }
-  nonisolated func test() { // expected-error{{invalid redeclaration of 'test()'}}
+#if ALLOW_TYPECHECKER_ERRORS
+  nonisolated func test() { // expected-typechecker-error{{invalid redeclaration of 'test()'}}
   }
+#endif
 }
 
-func redecl(_: TestActor) { } // expected-note{{'redecl' previously declared here}}
-func redecl(_: isolated TestActor) { } // expected-error{{invalid redeclaration of 'redecl'}}
+#if ALLOW_TYPECHECKER_ERRORS
 
-func tuplify<Ts>(_ fn: (Ts) -> Void) {} // expected-note {{in call to function 'tuplify'}}
+func redecl(_: TestActor) { } // expected-typechecker-note{{'redecl' previously declared here}}
+func redecl(_: isolated TestActor) { } // expected-typechecker-error{{invalid redeclaration of 'redecl'}}
+
+#endif
+
+func tuplify<Ts>(_ fn: (Ts) -> Void) {} // expected-typechecker-note {{in call to function 'tuplify'}}
+
+#if ALLOW_TYPECHECKER_ERRORS
 
 @available(SwiftStdlib 5.1, *)
 func testTuplingIsolated(
-                         _ a: isolated A, // expected-note {{previous 'isolated' parameter 'a'}}
-                         _ b: isolated A  // expected-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+                         _ a: isolated A, // expected-typechecker-note {{previous 'isolated' parameter 'a'}}
+                         _ b: isolated A  // expected-typechecker-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
                         ) {
   tuplify(testTuplingIsolated)
-  // expected-error@-1 {{generic parameter 'Ts' could not be inferred}}
-  // expected-error@-2 {{cannot convert value of type '(isolated A, isolated A) -> ()' to expected argument type '(Ts) -> Void'}}
+  // expected-typechecker-error@-1 {{generic parameter 'Ts' could not be inferred}}
+  // expected-typechecker-error@-2 {{cannot convert value of type '(isolated A, isolated A) -> ()' to expected argument type '(Ts) -> Void'}}
 }
+
+#endif
 
 // Inference of "isolated" on closure parameters.
 @available(SwiftStdlib 5.1, *)
@@ -194,9 +233,10 @@ func testIsolatedClosureInference(one: A, two: A) async {
     a2.f()
   }
 
-  let f: (isolated A, isolated A) -> Void = // expected-warning {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-      // expected-note@+2 {{previous 'isolated' parameter 'a1'}}
-      // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+#if ALLOW_TYPECHECKER_ERRORS
+  let f: (isolated A, isolated A) -> Void = // expected-typechecker-warning {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+      // expected-typechecker-note@+2 {{previous 'isolated' parameter 'a1'}}
+      // expected-typechecker-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
       { (a1, a2) in
         a1.f()
         a2.f()
@@ -204,35 +244,42 @@ func testIsolatedClosureInference(one: A, two: A) async {
 
   await f(one, two)
 
-  let g: (isolated A, isolated A) -> Void = // expected-warning {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-      // expected-note@+2 {{previous 'isolated' parameter '$0'}}
-      // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  let g: (isolated A, isolated A) -> Void = // expected-typechecker-warning {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+      // expected-typechecker-note@+2 {{previous 'isolated' parameter '$0'}}
+      // expected-typechecker-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
       {
         $0.f()
         $1.f()
       }
 
   await g(one, two)
+  #endif
 }
+
+#if ALLOW_TYPECHECKER_ERRORS
 
 struct CheckIsolatedFunctionTypes {
-  // expected-warning@+2 {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
-  // expected-warning@+1 {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  // expected-typechecker-warning@+2 {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  // expected-typechecker-warning@+1 {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
   func a(_ f: @MainActor @Sendable (isolated A, isolated A) -> ()) {}
 
-  // expected-note@+2 {{calls to parameter 'callback' from outside of its actor context are implicitly asynchronous}}
-  // expected-warning@+1 {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  // expected-typechecker-note@+2 {{calls to parameter 'callback' from outside of its actor context are implicitly asynchronous}}
+  // expected-typechecker-warning@+1 {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
   @MainActor func update<R>(_ callback: @Sendable @escaping @MainActor (isolated A) -> R) -> R {
-    callback(A()) // expected-error {{call to actor-isolated parameter 'callback' in a synchronous main actor-isolated context}}
+    callback(A()) // expected-typechecker-error {{call to actor-isolated parameter 'callback' in a synchronous main actor-isolated context}}
   }
 }
+
+#endif
 
 @available(SwiftStdlib 5.1, *)
 func checkIsolatedAndGlobalClosures(_ a: A) {
   let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
       = {
     $0.f()
-    mainActorFn() // expected-error {{call to main actor-isolated global function 'mainActorFn()' in a synchronous actor-isolated context}}
+    #if ALLOW_TYPECHECKER_ERRORS
+    mainActorFn() // expected-typechecker-error {{call to main actor-isolated global function 'mainActorFn()' in a synchronous actor-isolated context}}
+    #endif
   }
 
   let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
@@ -241,13 +288,15 @@ func checkIsolatedAndGlobalClosures(_ a: A) {
     mainActorFn()
   }
 
-  let _ = { @MainActor (a: isolated A, // expected-warning {{closure with 'isolated' parameter 'a' cannot have a global actor; this is an error in the Swift 6 language mode}}{{13-24=}}
-                                       // expected-note@-1 {{previous 'isolated' parameter 'a'}}
-                        b: isolated A, // expected-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+#if ALLOW_TYPECHECKER_ERRORS
+  let _ = { @MainActor (a: isolated A, // expected-typechecker-warning {{closure with 'isolated' parameter 'a' cannot have a global actor; this is an error in the Swift 6 language mode}}{{13-24=}}
+                                       // expected-typechecker-note@-1 {{previous 'isolated' parameter 'a'}}
+                        b: isolated A, // expected-typechecker-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
                         c: isolated A) async in
     a.f()
     mainActorFn()
   }
+#endif
 }
 
 // "isolated" existential parameters.
@@ -259,19 +308,23 @@ protocol P2: Actor {
 func testExistentialIsolated(a: isolated P2, b: P2) async {
   a.m()
   await b.m()
-  b.m() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to instance method 'm()' from outside of its actor context are implicitly asynchronous}}
+  #if ALLOW_TYPECHECKER_ERRORS
+  b.m() // expected-typechecker-error{{expression is 'async' but is not marked with 'await'}}
+  // expected-typechecker-note@-1{{calls to instance method 'm()' from outside of its actor context are implicitly asynchronous}}
+  #endif
 }
 
 // "isolated" parameters of closures make the closure itself isolated.
 extension TestActor {
   func isolatedMethod() { }
-  // expected-note@-1{{calls to instance method 'isolatedMethod()' from outside of its actor context are implicitly asynchronous}}
+  // expected-typechecker-note@-1{{calls to instance method 'isolatedMethod()' from outside of its actor context are implicitly asynchronous}}
 
   // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
   nonisolated func isolatedToParameter(_ other: isolated TestActor) {
+    #if ALLOW_TYPECHECKER_ERRORS
     isolatedMethod()
-    // expected-error@-1{{call to actor-isolated instance method 'isolatedMethod()' in a synchronous actor-isolated context}}
+    // expected-typechecker-error@-1{{call to actor-isolated instance method 'isolatedMethod()' in a synchronous actor-isolated context}}
+    #endif
 
     other.isolatedMethod()
   }
@@ -294,31 +347,37 @@ func isolatedClosures() {
   a.f()
 }
 
+#if ALLOW_TYPECHECKER_ERRORS
+
 @MainActor class MAClass {
 
-  // expected-note@+2 {{previous 'isolated' parameter 'a'}}
-  // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  // expected-typechecker-note@+2 {{previous 'isolated' parameter 'a'}}
+  // expected-typechecker-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
   init(_ a: isolated A, _ b: isolated A) {
     // FIXME: wrong isolation. should be isolated to `a` only!
     a.f()
     b.f()
   }
 
-  // expected-note@+3 {{previous 'isolated' parameter 'a'}}
-  // expected-warning@+2 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
-  // expected-warning@+1 {{subscript with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
+  // expected-typechecker-note@+3 {{previous 'isolated' parameter 'a'}}
+  // expected-typechecker-warning@+2 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  // expected-typechecker-warning@+1 {{subscript with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
   nonisolated subscript(_ a: isolated A, _ b: isolated A) -> Int {
     // FIXME: wrong isolation. should be isolated to `a`.
-    a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous actor-isolated context}}
-    b.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous actor-isolated context}}
+    #if ALLOW_TYPECHECKER_ERRORS
+    a.f() // expected-typechecker-error {{call to actor-isolated instance method 'f()' in a synchronous actor-isolated context}}
+    b.f() // expected-typechecker-error {{call to actor-isolated instance method 'f()' in a synchronous actor-isolated context}}
+    #endif
     return 0
   }
 
-  // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
+  // expected-typechecker-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
   nonisolated func millionDollars(_ a: isolated A) {
     a.f()
   }
 }
+
+#endif
 
 // Test case for https://github.com/apple/swift/issues/62568
 func execute<ActorType: Actor>(
@@ -349,22 +408,25 @@ func getValues(
   }
 }
 
+#if ALLOW_TYPECHECKER_ERRORS
+
 func isolated_generic_bad_1<T>(_ t: isolated T) {}
-// expected-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
+// expected-typechecker-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
 func isolated_generic_bad_2<T: Equatable>(_ t: isolated T) {}
-// expected-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
+// expected-typechecker-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
 func isolated_generic_bad_3<T: AnyActor>(_ t: isolated T) {}
-// expected-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
-// expected-warning@-2 {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
+// expected-typechecker-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
+// expected-typechecker-warning@-2 {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
 
 func isolated_generic_bad_4<T>(_ t: isolated Array<T>) {}
-// expected-error@-1 {{'isolated' parameter type 'Array<T>' does not conform to 'Actor' or 'DistributedActor'}}
+// expected-typechecker-error@-1 {{'isolated' parameter type 'Array<T>' does not conform to 'Actor' or 'DistributedActor'}}
+
+#endif
 
 func isolated_generic_ok_1<T: Actor>(_ t: isolated T) {}
 
 
 class NotSendable {} // expected-complete-note 5 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
-// expected-note@-1 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
 
 func optionalIsolated(_ ns: NotSendable, to actor: isolated (any Actor)?) async {}
 func optionalIsolatedSync(_ ns: NotSendable, to actor: isolated (any Actor)?) {}
@@ -378,28 +440,36 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
 
   await optionalIsolated(ns, to: myActor)
   // expected-complete-warning@-1 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-2 {{pattern that the region based isolation checker does not understand how to check. Please file a bug}}
 
+#if ALLOW_TYPECHECKER_ERRORS
   optionalIsolatedSync(ns, to: myActor)
-  // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-2 {{calls to global function 'optionalIsolatedSync(_:to:)' from outside of its actor context are implicitly asynchronous}}
+  // expected-typechecker-error@-1 {{expression is 'async' but is not marked with 'await'}}
+  // expected-typechecker-note@-2 {{calls to global function 'optionalIsolatedSync(_:to:)' from outside of its actor context are implicitly asynchronous}}
   // expected-complete-warning@-3 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  #endif
 }
 
 @MainActor func callFromMainActor(ns: NotSendable) async {
   await optionalIsolated(ns, to: nil)
-  // expected-complete-warning@-1 {{passing argument of non-sendable type 'NotSendable' outside of main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NotSendable' outside of main actor-isolated context may introduce data races}}
+  // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
+  // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated global function 'optionalIsolated(_:to:)' risks causing data races between nonisolated and main actor-isolated uses}}
 
-  optionalIsolatedSync(ns, to: nil)
+  optionalIsolatedSync(ns, to: nil) // expected-tns-warning {{pattern that the region based isolation checker does not understand how to check. Please file a bug}}
 
   let myActor = A()
 
   await optionalIsolated(ns, to: myActor)
   // expected-complete-warning@-1 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-2 {{pattern that the region based isolation checker does not understand how to check. Please file a bug}}
 
+#if ALLOW_TYPECHECKER_ERRORS
   optionalIsolatedSync(ns, to: myActor)
-  // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-2 {{calls to global function 'optionalIsolatedSync(_:to:)' from outside of its actor context are implicitly asynchronous}}
+  // expected-typechecker-error@-1 {{expression is 'async' but is not marked with 'await'}}
+  // expected-typechecker-note@-2 {{calls to global function 'optionalIsolatedSync(_:to:)' from outside of its actor context are implicitly asynchronous}}
   // expected-complete-warning@-3 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+#endif
 }
 
 // TODO: Consider making an actor's Self behave like in a struct, removing this special casing.
@@ -407,10 +477,12 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
 //       See: https://github.com/apple/swift/issues/70954 and rdar://121091417
 actor A2 {
   nonisolated func f1() async {
+#if ALLOW_TYPECHECKER_ERRORS
     await { (self: isolated Self) in }(self)
-    // expected-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self'}}
+    // expected-typechecker-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self'}}
     await { (self: isolated Self?) in }(self)
-    // expected-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self?'}}
+    // expected-typechecker-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self?'}}
+#endif
   }
   nonisolated func f2() async -> Self {
     await { (self: isolated Self) in }(self)
@@ -427,9 +499,9 @@ func testNonSendableCaptures(ns: NotSendable, a: isolated MyActor) {
 
   // FIXME: The `a` in the capture list and `isolated a` are the same,
   // but the actor isolation checker doesn't know that.
-  Task { [a] in
+  Task { [a] in // expected-tns-warning {{'a'-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
     _ = a
-    _ = ns // expected-warning {{capture of 'ns' with non-sendable type 'NotSendable' in a `@Sendable` closure}}
+    _ = ns
   }
 }
 
@@ -475,9 +547,13 @@ nonisolated func fromNonisolated(ns: NotSendable) async -> NotSendable {
   await pass(value: ns, isolation: nil)
 }
 
-func invalidIsolatedClosureParam<A: AnyActor> ( // expected-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
-  _: (isolated A) async throws -> Void // expected-error {{'isolated' parameter type 'A' does not conform to 'Actor' or 'DistributedActor'}}
+#if ALLOW_TYPECHECKER_ERRORS
+
+func invalidIsolatedClosureParam<A: AnyActor> ( // expected-typechecker-warning {{'AnyActor' is deprecated: Use 'any Actor' with 'DistributedActor.asLocalActor' instead}}
+  _: (isolated A) async throws -> Void // expected-typechecker-error {{'isolated' parameter type 'A' does not conform to 'Actor' or 'DistributedActor'}}
 ) {}
+
+#endif
 
 public func useDefaultIsolation(
   _ isolation: isolated (any Actor)? = #isolation

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -352,9 +352,10 @@ func callNonisolatedAsyncClosure(
 func testLocalCaptures() {
   let ns = NonSendable()
 
-  @Sendable func a2() -> NonSendable {
+  @Sendable
+  func a2() -> NonSendable {
     return ns
-    // expected-complete-and-tns-warning@-1 {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` local function}}
+    // expected-complete-and-tns-warning @-1 {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` local function}}
   }
 }
 
@@ -430,10 +431,11 @@ struct DowngradeForPreconcurrency {
     preconcurrencyContext {
       Task {
         completion()
-        // expected-warning@-1 2 {{capture of 'completion' with non-sendable type '@MainActor () -> Void' in a `@Sendable` closure; this is an error in the Swift 6 language mode}}
-        // expected-note@-2 2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-        // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
-        // expected-note@-4 {{calls to parameter 'completion' from outside of its actor context are implicitly asynchronous}}
+        // expected-warning@-1 {{capture of 'completion' with non-sendable type '@MainActor () -> Void' in a `@Sendable` closure}}
+        // expected-warning@-2 {{capture of 'completion' with non-sendable type '@MainActor () -> Void' in an isolated closure}}
+        // expected-note@-3 2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+        // expected-warning@-4 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
+        // expected-note@-5 {{calls to parameter 'completion' from outside of its actor context are implicitly asynchronous}}
       }
     }
   }

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -3,8 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-swift-frontend -strict-concurrency=minimal -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix targeted-complete-
-// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete- -verify-additional-prefix targeted-complete-
-// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete- -verify-additional-prefix targeted-complete- -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete- -verify-additional-prefix targeted-complete- -verify-additional-prefix tns-
 
 // REQUIRES: concurrency
 
@@ -15,24 +14,23 @@ actor A {
   func f() -> [StrictStruct: NonStrictClass] { [:] }
 }
 
-class NS { } // expected-targeted-complete-note{{class 'NS' does not conform to the 'Sendable' protocol}}
+class NS { }
 
-struct MyType { // expected-complete-note {{consider making struct 'MyType' conform to the 'Sendable' protocol}}
+struct MyType {
   var nsc: NonStrictClass
 }
 
-struct MyType2 { // expected-targeted-complete-note{{consider making struct 'MyType2' conform to the 'Sendable' protocol}}
+struct MyType2 {
   var nsc: NonStrictClass
   var ns: NS
 }
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClass) async {
-  Task {
-    print(ns) // expected-targeted-complete-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+  Task { // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter; later accesses could race}}
+    print(ns)
     print(mt) // no warning by default: MyType is Sendable because we suppressed NonStrictClass's warning
-    // expected-complete-warning @-1 {{capture of 'mt' with non-sendable type 'MyType' in a `@Sendable` closure}}
-    print(mt2) // expected-targeted-complete-warning{{capture of 'mt2' with non-sendable type 'MyType2' in a `@Sendable` closure}}
-    print(sc) // expected-warning{{capture of 'sc' with non-sendable type 'StrictClass' in a `@Sendable` closure}}
+    print(mt2)
+    print(sc)
   }
 }
 

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -1,9 +1,12 @@
 // RUN: %empty-directory(%t)
+
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+
 // RUN: %target-swift-frontend -strict-concurrency=minimal -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
 // RUN: %target-swift-frontend -strict-concurrency=targeted -verify-additional-prefix targeted-complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
+
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null -verify-additional-prefix tns-
 
 // REQUIRES: concurrency
 
@@ -15,9 +18,8 @@ actor A {
 }
 
 class NS { } // expected-note {{class 'NS' does not conform to the 'Sendable' protocol}}
-// expected-targeted-complete-note@-1 {{class 'NS' does not conform to the 'Sendable' protocol}}
 
-struct MyType { // expected-complete-note {{consider making struct 'MyType' conform to the 'Sendable' protocol}}
+struct MyType {
   var nsc: NonStrictClass
 }
 
@@ -27,13 +29,12 @@ struct MyType2: Sendable {
 }
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClass) async {
-  Task {
-    print(ns) // expected-targeted-complete-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+  Task { // expected-tns-warning {{task-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+    print(ns)
     print(mt) // no warning with targeted: MyType is Sendable because we suppressed NonStrictClass's warning
-    // expected-complete-warning @-1 {{capture of 'mt' with non-sendable type 'MyType' in a `@Sendable` closure}}
     print(mt2)
-    print(sc) // expected-warning {{capture of 'sc' with non-sendable type 'StrictClass' in a `@Sendable` closure}}
-    print(nsc) // expected-targeted-complete-warning {{capture of 'nsc' with non-sendable type 'NonStrictClass' in a `@Sendable` closure}}
+    print(sc)
+    print(nsc)
   }
 }
 

--- a/test/Concurrency/sending_mangling.swift
+++ b/test/Concurrency/sending_mangling.swift
@@ -79,11 +79,14 @@ extension SendingProtocol {
   // CHECK: sil hidden [ossa] @(extension in sending_mangling):sending_mangling.SendingProtocol.sendingResult() -> sending_mangling.NonSendableKlass : $@convention(method) <Self where Self : SendingProtocol> (@in_guaranteed Self) -> @sil_sending @owned NonSendableKlass {
   func sendingResult() -> sending NonSendableKlass { fatalError() }
 
-  // CHECK: sil hidden [ossa] @(extension in sending_mangling):sending_mangling.SendingProtocol.sendingArgWithFunctionSendingArg(__owned (sending __owned sending_mangling.NonSendableKlass) -> ()) -> () : $@convention(method) <Self where Self : SendingProtocol> (@sil_sending @owned @noescape @callee_guaranteed (@sil_sending @owned NonSendableKlass) -> (), @in_guaranteed Self) -> () {
+  // CHECK: sil hidden [ossa] @(extension in sending_mangling):sending_mangling.SendingProtocol.sendingArgWithFunctionSendingArg((sending __owned sending_mangling.NonSendableKlass) -> ()) -> () : $@convention(method) <Self where Self : SendingProtocol> (@sil_sending @guaranteed @noescape @callee_guaranteed (@sil_sending @owned NonSendableKlass) -> (), @in_guaranteed Self) -> () {
   func sendingArgWithFunctionSendingArg(_ x: sending (sending NonSendableKlass) -> ()) {}
 
   // CHECK: sil hidden [ossa] @(extension in sending_mangling):sending_mangling.SendingProtocol.sendingArgWithFunctionSendingResult() -> (sending __owned sending_mangling.NonSendableKlass) -> () : $@convention(method) <Self where Self : SendingProtocol> (@in_guaranteed Self) -> @sil_sending @owned @callee_guaranteed (@sil_sending @owned NonSendableKlass) -> () {
   func sendingArgWithFunctionSendingResult() -> sending (sending NonSendableKlass) -> () { fatalError() }
+
+  // CHECK: sil hidden [ossa] @(extension in sending_mangling):sending_mangling.SendingProtocol.sendingArgWithEscapingFunctionSendingArg(__owned (sending __owned sending_mangling.NonSendableKlass) -> ()) -> () : $@convention(method) <Self where Self : SendingProtocol> (@sil_sending @owned @callee_guaranteed (@sil_sending @owned NonSendableKlass) -> (), @in_guaranteed Self) -> () {
+  func sendingArgWithEscapingFunctionSendingArg(_ x: sending @escaping (sending NonSendableKlass) -> ()) {}
 }
 
 // Make sure we only do not mangle in __shared if we are borrowed by default and

--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -108,14 +108,16 @@ func asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure(@_inheritActo
 @MainActor
 func asyncInheritActorContextGlobalActorAcceptsSendableAsyncClosure(@_inheritActorContext _ x: @Sendable () async -> ()) async {}
 
+actor MyActor {}
+
 @MainActor
 var mainActorIsolatedValue = NonSendableKlass()
 
 func useValue<T>(_ x: T) { }
 
-////////////////////////////////////////
-// MARK: Sync User Sync Closure Tests //
-////////////////////////////////////////
+//////////////////////////////////////////////////////
+// MARK: Global Actor: Sync User Sync Closure Tests //
+//////////////////////////////////////////////////////
 
 @CustomActor
 func test_CallerSyncNormal_CalleeSyncNonIsolated() async {
@@ -144,9 +146,11 @@ func test_CallerSyncInheritsActorContext_CalleeSyncNonisolated() {
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     inheritActorContextAcceptsClosure { }
 
+    // This is a synchronous closure, so we error here.
+    //
     // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    inheritActorContextAcceptsSendingClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() -> ()' passed as a strongly transferred parameter; later accesses could race}}
+    inheritActorContextAcceptsSendingClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() -> ()' passed as a strongly transferred parameter}}
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
@@ -178,6 +182,8 @@ func test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await inheritActorContextGlobalActorAcceptsClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() -> ()' with later accesses to main actor-isolated context risks causing data races}}
 
+    // This is a synchronous closure, so we error here.
+    //
     // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await inheritActorContextGlobalActorAcceptsSendingClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() -> ()' passed as a strongly transferred parameter}}
@@ -187,14 +193,13 @@ func test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
     await inheritActorContextGlobalActorAcceptsSendableClosure { }
 }
 
-///////////////////////////////////
-// MARK: Sync User Async Closure //
-///////////////////////////////////
+////////////////////////////////////////////////
+// MARK: Global Actor Sync User Async Closure //
+////////////////////////////////////////////////
 
 @CustomActor
 func test_CallerSyncNormal_CalleeAsyncNonIsolated() async {
     // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference44test_CallerSyncNormal_CalleeAsyncNonIsolatedyyYaF'
-
     // CHECK-LABEL: closure #1 in test_CallerSyncNormal_CalleeAsyncNonIsolated()
     // CHECK-NEXT: Isolation: global_actor. type: CustomActor
     normalAcceptsAsyncClosure { }
@@ -218,7 +223,7 @@ func test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated() {
 
     // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    inheritActorContextAcceptsSendingAsyncClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() async -> ()' passed as a strongly transferred parameter; later accesses could race}}
+    inheritActorContextAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
@@ -248,20 +253,20 @@ func test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated() async {
 
     // CHECK-LABEL: // closure #1 in test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await inheritActorContextGlobalActorAcceptsAsyncClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() async -> ()' with later accesses to main actor-isolated context risks causing data races}}
+    await inheritActorContextGlobalActorAcceptsAsyncClosure { }
 
     // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await inheritActorContextGlobalActorAcceptsSendingAsyncClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+    await inheritActorContextGlobalActorAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await inheritActorContextGlobalActorAcceptsSendableAsyncClosure { }
 }
 
-/////////////////////////////////////////
-// MARK: Async User Sync Closure Tests //
-/////////////////////////////////////////
+//////////////////////////////////////////////////////
+// MARK: Global Actor Async User Sync Closure Tests //
+//////////////////////////////////////////////////////
 
 @CustomActor
 func test_CallerAsyncNormal_CalleeSyncNonIsolated() async {
@@ -290,9 +295,11 @@ func test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated() async {
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await asyncInheritActorContextAcceptsClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() -> ()' with later accesses to nonisolated context risks causing data races}}
 
+    // This is a synchronous closure, so we error here.
+    //
     // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextAcceptsSendingClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() -> ()' passed as a strongly transferred parameter; later accesses could race}}
+    await asyncInheritActorContextAcceptsSendingClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() -> ()' passed as a strongly transferred parameter}}
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
@@ -324,6 +331,8 @@ func test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await asyncInheritActorContextGlobalActorAcceptsClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() -> ()' with later accesses to main actor-isolated context risks causing data races}}
 
+    // This is a synchronous closure, so we error here.
+    //
     // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await asyncInheritActorContextGlobalActorAcceptsSendingClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() -> ()' passed as a strongly transferred parameter}}
@@ -333,9 +342,9 @@ func test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
     await asyncInheritActorContextGlobalActorAcceptsSendableClosure { }
 }
 
-////////////////////////////////////
-// MARK: Async User Async Closure //
-////////////////////////////////////
+/////////////////////////////////////////////////
+// MARK: Global Actor Async User Async Closure //
+/////////////////////////////////////////////////
 
 @CustomActor
 func test_CallerAsyncNormal_CalleeAsyncNonIsolated() async {
@@ -360,11 +369,11 @@ func test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated() async {
 
     // CHECK-LABEL: // closure #1 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextAcceptsAsyncClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() async -> ()' with later accesses to nonisolated context risks causing data races}}
+    await asyncInheritActorContextAcceptsAsyncClosure { }
 
     // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextAcceptsSendingAsyncClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() async -> ()' passed as a strongly transferred parameter; later accesses could race}}
+    await asyncInheritActorContextAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
@@ -402,11 +411,11 @@ func test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated() async {
 
     // CHECK-LABEL: // closure #1 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextGlobalActorAcceptsAsyncClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() async -> ()' with later accesses to main actor-isolated context risks causing data races}}
+    await asyncInheritActorContextGlobalActorAcceptsAsyncClosure { }
 
     // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+    await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
@@ -419,4 +428,313 @@ func test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated() async {
     // CHECK-LABEL: // closure #5 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await asyncInheritActorContextGlobalActorAcceptsSendableAsyncClosure { }
+}
+
+////////////////////////////////////////////////////////
+// MARK: Actor Instance: Sync User Sync Closure Tests //
+////////////////////////////////////////////////////////
+
+extension MyActor {
+    func test_CallerSyncNormal_CalleeSyncNonIsolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC028test_CallerSyncNormal_CalleeH11NonIsolatedyyYaF'
+
+        // CHECK-LABEL: closure #1 in MyActor.test_CallerSyncNormal_CalleeSyncNonIsolated()
+        // CHECK-NEXT: Isolation: actor_instance. name: 'self'
+        normalAcceptsClosure { print(self) }
+
+        // CHECK-LABEL: closure #2 in MyActor.test_CallerSyncNormal_CalleeSyncNonIsolated()
+        // CHECK-NEXT: Isolation: nonisolated
+        normalAcceptsSendingClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncNormal_CalleeSyncNonIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        normalAcceptsSendableClosure { print(self) }
+    }
+
+    func test_CallerSyncInheritsActorContext_CalleeSyncNonisolated() {
+        // CHECK: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC023test_CallerSyncInheritse14Context_CalleeH11NonisolatedyyF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        inheritActorContextAcceptsClosure { print(self) }
+
+        // This is a synchronous closure, so we error here.
+        //
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        inheritActorContextAcceptsSendingClosure { print(self) } // expected-error {{'self'-isolated value of type '() -> ()' passed as a strongly transferred parameter}}
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        inheritActorContextAcceptsSendableClosure { print(self) }
+    }
+
+    func test_CallerSyncNormal_CalleeSyncMainActorIsolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC028test_CallerSyncNormal_Calleeh4MainE8IsolatedyyYaF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerSyncNormal_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await normalGlobalActorAcceptsClosure { print(self) } // expected-error {{sending 'self'-isolated value of type '() -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncNormal_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        await normalGlobalActorAcceptsSendingClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncNormal_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        await normalGlobalActorAcceptsSendableClosure { print(self) }
+    }
+
+    func test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC023test_CallerSyncInheritse14Context_Calleeh4MainE8IsolatedyyYaF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await inheritActorContextGlobalActorAcceptsClosure { print(self) } // expected-error {{sending 'self'-isolated value of type '() -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+        // This is a synchronous closure, so we error here.
+        //
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await inheritActorContextGlobalActorAcceptsSendingClosure { print(self) } // expected-error {{'self'-isolated value of type '() -> ()' passed as a strongly transferred parameter}}
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await inheritActorContextGlobalActorAcceptsSendableClosure { print(self) }
+    }
+}
+
+//////////////////////////////////////////////////
+// MARK: Actor Instance Sync User Async Closure //
+//////////////////////////////////////////////////
+
+extension MyActor {
+
+    func test_CallerSyncNormal_CalleeAsyncNonIsolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC44test_CallerSyncNormal_CalleeAsyncNonIsolatedyyYaF'
+
+        // CHECK-LABEL: closure #1 in MyActor.test_CallerSyncNormal_CalleeAsyncNonIsolated()
+        // CHECK-NEXT: Isolation: actor_instance. name: 'self'
+        normalAcceptsAsyncClosure { print(self) }
+
+        // CHECK-LABEL: closure #2 in MyActor.test_CallerSyncNormal_CalleeAsyncNonIsolated()
+        // CHECK-NEXT: Isolation: nonisolated
+        normalAcceptsSendingAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncNormal_CalleeAsyncNonIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        normalAcceptsSendableAsyncClosure { print(self) }
+    }
+
+    func test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated() {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC023test_CallerSyncInheritsE30Context_CalleeAsyncNonisolatedyyF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        inheritActorContextAcceptsAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        inheritActorContextAcceptsSendingAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        inheritActorContextAcceptsSendableAsyncClosure { print(self) }
+    }
+
+    func test_CallerSyncNormal_CalleeAsyncMainActorIsolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC037test_CallerSyncNormal_CalleeAsyncMainE8IsolatedyyYaF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await normalGlobalActorAcceptsAsyncClosure { print(self) } // expected-error {{sending 'self'-isolated value of type '() async -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        await normalGlobalActorAcceptsSendingAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        await normalGlobalActorAcceptsSendableAsyncClosure { print(self) }
+    }
+
+    func test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC023test_CallerSyncInheritse23Context_CalleeAsyncMainE8IsolatedyyYaF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await inheritActorContextGlobalActorAcceptsAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await inheritActorContextGlobalActorAcceptsSendingAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await inheritActorContextGlobalActorAcceptsSendableAsyncClosure { print(self) }
+    }
+}
+
+////////////////////////////////////////////////////////
+// MARK: Actor Instance Async User Sync Closure Tests //
+////////////////////////////////////////////////////////
+
+extension MyActor {
+
+    func test_CallerAsyncNormal_CalleeSyncNonIsolated() async {
+        // Just to help start our pattern matchin since the closure #$NUM line
+        // appears in other parts of the file.
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC44test_CallerAsyncNormal_CalleeSyncNonIsolatedyyYaF'
+
+        // CHECK-LABEL: closure #1 in MyActor.test_CallerAsyncNormal_CalleeSyncNonIsolated()
+        // CHECK-NEXT: Isolation: actor_instance. name: 'self'
+        await asyncNormalAcceptsClosure { print(self) } // expected-error {{sending 'self'-isolated value of type '() -> ()' with later accesses to nonisolated context risks causing data races}}
+
+        // CHECK-LABEL: closure #2 in MyActor.test_CallerAsyncNormal_CalleeSyncNonIsolated()
+        // CHECK-NEXT: Isolation: nonisolated
+        await asyncNormalAcceptsSendingClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncNormal_CalleeSyncNonIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        await asyncNormalAcceptsSendableClosure { print(self) }
+    }
+
+    func test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated() async {
+        // CHECK: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC024test_CallerAsyncInheritsE29Context_CalleeSyncNonisolatedyyYaF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextAcceptsClosure { print(self) } // expected-error {{sending 'self'-isolated value of type '() -> ()' with later accesses to nonisolated context risks causing data races}}
+
+        // This is a synchronous closure, so we error here.
+        //
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextAcceptsSendingClosure { print(self) } // expected-error {{'self'-isolated value of type '() -> ()' passed as a strongly transferred parameter}}
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextAcceptsSendableClosure { print(self) }
+    }
+
+    func test_CallerAsyncNormal_CalleeSyncMainActorIsolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC037test_CallerAsyncNormal_CalleeSyncMainE8IsolatedyyYaF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncNormalGlobalActorAcceptsClosure { print(self) } // expected-error {{sending 'self'-isolated value of type '() -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        await asyncNormalGlobalActorAcceptsSendingClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        await asyncNormalGlobalActorAcceptsSendableClosure { print(self) }
+    }
+
+    func test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC024test_CallerAsyncInheritse22Context_CalleeSyncMainE8IsolatedyyYaF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextGlobalActorAcceptsClosure { print(self) } // expected-error {{sending 'self'-isolated value of type '() -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+        // This is a synchronous function, so we error.
+        //
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextGlobalActorAcceptsSendingClosure { print(self) } // expected-error {{'self'-isolated value of type '() -> ()' passed as a strongly transferred parameter}}
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextGlobalActorAcceptsSendableClosure { print(self) }
+    }
+}
+
+///////////////////////////////////////////////////
+// MARK: Actor Instance Async User Async Closure //
+///////////////////////////////////////////////////
+
+extension MyActor {
+
+    func test_CallerAsyncNormal_CalleeAsyncNonIsolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC029test_CallerAsyncNormal_CalleeH11NonIsolatedyyYaF'
+
+        // CHECK-LABEL: closure #1 in MyActor.test_CallerAsyncNormal_CalleeAsyncNonIsolated()
+        // CHECK-NEXT: Isolation: actor_instance. name: 'self'
+        await asyncNormalAcceptsAsyncClosure { print(self) } // expected-error {{sending 'self'-isolated value of type '() async -> ()' with later accesses to nonisolated context risks causing data races}}
+
+        // CHECK-LABEL: closure #2 in MyActor.test_CallerAsyncNormal_CalleeAsyncNonIsolated()
+        // CHECK-NEXT: Isolation: nonisolated
+        await asyncNormalAcceptsSendingAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncNormal_CalleeAsyncNonIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        await asyncNormalAcceptsSendableAsyncClosure { print(self) }
+    }
+
+    func test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC024test_CallerAsyncInheritse14Context_CalleeH11NonisolatedyyYaF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextAcceptsAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextAcceptsSendingAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+        await asyncInheritActorContextAcceptsSendingAsyncClosure { @CustomActor in print(self) }
+
+        // CHECK-LABEL: // closure #4 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+        await asyncInheritActorContextAcceptsSendingAsyncClosure { @MainActor in print(self) }
+
+        // CHECK-LABEL: // closure #5 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextAcceptsSendableAsyncClosure { print(self) }
+    }
+
+    func test_CallerAsyncNormal_CalleeAsyncMainActorIsolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC029test_CallerAsyncNormal_Calleeh4MainE8IsolatedyyYaF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncNormalGlobalActorAcceptsAsyncClosure { print(self) } // expected-error {{sending 'self'-isolated value of type '() async -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        await asyncNormalGlobalActorAcceptsSendingAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: nonisolated
+        await asyncNormalGlobalActorAcceptsSendableAsyncClosure { print(self) }
+    }
+
+    func test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated() async {
+        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC024test_CallerAsyncInheritse14Context_Calleeh4MainE8IsolatedyyYaF'
+
+        // CHECK-LABEL: // closure #1 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextGlobalActorAcceptsAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { print(self) }
+
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+        await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { @CustomActor in print(self) }
+
+        // CHECK-LABEL: // closure #4 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+        await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { @MainActor in print(self) }
+
+        // CHECK-LABEL: // closure #5 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
+        await asyncInheritActorContextGlobalActorAcceptsSendableAsyncClosure { print(self) }
+    }
 }

--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -368,11 +368,11 @@ func test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated() async {
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextAcceptsSendingAsyncClosure { @CustomActor in } // expected-error {{global actor 'CustomActor'-isolated value of type '@CustomActor () async -> ()' passed as a strongly transferred parameter; later accesses could race}}
+    await asyncInheritActorContextAcceptsSendingAsyncClosure { @CustomActor in }
 
     // CHECK-LABEL: // closure #4 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: MainActor
-    await asyncInheritActorContextAcceptsSendingAsyncClosure { @MainActor in } // expected-error {{main actor-isolated value of type '@MainActor () async -> ()' passed as a strongly transferred parameter; later accesses could race}}
+    await asyncInheritActorContextAcceptsSendingAsyncClosure { @MainActor in }
 
     // CHECK-LABEL: // closure #5 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
@@ -410,7 +410,7 @@ func test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated() async {
 
     // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { @CustomActor in } // expected-error {{global actor 'CustomActor'-isolated value of type '@CustomActor () async -> ()' passed as a strongly transferred parameter}}
+    await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { @CustomActor in }
 
     // CHECK-LABEL: // closure #4 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: MainActor

--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -1,0 +1,422 @@
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -disable-availability-checking -swift-version 5 -strict-concurrency=complete %s -o - | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -disable-availability-checking -swift-version 6 -verify %s -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// This test validates the behavior of transfernonsendable around
+// closure literals
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+func normalAcceptsClosure(_ x: () -> ()) {}
+func normalAcceptsSendingClosure(_ x: sending () -> ()) {}
+func normalAcceptsSendableClosure(_ x: @Sendable () -> ()) {}
+
+func inheritActorContextAcceptsClosure(@_inheritActorContext _ x: () -> ()) { }
+func inheritActorContextAcceptsSendingClosure(@_inheritActorContext _ x: sending () -> ()) { }
+func inheritActorContextAcceptsSendableClosure(@_inheritActorContext _ x: @Sendable () -> ()) { }
+
+@MainActor
+func normalGlobalActorAcceptsClosure(_ x: () -> ()) { }
+@MainActor
+func normalGlobalActorAcceptsSendingClosure(_ x: sending () -> ()) { }
+@MainActor
+func normalGlobalActorAcceptsSendableClosure(_ x: @Sendable () -> ()) { }
+
+@MainActor
+func inheritActorContextGlobalActorAcceptsClosure(@_inheritActorContext _ x: () -> ()) { }
+@MainActor
+func inheritActorContextGlobalActorAcceptsSendingClosure(@_inheritActorContext _ x: sending () -> ()) { }
+@MainActor
+func inheritActorContextGlobalActorAcceptsSendableClosure(@_inheritActorContext _ x: @Sendable () -> ()) { }
+
+func normalAcceptsAsyncClosure(_ x: () async -> ()) {}
+func normalAcceptsSendingAsyncClosure(_ x: sending () async -> ()) {}
+func normalAcceptsSendableAsyncClosure(_ x: @Sendable () async -> ()) {}
+
+func inheritActorContextAcceptsAsyncClosure(@_inheritActorContext _ x: () async -> ()) { }
+func inheritActorContextAcceptsSendingAsyncClosure(@_inheritActorContext _ x: sending () async -> ()) { }
+func inheritActorContextAcceptsSendableAsyncClosure(@_inheritActorContext _ x: @Sendable () async -> ()) { }
+
+@MainActor
+func normalGlobalActorAcceptsAsyncClosure(_ x: () async -> ()) { }
+@MainActor
+func normalGlobalActorAcceptsSendingAsyncClosure(_ x: sending () async -> ()) { }
+@MainActor
+func normalGlobalActorAcceptsSendableAsyncClosure(_ x: @Sendable () async -> ()) { }
+
+@MainActor
+func inheritActorContextGlobalActorAcceptsAsyncClosure(@_inheritActorContext _ x: () async -> ()) { }
+@MainActor
+func inheritActorContextGlobalActorAcceptsSendingAsyncClosure(@_inheritActorContext _ x: sending () async -> ()) { }
+@MainActor
+func inheritActorContextGlobalActorAcceptsSendableAsyncClosure(@_inheritActorContext _ x: @Sendable () async -> ()) { }
+
+func asyncNormalAcceptsClosure(_ x: () -> ()) async {}
+func asyncNormalAcceptsSendingClosure(_ x: sending () -> ()) async {}
+func asyncNormalAcceptsSendableClosure(_ x: @Sendable () -> ()) async {}
+
+func asyncInheritActorContextAcceptsClosure(@_inheritActorContext _ x: () -> ()) async {}
+func asyncInheritActorContextAcceptsSendingClosure(@_inheritActorContext _ x: sending () -> ()) async {}
+func asyncInheritActorContextAcceptsSendableClosure(@_inheritActorContext _ x: @Sendable () -> ()) async {}
+
+@MainActor
+func asyncNormalGlobalActorAcceptsClosure(_ x: () -> ()) async {}
+@MainActor
+func asyncNormalGlobalActorAcceptsSendingClosure(_ x: sending () -> ()) async {}
+@MainActor
+func asyncNormalGlobalActorAcceptsSendableClosure(_ x: @Sendable () -> ()) async {}
+
+@MainActor
+func asyncInheritActorContextGlobalActorAcceptsClosure(@_inheritActorContext _ x: () -> ()) async {}
+@MainActor
+func asyncInheritActorContextGlobalActorAcceptsSendingClosure(@_inheritActorContext _ x: sending () -> ()) async {}
+@MainActor
+func asyncInheritActorContextGlobalActorAcceptsSendableClosure(@_inheritActorContext _ x: @Sendable () -> ()) async {}
+
+func asyncNormalAcceptsAsyncClosure(_ x: () async -> ()) async {}
+func asyncNormalAcceptsSendingAsyncClosure(_ x: sending () async -> ()) async {}
+func asyncNormalAcceptsSendableAsyncClosure(_ x: @Sendable () async -> ()) async {}
+
+func asyncInheritActorContextAcceptsAsyncClosure(@_inheritActorContext _ x: () async -> ()) async {}
+func asyncInheritActorContextAcceptsSendingAsyncClosure(@_inheritActorContext _ x: sending () async -> ()) async {}
+func asyncInheritActorContextAcceptsSendableAsyncClosure(@_inheritActorContext _ x: @Sendable () async -> ()) async {}
+
+@MainActor
+func asyncNormalGlobalActorAcceptsAsyncClosure(_ x: () async -> ()) async {}
+@MainActor
+func asyncNormalGlobalActorAcceptsSendingAsyncClosure(_ x: sending () async -> ()) async {}
+@MainActor
+func asyncNormalGlobalActorAcceptsSendableAsyncClosure(_ x: @Sendable () async -> ()) async {}
+
+@MainActor
+func asyncInheritActorContextGlobalActorAcceptsAsyncClosure(@_inheritActorContext _ x: () async -> ()) async {}
+@MainActor
+func asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure(@_inheritActorContext _ x: sending () async -> ()) async {}
+@MainActor
+func asyncInheritActorContextGlobalActorAcceptsSendableAsyncClosure(@_inheritActorContext _ x: @Sendable () async -> ()) async {}
+
+@MainActor
+var mainActorIsolatedValue = NonSendableKlass()
+
+func useValue<T>(_ x: T) { }
+
+////////////////////////////////////////
+// MARK: Sync User Sync Closure Tests //
+////////////////////////////////////////
+
+@CustomActor
+func test_CallerSyncNormal_CalleeSyncNonIsolated() async {
+    // Just to help start our pattern matchin since the closure #$NUM line
+    // appears in other parts of the file.
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference028test_CallerSyncNormal_CalleeF11NonIsolatedyyYaF'
+
+    // CHECK-LABEL: closure #1 in test_CallerSyncNormal_CalleeSyncNonIsolated()
+    // CHECK-NEXT: Isolation: global_actor. type: CustomActor
+    normalAcceptsClosure { }
+
+    // CHECK-LABEL: closure #2 in test_CallerSyncNormal_CalleeSyncNonIsolated()
+    // CHECK-NEXT: Isolation: nonisolated
+    normalAcceptsSendingClosure { }
+
+    // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeSyncNonIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    normalAcceptsSendableClosure { }
+}
+
+@CustomActor
+func test_CallerSyncInheritsActorContext_CalleeSyncNonisolated() {
+    // CHECK: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference042test_CallerSyncInheritsActorContext_CalleeF11NonisolatedyyF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    inheritActorContextAcceptsClosure { }
+
+    // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    inheritActorContextAcceptsSendingClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() -> ()' passed as a strongly transferred parameter; later accesses could race}}
+
+    // CHECK-LABEL: // closure #3 in test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    inheritActorContextAcceptsSendableClosure { }
+}
+
+@CustomActor
+func test_CallerSyncNormal_CalleeSyncMainActorIsolated() async {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference028test_CallerSyncNormal_CalleeF17MainActorIsolatedyyYaF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerSyncNormal_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await normalGlobalActorAcceptsClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+    // CHECK-LABEL: // closure #2 in test_CallerSyncNormal_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    await normalGlobalActorAcceptsSendingClosure { }
+
+    // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    await normalGlobalActorAcceptsSendableClosure { }
+}
+
+@CustomActor
+func test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference042test_CallerSyncInheritsActorContext_Calleef4MainH8IsolatedyyYaF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await inheritActorContextGlobalActorAcceptsClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+    // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await inheritActorContextGlobalActorAcceptsSendingClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() -> ()' passed as a strongly transferred parameter}}
+
+    // CHECK-LABEL: // closure #3 in test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await inheritActorContextGlobalActorAcceptsSendableClosure { }
+}
+
+///////////////////////////////////
+// MARK: Sync User Async Closure //
+///////////////////////////////////
+
+@CustomActor
+func test_CallerSyncNormal_CalleeAsyncNonIsolated() async {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference44test_CallerSyncNormal_CalleeAsyncNonIsolatedyyYaF'
+
+    // CHECK-LABEL: closure #1 in test_CallerSyncNormal_CalleeAsyncNonIsolated()
+    // CHECK-NEXT: Isolation: global_actor. type: CustomActor
+    normalAcceptsAsyncClosure { }
+
+    // CHECK-LABEL: closure #2 in test_CallerSyncNormal_CalleeAsyncNonIsolated()
+    // CHECK-NEXT: Isolation: nonisolated
+    normalAcceptsSendingAsyncClosure { }
+
+    // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeAsyncNonIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    normalAcceptsSendableAsyncClosure { }
+}
+
+@CustomActor
+func test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated() {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference58test_CallerSyncInheritsActorContext_CalleeAsyncNonisolatedyyF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    inheritActorContextAcceptsAsyncClosure { }
+
+    // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    inheritActorContextAcceptsSendingAsyncClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() async -> ()' passed as a strongly transferred parameter; later accesses could race}}
+
+    // CHECK-LABEL: // closure #3 in test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    inheritActorContextAcceptsSendableAsyncClosure { }
+}
+
+@CustomActor
+func test_CallerSyncNormal_CalleeAsyncMainActorIsolated() async {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference50test_CallerSyncNormal_CalleeAsyncMainActorIsolatedyyYaF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await normalGlobalActorAcceptsAsyncClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() async -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+    // CHECK-LABEL: // closure #2 in test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    await normalGlobalActorAcceptsSendingAsyncClosure { }
+
+    // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    await normalGlobalActorAcceptsSendableAsyncClosure { }
+}
+
+@CustomActor
+func test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated() async {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference051test_CallerSyncInheritsActorContext_CalleeAsyncMainH8IsolatedyyYaF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await inheritActorContextGlobalActorAcceptsAsyncClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() async -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+    // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await inheritActorContextGlobalActorAcceptsSendingAsyncClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+
+    // CHECK-LABEL: // closure #3 in test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await inheritActorContextGlobalActorAcceptsSendableAsyncClosure { }
+}
+
+/////////////////////////////////////////
+// MARK: Async User Sync Closure Tests //
+/////////////////////////////////////////
+
+@CustomActor
+func test_CallerAsyncNormal_CalleeSyncNonIsolated() async {
+    // Just to help start our pattern matchin since the closure #$NUM line
+    // appears in other parts of the file.
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference44test_CallerAsyncNormal_CalleeSyncNonIsolatedyyYaF'
+
+    // CHECK-LABEL: closure #1 in test_CallerAsyncNormal_CalleeSyncNonIsolated()
+    // CHECK-NEXT: Isolation: global_actor. type: CustomActor
+    await asyncNormalAcceptsClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() -> ()' with later accesses to nonisolated context risks causing data races}}
+
+    // CHECK-LABEL: closure #2 in test_CallerAsyncNormal_CalleeSyncNonIsolated()
+    // CHECK-NEXT: Isolation: nonisolated
+    await asyncNormalAcceptsSendingClosure { }
+
+    // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeSyncNonIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    await asyncNormalAcceptsSendableClosure { }
+}
+
+@CustomActor
+func test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated() async {
+    // CHECK: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference58test_CallerAsyncInheritsActorContext_CalleeSyncNonisolatedyyYaF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextAcceptsClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() -> ()' with later accesses to nonisolated context risks causing data races}}
+
+    // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextAcceptsSendingClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() -> ()' passed as a strongly transferred parameter; later accesses could race}}
+
+    // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextAcceptsSendableClosure { }
+}
+
+@CustomActor
+func test_CallerAsyncNormal_CalleeSyncMainActorIsolated() async {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference50test_CallerAsyncNormal_CalleeSyncMainActorIsolatedyyYaF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncNormalGlobalActorAcceptsClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+    // CHECK-LABEL: // closure #2 in test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    await asyncNormalGlobalActorAcceptsSendingClosure { }
+
+    // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    await asyncNormalGlobalActorAcceptsSendableClosure { }
+}
+
+@CustomActor
+func test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference051test_CallerAsyncInheritsActorContext_CalleeSyncMainH8IsolatedyyYaF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextGlobalActorAcceptsClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+    // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextGlobalActorAcceptsSendingClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() -> ()' passed as a strongly transferred parameter}}
+
+    // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextGlobalActorAcceptsSendableClosure { }
+}
+
+////////////////////////////////////
+// MARK: Async User Async Closure //
+////////////////////////////////////
+
+@CustomActor
+func test_CallerAsyncNormal_CalleeAsyncNonIsolated() async {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference029test_CallerAsyncNormal_CalleeF11NonIsolatedyyYaF'
+
+    // CHECK-LABEL: closure #1 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
+    // CHECK-NEXT: Isolation: global_actor. type: CustomActor
+    await asyncNormalAcceptsAsyncClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() async -> ()' with later accesses to nonisolated context risks causing data races}}
+
+    // CHECK-LABEL: closure #2 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
+    // CHECK-NEXT: Isolation: nonisolated
+    await asyncNormalAcceptsSendingAsyncClosure { }
+
+    // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    await asyncNormalAcceptsSendableAsyncClosure { }
+}
+
+@CustomActor
+func test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated() async {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference043test_CallerAsyncInheritsActorContext_CalleeF11NonisolatedyyYaF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextAcceptsAsyncClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() async -> ()' with later accesses to nonisolated context risks causing data races}}
+
+    // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextAcceptsSendingAsyncClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() async -> ()' passed as a strongly transferred parameter; later accesses could race}}
+
+    // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextAcceptsSendingAsyncClosure { @CustomActor in } // expected-error {{global actor 'CustomActor'-isolated value of type '@CustomActor () async -> ()' passed as a strongly transferred parameter; later accesses could race}}
+
+    // CHECK-LABEL: // closure #4 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+    await asyncInheritActorContextAcceptsSendingAsyncClosure { @MainActor in } // expected-error {{main actor-isolated value of type '@MainActor () async -> ()' passed as a strongly transferred parameter; later accesses could race}}
+
+    // CHECK-LABEL: // closure #5 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextAcceptsSendableAsyncClosure { }
+}
+
+@CustomActor
+func test_CallerAsyncNormal_CalleeAsyncMainActorIsolated() async {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference029test_CallerAsyncNormal_CalleeF17MainActorIsolatedyyYaF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncNormalGlobalActorAcceptsAsyncClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() async -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+    // CHECK-LABEL: // closure #2 in test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    await asyncNormalGlobalActorAcceptsSendingAsyncClosure { }
+
+    // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: nonisolated
+    await asyncNormalGlobalActorAcceptsSendableAsyncClosure { }
+}
+
+@CustomActor
+func test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated() async {
+    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference043test_CallerAsyncInheritsActorContext_Calleef4MainH8IsolatedyyYaF'
+
+    // CHECK-LABEL: // closure #1 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextGlobalActorAcceptsAsyncClosure { } // expected-error {{sending global actor 'CustomActor'-isolated value of type '() async -> ()' with later accesses to main actor-isolated context risks causing data races}}
+
+    // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { } // expected-error {{global actor 'CustomActor'-isolated value of type '() async -> ()' passed as a strongly transferred parameter}}
+
+    // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { @CustomActor in } // expected-error {{global actor 'CustomActor'-isolated value of type '@CustomActor () async -> ()' passed as a strongly transferred parameter}}
+
+    // CHECK-LABEL: // closure #4 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+    await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { @MainActor in }
+
+    // CHECK-LABEL: // closure #5 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
+    await asyncInheritActorContextGlobalActorAcceptsSendableAsyncClosure { }
+}

--- a/test/Concurrency/transfernonsendable_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_sending_params.swift
@@ -411,3 +411,10 @@ actor NonSendableInit {
     set { fatalError() }
   }
 }
+
+func testNoCrashWhenSendingNoEscapeClosure() async {
+  func test(_ x: sending () -> ()) async {}
+
+  let c = Klass()
+  await test { print(c) }
+}

--- a/test/Distributed/distributed_actor_to_actor.swift
+++ b/test/Distributed/distributed_actor_to_actor.swift
@@ -43,7 +43,7 @@ distributed actor WorkerPool<Worker, ActorSystem: DistributedActorSystem>: Async
     self.actorSystem = system
     self.level = 0
 
-    // CHECK-SIL: sil private @$s021distributed_actor_to_B010WorkerPoolC0B6SystemACyxq_Gq__tYaKcfcyyYaYbcfU_ : $@convention(thin) @Sendable @async <Worker, ActorSystem where ActorSystem : DistributedActorSystem> (@guaranteed Optional<any Actor>, @sil_isolated @guaranteed WorkerPool<Worker, ActorSystem>) -> @out
+    // CHECK-SIL: sil private @$s021distributed_actor_to_B010WorkerPoolC0B6SystemACyxq_Gq__tYaKcfcyyYacfU_ : $@convention(thin) @Sendable @async <Worker, ActorSystem where ActorSystem : DistributedActorSystem> (@guaranteed Optional<any Actor>, @sil_isolated @guaranteed WorkerPool<Worker, ActorSystem>) -> @out () {
     // CHECK-SIL: hop_to_executor {{%.*}} : $WorkerPool<Worker, ActorSystem>
     _ = Task {
       for await x in self {

--- a/test/IRGen/async/builtins.sil
+++ b/test/IRGen/async/builtins.sil
@@ -31,23 +31,23 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: define hidden swift{{(tail)?}}cc void @launch_future
-sil hidden [ossa] @launch_future : $@convention(method) <T> (Int, @owned @Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) -> () {
-bb0(%flags : $Int, %taskFunction: @owned $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>):
+sil hidden [ossa] @launch_future : $@convention(method) <T> (Int, @owned @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) -> () {
+bb0(%flags : $Int, %taskFunction: @owned $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>):
   // CHECK-NOT: br i1
   // CHECK: [[NEW_TASK_AND_CONTEXT:%.*]] = call swift{{(tail)?}}cc %swift.async_task_and_context @swift_task_create([[INT]] %0, ptr null, ptr %T, ptr %1, ptr %2)
   %optSerialExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskGroup = enum $Optional<Builtin.RawPointer>, #Optional.none
   %optTaskExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskExecutorOwned = enum $Optional<any TaskExecutor>, #Optional.none
-  %20 = builtin "createAsyncTask"<T>(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+  %20 = builtin "createAsyncTask"<T>(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
   destroy_value %20 : $(Builtin.NativeObject, Builtin.RawPointer)
   %21 = tuple ()
   return %21 : $()
 }
 
 // CHECK-LABEL: define hidden swift{{(tail)?}}cc void @launch_future_on(
-sil hidden [ossa] @launch_future_on : $@convention(method) <T> (Int, Builtin.Executor, @owned @Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) -> () {
-bb0(%flags : $Int, %serialExecutor : $Builtin.Executor, %taskFunction: @owned $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>):
+sil hidden [ossa] @launch_future_on : $@convention(method) <T> (Int, Builtin.Executor, @owned @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) -> () {
+bb0(%flags : $Int, %serialExecutor : $Builtin.Executor, %taskFunction: @owned $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>):
   // CHECK: [[EXECUTOR_RECORD:%.*]] = alloca %swift.serial_executor_task_option
   // CHECK-NOT: br i1
   // CHECK: [[BASE_GEP:%.*]] = getelementptr inbounds %swift.serial_executor_task_option, ptr [[EXECUTOR_RECORD]], i32 0, i32 0
@@ -65,7 +65,7 @@ bb0(%flags : $Int, %serialExecutor : $Builtin.Executor, %taskFunction: @owned $@
   %optTaskGroup = enum $Optional<Builtin.RawPointer>, #Optional.none
   %optTaskExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskExecutorOwned = enum $Optional<any TaskExecutor>, #Optional.none
-  %20 = builtin "createAsyncTask"<T>(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+  %20 = builtin "createAsyncTask"<T>(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
   destroy_value %20 : $(Builtin.NativeObject, Builtin.RawPointer)
   %21 = tuple ()
   return %21 : $()
@@ -82,13 +82,13 @@ bb0(%flags : $Int, %serialExecutor : $Builtin.Executor, %taskFunction: @owned $@
 // CHECK: [[GROUP_GEP:%.*]] = getelementptr inbounds %swift.task_group_task_option, ptr [[OPTIONS]], i32 0, i32 1
 // CHECK: store ptr %0, ptr [[GROUP_GEP]], align
 // CHECK: call swiftcc %swift.async_task_and_context @swift_task_create([[INT]] %3, ptr [[OPTIONS]],
-sil hidden @launch_future_in_group : $@convention(thin) (Builtin.RawPointer, @owned @Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>, Int) -> () {
-bb0(%taskGroup : $Builtin.RawPointer, %taskFunction : $@Sendable @async @callee_guaranteed  @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>, %flags: $Int):
+sil hidden @launch_future_in_group : $@convention(thin) (Builtin.RawPointer, @owned @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>, Int) -> () {
+bb0(%taskGroup : $Builtin.RawPointer, %taskFunction : $@async @callee_guaranteed  @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>, %flags: $Int):
   %optSerialExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskGroup = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt, %taskGroup : $Builtin.RawPointer
   %optTaskExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskExecutorOwned = enum $Optional<any TaskExecutor>, #Optional.none
-  %9 = builtin "createAsyncTask"<Int>(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>) : $(Builtin.NativeObject, Builtin.RawPointer)
+  %9 = builtin "createAsyncTask"<Int>(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>) : $(Builtin.NativeObject, Builtin.RawPointer)
   %10 = tuple_extract %9 : $(Builtin.NativeObject, Builtin.RawPointer), 0
   strong_release %10 : $Builtin.NativeObject
   %12 = tuple ()
@@ -96,8 +96,8 @@ bb0(%taskGroup : $Builtin.RawPointer, %taskFunction : $@Sendable @async @callee_
 }
 
 // CHECK-LABEL: define hidden swift{{(tail)?}}cc void @launch_future_opt_task_group
-sil hidden [ossa] @launch_future_opt_task_group : $@convention(method) <T> (Int, Optional<Builtin.RawPointer>, @owned @Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) -> () {
-bb0(%flags : $Int, %optTaskGroup : $Optional<Builtin.RawPointer>, %taskFunction: @owned $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>):
+sil hidden [ossa] @launch_future_opt_task_group : $@convention(method) <T> (Int, Optional<Builtin.RawPointer>, @owned @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) -> () {
+bb0(%flags : $Int, %optTaskGroup : $Optional<Builtin.RawPointer>, %taskFunction: @owned $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>):
   // CHECK: [[OPTIONS:%.*]] = alloca %swift.task_group_task_option
   // CHECK: [[GROUP_IS_NULL:%.*]] = icmp eq [[INT]] %1, 0
   // CHECK: br i1 [[GROUP_IS_NULL]], label %task_group.cont, label %task_group.some
@@ -118,22 +118,22 @@ bb0(%flags : $Int, %optTaskGroup : $Optional<Builtin.RawPointer>, %taskFunction:
   %optSerialExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskExecutorOwned = enum $Optional<any TaskExecutor>, #Optional.none
-  %20 = builtin "createAsyncTask"<T>(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+  %20 = builtin "createAsyncTask"<T>(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
   destroy_value %20 : $(Builtin.NativeObject, Builtin.RawPointer)
   %result = tuple ()
   return %result : $()
 }
 
 // CHECK-LABEL: define hidden swift{{(tail)?}}cc void @launch_discarding_future_in_group
-sil hidden @launch_discarding_future_in_group : $@convention(thin) (Builtin.RawPointer, @owned @Sendable @async @callee_guaranteed () -> @error Error, Int) -> () {
-bb0(%taskGroup : $Builtin.RawPointer, %taskFunction : $@Sendable @async @callee_guaranteed () -> @error Error, %flags: $Int):
+sil hidden @launch_discarding_future_in_group : $@convention(thin) (Builtin.RawPointer, @owned @async @callee_guaranteed () -> @error Error, Int) -> () {
+bb0(%taskGroup : $Builtin.RawPointer, %taskFunction : $@async @callee_guaranteed () -> @error Error, %flags: $Int):
   %optSerialExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskGroup = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt, %taskGroup : $Builtin.RawPointer
   %optTaskExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskExecutorOwned = enum $Optional<any TaskExecutor>, #Optional.none
   // CHECK-NOT: br i1
   // CHECK: call swift{{(tail)?}}cc %swift.async_task_and_context @swift_task_create(
-  %9 = builtin "createAsyncTask"(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@Sendable @async @callee_guaranteed () -> @error Error) : $(Builtin.NativeObject, Builtin.RawPointer)
+  %9 = builtin "createAsyncTask"(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@async @callee_guaranteed () -> @error Error) : $(Builtin.NativeObject, Builtin.RawPointer)
   %10 = tuple_extract %9 : $(Builtin.NativeObject, Builtin.RawPointer), 0
   strong_release %10 : $Builtin.NativeObject
   %12 = tuple ()
@@ -141,8 +141,8 @@ bb0(%taskGroup : $Builtin.RawPointer, %taskFunction : $@Sendable @async @callee_
 }
 
 // CHECK-LABEL: define hidden swift{{(tail)?}}cc void @launch_discarding_future_in_group_with_executor
-sil hidden @launch_discarding_future_in_group_with_executor : $@convention(thin) (Builtin.RawPointer, Builtin.Executor, @owned @Sendable @async @callee_guaranteed () -> @error Error, Int) -> () {
-bb0(%taskGroup : $Builtin.RawPointer, %taskExecutor : $Builtin.Executor, %taskFunction : $@Sendable @async @callee_guaranteed () -> @error Error, %flags: $Int):
+sil hidden @launch_discarding_future_in_group_with_executor : $@convention(thin) (Builtin.RawPointer, Builtin.Executor, @owned @async @callee_guaranteed () -> @error Error, Int) -> () {
+bb0(%taskGroup : $Builtin.RawPointer, %taskExecutor : $Builtin.Executor, %taskFunction : $@async @callee_guaranteed () -> @error Error, %flags: $Int):
   %optSerialExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskGroup = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt, %taskGroup : $Builtin.RawPointer
   %optTaskExecutor = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, %taskExecutor : $Builtin.Executor
@@ -171,7 +171,7 @@ bb0(%taskGroup : $Builtin.RawPointer, %taskExecutor : $Builtin.Executor, %taskFu
   // CHECK: store [[INT]] %2, ptr [[EXECUTOR_IMPL_GEP]], align
 
   // CHECK: call swift{{(tail)?}}cc %swift.async_task_and_context @swift_task_create([[INT]] %5, ptr [[EXECUTOR_RECORD]]
-  %9 = builtin "createAsyncTask"(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor: $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@Sendable @async @callee_guaranteed () -> @error Error) : $(Builtin.NativeObject, Builtin.RawPointer)
+  %9 = builtin "createAsyncTask"(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor: $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@async @callee_guaranteed () -> @error Error) : $(Builtin.NativeObject, Builtin.RawPointer)
   %10 = tuple_extract %9 : $(Builtin.NativeObject, Builtin.RawPointer), 0
   strong_release %10 : $Builtin.NativeObject
   %12 = tuple ()
@@ -179,14 +179,14 @@ bb0(%taskGroup : $Builtin.RawPointer, %taskExecutor : $Builtin.Executor, %taskFu
 }
 
 // CHECK-LABEL: define hidden swift{{(tail)?}}cc void @launch_void_future
-sil hidden [ossa] @launch_void_future : $@convention(method) (Int, Builtin.RawPointer, @owned @Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) -> () {
-bb0(%flags : $Int, %taskGroup : $Builtin.RawPointer, %taskFunction: @owned $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>):
+sil hidden [ossa] @launch_void_future : $@convention(method) (Int, Builtin.RawPointer, @owned @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) -> () {
+bb0(%flags : $Int, %taskGroup : $Builtin.RawPointer, %taskFunction: @owned $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>):
   %optSerialExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskGroup = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt, %taskGroup : $Builtin.RawPointer
   %optTaskExecutor = enum $Optional<Builtin.Executor>, #Optional.none
   %optTaskExecutorOwned = enum $Optional<any TaskExecutor>, #Optional.none
   // CHECK: [[NEW_TASK_AND_CONTEXT:%.*]] = call swift{{(tail)?}}cc %swift.async_task_and_context @swift_task_create(
-  %20 = builtin "createAsyncTask"<()>(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) : $(Builtin.NativeObject, Builtin.RawPointer)
+  %20 = builtin "createAsyncTask"<()>(%flags : $Int, %optSerialExecutor : $Optional<Builtin.Executor>, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor : $Optional<Builtin.Executor>, %optTaskExecutorOwned : $Optional<any TaskExecutor>, %taskFunction : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) : $(Builtin.NativeObject, Builtin.RawPointer)
   destroy_value %20 : $(Builtin.NativeObject, Builtin.RawPointer)
   %21 = tuple ()
   return %21 : $()

--- a/test/SILGen/async_builtins.swift
+++ b/test/SILGen/async_builtins.swift
@@ -22,10 +22,10 @@ public struct X {
   // CHECK: [[GROUP:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.none
   // CHECK: [[TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
   // CHECK: [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
-  // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s4test1XV12launchFutureyyxlFxyYaYbKcfU_ :
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>({{.*}}) : $@convention(thin) @Sendable @async <τ_0_0> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @error any Error)
-  // CHECK: [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> (@out T, @error any Error) to $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
-  // CHECK: builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+  // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s4test1XV12launchFutureyyxlFxyYaKcfU_ :
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>({{.*}}) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @error any Error)
+  // CHECK: [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@async @callee_guaranteed () -> (@out T, @error any Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
+  // CHECK: builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
   func launchFuture<T>(_ value: T) {
     _ = Builtin.createAsyncTask(0) { () async throws -> T in
       return value
@@ -38,10 +38,10 @@ public struct X {
   // CHECK: [[GROUP:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt, %1 : $Builtin.RawPointer
   // CHECK: [[TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
   // CHECK: [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
-  // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s4test1XV16launchGroupChild_5groupyx_BptlFxyYaYbKcfU_ :
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>({{.*}}) : $@convention(thin) @Sendable @async <τ_0_0> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @error any Error)
-  // CHECK: [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> (@out T, @error any Error) to $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
-  // CHECK: builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+  // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s4test1XV16launchGroupChild_5groupyx_BptlFxyYaKcfU_ :
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>({{.*}}) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @error any Error)
+  // CHECK: [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@async @callee_guaranteed () -> (@out T, @error any Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
+  // CHECK: builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
   func launchGroupChild<T>(_ value: T, group: Builtin.RawPointer) {
      _ = Builtin.createAsyncTaskInGroup(0, group) { () async throws -> T in
       return value
@@ -54,9 +54,9 @@ public struct X {
   // CHECK: [[GROUP:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt, %0 : $Builtin.RawPointer
   // CHECK: [[TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
   // CHECK: [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
-  // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s4test1XV26launchDiscardingGroupChild5groupyBp_tFyyYaYbKcfU_ :
+  // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s4test1XV26launchDiscardingGroupChild5groupyBp_tFyyYaKcfU_ :
   // CHECK: [[CLOSURE:%.*]] = thin_to_thick_function [[CLOSURE_FN]]
-  // CHECK: builtin "createAsyncTask"([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> @error any Error) : $(Builtin.NativeObject, Builtin.RawPointer)
+  // CHECK: builtin "createAsyncTask"([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CLOSURE]] : $@async @callee_guaranteed () -> @error any Error) : $(Builtin.NativeObject, Builtin.RawPointer)
   func launchDiscardingGroupChild(group: Builtin.RawPointer) {
     _ = Builtin.createAsyncDiscardingTaskInGroup(0, group) { () async throws in
       return
@@ -73,10 +73,10 @@ public struct X {
   // CHECK: [[GROUP:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.none
   // CHECK: [[TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, %1 : $Builtin.Executor
   // CHECK: [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
-  // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s4test1XV24launchFutureWithExecutor_8executoryx_BetlFxyYaYbKcfU_ :
-  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>({{.*}}) : $@convention(thin) @Sendable @async <τ_0_0> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @error any Error)
-  // CHECK: [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> (@out T, @error any Error) to $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
-  // CHECK: builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+  // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s4test1XV24launchFutureWithExecutor_8executoryx_BetlFxyYaKcfU_ :
+  // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>({{.*}}) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @error any Error)
+  // CHECK: [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@async @callee_guaranteed () -> (@out T, @error any Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
+  // CHECK: builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
   func launchFutureWithExecutor<T>(_ value: T, executor: Builtin.Executor) {
     _ = Builtin.createAsyncTaskWithExecutor(0, executor) { () async throws -> T in
       return value
@@ -89,9 +89,9 @@ public struct X {
   // CHECK: [[GROUP:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt, %0 : $Builtin.RawPointer
   // CHECK: [[TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, %1 : $Builtin.Executor
   // CHECK: [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
-  // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s4test1XV34launchDiscardingFutureWithExecutor5group8executoryBp_BetFyyYaYbKcfU_ :
+  // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s4test1XV34launchDiscardingFutureWithExecutor5group8executoryBp_BetFyyYaKcfU_ :
   // CHECK: [[CLOSURE:%.*]] = thin_to_thick_function [[CLOSURE_FN]]
-  // CHECK: builtin "createAsyncTask"([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> @error any Error) : $(Builtin.NativeObject, Builtin.RawPointer)
+  // CHECK: builtin "createAsyncTask"([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[GROUP]] : $Optional<Builtin.RawPointer>, [[TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CLOSURE]] : $@async @callee_guaranteed () -> @error any Error) : $(Builtin.NativeObject, Builtin.RawPointer)
   func launchDiscardingFutureWithExecutor(group: Builtin.RawPointer, executor: Builtin.Executor) {
     _ = Builtin.createAsyncDiscardingTaskInGroupWithExecutor(0, group, executor) { () async throws in
       return
@@ -106,8 +106,8 @@ public struct X {
 // CHECK-NEXT:    [[OPT_TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK:         [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
 // CHECK:         [[CLOSURE:%.*]] = partial_apply
-// CHECK-NEXT:    [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> (@out T, @error any Error) to $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
-// CHECK-NEXT:    builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+// CHECK-NEXT:    [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@async @callee_guaranteed () -> (@out T, @error any Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
+// CHECK-NEXT:    builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
 func testCreateTask<T>(value: T) {
   _ = Builtin.createTask(flags: 0) {
     value
@@ -121,8 +121,8 @@ func testCreateTask<T>(value: T) {
 // CHECK-NEXT:    [[OPT_TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK:         [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
 // CHECK:         [[CLOSURE:%.*]] = partial_apply
-// CHECK-NEXT:    [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> (@out T, @error any Error) to $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
-// CHECK-NEXT:    builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+// CHECK-NEXT:    [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@async @callee_guaranteed () -> (@out T, @error any Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
+// CHECK-NEXT:    builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
 func testCreateTask<T>(group: Builtin.RawPointer, value: T) {
   _ = Builtin.createTask(flags: 0, taskGroup: group) {
     value
@@ -136,8 +136,8 @@ func testCreateTask<T>(group: Builtin.RawPointer, value: T) {
 // CHECK-NEXT:    [[OPT_TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, %0 : $Builtin.Executor
 // CHECK:         [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
 // CHECK:         [[CLOSURE:%.*]] = partial_apply
-// CHECK-NEXT:    [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> (@out T, @error any Error) to $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
-// CHECK-NEXT:    builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+// CHECK-NEXT:    [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@async @callee_guaranteed () -> (@out T, @error any Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
+// CHECK-NEXT:    builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
 func testCreateTask<T>(taskExecutor: Builtin.Executor, value: T) {
   _ = Builtin.createTask(flags: 0, initialTaskExecutor: taskExecutor) {
     value
@@ -151,8 +151,8 @@ func testCreateTask<T>(taskExecutor: Builtin.Executor, value: T) {
 // CHECK-NEXT:    [[OPT_TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK:         [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
 // CHECK:         [[CLOSURE:%.*]] = partial_apply
-// CHECK-NEXT:    [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> (@out T, @error any Error) to $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
-// CHECK-NEXT:    builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+// CHECK-NEXT:    [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@async @callee_guaranteed () -> (@out T, @error any Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
+// CHECK-NEXT:    builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
 func testCreateTask<T>(serialExecutor: Builtin.Executor, value: T) {
   _ = Builtin.createTask(flags: 0, initialSerialExecutor: serialExecutor) {
     value
@@ -165,8 +165,8 @@ func testCreateTask<T>(serialExecutor: Builtin.Executor, value: T) {
 // CHECK-NEXT:    [[OPT_TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, %1 : $Builtin.Executor
 // CHECK:         [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
 // CHECK:         [[CLOSURE:%.*]] = partial_apply
-// CHECK-NEXT:    [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> (@out T, @error any Error) to $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
-// CHECK-NEXT:    builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+// CHECK-NEXT:    [[CONVERTED_CLOSURE:%.*]] = convert_function [[CLOSURE]] : $@async @callee_guaranteed () -> (@out T, @error any Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>
+// CHECK-NEXT:    builtin "createAsyncTask"<T>([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CONVERTED_CLOSURE]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
 func testCreateTask<T>(group: Builtin.RawPointer, executor: Builtin.Executor, value: T) {
   _ = Builtin.createTask(flags: 0, taskGroup: group, initialTaskExecutor: executor) {
     value
@@ -183,7 +183,7 @@ func testCreateTask<T>(group: Builtin.RawPointer, executor: Builtin.Executor, va
 // CHECK-NEXT:    [[OPT_TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK:         [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
 // CHECK:         [[CLOSURE:%.*]] = partial_apply
-// CHECK-NEXT:    builtin "createAsyncTask"([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> @error any Error) : $(Builtin.NativeObject, Builtin.RawPointer)
+// CHECK-NEXT:    builtin "createAsyncTask"([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CLOSURE]] : $@async @callee_guaranteed () -> @error any Error) : $(Builtin.NativeObject, Builtin.RawPointer)
 func testCreateDiscardingTask<T>(value: T) {
   _ = Builtin.createDiscardingTask(flags: 0) {
     _ = value
@@ -200,7 +200,7 @@ func testCreateDiscardingTask<T>(value: T) {
 // CHECK-NEXT:    [[OPT_TASK_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, %1 : $Builtin.Executor
 // CHECK:         [[TASK_EXECUTOR_OWNED:%.*]] = enum $Optional<[[TASK_EXECUTOR_OWNED_TYPE:.*]]>, #Optional.none
 // CHECK:         [[CLOSURE:%.*]] = partial_apply
-// CHECK-NEXT:    builtin "createAsyncTask"([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CLOSURE]] : $@Sendable @async @callee_guaranteed () -> @error any Error) : $(Builtin.NativeObject, Builtin.RawPointer)
+// CHECK-NEXT:    builtin "createAsyncTask"([[FLAGS]] : $Int, [[OPT_SERIAL_EXECUTOR]] : $Optional<Builtin.Executor>, [[OPT_GROUP]] : $Optional<Builtin.RawPointer>, [[OPT_TASK_EXECUTOR]] : $Optional<Builtin.Executor>, [[TASK_EXECUTOR_OWNED]] : $Optional<[[TASK_EXECUTOR_OWNED_TYPE]]>, [[CLOSURE]] : $@async @callee_guaranteed () -> @error any Error) : $(Builtin.NativeObject, Builtin.RawPointer)
 func testCreateDiscardingTask<T>(group: Builtin.RawPointer, executor: Builtin.Executor, value: T) {
   _ = Builtin.createDiscardingTask(flags: 0, taskGroup: group, initialTaskExecutor: executor) {
     _ = value

--- a/test/SILGen/async_initializer.swift
+++ b/test/SILGen/async_initializer.swift
@@ -205,7 +205,7 @@ func callActorMethodFromGeneric(a: SomeActor) async {
 // CHECK:          [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK-NEXT:     hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
 // CHECK:          apply
-// CHECK-LABEL: sil private [ossa] @$s12initializers15makeActorInTaskyyYaFAA04SomeC0CyYaYbcfU_ : $@convention(thin) @Sendable @async @substituted <τ_0_0> (@guaranteed Optional<any Actor>) -> @out τ_0_0 for <SomeActor> {
+// CHECK-LABEL: sil private [ossa] @$s12initializers15makeActorInTaskyyYaFAA04SomeC0CyYacfU_ : $@convention(thin) @async @substituted <τ_0_0> (@guaranteed Optional<any Actor>) -> @out τ_0_0 for <SomeActor> {
 // CHECK:          [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK-NEXT:     hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
 // CHECK:          apply
@@ -219,7 +219,7 @@ func makeActorInTask() async {
 // CHECK:          [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK-NEXT:     hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
 // CHECK:          apply
-// CHECK-LABEL: sil private [ossa] @$s12initializers21callActorMethodInTask1ayAA04SomeC0C_tYaFyyYaYbcfU_ : $@convention(thin) @Sendable @async @substituted <τ_0_0> (@guaranteed Optional<any Actor>, @guaranteed SomeActor) -> @out τ_0_0 for <()> {
+// CHECK-LABEL: sil private [ossa] @$s12initializers21callActorMethodInTask1ayAA04SomeC0C_tYaFyyYacfU_ : $@convention(thin) @async @substituted <τ_0_0> (@guaranteed Optional<any Actor>, @guaranteed SomeActor) -> @out τ_0_0 for <()> {
 // CHECK:          [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK-NEXT:     hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
 // CHECK:          apply

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -641,7 +641,7 @@ struct Blah {
     @StateObject private var coordinator = Coordinator()
 
     // closure #1 in Blah.test()
-    // CHECK-LABEL: sil private [ossa] @$s4test4BlahVAAyyFyyYaYbcfU_ :
+    // CHECK-LABEL: sil private [ossa] @$s4test4BlahVAAyyFyyYacfU_ : $@convention(thin) @async @substituted <τ_0_0> (@guaranteed Optional<any Actor>, Blah) -> @out τ_0_0 for <()> {
     // CHECK:       [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
     // CHECK:       hop_to_executor [[GENERIC_EXEC]] :
     // CHECK:       hop_to_executor {{%[0-9]+}} : $MainActor
@@ -654,7 +654,7 @@ struct Blah {
     // CHECK:       {{%[0-9]+}} = load [trivial] [[VAL_ACCESS]] : $*Optional<Int>
     // CHECK:       end_access [[VAL_ACCESS]] : $*Optional<Int>
     // CHECK:       hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
-    // CHECK: } // end sil function '$s4test4BlahVAAyyFyyYaYbcfU_'
+    // CHECK: } // end sil function '$s4test4BlahVAAyyFyyYacfU_'
     @available(SwiftStdlib 5.1, *)
     func test() {
         Task.detached {

--- a/test/SILOptimizer/definite_init_actor.swift
+++ b/test/SILOptimizer/definite_init_actor.swift
@@ -291,9 +291,9 @@ actor TaskMaster {
     init() async {
 
         ////// for the closure
-        // CHECK-LABEL: sil private @$s4test10TaskMasterCACyYacfcyyYaYbcfU_ :
+        // CHECK-LABEL: sil private @$s4test10TaskMasterCACyYacfcyyYacfU_ :
         // CHECK:           hop_to_executor {{%[0-9]+}} : $TaskMaster
-        // CHECK: } // end sil function '$s4test10TaskMasterCACyYacfcyyYaYbcfU_'
+        // CHECK: } // end sil function '$s4test10TaskMasterCACyYacfcyyYacfU_'
         task = Task.detached { await self.sayHello() }
     }
 }


### PR DESCRIPTION
Just creating the PR now for discussion. Going to add more here.

Resolves: https://github.com/apple/swift/issues/74382