### PR TITLE
[ASTDumper] Respect function body skipping

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1561,7 +1561,8 @@ namespace {
         });
       }
 
-      if (auto Body = D->getBody(/*canSynthesize=*/ParseIfNeeded)) {
+      auto canParse = ParseIfNeeded && !D->isBodySkipped();
+      if (auto Body = D->getBody(canParse)) {
         printRec(Body, &D->getASTContext());
       }
     }

--- a/test/Frontend/dump-parse-skip-function-body.swift
+++ b/test/Frontend/dump-parse-skip-function-body.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -dump-parse -experimental-skip-all-function-bodies %s | %FileCheck %s
+
+func foo() {
+  print("hello")
+}
+// CHECK-NOT: brace_stmt


### PR DESCRIPTION
Avoid parsing a body for e.g `-experimental-skip-all-function-bodies`.