### PR TITLE
[6.0][stdlib] _Builtin_float: More availability adjustments

### DIFF
--- a/stdlib/public/ClangOverlays/float.swift.gyb
+++ b/stdlib/public/ClangOverlays/float.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -13,8 +13,8 @@
 @_exported import _Builtin_float
 
 @available(swift, deprecated: 3.0, message: "Please use 'T.radix' to get the radix of a FloatingPoint type 'T'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
-@_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
+@_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let FLT_RADIX = Double.radix
 
 %for type, prefix in [('Float', 'FLT'), ('Double', 'DBL'), ('Float80', 'LDBL')]:
@@ -24,7 +24,7 @@ public let FLT_RADIX = Double.radix
 //  Where does the 1 come from? C counts the usually-implicit leading
 //  significand bit, but Swift does not. Neither is really right or wrong.
 @available(swift, deprecated: 3.0, message: "Please use '${type}.significandBitCount + 1'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MANT_DIG = ${type}.significandBitCount + 1
 
@@ -33,32 +33,32 @@ public let ${prefix}_MANT_DIG = ${type}.significandBitCount + 1
 //  significand to be in [1, 2). This rationale applies to ${prefix}_MIN_EXP
 //  as well.
 @available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude.exponent + 1'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MAX_EXP = ${type}.greatestFiniteMagnitude.exponent + 1
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude.exponent + 1'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MIN_EXP = ${type}.leastNormalMagnitude.exponent + 1
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude' or '.greatestFiniteMagnitude'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MAX = ${type}.greatestFiniteMagnitude
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.ulpOfOne' or '.ulpOfOne'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_EPSILON = ${type}.ulpOfOne
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude' or '.leastNormalMagnitude'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_MIN = ${type}.leastNormalMagnitude
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNonzeroMagnitude' or '.leastNonzeroMagnitude'.")
-@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0)
 public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
 


### PR DESCRIPTION
- **Explanation:** This resolves issues uncovered since #74367 has landed, unblocking swift.org toolchain builds.
- **Scope:** Standard Library (`_Builtin_float` module).
- **Risk:** Low.
- **Testing:** Regular PR testing, incl. toolchain builds.
- **Reviewer:** @ian-twilightcoder 
- **Original PR:** #74486 
- **Issue:** Word of mouth
