### PR TITLE
[6.0] Fix function subtyping rules for sending

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7952,6 +7952,19 @@ ERROR(sending_only_on_parameters_and_results, none,
       "'sending' may only be used on parameters and results", ())
 ERROR(sending_cannot_be_applied_to_tuple_elt, none,
       "'sending' cannot be applied to tuple elements", ())
+ERROR(sending_function_wrong_sending,none,
+      "converting a value of type %0 to type %1 risks causing data races",
+      (Type, Type))
+NOTE(sending_function_param_with_sending_param_note, none,
+     "converting a function typed value with a sending parameter to one "
+     "without risks allowing actor-isolated values to escape their isolation "
+     "domain as an argument to an invocation of value",
+     ())
+NOTE(sending_function_result_with_sending_param_note, none,
+     "converting a function typed value without a sending result as one with "
+     "risks allowing actor-isolated values to escape their "
+     "isolation domain through a result of an invocation of value",
+     ())
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3237,6 +3237,9 @@ public:
     /// Whether the parameter is 'isolated'.
     bool isIsolated() const { return Flags.isIsolated(); }
 
+    /// Whether or not the parameter is 'sending'.
+    bool isSending() const { return Flags.isSending(); }
+
     /// Whether the parameter is 'isCompileTimeConst'.
     bool isCompileTimeConst() const { return Flags.isCompileTimeConst(); }
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1555,6 +1555,8 @@ bool Parser::canParseType() {
     consumeToken();
   } else if (Tok.isContextualKeyword("each")) {
     consumeToken();
+  } else if (Tok.isContextualKeyword("sending")) {
+    consumeToken();
   }
 
   switch (Tok.getKind()) {

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2425,7 +2425,9 @@ AssociatedTypeInference::computeFailureTypeWitness(
   // it.
   for (const auto &witness : valueWitnesses) {
     if (isAsyncIteratorProtocolNext(witness.first)) {
-      if (auto witnessFunc = dyn_cast<AbstractFunctionDecl>(witness.second)) {
+      // We use a dyn_cast_or_null since we can get a nullptr here if we fail to
+      // match a witness. In such a case, we should just fail here.
+      if (auto witnessFunc = dyn_cast_or_null<AbstractFunctionDecl>(witness.second)) {
         auto thrownError = witnessFunc->getEffectiveThrownErrorType();
 
         // If it doesn't throw, Failure == Never.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7918,6 +7918,24 @@ bool NonEphemeralConversionFailure::diagnoseAsError() {
   return true;
 }
 
+bool SendingOnFunctionParameterMismatchFail::diagnoseAsError() {
+  emitDiagnosticAt(getLoc(), diag::sending_function_wrong_sending,
+                   getFromType(), getToType())
+      .warnUntilSwiftVersion(6);
+  emitDiagnosticAt(getLoc(),
+                   diag::sending_function_param_with_sending_param_note);
+  return true;
+}
+
+bool SendingOnFunctionResultMismatchFailure::diagnoseAsError() {
+  emitDiagnosticAt(getLoc(), diag::sending_function_wrong_sending,
+                   getFromType(), getToType())
+      .warnUntilSwiftVersion(6);
+  emitDiagnosticAt(getLoc(),
+                   diag::sending_function_result_with_sending_param_note);
+  return true;
+}
+
 bool AssignmentTypeMismatchFailure::diagnoseMissingConformance() const {
   auto srcType = getFromType();
   auto dstType = getToType()->lookThroughAllOptionalTypes();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2291,6 +2291,28 @@ private:
   void emitSuggestionNotes() const;
 };
 
+class SendingOnFunctionParameterMismatchFail final : public ContextualFailure {
+public:
+  SendingOnFunctionParameterMismatchFail(const Solution &solution, Type srcType,
+                                         Type dstType,
+                                         ConstraintLocator *locator,
+                                         FixBehavior fixBehavior)
+      : ContextualFailure(solution, srcType, dstType, locator, fixBehavior) {}
+
+  bool diagnoseAsError() override;
+};
+
+class SendingOnFunctionResultMismatchFailure final : public ContextualFailure {
+public:
+  SendingOnFunctionResultMismatchFailure(const Solution &solution, Type srcType,
+                                         Type dstType,
+                                         ConstraintLocator *locator,
+                                         FixBehavior fixBehavior)
+      : ContextualFailure(solution, srcType, dstType, locator, fixBehavior) {}
+
+  bool diagnoseAsError() override;
+};
+
 class AssignmentTypeMismatchFailure final : public ContextualFailure {
 public:
   AssignmentTypeMismatchFailure(const Solution &solution,

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1636,10 +1636,9 @@ namespace {
     }
 
     Type
-    resolveTypeReferenceInExpression(TypeRepr *repr, TypeResolverContext resCtx,
+    resolveTypeReferenceInExpression(TypeRepr *repr,
+                                     TypeResolutionOptions options,
                                      const ConstraintLocatorBuilder &locator) {
-      TypeResolutionOptions options(resCtx);
-
       // Introduce type variables for unbound generics.
       const auto genericOpener = OpenUnboundGenericType(CS, locator);
       const auto placeholderHandler = HandlePlaceholderType(CS, locator);
@@ -2528,9 +2527,11 @@ namespace {
             return declaredTy;
           }
 
+          auto options =
+              TypeResolutionOptions(TypeResolverContext::InExpression);
+          options.setContext(TypeResolverContext::ClosureExpr);
           const auto resolvedTy = resolveTypeReferenceInExpression(
-              closure->getExplicitResultTypeRepr(),
-              TypeResolverContext::InExpression, resultLocator);
+              closure->getExplicitResultTypeRepr(), options, resultLocator);
           if (resolvedTy)
             return resolvedTy;
         }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11783,10 +11783,10 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
         if (contextualParam->isIsolated() && !flags.isIsolated() && paramDecl)
           isolatedParams.insert(paramDecl);
 
-        param =
-            param.withFlags(flags.withInOut(contextualParam->isInOut())
-                                 .withVariadic(contextualParam->isVariadic())
-                                 .withIsolated(contextualParam->isIsolated()));
+        param = param.withFlags(flags.withInOut(contextualParam->isInOut())
+                                    .withVariadic(contextualParam->isVariadic())
+                                    .withIsolated(contextualParam->isIsolated())
+                                    .withSending(contextualParam->isSending()));
       }
     }
 
@@ -11911,6 +11911,12 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   if (auto contextualFnType = contextualType->getAs<FunctionType>()) {
     if (contextualFnType->isSendable())
       closureExtInfo = closureExtInfo.withSendable();
+  }
+
+  // Propagate sending result from the contextual type to the closure.
+  if (auto contextualFnType = contextualType->getAs<FunctionType>()) {
+    if (contextualFnType->hasExtInfo() && contextualFnType->hasSendingResult())
+      closureExtInfo = closureExtInfo.withSendingResult();
   }
 
   // Isolated parameters override any other kind of isolation we might infer.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3236,6 +3236,12 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       return getTypeMatchFailure(locator);
   }
 
+  // () -> sending T can be a subtype of () -> T... but not vis-a-versa.
+  if (func1->hasSendingResult() != func2->hasSendingResult() &&
+      (!func1->hasSendingResult() || kind < ConstraintKind::Subtype)) {
+    return getTypeMatchFailure(locator);
+  }
+
   if (!matchFunctionIsolations(func1, func2, kind, flags, locator))
     return getTypeMatchFailure(locator);
 
@@ -3663,6 +3669,13 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       // discarded.
       if (func1->isDifferentiable() && func2->isDifferentiable() &&
           func1Param.isNoDerivative() && !func2Param.isNoDerivative()) {
+        return getTypeMatchFailure(argumentLocator);
+      }
+
+      // Do not allow for functions that expect a sending parameter to match
+      // with a function that expects a non-sending parameter.
+      if (func1Param.getParameterFlags().isSending() &&
+          !func2Param.getParameterFlags().isSending()) {
         return getTypeMatchFailure(argumentLocator);
       }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -746,9 +746,11 @@ RequirementMatch swift::matchWitness(
       // If our requirement says that it has a sending result, then our witness
       // must also have a sending result since otherwise, in generic contexts,
       // we would be returning non-disconnected values as disconnected.
-      if (reqFnType->hasExtInfo() && reqFnType->hasSendingResult() &&
-          (!witnessFnType->hasExtInfo() || !witnessFnType->hasSendingResult()))
-        return RequirementMatch(witness, MatchKind::TypeConflict, witnessType);
+      if (dc->getASTContext().LangOpts.isSwiftVersionAtLeast(6)) {
+        if (reqFnType->hasExtInfo() && reqFnType->hasSendingResult() &&
+            (!witnessFnType->hasExtInfo() || !witnessFnType->hasSendingResult()))
+          return RequirementMatch(witness, MatchKind::TypeConflict, witnessType);
+      }
 
       if (auto result = matchTypes(std::get<0>(types), std::get<1>(types))) {
         return std::move(result.value());
@@ -784,9 +786,11 @@ RequirementMatch swift::matchWitness(
 
       // If we have a requirement without sending and our witness expects a
       // sending parameter, error.
-      if (!reqParams[i].getParameterFlags().isSending() &&
-          witnessParams[i].getParameterFlags().isSending())
-        return RequirementMatch(witness, MatchKind::TypeConflict, witnessType);
+      if (dc->getASTContext().isSwiftVersionAtLeast(6)) {
+        if (!reqParams[i].getParameterFlags().isSending() &&
+            witnessParams[i].getParameterFlags().isSending())
+          return RequirementMatch(witness, MatchKind::TypeConflict, witnessType);
+      }
 
       auto reqParamDecl = reqParamList->get(i);
       auto witnessParamDecl = witnessParamList->get(i);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4971,7 +4971,8 @@ TypeResolver::resolveSendingTypeRepr(SendingTypeRepr *repr,
     return ErrorType::get(getASTContext());
   }
 
-  if (!options.is(TypeResolverContext::FunctionResult) &&
+  if (!options.is(TypeResolverContext::ClosureExpr) &&
+      !options.is(TypeResolverContext::FunctionResult) &&
       (!options.is(TypeResolverContext::FunctionInput) ||
        options.hasBase(TypeResolverContext::EnumElementDecl))) {
     diagnoseInvalid(repr, repr->getSpecifierLoc(),

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -118,7 +118,7 @@ enum class TypeResolverContext : uint8_t {
   /// Whether we are checking the parameter list of a subscript.
   SubscriptDecl,
 
-  /// Whether we are checking the parameter list of a closure.
+  /// Whether we are checking the parameter list or result of a closure.
   ClosureExpr,
 
   /// Whether we are in the input type of a function, or under one level of

--- a/test/Concurrency/sending_asynciteratornext_typechecker_error.swift
+++ b/test/Concurrency/sending_asynciteratornext_typechecker_error.swift
@@ -1,0 +1,77 @@
+// RUN: not %target-swift-frontend %s -c  -swift-version 6 -module-name _Concurrency
+
+// READ THIS: This test is only supposed to be making sure that we do not crash
+// when we fail to match a witness that doesn't match AsyncIteratorProtocol.next
+// b/c of sending. It should fail... but not crash.
+
+@available(SwiftStdlib 5.1, *)
+public protocol AsyncIteratorProtocol<Element, Failure> {
+  associatedtype Element
+
+  /// The type of failure produced by iteration.
+  @available(SwiftStdlib 6.0, *)
+  associatedtype Failure: Error = any Error
+
+  /// Asynchronously advances to the next element and returns it, or ends the
+  /// sequence if there is no next element.
+  ///
+  /// - Returns: The next element, if it exists, or `nil` to signal the end of
+  ///   the sequence.
+  mutating func next() async throws -> sending Element?
+
+  /// Asynchronously advances to the next element and returns it, or ends the
+  /// sequence if there is no next element.
+  ///
+  /// - Returns: The next element, if it exists, or `nil` to signal the end of
+  ///   the sequence.
+  @available(SwiftStdlib 6.0, *)
+  mutating func next(isolation actor: isolated (any Actor)?) async throws(Failure) -> sending Element?
+}
+
+@available(SwiftStdlib 5.1, *)
+extension AsyncIteratorProtocol {
+  /// Default implementation of `next(isolation:)` in terms of `next()`, which
+  /// is required to maintain backward compatibility with existing async
+  /// iterators.
+  @available(SwiftStdlib 6.0, *)
+  @inlinable
+  public mutating func next(isolation actor: isolated (any Actor)?) async throws(Failure) -> sending Element? {
+    do {
+      return try await next()
+    } catch {
+      throw error as! Failure
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+extension AsyncIteratorProtocol {
+  /// Default implementation of `next()` in terms of `next(isolation:)`, which
+  /// is required to maintain backward compatibility with existing async
+  /// iterators.
+  @available(SwiftStdlib 6.0, *)
+  @inlinable
+  public mutating func next() async throws(Failure) -> sending Element? {
+#if $OptionalIsolatedParameters
+    return try await next(isolation: nil)
+#else
+    fatalError("unsupported compiler")
+#endif
+  }
+}
+
+public struct FakeMapSequence<T> : AsyncIteratorProtocol {
+  typealias Element = T
+
+  @available(SwiftStdlib 6.0, *)
+  @inlinable
+  public mutating func next(isolation actor: isolated (any Actor)?) async throws(Failure) -> Element? {
+    fatalError()
+  }
+
+  @inlinable
+  public mutating func next() async throws -> Element? {
+    fatalError()
+  }
+}
+

--- a/test/Concurrency/sending_closure_inference.swift
+++ b/test/Concurrency/sending_closure_inference.swift
@@ -42,3 +42,7 @@ func testNamedTypeParameterSendingInference() {
 func testSendingResultInference() {
   let _: () -> sending String = { "" }
 }
+
+func testSendingResultOnClosure() {
+  let _ = { (x: String) -> sending String in x }
+}

--- a/test/Concurrency/sending_closure_inference.swift
+++ b/test/Concurrency/sending_closure_inference.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-frontend -swift-version 6 %s -emit-silgen | %FileCheck %s
+
+// READ THIS! This file only contains tests that validate that the relevant
+// function subtyping rules for sending work. Please do not put other tests in
+// the file!
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// CHECK: sil private [ossa] @$s25sending_closure_inference38testAnonymousParameterSendingInferenceyyFySSYucfU_ : $@convention(thin) (@sil_sending @guaranteed String) -> () {
+func testAnonymousParameterSendingInference() {
+  let _: (sending String) -> () = {
+    print($0)
+  }
+}
+
+// CHECK: sil private [ossa] @$s25sending_closure_inference38testNamedOnlyParameterSendingInferenceyyFySSYucfU_ : $@convention(thin) (@sil_sending @guaranteed String) -> () {
+func testNamedOnlyParameterSendingInference() {
+  let _: (sending String) -> () = { x in
+    print(x)
+  }
+}
+
+// CHECK: sil private [ossa] @$s25sending_closure_inference38testNamedTypeParameterSendingInferenceyyFySSnYucfU_ : $@convention(thin) (@sil_sending @owned String) -> () {
+func testNamedTypeParameterSendingInference() {
+  let _: (sending String) -> () = { (x: sending String) in
+    print(x)
+  }
+}
+
+// CHECK: sil private [ossa] @$s25sending_closure_inference26testSendingResultInferenceyyFSSyYTcfU_ : $@convention(thin) () -> @sil_sending @owned String {
+func testSendingResultInference() {
+  let _: () -> sending String = { "" }
+}

--- a/test/Concurrency/transfernonsendable_functionsubtyping.swift
+++ b/test/Concurrency/transfernonsendable_functionsubtyping.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -swift-version 6 -verify -c %s
+// RUN: %target-typecheck-verify-swift -swift-version 6 %s
 
 // READ THIS! This file only contains tests that validate that the relevant
 // function subtyping rules for sending work. Please do not put other tests in
@@ -103,3 +103,4 @@ struct FailToMatch4 : ProtocolWithMixedReqs { // expected-error {{}}
   func nonSendingParamAndSendingResult(_ x: sending NonSendableKlass) -> sending NonSendableKlass { fatalError() }
   // expected-note @-1 {{candidate has non-matching type '(sending NonSendableKlass) -> sending NonSendableKlass'}}
 }
+

--- a/test/Concurrency/transfernonsendable_functionsubtyping.swift
+++ b/test/Concurrency/transfernonsendable_functionsubtyping.swift
@@ -1,0 +1,57 @@
+// RUN: %target-swift-frontend -swift-version 6 -verify -c %s
+
+// READ THIS! This file only contains tests that validate that the relevant
+// function subtyping rules for sending work. Please do not put other tests in
+// the file!
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+protocol ProtocolWithSendingReqs {
+  func sendingResult() -> sending NonSendableKlass // expected-note {{}}
+  func nonSendingParam(_ x: NonSendableKlass) // expected-note {{}}
+}
+
+protocol ProtocolWithMixedReqs {
+  func nonSendingParamAndSendingResult(_ x: NonSendableKlass) -> sending NonSendableKlass // expected-note 4{{}}
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+struct MatchSuccess : ProtocolWithSendingReqs, ProtocolWithMixedReqs {
+  func sendingResult() -> sending NonSendableKlass { fatalError() }
+  func nonSendingParam(_ x: NonSendableKlass) -> () { fatalError() }
+  func nonSendingParamAndSendingResult(_ x: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
+}
+
+struct FailToMatch : ProtocolWithSendingReqs, ProtocolWithMixedReqs { // expected-error 2{{}}
+  func sendingResult() -> NonSendableKlass { fatalError() }
+  // expected-note @-1 {{candidate has non-matching type '() -> NonSendableKlass'}}
+  func nonSendingParam(_ x: sending NonSendableKlass) -> () { fatalError() }
+  // expected-note @-1 {{candidate has non-matching type '(sending NonSendableKlass) -> ()'}}
+  func nonSendingParamAndSendingResult(_ x: sending NonSendableKlass) -> NonSendableKlass { fatalError() }
+  // expected-note @-1 {{candidate has non-matching type '(sending NonSendableKlass) -> NonSendableKlass'}}
+}
+
+struct FailToMatch2 : ProtocolWithMixedReqs { // expected-error {{}}
+  func nonSendingParamAndSendingResult(_ x: sending NonSendableKlass) -> NonSendableKlass { fatalError() }
+  // expected-note @-1 {{candidate has non-matching type '(sending NonSendableKlass) -> NonSendableKlass'}}
+}
+
+struct FailToMatch3 : ProtocolWithMixedReqs { // expected-error {{}}
+  func nonSendingParamAndSendingResult(_ x: NonSendableKlass) -> NonSendableKlass { fatalError() }
+  // expected-note @-1 {{candidate has non-matching type '(NonSendableKlass) -> NonSendableKlass'}}
+}
+
+struct FailToMatch4 : ProtocolWithMixedReqs { // expected-error {{}}
+  func nonSendingParamAndSendingResult(_ x: sending NonSendableKlass) -> sending NonSendableKlass { fatalError() }
+  // expected-note @-1 {{candidate has non-matching type '(sending NonSendableKlass) -> sending NonSendableKlass'}}
+}

--- a/test/Concurrency/transfernonsendable_functionsubtyping_swift5.swift
+++ b/test/Concurrency/transfernonsendable_functionsubtyping_swift5.swift
@@ -1,0 +1,107 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+// READ THIS! This file only contains tests that validate how the relevant
+// function subtyping rules for sending work in swift 5 mode
+// specifically. Please do not put other tests in the file!
+//
+// We expect today that protocol mismatch errors are elided and function
+// mismatch errors are warnings.
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+protocol ProtocolWithSendingReqs {
+  func sendingResult() -> sending NonSendableKlass
+  func nonSendingParam(_ x: NonSendableKlass)
+}
+
+protocol ProtocolWithMixedReqs {
+  func nonSendingParamAndSendingResult(_ x: NonSendableKlass) -> sending NonSendableKlass
+}
+
+/////////////////////////////////
+// MARK: Normal Function Tests //
+/////////////////////////////////
+
+func functionWithSendingResult() -> sending NonSendableKlass { fatalError() }
+func functionWithoutSendingResult() -> NonSendableKlass { fatalError() }
+func functionWithSendingParameter(_ x: sending NonSendableKlass)  { fatalError() }
+func functionWithoutSendingParameter(_ x: NonSendableKlass)  { fatalError() }
+
+func takeFnWithSendingResult(_ fn: () -> sending NonSendableKlass) {}
+func takeFnWithoutSendingResult(_ fn: () -> NonSendableKlass) {}
+func takeFnWithSendingParam(_ fn: (sending NonSendableKlass) -> ()) {}
+func takeFnWithoutSendingParam(_ fn: (NonSendableKlass) -> ()) {}
+
+func testFunctionMatching() {
+  let _: (NonSendableKlass) -> () = functionWithSendingParameter
+  // expected-warning @-1 {{converting a value of type '(sending NonSendableKlass) -> ()' to type '(NonSendableKlass) -> ()' risks causing data races}}
+  // expected-note @-2 {{converting a function typed value with a sending parameter to one without risks allowing actor-isolated values to escape their isolation domain as an argument to an invocation of value}}
+  let _: (sending NonSendableKlass) -> () = functionWithSendingParameter
+
+  let _: (NonSendableKlass) -> () = functionWithoutSendingParameter
+  let _: (sending NonSendableKlass) -> () = functionWithoutSendingParameter
+
+  takeFnWithSendingParam(functionWithSendingParameter)
+  takeFnWithoutSendingParam(functionWithSendingParameter)
+  // expected-warning @-1 {{converting a value of type '(sending NonSendableKlass) -> ()' to type '(NonSendableKlass) -> ()' risks causing data races}}
+  // expected-note @-2 {{converting a function typed value with a sending parameter to one without risks allowing actor-isolated values to escape their isolation domain as an argument to an invocation of value}}
+  takeFnWithSendingParam(functionWithoutSendingParameter)
+  takeFnWithoutSendingParam(functionWithoutSendingParameter)
+}
+
+func testReturnValueMatching() {
+  let _: () -> NonSendableKlass = functionWithSendingResult
+  let _: () -> sending NonSendableKlass = functionWithSendingResult
+  let _: () -> NonSendableKlass = functionWithoutSendingResult
+  let _: () -> sending NonSendableKlass = functionWithoutSendingResult
+  // expected-warning @-1 {{converting a value of type '() -> NonSendableKlass' to type '() -> sending NonSendableKlass' risks causing data races}}
+  // expected-note @-2 {{converting a function typed value without a sending result as one with risks allowing actor-isolated values to escape their isolation domain through a result of an invocation of value}}
+
+  takeFnWithSendingResult(functionWithSendingResult)
+  takeFnWithSendingResult(functionWithoutSendingResult)
+  // expected-warning @-1 {{converting a value of type '() -> NonSendableKlass' to type '() -> sending NonSendableKlass' risks causing data races}}
+  // expected-note @-2 {{converting a function typed value without a sending result as one with risks allowing actor-isolated values to escape their isolation domain through a result of an invocation of value}}
+  let x: () -> NonSendableKlass = { fatalError() }
+  takeFnWithSendingResult(x)
+  // expected-warning @-1 {{converting a value of type '() -> NonSendableKlass' to type '() -> sending NonSendableKlass' risks causing data races}}
+  // expected-note @-2 {{converting a function typed value without a sending result as one with risks allowing actor-isolated values to escape their isolation domain through a result of an invocation of value}}
+
+  takeFnWithoutSendingResult(functionWithSendingResult)
+  takeFnWithoutSendingResult(functionWithoutSendingResult)
+  takeFnWithoutSendingResult(x)
+}
+
+//////////////////////////
+// MARK: Protocol Tests //
+//////////////////////////
+
+struct MatchSuccess : ProtocolWithSendingReqs, ProtocolWithMixedReqs {
+  func sendingResult() -> sending NonSendableKlass { fatalError() }
+  func nonSendingParam(_ x: NonSendableKlass) -> () { fatalError() }
+  func nonSendingParamAndSendingResult(_ x: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
+}
+
+struct FailToMatch : ProtocolWithSendingReqs, ProtocolWithMixedReqs {
+  func sendingResult() -> NonSendableKlass { fatalError() }
+  func nonSendingParam(_ x: sending NonSendableKlass) -> () { fatalError() }
+  func nonSendingParamAndSendingResult(_ x: sending NonSendableKlass) -> NonSendableKlass { fatalError() }
+}
+
+struct FailToMatch2 : ProtocolWithMixedReqs {
+  func nonSendingParamAndSendingResult(_ x: sending NonSendableKlass) -> NonSendableKlass { fatalError() }
+}
+
+struct FailToMatch3 : ProtocolWithMixedReqs {
+  func nonSendingParamAndSendingResult(_ x: NonSendableKlass) -> NonSendableKlass { fatalError() }
+}
+
+struct FailToMatch4 : ProtocolWithMixedReqs {
+  func nonSendingParamAndSendingResult(_ x: sending NonSendableKlass) -> sending NonSendableKlass { fatalError() }
+}

--- a/test/DebugInfo/sending_params_and_results.swift
+++ b/test/DebugInfo/sending_params_and_results.swift
@@ -14,11 +14,11 @@ public struct SendableStruct: Sendable {
 //
 //   @escaping @callee_guaranteed (@guaranteed sending Swift.Result<test.SendableStruct, Swift.Error>) -> ()
 //
-// CHECK: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$ss6ResultOy4test14SendableStructVs5Error_pGIeggT_D", flags: DIFlagFwdDecl, runtimeLang: DW_LANG_Swift)
+// CHECK: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$ss6ResultOy4test14SendableStructVs5Error_pGIeggT_D",
 func testReconstructingEscapingClosureWithSendingParam() async throws -> SendableStruct {
   func callSendableFunction(_ x: @Sendable () -> ()) {}
 
-  func helper(_ completion: @escaping (Result<SendableStruct, Swift.Error>) -> Void) {
+  func helper(_ completion: @escaping (__shared sending Result<SendableStruct, Swift.Error>) -> Void) {
     fatalError()
   }
 


### PR DESCRIPTION
Explanation: This PR fixes function sub typing rules for sending. Specifically:

- We emit a diagnostic if one attempts to convert a function with a sending parameter to one without a sending parameter.
- We emit a diagnostic if one attempts to convert a function without a sending result to one with a sending result.
- We prevent the same sort of mismatches in protocols.

Radars:
- rdar://129300953
- rdar://127675288

Original PRs:

- https://github.com/apple/swift/pull/74129

Risk: Low. This is improving the compiler since these concurrency holes would result in other weird crashes.
Testing: Added exhaustive tests to the test suite.
Reviewer: N/A