### PR TITLE
[docs] Suggest `--skip-xros` in the Getting Started guide

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -262,7 +262,7 @@ Build the toolchain with optimizations, debuginfo, and assertions, using Ninja:
 - macOS:
   ```sh
   utils/build-script --skip-build-benchmarks \
-    --skip-ios --skip-watchos --skip-tvos --swift-darwin-supported-archs "$(uname -m)" \
+    --skip-ios --skip-watchos --skip-tvos --skip-xros --swift-darwin-supported-archs "$(uname -m)" \
     --sccache --release-debuginfo --swift-disable-dead-stripping \
     --bootstrapping=hosttools
   ```


### PR DESCRIPTION
The Getting Started guide offers a build-script command that new contributors can use to quickly build a debug compiler on their local machine. The command already has `--skip-tvos` and `--skip-watchos` flags since most compiler contributors don't need to build for those platforms. This change adds `--skip-xros` flag to the command.
