### PR TITLE
[Sema] Fix hole where missing_nullary_call wasn't diagnosed in ternary condition.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6524,6 +6524,9 @@ bool ConstraintSystem::repairFailures(
                                 locator))
       return true;
 
+    if (repairByInsertingExplicitCall(lhs, rhs))
+      return true;
+
     conversionsOrFixes.push_back(IgnoreContextualType::create(
         *this, lhs, rhs, getConstraintLocator(locator)));
     break;

--- a/test/Constraints/ternary_expr.swift
+++ b/test/Constraints/ternary_expr.swift
@@ -59,6 +59,9 @@ _ = true ? x : 1.2 // expected-error {{result values in '? :' expression have mi
 _ = (x: true) ? true : false // expected-error {{cannot convert value of type '(x: Bool)' to expected condition type 'Bool'}}
 _ = (x: 1) ? true : false // expected-error {{cannot convert value of type '(x: Int)' to expected condition type 'Bool'}}
 
+func resultBool() -> Bool { true }
+_ = resultBool ? true : false // expected-error {{function 'resultBool' was used as a property; add () to call it}} {{15-15=()}}
+
 let ib: Bool! = false
 let eb: Bool? = .some(false)
 let conditional = ib ? "Broken" : "Heart" // should infer Bool!


### PR DESCRIPTION
Added a check for `function produces expected type 'Bool'; did you mean to call it with '()'?`  when in the position of a condition for a ternary expression. Because of the way `ContextualFailure`s are diagnosed, this particular diagnostic couldn't be hit before.

Resolves #46902.
