### PR TITLE
[Concurrency] if let value on async value should be banned (not crash)

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -129,7 +129,7 @@ extension ASTGenVisitor {
       } else {
         let identifier = pat.boundName
         if identifier != nil {
-          // For `if let foo { }` Create an implicit `foo` expression as the initializer.
+          // For `if let foo { }` Create a `foo` expression as the initializer.
           let ref = BridgedDeclNameRef.createParsed(.createIdentifier(identifier))
           let loc = BridgedDeclNameLoc.createParsed(self.generateSourceLoc(node.pattern))
           initializer =
@@ -139,7 +139,6 @@ extension ASTGenVisitor {
               kind: .ordinary,
               loc: loc
             ).asExpr
-          initializer.setImplicit()
         } else {
           // FIXME: Implement.
           // For `if let foo.bar {`, diagnose and convert it to `if let _ =  foo.bar`

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1793,8 +1793,12 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
     auto declRefExpr = new (Context) UnresolvedDeclRefExpr(bindingName,
                                                            DeclRefKind::Ordinary,
                                                            loc);
-    
-    declRefExpr->setImplicit();
+    // We do NOT mark this declRefExpr as implicit because that'd avoid
+    // reporting errors if it were used in a synchronous context in
+    // 'diagnoseUnhandledAsyncSite'. There may be other ways to resolve the
+    // reporting issue that we could explore in the future.
+    //
+    // Even though implicit, the ast node has correct source location.
     Init = makeParserResult(declRefExpr);
   } else if (BindingKindStr != "case") {
     // If the pattern is present but isn't an identifier, the user wrote

--- a/test/Concurrency/effectful_properties_async_if_optional_unwrap.swift
+++ b/test/Concurrency/effectful_properties_async_if_optional_unwrap.swift
@@ -1,0 +1,57 @@
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -verify %s
+
+// REQUIRES: concurrency
+
+@available(SwiftStdlib 5.1, *)
+struct Kappa {
+  var maybeData: Int? {
+    get async { 12 }
+  }
+
+  func take() -> Int? { // expected-note 3{{add 'async' to function 'take()' to make it asynchronous}}
+
+    if let data = maybeData { // expected-error{{'async' property access in a function that does not support concurrency}}
+      return data
+    }
+
+    let x = maybeData // expected-error{{'async' property access in a function that does not support concurrency}}
+      _ = x
+
+    if let maybeData { // expected-error{{'async' property access in a function that does not support concurrency}}
+      return maybeData
+    }
+
+    return nil
+  }
+
+  func takeAsync() async -> Int? {
+
+    if let data = maybeData { // expected-error{{expression is 'async' but is not marked with 'await'}}
+      // expected-note@-1{{property access is 'async'}}
+      return data
+    }
+
+    let x = maybeData // expected-error{{expression is 'async' but is not marked with 'await'}}
+    // expected-note@-1{{property access is 'async'}}
+    _ = x
+
+    if let maybeData { // expected-error{{expression is 'async' but is not marked with 'await'}}
+      // expected-note@-1{{property access is 'async'}}
+      return maybeData
+    }
+
+    return nil
+  }
+
+  func illegalSyntax() async -> Int? {
+    // This is NOT valid syntax and we reject it properly,
+    // though we could try to could give a better message
+    if let await maybeData { // expected-error{{unwrap condition requires a valid identifier}}
+      // expected-error@-1{{pattern variable binding cannot appear in an expression}}
+      // expected-warning@-2{{no 'async' operations occur within 'await' expression}}
+      return maybeData // expected-error{{expression is 'async' but is not marked with 'await'}}
+      // expected-note@-1{{property access is 'async'}}
+    }
+
+  }
+}

--- a/test/DebugInfo/guard-let-scope3.swift
+++ b/test/DebugInfo/guard-let-scope3.swift
@@ -11,11 +11,12 @@ public class S {
       // CHECK: sil_scope [[X1_RHS:[0-9]+]] { loc "{{.*}}":9:19 parent [[P]]
       // CHECK: sil_scope [[X1:[0-9]+]] { loc "{{.*}}":9:19 parent [[P]]
       // CHECK: sil_scope [[X2:[0-9]+]] { loc "{{.*}}":9:29 parent [[X1]]
+      // CHECK: sil_scope [[X3:[0-9]+]] { loc "{{.*}}":9:29 parent [[X1]]
       // CHECK: sil_scope [[GUARD:[0-9]+]] { loc "{{.*}}":9:36 parent [[P]]
       // CHECK: debug_value {{.*}} : $Optional<C>, let, name "x", {{.*}}, scope [[X1]]
-      // CHECK: debug_value {{.*}} : $C, let, name "x", {{.*}}, scope [[X2]]
+      // CHECK: debug_value {{.*}} : $C, let, name "x", {{.*}}, scope [[X3]]
       // FIXME: This source location is a little wild.
-      // CHECK-NEXT: release_value{{.*}}:[[@LINE+5]]:3, scope [[X2]]
+      // CHECK-NEXT: release_value{{.*}}:[[@LINE+5]]:3, scope [[X3]]
       throw MyError()
       // CHECK: function_ref {{.*}}MyError{{.*}}:[[@LINE-1]]:13, scope [[GUARD]]
     }

--- a/test/DebugInfo/if-let-scope.swift
+++ b/test/DebugInfo/if-let-scope.swift
@@ -5,6 +5,7 @@ public func f(value: String?) {
   if let value, let value = Int(value) {
     // CHECK: sil_scope [[S1:[0-9]+]] { loc "{{.*}}":5:3
     // CHECK: sil_scope [[S2:[0-9]+]] { loc "{{.*}}":5:10
+    // CHECK: sil_scope [[S2:[0-9]+]] { loc "{{.*}}":5:10
     // CHECK: sil_scope [[S3:[0-9]+]] { loc "{{.*}}":5:29 parent [[S2]] }
     // CHECK: sil_scope [[S4:[0-9]+]] { loc "{{.*}}":5:29 parent [[S2]] }
     // CHECK: sil_scope [[S5:[0-9]+]] { loc "{{.*}}":5:40 parent [[S4]] }

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -226,13 +226,13 @@ func testAsyncExprWithoutAwait() async {
   if let result: A = result {} // expected-error {{expression is 'async' but is not marked with 'await'}} {{22-22=await }}
   // expected-warning@-1 {{immutable value 'result' was never used; consider replacing with '_' or removing it}}
   // expected-note@-2 {{reference to async let 'result' is 'async'}}
-  if let result: A {} // expected-error {{expression is 'async' but is not marked with 'await'}} {{19-19= = await result}}
+  if let result: A {} // expected-error {{expression is 'async' but is not marked with 'await'}} {{18-18=await }}
   // expected-warning@-1 {{immutable value 'result' was never used; consider replacing with '_' or removing it}}
   // expected-note@-2 {{reference to async let 'result' is 'async'}}
   if let result = result {} // expected-error {{expression is 'async' but is not marked with 'await'}} {{19-19=await }}
   // expected-warning@-1 {{value 'result' was defined but never used; consider replacing with boolean test}}
   // expected-note@-2 {{reference to async let 'result' is 'async'}}
-  if let result {} // expected-error {{expression is 'async' but is not marked with 'await'}} {{16-16= = await result}}
+  if let result {} // expected-error {{expression is 'async' but is not marked with 'await'}} {{10-10=await }}
   // expected-warning@-1 {{value 'result' was defined but never used; consider replacing with boolean test}}
   // expected-note@-2 {{reference to async let 'result' is 'async'}}
   let a = f("a") // expected-error {{expression is 'async' but is not marked with 'await'}} {{11-11=await }}


### PR DESCRIPTION
The issue is that the shorthand if let syntax injects an implicit expression: https://github.com/apple/swift/pull/40694/ in ParseStmt and that the 'diagnoseUnhandledAsyncSite' explicitly avoids reporting errors in implicit expressions.

This patch "peeks" at the expression to notice this case, however perhaps we should mark this implicit expression in ParseStmt and then detect it explicitly.

Added some tests covering this as well as properly erroring out for the nonexistent syntax of shortand + awaiting which doesn't exist, and we properly error on it.

Resolves rdar://126169564
