### PR TITLE
Sema: Re-introduce the hack for re-using generic signature of extended protocol

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -815,6 +815,25 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
 
     auto *extendedNominal = ext->getExtendedNominal();
 
+    // Avoid building a generic signature if we have an unconstrained protocol
+    // extension of a protocol that does not suppress conformance to ~Copyable
+    // or ~Escapable. This avoids a request cycle when referencing a protocol
+    // extension type alias via an unqualified name from a `where` clause on
+    // the protocol.
+    if (auto *proto = dyn_cast<ProtocolDecl>(extendedNominal)) {
+      if (extraReqs.empty() &&
+          !ext->getTrailingWhereClause()) {
+        InvertibleProtocolSet protos;
+        for (auto *inherited : proto->getAllInheritedProtocols()) {
+          if (auto kind = inherited->getInvertibleProtocolKind())
+            protos.insert(*kind);
+        }
+
+        if (protos == InvertibleProtocolSet::allKnown())
+          return extendedNominal->getGenericSignatureOfContext();
+      }
+    }
+
     if (isa<BuiltinTupleDecl>(extendedNominal)) {
       genericParams = ext->getGenericParams();
     } else {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -735,7 +735,8 @@ void swift::diagnoseInvalidGenericArguments(SourceLoc loc,
 /// error.
 ///
 /// \see TypeResolution::applyUnboundGenericArguments
-static Type applyGenericArguments(Type type, TypeResolution resolution,
+static Type applyGenericArguments(Type type,
+                                  const TypeResolution &resolution,
                                   SILTypeResolutionContext *silContext,
                                   DeclRefTypeRepr *repr) {
   auto options = resolution.getOptions();
@@ -1249,7 +1250,7 @@ static void maybeDiagnoseBadConformanceRef(DeclContext *dc,
 
 /// Returns a valid type or ErrorType in case of an error.
 static Type resolveTypeDecl(TypeDecl *typeDecl, DeclContext *foundDC,
-                            TypeResolution resolution,
+                            const TypeResolution &resolution,
                             SILTypeResolutionContext *silContext,
                             UnqualifiedIdentTypeRepr *repr) {
   // Resolve the type declaration to a specific type. How this occurs
@@ -1306,7 +1307,7 @@ static std::string getDeclNameFromContext(DeclContext *dc,
 ///
 /// \returns either the corrected type, if possible, or an error type to
 /// that correction failed.
-static Type diagnoseUnknownType(TypeResolution resolution,
+static Type diagnoseUnknownType(const TypeResolution &resolution,
                                 Type parentType,
                                 SourceRange parentRange,
                                 DeclRefTypeRepr *repr,
@@ -1570,7 +1571,7 @@ static SelfTypeKind getSelfTypeKind(DeclContext *dc,
   }
 }
 
-static void diagnoseGenericArgumentsOnSelf(TypeResolution resolution,
+static void diagnoseGenericArgumentsOnSelf(const TypeResolution &resolution,
                                            UnqualifiedIdentTypeRepr *repr,
                                            DeclContext *typeDC) {
   ASTContext &ctx = resolution.getASTContext();
@@ -1597,7 +1598,7 @@ static void diagnoseGenericArgumentsOnSelf(TypeResolution resolution,
 /// \returns Either the resolved type or a null type, the latter of
 /// which indicates that some dependencies were unsatisfied.
 static Type
-resolveUnqualifiedIdentTypeRepr(TypeResolution resolution,
+resolveUnqualifiedIdentTypeRepr(const TypeResolution &resolution,
                                 SILTypeResolutionContext *silContext,
                                 UnqualifiedIdentTypeRepr *repr) {
   const auto options = resolution.getOptions();
@@ -1773,7 +1774,7 @@ static void diagnoseAmbiguousMemberType(Type baseTy, SourceRange baseRange,
 /// lookup within the given parent type, returning the type it
 /// references.
 /// \param silContext Used to look up generic parameters in SIL mode.
-static Type resolveQualifiedIdentTypeRepr(TypeResolution resolution,
+static Type resolveQualifiedIdentTypeRepr(const TypeResolution &resolution,
                                           SILTypeResolutionContext *silContext,
                                           Type parentTy,
                                           QualifiedIdentTypeRepr *repr) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -536,10 +536,10 @@ Type TypeResolution::resolveTypeInContext(TypeDecl *typeDecl,
       typeDecl->getDeclContext()->getSelfProtocolDecl()) {
     // When looking up a nominal type declaration inside of a
     // protocol extension, always use the nominal type and
-    // not the protocol 'Self' type.
-    if (!foundDC->getDeclaredInterfaceType())
-      return ErrorType::get(ctx);
-
+    // not the protocol 'Self' type. This is invalid and will
+    // be diagnosed anyway, but we want to avoid an invariant
+    // violation from trying to construct a nominal type with
+    // a generic parameter as its parent type.
     selfType = foundDC->getDeclaredInterfaceType();
   } else {
     // Otherwise, we want the protocol 'Self' type for

--- a/test/Generics/rdar123013710.swift
+++ b/test/Generics/rdar123013710.swift
@@ -15,7 +15,7 @@ extension Never: Q, P { // expected-note 2{{through reference here}}
    public static func f() -> Any? { nil }
 }
 
-extension Q { // expected-note {{through reference here}}
-   public var b: Never { fatalError() } // expected-note 4{{through reference here}}
+extension Q {
+   public var b: Never { fatalError() } // expected-note {{through reference here}}
 }
 

--- a/test/NameLookup/protocol_extension_where_clause.swift
+++ b/test/NameLookup/protocol_extension_where_clause.swift
@@ -29,3 +29,14 @@ extension P1 where Self: A {
 extension P1 where Self: A, B: Hashable {
   func h(_: Set<B>) {}
 }
+
+// This is also terrible and we should ban it
+public protocol P3 {
+  associatedtype A
+}
+
+public protocol P4: P3 where A == B {}
+
+extension P4 {
+  public typealias B = String
+}


### PR DESCRIPTION
In Swift 5.10 if you wrote `extension Foo {}` for some protocol Foo,
the extension would always re-use the generic signature of Foo, which
is <Self where Self: Foo>. In Swift 6 this no longer works because Foo
might be ~Copyable, in which case `extension Foo {}` adds default
requirements, so we changed GenericSignatureRequest to just always
build a new signature if we're given an extension.

However, to avoid a request cycle with a code example that really should
have never worked at all, I'm re-introducing the hack for re-using the
signature.

Fixes rdar://problem/129540617.