### PR TITLE
[CS] Fill in ErrorTypes for expressions that fail to type-check

### DIFF
--- a/lib/Sema/SyntacticElementTarget.cpp
+++ b/lib/Sema/SyntacticElementTarget.cpp
@@ -303,9 +303,15 @@ bool SyntacticElementTarget::contextualTypeIsOnlyAHint() const {
 
 void SyntacticElementTarget::markInvalid() const {
   class InvalidationWalker : public ASTWalker {
+    ASTContext &Ctx;
+
+  public:
+    InvalidationWalker(ASTContext &ctx) : Ctx(ctx) {}
+
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
-      // TODO: We ought to fill in ErrorTypes for expressions here; ultimately
-      // type-checking should always produce typed AST.
+      if (!E->getType())
+        E->setType(ErrorType::get(Ctx));
+
       return Action::Continue(E);
     }
 
@@ -321,7 +327,7 @@ void SyntacticElementTarget::markInvalid() const {
       return Action::VisitNodeIf(isa<PatternBindingDecl>(D));
     }
   };
-  InvalidationWalker walker;
+  InvalidationWalker walker(getDeclContext()->getASTContext());
   walk(walker);
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2706,7 +2706,7 @@ namespace {
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       // Skip expressions that didn't make it to solution application
       // because the constraint system diagnosed an error.
-      if (!expr->getType())
+      if (!expr->getType() || expr->getType()->hasError())
         return Action::SkipNode(expr);
 
       if (auto *openExistential = dyn_cast<OpenExistentialExpr>(expr)) {

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1283,7 +1283,7 @@ public:
     thrownValue = removeErasureToExistentialError(thrownValue);
 
     Type thrownType = thrownValue->getType();
-    if (!thrownType)
+    if (!thrownType || thrownType->hasError())
       return Classification::forInvalidCode();
 
     // FIXME: Add a potential effect reason for a throw site.

--- a/test/SourceKit/CursorInfo/rdar129417672.swift
+++ b/test/SourceKit/CursorInfo/rdar129417672.swift
@@ -1,0 +1,19 @@
+// RUN: %sourcekitd-test -req=cursor -pos=12:11 %s -- %s
+
+private class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
+
+  override func visitAny(_ node: Syntax) -> Syntax? {
+    if var declSyntax = node.as(DeclSyntax.self),
+      let attributedNode = node.asProtocol(WithAttributesSyntax.self),
+      !attributedNode.attributes.isEmpty
+    {
+      for (attribute, spec) in attributesToRemove {
+        if let index = self.expandedAttributes.firstIndex(where: { expandedAttribute in
+          expandedAttribute.position == attribute.position
+        }) {
+        } else {
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ensure we always produce typed AST, even if we fail to apply a solution. This fixes a cursor info issue where we'd to type-check a closure twice due to it not having a type set.

rdar://129417672