### PR TITLE
Bump the DWARF version number to 5 on Darwin.

### DIFF
--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -659,23 +659,40 @@ toolchains::Darwin::addDeploymentTargetArgs(ArgStringList &Arguments,
 static unsigned getDWARFVersionForTriple(const llvm::Triple &triple) {
   llvm::VersionTuple osVersion;
   const DarwinPlatformKind kind = getDarwinPlatformKind(triple);
+  // Default to DWARF 2 on OS X 10.10 / iOS 8 and lower.
+  // Default to DWARF 4 on OS X 10.11 - macOS 14 / iOS - iOS 17.
   switch (kind) {
   case DarwinPlatformKind::MacOS:
     triple.getMacOSXVersion(osVersion);
     if (osVersion < llvm::VersionTuple(10, 11))
       return 2;
-    return 4;
+    if (osVersion < llvm::VersionTuple(15))
+      return 4;
+    return 5;
   case DarwinPlatformKind::IPhoneOSSimulator:
   case DarwinPlatformKind::IPhoneOS:
   case DarwinPlatformKind::TvOS:
   case DarwinPlatformKind::TvOSSimulator:
     osVersion = triple.getiOSVersion();
-    if (osVersion < llvm::VersionTuple(9))
-      return 2;
-    return 4;
-  default:
-    return 4;
+   if (osVersion < llvm::VersionTuple(9))
+     return 2;
+    if (osVersion < llvm::VersionTuple(18))
+      return 4;
+    return 5;
+  case DarwinPlatformKind::WatchOS:
+  case DarwinPlatformKind::WatchOSSimulator:
+    osVersion = triple.getWatchOSVersion();
+    if (osVersion < llvm::VersionTuple(11))
+      return 4;
+    return 5;
+  case DarwinPlatformKind::VisionOS:
+  case DarwinPlatformKind::VisionOSSimulator:
+    osVersion = triple.getOSVersion();
+    if (osVersion < llvm::VersionTuple(2))
+      return 4;
+    return 5;
   }
+  llvm_unreachable("unsupported platform kind");
 }
 
 void toolchains::Darwin::addCommonFrontendArgs(

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -109,6 +109,7 @@
 // MISSING_OPTION_G_ERROR: error: option '-debug-info-format={{.*}}' is missing a required argument (-g)
 
 // RUN: %swift_driver -### -g -dwarf-version=3 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_3 %s
+// DWARF_VERSION_5: -dwarf-version=5
 // DWARF_VERSION_4: -dwarf-version=4
 // DWARF_VERSION_3: -dwarf-version=3
 // DWARF_VERSION_2: -dwarf-version=2
@@ -134,6 +135,17 @@
 // RUN: %swiftc_driver -### -g -target arm64-apple-tvos17.0 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_4 %s
 // RUN: %swift_driver -### -g -target arm64_32-apple-watchos10.0 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_4 %s
 // RUN: %swiftc_driver -### -g -target arm64_32-apple-watchos10.0 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_4 %s
+
+// RUN: %swift_driver -### -g -target x86_64-apple-macosx15 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swiftc_driver -### -g -target x86_64-apple-macosx15 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swift_driver -### -g -target arm64-apple-ios18.0 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swiftc_driver -### -g -target arm64-apple-ios18.0 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swift_driver -### -g -target arm64-apple-ios18.0-macabi %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swiftc_driver -### -g -target arm64-apple-ios18.0-macabi %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swift_driver -### -g -target arm64-apple-tvos18 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swiftc_driver -### -g -target arm64-apple-tvos18 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swift_driver -### -g -target arm64_32-apple-watchos11 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
+// RUN: %swiftc_driver -### -g -target arm64_32-apple-watchos11 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_5 %s
 
 // RUN: not %swift_driver -gline-tables-only -debug-info-format=codeview %s 2>&1 | %FileCheck -check-prefix BAD_DEBUG_LEVEL_ERROR %s
 // RUN: not %swift_driver -gdwarf-types -debug-info-format=codeview %s 2>&1 | %FileCheck -check-prefix BAD_DEBUG_LEVEL_ERROR %s


### PR DESCRIPTION
The default debug info format for newer versions of Darwin is DWARF 5.

https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes

rdar://110925733
(cherry picked from commit 1a06ddc3ba91928ff0286838a4435ed7850f1b31)
