### PR TITLE
[6.0] PerformanceDiagnostics: avoid false meta-data alarms for non-loadable types

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -366,6 +366,9 @@ public:
   /// address-only. This is the opposite of isLoadable.
   bool isAddressOnly(const SILFunction &F) const;
 
+  /// For details see the comment of `IsFixedABI_t`.
+  bool isFixedABI(const SILFunction &F) const;
+
   /// True if the underlying AST type is trivial, meaning it is loadable and can
   /// be trivially copied, moved or destroyed. Returns false for address types
   /// even though they are technically trivial.

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -450,6 +450,11 @@ bool SILType::isAddressOnly(const SILFunction &F) const {
   return F.getTypeLowering(contextType).isAddressOnly();
 }
 
+bool SILType::isFixedABI(const SILFunction &F) const {
+  auto contextType = hasTypeParameter() ? F.mapTypeIntoContext(*this) : *this;
+  return F.getTypeLowering(contextType).isFixedABI();
+}
+
 SILType SILType::substGenericArgs(SILModule &M, SubstitutionMap SubMap,
                                   TypeExpansionContext context) const {
   auto fnTy = castTo<SILFunctionType>();

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -616,7 +616,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
   case SILInstructionKind::StructElementAddrInst:
   case SILInstructionKind::IndexAddrInst:
     // TODO: hasArchetype() ?
-    if (!inst->getOperand(0)->getType().isLoadable(*inst->getFunction())) {
+    if (!inst->getOperand(0)->getType().isFixedABI(*inst->getFunction())) {
       impactType = inst->getOperand(0)->getType();
       return RuntimeEffect::MetaData;
     }

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -import-objc-header %S/Inputs/perf-annotations.h -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -enable-experimental-feature RawLayout -import-objc-header %S/Inputs/perf-annotations.h -emit-sil %s -o /dev/null -verify
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
@@ -541,4 +541,17 @@ extension G where T == Int {
       takesGInt(self)
     }
   }
+}
+
+public struct RawLayoutWrapper: ~Copyable {
+  private let x = RawLayout<Int>()
+
+  @_noLocks func testit() {
+    x.test()
+  }
+}
+
+@_rawLayout(like: T)
+public struct RawLayout<T>: ~Copyable {
+  public func test() {}
 }


### PR DESCRIPTION
* **Explanation**: This fixes a false performance error when using a type with a `@_rawLayout` attribute. This change adds fixes the check that non-loadable types don't necessarily need metadata.
* **Scope**: Only affects performance diagnostics, i.e. diagnostics for functions which are annotated with `@_noLocks` or `@_noAllocation`.
* **Risk**: very low. The change is trivial and does not impact code generation.
* **Testing**: Tested by a test case
* **Issue**: rdar://129694384, https://github.com/apple/swift/issues/73951
* **Reviewer**:  @jckarter
* **Main branch PR**: https://github.com/apple/swift/pull/74259
