### PR TITLE
SIL: Consistently drop substitution map when forming apply instructions

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2678,6 +2678,8 @@ protected:
         SpecializationInfo(specializationInfo), NumCallArguments(args.size()),
         NumTypeDependentOperands(typeDependentOperands.size()),
         Substitutions(subs) {
+    assert(!!subs == !!callee->getType().castTo<SILFunctionType>()
+        ->getInvocationGenericSignature());
 
     // Initialize the operands.
     auto allOperands = getAllOperands();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1934,7 +1934,12 @@ unsigned AbstractClosureExpr::getDiscriminator() const {
         Bits.AbstractClosureExpr.Discriminator = discriminator;
   }
 
-  assert(getRawDiscriminator() != InvalidDiscriminator);
+  if (getRawDiscriminator() == InvalidDiscriminator) {
+    llvm::errs() << "Closure does not have an assigned discriminator:\n";
+    dump(llvm::errs());
+    abort();
+  }
+
   return getRawDiscriminator();
 }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1886,6 +1886,11 @@ static void emitRawApply(SILGenFunction &SGF,
                          SILValue indirectErrorAddr,
                          SmallVectorImpl<SILValue> &rawResults,
                          ExecutorBreadcrumb prevExecutor) {
+  // We completely drop the generic signature if all generic parameters were
+  // concrete.
+  if (subs && subs.getGenericSignature()->areAllParamsConcrete())
+    subs = SubstitutionMap();
+
   SILFunctionConventions substFnConv(substFnType, SGF.SGM.M);
   // Get the callee value.
   bool isConsumed = substFnType->isCalleeConsumed();
@@ -5857,6 +5862,11 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc, SILValue fn,
                                               SILType substFnType,
                                               SubstitutionMap subs,
                                               ArrayRef<SILValue> args) {
+  // We completely drop the generic signature if all generic parameters were
+  // concrete.
+  if (subs && subs.getGenericSignature()->areAllParamsConcrete())
+    subs = SubstitutionMap();
+
   CanSILFunctionType silFnType = substFnType.castTo<SILFunctionType>();
   SILFunctionConventions fnConv(silFnType, SGM.M);
   SILType resultType = fnConv.getSILResultType(getTypeExpansionContext());

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -987,7 +987,13 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
         constant, loweredCaptureInfo, subs);
   }
 
-  if (subs) {
+  // We completely drop the generic signature if all generic parameters were
+  // concrete.
+  if (!pft->isPolymorphic()) {
+    subs = SubstitutionMap();
+  } else {
+    assert(!subs.getGenericSignature()->areAllParamsConcrete());
+
     auto specialized =
         pft->substGenericArgs(F.getModule(), subs, getTypeExpansionContext());
     functionTy = SILType::getPrimitiveObjectType(specialized);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5557,7 +5557,6 @@ namespace {
       assert(OpenedExistentials.empty());
 
       auto &ctx = cs.getASTContext();
-      auto *module = dc->getParentModule();
 
       // Look at all of the suspicious optional injections
       for (auto injection : SuspiciousOptionalInjections) {

--- a/test/SILOptimizer/performance-annotations-noassert-stdlib.swift
+++ b/test/SILOptimizer/performance-annotations-noassert-stdlib.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -import-objc-header %S/Inputs/perf-annotations.h -emit-sil %s -o /dev/null -verify
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+@_noAllocation
+func createEmptyArray() {
+  _ = [Int]() // expected-error {{ending the lifetime of a value of type}}
+}

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -enable-experimental-feature RawLayout -import-objc-header %S/Inputs/perf-annotations.h -emit-sil %s -o /dev/null -verify
-// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
 // REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
 
 protocol P {
   func protoMethod(_ a: Int) -> Int
@@ -231,11 +232,6 @@ func closueWhichModifiesLocalVar() -> Int {
   }
   localNonEscapingClosure()
   return x
-}
-
-@_noAllocation
-func createEmptyArray() {
-  _ = [Int]() // expected-error {{ending the lifetime of a value of type}}
 }
 
 struct Buffer {
@@ -526,4 +522,36 @@ public struct RawLayoutWrapper: ~Copyable {
 @_rawLayout(like: T)
 public struct RawLayout<T>: ~Copyable {
   public func test() {}
+}
+
+func takesClosure(_: () -> ()) {}
+
+@_noLocks
+func testClosureExpression<T>(_ t: T) {
+  takesClosure {
+  // expected-error@-1 {{generic closures or local functions can cause metadata allocation or locks}}
+    _ = T.self
+  }
+}
+
+@_noLocks
+func testLocalFunction<T>(_ t: T) {
+  func localFunc() {
+    _ = T.self
+  }
+
+  takesClosure(localFunc)
+  // expected-error@-1 {{generic closures or local functions can cause metadata allocation or locks}}
+}
+
+func takesGInt(_ x: G<Int>) {}
+
+struct G<T> {}
+
+extension G where T == Int {
+  @_noAllocation func method() {
+    takesClosure {
+      takesGInt(self) // OK
+    }
+  }
 }


### PR DESCRIPTION
Fixes rdar://129298104.