### PR TITLE
[SwiftCompilerSources] Remove unnecessary default case from SerializedKind funcs

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -147,7 +147,6 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     case .IsNotSerialized: return .notSerialized
     case .IsSerialized: return .serialized
     case .IsSerializedForPackage: return .serializedForPackage
-    default: fatalError()
     }
   }
 
@@ -156,7 +155,6 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     case .notSerialized: return .IsNotSerialized
     case .serialized: return .IsSerialized
     case .serializedForPackage: return .IsSerializedForPackage
-    default: fatalError()
     }
   }
 


### PR DESCRIPTION
This removes warnings.