### PR TITLE
[embedded] Respect float arg lowering convention under -mfloat-abi=hard

### DIFF
--- a/test/embedded/float-abi-hard.swift
+++ b/test/embedded/float-abi-hard.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-emit-ir %t/Main.swift -import-bridging-header %t/BridgingHeader.h -parse-as-library -enable-experimental-feature Embedded -wmo \
+// RUN:  -target armv7em-none-none-eabi -Xcc -mthumb -Xcc -mcpu=cortex-m7 -Xcc -mfloat-abi=hard -Xcc -mfpu=fpv5-sp-d16 -Xcc -D__FPU_USED=1 -Xcc -falign-functions=16
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: CODEGENERATOR=ARM
+
+// BEGIN BridgingHeader.h
+
+typedef struct
+{
+  float x;
+  float y;
+  float width;
+  float height;
+} Rect;
+
+typedef void FunctionType(Rect, Rect);
+void (* _Nonnull callback)(FunctionType * _Nonnull func);
+void c_function(Rect, Rect);
+
+// BEGIN Main.swift
+
+@main
+struct Main {
+  static func main() {
+    callback({ a, b in
+      c_function(a, b)
+    })
+  }
+}


### PR DESCRIPTION
In IRGen, when we emit an entry point to a @convention(c) function, we have an assumption that if you have a coersion type that is a StructType, the elements are always supposed to be passed as individual elements of the struct (multiple elements of the explosion). This is not true under `-mfloat-abi=hard`. Let's fix that by only limiting the struct explosion to args that have `AI.getCanBeFlattened() == true`.

Fixes https://github.com/apple/swift/issues/72626

rdar://119725141