### PR TITLE
[Sema] Specific fixit to prepend 'let' if we can't find name in scope in an assignment dest position.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1092,6 +1092,8 @@ ERROR(cannot_find_in_scope,none,
 ERROR(cannot_find_in_scope_corrected,none,
       "cannot %select{find|find operator}1 %0 in scope; did you mean '%2'?",
       (DeclNameRef, bool, StringRef))
+ERROR(cannot_find_in_scope_bind,none,
+      "cannot find %0 in scope; did you mean to bind it?", (DeclNameRef))
 ERROR(cannot_find_self_in_scope,none,
       "cannot find 'self' in scope; did you mean to use it in a type or extension context?", ())
 NOTE(confusable_character,none,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3057,11 +3057,17 @@ bool ContextualFailure::diagnoseConversionToBool() const {
   auto *anchor = castToExpr(getAnchor());
   // Check for "=" converting to Bool.  The user probably meant ==.
   if (auto *AE = dyn_cast<AssignExpr>(anchor->getValueProvidingExpr())) {
-    emitDiagnosticAt(AE->getEqualLoc(), diag::use_of_equal_instead_of_equality)
-        .fixItReplace(AE->getEqualLoc(), "==")
-        .highlight(AE->getDest()->getLoc())
-        .highlight(AE->getSrc()->getLoc());
-    return true;
+    if (AE->getDest()->getKind() == ExprKind::Error && !findParentExpr(AE)) {
+      // Already diagnosed as user probably meant a pattern binding
+      return true;
+    } else {
+      emitDiagnosticAt(AE->getEqualLoc(),
+                       diag::use_of_equal_instead_of_equality)
+          .fixItReplace(AE->getEqualLoc(), "==")
+          .highlight(AE->getDest()->getLoc())
+          .highlight(AE->getSrc()->getLoc());
+      return true;
+    }
   }
 
   // Determine if the boolean negation operator was applied to the anchor. This

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -405,7 +405,8 @@ static BinaryExpr *getCompositionExpr(Expr *expr) {
 /// for the lookup.
 Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
                                       DeclContext *DC,
-                                      bool replaceInvalidRefsWithErrors) {
+                                      bool replaceInvalidRefsWithErrors,
+                                      bool inAssignmentPosition) {
   // Process UnresolvedDeclRefExpr by doing an unqualified lookup.
   DeclNameRef Name = UDRE->getName();
   SourceLoc Loc = UDRE->getLoc();
@@ -579,9 +580,11 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
       
       if (Name.isSimpleName(Context.Id_self)) {
         // `self` gets diagnosed with a different error when it can't be found.
-        Context.Diags
-            .diagnose(Loc, diag::cannot_find_self_in_scope)
+        Context.Diags.diagnose(Loc, diag::cannot_find_self_in_scope)
             .highlight(UDRE->getSourceRange());
+      } else if (inAssignmentPosition) {
+        Context.Diags.diagnose(Loc, diag::cannot_find_in_scope_bind, Name)
+            .fixItInsert(UDRE->getStartLoc(), "let ");
       } else {
         Context.Diags
             .diagnose(Loc, diag::cannot_find_in_scope, Name,
@@ -1213,8 +1216,16 @@ namespace {
                         new (Ctx) ErrorExpr(unresolved->getSourceRange()));
         }
 
-        auto *refExpr =
-            TypeChecker::resolveDeclRefExpr(unresolved, DC, UseErrorExprs);
+        bool inAssignment = false;
+        if (!ExprStack.empty()) {
+          if (auto sequence = dyn_cast<SequenceExpr>(ExprStack.back())) {
+            auto elements = sequence->getElements();
+            inAssignment = elements[0] == unresolved &&
+                           elements[1]->getKind() == ExprKind::Assign;
+          }
+        }
+        auto *refExpr = TypeChecker::resolveDeclRefExpr(
+            unresolved, DC, UseErrorExprs, inAssignment);
 
         // Check whether this is standalone `self` in init accessor, which
         // is invalid.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -297,7 +297,8 @@ Type getOptionalType(SourceLoc loc, Type elementType);
 /// \param replaceInvalidRefsWithErrors Indicates whether it's allowed
 /// to replace any discovered invalid member references with `ErrorExpr`.
 Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context,
-                         bool replaceInvalidRefsWithErrors);
+                         bool replaceInvalidRefsWithErrors,
+                         bool inAssignmentPosition = false);
 
 /// Check for invalid existential types in the given declaration.
 void checkExistentialTypes(Decl *decl);

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -127,6 +127,16 @@ if 1 != 2, let x = opt,
    let a = opt, var b = opt { // expected-warning {{immutable value 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
 }
 
+// Test leading expr missing binding keyword
+if y = opt {} // expected-error {{cannot find 'y' in scope; did you mean to bind it?}} {{4-4=let }}
+while y = opt {} // expected-error {{cannot find 'y' in scope; did you mean to bind it?}} {{7-7=let }}
+if y = opt, z = opt {} // expected-error {{cannot find 'y' in scope; did you mean to bind it?}} {{4-4=let }}
+// expected-error@-1 {{cannot find 'z' in scope; did you mean to bind it?}} {{13-13=let }}
+if 1 != 2, y = opt {} // expected-error {{cannot find 'y' in scope; did you mean to bind it?}} {{12-12=let }}
+y = opt // expected-error {{cannot find 'y' in scope; did you mean to bind it?}} {{1-1=let }}
+if 1 != 2 && y = opt {} // expected-error {{cannot find 'y' in scope}}
+// expected-error@-1 {{use of '=' in a boolean context, did you mean '=='?}}
+
 // <rdar://problem/20457938> typed pattern is not allowed on if/let condition
 if 1 != 2, let x : Int? = opt {} // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
 // expected-warning @-1 {{explicitly specified type 'Int?' adds an additional level of optional to the initializer, making the optional check always succeed}} {{20-24=Int}}


### PR DESCRIPTION
Example:
```
let x: Int?
if y = x {}
```
Formerly you'd get `cannot find 'y' in scope` and also  `use of '=' in a boolean context, did you mean '=='?` diagnosis here. Now the new single error will be `cannot find 'y' in scope; did you mean to bind it?` with a fixit to add `let `. This happens anywhere where we're walking expressions pre-typechecking and find an unresolved decl ref at the beginning of a SequenceExpr and followed by an AssignExpr. 

Thus, you also get this diagnosis for standalone statements like `y = 1` (when 'y' isn't defined), which is an appropriate place to suggest it, but means that the pre-existing diagnosis `expected 'let' in conditional` would read wrong in that situation. That other diagnosis happens during Parse and only occurs if we parsed one let/var pattern and then a comma, and something with an assignment with no binding keyword (e.g. `if let x = foo, y = bar` -- the second potential pattern there). 

In theory the code for that other `expected 'let' in conditional` diagnosis could now be removed, because the new diagnosis will catch this and also be somewhat smarter because if 'y' IS defined, you'd get `use of '=' in a boolean context, did you mean '=='?`. But wanted to ask if that seems appropriate before seriously looking into it. 


Resolves #46561.
