### PR TITLE
[Concurrency] Calls that pass an isolated parameter matching the isolation of the context do not exit to nonisolated.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3475,17 +3475,6 @@ namespace {
         if (getIsolatedActor(arg) || isa<CurrentContextIsolationExpr>(arg))
           continue;
 
-        // An isolated parameter was provided with a non-isolated argument.
-        // FIXME: The modeling of unsatisfiedIsolation is not great here.
-        // We'd be better off using something more like closure isolation
-        // that can talk about specific parameters.
-        auto nominal = getType(arg)->getAnyNominal();
-        if (!nominal) {
-          // FIXME: This is wrong for distributed actors.
-          nominal = getType(arg)->getASTContext().getProtocol(
-              KnownProtocolKind::Actor);
-        }
-
         auto calleeIsolation = ActorIsolation::forActorInstanceParameter(
             const_cast<Expr *>(arg->findOriginalValue()), paramIdx);
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3463,6 +3463,15 @@ namespace {
 
         argForIsolatedParam = arg;
         unsatisfiedIsolation = std::nullopt;
+
+        // Assume that a callee with an isolated parameter does not
+        // cross an isolation boundary. We'll set this again below if
+        // the given isolated argument doesn't match the isolation of the
+        // caller.
+        mayExitToNonisolated = false;
+
+        // If the argument is an isolated parameter from the enclosing context,
+        // or #isolation, then the call does not cross an isolation boundary.
         if (getIsolatedActor(arg) || isa<CurrentContextIsolationExpr>(arg))
           continue;
 
@@ -3477,7 +3486,6 @@ namespace {
               KnownProtocolKind::Actor);
         }
 
-        mayExitToNonisolated = false;
         auto calleeIsolation = ActorIsolation::forActorInstanceParameter(
             const_cast<Expr *>(arg->findOriginalValue()), paramIdx);
 

--- a/test/Concurrency/isolated_parameter_valid.swift
+++ b/test/Concurrency/isolated_parameter_valid.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 %s -emit-sil -o /dev/null -verify
+
+public func doNotCross(
+  isolation: isolated (any Actor)? = #isolation,
+  _ block: () async -> Void
+) async {
+  await block()
+}
+
+actor MyActor {
+  func doStuff() {}
+
+  func test() async {
+    await doNotCross {
+      doStuff()
+    }
+  }
+}


### PR DESCRIPTION
Setting the `mayExitToNonisolated` during isolated parameter checking was done after a check that bails out early when the isolated argument matches the isolated parameter of the caller, so the actor isolation checker was accidentally considering the call as exiting to a nonisolated context. This lead to bogus diagnostics during the region isolation pass.

Resolves: rdar://125078448