### PR TITLE
[6.0][SILGen] Compute the reduced thrown error type when emitting a function prolog and epilog.

### DIFF
--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -65,6 +65,7 @@ void SILGenFunction::prepareEpilog(
 
   if (errorType) {
     auto genericSig = DC->getGenericSignatureOfContext();
+    errorType = (*errorType)->getReducedType(genericSig);
     AbstractionPattern origErrorType = TypeContext
       ? *TypeContext->OrigType.getFunctionThrownErrorType()
       : AbstractionPattern(genericSig.getCanonicalSignature(),

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1548,6 +1548,8 @@ uint16_t SILGenFunction::emitBasicProlog(
   // Create the indirect result parameters.
   auto genericSig = DC->getGenericSignatureOfContext();
   resultType = resultType->getReducedType(genericSig);
+  if (errorType)
+    errorType = (*errorType)->getReducedType(genericSig);
 
   std::optional<AbstractionPattern> origClosureType;
   if (TypeContext) origClosureType = TypeContext->OrigType;

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -378,3 +378,12 @@ struct GSF2<F: Error, T>: P2 {
 struct GSA<T>: P2 {
   typealias Failure = any Error
 }
+
+struct ReducedError<T: Error> {}
+
+extension ReducedError where T == MyError {
+  // CHECK-LABEL: sil hidden [ossa] @$s20typed_throws_generic12ReducedErrorVA2A02MyE0ORszrlE05throwfE0yyAEYKF : $@convention(method) (ReducedError<MyError>) -> @error MyError {
+  func throwMyError() throws(T) {
+    throw MyError.fail
+  }
+}


### PR DESCRIPTION
* **Explanation**: Currently, the compiler crashes if you use a thrown error type that is reduced in the minimal generic signature, e.g.

   ```swift
   struct ReducedError<T: Error> {}

   extension ReducedError where T == MyError {
     func throwMyError() throws(T) { ... } // crash in SILGen
   }
   ```

   This resolves the crash by computing the reduced type of the thrown error type in `SILGenFunction::emitBasicProlog ` and `SILGenFunction::prepareEpilog`.
* **Scope**: Only impacts typed throws.
* **Issue**: rdar://124623601
* **Risk**: Low, only impacts a new language feature in Swift 6.0.
* **Testing**: Added a new test.
* **Reviewer**: @slavapestov 
* **Main branch PR**: https://github.com/apple/swift/pull/74456