### PR TITLE
[6.0][concurrency] Mark the global _emptyDequeStorage as nonisolated(unsafe).

### DIFF
--- a/stdlib/public/Concurrency/Deque/_DequeBuffer.swift
+++ b/stdlib/public/Concurrency/Deque/_DequeBuffer.swift
@@ -41,7 +41,7 @@ extension _DequeBuffer: CustomStringConvertible {
 }
 
 /// The type-punned empty singleton storage instance.
-internal let _emptyDequeStorage = _DequeBuffer<Void>.create(
+nonisolated(unsafe) internal let _emptyDequeStorage = _DequeBuffer<Void>.create(
   minimumCapacity: 0,
   makingHeaderWith: { _ in
     _DequeBufferHeader(capacity: 0, count: 0, startSlot: .init(at: 0))


### PR DESCRIPTION
Explanation: This is just an internal global that is only written to during initialization. I validated together with @ktoso that there aren't any write uses to it. This just turns off a warning in the concurrency library due to strict concurrency.

- rdar://130171701

Original PRs:

- https://github.com/apple/swift/pull/74149

Risk: Low.
Testing: N/A.
Reviewer: @ktoso 