### PR TITLE
[Sema] Tuple mismatch with argument locator should be handled by ArgumentMismatch

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6452,6 +6452,8 @@ bool ConstraintSystem::repairFailures(
     ConstraintFix *fix;
     if (tupleLocator->isLastElement<LocatorPathElt::FunctionArgument>()) {
       fix = AllowFunctionTypeMismatch::create(*this, lhs, rhs, tupleLocator, index);
+    } else if (tupleLocator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
+      fix = AllowArgumentMismatch::create(*this, lhs, rhs, tupleLocator);
     } else {
       fix = AllowTupleTypeMismatch::create(*this, lhs, rhs, tupleLocator, index);
     }

--- a/test/Sema/call_function_with_tuple.swift
+++ b/test/Sema/call_function_with_tuple.swift
@@ -9,3 +9,13 @@ func call() {
   let namedTuple: (x: Int, y: Int) = (1, 1)
   twoArgs(namedTuple) // expected-error{{global function 'twoArgs' expects 2 separate arguments}} expected-error{{missing argument label ':' in call}}
 }
+
+func foo(_: (Int, Int)) -> String {}
+
+func test() -> String {
+  return foo((0, true))
+  // expected-error@-1 {{cannot convert value of type '(Int, Bool)' to expected argument type '(Int, Int)'}}
+}
+
+func bar(_: (Int,Int), _: (Int,Bool)) {} // expected-note {{'bar' declared here}}
+bar((0,false)) // expected-error {{missing argument for parameter #1 in call}}

--- a/test/Sema/diag_non_ephemeral.swift
+++ b/test/Sema/diag_non_ephemeral.swift
@@ -537,5 +537,5 @@ func testTuplingNonEphemeral(_ ptr: UnsafePointer<Int>) {
 
   // Note we can't perform X-to-pointer conversions in this case even if we
   // wanted to.
-  fn(([1], ptr)) // expected-error {{tuple type '([Int], UnsafePointer<Int>)' is not convertible to tuple type '(UnsafePointer<Int>, UnsafePointer<Int>)'}}
+  fn(([1], ptr)) // expected-error {{cannot convert value of type '([Int], UnsafePointer<Int>)' to expected argument type '(UnsafePointer<Int>, UnsafePointer<Int>)'}}
 }


### PR DESCRIPTION
For tuple mismatches whose locator ends in an arg/param mismatch, we both get better diagnoses for argument-related shenanigans (like a missing argument), but also gets the right message for an argument type mismatch, which was wrong for tuples because the tuple-specific path doesn't try to figure out ContextualTypePurpose.

Resolves #74463.
