### PR TITLE
[embedded] Skip EagerSpecializer on embedded Swift

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -683,7 +683,14 @@ static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
 static void addHighLevelFunctionPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("HighLevel,Function+EarlyLoopOpt",
                   true /*isFunctionPassPipeline*/);
-  P.addEagerSpecializer();
+
+  // Skip EagerSpecializer on embedded Swift, which already specializes
+  // everything. Otherwise this would create metatype references for functions
+  // with @_specialize attribute and those are incompatible with Emebdded Swift.
+  if (!P.getOptions().EmbeddedSwift) {
+    P.addEagerSpecializer();
+  }
+
   P.addObjCBridgingOptimization();
 
   addFunctionPasses(P, OptimizationLevelKind::HighLevel);

--- a/test/embedded/specialize-attrs2.swift
+++ b/test/embedded/specialize-attrs2.swift
@@ -1,0 +1,20 @@
+// RUN: %target-run-simple-swift(-parse-as-library -Onone -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+
+@main
+struct Main {
+  static func main() {
+    let chars: [Character] = ["a", "b", "c"]
+    let s = Substring.init(chars)
+    print(s)
+    print("OK!")
+  }
+}
+
+// CHECK: OK!


### PR DESCRIPTION
EagerSpecializer SIL pass processes `@_specialize`-annotated functions and creates a "type check" in them that compares metadata. This is (1) incompatible with Embedded Swift, because metadata are not available there, and (2) unnecessary in Embedded Swift because all functions are fully specialized already. Let's disable EagerSpecializer when compiling in Embedded Swift mode.

This fixes a compilation error when using anything that's `@_specialize`-annotated. Before this fix, using e.g. the `Substring.init<S: Sequence>(_ elements: S) where S.Element == Character` function from the stdlib (which has the annotation) results in:

```
in function specialized Substring.init<A>(_:)
<unknown>:0: error: cannot use metatype of type 'Array<Character>' in embedded Swift
```

See the attached testcase.