### PR TITLE
Add support for swift style diagnostics for swift caching

### DIFF
--- a/include/swift/AST/DiagnosticBridge.h
+++ b/include/swift/AST/DiagnosticBridge.h
@@ -1,0 +1,71 @@
+//===--- DiagnosticBridge.h - Diagnostic Bridge to SwiftSyntax --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file declares the DiagnosticBridge class, which bridges to swift-syntax
+//  for diagnostics printing.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_DIAGNOSTICBRIDGE_H
+#define SWIFT_BASIC_DIAGNOSTICBRIDGE_H
+
+#include "swift/AST/DiagnosticConsumer.h"
+#include "swift/Basic/SourceManager.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace swift {
+/// Declare the bridge between swift-syntax and swift-frontend for diagnostics
+/// handling. The methods in this class should only be called when
+/// `SWIFT_BUILD_SWIFT_SYNTAX` is defined as they are otherwise undefined.
+class DiagnosticBridge {
+  /// A queued up source file known to the queued diagnostics.
+  using QueuedBuffer = void *;
+
+  /// The queued diagnostics structure.
+  void *queuedDiagnostics = nullptr;
+  llvm::DenseMap<unsigned, QueuedBuffer> queuedBuffers;
+
+  /// Source file syntax nodes cached by { source manager, buffer ID }.
+  llvm::DenseMap<std::pair<SourceManager *, unsigned>, void *> sourceFileSyntax;
+
+public:
+  /// Enqueue diagnostics.
+  void enqueueDiagnostic(SourceManager &SM, const DiagnosticInfo &Info,
+                         unsigned innermostBufferID);
+
+  /// Flush all enqueued diagnostics.
+  void flush(llvm::raw_ostream &OS, bool includeTrailingBreak,
+             bool forceColors);
+
+  /// Retrieve the stack of source buffers from the provided location out to
+  /// a physical source file, with source buffer IDs for each step along the way
+  /// due to (e.g.) macro expansions or generated code.
+  ///
+  /// The resulting vector will always contain valid source locations. If the
+  /// initial location is invalid, the result will be empty.
+  static SmallVector<unsigned, 1> getSourceBufferStack(SourceManager &sourceMgr,
+                                                       SourceLoc loc);
+
+  DiagnosticBridge() = default;
+  ~DiagnosticBridge();
+
+private:
+  /// Retrieve the SourceFileSyntax for the given buffer.
+  void *getSourceFileSyntax(SourceManager &SM, unsigned bufferID,
+                            StringRef displayName);
+
+  void queueBuffer(SourceManager &sourceMgr, unsigned bufferID);
+};
+} // namespace swift
+
+#endif

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1687,10 +1687,6 @@ namespace swift {
     const StringRef Message;
   };
 
-/// Retrieve the macro name for a generated source info that represents
-/// a macro expansion.
-DeclName getGeneratedSourceInfoMacroName(const GeneratedSourceInfo &info);
-
 } // end namespace swift
 
 #endif

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -69,6 +69,10 @@ public:
   /// The custom attribute for an attached macro.
   CustomAttr *attachedMacroCustomAttr = nullptr;
 
+  /// MacroDecl name if the generated source is coming from macro expansion,
+  /// otherwise empty string.
+  std::string macroName = "";
+
   /// The name of the source file on disk that was created to hold the
   /// contents of this file for external clients.
   StringRef onDiskBufferCopyFileName = StringRef();

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -18,13 +18,13 @@
 #ifndef SWIFT_PRINTINGDIAGNOSTICCONSUMER_H
 #define SWIFT_PRINTINGDIAGNOSTICCONSUMER_H
 
+#include "swift/AST/DiagnosticBridge.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/Basic/DiagnosticOptions.h"
 #include "swift/Basic/LLVM.h"
 
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/Process.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace swift {
 
@@ -43,16 +43,7 @@ class PrintingDiagnosticConsumer : public DiagnosticConsumer {
   bool SuppressOutput = false;
 
   /// swift-syntax rendering
-
-  /// A queued up source file known to the queued diagnostics.
-  using QueuedBuffer = void *;
-
-  /// The queued diagnostics structure.
-  void *queuedDiagnostics = nullptr;
-  llvm::DenseMap<unsigned, QueuedBuffer> queuedBuffers;
-
-  /// Source file syntax nodes cached by { source manager, buffer ID }.
-  llvm::DenseMap<std::pair<SourceManager *, unsigned>, void *> sourceFileSyntax;
+  DiagnosticBridge DiagBridge;
 
 public:
   PrintingDiagnosticConsumer(llvm::raw_ostream &stream = llvm::errs());

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -38,6 +38,7 @@ add_swift_host_library(swiftAST STATIC
   Decl.cpp
   DeclContext.cpp
   DeclNameLoc.cpp
+  DiagnosticBridge.cpp
   DiagnosticConsumer.cpp
   DiagnosticEngine.cpp
   DiagnosticList.cpp

--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -1,0 +1,193 @@
+//===--- DiagnosticBridge.cpp - Diagnostic Bridge to swift-syntax ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the DiagnosticBridge class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/DiagnosticBridge.h"
+#include "swift/AST/ASTBridging.h"
+#include "swift/AST/DiagnosticConsumer.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/Basic/SourceManager.h"
+#include "swift/Bridging/ASTGen.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace swift;
+
+#if SWIFT_BUILD_SWIFT_SYNTAX
+/// Enqueue a diagnostic with ASTGen's diagnostic rendering.
+static void addQueueDiagnostic(void *queuedDiagnostics,
+                               const DiagnosticInfo &info, SourceManager &SM) {
+  llvm::SmallString<256> text;
+  {
+    llvm::raw_svector_ostream out(text);
+    DiagnosticEngine::formatDiagnosticText(out, info.FormatString,
+                                           info.FormatArgs);
+  }
+
+  BridgedDiagnosticSeverity severity;
+  switch (info.Kind) {
+  case DiagnosticKind::Error:
+    severity = BridgedDiagnosticSeverity::BridgedError;
+    break;
+
+  case DiagnosticKind::Warning:
+    severity = BridgedDiagnosticSeverity::BridgedWarning;
+    break;
+
+  case DiagnosticKind::Remark:
+    severity = BridgedDiagnosticSeverity::BridgedRemark;
+    break;
+
+  case DiagnosticKind::Note:
+    severity = BridgedDiagnosticSeverity::BridgedNote;
+    break;
+  }
+
+  // Map the highlight ranges.
+  SmallVector<const void *, 2> highlightRanges;
+  for (const auto &range : info.Ranges) {
+    if (range.isInvalid())
+      continue;
+
+    highlightRanges.push_back(range.getStart().getOpaquePointerValue());
+    highlightRanges.push_back(range.getEnd().getOpaquePointerValue());
+  }
+
+  // FIXME: Translate Fix-Its.
+  swift_ASTGen_addQueuedDiagnostic(queuedDiagnostics, text.data(), text.size(),
+                                   severity, info.Loc.getOpaquePointerValue(),
+                                   highlightRanges.data(),
+                                   highlightRanges.size() / 2);
+}
+
+void DiagnosticBridge::enqueueDiagnostic(SourceManager &SM,
+                                         const DiagnosticInfo &Info,
+                                         unsigned innermostBufferID) {
+  // If there are no enqueued diagnostics, or we have hit a non-note
+  // diagnostic, flush any enqueued diagnostics and start fresh.
+  if (!queuedDiagnostics)
+    queuedDiagnostics = swift_ASTGen_createQueuedDiagnostics();
+
+  queueBuffer(SM, innermostBufferID);
+  addQueueDiagnostic(queuedDiagnostics, Info, SM);
+}
+
+void DiagnosticBridge::flush(llvm::raw_ostream &OS, bool includeTrailingBreak,
+                             bool forceColors) {
+  if (!queuedDiagnostics)
+    return;
+
+  BridgedStringRef bridgedRenderedString{nullptr, 0};
+  swift_ASTGen_renderQueuedDiagnostics(queuedDiagnostics, /*contextSize=*/2,
+                                       forceColors ? 1 : 0,
+                                       &bridgedRenderedString);
+  auto renderedString = bridgedRenderedString.unbridged();
+  if (renderedString.data()) {
+    OS.write(renderedString.data(), renderedString.size());
+    swift_ASTGen_freeBridgedString(renderedString);
+  }
+  swift_ASTGen_destroyQueuedDiagnostics(queuedDiagnostics);
+  queuedDiagnostics = nullptr;
+  queuedBuffers.clear();
+
+  if (includeTrailingBreak)
+    OS << "\n";
+}
+
+void *DiagnosticBridge::getSourceFileSyntax(SourceManager &sourceMgr,
+                                            unsigned bufferID,
+                                            StringRef displayName) {
+  auto known = sourceFileSyntax.find({&sourceMgr, bufferID});
+  if (known != sourceFileSyntax.end())
+    return known->second;
+
+  auto bufferContents = sourceMgr.getEntireTextForBuffer(bufferID);
+  auto sourceFile = swift_ASTGen_parseSourceFile(
+      bufferContents.data(), bufferContents.size(), "module",
+      displayName.str().c_str(), /*ctx*/ nullptr);
+
+  sourceFileSyntax[{&sourceMgr, bufferID}] = sourceFile;
+  return sourceFile;
+}
+
+void DiagnosticBridge::queueBuffer(SourceManager &sourceMgr,
+                                   unsigned bufferID) {
+  QueuedBuffer knownSourceFile = queuedBuffers[bufferID];
+  if (knownSourceFile)
+    return;
+
+  // Find the parent and position in parent, if there is one.
+  int parentID = -1;
+  int positionInParent = 0;
+  std::string displayName;
+  auto generatedSourceInfo = sourceMgr.getGeneratedSourceInfo(bufferID);
+  if (generatedSourceInfo) {
+    SourceLoc parentLoc = generatedSourceInfo->originalSourceRange.getEnd();
+    if (parentLoc.isValid()) {
+      parentID = sourceMgr.findBufferContainingLoc(parentLoc);
+      positionInParent = sourceMgr.getLocOffsetInBuffer(parentLoc, parentID);
+
+      // Queue the parent buffer.
+      queueBuffer(sourceMgr, parentID);
+    }
+
+    if (!generatedSourceInfo->macroName.empty()) {
+      if (generatedSourceInfo->attachedMacroCustomAttr)
+        displayName = "macro expansion @" + generatedSourceInfo->macroName;
+      else
+        displayName = "macro expansion #" + generatedSourceInfo->macroName;
+    }
+  }
+
+  if (displayName.empty()) {
+    displayName =
+        sourceMgr.getDisplayNameForLoc(sourceMgr.getLocForBufferStart(bufferID))
+            .str();
+  }
+
+  auto sourceFile = getSourceFileSyntax(sourceMgr, bufferID, displayName);
+  swift_ASTGen_addQueuedSourceFile(queuedDiagnostics, bufferID, sourceFile,
+                                   (const uint8_t *)displayName.data(),
+                                   displayName.size(), parentID,
+                                   positionInParent);
+  queuedBuffers[bufferID] = sourceFile;
+}
+
+SmallVector<unsigned, 1>
+DiagnosticBridge::getSourceBufferStack(SourceManager &sourceMgr,
+                                       SourceLoc loc) {
+  SmallVector<unsigned, 1> stack;
+  while (true) {
+    if (loc.isInvalid())
+      return stack;
+
+    unsigned bufferID = sourceMgr.findBufferContainingLoc(loc);
+    stack.push_back(bufferID);
+
+    auto generatedSourceInfo = sourceMgr.getGeneratedSourceInfo(bufferID);
+    if (!generatedSourceInfo)
+      return stack;
+
+    loc = generatedSourceInfo->originalSourceRange.getStart();
+  }
+}
+
+DiagnosticBridge::~DiagnosticBridge() {
+  assert(!queuedDiagnostics && "unflushed diagnostics");
+  for (const auto &sourceFileSyntax : sourceFileSyntax) {
+    swift_ASTGen_destroySourceFile(sourceFileSyntax.second);
+  }
+}
+
+#endif // SWIFT_BUILD_SWIFT_SYNTAX

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/SILOptions.h"
+#include "swift/Basic/DiagnosticOptions.h"
 #include "swift/Frontend/Frontend.h"
 
 #include "ArgsToFrontendOptionsConverter.h"
@@ -2228,8 +2229,12 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
       Args.hasFlag(OPT_color_diagnostics,
                    OPT_no_color_diagnostics,
                    /*Default=*/llvm::sys::Process::StandardErrHasColors());
-  // If no style options are specified, default to Swift style.
-  Opts.PrintedFormattingStyle = DiagnosticOptions::FormattingStyle::Swift;
+  // If no style options are specified, default to Swift style, unless it is
+  // under swift caching, which llvm style is preferred because LLVM style
+  // replays a lot faster.
+  Opts.PrintedFormattingStyle = Args.hasArg(OPT_cache_compile_job)
+                                    ? DiagnosticOptions::FormattingStyle::LLVM
+                                    : DiagnosticOptions::FormattingStyle::Swift;
   if (const Arg *arg = Args.getLastArg(OPT_diagnostic_style)) {
     StringRef contents = arg->getValue();
     if (contents == "llvm") {
@@ -2242,9 +2247,6 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
       return true;
     }
   }
-  // Swift style is not fully supported in cached mode yet.
-  if (Args.hasArg(OPT_cache_compile_job))
-    Opts.PrintedFormattingStyle = DiagnosticOptions::FormattingStyle::LLVM;
 
   for (const Arg *arg: Args.filtered(OPT_emit_macro_expansion_files)) {
     StringRef contents = arg->getValue();

--- a/test/CAS/cached_diagnostics_macro.swift
+++ b/test/CAS/cached_diagnostics_macro.swift
@@ -1,0 +1,60 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %t/macro.swift
+
+// RUN: %target-swift-frontend -typecheck -module-load-mode prefer-serialized -module-name MyApp -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift -swift-version 5 -external-plugin-path %t#%swift-plugin-server 2> %t/diag1.txt
+
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-serialized -module-name MyApp -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -external-plugin-path %t#%swift-plugin-server
+
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json MyApp casFSRootID > %t/fs.casid
+// RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/fs.casid | %FileCheck %s --check-prefix=FS
+
+// FS: MacroDefinition
+// RUN: %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/SwiftShims.cmd
+// RUN: %swift_frontend_plain @%t/SwiftShims.cmd
+
+// RUN: %S/Inputs/BuildCommandExtractor.py %t/deps.json MyApp > %t/MyApp.cmd
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
+// RUN: %target-swift-frontend -diagnostic-style=swift \
+// RUN:   -emit-module -o %t/Test.swiftmodule -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -external-plugin-path %t#%swift-plugin-server \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map.casid -O \
+// RUN:   %t/main.swift @%t/MyApp.cmd -serialize-diagnostics-path %t/Test.diag 2> %t/diag2.txt
+
+// RUN: diff %t/diag1.txt %t/diag2.txt
+
+//--- macro.swift
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntax
+import SwiftSyntaxBuilder
+@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+
+public struct CallDeprecatedMacro: ExpressionMacro {
+   public static func expansion(
+     of macro: some FreestandingMacroExpansionSyntax,
+     in context: some MacroExpansionContext
+   ) throws -> ExprSyntax {
+     return "testDeprecated()"
+  }
+}
+
+//--- main.swift
+@freestanding(expression) macro myWarning(_ message: String) = #externalMacro(module: "MacroDefinition", type: "CallDeprecatedMacro")
+
+@available(*, deprecated)
+func testDeprecated() {}
+
+func testDiscardableStringify(x: Int) {
+  #myWarning("this is a warning")
+}


### PR DESCRIPTION
Add support for swift style diagnostics for swift caching. This includes
pre-populate the GeneratedSourceInfo with macro name so it doesn't need
to infer from an ASTNode, which the caching mechanism cannot preserve.

Still leave the default diagnostic style to LLVM style because replaying
swift style diagnostics is still very slow and including parsing source
file using swift-syntax.

rdar://128615572