### PR TITLE
[Sema] Score non-settable overload choices higher in RValueToLValue fix

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15201,7 +15201,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
                locator.endsWith<LocatorPathElt::SubscriptMember>())
                   ? 1
                   : 0;
-
+    // An overload choice that isn't settable is least interesting for diagnosis.
+    if (auto overload = findSelectedOverloadFor(getCalleeLocator(fix->getLocator()))) {
+      if (auto *var = dyn_cast_or_null<VarDecl>(overload->choice.getDeclOrNull())) {
+         impact += !var->isSettableInSwift(DC) ? 1 : 0;
+      }
+    }
     return recordFix(fix, impact) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -762,3 +762,16 @@ struct S2<T> {
     // expected-note@-1 {{add explicit 'S2<T>.' to refer to mutable static property of 'S2<T>'}} {{5-5=S2<T>.}}
   }
 }
+
+// SR-3680, https://github.com/apple/swift/issues/46265
+protocol HasFoo {
+  var foo: String { get }
+}
+protocol CanSetFoo {
+  var foo: String { get set }
+}
+extension HasFoo where Self: CanSetFoo {
+  func bar() { // expected-note {{mark method 'mutating' to make 'self' mutable}}{{3-3=mutating }}
+    self.foo = "bar" // expected-error {{cannot assign to property: 'self' is immutable}}
+  }
+}


### PR DESCRIPTION
With multiple overload choices, TreatRValueAsLValue used to just pick the first solution. We get better diagnostics if we pick a solution where the chosen VarDecl is settable. So make the impact of fixing non-settable overload choices higher, so we get a settable overload, if one exists.

I.e. if you conform to two protocols with same-named property, one of which is {get} and the other is {get set} and both possibilities end up with the same fix in the same location, it isn't much help to use the "it's a get-only property" choice.

Resolves #46265 

Removed the previous commit and force pushed my branch before committing the new changes, and hadn't realized that makes GitHub automatically close the PR when there's (briefly) no changes. Oops. So here's a new PR.