### PR TITLE
[ConsumeAddrChecker] Diagnose consumes of borrows.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -887,10 +887,10 @@ namespace swift {
 /// For convenience, encapsulate and AccessStorage value along with its
 /// accessed base address.
 struct AccessStorageWithBase {
-  /// Identical to AccessStorage::compute but preserves the access base.
+  /// Identical to AccessStorage::computeInScope but walks through begin_access.
   static AccessStorageWithBase compute(SILValue sourceAddress);
 
-  /// Identical to AccessStorage::computeInScope but preserves the base.
+  /// Identical to AccessStorage::compute but stops at begin_access
   static AccessStorageWithBase computeInScope(SILValue sourceAddress);
 
   AccessStorage storage;

--- a/test/SILOptimizer/consume_operator_kills_copyable_addressonly_lets.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_addressonly_lets.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -verify %s -parse-stdlib -emit-sil -o /dev/null
+// RUN: %target-swift-frontend -sil-verify-all -verify %s -parse-stdlib -emit-sil -o /dev/null
 
 
 import Swift
@@ -146,8 +146,8 @@ public func conditionalBadConsumingUseLoop2<T>(_ x: T) {
 // Parameters
 
 // This is ok, no uses after.
-public func simpleMoveOfParameter<T>(_ x: T) -> () {
-    let _ = consume x
+public func simpleMoveOfParameter<T>(_ x: T) -> () { // expected-error {{'x' is borrowed and cannot be consumed}}
+    let _ = consume x // expected-note {{consumed here}}
 }
 
 public func simpleMoveOfOwnedParameter<T>(_ x: __owned T) -> () {
@@ -214,12 +214,12 @@ func consumeOwned<T>(_ k: __owned T) {
   _ = consume k
 }
 
-func consumeShared<T>(_ k: __shared T) {
-  _ = consume k
+func consumeShared<T>(_ k: __shared T) { // expected-error {{'k' is borrowed and cannot be consumed}}
+  _ = consume k // expected-note {{consumed here}}
 }
 
-func consumeBare<T>(_ k: T) {
-  _ = consume k
+func consumeBare<T>(_ k: T) { // expected-error {{'k' is borrowed and cannot be consumed}}
+  _ = consume k // expected-note {{consumed here}}
 }
 
 ////////////////////////
@@ -382,6 +382,20 @@ public func castTestIfLet2(_ x : __owned EnumWithKlass) { // expected-error {{'x
     } else {
         print("no")
     }
+}
+
+enum rdar125817827<A, B> {
+  case a(A)
+  case b(B)
+}
+
+extension rdar125817827 {
+  func foo() { // expected-error {{'self' is borrowed and cannot be consumed}}
+    switch consume self { // expected-note {{consumed here}}
+    case let .a(a): print(a)
+    case let .b(b): print(b)
+    }
+  }
 }
 
 /////////////////////////


### PR DESCRIPTION
When checking a `mark_unresolved_move_addr` instruction, first check whether it is legal to consume the source.

rdar://127518559&125817827
