### PR TITLE
[6.0][ModuleInterface] Save `-public-autolink-library` module option

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -207,9 +207,6 @@ def no_serialize_debugging_options :
 def autolink_library : Separate<["-"], "autolink-library">,
   HelpText<"Add dependent library">, Flags<[FrontendOption]>;
 
-def public_autolink_library : Separate<["-"], "public-autolink-library">,
-  HelpText<"Add public dependent library">, Flags<[FrontendOption]>;
-
 def disable_typo_correction : Flag<["-"], "disable-typo-correction">,
   HelpText<"Disable typo correction">;
 
@@ -369,6 +366,10 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
 def enable_experimental_async_top_level :
   Flag<["-"], "enable-experimental-async-top-level">,
   HelpText<"Enable experimental concurrency in top-level code">;
+
+def public_autolink_library :
+  Separate<["-"], "public-autolink-library">,
+  HelpText<"Add public dependent library">;
 }
 
 // HIDDEN FLAGS

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -276,6 +276,8 @@ std::error_code ExplicitModuleInterfaceBuilder::buildSwiftModuleFromInterface(
   SerializationOpts.ModuleLinkName = FEOpts.ModuleLinkName;
   SerializationOpts.AutolinkForceLoad =
       !Invocation.getIRGenOptions().ForceLoadSymbolName.empty();
+  SerializationOpts.PublicDependentLibraries =
+      Invocation.getIRGenOptions().PublicLinkLibraries;
   SerializationOpts.UserModuleVersion = FEOpts.UserModuleVersion;
   SerializationOpts.AllowableClients = FEOpts.AllowableClients;
   StringRef SDKPath = Instance.getASTContext().SearchPathOpts.getSDKPath();

--- a/test/ModuleInterface/public-autolink-library.swift
+++ b/test/ModuleInterface/public-autolink-library.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -module-name Foo -emit-module-interface-path %t/Foo.swiftinterface %s -module-link-name Foo -enable-library-evolution -public-autolink-library Bar
+// RUN: %target-swift-frontend -compile-module-from-interface -o %t/Foo.swiftmodule %t/Foo.swiftinterface
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print Foo -I %t -source-filename %s | %FileCheck %s
+
+// CHECK: link library: Bar


### PR DESCRIPTION
**Explanation**: Fixes inconsistent swiftmodule compilation issue revealed by recent explicit module improvements
**Scope**: Only affects static-linking scenario
**Risk**: Low; just save/restore an option that has existed since Swift 5.6 and only affects to static-linking
**Testing**: Added a new test to cover the case
**Reviewer**: @artemcm 
**Original PR:** https://github.com/apple/swift/pull/74277
