### PR TITLE
[SwiftCompilerSources] add unknown default case for bridged function serializedkind.

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -147,6 +147,7 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     case .IsNotSerialized: return .notSerialized
     case .IsSerialized: return .serialized
     case .IsSerializedForPackage: return .serializedForPackage
+    @unknown default: fatalError()
     }
   }
 


### PR DESCRIPTION
This removes warning. 