### PR TITLE
Frontend: share the module cache path with clang

### DIFF
--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -14,6 +14,7 @@
 
 #include "ArgsToFrontendInputsConverter.h"
 #include "ArgsToFrontendOutputsConverter.h"
+#include "clang/Driver/Driver.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Frontend/Frontend.h"
@@ -68,7 +69,7 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.ExplicitModulesOutputPath = A->getValue();
   } else {
     SmallString<128> defaultPath;
-    llvm::sys::path::cache_directory(defaultPath);
+    clang::driver::Driver::getDefaultModuleCachePath(defaultPath);
     Opts.ExplicitModulesOutputPath = defaultPath.str().str();
   }
   if (const Arg *A = Args.getLastArg(OPT_backup_module_interface_path)) {


### PR DESCRIPTION
Rather than trying to re-compute the cache path manually for the default, use the clang provided interface to home the module cache. This ensures that we do not write the files into a top-level directory on Windows.