### PR TITLE
[ASTDumper] Avoid parsing decl members

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1305,7 +1305,9 @@ public:
   SourceLoc getStartLoc() const {
     if (UnknownAttrLoc.isValid())
       return UnknownAttrLoc;
-    return getLoc();
+    if (ItemIntroducerLoc.isValid())
+      return ItemIntroducerLoc;
+    return getBody()->getStartLoc();
   }
   SourceLoc getEndLoc() const { return getBody()->getEndLoc(); }
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -482,21 +482,22 @@ namespace {
     raw_ostream &OS;
     unsigned Indent;
   public:
+    bool ParseIfNeeded;
     llvm::function_ref<Type(Expr *)> GetTypeOfExpr;
     llvm::function_ref<Type(TypeRepr *)> GetTypeOfTypeRepr;
     llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
         GetTypeOfKeyPathComponent;
     char quote = '"';
 
-    explicit PrintBase(raw_ostream &os, unsigned indent = 0,
-                       llvm::function_ref<Type(Expr *)> getTypeOfExpr = defaultGetTypeOfExpr,
-                       llvm::function_ref<Type(TypeRepr *)> getTypeOfTypeRepr = nullptr,
-                       llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
-                          getTypeOfKeyPathComponent =
-                              defaultGetTypeOfKeyPathComponent)
-        : OS(os), Indent(indent), GetTypeOfExpr(getTypeOfExpr),
-          GetTypeOfTypeRepr(getTypeOfTypeRepr),
-          GetTypeOfKeyPathComponent(getTypeOfKeyPathComponent) { }
+    explicit PrintBase(
+        raw_ostream &os, unsigned indent = 0, bool parseIfNeeded = false,
+        llvm::function_ref<Type(Expr *)> getTypeOfExpr = defaultGetTypeOfExpr,
+        llvm::function_ref<Type(TypeRepr *)> getTypeOfTypeRepr = nullptr,
+        llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
+            getTypeOfKeyPathComponent = defaultGetTypeOfKeyPathComponent)
+        : OS(os), Indent(indent), ParseIfNeeded(parseIfNeeded),
+          GetTypeOfExpr(getTypeOfExpr), GetTypeOfTypeRepr(getTypeOfTypeRepr),
+          GetTypeOfKeyPathComponent(getTypeOfKeyPathComponent) {}
 
     bool hasNonStandardOutput() {
       return &OS != &llvm::errs() && &OS != &llvm::dbgs();
@@ -1301,7 +1302,9 @@ namespace {
         break;
       }
 
-      for (Decl *D : IDC->getMembers()) {
+      auto members = ParseIfNeeded ? IDC->getMembers()
+                                   : IDC->getCurrentMembersWithoutLoading();
+      for (Decl *D : members) {
         printRec(D);
       }
       printFoot();
@@ -1313,7 +1316,9 @@ namespace {
         OS << SF.getFilename();
       });
 
-      if (auto items = SF.getCachedTopLevelItems()) {
+      auto items =
+          ParseIfNeeded ? SF.getTopLevelItems() : SF.getCachedTopLevelItems();
+      if (items) {
         for (auto item : *items) {
           if (item.isImplicit())
             continue;
@@ -1556,7 +1561,7 @@ namespace {
         });
       }
 
-      if (auto Body = D->getBody(/*canSynthesize=*/false)) {
+      if (auto Body = D->getBody(/*canSynthesize=*/ParseIfNeeded)) {
         printRec(Body, &D->getASTContext());
       }
     }
@@ -1858,13 +1863,7 @@ void SourceFile::dump() const {
 }
 
 void SourceFile::dump(llvm::raw_ostream &OS, bool parseIfNeeded) const {
-  // If we're allowed to parse the SourceFile, do so now. We need to force the
-  // parsing request as by default the dumping logic tries not to kick any
-  // requests.
-  if (parseIfNeeded)
-    (void)getTopLevelItems();
-
-  PrintDecl(OS).visitSourceFile(*this);
+  PrintDecl(OS, /*indent*/ 0, parseIfNeeded).visitSourceFile(*this);
   llvm::errs() << '\n';
 }
 
@@ -1889,13 +1888,16 @@ public:
   using PrintBase::PrintBase;
   const ASTContext *Ctx;
 
-  PrintStmt(raw_ostream &os, const ASTContext *ctx, unsigned indent = 0,
-            llvm::function_ref<Type(Expr *)> getTypeOfExpr = defaultGetTypeOfExpr,
-            llvm::function_ref<Type(TypeRepr *)> getTypeOfTypeRepr = nullptr,
-            llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
-                getTypeOfKeyPathComponent = defaultGetTypeOfKeyPathComponent)
-    : PrintBase(os, indent, getTypeOfExpr, getTypeOfTypeRepr,
-                getTypeOfKeyPathComponent), Ctx(ctx) { }
+  PrintStmt(
+      raw_ostream &os, const ASTContext *ctx, unsigned indent = 0,
+      bool parseIfNeeded = false,
+      llvm::function_ref<Type(Expr *)> getTypeOfExpr = defaultGetTypeOfExpr,
+      llvm::function_ref<Type(TypeRepr *)> getTypeOfTypeRepr = nullptr,
+      llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
+          getTypeOfKeyPathComponent = defaultGetTypeOfKeyPathComponent)
+      : PrintBase(os, indent, parseIfNeeded, getTypeOfExpr, getTypeOfTypeRepr,
+                  getTypeOfKeyPathComponent),
+        Ctx(ctx) {}
 
   using PrintBase::printRec;
 
@@ -3259,8 +3261,8 @@ void Expr::dump(raw_ostream &OS, llvm::function_ref<Type(Expr *)> getTypeOfExpr,
                 llvm::function_ref<Type(KeyPathExpr *E, unsigned index)>
                     getTypeOfKeyPathComponent,
                 unsigned Indent) const {
-  PrintExpr(OS, Indent, getTypeOfExpr, getTypeOfTypeRepr,
-            getTypeOfKeyPathComponent)
+  PrintExpr(OS, Indent, /*parseIfNeeded*/ false, getTypeOfExpr,
+            getTypeOfTypeRepr, getTypeOfKeyPathComponent)
       .visit(const_cast<Expr *>(this), "");
 }
 
@@ -3564,8 +3566,9 @@ void PrintBase::printRec(Decl *D, StringRef label) {
       printHead("<null decl>", DeclColor, label);
       printFoot();
     } else {
-      PrintDecl(OS, Indent, GetTypeOfExpr, GetTypeOfTypeRepr,
-                GetTypeOfKeyPathComponent).visit(D, label);
+      PrintDecl(OS, Indent, ParseIfNeeded, GetTypeOfExpr, GetTypeOfTypeRepr,
+                GetTypeOfKeyPathComponent)
+          .visit(D, label);
     }
   }, label);
 }
@@ -3575,8 +3578,9 @@ void PrintBase::printRec(Expr *E, StringRef label) {
       printHead("<null expr>", ExprColor, label);
       printFoot();
     } else {
-      PrintExpr(OS, Indent, GetTypeOfExpr, GetTypeOfTypeRepr,
-                GetTypeOfKeyPathComponent).visit(E, label);
+      PrintExpr(OS, Indent, ParseIfNeeded, GetTypeOfExpr, GetTypeOfTypeRepr,
+                GetTypeOfKeyPathComponent)
+          .visit(E, label);
     }
   }, label);
 }
@@ -3586,8 +3590,9 @@ void PrintBase::printRec(Stmt *S, const ASTContext *Ctx, StringRef label) {
       printHead("<null stmt>", ExprColor, label);
       printFoot();
     } else {
-      PrintStmt(OS, Ctx, Indent, GetTypeOfExpr, GetTypeOfTypeRepr,
-                GetTypeOfKeyPathComponent).visit(S, label);
+      PrintStmt(OS, Ctx, Indent, ParseIfNeeded, GetTypeOfExpr,
+                GetTypeOfTypeRepr, GetTypeOfKeyPathComponent)
+          .visit(S, label);
     }
   }, label);
 }
@@ -3597,8 +3602,9 @@ void PrintBase::printRec(TypeRepr *T, StringRef label) {
       printHead("<null typerepr>", TypeReprColor, label);
       printFoot();
     } else {
-      PrintTypeRepr(OS, Indent, GetTypeOfExpr, GetTypeOfTypeRepr,
-                    GetTypeOfKeyPathComponent).visit(T, label);
+      PrintTypeRepr(OS, Indent, ParseIfNeeded, GetTypeOfExpr, GetTypeOfTypeRepr,
+                    GetTypeOfKeyPathComponent)
+          .visit(T, label);
     }
   }, label);
 }
@@ -3608,9 +3614,9 @@ void PrintBase::printRec(const Pattern *P, StringRef label) {
       printHead("<null pattern>", PatternColor, label);
       printFoot();
     } else {
-      PrintPattern(OS, Indent, GetTypeOfExpr, GetTypeOfTypeRepr,
-                   GetTypeOfKeyPathComponent).visit(const_cast<Pattern *>(P),
-                                                    label);
+      PrintPattern(OS, Indent, ParseIfNeeded, GetTypeOfExpr, GetTypeOfTypeRepr,
+                   GetTypeOfKeyPathComponent)
+          .visit(const_cast<Pattern *>(P), label);
     }
   }, label);
 }
@@ -4536,8 +4542,9 @@ namespace {
         printHead("<null type>", DeclColor, label);
         printFoot();
       } else {
-        PrintType(OS, Indent, GetTypeOfExpr, GetTypeOfTypeRepr,
-                  GetTypeOfKeyPathComponent).visit(type, label);
+        PrintType(OS, Indent, ParseIfNeeded, GetTypeOfExpr, GetTypeOfTypeRepr,
+                  GetTypeOfKeyPathComponent)
+            .visit(type, label);
       }
     }, label);
   }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1650,11 +1650,6 @@ CompilerInstance::getSourceFileParsingOptions(bool forPrimary) const {
         action != ActionType::ScanDependencies) {
       opts |= ParsingFlags::DisablePoundIfEvaluation;
     }
-
-    // If we need to dump the parse tree, disable delayed bodies as we want to
-    // show everything.
-    if (action == ActionType::DumpParse)
-      opts |= ParsingFlags::DisableDelayedBodies;
   }
 
   const auto &typeOpts = getASTContext().TypeCheckerOpts;


### PR DESCRIPTION
Previously we would call `getMembers`, which could kick delayed member parsing. Instead, propagate a `parseIfNeeded` flag through the ASTDumper logic, and use it to determine whether to parse a SourceFile, type/extension body, or function body. This is needed for things like `-dump-parse` which expects to dump the entire AST tree.