### PR TITLE
[region-isolation] Check if we have a self param before attempting to get the self type.

### DIFF
--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -538,14 +538,16 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       //
       auto *func = fri->getReferencedFunction();
       auto funcType = func->getLoweredFunctionType();
-      auto selfParam = funcType->getSelfInstanceType(
-          fri->getModule(), func->getTypeExpansionContext());
-      if (auto *nomDecl = selfParam->getNominalOrBoundGenericNominal()) {
-        auto isolation = swift::getActorIsolation(nomDecl);
-        if (isolation.isGlobalActor()) {
-          return SILIsolationInfo::getGlobalActorIsolated(
-                     fri, isolation.getGlobalActor())
+      if (funcType->hasSelfParam()) {
+        auto selfParam = funcType->getSelfInstanceType(
+            fri->getModule(), func->getTypeExpansionContext());
+        if (auto *nomDecl = selfParam->getNominalOrBoundGenericNominal()) {
+          auto isolation = swift::getActorIsolation(nomDecl);
+          if (isolation.isGlobalActor()) {
+            return SILIsolationInfo::getGlobalActorIsolated(
+                fri, isolation.getGlobalActor())
               .withUnsafeNonIsolated(true);
+          }
         }
       }
     }

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -30,6 +30,8 @@ protocol ProvidesStaticValue {
 @MainActor func transferToMainIndirectConsuming<T>(_ t: consuming T) async {}
 @MainActor func transferToMainDirectConsuming(_ t: consuming NonSendableKlass) async {}
 
+func useInOut<T>(_ t: inout T) {}
+
 actor CustomActorInstance {}
 
 @globalActor
@@ -349,11 +351,26 @@ func testAccessStaticGlobals() async {
 nonisolated(unsafe) let globalNonIsolatedUnsafeLetObject = NonSendableKlass()
 nonisolated(unsafe) var globalNonIsolatedUnsafeVarObject = NonSendableKlass()
 
-func testAccessGlobals() async {
+func testPassGlobalToMainActorIsolatedFunction() async {
   await transferToMainDirect(globalNonIsolatedUnsafeLetObject)
   await transferToMainIndirect(globalNonIsolatedUnsafeLetObject)
   await transferToMainDirect(globalNonIsolatedUnsafeVarObject)
   await transferToMainIndirect(globalNonIsolatedUnsafeVarObject)
+}
+
+// We use this to force the modify in testPassGlobalToModify
+nonisolated(unsafe)
+var computedGlobalNonIsolatedUnsafeVarObject : NonSendableKlass {
+  _read {
+    yield globalNonIsolatedUnsafeVarObject
+  }
+  _modify {
+    yield &globalNonIsolatedUnsafeVarObject
+  }
+}
+
+func testPassGlobalToModify() async {
+  useInOut(&computedGlobalNonIsolatedUnsafeVarObject)
 }
 
 ///////////////////////


### PR DESCRIPTION
Otherwise in asserts builds we get an assert and in no-asserts we get a crash.

rdar://129975097
