### PR TITLE
[6.0][cmake] Add missing dependency SwiftMacros -> SwiftOperators

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
@@ -18,6 +18,7 @@ add_swift_macro_library(SwiftMacros
   TaskLocalMacro.swift
 SWIFT_DEPENDENCIES
     SwiftDiagnostics
+    SwiftOperators
     SwiftSyntax
     SwiftSyntaxBuilder
     SwiftSyntaxMacros


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/72309 into release/6.0

* **Explanation**: Add missing dependency `SwiftOperators` to `SwiftMacros`.
* **Scope**: `SwiftMacros` plugin
* **Risk**: Low. The dependency listing was wrong, just fixing it
* **Testing**: Passes current test suite
* **Issues**: N/A
* **Reviewer**: Hamish Knight (@hamishknight) as the author, Rintaro Ishizaki (@rintaro)