### PR TITLE
[6.0] [Mangler] Mangle function type for invalid enum element

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3837,8 +3837,11 @@ CanType ASTMangler::getDeclTypeForMangling(
   parentGenericSig = GenericSignature();
 
   auto &C = decl->getASTContext();
-  if (decl->isInvalid()) {
-    if (isa<AbstractFunctionDecl>(decl)) {
+
+  auto ty = decl->getInterfaceType()->getReferenceStorageReferent();
+  if (ty->hasError()) {
+    if (isa<AbstractFunctionDecl>(decl) || isa<EnumElementDecl>(decl) ||
+        isa<SubscriptDecl>(decl)) {
       // FIXME: Verify ExtInfo state is correct, not working by accident.
       CanFunctionType::ExtInfo info;
       return CanFunctionType::get({AnyFunctionType::Param(C.TheErrorType)},
@@ -3846,8 +3849,6 @@ CanType ASTMangler::getDeclTypeForMangling(
     }
     return C.TheErrorType;
   }
-
-  Type ty = decl->getInterfaceType()->getReferenceStorageReferent();
 
   // If this declaration predates concurrency, adjust its type to not
   // contain type features that were not available pre-concurrency. This

--- a/test/Index/enum_case_with_invalid_associated_type.swift
+++ b/test/Index/enum_case_with_invalid_associated_type.swift
@@ -1,0 +1,7 @@
+enum MyEnum {
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+  case test(artifactID: String, hostTriple: Triple)
+// CHECK: enumerator/Swift | test(artifactID:hostTriple:)
+// CHECK: param/Swift | artifactID
+// CHECK: param/Swift | hostTriple
+}

--- a/test/Index/rdar129065620.swift
+++ b/test/Index/rdar129065620.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -typecheck %s -index-store-path %t
+
+// rdar://129065620 - Make sure we don't crash when verifying the mangling.
+enum Foo {
+  case bar(id: UInt32)
+  case bar(id: UInt32)
+}
+
+struct S {
+  subscript(x: Invalid) -> Invalid {}
+}

--- a/test/SourceKit/Indexing/index_effective_access_level.swift.response
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift.response
@@ -1302,14 +1302,14 @@
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyXeXecip",
           key.line: 93,
           key.column: 5,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyXeXecig",
               key.line: 93,
               key.column: 46
             },
@@ -1333,14 +1333,14 @@
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyXeXecip",
           key.line: 94,
           key.column: 17,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyXeXecig",
               key.line: 94,
               key.column: 61
             },
@@ -1369,14 +1369,14 @@
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeip",
+          key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyXeXecip",
           key.line: 95,
           key.column: 13,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVXeig",
+              key.usr: "s:28index_effective_access_level18ScopeReducerStruct33_2295DDF1454D6A6D9229E8222CD85214LLVyXeXecig",
               key.line: 95,
               key.column: 53
             },
@@ -2077,14 +2077,14 @@
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXeip",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVyXeXecip",
           key.line: 121,
           key.column: 5,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXeig",
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructVyXeXecig",
               key.line: 121,
               key.column: 46
             },
@@ -2108,14 +2108,14 @@
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVyXeXec33_2295DDF1454D6A6D9229E8222CD85214Llip",
           key.line: 122,
           key.column: 17,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructVyXeXec33_2295DDF1454D6A6D9229E8222CD85214Llig",
               key.line: 122,
               key.column: 61
             },
@@ -2144,14 +2144,14 @@
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
+          key.usr: "s:28index_effective_access_level17ScopeKeeperStructVyXeXec33_2295DDF1454D6A6D9229E8222CD85214Llip",
           key.line: 123,
           key.column: 13,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level17ScopeKeeperStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
+              key.usr: "s:28index_effective_access_level17ScopeKeeperStructVyXeXec33_2295DDF1454D6A6D9229E8222CD85214Llig",
               key.line: 123,
               key.column: 53
             },
@@ -2852,14 +2852,14 @@
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXeip",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVyXeXecip",
           key.line: 149,
           key.column: 5,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXeig",
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVyXeXecig",
               key.line: 149,
               key.column: 46
             },
@@ -2883,14 +2883,14 @@
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVyXeXec33_2295DDF1454D6A6D9229E8222CD85214Llip",
           key.line: 150,
           key.column: 17,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVyXeXec33_2295DDF1454D6A6D9229E8222CD85214Llig",
               key.line: 150,
               key.column: 61
             },
@@ -2919,14 +2919,14 @@
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llip",
+          key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVyXeXec33_2295DDF1454D6A6D9229E8222CD85214Llip",
           key.line: 151,
           key.column: 13,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
-              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVXe33_2295DDF1454D6A6D9229E8222CD85214Llig",
+              key.usr: "s:28index_effective_access_level25PartialScopeReducerStructVyXeXec33_2295DDF1454D6A6D9229E8222CD85214Llig",
               key.line: 151,
               key.column: 53
             },


### PR DESCRIPTION
*6.0 cherry-pick of #74288*

- Explanation: Fixes an assertion failure for an invalid enum case when generating a USR
- Scope: Affects USR generation for invalid enum cases
- Issue: rdar://129065620
- Risk: Low
- Testing: Added tests to test suite
- Reviewer: Alex Hoppen