### PR TITLE
[cxx-interop] Only run tests for reference types against a recent Swift runtime

### DIFF
--- a/test/Interop/Cxx/foreign-reference/reference-counted.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted.swift
@@ -4,8 +4,9 @@
 // REQUIRES: executable_test
 // XFAIL: OS=windows-msvc
 
-// Temporarily disable on arm64e (rdar://128681137)
-// UNSUPPORTED: CPU=arm64e
+// Temporarily disable when running with an older runtime (rdar://128681137)
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 import StdlibUnittest
 import ReferenceCounted


### PR DESCRIPTION
Having a Swift array of C++ reference types without crashing at runtime only became possible recently (https://github.com/apple/swift/pull/73615). When building against an older runtime, one would still see runtime crashes. This is expected because part of the fix is in the Swift runtime.

This makes sure we don't try to run tests for C++ reference types with an older Swift runtime.

rdar://128681137