### PR TITLE
[6.0] Include error type when considering whether a SILFunctionType needs its substitutions.

### DIFF
--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -103,6 +103,10 @@ SILType SILBuilder::getPartialApplyResultType(
   for (auto yield : FTI->getYields()) {
     needsSubstFunctionType |= yield.getInterfaceType()->hasTypeParameter();
   }
+  if (FTI->hasErrorResult()) {
+    needsSubstFunctionType
+      |= FTI->getErrorResult().getInterfaceType()->hasTypeParameter();
+  }
 
   SubstitutionMap appliedSubs;
   if (needsSubstFunctionType) {

--- a/test/SILGen/error_type_substitution.swift
+++ b/test/SILGen/error_type_substitution.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+func consume_a_pointer(x: inout Int) { }
+
+func func_that_rethrows<E: Error>(initializingWith callback: () throws(E) -> Void) throws(E) {
+}
+
+public func foo() {
+  var pk = 42
+  func_that_rethrows() {
+    consume_a_pointer(x: &pk)
+  }
+}


### PR DESCRIPTION
Explanation: Fixes a compiler crash when a closure literal with a concrete error type is used in the context of a function that's generic over the closure's error parameter.
Scope: Bug fix.
Issue: rdar://128205122
Original PR: https://github.com/apple/swift/pull/74525
Risk: Low. A small bug fix that should only affect new code using typed throws.
Testing: Swift CI, test case from bug report
Reviewer: @slavapestov, @rjmccall 