### PR TITLE
[6.0] Guard lifetime dependence diagnostics by experimental flag

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -29,6 +29,9 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let lifetimeDependenceDiagnosticsPass = FunctionPass(
   name: "lifetime-dependence-diagnostics")
 { (function: Function, context: FunctionPassContext) in
+  if !context.options.hasFeature(.NonescapableTypes) {
+    return
+  }
   log(prefix: false, "\n--- Diagnosing lifetime dependence in \(function.name)")
   log("\(function)")
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
@@ -31,6 +31,9 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let lifetimeDependenceInsertionPass = FunctionPass(
   name: "lifetime-dependence-insertion")
 { (function: Function, context: FunctionPassContext) in
+  if !context.options.hasFeature(.NonescapableTypes) {
+    return
+  }
   log(prefix: false, "\n--- Inserting lifetime dependence markers in \(function.name)")
 
   for instruction in function.instructions {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -31,6 +31,9 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let lifetimeDependenceScopeFixupPass = FunctionPass(
   name: "lifetime-dependence-scope-fixup")
 { (function: Function, context: FunctionPassContext) in
+  if !context.options.hasFeature(.NonescapableTypes) {
+    return
+  }
   log(prefix: false, "\n--- Scope fixup for lifetime dependence in \(function.name)")
 
   let localReachabilityCache = LocalVariableReachabilityCache()


### PR DESCRIPTION
by -enable-experimental-feature NonescapableTypes

These passes do nothing unless the above feature flag is enabled, so there's no reason to be running them.

These passes rely on fundamental SwiftCompilerSources abstractions which have not yet been tested outside of the passes. They don't yet handle all SIL patterns, and SIL continues to evolve. We should not expose these issues on a release branch.

This reverts commit 6efcb595b0731dfe34cf384ad52aac95d4b79106. "Always-enable lifetime-depenence diagnostics."

Workaround for:

** rdar://129931868 [nonescapable] (Crash on attempt to compile unit
   test); SIL/FunctionConvention.swift:29: Fatal error: requires
   contextual type

** rdar://129494573 [nonescapable] [LifetimeDependenceDiagnostics]

** rdar://128434000 ([nonescapable] [LifetimeDependenceInsertion] Package resolution fails with arm64 Windows toolchain)

--- CCC ---

Explanation: Guard lifetime dependence diagnostics by -enable-experimental-feature NonescapableTypes.

Scope: [NFC] This bypasses compiler code that has no effect when the experimental flag is disable. 

Radar/SR Issue:

    ** rdar://129931868 [nonescapable] (Crash on attempt to compile unit
       test); SIL/FunctionConvention.swift:29: Fatal error: requires
       contextual type

    ** rdar://129494573 [nonescapable] [LifetimeDependenceDiagnostics]

    ** rdar://128434000 ([nonescapable] [LifetimeDependenceInsertion] Package resolution fails with arm64 Windows toolchain)

main PR: N/A

Risk: We may miss out on some bug reports in the 6.0 release. But, so far, these bug reports have been nothing but a waste of time.

Testing: Existing unit tests.

Reviewer: TBD

