### PR TITLE
[Completion] Completions for `inout`, `borrowing`, `consuming`, `isolated`, `consume`, and `copy`

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -453,10 +453,10 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(_local, KnownToBeLocal,
   DeclModifier | OnFunc | OnParam | OnVar | UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   130)
 CONTEXTUAL_SIMPLE_DECL_ATTR(consuming, Consuming,
-  OnFunc | OnAccessor | DeclModifier | UserInaccessible | NotSerialized | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
+  OnFunc | OnAccessor | DeclModifier | NotSerialized | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   140)
 CONTEXTUAL_SIMPLE_DECL_ATTR(borrowing, Borrowing,
-  OnFunc | OnAccessor | DeclModifier | UserInaccessible | NotSerialized | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
+  OnFunc | OnAccessor | DeclModifier | NotSerialized | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   141)
 DECL_ATTR(attached, MacroRole,
   OnMacro | AllowMultipleAttributes | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIBreakingToRemove,

--- a/include/swift/AST/TokenKinds.def
+++ b/include/swift/AST/TokenKinds.def
@@ -145,7 +145,6 @@ DECL_KEYWORD(extension)
 DECL_KEYWORD(func)
 DECL_KEYWORD(import)
 DECL_KEYWORD(init)
-DECL_KEYWORD(inout)
 DECL_KEYWORD(let)
 DECL_KEYWORD(operator)
 DECL_KEYWORD(precedencegroup)
@@ -259,8 +258,9 @@ MISC(string_interpolation_anchor)
 MISC(kw_yield)
 MISC(kw_discard)
 MISC(kw_then)
+SWIFT_KEYWORD(inout)
 
-// The following tokens are irrelevant for swiftSyntax and thus only declared 
+// The following tokens are irrelevant for swiftSyntax and thus only declared
 // in this .def file
 
 SIL_KEYWORD(undef)

--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -197,6 +197,7 @@ enum class CompletionKind : uint8_t {
   PostfixExpr,
   KeyPathExprObjC,
   KeyPathExprSwift,
+  TypePossibleFunctionParamBeginning,
   TypeDeclResultBeginning,
   TypeBeginning,
   TypeSimpleOrComposition,

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -178,6 +178,12 @@ public:
   /// #keyPath argument have been parsed yet.
   virtual void completeExprKeyPath(KeyPathExpr *KPE, SourceLoc DotLoc) {};
 
+  /// Complete the beginning of the type for a parameter of a
+  /// func/subscript/closure, or the type for a parameter in a function type.
+  /// For the latter, we cannot know for sure whether the user is trying to
+  /// write a function type, so will complete for e.g `let x: (#^COMPLETE^#`.
+  virtual void completeTypePossibleFunctionParamBeginning() {}
+
   /// Complete the beginning of the type of result of func/var/let/subscript.
   virtual void completeTypeDeclResultBeginning() {};
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -905,6 +905,8 @@ void swift::ide::addExprKeywords(CodeCompletionResultSink &Sink,
   addKeyword(Sink, "try!", CodeCompletionKeywordKind::kw_try, "", flair);
   addKeyword(Sink, "try?", CodeCompletionKeywordKind::kw_try, "", flair);
   addKeyword(Sink, "await", CodeCompletionKeywordKind::None, "", flair);
+  addKeyword(Sink, "consume", CodeCompletionKeywordKind::None, "", flair);
+  addKeyword(Sink, "copy", CodeCompletionKeywordKind::None, "", flair);
 }
 
 void swift::ide::addSuperKeyword(CodeCompletionResultSink &Sink,

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -259,6 +259,7 @@ public:
   void completePostfixExpr(CodeCompletionExpr *E, bool hasSpace) override;
   void completeExprKeyPath(KeyPathExpr *KPE, SourceLoc DotLoc) override;
 
+  void completeTypePossibleFunctionParamBeginning() override;
   void completeTypeDeclResultBeginning() override;
   void completeTypeBeginning() override;
   void completeTypeSimpleOrComposition() override;
@@ -427,6 +428,11 @@ void CodeCompletionCallbacksImpl::completeExprKeyPath(KeyPathExpr *KPE,
 
 void CodeCompletionCallbacksImpl::completePoundAvailablePlatform() {
   Kind = CompletionKind::PoundAvailablePlatform;
+  CurDeclContext = P.CurDeclContext;
+}
+
+void CodeCompletionCallbacksImpl::completeTypePossibleFunctionParamBeginning() {
+  Kind = CompletionKind::TypePossibleFunctionParamBeginning;
   CurDeclContext = P.CurDeclContext;
 }
 
@@ -1058,6 +1064,12 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
     }
     break;
 
+  case CompletionKind::TypePossibleFunctionParamBeginning:
+    addKeyword(Sink, "inout", CodeCompletionKeywordKind::kw_inout);
+    addKeyword(Sink, "borrowing", CodeCompletionKeywordKind::None);
+    addKeyword(Sink, "consuming", CodeCompletionKeywordKind::None);
+    addKeyword(Sink, "isolated", CodeCompletionKeywordKind::None);
+    LLVM_FALLTHROUGH;
   case CompletionKind::TypeBeginning:
     addKeyword(Sink, "repeat", CodeCompletionKeywordKind::None);
     LLVM_FALLTHROUGH;
@@ -1262,6 +1274,7 @@ void swift::ide::postProcessCompletionResults(
     // names at non-type name position are "rare".
     if (result->getKind() == CodeCompletionResultKind::Declaration &&
         result->getAssociatedDeclKind() == CodeCompletionDeclKind::Protocol &&
+        Kind != CompletionKind::TypePossibleFunctionParamBeginning &&
         Kind != CompletionKind::TypeBeginning &&
         Kind != CompletionKind::TypeSimpleOrComposition &&
         Kind != CompletionKind::TypeSimpleBeginning &&
@@ -1755,6 +1768,7 @@ void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
     break;
   }
 
+  case CompletionKind::TypePossibleFunctionParamBeginning:
   case CompletionKind::TypeDeclResultBeginning:
   case CompletionKind::TypeBeginning:
   case CompletionKind::TypeSimpleOrComposition:

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -355,6 +355,22 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         .fixItReplace(Tok.getLoc(), "`" + Tok.getText().str() + "`");
     }
 
+    auto parseParamType = [&]() -> ParserResult<TypeRepr> {
+      // Currently none of the parameter type completions are relevant for
+      // enum cases, so don't include them. We'll complete for a regular type
+      // beginning instead.
+      if (Tok.is(tok::code_complete) &&
+          paramContext != ParameterContextKind::EnumElement) {
+        if (CodeCompletionCallbacks)
+          CodeCompletionCallbacks->completeTypePossibleFunctionParamBeginning();
+
+        auto CCLoc = consumeToken(tok::code_complete);
+        auto *ET = ErrorTypeRepr::create(Context, CCLoc);
+        return makeParserCodeCompletionResult<TypeRepr>(ET);
+      }
+      return parseType(diag::expected_parameter_type);
+    };
+
     if (startsParameterName(isClosure)) {
       // identifier-or-none for the first name
       param.FirstNameLoc = consumeArgumentLabel(param.FirstName,
@@ -402,7 +418,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
       // (':' type)?
       if (consumeIf(tok::colon)) {
 
-        auto type = parseType(diag::expected_parameter_type);
+        auto type = parseParamType();
         status |= type;
         param.Type = type.getPtrOrNull();
 
@@ -425,7 +441,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
       }
 
       if (isBareType && paramContext == ParameterContextKind::EnumElement) {
-        auto type = parseType(diag::expected_parameter_type);
+        auto type = parseParamType();
         status |= type;
         param.Type = type.getPtrOrNull();
         param.FirstName = Identifier();
@@ -440,7 +456,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         // the user is about to type the parameter label and we shouldn't
         // suggest types.
         SourceLoc typeStartLoc = Tok.getLoc();
-        auto type = parseType(diag::expected_parameter_type);
+        auto type = parseParamType();
         status |= type;
         param.Type = type.getPtrOrNull();
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1202,6 +1202,16 @@ ParserResult<TypeRepr> Parser::parseTypeTupleBody() {
     }
     Backtracking.reset();
 
+    // If we have a code completion token, treat this as a possible parameter
+    // type since the user may be writing this as a function type.
+    if (Tok.is(tok::code_complete)) {
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeTypePossibleFunctionParamBeginning();
+
+      consumeToken();
+      return makeParserCodeCompletionStatus();
+    }
+
     // Parse the type annotation.
     auto type = parseType(diag::expected_type);
     if (type.hasCodeCompletion())

--- a/test/IDE/complete_at_top_level_library.swift
+++ b/test/IDE/complete_at_top_level_library.swift
@@ -19,7 +19,6 @@ protocol MyProtocol {}
 // LIBRARY-DAG: Keyword[func]/None:                 func; name=func
 // LIBRARY-DAG: Keyword[import]/None:               import; name=import
 // LIBRARY-DAG: Keyword[init]/None:                 init; name=init
-// LIBRARY-DAG: Keyword[inout]/None:                inout; name=inout
 // LIBRARY-DAG: Keyword[operator]/None:             operator; name=operator
 // LIBRARY-DAG: Keyword[precedencegroup]/None:      precedencegroup; name=precedencegroup
 // LIBRARY-DAG: Keyword[protocol]/None/Flair[CommonKeyword]: protocol; name=protocol
@@ -86,7 +85,6 @@ protocol MyProtocol {}
 // SCRIPT-DAG: Keyword[func]/None:                 func; name=func
 // SCRIPT-DAG: Keyword[import]/None:               import; name=import
 // SCRIPT-DAG: Keyword[init]/None:                 init; name=init
-// SCRIPT-DAG: Keyword[inout]/None:                inout; name=inout
 // SCRIPT-DAG: Keyword[operator]/None:             operator; name=operator
 // SCRIPT-DAG: Keyword[precedencegroup]/None:      precedencegroup; name=precedencegroup
 // SCRIPT-DAG: Keyword[protocol]/None:             protocol; name=protocol

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -6,6 +6,8 @@
 // KW_IN: Keyword[in]/None: in{{; name=.+$}}
 // KW_NO_IN-NOT: Keyword[in]
 
+// KW_NO_INOUT-NOT: Keyword[inout]
+
 // KW_DECL-DAG: Keyword[class]/None: class{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: actor{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: convenience{{; name=.+$}}
@@ -293,7 +295,7 @@
 // KW_EXPR_NEG-NOT: Keyword{{.*}}catch
 // KW_EXPR_NEG-NOT: Keyword{{.*}}break
 
-#^TOP_LEVEL_1?check=KW_DECL_STMT_TOPLEVEL;check=KW_NO_RETURN;check=KW_NO_IN^#
+#^TOP_LEVEL_1?check=KW_DECL_STMT_TOPLEVEL;check=KW_NO_RETURN;check=KW_NO_IN;check=KW_NO_INOUT^#
 
 for _ in 1...10 {
   #^TOP_LEVEL_2?check=KW_DECL_STMT;check=KW_NO_RETURN;check=KW_NO_IN^#
@@ -367,19 +369,19 @@ struct InInit {
 }
 
 struct InStruct {
-  #^IN_NOMINAL_DECL_1?check=KW_DECL_TYPECONTEXT^#
+  #^IN_NOMINAL_DECL_1?check=KW_DECL_TYPECONTEXT;check=KW_NO_INOUT^#
 }
 
 enum InEnum {
-  #^IN_NOMINAL_DECL_2?check=KW_DECL_TYPECONTEXT^#
+  #^IN_NOMINAL_DECL_2?check=KW_DECL_TYPECONTEXT;check=KW_NO_INOUT^#
 }
 
 class InClass {
-  #^IN_NOMINAL_DECL_3?check=KW_DECL_TYPECONTEXT^#
+  #^IN_NOMINAL_DECL_3?check=KW_DECL_TYPECONTEXT;check=KW_NO_INOUT^#
 }
 
 protocol InProtocol {
-  #^IN_NOMINAL_DECL_4?check=KW_DECL_PROTOCOL^#
+  #^IN_NOMINAL_DECL_4?check=KW_DECL_PROTOCOL;check=KW_NO_INOUT^#
 }
 
 struct AfterOtherKeywords1 {

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -23,6 +23,8 @@
 // KW_DECL-DAG: Keyword[let]/None: let{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: mutating{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: nonmutating{{; name=.+$}}
+// KW_DECL-DAG: Keyword/None: consuming{{; name=.+$}}
+// KW_DECL-DAG: Keyword/None: borrowing{{; name=.+$}}
 // KW_DECL-DAG: Keyword[operator]/None: operator{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: optional{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: override{{; name=.+$}}
@@ -58,6 +60,8 @@
 // KW_DECL_PROTOCOL-DAG: Keyword[let]/None: let{{; name=.+$}}
 // KW_DECL_PROTOCOL-DAG: Keyword/None: mutating{{; name=.+$}}
 // KW_DECL_PROTOCOL-DAG: Keyword/None: nonmutating{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: consuming{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: borrowing{{; name=.+$}}
 // KW_DECL_PROTOCOL-DAG: Keyword[operator]/None/Flair[RareKeyword]: operator{{; name=.+$}}
 // KW_DECL_PROTOCOL-DAG: Keyword/None: optional{{; name=.+$}}
 // KW_DECL_PROTOCOL-DAG: Keyword/None: override{{; name=.+$}}
@@ -93,6 +97,8 @@
 // KW_DECL_TYPECONTEXT-DAG: Keyword[let]/None: let{{; name=.+$}}
 // KW_DECL_TYPECONTEXT-DAG: Keyword/None: mutating{{; name=.+$}}
 // KW_DECL_TYPECONTEXT-DAG: Keyword/None: nonmutating{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: consuming{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: borrowing{{; name=.+$}}
 // KW_DECL_TYPECONTEXT-DAG: Keyword[operator]/None/Flair[RareKeyword]: operator{{; name=.+$}}
 // KW_DECL_TYPECONTEXT-DAG: Keyword/None: optional{{; name=.+$}}
 // KW_DECL_TYPECONTEXT-DAG: Keyword/None: override{{; name=.+$}}
@@ -132,6 +138,8 @@
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[let]/None: let{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: mutating{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: nonmutating{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: consuming{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: borrowing{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[operator]/None: operator{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: optional{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: override{{; name=.+$}}
@@ -198,6 +206,8 @@
 // KW_DECL_STMT-DAG: Keyword[let]/None: let{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword/None: mutating{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword/None: nonmutating{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None: consuming{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None: borrowing{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[operator]/None/Flair[RareKeyword]: operator{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: optional{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: override{{; name=.+$}}

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -182,6 +182,9 @@
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[try]/None: try{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[try]/None: try!{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[try]/None: try?{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: await{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: consume{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: copy{{; name=.+$}}
 //
 // Literals
 //
@@ -250,6 +253,9 @@
 // KW_DECL_STMT-DAG: Keyword[try]/None: try{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[try]/None: try!{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[try]/None: try?{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None: await{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None: consume{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None: copy{{; name=.+$}}
 //
 // Literals
 //
@@ -264,6 +270,9 @@
 // KW_EXPR-DAG: Keyword[try]/None: try{{; name=.+$}}
 // KW_EXPR-DAG: Keyword[try]/None: try!{{; name=.+$}}
 // KW_EXPR-DAG: Keyword[try]/None: try?{{; name=.+$}}
+// KW_EXPR-DAG: Keyword/None: await{{; name=.+$}}
+// KW_EXPR-DAG: Keyword/None: consume{{; name=.+$}}
+// KW_EXPR-DAG: Keyword/None: copy{{; name=.+$}}
 //
 // let and var
 //

--- a/test/IDE/complete_ownership_specifier.swift
+++ b/test/IDE/complete_ownership_specifier.swift
@@ -1,0 +1,34 @@
+// RUN: %batch-code-completion
+
+func foo(x: #^FUNC_PARAM?check=SPECIFIER^#) {
+  let fn1 = { (x: #CLOSURE_PARAM?check=SPECIFIER#) in }
+  let fn2: (#^CLOSURE_PARAM_TY_COMPLETE?check=SPECIFIER^#) -> Void
+  let fn3: (#^CLOSURE_PARAM_TY_INCOMPLETE?check=SPECIFIER^#
+}
+
+struct S {
+  init(x: #^INIT_PARAM?check=SPECIFIER^#) {}
+  subscript(x: #SUBSCRIPT_PARAM?check=SPECIFIER#) {}
+}
+
+// Don't complete for enum cases.
+enum E {
+  case e(#^ENUM_CASE_TY?check=SPECIFIER_NOT^#)
+  case f(x: #^ENUM_CASE_LABELED_TY?check=SPECIFIER_NOT^#)
+}
+
+// Don't complete for a regular variable type.
+let x: #^VAR_TY?check=SPECIFIER_NOT^#
+
+// Or for a return type.
+func bar() -> #^RETURN_TY?check=SPECIFIER_NOT^# {}
+
+// SPECIFIER-DAG: Keyword[inout]/None: inout; name=inout
+// SPECIFIER-DAG: Keyword/None: consuming; name=consuming
+// SPECIFIER-DAG: Keyword/None: borrowing; name=borrowing
+// SPECIFIER-DAG: Keyword/None: isolated; name=isolated
+
+// SPECIFIER_NOT-NOT: Keyword[inout]/None: inout
+// SPECIFIER_NOT-NOT: Keyword/None: consuming
+// SPECIFIER_NOT-NOT: Keyword/None: borrowing
+// SPECIFIER_NOT-NOT: Keyword/None: isolated

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -175,6 +175,7 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
         addCompletion(custom);
       }
       break;
+    case CompletionKind::TypePossibleFunctionParamBeginning:
     case CompletionKind::TypeDeclResultBeginning:
     case CompletionKind::TypeBeginning:
     case CompletionKind::TypeSimpleOrComposition:
@@ -452,6 +453,7 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
   if (filterText.empty()) {
     bool hideLowPriority =
         options.hideLowPriority &&
+        completionKind != CompletionKind::TypePossibleFunctionParamBeginning &&
         completionKind != CompletionKind::TypeDeclResultBeginning &&
         completionKind != CompletionKind::TypeBeginning &&
         completionKind != CompletionKind::TypeSimpleOrComposition &&


### PR DESCRIPTION
Add completion support for a bunch of new keywords (and `inout`).

- Adds `consume` and `copy` as expression keywords (similar to `await`)
- Stops `inout` from being completed as a decl keyword
- Adds `borrowing`, `consuming`, `isolated`, and `inout` as parameter type keywords
- Allows `borrowing` and `consuming` to be completed as decl keywords


rdar://127261573