### PR TITLE
Define availability for the 6.0 stdlib & runtime; define placeholder availability for 6.1

### DIFF
--- a/benchmark/single-source/CharacterRecognizer.swift
+++ b/benchmark/single-source/CharacterRecognizer.swift
@@ -13,7 +13,7 @@
 import TestsUtils
 
 public var benchmarks: [BenchmarkInfo] {
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+  guard #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) else {
     return []
   }
   return [
@@ -82,7 +82,7 @@ let _asciiString = #"""
   """#
 let asciiString = String(repeating: _asciiString, count: 10)
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 func run(string: String, n: Int) {
   var state = Unicode._CharacterRecognizer()
   var c = 0

--- a/benchmark/single-source/StringTests.swift
+++ b/benchmark/single-source/StringTests.swift
@@ -14,36 +14,43 @@ import TestsUtils
 @_spi(_Unicode)
 import Swift
 
-public let benchmarks = [
-  BenchmarkInfo(
-    name: "StringEqualPointerComparison",
-    runFunction: run_StringEqualPointerComparison,
-    tags: [.validation, .api, .String]),
-  BenchmarkInfo(
-    name: "StringHasPrefixAscii",
-    runFunction: run_StringHasPrefixAscii,
-    tags: [.validation, .api, .String],
-    legacyFactor: 10),
-  BenchmarkInfo(
-    name: "StringHasPrefixUnicode",
-    runFunction: run_StringHasPrefixUnicode,
-    tags: [.validation, .api, .String],
-    legacyFactor: 1000),
-  BenchmarkInfo(
-    name: "StringHasSuffixAscii",
-    runFunction: run_StringHasSuffixAscii,
-    tags: [.validation, .api, .String],
-    legacyFactor: 10),
-  BenchmarkInfo(
-    name: "StringHasSuffixUnicode",
-    runFunction: run_StringHasSuffixUnicode,
-    tags: [.validation, .api, .String],
-    legacyFactor: 1000),
-  BenchmarkInfo(
-    name: "StringIterateWords",
-    runFunction: run_iterateWords,
-    tags: [.validation, .String]),
-]
+public var benchmarks: [BenchmarkInfo] {
+  var result = [
+    BenchmarkInfo(
+      name: "StringEqualPointerComparison",
+      runFunction: run_StringEqualPointerComparison,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "StringHasPrefixAscii",
+      runFunction: run_StringHasPrefixAscii,
+      tags: [.validation, .api, .String],
+      legacyFactor: 10),
+    BenchmarkInfo(
+      name: "StringHasPrefixUnicode",
+      runFunction: run_StringHasPrefixUnicode,
+      tags: [.validation, .api, .String],
+      legacyFactor: 1000),
+    BenchmarkInfo(
+      name: "StringHasSuffixAscii",
+      runFunction: run_StringHasSuffixAscii,
+      tags: [.validation, .api, .String],
+      legacyFactor: 10),
+    BenchmarkInfo(
+      name: "StringHasSuffixUnicode",
+      runFunction: run_StringHasSuffixUnicode,
+      tags: [.validation, .api, .String],
+      legacyFactor: 1000),
+  ]
+
+  if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
+    result.append(
+      BenchmarkInfo(
+        name: "StringIterateWords",
+        runFunction: run_iterateWords,
+        tags: [.validation, .String]))
+  }
+  return result
+}
 
 // FIXME(string)
 public func run_StringHasPrefixAscii(_ n: Int) {
@@ -1644,11 +1651,8 @@ architecture on Linux.</p>
 
 extension String {
   @inline(never)
-  @available(SwiftStdlib 5.9, *)
+  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   var _words: [Substring] {
-    guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
-      fatalError("Can't run this benchmark")
-    }
     var result: [Substring] = []
     
     var i = startIndex
@@ -1666,6 +1670,7 @@ extension String {
   }
 }
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public func run_iterateWords(_ n: Int) {
   for _ in 0 ..< n {
     blackHole(swiftOrgHTML._words)

--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -64,12 +64,12 @@ FEATURE(ConcurrencyDiscardingTaskGroup,                 (5, 9))
 FEATURE(ConcurrencyDistributedActorWithCustomExecutor,  (5, 9))
 FEATURE(SignedDescriptor,                               (5, 9))
 
-FEATURE(ObjCSymbolicReferences,                         (5, 11))
-FEATURE(TypedThrows,                                    (5, 11))
-FEATURE(StaticReadOnlyArrays,                           (5, 11))
-FEATURE(SwiftExceptionPersonality,                      (5, 11))
+FEATURE(ObjCSymbolicReferences,                         (6, 0))
+FEATURE(TypedThrows,                                    (6, 0))
+FEATURE(StaticReadOnlyArrays,                           (6, 0))
+FEATURE(SwiftExceptionPersonality,                      (6, 0))
 // Metadata support for @isolated(any) function types
-FEATURE(IsolatedAny,                                    (5, 11))
+FEATURE(IsolatedAny,                                    (6, 0))
 
 FEATURE(TaskExecutor,                                   FUTURE)
 FEATURE(Differentiation,                                FUTURE)

--- a/include/swift/AST/RuntimeVersions.def
+++ b/include/swift/AST/RuntimeVersions.def
@@ -138,12 +138,19 @@ RUNTIME_VERSION(
   PLATFORM(xrOS, (1, 0, 0))
 )
 
+END_MAJOR_VERSION(5)
+
+MAJOR_VERSION(6)
+
 RUNTIME_VERSION(
-  (5, 11),
-  FUTURE
+  (6, 0),
+  PLATFORM(macOS,   (15, 0, 0))
+  PLATFORM(iOS,     (18, 0, 0))
+  PLATFORM(watchOS, (11, 0, 0))
+  PLATFORM(xrOS, (2, 0, 0))
 )
 
-END_MAJOR_VERSION(5)
+END_MAJOR_VERSION(6)
 
 // .......................................................................... //
 

--- a/include/swift/AST/RuntimeVersions.def
+++ b/include/swift/AST/RuntimeVersions.def
@@ -150,6 +150,11 @@ RUNTIME_VERSION(
   PLATFORM(xrOS, (2, 0, 0))
 )
 
+RUNTIME_VERSION(
+  (6, 1),
+  FUTURE
+)
+
 END_MAJOR_VERSION(6)
 
 // .......................................................................... //

--- a/stdlib/public/ClangOverlays/float.swift.gyb
+++ b/stdlib/public/ClangOverlays/float.swift.gyb
@@ -25,7 +25,7 @@ public let FLT_RADIX = Double.radix
 //  significand bit, but Swift does not. Neither is really right or wrong.
 @available(swift, deprecated: 3.0, message: "Please use '${type}.significandBitCount + 1'.")
 @available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
-@_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
+@_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MANT_DIG = ${type}.significandBitCount + 1
 
 //  Where does the 1 come from? C models floating-point numbers as having a
@@ -34,32 +34,32 @@ public let ${prefix}_MANT_DIG = ${type}.significandBitCount + 1
 //  as well.
 @available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude.exponent + 1'.")
 @available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
-@_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
+@_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MAX_EXP = ${type}.greatestFiniteMagnitude.exponent + 1
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude.exponent + 1'.")
 @available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
-@_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
+@_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MIN_EXP = ${type}.leastNormalMagnitude.exponent + 1
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude' or '.greatestFiniteMagnitude'.")
 @available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
-@_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
+@_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MAX = ${type}.greatestFiniteMagnitude
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.ulpOfOne' or '.ulpOfOne'.")
 @available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
-@_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
+@_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_EPSILON = ${type}.ulpOfOne
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude' or '.leastNormalMagnitude'.")
 @available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
-@_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
+@_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MIN = ${type}.leastNormalMagnitude
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNonzeroMagnitude' or '.leastNonzeroMagnitude'.")
 @available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
-@_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
+@_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
 
 % if type == "Float80":

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -103,9 +103,11 @@ extension _SwiftStdlibVersion {
   public static var v5_10_0: Self { Self(_value: 0x050A00) }
   @_alwaysEmitIntoClient
   public static var v6_0_0: Self { Self(_value: 0x060000) }
+  @_alwaysEmitIntoClient
+  public static var v6_1_0: Self { Self(_value: 0x060100) }
 
   @available(SwiftStdlib 5.7, *)
-  public static var current: Self { .v6_0_0 }
+  public static var current: Self { .v6_1_0 }
 }
 
 @available(SwiftStdlib 5.7, *)

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -195,7 +195,7 @@ func _willThrowTypedImpl<E: Error>(_ error: E)
 @_alwaysEmitIntoClient
 @_silgen_name("swift_willThrowTyped")
 public func _willThrowTyped<E: Error>(_ error: E) {
-  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999, *) {
+  if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
     _willThrowTypedImpl(error)
   }
 }

--- a/test/ModuleInterface/distributed-actor.swift
+++ b/test/ModuleInterface/distributed-actor.swift
@@ -67,7 +67,7 @@ public distributed actor DAG<ActorSystem> where ActorSystem: DistributedActorSys
 // CHECK:   get
 // CHECK: }
 // CHECK: public init(actorSystem system: ActorSystem)
-// CHECK: @available(iOS 9999, tvOS 9999, watchOS 9999, visionOS 9999, macOS 9999, *)
+// CHECK: @available(iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, macOS 15.0, *)
 // CHECK: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
 // CHECK:   get
 // CHECK: }
@@ -84,7 +84,7 @@ public distributed actor DAG<ActorSystem> where ActorSystem: DistributedActorSys
 // CHECK-NEXT:extension Library.DA : Swift.Decodable {}
 
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
-// CHECK: @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999, *)
+// CHECK: @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 // CHECK-NEXT: extension Library.DAG : Distributed.DistributedActor {}
 
 //--- Client.swift

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -35,7 +35,7 @@ SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0
 SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4
 SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0
 SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1
-SwiftStdlib 6.0:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
+SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
 # TODO: Also update ASTContext::getSwift510Availability when needed
 # TODO: Also update ASTContext::getSwift60Availability when needed
 

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -36,6 +36,7 @@ SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4
 SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0
 SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1
 SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
+SwiftStdlib 6.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
 # TODO: Also update ASTContext::getSwift510Availability when needed
 # TODO: Also update ASTContext::getSwift60Availability when needed
 


### PR DESCRIPTION
This PR updates the Standard Library to resolve `SwiftStdlib 6.0` to the new OS releases that were announced this week:

```
SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
```

It also updates RuntimeVersions.def to define availability for the 6.0 runtime within the compiler.

Additionally, this PR defines stdlib/runtime version 6.1 with placeholder availability, and updates `_SwiftStdlibVersion.current` to report itself as that.