### PR TITLE
[Sema] Requestify pattern resolution

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2527,6 +2527,33 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Perform top-down syntactic disambiguation of a pattern. Where ambiguous
+/// expr/pattern productions occur (tuples, function calls, etc.), favor the
+/// pattern interpretation if it forms a valid pattern; otherwise, leave it as
+/// an expression. This does no type-checking except for the bare minimum to
+/// disambiguate semantics-dependent pattern forms.
+///
+/// Currently cached to ensure the constraint system does not resolve the same
+/// pattern multiple times along different solver paths. Once we move pattern
+/// resolution into pre-checking, we could make this uncached.
+class ResolvePatternRequest
+    : public SimpleRequest<ResolvePatternRequest,
+                           Pattern *(Pattern *, DeclContext *, bool),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  Pattern *evaluate(Evaluator &evaluator, Pattern *P, DeclContext *DC,
+                    bool isStmtCondition) const;
+public:
+  // Cached.
+  bool isCached() const { return true; }
+};
+
 class InterfaceTypeRequest :
     public SimpleRequest<InterfaceTypeRequest,
                          Type (ValueDecl *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -248,6 +248,9 @@ SWIFT_REQUEST(TypeChecker, ExprPatternMatchRequest,
 SWIFT_REQUEST(TypeChecker, EnumElementExprPatternRequest,
               ExprPattern *(const EnumElementPattern *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ResolvePatternRequest,
+              Pattern *(Pattern *, DeclContext *, bool),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, OpaqueReadOwnershipRequest,
               OpaqueReadOwnership(AbstractStorageDecl *), SeparatelyCached,
               NoLocationInfo)

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -624,13 +624,9 @@ public:
 
 } // end anonymous namespace
 
-/// Perform top-down syntactic disambiguation of a pattern. Where ambiguous
-/// expr/pattern productions occur (tuples, function calls, etc.), favor the
-/// pattern interpretation if it forms a valid pattern; otherwise, leave it as
-/// an expression. This does no type-checking except for the bare minimum to
-/// disambiguate semantics-dependent pattern forms.
-Pattern *TypeChecker::resolvePattern(Pattern *P, DeclContext *DC,
-                                     bool isStmtCondition) {
+Pattern *ResolvePatternRequest::evaluate(Evaluator &evaluator, Pattern *P,
+                                         DeclContext *DC,
+                                         bool isStmtCondition) const {
   P = ResolvePattern(DC).visit(P);
 
   TypeChecker::diagnoseDuplicateBoundVars(P);
@@ -689,6 +685,13 @@ Pattern *TypeChecker::resolvePattern(Pattern *P, DeclContext *DC,
   }
 
   return P;
+}
+
+Pattern *TypeChecker::resolvePattern(Pattern *P, DeclContext *DC,
+                                     bool isStmtCondition) {
+  auto &eval = DC->getASTContext().evaluator;
+  return evaluateOrDefault(eval, ResolvePatternRequest{P, DC, isStmtCondition},
+                           nullptr);
 }
 
 static Type

--- a/validation-test/IDE/crashers_2_fixed/rdar128661960.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar128661960.swift
@@ -1,0 +1,10 @@
+// RUN: %batch-code-completion
+
+func takeClosure(closure: () -> Bool) {}
+
+func test(someLocal: Int) {
+  takeClosure {
+    if case .begin(#^COMPLETE^#)
+  }
+}
+// COMPLETE: someLocal

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar92327807.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar92327807.swift
@@ -18,13 +18,13 @@ func test(result: MyEnum, optResult: MyEnum?) {
   }
 
   let _ = {
-    if let .co = result { // expected-error 2 {{pattern matching in a condition requires the 'case' keyword}}
+    if let .co = result { // expected-error {{pattern matching in a condition requires the 'case' keyword}}
       // expected-error@-1 {{type 'MyEnum' has no member 'co'}}
     }
   }
 
   let _ = {
-    if let .co = optResult { // expected-error 2 {{pattern matching in a condition requires the 'case' keyword}}
+    if let .co = optResult { // expected-error {{pattern matching in a condition requires the 'case' keyword}}
       // expected-error@-1 {{type 'MyEnum?' has no member 'co'}}
     }
   }


### PR DESCRIPTION
Add a cached request to perform pattern resolution. This is needed to prevent the constraint system from resolving the same pattern multiple times along different solver paths, which could result in creating different pattern nodes for each path. Once pattern resolution is moved to pre-checking we ought to be able to make this uncached.

rdar://128661960