### PR TITLE
[6.0] [Completion] Only skip result builder expressions in the same builder

### DIFF
--- a/test/IDE/complete_actorisolation.swift
+++ b/test/IDE/complete_actorisolation.swift
@@ -1,5 +1,5 @@
 // REQUIRES: concurrency
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -warn-concurrency
+// RUN: %batch-code-completion -warn-concurrency
 
 class MyNonSendable {}
 struct MySendable {}

--- a/test/IDE/complete_after_pattern_in_closure.swift
+++ b/test/IDE/complete_after_pattern_in_closure.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -enable-experimental-concurrency
+// RUN: %batch-code-completion -enable-experimental-concurrency
 
 func makeURL(withExtension ext: Int?) -> Int? {
   return nil

--- a/test/IDE/complete_annotation.swift
+++ b/test/IDE/complete_annotation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -code-completion-annotate-results -code-completion-sourcetext -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion -code-completion-annotate-results -code-completion-sourcetext
 
 struct MyStruct {
   init(x: Int) {}

--- a/test/IDE/complete_annotation_concurrency.swift
+++ b/test/IDE/complete_annotation_concurrency.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -code-completion-annotate-results -code-completion-sourcetext -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion -code-completion-annotate-results -code-completion-sourcetext
 
 // REQUIRES: concurrency
 

--- a/test/IDE/complete_call_pattern.swift
+++ b/test/IDE/complete_call_pattern.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -disable-objc-attr-requires-foundation-module
+// RUN: %batch-code-completion -disable-objc-attr-requires-foundation-module
 
 struct FooStruct {
   init() {}

--- a/test/IDE/complete_concurrency_keyword.swift
+++ b/test/IDE/complete_concurrency_keyword.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -enable-experimental-concurrency
+// RUN: %batch-code-completion -enable-experimental-concurrency
 
 // REQUIRES: concurrency
 

--- a/test/IDE/complete_diagnostics_concurrency.swift
+++ b/test/IDE/complete_diagnostics_concurrency.swift
@@ -1,7 +1,6 @@
 // REQUIRES: concurrency 
 
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t/output -warn-concurrency
+// RUN: %batch-code-completion -warn-concurrency
 
 func asyncFunc() async {}
 func syncFunc() {}

--- a/test/IDE/complete_globalactorunsafe_strict.swift
+++ b/test/IDE/complete_globalactorunsafe_strict.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t  -warn-concurrency
+// RUN: %batch-code-completion -warn-concurrency
 // REQUIRES: concurrency
 
 // SAFE_NOTREC: Begin completions, 2 items

--- a/test/IDE/complete_if_switch_expr.swift
+++ b/test/IDE/complete_if_switch_expr.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -debug-forbid-typecheck-prefix FORBIDDEN -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion -debug-forbid-typecheck-prefix FORBIDDEN
 
 enum E {
   case e

--- a/test/IDE/complete_implicit_last_expr.swift
+++ b/test/IDE/complete_implicit_last_expr.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -enable-experimental-feature ImplicitLastExprResults -debug-forbid-typecheck-prefix FORBIDDEN -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion -enable-experimental-feature ImplicitLastExprResults -debug-forbid-typecheck-prefix FORBIDDEN
 
 // Experimental feature requires asserts
 // REQUIRES: asserts

--- a/test/IDE/complete_member_basetypes.swift
+++ b/test/IDE/complete_member_basetypes.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -module-name "Mod"
+// RUN: %batch-code-completion -module-name "Mod"
 
 protocol BaseP1 {}
 protocol BaseP2 {}

--- a/test/IDE/complete_optionset.swift
+++ b/test/IDE/complete_optionset.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -plugin-path %swift-plugin-dir
+// RUN: %batch-code-completion -plugin-path %swift-plugin-dir
 
 // REQUIRES: swift_swift_parser
 

--- a/test/IDE/complete_rdar126168123.swift
+++ b/test/IDE/complete_rdar126168123.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // rdar://126168123
 

--- a/test/IDE/complete_rdar127154780.swift
+++ b/test/IDE/complete_rdar127154780.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+// rdar://127154780 - Make sure we provide completions on variables that rely
+// on result builders being solved.
+
+@resultBuilder
+enum Builder {
+  static func buildBlock<T>(_ x: T) -> T { x }
+}
+
+struct S {}
+
+struct R<T> {
+  init(@Builder _: () -> T) {}
+}
+
+extension R where T == S {
+  func bar() {}
+}
+
+func foo() {
+  let r = R() {
+    S()
+  }
+  r.#^COMPLETE1?check=COMPLETE^#
+
+  let fn = {
+    let r = R() {
+      S()
+    }
+    r.#^COMPLETE2?check=COMPLETE^#
+  }
+}
+// COMPLETE-DAG: Keyword[self]/CurrNominal:          self[#R<S>#]; name=self
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   bar()[#Void#]; name=bar()

--- a/test/IDE/complete_rdar127154780.swift
+++ b/test/IDE/complete_rdar127154780.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // rdar://127154780 - Make sure we provide completions on variables that rely
 // on result builders being solved.

--- a/test/IDE/complete_rdar63965160.swift
+++ b/test/IDE/complete_rdar63965160.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 protocol View {}
 

--- a/test/IDE/complete_rdar94369218.swift
+++ b/test/IDE/complete_rdar94369218.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -code-complete-inits-in-postfix-expr -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion -code-complete-inits-in-postfix-expr
 
 protocol MyProto {
   init(value: String)

--- a/test/IDE/complete_subtype_overload.swift
+++ b/test/IDE/complete_subtype_overload.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 class C {
   static func cMethod() -> C {}

--- a/test/IDE/complete_then_stmt.swift
+++ b/test/IDE/complete_then_stmt.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -enable-experimental-feature ThenStatements -debug-forbid-typecheck-prefix FORBIDDEN -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion -enable-experimental-feature ThenStatements -debug-forbid-typecheck-prefix FORBIDDEN
 
 // Experimental feature requires asserts
 // REQUIRES: asserts

--- a/test/IDE/complete_type_relation_any_some.swift
+++ b/test/IDE/complete_type_relation_any_some.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck --completion-output-dir %t
+// RUN: %batch-code-completion
 
 protocol Shape {}
 

--- a/test/IDE/complete_typerelation.swift
+++ b/test/IDE/complete_typerelation.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -disable-objc-attr-requires-foundation-module
+// RUN: %batch-code-completion -disable-objc-attr-requires-foundation-module
 
 // SE-0353
 struct ConstraintedExistentialTest {

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s %S/Inputs/EnumFromOtherFile.swift -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion %S/Inputs/EnumFromOtherFile.swift
 
 // NOCRASH: Token
 


### PR DESCRIPTION
*6.0 cherry-pick of #74219 + #74233*

- Explanation: Fixes code completion on values that depend on result builders being solved
- Scope: Affects code completion around result builders
- Issue: rdar://127154780, #72399
- Risk: Low, causes us to avoid skipping result builder expressions in more cases, stress tester didn't show any performance-related failures
- Testing: Added tests to test suite
- Reviewer: Alex Hoppen