### PR TITLE
[6.0🍒] SE-427: Make conditional conformances to Copyable more explicit.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7750,6 +7750,9 @@ ERROR(suppress_nonsuppressable_protocol,none,
       "conformance to %0 cannot be suppressed", (const ProtocolDecl *))
 WARNING(suppress_already_suppressed_protocol,none,
       "already suppressed conformance to %0", (const ProtocolDecl *))
+ERROR(extension_conforms_to_invertible_and_others, none,
+      "conformance to '%0' must be declared in a separate extension",
+      (StringRef))
 
 // -- older ones below --
 ERROR(noncopyable_parameter_requires_ownership, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7681,8 +7681,8 @@ ERROR(inverse_conflicts_explicit_composition, none,
       "composition cannot contain '~%0' when another member requires '%0'",
       (StringRef))
 ERROR(inverse_extension, none,
-      "cannot suppress %0 in extension",
-      (Type))
+      "cannot suppress '%0' in extension",
+      (StringRef))
 ERROR(copyable_illegal_deinit, none,
       "deinitializer cannot be declared in %kind0 that conforms to 'Copyable'",
       (const ValueDecl *))

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2920,6 +2920,7 @@ static bool isExtensionAddingInvertibleConformance(const ExtensionDecl *ext) {
   auto conformances = ext->getLocalConformances();
   for (auto *conf : conformances) {
     if (conf->getProtocol()->getInvertibleProtocolKind()) {
+      assert(conformances.size() == 1 && "expected solo conformance");
       return true;
     }
   }

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -782,7 +782,6 @@ InferredGenericSignatureRequest::evaluate(
 
   unsigned numOuterParams = genericParams.size();
   if (isExtension) {
-    assert(allowInverses);
     numOuterParams = 0;
   }
 

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -801,7 +801,7 @@ public:
   }
 
   /// If there were any conditional conformances that couldn't be printed,
-  /// make a dummy extension that conforms to all of them, constrained by a
+  /// make dummy extension(s) that conforms to all of them, constrained by a
   /// fake protocol.
   bool printInaccessibleConformanceExtensionIfNeeded(
       raw_ostream &out, const PrintOptions &printOptions,
@@ -810,20 +810,35 @@ public:
       return false;
     assert(nominal->isGenericContext());
 
-    if (!printOptions.printPublicInterface())
-      out << "@_spi(" << DummyProtocolName << ")\n";
-    out << "@available(*, unavailable)\nextension ";
-    nominal->getDeclaredType().print(out, printOptions);
-    out << " : ";
-    llvm::interleave(
-        ConditionalConformanceProtocols,
-        [&out, &printOptions](const ProtocolType *protoTy) {
-          protoTy->print(out, printOptions);
-        },
-        [&out] { out << ", "; });
-    out << " where "
-        << nominal->getGenericSignature().getGenericParams().front()->getName()
-        << " : " << DummyProtocolName << " {}\n";
+    auto emitExtension =
+        [&](ArrayRef<const ProtocolType *> conformanceProtos) {
+      if (!printOptions.printPublicInterface())
+        out << "@_spi(" << DummyProtocolName << ")\n";
+      out << "@available(*, unavailable)\nextension ";
+      nominal->getDeclaredType().print(out, printOptions);
+      out << " : ";
+      llvm::interleave(
+          conformanceProtos,
+          [&out, &printOptions](const ProtocolType *protoTy) {
+            protoTy->print(out, printOptions);
+          },
+          [&out] { out << ", "; });
+      out << " where "
+          << nominal->getGenericSignature().getGenericParams()[0]->getName()
+          << " : " << DummyProtocolName << " {}\n";
+    };
+
+    // We have to print conformances for invertible protocols in separate
+    // extensions, so do those first and save the rest for one extension.
+    SmallVector<const ProtocolType *, 8> regulars;
+    for (auto *proto : ConditionalConformanceProtocols) {
+      if (proto->getDecl()->getInvertibleProtocolKind()) {
+        emitExtension(proto);
+        continue;
+      }
+      regulars.push_back(proto);
+    }
+    emitExtension(regulars);
     return true;
   }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -295,10 +295,15 @@ static void checkInheritanceClause(
       auto layout = inheritedTy->getExistentialLayout();
 
       // An inverse on an extension is an error.
-      if (isa<ExtensionDecl>(decl))
-        if (auto pct = inheritedTy->getAs<ProtocolCompositionType>())
-          if (!pct->getInverses().empty())
-            decl->diagnose(diag::inverse_extension, inheritedTy);
+      if (isa<ExtensionDecl>(decl)) {
+        auto canInheritedTy = inheritedTy->getCanonicalType();
+        if (auto pct = canInheritedTy->getAs<ProtocolCompositionType>()) {
+          for (auto inverse : pct->getInverses()) {
+            decl->diagnose(diag::inverse_extension,
+                           getProtocolName(getKnownProtocolKind(inverse)));
+          }
+        }
+      }
 
       // Subclass existentials are not allowed except on classes and
       // non-@objc protocols.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -687,6 +687,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
   SmallVector<TypeBase *, 2> inferenceSources;
   SmallVector<Requirement, 2> extraReqs;
   SourceLoc loc;
+  bool inferInvertibleReqs = true;
 
   if (auto VD = dyn_cast<ValueDecl>(GC->getAsDecl())) {
     loc = VD->getLoc();
@@ -784,6 +785,35 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
   } else if (auto *ext = dyn_cast<ExtensionDecl>(GC)) {
     loc = ext->getLoc();
 
+    // The inherited entries influence the generic signature of the extension,
+    // because if it introduces conformance to invertible protocol IP, we do not
+    // we do not infer any requirements that the generic parameters to conform
+    // to invertible protocols. This forces people to write out the conditions.
+    const unsigned numEntries = ext->getInherited().size();
+    for (unsigned i = 0; i < numEntries; ++i) {
+      InheritedTypeRequest request{ext, i, TypeResolutionStage::Structural};
+      auto result = evaluateOrDefault(ctx.evaluator, request,
+                                      InheritedTypeResult::forDefault());
+      Type inheritedTy;
+      switch (result) {
+      case InheritedTypeResult::Inherited:
+        inheritedTy = result.getInheritedType();
+        break;
+      case InheritedTypeResult::Suppressed:
+      case InheritedTypeResult::Default:
+        continue;
+      }
+
+      if (inheritedTy) {
+        if (auto kp = inheritedTy->getKnownProtocol()) {
+          if (getInvertibleProtocolKind(*kp)) {
+            inferInvertibleReqs = false;
+            break;
+          }
+        }
+      }
+    }
+
     collectAdditionalExtensionRequirements(ext->getExtendedType(), extraReqs);
 
     auto *extendedNominal = ext->getExtendedNominal();
@@ -815,7 +845,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
       genericParams, WhereClauseOwner(GC),
       extraReqs, inferenceSources, loc,
       /*isExtension=*/isa<ExtensionDecl>(GC),
-      /*allowInverses=*/true};
+      /*allowInverses=*/inferInvertibleReqs};
   return evaluateOrDefault(ctx.evaluator, request,
                            GenericSignatureWithError()).getPointer();
 }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -132,7 +132,7 @@ public enum Optional<Wrapped: ~Copyable>: ~Copyable {
   case some(Wrapped)
 }
 
-extension Optional: Copyable /* where Wrapped: Copyable */ {}
+extension Optional: Copyable where Wrapped: Copyable {}
 
 extension Optional: Sendable where Wrapped: ~Copyable & Sendable { }
 

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -21,7 +21,7 @@ public enum Result<Success: ~Copyable, Failure: Error> {
   case failure(Failure)
 }
 
-extension Result: Copyable /* where Success: Copyable */ {}
+extension Result: Copyable where Success: Copyable {}
 
 extension Result: Sendable where Success: Sendable & ~Copyable {}
 

--- a/test/Generics/inverse_conditional_conformance_restriction.swift
+++ b/test/Generics/inverse_conditional_conformance_restriction.swift
@@ -7,12 +7,15 @@ protocol Q {}
 class DoggoClass {}
 
 struct Blah<T: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {}
-extension Blah: Copyable {} // expected-error {{conditional conformance to suppressible protocol 'Copyable' cannot depend on 'T: Escapable'}}
-extension Blah: Escapable {} // expected-error {{conditional conformance to suppressible protocol 'Escapable' cannot depend on 'T: Copyable'}}
+extension Blah: Copyable where T: Copyable & Escapable {}
+// expected-error@-1 {{conditional conformance to suppressible protocol 'Copyable' cannot depend on 'T: Escapable'}}
 
-struct Yuck<T: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {}
-extension Yuck: Copyable where T: ~Escapable {}
-extension Yuck: Escapable where T: ~Copyable {}
+extension Blah: Escapable where T: Copyable, T: Escapable {}
+// expected-error@-1 {{conditional conformance to suppressible protocol 'Escapable' cannot depend on 'T: Copyable'}}
+
+struct Fixed<T: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {}
+extension Fixed: Copyable where T: Copyable {}
+extension Fixed: Escapable where T: Escapable {}
 
 struct TryConformance<Whatever: ~Copyable>: ~Copyable {}
 extension TryConformance: Copyable

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -2,11 +2,26 @@
 // RUN: -enable-experimental-feature NonescapableTypes \
 // RUN: -enable-experimental-feature SuppressedAssociatedTypes
 
+// expected-note@+1 {{'T' has '~Copyable' constraint preventing implicit 'Copyable' conformance}}
+struct AttemptImplicitConditionalConformance<T: ~Copyable>: ~Copyable {
+  var t: T // expected-error {{stored property 't' of 'Copyable'-conforming generic struct 'AttemptImplicitConditionalConformance' has non-Copyable type 'T'}}
+}
+extension AttemptImplicitConditionalConformance: Copyable {}
+// expected-error@-1 {{generic struct 'AttemptImplicitConditionalConformance' required to be 'Copyable' but is marked with '~Copyable'}}
 
+enum Hello<T: ~Escapable & ~Copyable>: ~Escapable & ~Copyable {}
+extension Hello: Escapable {} // expected-error {{generic enum 'Hello' required to be 'Escapable' but is marked with '~Escapable'}}
+extension Hello: Copyable {} // expected-error {{generic enum 'Hello' required to be 'Copyable' but is marked with '~Copyable'}}
+
+enum HelloExplicitlyFixed<T: ~Escapable & ~Copyable>: Escapable, Copyable {}
+
+struct NoInverseBecauseNoDefault<T: ~Copyable & ~Escapable>: ~Copyable {}
+extension NoInverseBecauseNoDefault: Copyable where T: Copyable, T: ~Escapable {}
+// expected-error@-1 {{cannot suppress '~Escapable' on generic parameter 'T' defined in outer scope}}
 
 // Check support for explicit conditional conformance
 public struct ExplicitCond<T: ~Copyable>: ~Copyable {}
-extension ExplicitCond: Copyable {}
+extension ExplicitCond: Copyable where T: Copyable {}
 // expected-note@-1 {{requirement from conditional conformance}}
 // expected-note@-2 {{requirement from conditional conformance of 'ExplicitCondAlias<NC>' (aka 'ExplicitCond<NC>') to 'Copyable'}}
 
@@ -80,7 +95,7 @@ struct ConditionalContainment<T: ~Copyable>: ~Copyable {
   var y: NC // expected-error {{stored property 'y' of 'Copyable'-conforming generic struct 'ConditionalContainment' has non-Copyable type 'NC'}}
 }
 
-extension ConditionalContainment: Copyable {}
+extension ConditionalContainment: Copyable where T: Copyable {}
 
 func chk(_ T: RequireCopyable<ConditionalContainment<Int>>) {}
 
@@ -126,7 +141,7 @@ enum Maybe<Wrapped: ~Copyable>: ~Copyable {
   deinit {} // expected-error {{deinitializer cannot be declared in generic enum 'Maybe' that conforms to 'Copyable'}}
 }
 
-extension Maybe: Copyable {}
+extension Maybe: Copyable where Wrapped: Copyable {}
 
 // expected-note@+4{{requirement specified as 'NC' : 'Copyable'}}
 // expected-note@+3{{requirement from conditional conformance of 'Maybe<NC>' to 'Copyable'}}
@@ -265,7 +280,7 @@ enum MaybeEscapes<T: ~Escapable>: ~Escapable { // expected-note {{generic enum '
   case none
 }
 
-extension MaybeEscapes: Escapable {}
+extension MaybeEscapes: Escapable where T: Escapable {}
 
 struct Escapes { // expected-note {{consider adding '~Escapable' to struct 'Escapes'}}
   let t: MaybeEscapes<NonescapingType> // expected-error {{stored property 't' of 'Escapable'-conforming struct 'Escapes' has non-Escapable type 'MaybeEscapes<NonescapingType>'}}

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -188,11 +188,11 @@ class NiceTry: ~Copyable, Copyable {} // expected-error {{classes cannot be '~Co
 
 
 struct Extendo: ~Copyable {}
-extension Extendo: Copyable, ~Copyable {} // expected-error {{cannot suppress '~Copyable' in extension}}
+extension Extendo: Copyable, ~Copyable {} // expected-error {{cannot suppress 'Copyable' in extension}}
 // expected-error@-1 {{struct 'Extendo' required to be 'Copyable' but is marked with '~Copyable'}}
 
 enum EnumExtendo {}
-extension EnumExtendo: ~Copyable {} // expected-error {{cannot suppress '~Copyable' in extension}}
+extension EnumExtendo: ~Copyable {} // expected-error {{cannot suppress 'Copyable' in extension}}
 
 extension NeedsCopyable where Self: ~Copyable {}
 // expected-error@-1 {{'Self' required to be 'Copyable' but is marked with '~Copyable'}}

--- a/test/Generics/inverse_generics_stdlib.swift
+++ b/test/Generics/inverse_generics_stdlib.swift
@@ -21,7 +21,7 @@ public enum Optional<T: ~Copyable>: ~Copyable {
   case none
 }
 
-extension Optional: Copyable {}
+extension Optional: Copyable where T: Copyable {}
 
 public func wrapping<T: ~Copyable>(_ t: consuming T) -> T? {
   return .some(t)

--- a/test/Inputs/Swiftskell.swift
+++ b/test/Inputs/Swiftskell.swift
@@ -36,7 +36,7 @@ public enum Either<Success: ~Copyable, Failure: Error>: ~Copyable {
   case failure(Failure)
 }
 
-extension Either: Copyable {}
+extension Either: Copyable where Success: Copyable {}
 
 extension Either where Failure == Swift.Error {
   public init(catching body: () throws -> Success) {
@@ -77,7 +77,7 @@ public enum Maybe<Wrapped: ~Copyable>: ~Copyable {
   case just(Wrapped)
   case nothing
 }
-extension Maybe: Copyable {}
+extension Maybe: Copyable where Wrapped: Copyable {}
 
 extension Maybe: Show where Wrapped: Show & ~Copyable {
   public borrowing func show() -> String {

--- a/test/Interpreter/moveonly_generics_casting.swift
+++ b/test/Interpreter/moveonly_generics_casting.swift
@@ -136,7 +136,7 @@ enum Maybe<Wrapped: ~Copyable>: ~Copyable {
   case just(Wrapped)
   case nothing
 }
-extension Maybe: Copyable {}
+extension Maybe: Copyable where Wrapped: Copyable {}
 extension Maybe: CustomDebugStringConvertible {
   var debugDescription: String {
     "cast succeeded"

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -55,12 +55,12 @@ public struct _Toys {
 public struct ExplicitHello<T: ~Copyable>: ~Copyable {
   let thing: T
 }
-extension ExplicitHello: Copyable {}
+extension ExplicitHello: Copyable where T: Copyable {}
 
 public struct Hello<T: ~Copyable>: ~Copyable, ~Escapable where T: ~Escapable {}
 
-extension Hello: Escapable where T: ~Copyable {}
-extension Hello: Copyable where T: ~Escapable {}
+extension Hello: Escapable where T: Escapable {}
+extension Hello: Copyable where T: Copyable {}
 
 public protocol TestAssocTypes {
   associatedtype A: ~Copyable, _NoCopyP = Int
@@ -94,11 +94,11 @@ public struct Outer<A: ~Copyable>: ~Copyable {
   public struct InnerVariation2<D: ~Escapable>: ~Copyable, ~Escapable {}
 }
 
-extension Outer: Copyable {}
-extension Outer.InnerStruct: Copyable {}
+extension Outer: Copyable where A: Copyable {}
+extension Outer.InnerStruct: Copyable where C: Copyable, A: Copyable {}
 
-extension Outer.InnerVariation1: Copyable {}
-extension Outer.InnerVariation2: Escapable where A: ~Copyable {}
+extension Outer.InnerVariation1: Copyable where A: Copyable, D: Copyable & Escapable {}
+extension Outer.InnerVariation2: Escapable where A: Escapable, D: Escapable {}
 
 extension Outer.InnerStruct {
     public func hello<T: ~Escapable>(_ t: T) {}

--- a/test/ModuleInterface/invertible_constraints.swift
+++ b/test/ModuleInterface/invertible_constraints.swift
@@ -26,14 +26,14 @@ public protocol P: ~Copyable {
 public struct X<T: ~Copyable>: ~Copyable { }
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK:      extension Test.X : Swift.Copyable {
+// CHECK:      extension Test.X : Swift.Copyable where T : Swift.Copyable {
 // CHECK-NEXT:   func f()
 // CHECK:      }
 // CHECK: #else
 // CHECK:      extension Test.X {
 // CHECK-NEXT:   func f()
 // CHECK:      }
-extension X: Copyable {
+extension X: Copyable where T: Copyable {
   public func f() { }
 }
 

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -77,18 +77,18 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC-NEXT: public struct ExplicitHello<T> : ~Swift.Copyable where T : ~Copyable {
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-MISC-NEXT: extension {{.*}}.ExplicitHello : Swift.Copyable {
+// CHECK-MISC-NEXT: extension {{.*}}.ExplicitHello : Swift.Copyable where T : Swift.Copyable {
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
 // CHECK-MISC-NEXT: public struct Hello<T> : ~Swift.Copyable, ~Swift.Escapable where T : ~Copyable, T : ~Escapable {
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-MISC-NEXT: extension NoncopyableGenerics_Misc.Hello : Swift.Escapable where T : ~Copyable {
+// CHECK-MISC-NEXT: extension NoncopyableGenerics_Misc.Hello : Swift.Escapable where T : Swift.Escapable {
 // CHECK-MISC-NEXT: }
 // CHECK-MISC: #endif
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-MISC-NEXT: extension NoncopyableGenerics_Misc.Hello : Swift.Copyable where T : ~Escapable {
+// CHECK-MISC-NEXT: extension NoncopyableGenerics_Misc.Hello : Swift.Copyable where T : Swift.Copyable {
 // CHECK-MISC-NEXT: }
 // CHECK-MISC: #endif
 
@@ -121,19 +121,19 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC:   public struct InnerVariation2<D> : ~Swift.Copyable, ~Swift.Escapable where D : ~Escapable
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-MISC-NEXT: extension {{.*}}.Outer : Swift.Copyable {
+// CHECK-MISC-NEXT: extension {{.*}}.Outer : Swift.Copyable where A : Swift.Copyable {
 // CHECK-MISC: #endif
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-MISC-NEXT: extension {{.*}}.Outer.InnerStruct : Swift.Copyable {
+// CHECK-MISC-NEXT: extension {{.*}}.Outer.InnerStruct : Swift.Copyable where A : Swift.Copyable, C : Swift.Copyable {
 // CHECK-MISC: #endif
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-MISC-NEXT: extension {{.*}}.Outer.InnerVariation1 : Swift.Copyable {
+// CHECK-MISC-NEXT: extension {{.*}}.Outer.InnerVariation1 : Swift.Copyable where A : Swift.Copyable, D : Swift.Copyable {
 // CHECK-MISC: #endif
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-MISC-NEXT: extension {{.*}}.Outer.InnerVariation2 : Swift.Escapable where A : ~Copyable {
+// CHECK-MISC-NEXT: extension {{.*}}.Outer.InnerVariation2 : Swift.Escapable where D : Swift.Escapable {
 // CHECK-MISC: #endif
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
@@ -250,7 +250,7 @@ import Swiftskell
 // CHECK: #endif
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: extension Swiftskell.Pair : Swift.Copyable {
+// CHECK-NEXT: extension Swiftskell.Pair : Swift.Copyable where L : Swift.Copyable, R : Swift.Copyable {
 // CHECK: #endif
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
@@ -258,7 +258,7 @@ import Swiftskell
 // CHECK: #endif
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: extension Swiftskell.Maybe : Swift.Copyable {
+// CHECK-NEXT: extension Swiftskell.Maybe : Swift.Copyable where Wrapped : Swift.Copyable {
 // CHECK: #endif
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -52,7 +52,7 @@ protocol Rope<Element>: Hashable, ~Copyable {  // expected-error {{'Self' requir
   associatedtype Element: ~Copyable
 }
 
-extension S: ~Copyable {} // expected-error {{cannot suppress '~Copyable' in extension}}
+extension S: ~Copyable {} // expected-error {{cannot suppress 'Copyable' in extension}}
 
 struct S: ~U, // expected-error {{type 'U' cannot be suppressed}}
           ~Copyable {}
@@ -129,4 +129,8 @@ func param2(_ t: ~Copyable.Type) {} // expected-error{{constraint that suppresse
 func param3(_ t: borrowing any ~Copyable) {}
 func param4(_ t: any ~Copyable.Type) {}
 
-func param3(_ t: borrowing ExtraNoncopyProto & ~Copyable) {} // expected-error{{constraint that suppresses conformance requires 'any'}}{{28-28=any }}
+protocol P: ~Copyable {}
+protocol Q: ~Copyable {}
+protocol R: ~Copyable {}
+struct Blooper<T: ~Copyable>: ~Copyable {}
+extension Blooper: (Q & (R & (~Copyable & P))) {} // expected-error {{cannot suppress 'Copyable' in extension}}

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -134,3 +134,20 @@ protocol Q: ~Copyable {}
 protocol R: ~Copyable {}
 struct Blooper<T: ~Copyable>: ~Copyable {}
 extension Blooper: (Q & (R & (~Copyable & P))) {} // expected-error {{cannot suppress 'Copyable' in extension}}
+
+protocol Edible {}
+protocol Portable {}
+typealias Alias = Portable & Copyable
+
+struct Burrito<Filling: ~Copyable>: ~Copyable {}
+extension Burrito: Alias {} // expected-error {{conformance to 'Copyable' must be declared in a separate extension}}
+// expected-note@-1 {{'Burrito<Filling>' declares conformance to protocol 'Copyable' here}}
+
+extension Burrito: Copyable & Edible & P {} // expected-error {{redundant conformance of 'Burrito<Filling>' to protocol 'Copyable'}}
+
+struct Blah<T: ~Copyable>: ~Copyable {}
+extension Blah: P, Q, Copyable, R {} // expected-error {{generic struct 'Blah' required to be 'Copyable' but is marked with '~Copyable'}}
+// expected-error@-1 {{conformance to 'Copyable' must be declared in a separate extension}}
+
+enum Hello<Gesture: ~Copyable>: ~Copyable {}
+extension Hello: Copyable & Edible & P {} // expected-error {{conformance to 'Copyable' must be declared in a separate extension}}

--- a/test/SILGen/mangling_inverse_generics.swift
+++ b/test/SILGen/mangling_inverse_generics.swift
@@ -145,7 +145,7 @@ public struct A<T: ~Copyable>: ~Copyable {
   // CHECK: sil hidden [ossa] @$s4test1AVAARi_zrlEACyxGycfC : $@convention(method) <T where T : ~Copyable> (@thin A<T>.Type) -> @owned A<T> {
 }
 
-extension A: Copyable {}
+extension A: Copyable where T: Copyable {}
 
 // <T: ~Copyable>
 extension A where T: ~Copyable {

--- a/test/SILGen/moveonly_empty_conditionally_copyable.swift
+++ b/test/SILGen/moveonly_empty_conditionally_copyable.swift
@@ -2,4 +2,4 @@
 
 struct G<T: ~Copyable>: ~Copyable { }
 
-extension G: Copyable {}
+extension G: Copyable where T: Copyable {}

--- a/test/SILGen/typelowering_inverses.swift
+++ b/test/SILGen/typelowering_inverses.swift
@@ -15,14 +15,14 @@ enum RudeEnum<T: ~Copyable>: Copyable {
 
 struct CondCopyableStruct<T: ~Copyable>: ~Copyable {}
 
-extension CondCopyableStruct: Copyable {}
+extension CondCopyableStruct: Copyable where T: Copyable {}
 
 enum CondCopyableEnum<T: ~Copyable>: ~Copyable {
   case some(T)
   case none
 }
 
-extension CondCopyableEnum: Copyable {}
+extension CondCopyableEnum: Copyable where T: Copyable {}
 
 protocol NoEscapeP: ~Escapable {}
 
@@ -39,14 +39,14 @@ enum TooRudeEnum<T: ~Escapable>: Escapable {
 
 struct CondEscapableStruct<T: ~Escapable>: ~Escapable {}
 
-extension CondEscapableStruct: Escapable {}
+extension CondEscapableStruct: Escapable where T: Escapable {}
 
 enum CondEscapableEnum<T: ~Escapable>: ~Escapable {
   case some(T)
   case none
 }
 
-extension CondEscapableEnum: Escapable {}
+extension CondEscapableEnum: Escapable where T: Escapable {}
 
 // MARK: ensure certain conditionally Copyable types are treated as trivial (no ownership in func signature).
 
@@ -144,18 +144,18 @@ struct MyStruct<T: ~Copyable & ~Escapable>: ~Copyable & ~Escapable {
   init(x: consuming T) { self.x = x }
 }
 
-extension MyStruct: Copyable where T: Copyable & ~Escapable {}
+extension MyStruct: Copyable where T: Copyable {}
 
-extension MyStruct: Escapable where T: Escapable & ~Copyable {}
+extension MyStruct: Escapable where T: Escapable {}
 
 enum MyEnum<T: ~Copyable & ~Escapable>: ~Copyable & ~Escapable {
     case x(T)
     case knoll
 }
 
-extension MyEnum: Copyable where T: Copyable & ~Escapable {}
+extension MyEnum: Copyable where T: Copyable {}
 
-extension MyEnum: Escapable where T: Escapable & ~Copyable {}
+extension MyEnum: Escapable where T: Escapable {}
 
 enum Trivial {
     case a, b, c

--- a/test/SILOptimizer/lifetime_dependence_optional.swift
+++ b/test/SILOptimizer/lifetime_dependence_optional.swift
@@ -20,9 +20,9 @@ public enum Nillable<Wrapped: ~Copyable & ~Escapable>: ~Copyable & ~Escapable {
   case some(Wrapped)
 }
 
-extension Nillable: Copyable where Wrapped: ~Escapable /* & Copyable */ {}
+extension Nillable: Copyable where Wrapped: Copyable {}
 
-extension Nillable: Escapable where Wrapped: ~Copyable /* & Escapable */ {}
+extension Nillable: Escapable where Wrapped: Escapable {}
 
 extension Nillable: Sendable where Wrapped: ~Copyable & ~Escapable & Sendable { }
 

--- a/test/Sema/conditionally_copyable.swift
+++ b/test/Sema/conditionally_copyable.swift
@@ -2,7 +2,7 @@
 
 struct G<T: ~Copyable>: ~Copyable {}
 
-extension G: Copyable {}
+extension G: Copyable where T: Copyable {}
 
 protocol Base {}
 protocol Derived: Base {}

--- a/test/Serialization/Inputs/ncgenerics.swift
+++ b/test/Serialization/Inputs/ncgenerics.swift
@@ -25,7 +25,7 @@ public enum Maybe<Wrapped: ~Copyable>: ~Copyable {
     case none
 }
 
-extension Maybe: Copyable {}
+extension Maybe: Copyable where Wrapped: Copyable {}
 
 public func ncIdentity<T: ~Copyable>(_ t: consuming T) -> T { return t }
 

--- a/test/Serialization/noncopyable_generics.swift
+++ b/test/Serialization/noncopyable_generics.swift
@@ -18,7 +18,7 @@
 
 // CHECK-PRINT-DAG: protocol Generator<Value> {
 // CHECK-PRINT-DAG: enum Maybe<Wrapped> : ~Copyable where Wrapped : ~Copyable {
-// CHECK-PRINT-DAG: extension Maybe : Copyable {
+// CHECK-PRINT-DAG: extension Maybe : Copyable where Wrapped : Copyable {
 // CHECK-PRINT-DAG: func ncIdentity<T>(_ t: consuming T) -> T where T : ~Copyable
 // CHECK-PRINT-DAG: protocol Either<Left, Right> : ~Copyable {
 // CHECK-PRINT-DAG:   associatedtype Left : ~Copyable

--- a/validation-test/ParseableInterface/rdar128577611.swift
+++ b/validation-test/ParseableInterface/rdar128577611.swift
@@ -7,4 +7,10 @@ struct InternalStruct {}
 extension [Int: InternalStruct]: Sendable {}
 
 // CHECK: @available(*, unavailable)
-// CHECK: extension Swift.Dictionary : Swift.Copyable, Swift.Escapable, Swift.Sendable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+// CHECK-NEXT: extension Swift.Dictionary : Swift.Copyable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension Swift.Dictionary : Swift.Escapable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension Swift.Dictionary : Swift.Sendable where Key : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}


### PR DESCRIPTION
- Explanation: Make conditional conformances to Copyable or Escapable require you to write out the requirements, rather than inferring them like we do for other extensions.
- Scope: Source-breaking for existing code that used noncopyable generics.
- Issue: rdar://128904812
- Original PR: https://github.com/apple/swift/pull/74322
- Risk: Source breaks. Should not introduce a condfail with the stdlib, since newer interfaces will now print requirements that were not being printed in older swiftinterface files.
- Testing: Need to test the condfail theory.
- Reviewer: @lorentey for stdlib parts