### PR TITLE
[cxx-interop][serialization] resolve x-refs to instantiated/synthesiz…

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -684,6 +684,13 @@ bool isCFTypeDecl(const clang::TypedefNameDecl *Decl);
 /// Determine the imported CF type for the given typedef-name, or the empty
 /// string if this is not an imported CF type name.
 llvm::StringRef getCFTypeName(const clang::TypedefNameDecl *decl);
+
+/// Lookup and return the synthesized conformance operator like '==' '-' or '+='
+/// for the given type.
+ValueDecl *getImportedMemberOperator(const DeclBaseName &name,
+                                     NominalTypeDecl *selfType,
+                                     std::optional<Type> parameterType);
+
 } // namespace importer
 
 struct ClangInvocationFileMapping {

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -394,6 +394,28 @@ bool swift::isIterator(const clang::CXXRecordDecl *clangDecl) {
   return getIteratorCategoryDecl(clangDecl);
 }
 
+ValueDecl *
+swift::importer::getImportedMemberOperator(const DeclBaseName &name,
+                                           NominalTypeDecl *selfType,
+                                           std::optional<Type> parameterType) {
+  assert(name.isOperator());
+  // Handle ==, -, and += operators, that are required operators for C++
+  // iterator types to conform to the corresponding Cxx iterator protocols.
+  // These operators can be instantiated and synthesized by clang importer below,
+  // and thus require additional lookup logic when they're being deserialized.
+  if (name.getIdentifier() == selfType->getASTContext().Id_EqualsOperator) {
+    return getEqualEqualOperator(selfType);
+  }
+  if (name.getIdentifier() == selfType->getASTContext().getIdentifier("-")) {
+    return getMinusOperator(selfType);
+  }
+  if (name.getIdentifier() == selfType->getASTContext().getIdentifier("+=") &&
+      parameterType) {
+    return getPlusEqualOperator(selfType, *parameterType);
+  }
+  return nullptr;
+}
+
 void swift::conformToCxxIteratorIfNeeded(
     ClangImporter::Implementation &impl, NominalTypeDecl *decl,
     const clang::CXXRecordDecl *clangDecl) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2039,6 +2039,26 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
     }
     filterValues(filterTy, nullptr, nullptr, isType, inProtocolExt,
                  importedFromClang, isStatic, std::nullopt, values);
+    if (values.empty() && importedFromClang && name.isOperator() && filterTy) {
+      // This could be a Clang-importer instantiated/synthesized conformance
+      // operator, like '==', '-' or '+=', that are required for conformances to
+      // one of the Cxx iterator protocols. Attempt to resolve it using clang importer
+      // lookup logic for the given type instead of looking for it in the module.
+      if (auto *fty = dyn_cast<AnyFunctionType>(filterTy.getPointer())) {
+        if (fty->getNumParams()) {
+          assert(fty->getNumParams() <= 2);
+          auto p = fty->getParams()[0].getParameterType();
+          if (auto sty = dyn_cast<NominalType>(p.getPointer())) {
+            if (auto *op = importer::getImportedMemberOperator(
+                    name, sty->getDecl(),
+                    fty->getNumParams() > 1
+                        ? fty->getParams()[1].getParameterType()
+                        : std::optional<Type>{}))
+              values.push_back(op);
+          }
+        }
+      }
+    }
     break;
   }
       

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -743,6 +743,20 @@ struct InheritedTemplatedConstRACIterator : BaseTemplatedRACIterator<T> {
 
 typedef InheritedTemplatedConstRACIterator<int> InheritedTemplatedConstRACIteratorInt;
 
+struct InheritedTypedConstRACIterator: InheritedTemplatedConstRACIterator<int> {
+  using _super = InheritedTemplatedConstRACIterator<int>;
+  using iterator_category = std::random_access_iterator_tag;
+  using pointer = int *;
+
+  InheritedTypedConstRACIterator(int x)
+    : InheritedTemplatedConstRACIterator<int>(value) {}
+
+  int operator-(const InheritedTypedConstRACIterator &other) const {
+    return _super::value - other.value;
+  }
+  void operator+=(typename _super::difference_type v) { _super::value += v; }
+};
+
 template <typename T>
 struct BaseTemplatedRACIteratorOutOfLineOps {
   using value_type = T;

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-conformance-operator-synthesis-conformance.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-conformance-operator-synthesis-conformance.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftxx-frontend -emit-module %s -module-name TestA -I %S/Inputs -o %t/test-part.swiftmodule
+// RUN: %target-swiftxx-frontend -merge-modules -emit-module %t/test-part.swiftmodule -module-name TestA -I %S/Inputs -o %t/TestA.swiftmodule -sil-verify-none
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -I %t
+
+#if USE
+
+import TestA
+
+public func test() {
+    print(testEqualEqual())
+    print(testPlusEqualMinus())
+}
+
+#else
+
+import CustomSequence
+
+@inlinable
+public func testEqualEqual() -> Bool {
+    let m = HasInheritedConstIterator()
+    return m.__beginUnsafe() == m.__endUnsafe()
+}
+
+@inlinable
+public func testPlusEqualOrMinus() -> Bool {
+    var b = InheritedTypedConstRACIterator(0)
+    b += 1
+    return (b - b) == 0
+}
+
+#endif


### PR DESCRIPTION
…ed C++ iterator conformance operators

These x-refs might not be resolvable using regular lookup from the 'std' module as they could be instantiated/synthesized by the clang importer. Augment the lookup logic in that case to try clang importer lookup logic that is used during the conformance to the C++ iterator protocol.

I first tried to embed additional information during serialization to denote synthesized/instantiated operators, but that actually doesn't cover all operators: https://github.com/apple/swift/pull/74524 .

Fixes Cmake adopter build that breaks in merge modules using Android NDK and std::unordered_map implicitly generated conformances:
```
C:\Users\alex\AppData\Local\Temp\FirestoreDataConverter-6e2827.swiftmodule:1:1: error: reference to top-level declaration '==' broken by a context change; the declaration kind of '=='  changed since building '...', it was in 'CxxStdlib' and now a candidate is found only in 'Swift'
1 | CxxStdlib.==
  | |- error: reference to top-level declaration '==' broken by a context change; the declaration kind of '=='  changed since building 'FirebaseFirestore', it was in 'CxxStdlib' and now a candidate is found only in 'Swift'
  | |- note: the declaration was expected to be found in module 'CxxStdlib' at 'S:\b\arm64\Android.platform\Developer\SDKs\Android.sdk\usr\lib\swift\android\CxxStdlib.swiftmodule\aarch64-unknown-linux-android.swiftmodule'
  | |- note: or expected to be found in the underlying module 'std' defined at 'S:\android-ndk26\android-ndk-r26c\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\include\c++\v1\module.modulemap'
  | |- note: the declaration was actually found in module 'Swift' at 'S:\b\arm64\Android.platform\Developer\SDKs\Android.sdk\usr\lib\swift\android\Swift.swiftmodule\aarch64-unknown-linux-android.private.swiftinterface'
  | |- note: a candidate was filtered out because of a type mismatch; expected: '(std.__ndk1.__hash_map_const_iterator<__hash_const_iterator<UnsafeMutablePointer<__hash_node<__hash_value_type<basic_string<CChar, char_traits<CChar>, allocator<CChar>>, FieldValue>, UnsafeMutablePointer<Void>>>>>, std.__ndk1.__hash_map_const_iterator<__hash_const_iterator<UnsafeMutablePointer<__hash_node<__hash_value_type<basic_string<CChar, char_traits<CChar>, allocator<CChar>>, FieldValue>, UnsafeMutablePointer<Void>>>>>) -> Bool', found: '(Builtin.NativeObject, Builtin.NativeObject) -> Bool'
```