### PR TITLE
[Completion] Don’t generate USRs for local decls

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3766,8 +3766,9 @@ void ASTMangler::appendClosureEntity(const AbstractClosureExpr *closure) {
 
   auto type = closure->getType();
 
-  // FIXME: CodeCompletionResultBuilder calls printValueDeclUSR() but the
-  // closure hasn't been type checked yet.
+  // FIXME: We can end up with a null type here in the presence of invalid
+  // code; the type-checker currently isn't strict about producing typed
+  // expression nodes when it fails. Once we enforce that, we can remove this.
   if (!type)
     type = ErrorType::get(closure->getASTContext());
 

--- a/lib/IDE/CodeCompletionResultBuilder.cpp
+++ b/lib/IDE/CodeCompletionResultBuilder.cpp
@@ -36,6 +36,11 @@ static bool shouldCopyAssociatedUSRForDecl(const ValueDecl *VD) {
   if (VD->hasClangNode() && !VD->getClangDecl())
     return false;
 
+  // Avoid generating USRs for decls in local contexts, we cannot guarantee
+  // any parent closures will be type-checked, which is needed for mangling.
+  if (VD->getDeclContext()->getLocalContext())
+    return false;
+
   return true;
 }
 

--- a/test/SourceKit/CodeComplete/complete_local_decl.swift
+++ b/test/SourceKit/CodeComplete/complete_local_decl.swift
@@ -1,0 +1,30 @@
+// rdar://128294522 - Make sure we don't generate USRs for decls in local contexts.
+
+func test1() {
+  let loclVar = 0 // This typo is intentional; otherwise mangling applies a substitution for 'local'.
+  // RUN: %sourcekitd-test -req=complete -pos=%(line):3 %s -- %s | %FileCheck %s --check-prefix LOCAL_VAR
+  // LOCAL_VAR-NOT: key.associated_usrs: "s:{{.*}}loclVar{{.*}}"
+  // LOCAL_VAR:     key.name: "loclVar"
+  // LOCAL_VAR-NOT: key.associated_usrs: "s:{{.*}}loclVar{{.*}}"
+}
+
+func test2() {
+  let _ = {
+    struct S {
+      func nestedMethod() {
+        // RUN: %sourcekitd-test -req=complete -pos=%(line):3 %s -- %s | %FileCheck %s --check-prefix LOCAL_METHOD
+        // RUN: %sourcekitd-test -req=complete -pos=%(line+1):14 %s -- %s | %FileCheck %s --check-prefix LOCAL_METHOD
+        self.
+        // LOCAL_METHOD-NOT: key.associated_usrs: "s:{{.*}}nestedMethod{{.*}}"
+        // LOCAL_METHOD:     key.name: "nestedMethod()"
+        // LOCAL_METHOD-NOT: key.associated_usrs: "s:{{.*}}nestedMethod{{.*}}"
+      }
+    }
+  }
+}
+
+// Just to make sure 'key.associated_usrs' is produced for a non-local decl
+// so the above CHECK-NOT's are working. If this fails, make sure to update the
+// above checks too.
+// RUN: %sourcekitd-test -req=complete -pos=%(line):1 %s -- %s | %FileCheck %s --check-prefix NON_LOCAL
+// NON_LOCAL: key.associated_usrs: "s:{{.*}}test2{{.*}}"


### PR DESCRIPTION
Doing so can cause issues since we cannot guarantee that e.g any parent closures have been type-checked.

rdar://128294522