### PR TITLE
[Concurrency] Fix `@Sendable` inference for global-actor-isolated function types.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3894,11 +3894,6 @@ Type AnyFunctionType::getThrownError() const {
 }
 
 bool AnyFunctionType::isSendable() const {
-  auto &ctx = getASTContext();
-  if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability)) {
-    // Global-actor-isolated function types are implicitly Sendable.
-    return getExtInfo().isSendable() || getIsolation().isGlobalActor();
-  }
   return getExtInfo().isSendable();
 }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1695,8 +1695,7 @@ void swift::getConcurrencyAttrs(ASTContext &SwiftContext,
   findSwiftAttributes(type, [&](const clang::SwiftAttrAttr *attr) {
     if (isMainActorAttr(attr)) {
       isMainActor = true;
-      isNonSendable = importKind == ImportTypeKind::Parameter ||
-                      importKind == ImportTypeKind::CompletionHandlerParameter;
+      isSendable = true; // MainActor implies Sendable
     } else if (attr->getAttribute() == "@Sendable")
       isSendable = true;
     else if (attr->getAttribute() == "@_nonSendable")

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2587,6 +2587,10 @@ namespace {
         return FunctionTypeIsolation::forNonIsolated();
       }();
       extInfo = extInfo.withIsolation(isolation);
+      if (isolation.isGlobalActor() &&
+          CS.getASTContext().LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability)) {
+        extInfo = extInfo.withSendable();
+      }
 
       auto *fnTy = FunctionType::get(closureParams, resultTy, extInfo);
       return CS.replaceInferableTypesWithTypeVars(

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3920,6 +3920,10 @@ NeverNullType TypeResolver::resolveASTFunctionType(
         globalActorAttr->setInvalid();
       } else {
         isolation = FunctionTypeIsolation::forGlobalActor(globalActor);
+
+        // This inference is currently gated because `@Sendable` impacts mangling.
+        if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability))
+          sendable = true;
       }
     }
 

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -25,14 +25,14 @@ struct X {
 
 func testInAsync(x: X) async {
   let _: Int = unsafelySendableClosure // expected-error{{type '@Sendable (@Sendable () -> Void) -> ()'}}
-  let _: Int = unsafelyMainActorClosure // expected-error{{type '@Sendable (@MainActor () -> Void) -> ()'}}
+  let _: Int = unsafelyMainActorClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = unsafelyDoEverythingClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = x.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = X.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (X) -> @Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
 
   let _: Int = x.sendableVar // expected-error{{type '@Sendable () -> Void'}}
-  let _: Int = x.mainActorVar // expected-error{{type '@MainActor () -> Void'}}
+  let _: Int = x.mainActorVar // expected-error{{type '@MainActor @Sendable () -> Void'}}
 
   let _: Int = x[{ onMainActor() }] // expected-error{{type '@Sendable () -> Void'}}
   let _: Int = X[statically: { onMainActor() }] // expected-error{{type '@Sendable () -> Void'}}
@@ -40,14 +40,14 @@ func testInAsync(x: X) async {
 
 func testElsewhere(x: X) {
   let _: Int = unsafelySendableClosure // expected-error{{type '@Sendable (@Sendable () -> Void) -> ()'}}
-  let _: Int = unsafelyMainActorClosure // expected-error{{type '@Sendable (@MainActor () -> Void) -> ()'}}
+  let _: Int = unsafelyMainActorClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = unsafelyDoEverythingClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = x.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = X.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (X) -> @Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
 
   let _: Int = x.sendableVar // expected-error{{type '@Sendable () -> Void'}}
-  let _: Int = x.mainActorVar // expected-error{{type '@MainActor () -> Void'}}
+  let _: Int = x.mainActorVar // expected-error{{type '@MainActor @Sendable () -> Void'}}
 
   let _: Int = x[{ onMainActor() }] // expected-error{{type '@Sendable () -> Void'}}
   let _: Int = X[statically: { onMainActor() }] // expected-error{{type '@Sendable () -> Void'}}

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
@@ -125,7 +125,7 @@ class TestConformanceWithStripping : InnerSendableTypes {
   }
 
   func test(withCallback name: String, handler: @escaping @MainActor ([String : Any], (any Error)?) -> Void) {
-    // expected-note@-1 {{candidate has non-matching type '(String, @escaping @MainActor ([String : Any], (any Error)?) -> Void) -> ()'}}
+    // expected-note@-1 {{candidate has non-matching type '(String, @escaping @MainActor @Sendable ([String : Any], (any Error)?) -> Void) -> ()'}}
   }
 }
 

--- a/test/Concurrency/transfernonsendable_global_actor_sending.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_sending.swift
@@ -26,7 +26,7 @@ func useValue<T>(_ t: T) {}
   let ns = NonSendableKlass()
 
   // Will be resolved once @MainActor is @Sendable
-  Task.fakeInit { @MainActor in // expected-error {{main actor-isolated value of type '@MainActor () async -> ()' passed as a strongly transferred parameter}}
+  Task.fakeInit { @MainActor in // expected-error {{main actor-isolated value of type '@MainActor @Sendable () async -> ()' passed as a strongly transferred parameter}}
     print(ns)
   }
 

--- a/test/Concurrency/transfernonsendable_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_sending_params.swift
@@ -358,20 +358,17 @@ func testTransferOtherParamTuple(_ x: sending Klass, y: (Klass, Klass)) async {
 func fakeInitOutside(operation: sending @escaping () async -> ()) {}
 
 func taskIsolatedOutsideError(_ x: @escaping @MainActor () async -> ()) {
-  fakeInitOutside(operation: x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{task-isolated 'x' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  fakeInitOutside(operation: x) // okay; x is @Sendable
 }
 
 @MainActor func actorIsolatedOutsideError(_ x: @escaping @MainActor () async -> ()) {
-  fakeInitOutside(operation: x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{main actor-isolated 'x' is passed as a 'sending' parameter; Uses in callee may race with later main actor-isolated uses}}
+  fakeInitOutside(operation: x) // okay; x is @Sendable
 }
 
 func taskIsolatedInsideError(_ x: @escaping @MainActor () async -> ()) {
   func fakeInit(operation: sending @escaping () async -> ()) {}
 
-  fakeInit(operation: x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{task-isolated 'x' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  fakeInit(operation: x)  // okay; x is @Sendable
 }
 
 @MainActor func actorIsolatedInsideError(_ x: @escaping @MainActor () async -> ()) {

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -90,7 +90,7 @@ import _Concurrency
 // CHECK: func __leap(_ height: Int) async -> String
 
 // CHECK: @available(*, renamed: "runOnMainThread()")
-// CHECK-NEXT: func runOnMainThread(completionHandler completion: (@MainActor (String) -> Void)? = nil)
+// CHECK-NEXT: func runOnMainThread(completionHandler completion: (@MainActor @Sendable (String) -> Void)? = nil)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func runOnMainThread() async -> String
 

--- a/test/IDE/print_clang_objc_effectful_properties.swift
+++ b/test/IDE/print_clang_objc_effectful_properties.swift
@@ -33,11 +33,11 @@
 // CHECK-NEXT:  var fromNullableHandler: String { get async }
 
 // CHECK:       @available(*, renamed: "getter:mainDogProp()")
-// CHECK-NEXT:  func getMainDog(_ completion: @escaping @MainActor (String) -> Void)
+// CHECK-NEXT:  func getMainDog(_ completion: @escaping @MainActor @Sendable (String) -> Void)
 // CHECK-NEXT:  var mainDogProp: String { get async }
 
 // CHECK:       @available(*, renamed: "regularMainDog()")
-// CHECK-NEXT:  func regularMainDog(_ completion: @escaping @MainActor (String) -> Void)
+// CHECK-NEXT:  func regularMainDog(_ completion: @escaping @MainActor @Sendable (String) -> Void)
 // CHECK-NEXT:  @discardableResult
 // CHECK-NEXT:  func regularMainDog() async -> String
 // CHECK: }


### PR DESCRIPTION
Consider the upcoming feature flags in the originating module when applying `@Sendable`. Otherwise, for libraries that do not enable `GlobalActorIsolatedTypesUsability`, clients that do will encounter mangling mismatches for any library APIs that have global-actor-isolated function types that are not explicitly `@Sendable`.

 This is done in type resolution, the Clang importer, and the constraint system when inferring closure types. Note that the Clang importer change is not gated behind the upcoming feature flag, because the change does not impact mangling and `Sendable` mismatches are not diagnosed in Swift 5 mode.

This change also appears to have fixed some issues where region isolation was not considering global-actor-isolated function types to be `@Sendable`.

Resolves: rdar://129978513, rdar://129384579, https://github.com/apple/swift/issues/74009