### PR TITLE
[6.0] Concurrency: Fix default type witness for AsyncSequence.Failure

### DIFF
--- a/stdlib/public/Concurrency/AsyncSequence.swift
+++ b/stdlib/public/Concurrency/AsyncSequence.swift
@@ -81,7 +81,7 @@ public protocol AsyncSequence<Element, Failure> {
 
   /// The type of errors produced when iteration over the sequence fails.
   @available(SwiftStdlib 6.0, *)
-  associatedtype Failure: Error = AsyncIterator.Failure
+  associatedtype Failure: Error = any Error
       where AsyncIterator.Failure == Failure
 
   /// Creates the asynchronous iterator that produces elements of this


### PR DESCRIPTION
6.0 cherry-pick of https://github.com/apple/swift/pull/74445

* **Description:** Fix an infinite loop when running older binaries that were built against a standard library that doesn't have the AsyncSequence.Failure associated type.

* **Origination:** New bug introduced with typed throws.

* **Reviewed by:** @hborla 

* **Radar:** rdar://129605725

* **Tested:** No test case because we don't have a way to automate testing binaries built against an old compiler/stdlib yet.