### PR TITLE
[6.0🍒] AST: fix `isWrittenWithConstraints`

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1827,6 +1827,7 @@ bool ExtensionDecl::isWrittenWithConstraints() const {
   // If the type has no inverse requirements, there are no extra constraints
   // to write.
   if (typeInverseReqs.empty()) {
+    assert(extInverseReqs.empty() && "extension retroactively added inverse?");
     return false;
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1809,14 +1809,20 @@ bool ExtensionDecl::isWrittenWithConstraints() const {
   typeSig->getRequirementsWithInverses(typeReqs, typeInverseReqs);
 
   // If the (non-inverse) requirements are different between the extension and
-  // the original type, it's written with constraints. Note that
-  // the extension can only add requirements, so we need only check the size
-  // (not the specific requirements).
-  if (extReqs.size() > typeReqs.size()) {
+  // the original type, it's written with constraints.
+  if (extReqs.size() != typeReqs.size()) {
     return true;
   }
 
-  assert(extReqs.size() == typeReqs.size());
+  // In case of equal number of constraints, we have to check the specific
+  // requirements. Extensions can end up with fewer requirements than the type
+  // extended, due to a same-type requirement in the extension.
+  //
+  // This mirrors the 'same' check in `ASTMangler::gatherGenericSignatureParts`
+  for (size_t i = 0; i < extReqs.size(); i++) {
+    if (extReqs[i] != typeReqs[i])
+      return true;
+  }
 
   // If the type has no inverse requirements, there are no extra constraints
   // to write.

--- a/validation-test/IRGen/issue-72719.swift
+++ b/validation-test/IRGen/issue-72719.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-frontend -interpret %s
-// REQUIRES: executable_test
+// RUN: %target-swift-frontend -emit-ir -g %s > /dev/null
 
-// This only reproduced if you provide the -interpret flag!
 // https://github.com/apple/swift/issues/72719
 
 protocol D {}

--- a/validation-test/execution/issue-72719.swift
+++ b/validation-test/execution/issue-72719.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -interpret %s
+// REQUIRES: executable_test
+
+// This only reproduced if you provide the -interpret flag!
+// https://github.com/apple/swift/issues/72719
+
+protocol D {}
+struct U: D, Equatable {}
+class Q<T> {}
+class R<V, E: D & Equatable> {}
+extension R where E == U {
+    struct S<X> {}
+    static func a<T>(_: T) -> R {
+        let x = Q<S<T>>()
+        fatalError()
+    }
+}


### PR DESCRIPTION
- Explanation: Strengthens how we answer this method's query on an extension, which fixes a rare issue where an assumption previously made is not actually true.
- Scope: Narrow. Fixes a rare issue.
- Issue: rdar://125659789
- Original PR: https://github.com/apple/swift/pull/74372 & https://github.com/apple/swift/pull/74400
- Risk: Low
- Testing: reproducer for initial issue is included.
- Reviewer: @slavapestov 