### PR TITLE
[6.0] Sema: Re-introduce the hack for re-using generic signature of extended protocol

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -818,6 +818,25 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
 
     auto *extendedNominal = ext->getExtendedNominal();
 
+    // Avoid building a generic signature if we have an unconstrained protocol
+    // extension of a protocol that does not suppress conformance to ~Copyable
+    // or ~Escapable. This avoids a request cycle when referencing a protocol
+    // extension type alias via an unqualified name from a `where` clause on
+    // the protocol.
+    if (auto *proto = dyn_cast<ProtocolDecl>(extendedNominal)) {
+      if (extraReqs.empty() &&
+          !ext->getTrailingWhereClause()) {
+        InvertibleProtocolSet protos;
+        for (auto *inherited : proto->getAllInheritedProtocols()) {
+          if (auto kind = inherited->getInvertibleProtocolKind())
+            protos.insert(*kind);
+        }
+
+        if (protos == InvertibleProtocolSet::allKnown())
+          return extendedNominal->getGenericSignatureOfContext();
+      }
+    }
+
     if (isa<BuiltinTupleDecl>(extendedNominal)) {
       genericParams = ext->getGenericParams();
     } else {

--- a/test/Generics/rdar123013710.swift
+++ b/test/Generics/rdar123013710.swift
@@ -15,7 +15,7 @@ extension Never: Q, P { // expected-note 2{{through reference here}}
    public static func f() -> Any? { nil }
 }
 
-extension Q { // expected-note {{through reference here}}
-   public var b: Never { fatalError() } // expected-note 4{{through reference here}}
+extension Q {
+   public var b: Never { fatalError() } // expected-note {{through reference here}}
 }
 

--- a/test/NameLookup/protocol_extension_where_clause.swift
+++ b/test/NameLookup/protocol_extension_where_clause.swift
@@ -29,3 +29,14 @@ extension P1 where Self: A {
 extension P1 where Self: A, B: Hashable {
   func h(_: Set<B>) {}
 }
+
+// This is also terrible and we should ban it
+public protocol P3 {
+  associatedtype A
+}
+
+public protocol P4: P3 where A == B {}
+
+extension P4 {
+  public typealias B = String
+}


### PR DESCRIPTION
6.0 cherry-pick of https://github.com/apple/swift/pull/74538

* **Description:** Fixes a circular reference error when a protocol `where` clause references a type alias in a protocol extension. This was supposed to be banned, but we allowed it for unqualified references.

* **Origination:** This is a regression from when we introduced noncopyable generics.

* **Risk:** Low.

* **Radar:** rdar://problem/129540617.