### PR TITLE
[Sema] Extension of favored type to unary minus and literals

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -219,10 +219,16 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
                         locator->directlyAt<LiteralExpr>())))
           continue;
 
+      auto expr = castToExpr(locator->getAnchor());
       auto *literalProtocol = TypeChecker::getLiteralProtocol(
-          getASTContext(), castToExpr(locator->getAnchor()));
+          getASTContext(), expr);
       if (!literalProtocol)
         continue;
+
+      if (auto *favored = getFavoredType(expr)) {
+        if (favored->getAnyNominal() == type->getAnyNominal())
+          continue;
+      }
 
       // If the protocol has a default type, check it.
       if (auto defaultType = TypeChecker::getDefaultType(literalProtocol, DC)) {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -993,7 +993,8 @@ do {
   // expected-note@+1 {{overloads for '+' exist with these partially matching parameter lists: (Float, Float), (S_48822, Int)}}
   let _: Float = S_48822(integerLiteral: 42) + x
 
-  // expected-error@+1 {{cannot convert value of type 'Double' to expected argument type 'Int'}} {{48-48=Int(}} {{52-52=)}}
+  // expected-error@+2 {{binary operator '+' cannot be applied to operands of type 'S_48822' and 'Double'}} {{none}}
+  // expected-note@+1 {{overloads for '+' exist with these partially matching parameter lists: (Float, Float), (S_48822, Int)}}
   let _: Float = S_48822(integerLiteral: 42) + 42.0
 
   // expected-error@+2 {{binary operator '+' cannot be applied to operands of type 'S_48822' and 'Float'}} {{none}}
@@ -1552,19 +1553,19 @@ func testNilCoalescingOperatorRemoveFix() {
   let _ = "" /* This is a comment */ ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{13-43=}}
 
   let _ = "" // This is a comment
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1554:13-1555:10=}}
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{-1:13-+0:10=}}
 
   let _ = "" // This is a comment
     /*
      * The blank line below is part of the test case, do not delete it
      */
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1557:13-1561:10=}}
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{-4:13-+0:10=}}
 
-  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-1564:9=}}
+  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-+1:9=}}
       "").isEmpty {}
 
   if ("" // This is a comment
-      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1566:9-1567:12=}}
+      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{-1:9-+0:12=}}
 }
 
 // https://github.com/apple/swift/issues/74617


### PR DESCRIPTION
Some small extensions to the favored type implementation for arithmetic expressions to make the type checker decide on happy paths sooner, if those work out. This is motivated by a particularly slow example: 
```
let result: Double = -(1 + 1) + -(1 + 1) - 1
```
First, if there are no favored types found by the linked expr analyzer, use the contextual type.
Second, allow unary minus to pass its favored type down to its argument, as binary arithmetic ops do.
Third, if the assigned type of a literal is its favored type, treat that as good and don't add `SK_NonDefaultLiteral` to the score.

The result is being able to stop looking for additional solutions if the favored path works. For this example expression, before: `Total number of scopes explored: 905225`, after: `Total number of scopes explored: 337057`.

There is one test diagnosis that changes because of the scoring, and it changes to look like the other diagnoses for similar uses.
