### PR TITLE
[ClangImporter] Always add `AnyObject` constraint to generic parameters

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7357,10 +7357,10 @@ std::optional<GenericParamList *> SwiftDeclConverter::importObjCGenericParams(
           TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()));
       }
     }
-    if (inherited.empty()) {
-      inherited.push_back(
-        TypeLoc::withoutLoc(Impl.SwiftContext.getAnyObjectConstraint()));
-    }
+
+    inherited.push_back(
+      TypeLoc::withoutLoc(Impl.SwiftContext.getAnyObjectConstraint()));
+
     genericParamDecl->setInherited(Impl.SwiftContext.AllocateCopy(inherited));
 
     genericParams.push_back(genericParamDecl);

--- a/test/ClangImporter/objc_method_with_sendable_generic_requirement.swift
+++ b/test/ClangImporter/objc_method_with_sendable_generic_requirement.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-silgen %t/main.swift -import-objc-header %t/Test.h | %FileCheck %t/main.swift
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+
+// rdar://127520993
+
+//--- Test.h
+#import <Foundation/Foundation.h>
+
+#define SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+
+@interface Test<N : id SWIFT_SENDABLE> : NSObject
+- (void)luckWithNumber:(nullable N)number;
+@end
+
+//--- main.swift
+import Foundation
+
+Test<NSNumber>().luck(withNumber: 5)
+// CHECK-LABEL: sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32
+// CHECK: [[NS_NUMBER_INIT:%.*]] = function_ref @$sSo8NSNumberC10FoundationE14integerLiteralABSi_tcfC : $@convention(method) (Int, @thick NSNumber.Type) -> @owned NSNumber
+// CHECK-NEXT:  [[NS_NUMBER:%.*]] = apply [[NS_NUMBER_INIT]]({{.*}}) : $@convention(method) (Int, @thick NSNumber.Type) -> @owned NSNumber
+// CHECK-NEXT:  [[OPT_NS_NUMBER:%.*]] = enum $Optional<NSNumber>, #Optional.some!enumelt, [[NS_NUMBER]] : $NSNumber
+// CHECK-NEXT:  [[LUCK_METHOD_REF:%.*]] = objc_method %4 : $Test<NSNumber>, #Test.luck!foreign : <N where N : AnyObject, N : Sendable> (Test<N>) -> (N?) -> (), $@convention(objc_method) @pseudogeneric <τ_0_0 where τ_0_0 : AnyObject, τ_0_0 : Sendable> (Optional<τ_0_0>, Test<τ_0_0>) -> ()
+// CHECK-NEXT:  %14 = apply [[LUCK_METHOD_REF]]<NSNumber>([[OPT_NS_NUMBER]], {{.*}}) : $@convention(objc_method) @pseudogeneric <τ_0_0 where τ_0_0 : AnyObject, τ_0_0 : Sendable> (Optional<τ_0_0>, Test<τ_0_0>) -> ()

--- a/test/Interpreter/objc_method_with_sendable_generic_requirement.swift
+++ b/test/Interpreter/objc_method_with_sendable_generic_requirement.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-clang %t/Test.m -c -o %t/Test.o
+// RUN: %target-build-swift %t/main.swift -import-objc-header %t/Test.h %t/Test.o -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %t/main.swift
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+// rdar://127520993
+
+//--- Test.h
+#import <Foundation/Foundation.h>
+
+#define SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+
+@interface Test<N : id SWIFT_SENDABLE> : NSObject
+- (void)luckWithNumber:(nullable N)number;
+@end
+
+//--- Test.m
+#import "Test.h"
+
+static void NSPrint(NSString *format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    NSString *string = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+
+    fprintf(stdout, "%s\n", [string UTF8String]);
+
+#if !__has_feature(objc_arc)
+    [string release];
+#endif
+}
+
+@implementation Test
+
+- (void)luckWithNumber:(id)number
+{
+    NSPrint(@"Lucky number: %@", number);
+}
+
+@end
+
+//--- main.swift
+Test<NSNumber>().luck(withNumber: 5)
+// CHECK: Lucky number: 5


### PR DESCRIPTION
`: AnyObject` was added only if there were no other constraints because all of them would imply it before, with introduction of `Sendable` this is no longer the case. Let's add `AnyObject` constraint unconditionally and let generic signature builder deal with the redundancy.

Resolves: rdar://127520993

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
