### PR TITLE
[6.0] Provide proper source locations for `@_documentation`.

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2456,7 +2456,7 @@ Parser::parseDocumentationAttribute(SourceLoc atLoc, SourceLoc loc) {
   StringRef finalMetadata = metadata.value_or("");
 
   return makeParserResult(
-    new (Context) DocumentationAttr(loc, range, finalMetadata,
+    new (Context) DocumentationAttr(atLoc, range, finalMetadata,
                                     visibility, false));
 }
 

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -220,3 +220,8 @@ struct SomeType {
 macro multipleFreestandingRoles<T>(_: T) -> Void = #externalMacro(module: "A", type: "B")
 // expected-warning@-1{{external macro implementation type}}
 // expected-error@-2{{macro can only have a single freestanding role}}
+
+@_documentation(visibility: private)
+@attached(peer)
+macro Foo() = #externalMacro(module: "ThisMacroModuleDoesNotExist", type: "ThisMacroTypeDoesNotExist")
+// expected-warning@-1{{external macro implementation type}}


### PR DESCRIPTION
**Explanation**: An improper source location in the parsing of `@_documentation` broke a recent optimization for macro definition checking.
**Original PR**:  https://github.com/apple/swift/pull/74404
**Radar / issue**: rdar://127206128
**Risk**: Low. It's just a wrong source location for an underscored attribute.
