### PR TITLE
[Distributed] Improve erroring out when distributed types not found

### DIFF
--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -81,15 +81,15 @@ static VarDecl*
 // what already has a witness.
 static VarDecl *addImplicitDistributedActorIDProperty(
     ClassDecl *nominal) {
-  if (!nominal)
-    return nullptr;
-  if (!nominal->isDistributedActor())
+  if (!nominal || !nominal->isDistributedActor())
     return nullptr;
 
   auto &C = nominal->getASTContext();
 
   // ==== Synthesize and add 'id' property to the actor decl
   Type propertyType = getDistributedActorIDType(nominal);
+  if (!propertyType || propertyType->hasError())
+    return nullptr;
 
   auto *propDecl = new (C)
       VarDecl(/*IsStatic*/false, VarDecl::Introducer::Let,

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -474,6 +474,9 @@ static ValueDecl *deriveDistributedActor_actorSystem(
   auto classDecl = dyn_cast<ClassDecl>(derived.Nominal);
   assert(classDecl && derived.Nominal->isDistributedActor());
 
+  if (!C.getLoadedModule(C.Id_Distributed))
+    return nullptr;
+
   // ```
   // nonisolated let actorSystem: ActorSystem
   // ```


### PR DESCRIPTION
Very minor improvement in erroring out when a distributed property type cannot be determined -- in practice this means a borked or old or none SDK, and other errors will already point towards this issue. We just avoid crashing here in synthesis in order for those other errors to become visible.

Resolves rdar://126130352