### PR TITLE
[Sema] Diagnose deprecated default implementations in the witness checker.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2705,6 +2705,10 @@ public:
     return getUnavailable(ctx) != nullptr;
   }
 
+  bool isDeprecated(const ASTContext &ctx) const {
+    return getDeprecated(ctx) != nullptr;
+  }
+
   /// Determine whether there is a swiftVersionSpecific attribute that's
   /// unavailable relative to the provided language version.
   bool

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3137,6 +3137,11 @@ ERROR(witness_unavailable,none,
         "unavailable %kind0 was used to satisfy a requirement of protocol %1%select{|: %2}2",
         (const ValueDecl *, Identifier, StringRef))
 
+WARNING(witness_deprecated,none,
+        "deprecated default implementation is used to satisfy %kind0 required by "
+        "protocol %1%select{|: %2}2",
+        (const ValueDecl *, Identifier, StringRef))
+
 ERROR(redundant_conformance,none,
       "redundant conformance of %0 to protocol %1", (Type, Identifier))
 ERROR(redundant_conformance_conditional,none,

--- a/include/swift/AST/RequirementMatch.h
+++ b/include/swift/AST/RequirementMatch.h
@@ -239,6 +239,10 @@ enum class CheckKind : unsigned {
 
   /// The witness itself is inaccessible.
   WitnessUnavailable,
+
+  /// The witness is a deprecated default implementation provided by the
+  /// protocol.
+  DefaultWitnessDeprecated,
 };
 /// Describes the suitability of the chosen witness for
 /// the requirement.

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1474,7 +1474,7 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, Decl *D):
       ObjCName(Ctx.getObjcName(D)),
       InitKind(Ctx.getInitKind(D)),
       IsImplicit(D->isImplicit()),
-      IsDeprecated(D->getAttrs().getDeprecated(D->getASTContext())),
+      IsDeprecated(D->getAttrs().isDeprecated(D->getASTContext())),
       IsABIPlaceholder(isABIPlaceholderRecursive(D)),
       IsFromExtension(isDeclaredInExtension(D)),
       DeclAttrs(collectDeclAttributes(D)) {

--- a/lib/IDE/CodeCompletionResultBuilder.cpp
+++ b/lib/IDE/CodeCompletionResultBuilder.cpp
@@ -212,7 +212,7 @@ void CodeCompletionResultBuilder::setAssociatedDecl(const Decl *D) {
     CurrentModule = MD;
   }
 
-  if (D->getAttrs().getDeprecated(D->getASTContext()))
+  if (D->getAttrs().isDeprecated(D->getASTContext()))
     setContextFreeNotRecommended(ContextFreeNotRecommendedReason::Deprecated);
   else if (D->getAttrs().getSoftDeprecated(D->getASTContext()))
     setContextFreeNotRecommended(

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4230,7 +4230,7 @@ findImportedCaseWithMatchingSuffix(Type instanceTy, DeclNameRef name) {
 
     // Is one more available than the other?
     WORSE(->getAttrs().isUnavailable(ctx));
-    WORSE(->getAttrs().getDeprecated(ctx));
+    WORSE(->getAttrs().isDeprecated(ctx));
 
     // Does one have a shorter name (so the non-matching prefix is shorter)?
     WORSE(->getName().getBaseName().userFacingName().size());

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -207,7 +207,7 @@ computeExportContextBits(ASTContext &Ctx, Decl *D,
   if (D->isImplicit() && !isDeferBody)
     *implicit = true;
 
-  if (D->getAttrs().getDeprecated(Ctx))
+  if (D->getAttrs().isDeprecated(Ctx))
     *deprecated = true;
 
   if (auto *A = D->getAttrs().getUnavailable(Ctx)) {

--- a/test/decl/protocol/req/deprecated.swift
+++ b/test/decl/protocol/req/deprecated.swift
@@ -1,0 +1,60 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol DeprecatedRequirement {
+  @available(*, deprecated)
+  func f()
+}
+
+extension DeprecatedRequirement {
+  @available(*, deprecated)
+  func f() {}
+}
+
+// No warning if both the requirement and the default implementation are deprecated
+struct S1: DeprecatedRequirement {}
+
+protocol DeprecatedDefault {
+  func f() // expected-note {{requirement 'f()' declared here}}
+}
+
+extension DeprecatedDefault {
+  @available(*, deprecated)
+  func f() {}  // expected-note {{'f()' declared here}}
+}
+
+// expected-warning@+1 {{deprecated default implementation is used to satisfy instance method 'f()' required by protocol 'DeprecatedDefault'}}
+struct S2: DeprecatedDefault {}
+
+// No warning if the conformance itself is deprecated
+@available(*, deprecated)
+struct S3: DeprecatedDefault {
+}
+
+struct S4: DeprecatedDefault {
+  func f() {}
+}
+
+struct S5 {}
+
+// No warning if the conformance itself is deprecated
+@available(*, deprecated)
+extension S5: DeprecatedDefault {}
+
+@available(*, deprecated)
+enum UnavailableEnum {
+  struct Nested: DeprecatedDefault {}
+}
+
+// Include message string from @available attribute if provided
+protocol DeprecatedDefaultWithMessage {
+  func f() // expected-note {{requirement 'f()' declared here}}
+}
+
+extension DeprecatedDefaultWithMessage {
+  @available(*, deprecated, message: "write it yourself")
+  func f() {} // expected-note {{'f()' declared here}}
+}
+
+
+// expected-warning@+1 {{deprecated default implementation is used to satisfy instance method 'f()' required by protocol 'DeprecatedDefaultWithMessage': write it yourself}}
+struct S6: DeprecatedDefaultWithMessage {}

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -448,7 +448,7 @@ static bool initDocEntityInfo(const Decl *D,
   }
 
   Info.IsUnavailable = AvailableAttr::isUnavailable(D);
-  Info.IsDeprecated = D->getAttrs().getDeprecated(D->getASTContext()) != nullptr;
+  Info.IsDeprecated = D->getAttrs().isDeprecated(D->getASTContext());
   Info.IsOptional = D->getAttrs().hasAttribute<OptionalAttr>();
   if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
     Info.IsAsync = AFD->hasAsync();


### PR DESCRIPTION
If a protocol provides a deprecated default implementation for a requirement that is not deprecated, the compiler should emit a warning so the programmer can provide an explicit implementation of the requirement. This is helpful for staging in new protocol requirements that should be implemented in conforming types.

Resolves: rdar://123403268