### PR TITLE
[stdlib] _Builtin_float: More availability adjustments

### DIFF
--- a/stdlib/public/ClangOverlays/float.swift.gyb
+++ b/stdlib/public/ClangOverlays/float.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -13,8 +13,8 @@
 @_exported import _Builtin_float
 
 @available(swift, deprecated: 3.0, message: "Please use 'T.radix' to get the radix of a FloatingPoint type 'T'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
-@_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+@_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let FLT_RADIX = Double.radix
 
 %for type, prefix in [('Float', 'FLT'), ('Double', 'DBL'), ('Float80', 'LDBL')]:
@@ -24,7 +24,7 @@ public let FLT_RADIX = Double.radix
 //  Where does the 1 come from? C counts the usually-implicit leading
 //  significand bit, but Swift does not. Neither is really right or wrong.
 @available(swift, deprecated: 3.0, message: "Please use '${type}.significandBitCount + 1'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MANT_DIG = ${type}.significandBitCount + 1
 
@@ -33,32 +33,32 @@ public let ${prefix}_MANT_DIG = ${type}.significandBitCount + 1
 //  significand to be in [1, 2). This rationale applies to ${prefix}_MIN_EXP
 //  as well.
 @available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude.exponent + 1'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MAX_EXP = ${type}.greatestFiniteMagnitude.exponent + 1
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude.exponent + 1'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MIN_EXP = ${type}.leastNormalMagnitude.exponent + 1
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude' or '.greatestFiniteMagnitude'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MAX = ${type}.greatestFiniteMagnitude
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.ulpOfOne' or '.ulpOfOne'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_EPSILON = ${type}.ulpOfOne
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude' or '.leastNormalMagnitude'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MIN = ${type}.leastNormalMagnitude
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNonzeroMagnitude' or '.leastNonzeroMagnitude'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
 


### PR DESCRIPTION
- Fix one placeholder availability I missed in the previous patch (#74366)
- Add `visionOS 1.0` availability to work around over-pedantic `@_originallyDefinedIn` diagnostic that started appearing in toolchain builds.

https://ci.swift.org/view/Swift%206.0/job/oss-swift-6.0-package-macos/219/console
```
/Users/ec2-user/jenkins/workspace/oss-swift-6.0-package-macos/swift/stdlib/public/ClangOverlays/float.swift.gyb:28:1: error: '@_originallyDefinedIn' requires that 'FLT_MANT_DIG' have explicit availability for visionOS
 24 | @available(swift, deprecated: 3.0, message: "Please use 'Float.significandBitCount + 1'.")
 25 | @available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
 26 | @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
    | `- error: '@_originallyDefinedIn' requires that 'FLT_MANT_DIG' have explicit availability for visionOS
 27 | public let FLT_MANT_DIG = Float.significandBitCount + 1
 28 | 
```