### PR TITLE
[cxx-interop] Avoid emitting methods that cause name clash

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -713,6 +713,18 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     if (kind == FunctionSignatureKind::CxxInlineThunk)
       ClangSyntaxPrinter(os).printGenericSignature(Signature);
   }
+  if (const auto *enumDecl = FD->getDeclContext()->getSelfEnumDecl())
+  {
+    // We cannot emit functions with the same name as an enum case yet, the resulting header
+    // does not compiler.
+    // FIXME: either do not emit cases as inline members, or rename the cases or the
+    //        colliding functions.
+    for (const auto *enumElement : enumDecl->getAllElements()) {
+      auto elementName = enumElement->getName();
+      if (!elementName.isSpecial() && elementName.getBaseIdentifier().str() == name)
+        return ClangRepresentation::unsupported;
+    }
+  }
   auto emittedModule = FD->getModuleContext();
   OutputLanguageMode outputLang = kind == FunctionSignatureKind::CFunctionProto
                                       ? OutputLanguageMode::ObjC
@@ -1521,7 +1533,8 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
   auto result = printFunctionSignature(
       FD, signature, cxx_translation::getNameForCxx(FD), resultTy,
       FunctionSignatureKind::CxxInlineThunk, modifiers);
-  assert(!result.isUnsupported() && "C signature should be unsupported too");
+  if (result.isUnsupported())
+    return;
 
   declAndTypePrinter.printAvailability(os, FD);
   if (!isDefinition) {

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -713,15 +713,14 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     if (kind == FunctionSignatureKind::CxxInlineThunk)
       ClangSyntaxPrinter(os).printGenericSignature(Signature);
   }
-  if (const auto *enumDecl = FD->getDeclContext()->getSelfEnumDecl())
-  {
+  if (const auto *enumDecl = FD->getDeclContext()->getSelfEnumDecl()) {
     // We cannot emit functions with the same name as an enum case yet, the resulting header
     // does not compiler.
     // FIXME: either do not emit cases as inline members, or rename the cases or the
     //        colliding functions.
     for (const auto *enumElement : enumDecl->getAllElements()) {
       auto elementName = enumElement->getName();
-      if (!elementName.isSpecial() && elementName.getBaseIdentifier().str() == name)
+      if (!elementName.isSpecial() && elementName.getBaseIdentifier().is(name))
         return ClangRepresentation::unsupported;
     }
   }

--- a/test/Interop/SwiftToCxx/enums/enum-element-method-name-clash.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-element-method-name-clash.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+public enum Foo: Hashable, Sendable {
+    case bar(Parameters)
+
+    // We do not want to generate C++ wrappers for this function yet
+    // because its name clashes with the enum element above preventing
+    // the generated header from compilation.
+    public static func bar(version: Int) -> Self {
+        Self.bar(Parameters(version: version))
+    }
+}
+
+extension Foo {
+    public struct Parameters: Hashable, Sendable {
+        public var version: Int
+
+        public init(version: Int) {
+            self.version = version
+        }
+    }
+}
+
+// CHECK-NOT:   Foo bar(swift::Int version)
+
+// CHECK:    switch (_getEnumTag()) {
+// CHECK-NEXT:      case 0: return cases::bar;
+// CHECK-NEXT:      default: abort();
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// CHECK-EMPTY:
+// Before the fix, we had the static method's thunk here.
+// CHECK-NEXT:    swift::Int getHashValue() const


### PR DESCRIPTION
In Swift, we can have enum elements and methods with the same name, they are overloaded. Unfortunately, this feature is not supported by C++ interop at the moment. This patch avoids emitting the methods with name collisions to make sure the resulting header can be compiler. A proper fix should follow in a later PR.

rdar://128162252
