### PR TITLE
Add CXX compiler to SCL-F Windows build

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1656,7 +1656,7 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
       -InstallTo $InstallPath `
       -Arch $Arch `
       -Platform $Platform `
-      -UseBuiltCompilers ASM,C,Swift `
+      -UseBuiltCompilers ASM,C,CXX,Swift `
       -BuildTargets $Targets `
       -Defines (@{
         FOUNDATION_BUILD_TOOLS = if ($Platform -eq "Windows") { "YES" } else { "NO" };


### PR DESCRIPTION
The swift-corelibs-foundation build now needs a CXX compiler because it implicitly builds swift-foundation-icu which is a C++ project. Adding the CXX compiler here ensures the build uses the appropriate compiler and resolves issues found during a toolchain build with swift-foundation enabled. Testing with this change and swift-foundation enabled shows that it actually begins the cmake build (unlike currently where cmake fails to detect a valid CXX compiler)