### PR TITLE
[Runtime] Fix key argument indexing when checking invertible protocols.

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -1864,8 +1864,8 @@ static DynamicCastResult tryCastToExtendedExistential(
         [&substitutions](unsigned depth, unsigned index) {
           return substitutions.getMetadata(depth, index).Ptr;
         },
-        [&substitutions](unsigned ordinal) {
-          return substitutions.getMetadataOrdinal(ordinal).Ptr;
+        [&substitutions](unsigned fullOrdinal, unsigned keyOrdinal) {
+          return substitutions.getMetadataKeyArgOrdinal(keyOrdinal).Ptr;
         },
         [](const Metadata *type, unsigned index) -> const WitnessTable * {
           swift_unreachable("Resolution of witness tables is not supported");

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1195,7 +1195,7 @@ public:
         genericParamCounts(genericParamCounts) {}
 
   MetadataOrPack getMetadata(unsigned depth, unsigned index) const;
-  MetadataOrPack getMetadataOrdinal(unsigned ordinal) const;
+  MetadataOrPack getMetadataFullOrdinal(unsigned ordinal) const;
   const WitnessTable *getWitnessTable(const Metadata *type,
                                       unsigned index) const;
 };
@@ -1415,8 +1415,8 @@ _gatherGenericParameters(const ContextDescriptor *context,
         [&substitutions](unsigned depth, unsigned index) {
           return substitutions.getMetadata(depth, index).Ptr;
         },
-        [&substitutions](unsigned ordinal) {
-          return substitutions.getMetadataOrdinal(ordinal).Ptr;
+        [&substitutions](unsigned fullOrdinal, unsigned keyOrdinal) {
+          return substitutions.getMetadataFullOrdinal(fullOrdinal).Ptr;
         },
         [&substitutions](const Metadata *type, unsigned index) {
           return substitutions.getWitnessTable(type, index);
@@ -1849,12 +1849,12 @@ public:
           // FIXME: variadic generics
           return genArgs[index].getMetadata();
         },
-        [genArgs](unsigned ordinal) {
-          if (ordinal >= genArgs.size())
+        [genArgs](unsigned fullOrdinal, unsigned keyOrdinal) {
+          if (fullOrdinal >= genArgs.size())
             return (const Metadata*)nullptr;
 
           // FIXME: variadic generics
-          return genArgs[ordinal].getMetadata();
+          return genArgs[fullOrdinal].getMetadata();
         },
         [](const Metadata *type, unsigned index) -> const WitnessTable * {
           swift_unreachable("never called");
@@ -2814,8 +2814,8 @@ swift_distributed_getWitnessTables(GenericEnvironmentDescriptor *genericEnv,
       [&substFn](unsigned depth, unsigned index) {
         return substFn.getMetadata(depth, index).Ptr;
       },
-      [&substFn](unsigned ordinal) {
-        return substFn.getMetadataOrdinal(ordinal).Ptr;
+      [&substFn](unsigned fullOrdinal, unsigned keyOrdinal) {
+        return substFn.getMetadataKeyArgOrdinal(keyOrdinal).Ptr;
       },
       [&substFn](const Metadata *type, unsigned index) {
         return substFn.getWitnessTable(type, index);
@@ -3243,8 +3243,8 @@ SubstGenericParametersFromMetadata::getMetadata(
   return MetadataOrPack(genericArgs[flatIndex]);
 }
 
-MetadataOrPack
-SubstGenericParametersFromMetadata::getMetadataOrdinal(unsigned ordinal) const {
+MetadataOrPack SubstGenericParametersFromMetadata::getMetadataKeyArgOrdinal(
+    unsigned ordinal) const {
   // Don't attempt anything if we have no generic parameters.
   if (genericArgs == nullptr)
     return MetadataOrPack();
@@ -3281,8 +3281,8 @@ MetadataOrPack SubstGenericParametersFromWrittenArgs::getMetadata(
   return MetadataOrPack();
 }
 
-MetadataOrPack SubstGenericParametersFromWrittenArgs::getMetadataOrdinal(
-                                        unsigned ordinal) const {
+MetadataOrPack SubstGenericParametersFromWrittenArgs::getMetadataFullOrdinal(
+    unsigned ordinal) const {
   if (ordinal < allGenericArgs.size()) {
     return MetadataOrPack(allGenericArgs[ordinal]);
   }

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -295,11 +295,13 @@ public:
     std::function<const void *(unsigned depth, unsigned index)>;
 
   /// Callback used to provide the substitution of a generic parameter
-  /// (described by the ordinal, or "flat index") to its metadata.
+  /// (described by the ordinal, or "flat index") to its metadata. The index may
+  /// be "full" or it may be only relative to key arguments. The call is
+  /// provided both indexes and may use the one it requires.
   ///
   /// The return type here is a lie; it's actually a MetadataOrPack.
   using SubstGenericParameterOrdinalFn =
-    std::function<const void *(unsigned ordinal)>;
+    std::function<const void *(unsigned fullOrdinal, unsigned keyOrdinal)>;
 
   /// Callback used to provide the substitution of a witness table based on
   /// its index into the enclosing generic environment.
@@ -460,7 +462,7 @@ public:
     const void * const *getGenericArgs() const { return genericArgs; }
 
     MetadataOrPack getMetadata(unsigned depth, unsigned index) const;
-    MetadataOrPack getMetadataOrdinal(unsigned ordinal) const;
+    MetadataOrPack getMetadataKeyArgOrdinal(unsigned ordinal) const;
     const WitnessTable *getWitnessTable(const Metadata *type,
                                         unsigned index) const;
   };


### PR DESCRIPTION
Track the key argument index separately from the generic parameter index when performing the invertible protocol checking in _checkGenericRequirements. This keeps the indexing correct when a non-key argument is followed by a key argument.

rdar://128774651