### PR TITLE
[cxx-interop] import static operator call from C++23 as member callAs…

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -319,6 +319,9 @@ public:
   /// method that dispatches the call dynamically.
   FuncDecl *makeVirtualMethod(const clang::CXXMethodDecl *clangMethodDecl);
 
+  FuncDecl *makeInstanceToStaticOperatorCallMethod(
+      const clang::CXXMethodDecl *clangMethodDecl);
+
   VarDecl *makeComputedPropertyFromCXXMethods(FuncDecl *getter,
                                               FuncDecl *setter);
 

--- a/test/Interop/Cxx/class/Inputs/protocol-conformance.h
+++ b/test/Interop/Cxx/class/Inputs/protocol-conformance.h
@@ -72,4 +72,8 @@ struct HasVirtualMethod {
   virtual int return42() { return 42; } 
 };
 
+struct HasStaticOperatorCall {
+  static int operator()(int x) { return x * 2; }
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_PROTOCOL_CONFORMANCE_H

--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -49,3 +49,9 @@ protocol HasOperatorPlusEqualProtocol {
 }
 
 extension HasOperatorPlusEqualInt : HasOperatorPlusEqualProtocol {}
+
+protocol HasOperatorCall {
+  func callAsFunction(_ x: Int32) -> Int32
+}
+
+extension HasStaticOperatorCall : HasOperatorCall {}

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -477,4 +477,19 @@ struct HasOperatorCallWithDefaultArg {
   int operator()(int x = 0) const { return value + x; }
 };
 
+class HasStaticOperatorCallBase {
+public:
+  static int operator()(int x) { return x + 42; }
+};
+
+class HasStaticOperatorCallDerived : public HasStaticOperatorCallBase {};
+
+class HasStaticOperatorCallWithConstOperator {
+public:
+  inline int operator()(int x, int y) const { return x + y; }
+  static int operator()(int x) {
+        return x - 1;
+   }
+};
+
 #endif

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -294,3 +294,16 @@
 // CHECK: struct HasOperatorCallWithDefaultArg {
 // CHECK:   func callAsFunction(_ x: Int32 = cxxDefaultArg) -> Int32
 // CHECK: }
+
+// CHECK: struct HasStaticOperatorCallBase {
+// CHECK:   func callAsFunction(_ x: Int32) -> Int32
+// CHECK: }
+
+// CHECK: struct HasStaticOperatorCallDerived {
+// CHECK:   func callAsFunction(_ x: Int32) -> Int32
+// CHECK: }
+
+// CHECK: struct HasStaticOperatorCallWithConstOperator {
+// CHECK:   func callAsFunction(_ x: Int32, _ y: Int32) -> Int32
+// CHECK:   func callAsFunction(_ x: Int32) -> Int32
+// CHECK: }

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -437,4 +437,24 @@ OperatorsTestSuite.test("HasOperatorCallWithDefaultArg.call") {
   expectEqual(444, res)
 }
 
+OperatorsTestSuite.test("HasStaticOperatorCallBase.call") {
+  let h = HasStaticOperatorCallBase()
+  let res = h(1)
+  expectEqual(43, res)
+}
+
+OperatorsTestSuite.test("HasStaticOperatorCallDerived.call") {
+  let h = HasStaticOperatorCallDerived()
+  let res = h(0)
+  expectEqual(42, res)
+}
+
+OperatorsTestSuite.test("HasStaticOperatorCallWithConstOperator.call") {
+  let h = HasStaticOperatorCallWithConstOperator()
+  let res = h(10)
+  expectEqual(9, res)
+  let res2 = h(3, 5)
+  expectEqual(8, res2)
+}
+
 runAllTests()


### PR DESCRIPTION
…Function functions in Swift to preserve source compatibility
