### PR TITLE
Demangler: edge case in existential demangling

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -783,8 +783,18 @@ Type ASTBuilder::createConstrainedExistentialType(
     }
     args.push_back(argTy->getSecond());
   }
-  Type constrainedBase =
-      ParameterizedProtocolType::get(base->getASTContext(), baseTy, args);
+
+  Type constrainedBase;
+
+  // We may not have any arguments because the constrained existential is a
+  // plain protocol with an inverse requirement.
+  if (args.empty()) {
+    constrainedBase =
+        ProtocolType::get(baseDecl, baseTy, base->getASTContext());
+  } else {
+    constrainedBase =
+        ParameterizedProtocolType::get(base->getASTContext(), baseTy, args);
+  }
 
   // Handle inverse requirements.
   if (!inverseRequirements.empty()) {

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -755,46 +755,53 @@ Type ASTBuilder::createExistentialMetatypeType(
 Type ASTBuilder::createConstrainedExistentialType(
     Type base, ArrayRef<BuiltRequirement> constraints,
     ArrayRef<BuiltInverseRequirement> inverseRequirements) {
-  // FIXME: Generalize to other kinds of bases.
-  if (!base->getAs<ProtocolType>())
-    return Type();
-  auto baseTy = base->castTo<ProtocolType>();
-  auto baseDecl = baseTy->getDecl();
-  llvm::SmallDenseMap<Identifier, Type> cmap;
-  for (const auto &req : constraints) {
-    switch (req.getKind()) {
-    case RequirementKind::SameShape:
-      llvm_unreachable("Same-shape requirement not supported here");
-    case RequirementKind::Conformance:
-    case RequirementKind::Superclass:
-    case RequirementKind::Layout:
-      continue;
-
-    case RequirementKind::SameType:
-      if (auto *DMT = req.getFirstType()->getAs<DependentMemberType>())
-        cmap[DMT->getName()] = req.getSecondType();
-    }
-  }
-  llvm::SmallVector<Type, 4> args;
-  for (auto *assocTy : baseDecl->getPrimaryAssociatedTypes()) {
-    auto argTy = cmap.find(assocTy->getName());
-    if (argTy == cmap.end()) {
-      return Type();
-    }
-    args.push_back(argTy->getSecond());
-  }
-
   Type constrainedBase;
 
-  // We may not have any arguments because the constrained existential is a
-  // plain protocol with an inverse requirement.
-  if (args.empty()) {
-    constrainedBase =
-        ProtocolType::get(baseDecl, baseTy, base->getASTContext());
+  if (auto baseTy = base->getAs<ProtocolType>()) {
+    auto baseDecl = baseTy->getDecl();
+    llvm::SmallDenseMap<Identifier, Type> cmap;
+    for (const auto &req : constraints) {
+      switch (req.getKind()) {
+      case RequirementKind::SameShape:
+        llvm_unreachable("Same-shape requirement not supported here");
+      case RequirementKind::Conformance:
+      case RequirementKind::Superclass:
+      case RequirementKind::Layout:
+        continue;
+
+      case RequirementKind::SameType:
+        if (auto *DMT = req.getFirstType()->getAs<DependentMemberType>())
+          cmap[DMT->getName()] = req.getSecondType();
+      }
+    }
+    llvm::SmallVector<Type, 4> args;
+    for (auto *assocTy : baseDecl->getPrimaryAssociatedTypes()) {
+      auto argTy = cmap.find(assocTy->getName());
+      if (argTy == cmap.end()) {
+        return Type();
+      }
+      args.push_back(argTy->getSecond());
+    }
+
+    // We may not have any arguments because the constrained existential is a
+    // plain protocol with an inverse requirement.
+    if (args.empty()) {
+      constrainedBase =
+          ProtocolType::get(baseDecl, baseTy, base->getASTContext());
+    } else {
+      constrainedBase =
+          ParameterizedProtocolType::get(base->getASTContext(), baseTy, args);
+    }
+  } else if (base->isAny()) {
+    // The only other case should be that we got an empty PCT, which is equal to
+    // the Any type. The other constraints should have been encoded in the
+    // existential's generic signature (and arrive as BuiltInverseRequirement).
+    constrainedBase = base;
   } else {
-    constrainedBase =
-        ParameterizedProtocolType::get(base->getASTContext(), baseTy, args);
+    return Type();
   }
+
+  assert(constrainedBase);
 
   // Handle inverse requirements.
   if (!inverseRequirements.empty()) {

--- a/test/Interpreter/moveonly_existentials.swift
+++ b/test/Interpreter/moveonly_existentials.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  %s -o %t/bin
+// RUN: %target-build-swift -g %s -o %t/bin
 // RUN: %target-codesign %t/bin
 // RUN: %target-run %t/bin | %FileCheck %s
 


### PR DESCRIPTION
We now may have constrained existentials that have no primary associated types, so there won't be any arguments for the parameterized protocol type. Because the "constrained" part is that there's an inverse.

resolves rdar://128695929