### PR TITLE
Update test/SILGen/keypaths_objc_optional.swift for SDK availability change.

### DIFF
--- a/test/SILGen/keypaths_objc_optional.swift
+++ b/test/SILGen/keypaths_objc_optional.swift
@@ -66,4 +66,4 @@ func testKeyPathAccessorsForOptionalStorageComponents() {
   _ = \ObjCProtocol.flag
 }
 
-// CHECK-macosx-x86_64: sil [transparent] [serialized] @$s10ObjectiveC22_convertObjCBoolToBoolySbAA0cD0VF : $@convention(thin) (ObjCBool) -> Bool
+// CHECK-macosx-x86_64: sil [transparent] [serialized] {{.*}}@$s10ObjectiveC22_convertObjCBoolToBoolySbAA0cD0VF : $@convention(thin) (ObjCBool) -> Bool


### PR DESCRIPTION
Relax the CHECK: line here to tolerate an [available] attribute on the `convertObjCBoolToBool` operation that was added in recent Apple SDKs. rdar://129894685