### PR TITLE
SIL: enable some SIL linkage related asserts in release builds

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -59,6 +59,7 @@
 #include "llvm/Support/Debug.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/Basic/Require.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/FormalLinkage.h"
 #include "swift/Serialization/SerializedSILLoader.h"
@@ -101,9 +102,9 @@ void SILLinkerVisitor::deserializeAndPushToWorklist(SILFunction *F) {
 void SILLinkerVisitor::maybeAddFunctionToWorklist(
     SILFunction *F, SerializedKind_t callerSerializedKind) {
   SILLinkage linkage = F->getLinkage();
-  assert((callerSerializedKind == IsNotSerialized ||
-          F->hasValidLinkageForFragileRef(callerSerializedKind) ||
-         hasSharedVisibility(linkage) || F->isExternForwardDeclaration()) &&
+  require(callerSerializedKind == IsNotSerialized ||
+            F->hasValidLinkageForFragileRef(callerSerializedKind) ||
+            hasSharedVisibility(linkage) || F->isExternForwardDeclaration(),
          "called function has wrong linkage for serialized function");
   if (!F->isExternalDeclaration()) {
     // The function is already in the module, so no need to de-serialized it.

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -14,6 +14,7 @@
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
 #include "swift/AST/Module.h"
+#include "swift/Basic/Require.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "llvm/Support/CommandLine.h"
 
@@ -851,8 +852,8 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
         !Callee->hasValidLinkageForFragileRef(Caller->getSerializedKind())) {
       llvm::errs() << "caller: " << Caller->getName() << "\n";
       llvm::errs() << "callee: " << Callee->getName() << "\n";
-      llvm_unreachable("Should never be inlining a resilient function into "
-                       "a fragile function");
+      require(false, "Should never be inlining a resilient function into "
+                     "a fragile function");
     }
     return nullptr;
   }


### PR DESCRIPTION
To catch wrong linkage bugs with a release-built compiler

related to rdar://129318806
