### PR TITLE
[cxx-interop] Fix unavailable generics triggering compilation error

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -874,6 +874,11 @@ public:
       // Emit an unavailable stub for a Swift type.
       if (auto *nmtd = dyn_cast<NominalTypeDecl>(vd)) {
         auto representation = cxx_translation::getDeclRepresentation(vd);
+        if (nmtd->isGeneric()) {
+          auto genericSignature =
+              nmtd->getGenericSignature().getCanonicalSignature();
+          ClangSyntaxPrinter(os).printGenericSignature(genericSignature);
+        }
         os << "class ";
         ClangSyntaxPrinter(os).printBaseName(vd);
         os << " { } SWIFT_UNAVAILABLE_MSG(\"";

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
@@ -47,17 +47,61 @@ public class Class1 {
   public var index1: Struct1<UInt32> { .init(rawValue: 123) }
 }
 
+public struct GlyphIndex<IntType: FixedWidthInteger & UnsignedInteger> {
+    private var value: IntType
+
+    init(value: IntType) {
+        self.value = value
+    }
+}
+
+public struct QueryResult<GlyphIndexInt: UnsignedInteger & FixedWidthInteger> {
+    public var glyphIDs: [GlyphIndex<GlyphIndexInt>]
+}
+
+public func makeQueryResult() -> QueryResult<UInt32> { .init(glyphIDs: []) }
+
 // CHECK: supported
 
 // CHECK: class SWIFT_SYMBOL("s:5Decls6Class1C") Class1 : public swift::_impl::RefCountedClass {
 // CHECK: 'index1' cannot be printed
 
+// CHECK: namespace Decls SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Decls") {
+// CHECK: namespace Decls SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Decls") {
+// CHECK: SWIFT_INLINE_THUNK void supportedFunc(const T_0_0& x) noexcept SWIFT_SYMBOL("s:5Decls13supportedFuncyyxlF") {
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: #ifdef __cpp_concepts
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: #endif // __cpp_concepts
+// CHECK-NEXT: class GlyphIndex { } SWIFT_UNAVAILABLE_MSG("generic requirements for generic struct 'GlyphIndex' can not yet be represented in C++");
+
+// CHECK: class Proto { } SWIFT_UNAVAILABLE_MSG("protocol 'Proto' can not yet be represented in C++");
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: #ifdef __cpp_concepts
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: #endif // __cpp_concepts
+// CHECK-NEXT: class QueryResult { } SWIFT_UNAVAILABLE_MSG("generic requirements for generic struct 'QueryResult' can not yet be represented in C++");
+
 // CHECK: class Struct1 { } SWIFT_UNAVAILABLE_MSG("generic requirements for generic struct 'Struct1' can not yet be represented in C++");
 
 // CHECK: // Unavailable in C++: Swift global function 'unsupportedFunc(_:)'.
 
-// CHECK: class unsupportedGenericClass { } SWIFT_UNAVAILABLE_MSG("generic generic class 'unsupportedGenericClass' can not yet be exposed to C++");
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: #ifdef __cpp_concepts
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: #endif // __cpp_concepts
+// CHECK-NEXT: class unsupportedGenericClass { } SWIFT_UNAVAILABLE_MSG("generic generic class 'unsupportedGenericClass' can not yet be exposed to C++");
 // CHECK-EMPTY:
+// CHECK-NEXT: template<class T_0_0>
+// CHECK-NEXT: #ifdef __cpp_concepts
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: #endif // __cpp_concepts
 // CHECK-NEXT: class unsupportedGenericEnum { } SWIFT_UNAVAILABLE_MSG("generic requirements for generic enum 'unsupportedGenericEnum' can not yet be represented in C++");
 // CHECK-EMPTY:
+// CHECK-NEXT: template<class T_0_0>
+// CHECK-NEXT: #ifdef __cpp_concepts
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: #endif // __cpp_concepts
 // CHECK-NEXT: class unsupportedGenericStruct { } SWIFT_UNAVAILABLE_MSG("generic requirements for generic struct 'unsupportedGenericStruct' can not yet be represented in C++");


### PR DESCRIPTION
In some cases, the reverse interop generated both a forward declaration and a definition with unavailable attribute in the C++ header. Unfortunately, the kinds of these symbol did not match. The forward declaration was templated while the definition was not. The forward declaration has the correct kind, so this patch extends the printing of unavailable definitions to include the generic arguments.

rdar://119835933