### PR TITLE
Teach "find imports" to equate overlay modules with their underlying modules

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2668,9 +2668,11 @@ ImportDeclRequest::evaluate(Evaluator &evaluator, const SourceFile *sf,
   auto &ctx = sf->getASTContext();
   auto imports = sf->getImports();
 
+  auto mutModule = const_cast<ModuleDecl *>(module);
   // Look to see if the owning module was directly imported.
   for (const auto &import : imports) {
-    if (import.module.importedModule == module)
+    if (import.module.importedModule
+            ->isSameModuleLookingThroughOverlays(mutModule))
       return import;
   }
 
@@ -2679,7 +2681,8 @@ ImportDeclRequest::evaluate(Evaluator &evaluator, const SourceFile *sf,
   for (const auto &import : imports) {
     auto &importSet = importCache.getImportSet(import.module.importedModule);
     for (const auto &transitive : importSet.getTransitiveImports()) {
-      if (transitive.importedModule == module) {
+      if (transitive.importedModule
+              ->isSameModuleLookingThroughOverlays(mutModule)) {
         return import;
       }
     }

--- a/test/Concurrency/predates_concurrency_import_foundation_darwin.swift
+++ b/test/Concurrency/predates_concurrency_import_foundation_darwin.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -swift-version 6 -I %t %s -emit-sil -o /dev/null -verify -parse-as-library
+
+// REQUIRES: OS=macosx
+
+import Foundation
+@preconcurrency import Darwin
+
+func mach_task_self() -> mach_port_t {
+    return mach_task_self_
+}


### PR DESCRIPTION
The operation that finds the best import for a given declaration was treating an overload module as being distinct from its underlying module, even though they both have the same name and are imported together. Teach it to treat those modules as equivalent, so we correctly identify the right import declaration for something that comes from the underlying module.

Fixes rdar://129401319.