### PR TITLE
[6.0][Distributed] Improve erroring out when distributed types not found

### DIFF
--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -81,15 +81,15 @@ static VarDecl*
 // what already has a witness.
 static VarDecl *addImplicitDistributedActorIDProperty(
     ClassDecl *nominal) {
-  if (!nominal)
-    return nullptr;
-  if (!nominal->isDistributedActor())
+  if (!nominal || !nominal->isDistributedActor())
     return nullptr;
 
   auto &C = nominal->getASTContext();
 
   // ==== Synthesize and add 'id' property to the actor decl
   Type propertyType = getDistributedActorIDType(nominal);
+  if (!propertyType || propertyType->hasError())
+    return nullptr;
 
   auto *propDecl = new (C)
       VarDecl(/*IsStatic*/false, VarDecl::Introducer::Let,

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -474,6 +474,9 @@ static ValueDecl *deriveDistributedActor_actorSystem(
   auto classDecl = dyn_cast<ClassDecl>(derived.Nominal);
   assert(classDecl && derived.Nominal->isDistributedActor());
 
+  if (!C.getLoadedModule(C.Id_Distributed))
+    return nullptr;
+
   // ```
   // nonisolated let actorSystem: ActorSystem
   // ```


### PR DESCRIPTION
**Description**: When invoked without an SDK Distributed actor synthesis would crash with trying to set a null type on a property. Instead, we should return early and let other code report the "missing sdk" issue; In synthesis we just need to avoid crashing.
**Scope/Impact**: Manual swiftc invocations without an SDK.
**Risk:** Low, just avoiding crash from null type being set on type.
**Testing**: CI testing, manually verified "swiftc invocation without sdk" and confirmed it doesn't crash.
**Reviewed by**: @DougGregor 

**Original PR:**  https://github.com/apple/swift/pull/74284
**Radar:** rdar://126130352