### PR TITLE
utils: copy static libraries for Android SDK

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1777,6 +1777,7 @@ function Install-Platform([Platform]$Platform, $Arch) {
       Copy-File "$PlatformLibSrc\$($Arch.LLVMName)\*.lib" "$PlatformLibDst\$($Arch.LLVMName)\"
     }
     Android {
+      Copy-File "$PlatformLibSrc\*.a" "$PlatformLibDst\$($Arch.LLVMName)\"
       Copy-File "$PlatformLibSrc\*.so" "$PlatformLibDst\$($Arch.LLVMName)\"
     }
   }


### PR DESCRIPTION
Update the SDK deployment to include the static libraries as well. This is primarily needed for the C++ interop libraries.