### PR TITLE
Disable SwiftCompilerSources for Windows ARM64. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -923,6 +923,12 @@ if (NOT BOOTSTRAPPING_MODE)
   message(FATAL_ERROR "turning off bootstrapping is not supported anymore")
 endif()
 
+# As a temporary workaround, disable SwiftCompilerSources on
+# Windows/ARM64 because the compiler segfaults
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64")
+  set(BOOTSTRAPPING_MODE "OFF")
+endif()
+
 set(SWIFT_RUNTIME_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin")
 set(SWIFT_LIBRARY_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib")
 if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")


### PR DESCRIPTION
This fixes the Windows ARM64 toolchain segfault issue in the official build: https://download.swift.org/development/windows10-arm64/swift-DEVELOPMENT-SNAPSHOT-2024-06-03-a/swift-DEVELOPMENT-SNAPSHOT-2024-06-03-a-windows10-arm64.exe
