### PR TITLE
SIL: Fix false positive in FlowIsolation with DynamicSelfType usage

### DIFF
--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -582,6 +582,12 @@ void AnalysisInfo::analyze(const SILArgument *selfParam) {
   worklist.pushUsesOfValueIfNotVisited(selfParam);
 
   while (Operand *operand = worklist.pop()) {
+    // A type-dependent use of `self` is an instruction that contains the
+    // DynamicSelfType. These instructions do not access any protected
+    // state.
+    if (operand->isTypeDependent())
+      continue;
+
     SILInstruction *user = operand->getUser();
 
     // First, check if this is an apply that involves `self`

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -684,8 +684,7 @@ actor OhBrother {
   static var DefaultResult: Int { 10 }
 
   init() {
-    // expected-note@+2 {{after this closure involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
-    // expected-warning@+1 {{cannot access property 'giver' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    // this is OK: we're using DynamicSelfType but that doesn't access protected state.
     self.giver = { (x: OhBrother) -> Int in Self.DefaultResult }
   }
 


### PR DESCRIPTION
If an instruction references the DynamicSelfType by calling a static member with `Self.foo()`, we consider this a type-dependent use of `self`. This means that at runtime we may need to load the isa pointer, but we don't need to touch any other protected state from the instance.

Therefore, we can skip type-dependent uses in the analysis to avoid false positives in this case.

An existing test case already exercised the overly-conservative behavior, so I just updated it to not expect an error.

Fixes rdar://129676769.