### PR TITLE
[6.0][Concurrency] CaseIterable synthesized allCases must be nonisolated 

### DIFF
--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -79,6 +79,8 @@ static Type deriveCaseIterable_AllCases(DerivedConformance &derived) {
 }
 
 ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
+  auto &C = requirement->getASTContext();
+
   // Conformance can't be synthesized in an extension.
   if (checkAndDiagnoseDisallowedContext(requirement))
     return nullptr;
@@ -101,6 +103,9 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
   std::tie(propDecl, pbDecl) = declareDerivedProperty(
       SynthesizedIntroducer::Var, Context.Id_allCases, returnTy, returnTy,
       /*isStatic=*/true, /*isFinal=*/true);
+
+  propDecl->getAttrs().add(
+              new (C) NonisolatedAttr(/*unsafe=*/false, /*implicit=*/true));
 
   // Define the getter.
   auto *getterDecl = addGetterToReadOnlyDerivedProperty(propDecl, returnTy);

--- a/test/Concurrency/CaseIterableIsolation.swift
+++ b/test/Concurrency/CaseIterableIsolation.swift
@@ -1,21 +1,12 @@
-// RUN: %target-run-simple-swift %t
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 
 import StdlibUnittest
 
 var CaseIterableTests = TestSuite("CaseIterableTests")
-
-CaseIterableTests.test("Simple Enums") {
-  enum SimpleEnum: CaseIterable {
-    case bar
-    case baz
-    case quux
-  }
-
-  expectEqual(SimpleEnum.allCases.count, 3)
-  expectEqual(SimpleEnum.allCases, [.bar, .baz, .quux])
-}
 
 CaseIterableTests.test("MainActor Isolated Enums") {
   @MainActor
@@ -28,3 +19,4 @@ CaseIterableTests.test("MainActor Isolated Enums") {
 }
 
 runAllTests()
+

--- a/test/SILGen/synthesized_conformance_enum.swift
+++ b/test/SILGen/synthesized_conformance_enum.swift
@@ -56,6 +56,7 @@ extension Enum: Codable where T: Codable {}
 
 extension NoValues: CaseIterable {}
 // CHECK-LABEL: // static NoValues.allCases.getter
+// CHECK-NEXT: // Isolation: nonisolated
 // CHECK-NEXT: sil hidden [ossa] @$s28synthesized_conformance_enum8NoValuesO8allCasesSayACGvgZ : $@convention(method) (@thin NoValues.Type) -> @owned Array<NoValues> {
 
 extension NoValues: Codable {}


### PR DESCRIPTION
**Description**: allCases synthesized by CaseIterable should be `nonisolated`, as otherwise it'll conflict in isolation with global actor isolated enums.
**Scope/Impact**: Global actor isolated enums with `CaseIterable` today don't compile
**Risk:** Low, adds nonisolated to `allCases`
**Testing**: CI testing
**Reviewed by**: @DougGregor 

**Original PR:** https://github.com/apple/swift/pull/74254
**Radar:** rdar://127968265