### PR TITLE
[6.0] Add CXX compiler to SCL-F Windows build

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1433,7 +1433,7 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
       -InstallTo "$($Arch.SDKInstallRoot)\usr" `
       -Arch $Arch `
       -Platform $Platform `
-      -UseBuiltCompilers ASM,C,Swift `
+      -UseBuiltCompilers ASM,C,CXX,Swift `
       -BuildTargets $Targets `
       -Defines (@{
         # Turn off safeseh for lld as it has safeseh enabled by default


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/74427

Explanation: Provides a valid CXX compiler to the swift-corelibs-foundation build on Windows
Scope: Only affects Windows builds of swift-corelibs-foundation
Original PR: https://github.com/apple/swift/pull/74427
Risk: Minimal - this change just ensures a CXX compiler is provided and the source today does not contain any C++ sources
Testing: PR testing via swift-ci and toolchain build via swift-ci
Reviewer: @compnerd