### PR TITLE
[cxx-interop] Fix generated declaration order

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -20,6 +20,7 @@
 #include "PrintSwiftToClangCoreScaffold.h"
 #include "SwiftToClangInteropContext.h"
 
+#include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Module.h"
@@ -671,6 +672,15 @@ public:
         llvm_unreachable("unknown top-level ObjC decl");
       };
 
+      // When we visit a function, we might also generate a thunk that calls into the
+      // implementation of structs/enums to get the opaque pointers. To avoid
+      // referencing these methods before we see the definition for the generated
+      // classes, we want to visit function definitions last.
+      if (isa<AbstractFunctionDecl>(*rhs) && isa<NominalTypeDecl>(*lhs))
+        return Descending;
+      if (isa<AbstractFunctionDecl>(*lhs) && isa<NominalTypeDecl>(*rhs))
+        return Ascending;
+
       // Sort by names.
       int result = getSortName(*rhs).compare(getSortName(*lhs));
       if (result != 0)
@@ -700,9 +710,9 @@ public:
       // even when the variable might not actually be emitted by the emitter.
       // In that case, order the function before the variable.
       if (isa<AbstractFunctionDecl>(*rhs) && isa<VarDecl>(*lhs))
-        return 1;
+        return Descending;
       if (isa<AbstractFunctionDecl>(*lhs) && isa<VarDecl>(*rhs))
-        return -1;
+        return Ascending;
 
       // Prefer value decls to extensions.
       assert(!(isa<ValueDecl>(*lhs) && isa<ValueDecl>(*rhs)));

--- a/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
@@ -102,13 +102,13 @@ public final class ClassWithIntField {
 // CHECK-EMPTY:
 // CHECK-NEXT: namespace Class SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Class") {
 
-// CHECK: SWIFT_INLINE_THUNK ClassWithIntField passThroughClassWithIntField(const ClassWithIntField& x) noexcept SWIFT_SYMBOL("s:5Class011passThroughA12WithIntFieldyAA0adeF0CADF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_ClassWithIntField::makeRetained(_impl::$s5Class011passThroughA12WithIntFieldyAA0adeF0CADF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x)));
-// CHECK-NEXT: }
-
 public final class register { }
 
 // CHECK: class SWIFT_SYMBOL("s:5Class8registerC") register_ final : public swift::_impl::RefCountedClass {
+
+// CHECK: SWIFT_INLINE_THUNK ClassWithIntField passThroughClassWithIntField(const ClassWithIntField& x) noexcept SWIFT_SYMBOL("s:5Class011passThroughA12WithIntFieldyAA0adeF0CADF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:  return _impl::_impl_ClassWithIntField::makeRetained(_impl::$s5Class011passThroughA12WithIntFieldyAA0adeF0CADF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x)));
+// CHECK-NEXT: }
 
 public func returnClassWithIntField() -> ClassWithIntField {
   return ClassWithIntField()

--- a/test/Interop/SwiftToCxx/functions/swift-operators.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-operators.swift
@@ -2,9 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Operators -clang-header-expose-decls=all-public -emit-clang-header-path %t/operators.h
 // RUN: %FileCheck %s < %t/operators.h
 
-// TODO: %check-interop-cxx-header-in-clang(%t/operators.h)
-// unfortunately the header still triggers an error:
-//   error: no member named '_impl_IntBox' in namespace 'Operators::_impl'
+// RUN: %check-interop-cxx-header-in-clang(%t/operators.h)
 
 // CHECK-LABEL: namespace Operators SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Operators") {
 


### PR DESCRIPTION
The generated thunks for functions can refer to some internal methods of their arguments. As a result, those generated thunks should always be after the definitions of the corresponding argument types. The printer ordered the declarations by name, and Swift had the convention starting types with upper case letters and functions with lower case letters. This naming convention together with the ordering resulted in the correct ordering in most of the cases. There were a couple of exceptions when people diverged from the naming conventions or wanted to export operators. This patch fixes this problem by always ordering type decls before function decls.

rdar://129276354
