### PR TITLE
Include error type when considering whether a SILFunctionType needs its substitutions.

### DIFF
--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -103,6 +103,10 @@ SILType SILBuilder::getPartialApplyResultType(
   for (auto yield : FTI->getYields()) {
     needsSubstFunctionType |= yield.getInterfaceType()->hasTypeParameter();
   }
+  if (FTI->hasErrorResult()) {
+    needsSubstFunctionType
+      |= FTI->getErrorResult().getInterfaceType()->hasTypeParameter();
+  }
 
   SubstitutionMap appliedSubs;
   if (needsSubstFunctionType) {

--- a/test/SILGen/error_type_substitution.swift
+++ b/test/SILGen/error_type_substitution.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+func consume_a_pointer(x: inout Int) { }
+
+func func_that_rethrows<E: Error>(initializingWith callback: () throws(E) -> Void) throws(E) {
+}
+
+public func foo() {
+  var pk = 42
+  func_that_rethrows() {
+    consume_a_pointer(x: &pk)
+  }
+}


### PR DESCRIPTION
Fixes rdar://128205122.