### PR TITLE
[cxx-interop][serialization] resolve x-refs to instantiated/synthesiz…

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -684,6 +684,13 @@ bool isCFTypeDecl(const clang::TypedefNameDecl *Decl);
 /// Determine the imported CF type for the given typedef-name, or the empty
 /// string if this is not an imported CF type name.
 llvm::StringRef getCFTypeName(const clang::TypedefNameDecl *decl);
+
+/// Lookup and return the synthesized conformance operator like '==' '-' or '++'
+/// for the given type.
+ValueDecl *getSynthesizedConformanceOperator(const DeclBaseName &name,
+                                             NominalTypeDecl *selfType,
+                                             std::optional<Type> parameterType);
+
 } // namespace importer
 
 struct ClangInvocationFileMapping {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2089,7 +2089,8 @@ namespace decls_block {
     IdentifierIDField, // name
     BCFixed<1>,        // restrict to protocol extension
     BCFixed<1>,        // imported from Clang?
-    BCFixed<1>         // static?
+    BCFixed<1>,        // static?
+    BCFixed<1>         // synthesized?
   >;
 
   using XRefInitializerPathPieceLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2198,7 +2198,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
     XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                          addTypeRef(ty), SUBSCRIPT_ID,
                                          isProtocolExt, SD->hasClangNode(),
-                                         SD->isStatic());
+                                         SD->isStatic(), SD->isSynthesized());
     break;
   }
 
@@ -2215,7 +2215,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
                                            addTypeRef(ty), nameID,
                                            isProtocolExt,
                                            storage->hasClangNode(),
-                                           storage->isStatic());
+                                           storage->isStatic(), storage->isSynthesized());
 
       abbrCode =
         DeclTypeAbbrCodes[XRefOperatorOrAccessorPathPieceLayout::Code];
@@ -2250,7 +2250,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
                                          addTypeRef(ty),
                                          addDeclBaseNameRef(fn->getBaseName()),
                                          isProtocolExt, fn->hasClangNode(),
-                                         fn->isStatic());
+                                         fn->isStatic(), fn->isSynthesized());
 
     if (fn->isOperator()) {
       // Encode the fixity as a filter on the func decls, to distinguish prefix
@@ -2357,7 +2357,7 @@ void Serializer::writeCrossReference(const Decl *D) {
   IdentifierID iid = addDeclBaseNameRef(val->getBaseName());
   XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                        addTypeRef(ty), iid, isProtocolExt,
-                                       D->hasClangNode(), val->isStatic());
+                                       D->hasClangNode(), val->isStatic(), val->isSynthesized());
 }
 
 /// Translate from the AST associativity enum to the Serialization enum

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-conformance-operator-synthesis-conformance.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-conformance-operator-synthesis-conformance.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftxx-frontend -emit-module %s -module-name TestA -I %S/Inputs -o %t/test-part.swiftmodule
+// RUN: %target-swiftxx-frontend -merge-modules -emit-module %t/test-part.swiftmodule -module-name TestA -I %S/Inputs -o %t/TestA.swiftmodule -sil-verify-none
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -I %t
+
+#if USE
+
+import TestA
+
+public func test() {
+    print(testEqualEqual())
+}
+
+#else
+
+import CustomSequence
+
+@inlinable
+public func testEqualEqual() -> Bool {
+    let m = HasInheritedConstIterator()
+    return m.__beginUnsafe() == m.__endUnsafe()
+}
+
+#endif


### PR DESCRIPTION
…ed C++ iterator conformance operators

These x-refs are not resolvable using regular lookup from the 'std' module as they're instantiated by the clang importer, and thus they need a different lookup path in order to get resolved. The new lookup uses the clang importer logic that is used during the conformance to the C++ iterator protocol.
