### PR TITLE
[6.0] embedded: add swift_dynamicCastClass runtime function

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -165,6 +165,20 @@ func swift_initStackObject(metadata: UnsafeMutablePointer<ClassMetadata>, object
 public func swift_setDeallocating(object: Builtin.RawPointer) {
 }
 
+@_cdecl("swift_dynamicCastClass")
+public func swift_dynamicCastClass(object: UnsafeMutableRawPointer, targetMetadata: UnsafeRawPointer) -> UnsafeMutableRawPointer? {
+  let sourceObj = object.assumingMemoryBound(to: HeapObject.self)
+  var type = _swift_embedded_get_heap_object_metadata_pointer(sourceObj).assumingMemoryBound(to: ClassMetadata.self)
+  let targetType = targetMetadata.assumingMemoryBound(to: ClassMetadata.self)
+  while type != targetType {
+    guard let superType = type.pointee.superclassMetadata else {
+      return nil
+    }
+    type = UnsafeMutablePointer(superType)
+  }
+  return object
+}
+
 @_cdecl("swift_isUniquelyReferenced_native")
 public func swift_isUniquelyReferenced_native(object: Builtin.RawPointer) -> Bool {
   if Int(Builtin.ptrtoint_Word(object)) == 0 { return false }

--- a/test/embedded/classes.swift
+++ b/test/embedded/classes.swift
@@ -15,15 +15,32 @@ class MyClass {
 }
 
 class MySubClass: MyClass {
+  var x = 27
+
   override init() { print("MySubClass.init") }
   deinit { print("MySubClass.deinit") }
   override func foo() { print("MySubClass.foo") }
+
+  func printX() {
+    print(x)
+  }
 }
 
 class MySubSubClass: MySubClass {
   override init() { print("MySubSubClass.init") }
   deinit { print("MySubSubClass.deinit") }
   override func foo() { print("MySubSubClass.foo") }
+}
+
+class OtherSubClass: MyClass {}
+
+func testCasting(_ title: StaticString, _ c: MyClass) {
+  print(title, terminator: "")
+  if let s = c as? MySubClass {
+    s.printX()
+  } else {
+    print("-")
+  }
 }
 
 @main
@@ -69,5 +86,14 @@ struct Main {
     // CHECK: MySubClass.deinit
     // CHECK: MyClass.deinit
     print("")
+
+    // CHECK: base: -
+    testCasting("base: ", MyClass())
+    // CHECK: sub: 27
+    testCasting("sub: ", MySubClass())
+    // CHECK: subsub: 27
+    testCasting("subsub: ", MySubSubClass())
+    // CHECK: other: -
+    testCasting("other: ", OtherSubClass())
   }
 }


### PR DESCRIPTION
* **Explanation**: Fixes a linker error when doing a dynamic class down cast. The `swift_dynamicCastClass` runtime function was missing.
* **Scope**: Only affects embedded swift.
* **Risk**: very low. There is no change in existing code. Just the new runtime function is added.
* **Testing**: Tested by a test case
* **Issue**: rdar://129672994
* **Reviewer**:  @kubamracek 
* **Main branch PR**: https://github.com/apple/swift/pull/74332
