### PR TITLE
[region-isolation] Dont crash when processing global actor isolated init accessors.

### DIFF
--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1688,6 +1688,19 @@ func initAccessorTests() {
       get { fatalError() }
       set { fatalError() }
     }
+
+    @MainActor
+    var third: NonSendableKlass
+    @MainActor
+    var fourth: NonSendableKlass? = nil {
+      @storageRestrictions(initializes: third)
+      init(initialValue)  {
+        third = initialValue!
+      }
+
+      get { fatalError() }
+      set { fatalError() }
+    }
   }
 }
 


### PR DESCRIPTION
This just means that I stopped treating it like an actor instance isolated thing. This was fun to track down since ActorIsolation has a union in it that was being misinterpreted, leading to memory corruption... my favorite! = ).

rdar://129256560
