### PR TITLE
[Macros] Remove unused dependency to SwiftOperators

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/Availability.swift
+++ b/lib/Macros/Sources/ObservationMacros/Availability.swift
@@ -12,7 +12,6 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftDiagnostics
-import SwiftOperators
 import SwiftSyntaxBuilder
 
 

--- a/lib/Macros/Sources/ObservationMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/ObservationMacros/CMakeLists.txt
@@ -16,7 +16,6 @@ add_swift_macro_library(ObservationMacros
   ObservableMacro.swift
   SWIFT_DEPENDENCIES
     SwiftDiagnostics
-    SwiftOperators
     SwiftSyntaxBuilder
     SwiftSyntax
     SwiftSyntaxMacros

--- a/lib/Macros/Sources/ObservationMacros/Extensions.swift
+++ b/lib/Macros/Sources/ObservationMacros/Extensions.swift
@@ -12,7 +12,6 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftDiagnostics
-import SwiftOperators
 import SwiftSyntaxBuilder
 
 extension VariableDeclSyntax {

--- a/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
@@ -18,7 +18,6 @@ add_swift_macro_library(SwiftMacros
   TaskLocalMacro.swift
   SWIFT_DEPENDENCIES
     SwiftDiagnostics
-    SwiftOperators
     SwiftSyntax
     SwiftSyntaxBuilder
     SwiftSyntaxMacros

--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -12,7 +12,6 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftDiagnostics
-import SwiftOperators
 import SwiftSyntaxBuilder
 
 /// Introduces:


### PR DESCRIPTION
`ObservationMacros` and `SwiftMacros` don't use anything in `SwiftOperators`
