### PR TITLE
[6.0] [Windows] Prepare for swift-foundation in the toolchain

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1408,6 +1408,7 @@ function Build-Dispatch([Platform]$Platform, $Arch, [switch]$Test = $false) {
 
 function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
   $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch
+  $SwiftSyntaxDir = Get-HostProjectCMakeModules Compilers
   $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch Foundation
   $ShortArch = $Arch.LLVMName
 
@@ -1450,6 +1451,10 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
         ZLIB_LIBRARY = "$LibraryRoot\zlib-1.3\usr\lib\$Platform\$ShortArch\zlibstatic.lib";
         ZLIB_INCLUDE_DIR = "$LibraryRoot\zlib-1.3\usr\include";
         dispatch_DIR = "$DispatchBinaryCache\cmake\modules";
+        SwiftSyntax_DIR = "$SwiftSyntaxDir";
+        _SwiftFoundation_SourceDIR = "$SourceCache\swift-foundation";
+        _SwiftFoundationICU_SourceDIR = "$SourceCache\swift-foundation-icu";
+        _SwiftCollections_SourceDIR = "$SourceCache\swift-collections"
       } + $TestingDefines)
   }
 }


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/74127

Explanation: Provides extra paths to the swift-corelibs-foundation build on Windows
Scope: Only affects Windows builds, and should have no effect currently as the SCL-F build does not yet use these paths
Original PR: https://github.com/apple/swift/pull/74127
Risk: Minimal - this change should not have any impact, and it is only possible to impact the Windows build
Testing: PR testing via swift-ci and toolchain build via swift-ci
Reviewer: @compnerd 