### PR TITLE
[6.0] SILGen: Don't use `diagnoseUnexpectedEnumCase` intrinsic for noncopyable enums.

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -3109,6 +3109,13 @@ static void emitDiagnoseOfUnexpectedEnumCaseValue(SILGenFunction &SGF,
 static void emitDiagnoseOfUnexpectedEnumCase(SILGenFunction &SGF,
                                              SILLocation loc,
                                              UnexpectedEnumCaseInfo ueci) {
+  if (ueci.subjectTy->isNoncopyable()) {
+    // TODO: The DiagnoseUnexpectedEnumCase intrinsic currently requires a
+    // Copyable parameter. For noncopyable enums it should be impossible to
+    // reach an unexpected case statically, so just emit a trap for now.
+    SGF.B.createUnconditionalFail(loc, "unexpected enum case");
+    return;
+  }
   ASTContext &ctx = SGF.getASTContext();
   auto diagnoseFailure = ctx.getDiagnoseUnexpectedEnumCase();
   if (!diagnoseFailure) {

--- a/test/SILGen/noncopyable_enum_unexpected_case.swift
+++ b/test/SILGen/noncopyable_enum_unexpected_case.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+struct NC: ~Copyable {}
+
+enum NoncopyableEnum: ~Copyable {
+  case copyable(Int)
+  case noncopyable(NC)
+}
+
+func test(foo: consuming NoncopyableEnum) {
+  switch foo {
+  case let x: // expected-warning{{'x' was never used}}
+    break
+  case .copyable(let x): // expected-warning{{already handled by previous patterns}} expected-warning{{'x' was never used}}
+    break
+  }
+}


### PR DESCRIPTION
Explanation: Fixes a compiler crash when a `switch` over a noncopyable enum contains a redundant enum case pattern after a wildcard pattern.
Scope: Bug fix.
Issue: rdar://130037881
Original PR: https://github.com/apple/swift/pull/74505
Risk: Low. Avoids an assertion failure in a rare code pattern.
Testing: Swift CI, test case from bug report
Reviewer: @slavapestov 