### PR TITLE
[stdlib] Mark UInt128.Words as frozen

### DIFF
--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -313,7 +313,7 @@ extension UInt128: Numeric {
 // MARK: - BinaryInteger conformance
 @available(SwiftStdlib 6.0, *)
 extension UInt128: BinaryInteger {
-  
+  @frozen
   public struct Words {
     @usableFromInline
     let _value: UInt128


### PR DESCRIPTION
It seems we forgot to label this new struct as `@frozen` which inhibits the optimizer's ability to specialize use cases of `UInt128`. Let's mark it as such. This is an ABI break, but hopefully this type isn't being used broadly yet as it's still pretty new and in beta.