### PR TITLE
Finalize Swift debug info before running Clang codegen, because it ma…

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1949,11 +1949,13 @@ bool IRGenModule::finalize() {
   }
   emitLazyPrivateDefinitions();
 
-  // Finalize clang IR-generation.
-  finalizeClangCodeGen();
-
+  // Finalize Swift debug info before running Clang codegen, because it may
+  // delete the llvm module.
   if (DebugInfo)
     DebugInfo->finalize();
+
+  // Finalize clang IR-generation.
+  finalizeClangCodeGen();
 
   // If that failed, report failure up and skip the final clean-up.
   if (!ClangCodeGen->GetModule())

--- a/test/DebugInfo/BridgingHeaderPCH.swift
+++ b/test/DebugInfo/BridgingHeaderPCH.swift
@@ -5,8 +5,6 @@
 
 // CHECK: !DICompileUnit(language: DW_LANG_Swift
 // CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},
-// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},
-// CHECK-SAME:           splitDebugFilename: "{{.*}}.pch"
-// CHECK-SAME:           dwoId:
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}}{{.*}}splitDebugFilename: "{{.*}}.pch",{{.*}}dwoId:
 
 Foo()

--- a/test/DebugInfo/ClangModuleBreadcrumbs.swift
+++ b/test/DebugInfo/ClangModuleBreadcrumbs.swift
@@ -16,29 +16,17 @@ import OtherClangModule.SubModule
 let _ = someFunc(0)
 
 // Check for Clang module breadcrumbs.
-// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}Swift
-// CHECK-SAME:           ClangModule
-// CHECK-SAME:           dwoId:
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}Swift{{.*}}ClangModule{{.*}}dwoId:
 
-// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}}, {{.*}} producer: "{{.*}}Swift
-// CHECK-SAME:           OtherClangModule
-// CHECK-SAME:           dwoId:
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}}, {{.*}} producer: "{{.*}}Swift{{.*}}OtherClangModule{{.*}}dwoId:
 
-// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}clang
-// CHECK-SAME:           ClangModule
-// CHECK-SAME:           dwoId:
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}clang{{.*}}ClangModule{{.*}}dwoId:
 
 // NONE: DICompileUnit({{.*}}
 // NONE-NOT: DICompileUnit({{.*}}ClangModule
 
-// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}Swift
-// REMAP-SAME:           PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}ClangModule
-// REMAP-SAME:           dwoId:
+// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}Swift{{.*}}PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}ClangModule{{.*}}dwoId:
 
-// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}Swift
-// REMAP-SAME:           PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}OtherClangModule
-// REMAP-SAME:           dwoId:
+// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}Swift{{.*}}PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}OtherClangModule{{.*}}dwoId:
 
-// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}clang
-// REMAP-SAME:           PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}ClangModule
-// REMAP-SAME:           dwoId:
+// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}clang{{.*}}PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}ClangModule{{.*}}dwoId:


### PR DESCRIPTION
…y delete

the llvm module.

rdar://128309024
(cherry picked from commit bba8b921ab9e907bd89d967cc89306d1ceb5beda)
