### PR TITLE
[6.0] MoveOnlyAddressChecker: Turn assertion into early exit.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2933,13 +2933,13 @@ bool GlobalLivenessChecker::testInstVectorLiveness(
           continue;
         case IsLive::LiveOut: {
           LLVM_DEBUG(llvm::dbgs() << "    Live out block!\n");
-          // If we see a live out block that is also a def block, we need to fa
-#ifndef NDEBUG
+          // If we see a live out block that is also a def block, skip.
           SmallBitVector defBits(addressUseState.getNumSubelements());
           liveness.isDefBlock(block, errorSpan, defBits);
-          assert((defBits & errorSpan).none() &&
-                 "If in def block... we are in liveness block");
-#endif
+          if (!(defBits & errorSpan).none()) {
+            LLVM_DEBUG(llvm::dbgs() << "    Also a def block; skipping!\n");
+            continue;
+          }
           [[clang::fallthrough]];
         }
         case IsLive::LiveWithin:

--- a/test/SILOptimizer/moveonly_addresschecker_branch_order.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_branch_order.swift
@@ -1,0 +1,26 @@
+//RUN: %target-swift-frontend -emit-sil -verify %s
+
+@_silgen_name("cond")
+func cond() -> Bool
+
+struct Foo: ~Copyable {}
+
+func consume(_: consuming Foo) {}
+
+func test1(_ x: inout Foo, _ y: consuming Foo) { // expected-error{{missing reinitialization}}
+    consume(x) // expected-note{{consumed here}}
+    if cond() {
+        return
+    } else {
+        x = y
+    }
+}
+
+func test2(_ x: inout Foo, _ y: consuming Foo) { // expected-error{{missing reinitialization}}
+    consume(x) // expected-note{{consumed here}}
+    if cond() {
+        x = y
+    } else {
+        return
+    }
+}


### PR DESCRIPTION
Explanation: Fixes a crash-on-invalid when an `inout` parameter is consumed but is only initialized on some but not all subsequent conditional paths that appear in a certain order.
Scope: Bug fix.
Issue: rdar://123604613
Original PR: https://github.com/apple/swift/pull/74374
Risk: Low. Removes an assertion and replaces it with control flow skipping the case.
Testing: Swift CI, test case from bug report
Reviewer: @gottesmm 