### PR TITLE
[SILGen] Fix `any Sendable` to `Any` bridging when result should be p…

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1170,8 +1170,8 @@ static ManagedValue emitCBridgedToNativeValue(
               .getAsSingleValue(SGF, loc);
     
     // Convert to the marker existential if necessary.
-    auto anyType = SGF.getASTContext().getAnyExistentialType();
-    if (nativeType != anyType) {
+    if (!v.isInContext()) {
+      auto anyType = SGF.getASTContext().getAnyExistentialType();
       v = SGF.emitTransformedValue(loc, v, anyType, nativeType);
     }
 

--- a/test/SILGen/Inputs/objc_bridging_sendable.h
+++ b/test/SILGen/Inputs/objc_bridging_sendable.h
@@ -2,5 +2,6 @@
 
 @interface NSBlah: NSObject
 - (void) takeSendable: (id __attribute__((swift_attr("@Sendable")))) x;
-@property (readonly) id __attribute__((swift_attr("@Sendable"))) x;
+@property(readonly) id __attribute__((swift_attr("@Sendable"))) x;
+- (nullable __attribute__((swift_attr("@Sendable"))) id)test:(NSError *_Nullable __autoreleasing * _Nullable)error;
 @end

--- a/test/SILGen/objc_bridging_sendable.swift
+++ b/test/SILGen/objc_bridging_sendable.swift
@@ -12,4 +12,25 @@ public func passSendableToObjC(_ s: Sendable) {
 
 public func useSendableProperty(_ ns: NSBlah) {
   _ = ns.x
+  let _: (Int, Any, String, [Any]) = (42, ns.x, "", [1, 2, 3])
+}
+
+// CHECK-LABEL: sil private [ossa] @$s22objc_bridging_sendable23test_use_of_buffer_inityyKFypSo6NSBlahCKXEfU_ : $@convention(thin) @substituted <τ_0_0> (@guaranteed NSBlah) -> (@out τ_0_0, @error any Error) for <Any>
+// CHECK: bb0(%0 : $*Any, %1 : @guaranteed $NSBlah):
+// CHECK: [[TEST_REF:%.*]] = objc_method %1 : $NSBlah, #NSBlah.test!foreign : (NSBlah) -> () throws -> any Sendable, $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, NSBlah) -> @autoreleased Optional<AnyObject>
+// CHECK: [[RESULT:%.*]] = apply [[TEST_REF]]({{.*}}, %1) : $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, NSBlah) -> @autoreleased Optional<AnyObject>
+// CHECK: switch_enum [[RESULT]] : $Optional<AnyObject>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+// CHECK: bb1([[SUCCESS:%.*]] : @owned $AnyObject)
+// CHECK-NEXT: [[OPT_RESULT_VALUE:%.*]] = unchecked_ref_cast [[SUCCESS]] : $AnyObject to $Optional<AnyObject>
+// CHECK-NEXT: // function_ref _bridgeAnyObjectToAny(_:)
+// CHECK-NEXT: [[BRIDGE_INTRINSIC_REF:%.*]] = function_ref @$ss018_bridgeAnyObjectToB0yypyXlSgF : $@convention(thin) (@guaranteed Optional<AnyObject>) -> @out Any
+// CHECK-NEXT:  apply [[BRIDGE_INTRINSIC_REF]](%0, [[OPT_RESULT_VALUE]]) : $@convention(thin) (@guaranteed Optional<AnyObject>) -> @out Any
+func test_use_of_buffer_init() throws {
+  func test<T: Sendable>(_: (NSBlah) throws -> T) rethrows -> T {
+    fatalError()
+  }
+
+  let _: Any = try test {
+      try $0.test()
+  }
 }


### PR DESCRIPTION
…laced in a buffer

If the context indicates that the result of `id-to-Any` should be placed in some pre-allocated buffer, let's not attempt marker existential transformation because that would much the expected layout already.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
