### PR TITLE
Add a missing config.available_features entry for SWIFT_ENABLE_VOLATILE

### DIFF
--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -159,6 +159,8 @@ if "@SWIFT_ENABLE_VOLATILE@" == "TRUE":
     config.available_features.add('volatile')
 if "@SWIFT_ENABLE_SYNCHRONIZATION@" == "TRUE":
     config.available_features.add('synchronization')
+if "@SWIFT_ENABLE_VOLATILE@" == "TRUE":
+    config.available_features.add('volatile')
 if "@SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB@" == "TRUE":
     config.available_features.add('embedded_stdlib')
 if "@SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING@" == "TRUE":


### PR DESCRIPTION
Missed this bit as part of https://github.com/apple/swift/pull/74493.