### PR TITLE
Fix Bad diagnostic for `any P!`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5769,7 +5769,7 @@ ERROR(incorrect_optional_any,none,
       "using '!' is not allowed here; perhaps '?' was intended",
       ())
 ERROR(incorrect_iuo_any,none,
-      "implicitly unwrapped 'any' type must be written (%0)!",
+      "implicitly unwrapped optional 'any' type must be written (%0)!",
       (StringRef))
 ERROR(existential_requires_any,none,
       "use of %select{protocol |}2%0 as a type must be written %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5769,7 +5769,7 @@ ERROR(incorrect_optional_any,none,
       "using '!' is not allowed here; perhaps '?' was intended",
       ())
 ERROR(incorrect_iuo_any,none,
-      "force unwrapped 'any' type must be written (%0)!",
+      "implicitly unwrapped 'any' type must be written (%0)!",
       (StringRef))
 ERROR(existential_requires_any,none,
       "use of %select{protocol |}2%0 as a type must be written %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5766,8 +5766,11 @@ ERROR(any_not_existential,none,
        "'any' has no effect on %select{concrete type|type parameter}0 %1",
        (bool, Type))
 ERROR(incorrect_optional_any,none,
-      "optional 'any' type must be written %0",
-      (Type))
+      "using '!' is not allowed here; perhaps '?' was intended",
+      ())
+ERROR(incorrect_iuo_any,none,
+      "force unwrapped 'any' type must be written (%0)!",
+      (StringRef))
 ERROR(existential_requires_any,none,
       "use of %select{protocol |}2%0 as a type must be written %1",
       (Type, Type, bool))

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5697,7 +5697,6 @@ TypeResolver::resolveExistentialType(ExistentialTypeRepr *repr,
 
     // Emit a tailored diagnostic for the incorrect optional
     // syntax 'any P?' with a fix-it to add parenthesis.
-    auto wrapped = constraintType->getOptionalObjectType();
     if (wrapped && (wrapped->is<ExistentialType>() ||
                     wrapped->is<ExistentialMetatypeType>())) {
       std::string fix;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5129,6 +5129,8 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
 
   bool doDiag = false;
   switch (options.getContext()) {
+  case TypeResolverContext::ExistentialConstraint:
+    break ;
   case TypeResolverContext::None:
   case TypeResolverContext::InoutFunctionInput:
     if (!isDirect || !(options & allowIUO))
@@ -5154,7 +5156,6 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
   case TypeResolverContext::TypeAliasDecl:
   case TypeResolverContext::GenericTypeAliasDecl:
   case TypeResolverContext::GenericRequirement:
-  case TypeResolverContext::ExistentialConstraint:
   case TypeResolverContext::SameTypeRequirement:
   case TypeResolverContext::ProtocolMetatypeBase:
   case TypeResolverContext::MetatypeBase:

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -479,7 +479,7 @@ func testAnyFixIt() {
   let _: any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type // OK
 
   // Misplaced '!'.
-  // expected-error@+1 {{force unwrapped 'any' type must be written (any HasAssoc)!}}{{10-23=(any HasAssoc)!}}
+  // expected-error@+1 {{implicitly unwrapped 'any' type must be written (any HasAssoc)!}}{{10-23=(any HasAssoc)!}}
   let _: any HasAssoc!
 
   // expected-error@+1 {{using '!' is not allowed here; perhaps '?' was intended}}{{16-29=(any HasAssoc)?}}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -478,6 +478,22 @@ func testAnyFixIt() {
   let _: (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type?
   let _: any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type // OK
 
+  // Misplaced '!'.
+  // expected-error@+1 {{force unwrapped 'any' type must be written (any HasAssoc)!}}{{10-23=(any HasAssoc)!}}
+  let _: any HasAssoc!
+
+  // expected-error@+1 {{using '!' is not allowed here; perhaps '?' was intended}}{{16-29=(any HasAssoc)?}}
+  let _: (Int, any HasAssoc!)
+
+  // expected-error@+1 {{using '!' is not allowed here; perhaps '?' was intended}}{{12-19=(any PP)?}}
+  let _: G<any PP!>
+
+  // expected-error@+1 {{using '!' is not allowed here; perhaps '?' was intended}}{{11-18=(any PP)?}}
+  let _: (any PP!) -> Void
+
+  // expected-error@+1 {{using '!' is not allowed here; perhaps '?' was intended}}{{11-17=(any PP)?}}
+  let _: (any P!)?
+
   // Misplaced '?'.
 
   // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc)?'}}{{10-23=(any HasAssoc)?}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Hello Team, In This PR tries to solve an issue where we get two errors emitted for: 


```swift
protocol P {}

// error: using '!' is not allowed here; perhaps '?' was intended? [implicitly_unwrapped_optional_in_illegal_position]
// error: optional 'any' type must be written '(any P2)?' [incorrect_optional_any]
let _: any P!
```


the first error here isn't useful, so we should only emit a single error.

i fixed it by exclude  `ExistentialConstraint` from `resolveImplicitlyUnwrappedOptionalType` thus, we don't get the un-needed diagnostic emitted.

i tried to work on a fix without touching  `resolveImplicitlyUnwrappedOptionalType` and instead do something in: 

`TypeResolver::resolveExistentialType` but it didn't work, as at that point we already get a diagnostics emitted from   `resolveImplicitlyUnwrappedOptionalType` 


after applying my fix we get only one error emitted

![image](https://github.com/apple/swift/assets/2325884/ce323868-b5ca-4a01-8285-18e0ed67b6b8)


Please let me know what do you think about this proposed solution!

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #72662

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
