### PR TITLE
[6.0] SILGen: ignore unreachable var decls

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -323,7 +323,7 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
 
       // PatternBindingBecls represent local variable bindings that execute
       // as part of the function's execution.
-      if (!isa<PatternBindingDecl>(D)) {
+      if (!isa<PatternBindingDecl>(D) && !isa<VarDecl>(D)) {
         // Other decls define entities that may be used by the program, such as
         // local function declarations. So handle them here, before checking for
         // reachability, and then continue looping.
@@ -428,12 +428,9 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
       SGF.emitIgnoredExpr(E);
     } else {
       auto *D = ESD.get<Decl*>();
-
-      // Only PatternBindingDecls should be emitted here.
-      // Other decls were handled above.
-      auto PBD = cast<PatternBindingDecl>(D);
-
-      SGF.visit(PBD);
+      assert((isa<PatternBindingDecl>(D) || isa<VarDecl>(D)) &&
+             "other decls should be handled before the reachability check");
+      SGF.visit(D);
     }
   }
 }

--- a/test/SILGen/local_decl_after_unreachable.swift
+++ b/test/SILGen/local_decl_after_unreachable.swift
@@ -13,4 +13,6 @@ func foo() {
     // CHECK-LABEL: sil {{.*}} @{{.*}}3foo{{.*}}3bar{{.*}}F : {{.*}} {
     func bar(_: Any) {}
 
+    // Check that we don't crash here
+    lazy var v = 42
 }


### PR DESCRIPTION
* **Explanation**: Fixes a crash in case a lazy var is declared after a return statement. SILGen didn't handle variable declarations correctly if they appear in unreachable code, e.g. after a return statement
* **Scope**: Only affects code where some kind of variable declarations (e.g. lazy variables) appear after a return (or similar) statement.
* **Risk**: low. The change is simple and only affects (unintentionally) unreachable code.
* **Testing**: Tested by a test case
* **Issue**: rdar://129694376, https://github.com/apple/swift/issues/73736
* **Reviewer**:  @jckarter 
* **Main branch PR**: https://github.com/apple/swift/pull/74256