### PR TITLE
[6.0][region-isolation] Dont crash when processing global actor isolated init accessors.

### DIFF
--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1688,6 +1688,19 @@ func initAccessorTests() {
       get { fatalError() }
       set { fatalError() }
     }
+
+    @MainActor
+    var third: NonSendableKlass
+    @MainActor
+    var fourth: NonSendableKlass? = nil {
+      @storageRestrictions(initializes: third)
+      init(initialValue)  {
+        third = initialValue!
+      }
+
+      get { fatalError() }
+      set { fatalError() }
+    }
   }
 }
 


### PR DESCRIPTION
Explanation: This PR makes sure that we do not crash when we process global actor isolated init accessors. The crash is a result of memory corruption due to misinterpreting a union + enum (a c++ version of an enum + associated values).

- rdar://129256560

Original PRs:

- https://github.com/apple/swift/pull/74321

Risk: Low. This only impacts global actor isolated init accessors that we would crash on without this anyways.
Testing: Added tests to the test suite.
Reviewer: N/A
