### PR TITLE
[6.0] Don't pass foundation build path to swift-driver/swift-package-manager

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdriver.py
@@ -92,10 +92,6 @@ def run_build_script_helper(action, host_target, product, args):
     dispatch_build_dir = os.path.join(
         build_root, '%s-%s' % ('libdispatch', host_target))
 
-    # Pass Foundation directory down if we built it
-    foundation_build_dir = os.path.join(
-        build_root, '%s-%s' % ('foundation', host_target))
-
     # Pass the swift lit tests if we're testing and the Swift tests were built
     swift_build_dir = os.path.join(
         build_root, 'swift-{}'.format(host_target))
@@ -117,10 +113,6 @@ def run_build_script_helper(action, host_target, product, args):
     if os.path.exists(dispatch_build_dir):
         helper_cmd += [
             '--dispatch-build-dir', dispatch_build_dir
-        ]
-    if os.path.exists(foundation_build_dir):
-        helper_cmd += [
-            '--foundation-build-dir', foundation_build_dir
         ]
     if os.path.exists(lit_test_dir) and action == 'test':
         helper_cmd += [

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -84,15 +84,6 @@ class SwiftPM(product.Product):
                 "--dispatch-build-dir", dispatch_build_dir
             ]
 
-        # Pass Foundation directory down if we built it
-        foundation_build_dir = os.path.join(
-            build_root, '%s-%s' % ("foundation", host_target))
-
-        if os.path.exists(foundation_build_dir):
-            helper_cmd += [
-                "--foundation-build-dir", foundation_build_dir
-            ]
-
         # Pass Cross compile host info
         if self.has_cross_compile_hosts():
             if self.is_darwin_host(host_target):


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/74217

Explanation: Removes the `--foundation-build-dir` parameter given to the swift driver and swiftpm builds allowing them to depend on the modules in the just-built toolchain instead
Scope: Affects the build of the Yams project within the swift driver and swiftpm builds
Original PR: https://github.com/apple/swift/pull/74217
Risk: Small - this is only used by the Yams build (which depends on Foundation) and in both of these cases, Foundation is already installed into the just-built toolchain
Testing: PR testing via swift-ci, toolchain build via swift-ci, and local toolchain builds
Reviewer: @etcwilde @bnbarham @iCharlesHu