### PR TITLE
Disable SwiftValueNSObject test (for now)

### DIFF
--- a/test/stdlib/SwiftValueNSObject.swift
+++ b/test/stdlib/SwiftValueNSObject.swift
@@ -21,6 +21,7 @@
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
+// REQUIRES: rdar127008956
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime


### PR DESCRIPTION
The underlying behavior of __SwiftValue bridging now has a couple of different possible behaviors depending on how libswiftCore was built and even (in some cases) the specific binary that's running.

This makes it very hard to craft an accurate test of this functionality. Disable it (for now) until we can figure out a better way to conditionalize the expected behavior here.

Related to (but does not resolve) rdar://127008956