### PR TITLE
[AST] `@preconcurrency` conformance applies to implied conformances a…

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -681,7 +681,12 @@ public:
     assert(sourceKind != ConformanceEntryKind::PreMacroExpansion &&
            "cannot create conformance pre-macro-expansion");
     Bits.NormalProtocolConformance.SourceKind = unsigned(sourceKind);
-    ImplyingConformance = implyingConformance;
+    if (auto implying = implyingConformance) {
+      ImplyingConformance = implying;
+      PreconcurrencyLoc = implying->getPreconcurrencyLoc();
+      Bits.NormalProtocolConformance.IsPreconcurrency =
+          implying->isPreconcurrency();
+    }
   }
 
   /// Determine whether this conformance is lazily loaded.

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -182,3 +182,19 @@ do {
     func test() {}
   }
 }
+
+// https://github.com/apple/swift/issues/74294
+protocol Parent {
+  func a()
+}
+
+protocol Child: Parent {
+  func b()
+}
+
+do {
+    actor Test: @preconcurrency Child {
+      func a() {} // Ok
+      func b() {} // Ok
+    }
+}

--- a/test/Interpreter/preconcurrency_conformances.swift
+++ b/test/Interpreter/preconcurrency_conformances.swift
@@ -34,6 +34,16 @@
 // RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/crash4.out 2>&1 | %FileCheck %t/src/Crash4.swift --check-prefix=LEGACY_CHECK
 // RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/crash4.out 2>&1 | %FileCheck %t/src/Crash4.swift --check-prefix=SWIFT6_CHECK --dump-input=always
 
+// RUN: %target-build-swift -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation -I %t -L %t -l Types %t/src/Crash5.swift -o %t/crash5.out
+// RUN: %target-codesign %t/crash5.out
+// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/crash5.out 2>&1 | %FileCheck %t/src/Crash5.swift --check-prefix=LEGACY_CHECK
+// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/crash5.out 2>&1 | %FileCheck %t/src/Crash5.swift --check-prefix=SWIFT6_CHECK --dump-input=always
+
+// RUN: %target-build-swift -Xfrontend -enable-upcoming-feature -Xfrontend DynamicActorIsolation -I %t -L %t -l Types %t/src/Crash6.swift -o %t/crash6.out
+// RUN: %target-codesign %t/crash6.out
+// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/crash6.out 2>&1 | %FileCheck %t/src/Crash6.swift --check-prefix=LEGACY_CHECK
+// RUN: not --crash env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=2 %target-run %t/crash6.out 2>&1 | %FileCheck %t/src/Crash6.swift --check-prefix=SWIFT6_CHECK --dump-input=always
+
 // REQUIRES: asserts
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
@@ -49,6 +59,10 @@ public protocol P {
 
   var prop: [String] { get set }
   func test() -> Int
+}
+
+public protocol Q : P {
+  func childTest()
 }
 
 //--- Types.swift
@@ -87,6 +101,21 @@ extension ActorTest : @preconcurrency P {
   public func test() -> Int { x }
 }
 
+@MainActor
+public struct TestWithParent : @preconcurrency Q {
+  public var prop: [String] = []
+
+  public init() {}
+
+  public func test() -> Int { 42 }
+  public func childTest() {}
+}
+
+public func runChildTest<T: Q>(_ type: T.Type) async {
+  let v = type.init()
+  return v.childTest()
+}
+
 //--- Crash1.swift
 import Types
 print(await runTest(Test.self))
@@ -121,4 +150,22 @@ print("OK")
 // LEGACY_CHECK: data race detected: actor-isolated function at Types/Types.swift:30 was not called on the same actor
 
 // SWIFT6_CHECK: Incorrect actor executor assumption
+// SWIFT6_CHECK-NOT: OK
+
+//--- Crash5.swift
+import Types
+print(await runTest(TestWithParent.self))
+print("OK")
+// LEGACY_CHECK: data race detected: @MainActor function at Types/Types.swift:40 was not called on the main thread
+
+// Crash without good message, since via 'dispatch_assert_queue'
+// SWIFT6_CHECK-NOT: OK
+
+//--- Crash6.swift
+import Types
+print(await runChildTest(TestWithParent.self))
+print("OK")
+// LEGACY_CHECK: data race detected: @MainActor function at Types/Types.swift:40 was not called on the main thread
+
+// Crash without good message, since via 'dispatch_assert_queue'
 // SWIFT6_CHECK-NOT: OK

--- a/test/SILGen/preconcurrency_conformances.swift
+++ b/test/SILGen/preconcurrency_conformances.swift
@@ -276,6 +276,39 @@ extension MyActor : @preconcurrency Q {
 // CHECK: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
 // CHECK-NEXT: {{.*}} = apply [[CHECK_EXEC_REF]]({{.*}}, [[EXEC]])
 
+// https://github.com/apple/swift/issues/74294
+protocol Parent {
+  func a()
+}
+
+protocol Child : Parent {
+  func b()
+}
+
+@MainActor
+struct PreconcurrencyAppliesToParentToo : @preconcurrency Child {
+  func a() {
+  }
+
+  func b() {
+  }
+}
+
+// protocol witness for Child.b() in conformance PreconcurrencyAppliesToParentToo
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances32PreconcurrencyAppliesToParentTooVAA5ChildA2aDP1byyFTW : $@convention(witness_method: Child) (@in_guaranteed PreconcurrencyAppliesToParentToo) -> ()
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow {{.*}} : $MainActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+// CHECK-NEXT: {{.*}} = apply [[CHECK_EXEC_REF]]({{.*}}, [[EXEC]])
+
+
+// protocol witness for Parent.a() in conformance PreconcurrencyAppliesToParentToo
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances32PreconcurrencyAppliesToParentTooVAA0F0A2aDP1ayyFTW : $@convention(witness_method: Parent) (@in_guaranteed PreconcurrencyAppliesToParentToo) -> ()
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow {{.*}} : $MainActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+// CHECK-NEXT: {{.*}} = apply [[CHECK_EXEC_REF]]({{.*}}, [[EXEC]])
+
 //--- checks_disabled.swift
 protocol P {
   associatedtype T
@@ -438,4 +471,30 @@ extension MyActor : @preconcurrency Q {
 
 // protocol witness for static Q.data.modify in conformance MyActor
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances7MyActorCAA1QA2aDP4dataSaySiGSgvMZTW : $@yield_once @convention(witness_method: Q) @substituted <τ_0_0> (@thick τ_0_0.Type) -> @yields @inout Optional<Array<Int>> for <MyActor>
+// CHECK-NOT: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+
+// https://github.com/apple/swift/issues/74294
+protocol Parent {
+  func a()
+}
+
+protocol Child : Parent {
+  func b()
+}
+
+@MainActor
+struct PreconcurrencyAppliesToParentToo : @preconcurrency Child {
+  func a() {
+  }
+
+  func b() {
+  }
+}
+
+// protocol witness for Child.b() in conformance PreconcurrencyAppliesToParentToo
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances32PreconcurrencyAppliesToParentTooVAA5ChildA2aDP1byyFTW : $@convention(witness_method: Child) (@in_guaranteed PreconcurrencyAppliesToParentToo) -> ()
+// CHECK-NOT: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+
+// protocol witness for Parent.a() in conformance PreconcurrencyAppliesToParentToo
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s27preconcurrency_conformances32PreconcurrencyAppliesToParentTooVAA0F0A2aDP1ayyFTW : $@convention(witness_method: Parent) (@in_guaranteed PreconcurrencyAppliesToParentToo) -> ()
 // CHECK-NOT: [[CHECK_EXEC_REF:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF


### PR DESCRIPTION
…s well

A `@preconcurrency` conformance to an inherited protocol should imply `@preconcurrency` on its parents as well. For example:

```swift
protocol Parent {
  func a()
}

protocol Child: Parent {
  func b()
}

@MainActor
class Test: @preconcurrency Child {
  func a() {
  }

  func b() {
  }
}
```

`Test` conformance to `Parent` implied by its conformance to `Child` should carry `@preconcurrency` and inject dynamic actor isolation checks to witness of `a()`.

Resolves: https://github.com/apple/swift/issues/74294
Resolves: rdar://129599097

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
