### PR TITLE
[cxx-interop] Fix exporting cdecl Swift functions to Obj-C++

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1440,6 +1440,7 @@ private:
     os << "SWIFT_EXTERN ";
     printFunctionDeclAsCFunctionDecl(FD, FD->getCDeclName(), resultTy);
     printFunctionClangAttributes(FD, funcTy);
+    os << " SWIFT_NOEXCEPT";
     printAvailability(FD);
     os << ";\n";
   }

--- a/test/Interop/SwiftToCxx/functions/swift-functions.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions.swift
@@ -6,6 +6,10 @@ import CxxStdlib
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
+@_cdecl("cdeclFunction") public func cdeclFunction(_ x: CInt) {}
+
+// CHECK: SWIFT_EXTERN void cdeclFunction(int x) SWIFT_NOEXCEPT;
+
 // CHECK-LABEL: namespace Functions SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Functions") {
 
 // CHECK-LABEL: namespace _impl {

--- a/test/PrintAsObjC/cdecl-imports.swift
+++ b/test/PrintAsObjC/cdecl-imports.swift
@@ -12,19 +12,19 @@ import Foundation
 // CHECK-NOT: @import Foundation;
 
 // CHECK: @class Bee;
-// CHECK-LABEL: Bee * _Nonnull fwd_declares_bee(void) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: Bee * _Nonnull fwd_declares_bee(void) SWIFT_WARN_UNUSED_RESULT SWIFT_NOEXCEPT;
 
 @_cdecl("fwd_declares_bee")
 public func fwdDeclaresBee() -> Bee { fatalError() }
 
 // CHECK: @class Hive;
-// CHECK-LABEL: void fwd_declares_hive(Hive * _Nonnull (* _Nonnull bzzz)(Bee * _Nonnull));
+// CHECK-LABEL: void fwd_declares_hive(Hive * _Nonnull (* _Nonnull bzzz)(Bee * _Nonnull)) SWIFT_NOEXCEPT;
 
 @_cdecl("fwd_declares_hive")
 public func fwdDeclaresHive(bzzz: @convention(c) (Bee) -> Hive) { fatalError() }
 
 // CHECK: @protocol NSWobbling;
-// CHECK-LABEL: void fwd_declares_wobble(id <NSWobbling> _Nonnull wobbler);
+// CHECK-LABEL: void fwd_declares_wobble(id <NSWobbling> _Nonnull wobbler) SWIFT_NOEXCEPT;
 
 @_cdecl("fwd_declares_wobble")
 public func fwdDeclaresWobble(wobbler: NSWobbling) { fatalError() }

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -8,51 +8,51 @@
 // REQUIRES: objc_interop
 
 // CHECK: /// What a nightmare!
-// CHECK-LABEL: SWIFT_EXTERN double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: SWIFT_EXTERN double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT SWIFT_NOEXCEPT;
 
 /// What a nightmare!
 @_cdecl("block_nightmare")
 public func block_nightmare(x: @convention(block) (Int) -> Float)
   -> @convention(block) (CChar) -> Double { return { _ in 0 } }
 
-// CHECK-LABEL: SWIFT_EXTERN double (^ _Nonnull block_recurring_nightmare(float (^ _Nonnull x)(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(double))))(SWIFT_NOESCAPE char (^ _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: SWIFT_EXTERN double (^ _Nonnull block_recurring_nightmare(float (^ _Nonnull x)(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(double))))(SWIFT_NOESCAPE char (^ _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT SWIFT_NOEXCEPT;
 @_cdecl("block_recurring_nightmare")
 public func block_recurring_nightmare(x: @escaping @convention(block) (@convention(block) (Double) -> Int) -> Float)
   -> @convention(block) (_ asdfasdf: @convention(block) (CUnsignedChar) -> CChar) -> Double {
   fatalError()
 }
 
-// CHECK-LABEL: SWIFT_EXTERN void foo_bar(NSInteger x, NSInteger y);
+// CHECK-LABEL: SWIFT_EXTERN void foo_bar(NSInteger x, NSInteger y) SWIFT_NOEXCEPT;
 @_cdecl("foo_bar")
 func foo(x: Int, bar y: Int) {}
 
-// CHECK-LABEL: SWIFT_EXTERN double (* _Nonnull function_pointer_nightmare(float (* _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: SWIFT_EXTERN double (* _Nonnull function_pointer_nightmare(float (* _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT SWIFT_NOEXCEPT;
 @_cdecl("function_pointer_nightmare")
 func function_pointer_nightmare(x: @convention(c) (Int) -> Float)
   -> @convention(c) (CChar) -> Double { return { _ in 0 } }
 
-// CHECK-LABEL: SWIFT_EXTERN double (* _Nonnull function_pointer_recurring_nightmare(float (* _Nonnull x)(NSInteger (* _Nonnull)(double))))(char (* _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: SWIFT_EXTERN double (* _Nonnull function_pointer_recurring_nightmare(float (* _Nonnull x)(NSInteger (* _Nonnull)(double))))(char (* _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT SWIFT_NOEXCEPT;
 @_cdecl("function_pointer_recurring_nightmare")
 public func function_pointer_recurring_nightmare(x: @escaping @convention(c) (@convention(c) (Double) -> Int) -> Float)
   -> @convention(c) (@convention(c) (CUnsignedChar) -> CChar) -> Double {
   fatalError()
 }
   
-// CHECK-LABEL: SWIFT_EXTERN void has_keyword_arg_names(NSInteger auto_, NSInteger union_);
+// CHECK-LABEL: SWIFT_EXTERN void has_keyword_arg_names(NSInteger auto_, NSInteger union_) SWIFT_NOEXCEPT;
 @_cdecl("has_keyword_arg_names")
 func keywordArgNames(auto: Int, union: Int) {}
 
 @objc
 class C {}
 
-// CHECK-LABEL: SWIFT_EXTERN C * _Null_unspecified return_iuo(void) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: SWIFT_EXTERN C * _Null_unspecified return_iuo(void) SWIFT_WARN_UNUSED_RESULT SWIFT_NOEXCEPT;
 @_cdecl("return_iuo")
 func returnIUO() -> C! { return C() }
 
-// CHECK-LABEL: SWIFT_EXTERN void return_never(void) SWIFT_NORETURN;
+// CHECK-LABEL: SWIFT_EXTERN void return_never(void) SWIFT_NORETURN SWIFT_NOEXCEPT;
 @_cdecl("return_never")
 func returnNever() -> Never { fatalError() }
 
-// CHECK-LABEL: SWIFT_EXTERN void takes_iuo(C * _Null_unspecified c);
+// CHECK-LABEL: SWIFT_EXTERN void takes_iuo(C * _Null_unspecified c) SWIFT_NOEXCEPT;
 @_cdecl("takes_iuo")
 func takesIUO(c: C!) {}


### PR DESCRIPTION
We export cdecl function declarations twice: for Objective-C and for C++. When the code is compiled in Objective-C++ both of the declarations are visible to the compiler. The generated header did not compile, because only one of the declarations were noexcept. There are multiple possible ways to fix this issue, one of them would make only C++ declarations visible in Objective-C++ mode. However, for this particular problem I decided to also make the Objective-C functions SWIFT_NOEXCEPT. This approach resolves the inconsistency that broke the code when compiled in Objective-C++ mode. Moreover, Swift guarantees that those cdecl declarations cannot raise errors, so in case we only generate the C declarations and consume them from C++ or Objective-C++, those are the correct declarations.

rdar://129550313
