### PR TITLE
[ARCOpts] Don't move releases before landingpads

### DIFF
--- a/lib/LLVMPasses/LLVMARCOpts.cpp
+++ b/lib/LLVMPasses/LLVMARCOpts.cpp
@@ -274,9 +274,9 @@ static bool performLocalReleaseMotion(CallInst &Release, BasicBlock &BB,
   while (BBI != BB.begin()) {
     --BBI;
 
-    // Don't analyze PHI nodes.  We can't move retains before them and they
-    // aren't "interesting".
-    if (isa<PHINode>(BBI) ||
+    // Don't analyze PHI nodes and landingpad instructions. We can't move
+    // releases before them and they aren't "interesting".
+    if (isa<PHINode>(BBI) || isa<LandingPadInst>(BBI) ||
         // If we found the instruction that defines the value we're releasing,
         // don't push the release past it.
         &*BBI == Release.getArgOperand(0)) {

--- a/test/LLVMPasses/release_motion_landingpad.ll
+++ b/test/LLVMPasses/release_motion_landingpad.ll
@@ -1,0 +1,29 @@
+; RUN: %swift-llvm-opt -passes=swift-llvm-arc-optimize %s | %FileCheck %s
+
+target datalayout = "e-p:64:64:64-S128-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f16:16:16-f32:32:32-f64:64:64-f128:128:128-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
+target triple = "x86_64-apple-macosx10.9"
+
+declare void @swift_release(ptr nocapture)
+declare void @swift_retain(ptr) nounwind
+declare ptr @_Znwm(i64)
+declare i32 @__gxx_personality_v0(...)
+
+define ptr @foo(ptr %0) personality ptr @__gxx_personality_v0 {
+entry:
+  %1 = tail call ptr @swift_retain(ptr %0)
+  %2 = invoke ptr @_Znwm(i64 16)
+          to label %continue unwind label %unwind
+continue:
+  tail call void @swift_release(ptr %1)
+  ret ptr %1
+unwind:
+  %3 = landingpad { ptr, i32 }
+          cleanup
+  tail call void @swift_release(ptr %1)
+  resume { ptr, i32 } %3
+}
+
+; CHECK:      unwind:
+; CHECK-NEXT: %3 = landingpad { ptr, i32 }
+; CHECK-NEXT:         cleanup
+; CHECK-NEXT: tail call void @swift_release(ptr %1)


### PR DESCRIPTION
Turns out that we allowed moving swift_release calls before landingpad instructions, resulting in invalid IR, per LangRef <https://llvm.org/docs/LangRef.html#landingpad-instruction>:

> A landing pad block must have a ‘landingpad’ instruction as its first non-PHI instruction.

See the attached testcase which fails without the fix in `performLocalReleaseMotion`.

rdar://122874601