### PR TITLE
Mark tests that use the _Volatile module as REQUIRES: volatile

### DIFF
--- a/test/Volatile/volatile-exec.swift
+++ b/test/Volatile/volatile-exec.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Volatile) | %FileCheck %s
 
 // REQUIRES: executable_test
+// REQUIRES: volatile
 
 import _Volatile
 

--- a/test/Volatile/volatile-feature-flag.swift
+++ b/test/Volatile/volatile-feature-flag.swift
@@ -2,6 +2,8 @@
 // RUN: not %target-swift-emit-ir %s -module-name main -parse-as-library 2>&1 | %FileCheck %s
 // RUN: %target-swift-emit-ir %s -module-name main -parse-as-library -enable-experimental-feature Volatile
 
+// REQUIRES: volatile
+
 import _Volatile
 
 // CHECK: importing _Volatile module requires '-enable-experimental-feature Volatile'

--- a/test/Volatile/volatile-ir.swift
+++ b/test/Volatile/volatile-ir.swift
@@ -3,6 +3,8 @@
 // RUN: %target-swift-emit-ir %s -module-name main -parse-as-library -enable-experimental-feature Volatile -O | %FileCheck %s
 // RUN: %target-swift-emit-ir %s -module-name main -parse-as-library -enable-experimental-feature Volatile -Osize | %FileCheck %s
 
+// REQUIRES: volatile
+
 import _Volatile
 
 public func test_uint8() -> UInt8 {

--- a/test/Volatile/volatile-null.swift
+++ b/test/Volatile/volatile-null.swift
@@ -3,6 +3,8 @@
 // RUN: %target-swift-emit-ir %s -module-name main -parse-as-library -enable-experimental-feature Volatile -O | %FileCheck %s
 // RUN: %target-swift-emit-ir %s -module-name main -parse-as-library -enable-experimental-feature Volatile -Osize | %FileCheck %s
 
+// REQUIRES: volatile
+
 import _Volatile
 
 public func test_volatilepointer() {

--- a/test/Volatile/volatile-repeat-loads.swift
+++ b/test/Volatile/volatile-repeat-loads.swift
@@ -3,6 +3,8 @@
 // RUN: %target-swift-emit-ir %s -module-name main -parse-as-library -enable-experimental-feature Volatile -O | %FileCheck %s
 // RUN: %target-swift-emit-ir %s -module-name main -parse-as-library -enable-experimental-feature Volatile -Osize | %FileCheck %s
 
+// REQUIRES: volatile
+
 import _Volatile
 
 public func test_volatilepointer() -> UInt8 {

--- a/test/embedded/volatile-exec.swift
+++ b/test/embedded/volatile-exec.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: volatile
 
 import _Volatile
 

--- a/test/embedded/volatile-ir.swift
+++ b/test/embedded/volatile-ir.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: volatile
 
 import _Volatile
 


### PR DESCRIPTION
Follow up to https://github.com/apple/swift/pull/74537.