### PR TITLE
[Runtime] Add `swift_retainMultiple`/`swift_releaseMultiple`.

### DIFF
--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -80,6 +80,7 @@ FEATURE(ClearSensitive,                                 FUTURE)
 FEATURE(UpdatePureObjCClassMetadata,                    FUTURE)
 FEATURE(ValueGenericType,                               FUTURE)
 FEATURE(InitRawStructMetadata2,                         FUTURE)
+FEATURE(RetainReleaseMultiple,                          FUTURE)
 
 #undef FEATURE
 #undef FUTURE

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -192,6 +192,29 @@ void swift_setDeallocating(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
 void swift_nonatomic_release_n(HeapObject *object, uint32_t n);
 
+/// Atomically increments the retain counts of each object in an array.
+///
+/// \param objects - A pointer to a contiguous array of object pointers.
+/// \param count - The number of object pointers in the array.
+SWIFT_RUNTIME_EXPORT
+void swift_retainMultiple(HeapObject **objects, size_t count);
+
+/// Non-atomic version of the above
+SWIFT_RUNTIME_EXPORT
+void swift_nonatomic_retainMultiple(HeapObject **objects, size_t count);
+
+/// Atomically decrements the retain counts of each object in an array.  If
+/// the retain count of an object reaches zero, the object will be destroyed.
+///
+/// \param objects - A pointer to a contiguous array of object pointers.
+/// \param count - The number of object pointers in the array.
+SWIFT_RUNTIME_EXPORT
+void swift_releaseMultiple(HeapObject **objects, size_t count);
+
+/// Non-atomic version of the above
+SWIFT_RUNTIME_EXPORT
+void swift_nonatomic_releaseMultiple(HeapObject **objects, size_t count);
+
 // Refcounting observation hooks for memory tools. Don't use these.
 SWIFT_RUNTIME_EXPORT
 size_t swift_retainCount(HeapObject *object);

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -236,6 +236,24 @@ FUNCTION(NativeStrongReleaseN, swift_release_n, C_CC, AlwaysAvailable,
          EFFECT(RefCounting, Deallocating),
          UNKNOWN_MEMEFFECTS)
 
+// void swift_retainMultiple(void **ptr, size_t count)
+FUNCTION(NativeStrongRetainMultiple, swift_retainMultiple, C_CC,
+         RetainReleaseMultipleAvailability,
+         RETURNS(VoidTy),
+         ARGS(Int8PtrTy, SizeTy),
+         ATTRS(NoUnwind),
+         EFFECT(RefCounting),
+         UNKNOWN_MEMEFFECTS)
+
+// void swift_releaseMultiple(void **ptr, size_t count)
+FUNCTION(NativeStrongReleaseMultiple, swift_releaseMultiple, C_CC,
+         RetainReleaseMultipleAvailability,
+         RETURNS(VoidTy),
+         ARGS(Int8PtrTy, SizeTy),
+         ATTRS(NoUnwind),
+         EFFECT(RefCounting, Deallocating),
+         UNKNOWN_MEMEFFECTS)
+
 // void swift_setDeallocating(void *ptr);
 FUNCTION(NativeSetDeallocating, swift_setDeallocating,
          C_CC, AlwaysAvailable,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -817,146 +817,38 @@ namespace RuntimeConstants {
     return deploymentAvailability.isContainedIn(featureAvailability);
   }
 
-  RuntimeAvailability OpaqueTypeAvailability(ASTContext &Context) {
-    auto featureAvailability = Context.getOpaqueTypeAvailability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
+#define FEATURE(name,version)                                           \
+  RuntimeAvailability name##Availability(ASTContext &context) {         \
+    auto featureAvailability = context.get##name##Availability();       \
+    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) { \
+      return RuntimeAvailability::ConditionallyAvailable;               \
+    }                                                                   \
+    return RuntimeAvailability::AlwaysAvailable;                        \
   }
 
+#include "swift/AST/FeatureAvailability.def"
+
+  // Legacy aliases
   RuntimeAvailability
   GetTypesInAbstractMetadataStateAvailability(ASTContext &context) {
-    auto featureAvailability =
-        context.getTypesInAbstractMetadataStateAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability DynamicReplacementAvailability(ASTContext &Context) {
-    auto featureAvailability = Context.getSwift51Availability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
-      return RuntimeAvailability::AvailableByCompatibilityLibrary;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability
-  CompareTypeContextDescriptorsAvailability(ASTContext &Context) {
-    auto featureAvailability =
-        Context.getCompareTypeContextDescriptorsAvailability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability
-  CompareProtocolConformanceDescriptorsAvailability(ASTContext &Context) {
-    auto featureAvailability =
-        Context.getCompareProtocolConformanceDescriptorsAvailability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
+    return TypesInAbstractMetadataStateAvailability(context);
   }
 
   RuntimeAvailability
   GetCanonicalSpecializedMetadataAvailability(ASTContext &context) {
-    auto featureAvailability =
-        context.getIntermodulePrespecializedGenericMetadataAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
+    return IntermodulePrespecializedGenericMetadataAvailability(context);
   }
 
   RuntimeAvailability
   GetCanonicalPrespecializedGenericMetadataAvailability(ASTContext &context) {
-    auto featureAvailability =
-        context.getPrespecializedGenericMetadataAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
+    return PrespecializedGenericMetadataAvailability(context);
   }
 
-  RuntimeAvailability ConcurrencyAvailability(ASTContext &context) {
-    auto featureAvailability = context.getConcurrencyAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability TaskExecutorAvailability(ASTContext &context) {
-    auto featureAvailability = context.getTaskExecutorAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability ConcurrencyDiscardingTaskGroupAvailability(ASTContext &context) {
-    auto featureAvailability =
-        context.getConcurrencyDiscardingTaskGroupAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability DifferentiationAvailability(ASTContext &context) {
-    auto featureAvailability = context.getDifferentiationAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability TypedThrowsAvailability(ASTContext &Context) {
-    auto featureAvailability = Context.getTypedThrowsAvailability();
+  // Not based on FeatureAvailability.def
+  RuntimeAvailability DynamicReplacementAvailability(ASTContext &Context) {
+    auto featureAvailability = Context.getSwift51Availability();
     if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability
-  MultiPayloadEnumTagSinglePayloadAvailability(ASTContext &context) {
-    auto featureAvailability = context.getMultiPayloadEnumTagSinglePayload();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability
-  ObjCIsUniquelyReferencedAvailability(ASTContext &context) {
-    auto featureAvailability =
-        context.getObjCIsUniquelyReferencedAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability SignedConformsToProtocolAvailability(ASTContext &context) {
-    auto featureAvailability =
-        context.getSignedConformsToProtocolAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability SignedDescriptorAvailability(ASTContext &context) {
-    auto featureAvailability =
-        context.getSignedDescriptorAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
+      return RuntimeAvailability::AvailableByCompatibilityLibrary;
     }
     return RuntimeAvailability::AlwaysAvailable;
   }
@@ -968,38 +860,6 @@ namespace RuntimeConstants {
     // swift_task_run_inline is only available under task-to-thread execution
     // model.
     return RuntimeAvailability::ConditionallyAvailable;
-  }
-
-  RuntimeAvailability ParameterizedExistentialAvailability(ASTContext &Context) {
-    auto featureAvailability = Context.getParameterizedExistentialAvailability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability ClearSensitiveAvailability(ASTContext &Context) {
-    auto featureAvailability = Context.getClearSensitiveAvailability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability InitRawStructMetadataAvailability(ASTContext &Context) {
-    auto featureAvailability = Context.getInitRawStructMetadataAvailability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
-  }
-
-  RuntimeAvailability InitRawStructMetadata2Availability(ASTContext &Context) {
-    auto featureAvailability = Context.getInitRawStructMetadata2Availability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
-      return RuntimeAvailability::ConditionallyAvailable;
-    }
-    return RuntimeAvailability::AlwaysAvailable;
   }
 
 } // namespace RuntimeConstants


### PR DESCRIPTION
These are here to provide a way for `Array` to optimize reference counting when copying; instead of having to call `swift_retain()` for every object in the `Array`, it can just do `swift_retainMultiple()` for each chunk of array storage.

The benefit of this is that we avoid a dyld stub if the retain calls are inlined into user programs (since in that case we have to call into `libswiftCore.dylib`).

rdar://126978101
