### PR TITLE
[6.0][Features] FullTypedThrows should only be enable-able in asserts builds.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -228,7 +228,7 @@ EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
 EXPERIMENTAL_FEATURE(CodeItemMacros, false)
 EXPERIMENTAL_FEATURE(PreambleMacros, false)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
-EXPERIMENTAL_FEATURE(FullTypedThrows, true)
+EXPERIMENTAL_FEATURE(FullTypedThrows, false)
 
 // Whether to enable @_used and @_section attributes
 EXPERIMENTAL_FEATURE(SymbolLinkageMarkers, true)

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-emit-silgen %s -enable-experimental-feature FullTypedThrows | %FileCheck %s
 
+// REQUIRES: asserts
+
 public func genericThrow<E>(e: E) throws(E) {
   throw e
 }

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature FullTypedThrows
 
+// REQUIRES: asserts
+
 enum MyError: Error {
 case failed
 case epicFailed


### PR DESCRIPTION
* **Explanation**: The implementation of this experimental feature is not complete and it's not ready to be enabled in production. This experimental feature only gates the source-breaking parts of SE-0413: Typed throws, which will not be enabled by default in the Swift 6 language mode.
* **Scope**: Only impacts which toolchains you can use the `FullTypedThrows` experimental feature flag in.
* **Risk**: Low.
* **Testing**: Updated existing tests to require asserts.
* **Main branch PR**: https://github.com/apple/swift/pull/74446