### PR TITLE
[6.0] Sema: Support access-level on imports with cross-import overlays

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -240,7 +240,8 @@ static void printImports(raw_ostream &out,
   // it's not obvious what higher-level optimization would be factored out here.
   ModuleDecl::ImportFilter allImportFilter = {
       ModuleDecl::ImportFilterKind::Exported,
-      ModuleDecl::ImportFilterKind::Default};
+      ModuleDecl::ImportFilterKind::Default,
+      ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay};
 
   // With -experimental-spi-imports:
   // When printing the private or package swiftinterface file, print implementation-only

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1345,6 +1345,13 @@ UnboundImport::UnboundImport(
   if (declaringOptions.contains(ImportFlags::ImplementationOnly) ||
       bystandingOptions.contains(ImportFlags::ImplementationOnly))
     import.options |= ImportFlags::ImplementationOnly;
+  if (declaringOptions.contains(ImportFlags::SPIOnly) ||
+      bystandingOptions.contains(ImportFlags::SPIOnly))
+    import.options |= ImportFlags::SPIOnly;
+
+  // Pick the most restrictive access level.
+  import.accessLevel = std::min(declaringImport.accessLevel,
+                                bystandingImport.accessLevel);
 
   // If either have a `@_documentation(visibility: <access>)` attribute, the
   // cross-import has the more restrictive of the two.

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -404,12 +404,13 @@ static void noteLimitingImport(const Decl *userDecl,
                      limitImport->accessLevel,
                      limitImport->module.importedModule);
 
-    ctx.Diags.diagnose(limitImport->importLoc,
-                       diag::decl_import_via_here,
-                       VD,
-                       limitImport->accessLevel,
-                       limitImport->module.importedModule);
-  } else {
+    if (limitImport->importLoc.isValid())
+      ctx.Diags.diagnose(limitImport->importLoc,
+                         diag::decl_import_via_here,
+                         VD,
+                         limitImport->accessLevel,
+                         limitImport->module.importedModule);
+  } else if (limitImport->importLoc.isValid()) {
     ctx.Diags.diagnose(limitImport->importLoc, diag::module_imported_here,
                        limitImport->module.importedModule,
                        limitImport->accessLevel);

--- a/test/CrossImport/access-level-imports-errors.swift
+++ b/test/CrossImport/access-level-imports-errors.swift
@@ -1,0 +1,68 @@
+/// Check semantic verification cross-import overlays with non-public imports.
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/lib-templates/* %t/
+// RUN: split-file --leading-lines %s %t
+
+//--- BothPublic.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/BothPublic.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+
+public import DeclaringLibrary
+public import BystandingLibrary
+
+public func fn(_: OverlayLibraryTy) {}
+
+
+//--- BothHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/BothHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary -verify
+
+internal import DeclaringLibrary
+internal import BystandingLibrary
+
+public func fn(_: OverlayLibraryTy) {}
+// expected-error @-1 {{function cannot be declared public because its parameter uses an internal type}}
+// expected-note @-2 {{struct 'OverlayLibraryTy' is imported by this file as 'internal' from '_OverlayLibrary'}}
+
+
+//--- FirstHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/FirstHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary -verify
+
+internal import DeclaringLibrary
+public import BystandingLibrary // expected-warning {{public import of 'BystandingLibrary' was not used in public declarations or inlinable code}}
+
+public func fn(_: OverlayLibraryTy) {}
+// expected-error @-1 {{function cannot be declared public because its parameter uses an internal type}}
+// expected-note @-2 {{struct 'OverlayLibraryTy' is imported by this file as 'internal' from '_OverlayLibrary'}}
+
+
+//--- SecondHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/SecondHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary -verify
+
+public import DeclaringLibrary // expected-warning {{public import of 'DeclaringLibrary' was not used in public declarations or inlinable code}}
+internal import BystandingLibrary
+
+public func fn(_: OverlayLibraryTy) {}
+// expected-error @-1 {{function cannot be declared public because its parameter uses an internal type}}
+// expected-note @-2 {{struct 'OverlayLibraryTy' is imported by this file as 'internal' from '_OverlayLibrary'}}
+
+
+//--- PrivateVsInternal.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/PrivateVsInternal.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary -verify
+
+private import DeclaringLibrary
+internal import BystandingLibrary
+
+internal func fn(_: OverlayLibraryTy) {}
+// expected-error @-1 {{function cannot be declared internal because its parameter uses a private type}}
+// expected-note @-2 {{struct 'OverlayLibraryTy' is imported by this file as 'private' from '_OverlayLibrary'}}
+
+
+//--- InternalVsPrivate.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/InternalVsPrivate.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary -verify
+
+internal import DeclaringLibrary
+private import BystandingLibrary
+
+internal func fn(_: OverlayLibraryTy) {}
+// expected-error @-1 {{function cannot be declared internal because its parameter uses a private type}}
+// expected-note @-2 {{struct 'OverlayLibraryTy' is imported by this file as 'private' from '_OverlayLibrary'}}

--- a/test/CrossImport/module-interface.swift
+++ b/test/CrossImport/module-interface.swift
@@ -10,7 +10,6 @@
 // RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
 // RUN: %FileCheck %s < %t.swiftinterface
-// RUN: %FileCheck -check-prefix NEGATIVE %s < %t.swiftinterface
 
 //
 // Should fail with -disable-cross-import-overlays
@@ -38,9 +37,9 @@ public func shadow(_: DeclaringLibrary.ShadowTy, _: ShadowTy) {}
 // CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
 
 // CHECK-DAG: import Swift
+// CHECK-DAG: import DeclaringLibrary
 // CHECK-DAG: import BystandingLibrary
 // CHECK-DAG: import _OverlayLibrary
-// NEGATIVE-NOT: import DeclaringLibrary
 
 // CHECK-DAG: public func fn(_: DeclaringLibrary.DeclaringLibraryTy, _: BystandingLibrary.BystandingLibraryTy, _: _OverlayLibrary.OverlayLibraryTy)
 // CHECK-DAG: public func alias(_: _OverlayLibrary.OverlayLibraryTy)

--- a/test/CrossImport/with-access-level-import.swift
+++ b/test/CrossImport/with-access-level-import.swift
@@ -1,0 +1,71 @@
+/// Check cross-import overlays with non-public imports.
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/lib-templates/* %t/
+// RUN: split-file --leading-lines %s %t
+
+//--- BothPublic.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/BothPublic.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/BothPublic.swift < %t.swiftinterface
+
+public import DeclaringLibrary
+public import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// CHECK-DAG: import DeclaringLibrary
+// CHECK-DAG: import BystandingLibrary
+// CHECK-DAG: import _OverlayLibrary
+
+
+//--- BothHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/BothHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/BothHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefix NEGATIVE %t/BothHidden.swift < %t.swiftinterface
+
+internal import DeclaringLibrary
+internal import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// NEGATIVE-NOT: import DeclaringLibrary
+// NEGATIVE-NOT: import BystandingLibrary
+// NEGATIVE-NOT: import _OverlayLibrary
+
+
+//--- FirstHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/FirstHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/FirstHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefix NEGATIVE %t/FirstHidden.swift < %t.swiftinterface
+
+internal import DeclaringLibrary
+public import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// CHECK-DAG: import BystandingLibrary
+// NEGATIVE-NOT: import DeclaringLibrary
+// NEGATIVE-NOT: import _OverlayLibrary
+
+
+//--- SecondHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/SecondHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/SecondHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefix NEGATIVE %t/SecondHidden.swift < %t.swiftinterface
+
+public import DeclaringLibrary
+internal import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// CHECK-DAG: import DeclaringLibrary
+// NEGATIVE-NOT: import BystandingLibrary
+// NEGATIVE-NOT: import _OverlayLibrary

--- a/test/CrossImport/with-implementation-only.swift
+++ b/test/CrossImport/with-implementation-only.swift
@@ -1,0 +1,71 @@
+/// Check cross-import overlays with @_implementationOnly imports.
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/lib-templates/* %t/
+// RUN: split-file --leading-lines %s %t
+
+//--- BothPublic.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/BothPublic.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/BothPublic.swift < %t.swiftinterface
+
+import DeclaringLibrary
+import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// CHECK-DAG: import DeclaringLibrary
+// CHECK-DAG: import BystandingLibrary
+// CHECK-DAG: import _OverlayLibrary
+
+
+//--- BothHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/BothHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/BothHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefix NEGATIVE %t/BothHidden.swift < %t.swiftinterface
+
+@_implementationOnly import DeclaringLibrary
+@_implementationOnly import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// NEGATIVE-NOT: import DeclaringLibrary
+// NEGATIVE-NOT: import BystandingLibrary
+// NEGATIVE-NOT: import _OverlayLibrary
+
+
+//--- FirstHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/FirstHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/FirstHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefix NEGATIVE %t/FirstHidden.swift < %t.swiftinterface
+
+@_implementationOnly import DeclaringLibrary
+import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// CHECK-DAG: import BystandingLibrary
+// NEGATIVE-NOT: import DeclaringLibrary
+// NEGATIVE-NOT: import _OverlayLibrary
+
+
+//--- SecondHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/SecondHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/SecondHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefix NEGATIVE %t/SecondHidden.swift < %t.swiftinterface
+
+import DeclaringLibrary
+@_implementationOnly import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// CHECK-DAG: import DeclaringLibrary
+// NEGATIVE-NOT: import BystandingLibrary
+// NEGATIVE-NOT: import _OverlayLibrary

--- a/test/CrossImport/with-spi-only-import.swift
+++ b/test/CrossImport/with-spi-only-import.swift
@@ -1,0 +1,86 @@
+/// Check cross-import overlays with @_spiOnly imports.
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/lib-templates/* %t/
+// RUN: split-file --leading-lines %s %t
+
+//--- BothPublic.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/BothPublic.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary -emit-private-module-interface-path %t.private.swiftinterface -swift-version 6
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.private.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/BothPublic.swift < %t.swiftinterface
+// RUN: %FileCheck %t/BothPublic.swift < %t.private.swiftinterface
+
+import DeclaringLibrary
+import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// CHECK-DAG: import DeclaringLibrary
+// CHECK-DAG: import BystandingLibrary
+// CHECK-DAG: import _OverlayLibrary
+
+
+//--- BothHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/BothHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary -emit-private-module-interface-path %t.private.swiftinterface -swift-version 6
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.private.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/BothHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefix NEGATIVE %t/BothHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefixes CHECK,PRIVATE %t/BothHidden.swift < %t.private.swiftinterface
+
+@_spiOnly import DeclaringLibrary
+@_spiOnly import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// NEGATIVE-NOT: import DeclaringLibrary
+// NEGATIVE-NOT: import BystandingLibrary
+// NEGATIVE-NOT: import _OverlayLibrary
+// PRIVATE-DAG: import DeclaringLibrary
+// PRIVATE-DAG: import BystandingLibrary
+// PRIVATE-DAG: import _OverlayLibrary
+
+
+//--- FirstHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/FirstHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary -emit-private-module-interface-path %t.private.swiftinterface -swift-version 6
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.private.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/FirstHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefix NEGATIVE %t/FirstHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefixes CHECK,PRIVATE %t/FirstHidden.swift < %t.private.swiftinterface
+
+@_spiOnly import DeclaringLibrary
+import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// CHECK-DAG: import BystandingLibrary
+// NEGATIVE-NOT: import DeclaringLibrary
+// NEGATIVE-NOT: import _OverlayLibrary
+// PRIVATE-DAG: import DeclaringLibrary
+// PRIVATE-DAG: import _OverlayLibrary
+
+
+//--- SecondHidden.swift
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/SecondHidden.swift -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary -emit-private-module-interface-path %t.private.swiftinterface -swift-version 6
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.private.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %FileCheck %t/SecondHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefix NEGATIVE %t/SecondHidden.swift < %t.swiftinterface
+// RUN: %FileCheck -check-prefixes CHECK,PRIVATE %t/SecondHidden.swift < %t.private.swiftinterface
+
+import DeclaringLibrary
+@_spiOnly import BystandingLibrary
+
+// CHECK: // swift-interface-format-version
+// CHECK: // swift-module-flags: {{.*}} -module-name ClientLibrary
+// CHECK-DAG: import Swift
+// CHECK-DAG: import DeclaringLibrary
+// NEGATIVE-NOT: import BystandingLibrary
+// NEGATIVE-NOT: import _OverlayLibrary
+// PRIVATE-DAG: import BystandingLibrary
+// PRIVATE-DAG: import _OverlayLibrary


### PR DESCRIPTION
Add support for access-level on imports and `@_spiOnly` imports to cross-import overlays. The overlay inherits the most restrictive import access-level of the declaring module and the bystander module, and any `@_spiOnly`-ness. These are applied in type-checking and at printing the module interface.

Also print the import of declaring module as it may be needed when the overlay module is hidden. Hiding that import was by design as it is also imported by the cross-import overlay, however printing it should preserve the current behavior and fix a bug in the logic printing imports in module interfaces.

- Scope: Affects clients of cross-import overlays combined with access-level on imports or `@_spiOnly` imports.
- Risk: Low, this should report early potentially SDK breaking issues already caught later by other systems.
- Reviewed by @artemcm and @tshortli
- Cherry-pick of https://github.com/apple/swift/pull/74351
- Resolves rdar://129606112