### PR TITLE
[ScanDependency] Track link libraries specified by `-public-autolink-library` option

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -214,7 +214,8 @@ struct InterfaceSubContextDelegate {
                                           SourceLoc diagLoc,
     llvm::function_ref<std::error_code(ASTContext&, ModuleDecl*,
                                        ArrayRef<StringRef>,
-                                       ArrayRef<StringRef>, StringRef)> action) = 0;
+                                       ArrayRef<StringRef>,
+                                       ArrayRef<std::string>, StringRef)> action) = 0;
   virtual std::error_code runInSubCompilerInstance(StringRef moduleName,
                                                    StringRef interfacePath,
                                                    StringRef sdkPath,

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -688,6 +688,7 @@ public:
                                   SourceLoc diagLoc,
     llvm::function_ref<std::error_code(ASTContext&, ModuleDecl*,
                                        ArrayRef<StringRef>, ArrayRef<StringRef>,
+                                       ArrayRef<std::string>,
                                        StringRef)> action) override;
   std::error_code runInSubCompilerInstance(StringRef moduleName,
                                            StringRef interfacePath,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2095,14 +2095,16 @@ InterfaceSubContextDelegateImpl::runInSubContext(StringRef moduleName,
                                                  StringRef outputPath,
                                                  SourceLoc diagLoc,
     llvm::function_ref<std::error_code(ASTContext&, ModuleDecl*, ArrayRef<StringRef>,
-                            ArrayRef<StringRef>, StringRef)> action) {
+                            ArrayRef<StringRef>, ArrayRef<std::string>, StringRef)> action) {
   return runInSubCompilerInstance(moduleName, interfacePath, sdkPath, outputPath,
                                   diagLoc, /*silenceErrors=*/false,
                                   [&](SubCompilerInstanceInfo &info){
+    auto irGenOpts = info.Instance->getInvocation().getIRGenOptions();
     return action(info.Instance->getASTContext(),
                   info.Instance->getMainModule(),
                   info.BuildArguments,
                   info.ExtraPCMArgs,
+                  irGenOpts.PublicLinkLibraries,
                   info.Hash);
   });
 }

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -153,7 +153,8 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
       realModuleName.str(), moduleInterfacePath.str(), sdkPath,
       StringRef(), SourceLoc(),
       [&](ASTContext &Ctx, ModuleDecl *mainMod, ArrayRef<StringRef> BaseArgs,
-          ArrayRef<StringRef> PCMArgs, StringRef Hash) {
+          ArrayRef<StringRef> PCMArgs, ArrayRef<std::string> PublicLinkLibs, StringRef Hash) {
+
         assert(mainMod);
         std::string InPath = moduleInterfacePath.str();
         auto compiledCandidates =
@@ -241,6 +242,12 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
                                    isFramework ? LibraryKind::Framework : LibraryKind::Library,
                                    true});
         }
+
+        // Register libraries specified by `-public-autolink-library`
+        for (auto publicLinkLibrary : PublicLinkLibs) {
+          linkLibraries.push_back(LinkLibrary(publicLinkLibrary, LibraryKind::Library));
+        }
+
         bool isStatic = llvm::find(ArgsRefs, "-static") != ArgsRefs.end();
 
         Result = ModuleDependencyInfo::forSwiftInterfaceModule(

--- a/test/ScanDependencies/Inputs/Swift/HasLinkDependency.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/HasLinkDependency.swiftinterface
@@ -1,0 +1,3 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name HasLinkDependency -public-autolink-library linkDep
+import Swift

--- a/test/ScanDependencies/module_deps_link_libs.swift
+++ b/test/ScanDependencies/module_deps_link_libs.swift
@@ -9,6 +9,7 @@ import C
 import E
 import G
 import SubE
+import HasLinkDependency
 
 // CHECK: "mainModuleName": "deps"
 
@@ -26,6 +27,10 @@ import SubE
 // CHECK-NEXT:          "shouldForceLoad": true
 
 // CHECK-DAG:           "linkName": "swiftCompatibilityPacks",
+// CHECK-NEXT:          "isFramework": false,
+// CHECK-NEXT:          "shouldForceLoad": false
+
+// CHECK-DAG:           "linkName": "linkDep",
 // CHECK-NEXT:          "isFramework": false,
 // CHECK-NEXT:          "shouldForceLoad": false
 


### PR DESCRIPTION
`explicit-auto-linking` mode should track library dependencies specified by `-public-autolink-library` option too.

Depends on https://github.com/apple/swift/pull/74277