### PR TITLE
Remove `@escaping` from inout closures

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4015,6 +4015,9 @@ ERROR(autoclosure_function_input_nonunit,none,
 ERROR(escaping_non_function_parameter,none,
       "@escaping attribute may only be used in function parameter position", ())
 
+ERROR(escaping_inout_parameter,none,
+      "inout expression is implicitly escaping", ())
+
 ERROR(escaping_optional_type_argument, none,
       "closure is already escaping in optional type argument", ())
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3393,6 +3393,10 @@ TypeResolver::resolveAttributedType(TypeRepr *repr, TypeResolutionOptions option
           diagnoseInvalid(repr, repr->getLoc(),
                           diag::escaping_optional_type_argument)
               .fixItRemove(attrRange);
+        } else if (options.is(TypeResolverContext::InoutFunctionInput)) {
+          diagnoseInvalid(repr, repr->getLoc(),
+                          diag::escaping_inout_parameter)
+              .fixItRemove(attrRange);
         } else {
           diagnoseInvalid(repr, loc, diag::escaping_non_function_parameter)
               .fixItRemove(attrRange);

--- a/test/attr/escaping_inout_arugment.swift
+++ b/test/attr/escaping_inout_arugment.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+let _: (_ v: inout @escaping () -> Void) -> ()
+// expected-error@-1 {{inout expression is implicitly escaping}}{{20-30=}}
+
+func m(v: inout @escaping () -> Void) {}
+// expected-error@-1 {{inout expression is implicitly escaping}}{{17-27=}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Hello Team, 
In This PR i add support for better diagnostics message when there's an `inout @escaping` closure

based on @belkaden's comment in https://github.com/apple/swift/issues/52061#issuecomment-1108348464

>Note that the `@escaping` is unnecessary in this case; by being inout it's structurally not a top-level parameter type (and therefore implicitly escaping), and it also doesn't make sense to have a non-escaping inout parameter. But we should diagnose it better.


so instead of: 
```swift
error: @escaping attribute may only be used in function parameter position
func m(v: inout @escaping () -> Void) {}
                ~~~~~~~~~~   ^
```

we get a better message reflecting the reason of the suggestion of removing `@escaping`, much like what we already do for escaping optionals

```swift
error: inout expression is implicitly escaping
func m(v: inout @escaping () -> Void) {}
                ~~~~~~~~~~   ^
```

additionally, i wrote tests for the new case. please let me know if there's something more to be added/supported, as this's my first contribution to the project. 

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #52061

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
