### PR TITLE
ArrayPropertyOpt: update borrowed-from instructions

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
@@ -64,6 +64,7 @@
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
+#include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
 #include "swift/SILOptimizer/Utils/LoopUtils.h"
 #include "swift/SILOptimizer/Utils/SILSSAUpdater.h"
 #include "llvm/ADT/SmallSet.h"
@@ -834,6 +835,8 @@ class SwiftArrayPropertyOptPass : public SILFunctionTransform {
       // Verify that no illegal critical edges were created.
       if (getFunction()->getModule().getOptions().VerifyAll)
         getFunction()->verifyCriticalEdges();
+
+      updateBorrowedFrom(getPassManager(), Fn);
 
       // We preserve the dominator tree. Let's invalidate everything
       // else.

--- a/test/SILOptimizer/simplify_cfg_crash.swift
+++ b/test/SILOptimizer/simplify_cfg_crash.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O %s -emit-sil -o /dev/null
+// RUN: %target-swift-frontend -O %s -enable-ossa-modules -emit-sil -o /dev/null
 
 public class X {}
 


### PR DESCRIPTION
Fixes a verifier crash when building with OSSA modules

rdar://129796888
