### PR TITLE
Add a proper `TaskGroup.Iterator.next(isolation:)`

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -1211,6 +1211,29 @@ extension TaskGroup: AsyncSequence {
       return element
     }
 
+    /// Advances to and returns the result of the next child task.
+    ///
+    /// The elements returned from this method
+    /// appear in the order that the tasks *completed*,
+    /// not in the order that those tasks were added to the task group.
+    /// After this method returns `nil`,
+    /// this iterator is guaranteed to never produce more values.
+    ///
+    /// For more information about the iteration order and semantics,
+    /// see `TaskGroup.next()`.
+    ///
+    /// - Returns: The value returned by the next child task that completes,
+    ///   or `nil` if there are no remaining child tasks,
+    @available(SwiftStdlib 6.0, *)
+    public mutating func next(isolation actor: isolated (any Actor)?) async -> Element? {
+      guard !finished else { return nil }
+      guard let element = await group.next(isolation: actor) else {
+        finished = true
+        return nil
+      }
+      return element
+    }
+
     public mutating func cancel() {
       finished = true
       group.cancelAll()
@@ -1324,7 +1347,7 @@ extension ThrowingTaskGroup: AsyncSequence {
     public mutating func next(isolation actor: isolated (any Actor)?) async throws(Failure) -> Element? {
       guard !finished else { return nil }
       do {
-        guard let element = try await group.next() else {
+        guard let element = try await group.next(isolation: actor) else {
           finished = true
           return nil
         }

--- a/test/Concurrency/async_sequence_macosx.swift
+++ b/test/Concurrency/async_sequence_macosx.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos14.0 %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14.0 %s -emit-sil -o /dev/null -verify -swift-version 6
 
 // REQUIRES: concurrency, OS=macosx
 
@@ -15,4 +15,14 @@ func f<S: AsyncSequence>(s: S) async throws {
   }
 }
 
-
+// Make sure we don't complain about crossing a concurrency boundary here.
+@MainActor
+class Store<Action: Sendable> {
+    private func intercept(_ action: Action) async {
+        await withTaskGroup(of: Optional<Action>.self) { group in
+            for await case let nextAction? in group {
+                _ = nextAction
+            }
+        }
+    }
+}

--- a/test/Concurrency/async_sequence_macosx.swift
+++ b/test/Concurrency/async_sequence_macosx.swift
@@ -18,11 +18,18 @@ func f<S: AsyncSequence>(s: S) async throws {
 // Make sure we don't complain about crossing a concurrency boundary here.
 @MainActor
 class Store<Action: Sendable> {
-    private func intercept(_ action: Action) async {
+    private func intercept(_ action: Action) async throws {
         await withTaskGroup(of: Optional<Action>.self) { group in
             for await case let nextAction? in group {
                 _ = nextAction
             }
         }
+
+        try await withThrowingTaskGroup(of: Optional<Action>.self) { group in
+            for try await case let nextAction? in group {
+                _ = nextAction
+            }
+        }
+
     }
 }

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -66,6 +66,10 @@ Added: _$sScS8IteratorV4next9isolationxSgScA_pSgYi_tYaF
 // async function pointer to Swift.AsyncStream.Iterator.next(isolation: isolated Swift.Actor?) async -> A?
 Added: _$sScS8IteratorV4next9isolationxSgScA_pSgYi_tYaFTu
 
+// Swift.TaskGroup.Iterator.next(isolation: isolated Swift.Actor?) async -> A?
+Added: _$sScG8IteratorV4next9isolationxSgScA_pSgYi_tYaF
+Added: _$sScG8IteratorV4next9isolationxSgScA_pSgYi_tYaFTu
+
 // Swift.ThrowingTaskGroup.Iterator.next(isolation: isolated Swift.Actor?) async throws(B) -> A?
 Added: _$sScg8IteratorV4next9isolationxSgScA_pSgYi_tYaq_YKF
 
@@ -319,4 +323,3 @@ Added: _$ss9TaskLocalC13withValueImpl_9operation9isolation4file4lineqd__xn_qd__y
 // Swift.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, isolation: isolated Swift.Actor?, file: Swift.String, line: Swift.UInt) async throws -> A1
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlF
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlFTu
-

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -66,6 +66,10 @@ Added: _$sScS8IteratorV4next9isolationxSgScA_pSgYi_tYaF
 // async function pointer to Swift.AsyncStream.Iterator.next(isolation: isolated Swift.Actor?) async -> A?
 Added: _$sScS8IteratorV4next9isolationxSgScA_pSgYi_tYaFTu
 
+// Swift.TaskGroup.Iterator.next(isolation: isolated Swift.Actor?) async -> A?
+Added: _$sScG8IteratorV4next9isolationxSgScA_pSgYi_tYaF
+Added: _$sScG8IteratorV4next9isolationxSgScA_pSgYi_tYaFTu
+
 // Swift.ThrowingTaskGroup.Iterator.next(isolation: isolated Swift.Actor?) async throws(B) -> A?
 Added: _$sScg8IteratorV4next9isolationxSgScA_pSgYi_tYaq_YKF
 


### PR DESCRIPTION
Implement this function to pass the isolation through to the task group's `next(isolation:)`. Fixes rdar://129690995.
