### PR TITLE
[embedded] Implement missing _convertConstStringToUTF8PointerArgument to support string to pointer conversion

### DIFF
--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -514,10 +514,11 @@ func _convertConstStringToUTF8PointerArgument<
 }
 #else
 @_transparent
-@_unavailableInEmbedded
-public
-func _convertConstStringToUTF8PointerArgument<ToPointer: _Pointer>(
-    _ str: String) -> (Builtin.NativeObject?, ToPointer) {
-  fatalError("unreachable in embedded Swift (marked as unavailable)")
+public // COMPILER_INTRINSIC
+func _convertConstStringToUTF8PointerArgument<
+  ToPointer: _Pointer
+>(_ str: String) -> (Builtin.NativeObject?, ToPointer) {
+  let utf8 = Array(str.utf8CString)
+  return _convertConstArrayToPointerArgument(utf8)
 }
 #endif

--- a/test/embedded/string-to-pointer.swift
+++ b/test/embedded/string-to-pointer.swift
@@ -1,0 +1,16 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -wmo) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+@_extern(c)
+func puts(_ string: UnsafePointer<CChar>?) -> CInt
+
+func foo(_ string: UnsafePointer<CChar>?) {
+  puts(string)
+}
+
+foo("hello")
+// CHECK: hello


### PR DESCRIPTION
Fixes https://github.com/apple/swift/issues/74386.