### PR TITLE
[6.0][Concurrency] Calls that pass an isolated parameter matching the isolation of the context do not exit to nonisolated.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3469,17 +3469,6 @@ namespace {
         if (getIsolatedActor(arg) || isa<CurrentContextIsolationExpr>(arg))
           continue;
 
-        // An isolated parameter was provided with a non-isolated argument.
-        // FIXME: The modeling of unsatisfiedIsolation is not great here.
-        // We'd be better off using something more like closure isolation
-        // that can talk about specific parameters.
-        auto nominal = getType(arg)->getAnyNominal();
-        if (!nominal) {
-          // FIXME: This is wrong for distributed actors.
-          nominal = getType(arg)->getASTContext().getProtocol(
-              KnownProtocolKind::Actor);
-        }
-
         auto calleeIsolation = ActorIsolation::forActorInstanceParameter(
             const_cast<Expr *>(arg->findOriginalValue()), paramIdx);
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3457,6 +3457,15 @@ namespace {
 
         argForIsolatedParam = arg;
         unsatisfiedIsolation = std::nullopt;
+
+        // Assume that a callee with an isolated parameter does not
+        // cross an isolation boundary. We'll set this again below if
+        // the given isolated argument doesn't match the isolation of the
+        // caller.
+        mayExitToNonisolated = false;
+
+        // If the argument is an isolated parameter from the enclosing context,
+        // or #isolation, then the call does not cross an isolation boundary.
         if (getIsolatedActor(arg) || isa<CurrentContextIsolationExpr>(arg))
           continue;
 
@@ -3471,7 +3480,6 @@ namespace {
               KnownProtocolKind::Actor);
         }
 
-        mayExitToNonisolated = false;
         auto calleeIsolation = ActorIsolation::forActorInstanceParameter(
             const_cast<Expr *>(arg->findOriginalValue()), paramIdx);
 

--- a/test/Concurrency/isolated_parameter_valid.swift
+++ b/test/Concurrency/isolated_parameter_valid.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 %s -emit-sil -o /dev/null -verify
+
+public func doNotCross(
+  isolation: isolated (any Actor)? = #isolation,
+  _ block: () async -> Void
+) async {
+  await block()
+}
+
+actor MyActor {
+  func doStuff() {}
+
+  func test() async {
+    await doNotCross {
+      doStuff()
+    }
+  }
+}


### PR DESCRIPTION
* **Explanation**: Setting the `mayExitToNonisolated` during isolated parameter checking was done after a check that bails out early when the isolated argument matches the isolated parameter of the caller, so the actor isolation checker was accidentally considering the call as exiting to a nonisolated context. This lead to bogus diagnostics during the region isolation pass.
* **Scope**: Only impacts calls with isolated parameters whose isolated argument is an isolated parameter from the caller.
* **Issue**: rdar://125078448
* **Risk**: Low; this code change is extremely narrow.
* **Testing**: Added new tests.
* **Reviewer**: @ktoso
* **Main branch PR**: https://github.com/apple/swift/pull/74560