### PR TITLE
[Parse] Fix nested ifConfig compiler checks

### DIFF
--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -843,10 +843,16 @@ Result Parser::parseIfConfigRaw(
         // Error in the condition;
         isActive = false;
         isVersionCondition = false;
-      } else if (!foundActive && shouldEvaluate) {
+      } else if (!foundActive) {
         // Evaluate the condition only if we haven't found any active one and
         // we're not in parse-only mode.
-        isActive = evaluateIfConfigCondition(Condition, Context);
+        if (shouldEvaluate) {
+          isActive = evaluateIfConfigCondition(Condition, Context);
+        }
+        // Determine isVersionCondition regardless of whether we're active.
+        // This is necessary in some edge cases, e.g. where we're in a nested,
+        // inactive #if block, and we encounter an inactive `#if compiler` check,
+        // as we have to explicitly skip parsing in such edge cases.
         isVersionCondition = isVersionIfConfigCondition(Condition);
       }
     }

--- a/test/Parse/ConditionalCompilation/compiler.swift
+++ b/test/Parse/ConditionalCompilation/compiler.swift
@@ -28,3 +28,21 @@
  // There should be no error here.
  foo bar
 #endif
+
+#if compiler(>=4.1)
+ let _: Int = 1
+#else
+ #if false
+ // There should be no error here.
+ foo bar
+ #endif
+#endif
+
+#if false
+#if compiler(>=4.1)
+ let _: Int = 1
+#else
+ // There should be no error here.
+ foo bar
+#endif
+#endif

--- a/test/Parse/ConditionalCompilation/compiler.swift
+++ b/test/Parse/ConditionalCompilation/compiler.swift
@@ -33,16 +33,16 @@
  let _: Int = 1
 #else
  #if false
- // There should be no error here.
- foo bar
+  // There should be no error here.
+  foo bar
  #endif
 #endif
 
 #if false
-#if compiler(>=4.1)
- let _: Int = 1
-#else
- // There should be no error here.
- foo bar
-#endif
+ #if compiler(>=4.1)
+  let _: Int = 1
+ #else
+  // There should be no error here.
+  foo bar
+ #endif
 #endif


### PR DESCRIPTION
The parser is supposed to avoid looking inside unmatched `#if compiler` (et al) blocks. This usually means that the following code builds fine

```swift
#if compiler(>=100)
foo bar
#endif
```

however, a logical bug meant that if the check was nested inside an already-inactive `#if` block, it would not adhere to this evaluation-skipping behavior
```swift
#if false
#if compiler(>=100)
foo bar // error!
#endif
#endif
```

This PR fixes this specific case.