### PR TITLE
[6.0] Fix MoveOnlyWrappedTypeEliminator; handle dealloc_box

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -180,6 +180,7 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   NO_UPDATE_NEEDED(MarkDependence)
   NO_UPDATE_NEEDED(DestroyAddr)
   NO_UPDATE_NEEDED(DeallocStack)
+  NO_UPDATE_NEEDED(DeallocBox)
   NO_UPDATE_NEEDED(Branch)
   NO_UPDATE_NEEDED(ExplicitCopyAddr)
   NO_UPDATE_NEEDED(CopyAddr)

--- a/test/SILOptimizer/moveonly_type_eliminator.sil
+++ b/test/SILOptimizer/moveonly_type_eliminator.sil
@@ -578,3 +578,24 @@ bb0(%x : @owned $Klass):
   %retval = tuple ()
   return %retval : $()
 }
+
+// SILGen occasionally uses dealloc_box instead of destroy_value. dealloc_box is needed when we don't want to destroy
+// the contents of the box. It seems to happen with property wrappers.
+//
+// CHECK-LABEL: sil [ossa] @dealoc_box : $@convention(thin) (@owned Klass) -> () {
+// CHECK:           [[BOX:%.*]] = alloc_box [moveable_value_debuginfo] ${ var Klass }
+// CHECK:           dealloc_box [[BOX]] : ${ var Klass }
+// CHECK-LABEL: } // end sil function 'dealoc_box'
+sil [ossa] @dealoc_box : $@convention(thin) (@owned Klass) -> () {
+bb0(%x : @owned $Klass):
+  %box = alloc_box ${ var @moveOnly Klass }
+  %addr = project_box %box : ${ var @moveOnly Klass }, 0
+  %unwrapped_addr = moveonlywrapper_to_copyable_addr %addr : $*@moveOnly Klass
+  store %x to [init] %unwrapped_addr : $*Klass
+  debug_value %addr : $*@moveOnly Klass, var, name "s", argno 1, expr op_deref
+  destroy_addr %addr : $*@moveOnly Klass
+  debug_value undef : $*@moveOnly Klass, var, name "s", argno 1, expr op_deref
+  dealloc_box %box : ${ var @moveOnly Klass }
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Speculatively fixes
rdar://129185450: Unhandled SIL Instruction: dealloc_box %3

(cherry picked from commit 2f747ad607c7e1b516c17d33919ad742759e0e4e)

--- CCC ---

Explanation: Fix MoveOnlyWrappedTypeEliminator to handle dealloc_box instructions.

Scope: This SIL pass crashes on certain valid SIL patterns. The test code has a property wrapper, but the problem may be broader than that.

Radar/SR Issue: rdar://129185450 Unhandled SIL Instruction: dealloc_box %3

main PR: https://github.com/apple/swift/pull/74477

Risk: The fix adds trivial check for this instruction type.

Testing: Unit test added.

Reviewer: Nate Chandler

