### PR TITLE
[6.0] SIL: Consistently drop substitution map when forming apply instructions

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2678,6 +2678,8 @@ protected:
         SpecializationInfo(specializationInfo), NumCallArguments(args.size()),
         NumTypeDependentOperands(typeDependentOperands.size()),
         Substitutions(subs) {
+    assert(!!subs == !!callee->getType().castTo<SILFunctionType>()
+        ->getInvocationGenericSignature());
 
     // Initialize the operands.
     auto allOperands = getAllOperands();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1950,6 +1950,11 @@ static void emitRawApply(SILGenFunction &SGF,
                          SILValue indirectErrorAddr,
                          SmallVectorImpl<SILValue> &rawResults,
                          ExecutorBreadcrumb prevExecutor) {
+  // We completely drop the generic signature if all generic parameters were
+  // concrete.
+  if (subs && subs.getGenericSignature()->areAllParamsConcrete())
+    subs = SubstitutionMap();
+
   SILFunctionConventions substFnConv(substFnType, SGF.SGM.M);
   // Get the callee value.
   bool isConsumed = substFnType->isCalleeConsumed();
@@ -5920,6 +5925,11 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc, SILValue fn,
                                               SILType substFnType,
                                               SubstitutionMap subs,
                                               ArrayRef<SILValue> args) {
+  // We completely drop the generic signature if all generic parameters were
+  // concrete.
+  if (subs && subs.getGenericSignature()->areAllParamsConcrete())
+    subs = SubstitutionMap();
+
   CanSILFunctionType silFnType = substFnType.castTo<SILFunctionType>();
   SILFunctionConventions fnConv(silFnType, SGM.M);
   SILType resultType = fnConv.getSILResultType(getTypeExpansionContext());

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -987,7 +987,13 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
         constant, loweredCaptureInfo, subs);
   }
 
-  if (subs) {
+  // We completely drop the generic signature if all generic parameters were
+  // concrete.
+  if (!pft->isPolymorphic()) {
+    subs = SubstitutionMap();
+  } else {
+    assert(!subs.getGenericSignature()->areAllParamsConcrete());
+
     auto specialized =
         pft->substGenericArgs(F.getModule(), subs, getTypeExpansionContext());
     functionTy = SILType::getPrimitiveObjectType(specialized);

--- a/test/SILOptimizer/performance-annotations-noassert-stdlib.swift
+++ b/test/SILOptimizer/performance-annotations-noassert-stdlib.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -import-objc-header %S/Inputs/perf-annotations.h -emit-sil %s -o /dev/null -verify
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+@_noAllocation
+func createEmptyArray() {
+  _ = [Int]() // expected-error {{ending the lifetime of a value of type}}
+}

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -import-objc-header %S/Inputs/perf-annotations.h -emit-sil %s -o /dev/null -verify
-// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
 // REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
 
 protocol P {
   func protoMethod(_ a: Int) -> Int
@@ -231,11 +232,6 @@ func closueWhichModifiesLocalVar() -> Int {
   }
   localNonEscapingClosure()
   return x
-}
-
-@_noAllocation
-func createEmptyArray() {
-  _ = [Int]() // expected-error {{ending the lifetime of a value of type}}
 }
 
 struct Buffer {
@@ -513,4 +509,36 @@ struct NonCopyableStruct: ~Copyable {
 func testNonCopyable() {
   let t = NonCopyableStruct()
   t.foo()
+}
+
+func takesClosure(_: () -> ()) {}
+
+@_noLocks
+func testClosureExpression<T>(_ t: T) {
+  takesClosure {
+  // expected-error@-1 {{generic closures or local functions can cause metadata allocation or locks}}
+    _ = T.self
+  }
+}
+
+@_noLocks
+func testLocalFunction<T>(_ t: T) {
+  func localFunc() {
+    _ = T.self
+  }
+
+  takesClosure(localFunc)
+  // expected-error@-1 {{generic closures or local functions can cause metadata allocation or locks}}
+}
+
+func takesGInt(_ x: G<Int>) {}
+
+struct G<T> {}
+
+extension G where T == Int {
+  @_noAllocation func method() {
+    takesClosure {
+      takesGInt(self)
+    }
+  }
 }


### PR DESCRIPTION
6.0 cherry-pick of https://github.com/apple/swift/pull/74266

* **Description:** Fixes a spurious diagnostic with `@_noLocks`. We diagnose partial applies that have non-empty substitution maps in a special SIL pass. As a result of the pack element capture changes, SILGen would sometimes generate a partial apply of a non-generic closure with a non-empty substitution map. This change asserts that the substitution map is non-empty if and only if the callee's generic signature is non-empty, and fixes the fallout from adding this assert.

* **Origination:** The specific test case here regressed recently but the invariant in question was never enforced so it was always broken.

* **Risk:** The new assertion might uncover more bugs in assert builds, but otherwise very low.

* **Radar:** rdar://129298104

* **Reviewed by:** @eeckstein 