### PR TITLE
[6.0] [Completion] Fix macro argument and protocol static member completion

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1431,14 +1431,14 @@ void CodeCompletionCallbacksImpl::typeCheckWithLookup(
     /// decl it could be attached to. Type check it standalone.
 
     // First try to check it as an attached macro.
-    auto resolvedMacro = evaluateOrDefault(
+    (void)evaluateOrDefault(
         CurDeclContext->getASTContext().evaluator,
         ResolveMacroRequest{AttrWithCompletion, CurDeclContext},
         ConcreteDeclRef());
 
     // If that fails, type check as a call to the attribute's type. This is
     // how, e.g., property wrappers are modelled.
-    if (!resolvedMacro) {
+    if (!Lookup.gotCallback()) {
       ASTNode Call = CallExpr::create(
           CurDeclContext->getASTContext(), AttrWithCompletion->getTypeExpr(),
           AttrWithCompletion->getArgs(), /*implicit=*/true);

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -116,29 +116,29 @@ public:
   }
 };
 
-/// Returns `true` if `ED` is an extension of `PD` that binds `Self` to a
-/// concrete type, like `extension MyProto where Self == MyStruct {}`.
+/// Returns `true` if `ED` is an extension that binds `Self` to a
+/// concrete type, like `extension MyProto where Self == MyStruct {}`. The
+/// protocol being extended must either be `PD`, or `Self` must be a type
+/// that conforms to `PD`.
 ///
 /// In these cases, it is possible to access static members defined in the
 /// extension when perfoming unresolved member lookup in a type context of
 /// `PD`.
 static bool isExtensionWithSelfBound(const ExtensionDecl *ED,
                                      ProtocolDecl *PD) {
-  if (!ED || !PD) {
+  if (!ED || !PD)
     return false;
-  }
-  if (ED->getExtendedNominal() != PD) {
-    return false;
-  }
+
   GenericSignature genericSig = ED->getGenericSignature();
   Type selfType = genericSig->getConcreteType(ED->getSelfInterfaceType());
-  if (!selfType) {
+  if (!selfType)
     return false;
-  }
-  if (selfType->is<ExistentialType>()) {
+
+  if (selfType->is<ExistentialType>())
     return false;
-  }
-  return true;
+
+  auto *M = ED->getParentModule();
+  return ED->getExtendedNominal() == PD || M->checkConformance(selfType, PD);
 }
 
 static bool isExtensionAppliedInternal(const DeclContext *DC, Type BaseTy,

--- a/test/IDE/complete_rdar129024996.swift
+++ b/test/IDE/complete_rdar129024996.swift
@@ -1,0 +1,49 @@
+// RUN: %batch-code-completion
+
+protocol P {}
+protocol Q : P {}
+
+// Applicable, S conforms to Q.
+struct S : Q {}
+extension P where Self == S {
+  static func foo() -> S { S() }
+}
+
+// Not applicable, Q does not inherit from K.
+protocol K {}
+extension S : K {}
+extension K where Self == S {
+  static func bar() -> S { S() }
+}
+
+// Make sure we don't try and complete for this type's init.
+struct R {
+  init(a: Int) {}
+}
+
+// Not applicable, A does not conform to Q.
+struct A: P {}
+extension P where Self == A {
+  static func baz() -> A { A() }
+}
+
+struct B<T>: P {}
+extension B: Q where T: Q {}
+
+// Applicable, B<S> conforms to Q.
+extension P where Self == B<S> {
+  static func qux() -> Self { .init() }
+}
+
+// Not applicable, B<A> does not conform to Q.
+extension P where Self == B<A> {
+  static func flim() -> Self { .init() }
+}
+
+@attached(peer) macro R(_: any Q) = #externalMacro(module: "", type: "")
+
+@R(.#^COMPLETE^#)
+func bar() {}
+// COMPLETE:     Begin completions, 2 items
+// COMPLETE-DAG: Decl[StaticMethod]/Super/TypeRelation[Convertible]: foo()[#S#]; name=foo()
+// COMPLETE-DAG: Decl[StaticMethod]/Super/TypeRelation[Convertible]: qux()[#B<S>#]; name=qux()


### PR DESCRIPTION
*6.0 cherry-pick of #74248*

- Explanation: Improves completion in macro arguments, and static member completion on protocols
- Scope: Affects completion of both macro arguments, and static members on protocols
- Issue: rdar://129024996
- Risk: Low, the fixes are fairly straightforward
- Testing: Added tests to test suite
- Reviewer: Rintaro Ishizaki