### PR TITLE
Concurrency: Fix default type witness for AsyncSequence.Failure

### DIFF
--- a/stdlib/public/Concurrency/AsyncSequence.swift
+++ b/stdlib/public/Concurrency/AsyncSequence.swift
@@ -81,7 +81,7 @@ public protocol AsyncSequence<Element, Failure> {
 
   /// The type of errors produced when iteration over the sequence fails.
   @available(SwiftStdlib 6.0, *)
-  associatedtype Failure: Error = AsyncIterator.Failure
+  associatedtype Failure: Error = any Error
       where AsyncIterator.Failure == Failure
 
   /// Creates the asynchronous iterator that produces elements of this


### PR DESCRIPTION
Setting this to Self.AsyncIterator.Failure doesn't work because
we replace it with its reduced type Self.Failure, and then if
you run a binary compiled against an older version of the stdlib
that does not declare the Failure associated type, we hit
infinite recursion while instantiating the witness table and
trying to populate the default type witness.

Instead, let's set the default to `any Error`. Associated type
inference is already smart enough to infer the type witness from
the AsyncIterator's Failure type; we don't need to rely on the
default mechanism for that.

Fixes rdar://129605725.