### PR TITLE
[android] do not import stdatomic from android's libc++

### DIFF
--- a/stdlib/public/Platform/SwiftAndroidNDK.h
+++ b/stdlib/public/Platform/SwiftAndroidNDK.h
@@ -24,7 +24,14 @@
 #include <math.h>
 #include <setjmp.h>
 #include <signal.h>
+#ifdef __cplusplus
+// The Android r26 NDK contains an old libc++ modulemap that requires C++23
+// for 'stdatomic', which can't be imported unless we're using C++23. Thus,
+// import stdatomic from the NDK directly, bypassing the stdatomic from the libc++.
+#pragma clang module import _stdatomic
+#else
 #include <stdatomic.h>
+#endif
 #include <stdint.h>
 #include <stdio.h>
 #include <stdio_ext.h>

--- a/stdlib/public/Platform/SwiftBionic.h
+++ b/stdlib/public/Platform/SwiftBionic.h
@@ -24,7 +24,14 @@
 #include <math.h>
 #include <setjmp.h>
 #include <signal.h>
+#ifdef __cplusplus
+// The Android r26 NDK contains an old libc++ modulemap that requires C++23
+// for 'stdatomic', which can't be imported unless we're using C++23. Thus,
+// import stdatomic from the NDK directly, bypassing the stdatomic from the libc++.
+#pragma clang module import _stdatomic
+#else
 #include <stdatomic.h>
+#endif
 #include <stdint.h>
 #include <stdio.h>
 #include <stdio_ext.h>

--- a/test/Interop/Cxx/stdlib/android-and-std-module.swift
+++ b/test/Interop/Cxx/stdlib/android-and-std-module.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -c -cxx-interoperability-mode=default -Xcc -std=c++14 -Xcc -fmodules-cache-path=%t
+// RUN: %target-swift-frontend %s -c -cxx-interoperability-mode=default -Xcc -std=c++17 -Xcc -fmodules-cache-path=%t
+// RUN: %target-swift-frontend %s -c -cxx-interoperability-mode=default -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t
+
+// RUN: find %t | %FileCheck %s
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %s -c -cxx-interoperability-mode=default -Xcc -std=c++17 -Xcc -fmodules-cache-path=%t -DADD_CXXSTDLIB
+// RUN: %target-swift-frontend %s -c -cxx-interoperability-mode=default -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t -DADD_CXXSTDLIB
+
+// REQUIRES: OS=linux-android
+
+import Android
+import Bionic
+
+#if ADD_CXXSTDLIB
+import CxxStdlib
+#endif
+
+func test() {
+#if ADD_CXXSTDLIB
+  let _ = std.string()
+#endif
+}
+
+// CHECK-DAG: Android{{.*}}.pcm
+// CHECK-DAG: std{{.*}}.pcm


### PR DESCRIPTION
android's libc++ uses an older module map that requires C++23 for stdatomic, and thus it fails to compile with anything else

not quite sure why this worked in the initial testing, but after some changes in LLVM/Swift the Android import requires stdatomic not to come from libc++ as it has an outdated requirement.