### PR TITLE
[6.0] Treat references to enum cases with associated values as `@Sendable` functions

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1710,8 +1710,16 @@ FunctionType *ConstraintSystem::adjustFunctionTypeForConcurrency(
       });
 
   if (Context.LangOpts.hasFeature(Feature::InferSendableFromCaptures)) {
+    DeclContext *DC = nullptr;
     if (auto *FD = dyn_cast<AbstractFunctionDecl>(decl)) {
-      auto *DC = FD->getDeclContext();
+      DC = FD->getDeclContext();
+    } else if (auto EED = dyn_cast<EnumElementDecl>(decl)) {
+      if (EED->hasAssociatedValues()) {
+        DC = EED->getDeclContext();
+      }
+    }
+
+    if (DC) {
       // All global functions should be @Sendable
       if (DC->isModuleScopeContext()) {
         if (!adjustedTy->getExtInfo().isSendable()) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1714,7 +1714,8 @@ FunctionType *ConstraintSystem::adjustFunctionTypeForConcurrency(
     if (auto *FD = dyn_cast<AbstractFunctionDecl>(decl)) {
       DC = FD->getDeclContext();
     } else if (auto EED = dyn_cast<EnumElementDecl>(decl)) {
-      if (EED->hasAssociatedValues()) {
+      if (EED->hasAssociatedValues() &&
+          !locator.endsWith<LocatorPathElt::PatternMatch>()) {
         DC = EED->getDeclContext();
       }
     }

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -42,6 +42,7 @@ struct InferredSendableS: P {
 
 enum InferredSendableE: P {
   case a, b
+  case c(Int)
   
   func f() { }
 }
@@ -59,6 +60,13 @@ struct GenericS<T> : P {
 
   func g() async { }
 }
+
+enum GenericE<T> {
+  case a
+  case b(T)
+}
+
+extension GenericE: Sendable where T: Sendable { }
 
 class NonSendable {
   func f() {}
@@ -265,3 +273,9 @@ do {
     true ? nil : c // Ok
   }
 }
+
+func acceptSendableFunc<T, U>(_: @Sendable (T) -> U) { }
+
+acceptSendableFunc(InferredSendableE.c)
+acceptSendableFunc(GenericE<Int>.b)
+acceptSendableFunc(GenericE<NonSendable>.b)

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -279,3 +279,10 @@ func acceptSendableFunc<T, U>(_: @Sendable (T) -> U) { }
 acceptSendableFunc(InferredSendableE.c)
 acceptSendableFunc(GenericE<Int>.b)
 acceptSendableFunc(GenericE<NonSendable>.b)
+
+// Make sure pattern matching isn't affected by @Sendable on cases.
+func testPatternMatch(ge: [GenericE<Int>]) {
+  if case .b(let a) = ge.first {
+    _ = a
+  }
+}


### PR DESCRIPTION
**Explanation**: When `InferSendableFromCaptures`, make sure to treat references to enum cases that have associated values as `@Sendable` functions.
**Original PR**: https://github.com/apple/swift/pull/74362
**Risk**: Low. Improves inference rules for Swift 6, but doesn't affect most code.
