### PR TITLE
[6.0][docs] Minor docs fixes for Task

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -123,7 +123,7 @@ import Swift
 /// And using it like this:
 ///
 /// ```
-/// await Actor().start()
+/// await Worker().start()
 /// ```
 ///
 /// Note that the actor is only retained by the start() method's use of `self`,

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -101,7 +101,6 @@ import Swift
 ///     var result: Work?
 ///
 ///     deinit {
-///         assert(work != nil)
 ///         // even though the task is still retained,
 ///         // once it completes it no longer causes a reference cycle with the actor
 ///

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -134,7 +134,7 @@ import Swift
 ///
 /// Therefore, the above call will consistently result in the following output:
 ///
-/// ```
+/// ```other
 /// start task work
 /// completed task work
 /// deinit actor

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -545,7 +545,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// to wait for all the child tasks to complete,
   /// collecting the values they returned:
   ///
-  ///     while let first = try await group.next() {
+  ///     while let value = try await group.next() {
   ///        collected += value
   ///     }
   ///     return collected


### PR DESCRIPTION
**Description**: Minor adjustments in docs:
- remove a line that'd be an error in Swift 6
- fix type name typo
- don't highlight non-swift snippet using swift highlighting
- typo on taskgroup variable

**Scope/Impact**: docs only
**Risk:** docs change only, low risk changes
**Testing**: docs change only, CI testing on main
**Reviewed by**: @hborla @DougGregor 

**Original PR:**  https://github.com/apple/swift/pull/74246
**Radar:** rdar://123325259 rdar://129357468