### PR TITLE
[Concurrency] Remove OPTNONE workaround for old clang version

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -220,12 +220,6 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define SWIFT_ASYNC_CONTEXT
 #endif
 
-#if __has_attribute(optnone)
-#define SWIFT_OPTNONE __attribute__((optnone))
-#else
-#define SWIFT_OPTNONE
-#endif
-
 // SWIFT_CC(swiftasync) is the Swift async calling convention.
 // We assume that it supports mandatory tail call elimination.
 #if __has_attribute(swiftasynccall)

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -2076,12 +2076,10 @@ static void runOnAssumedThread(AsyncTask *task, SerialExecutorRef executor,
     asImpl(executor.getDefaultActor())->unlock(true);
 }
 
-// TODO (rokhinip): Workaround rdar://88700717. To be removed with
-// rdar://88711954
 SWIFT_CC(swiftasync)
 static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContext,
                                   TaskContinuationFunction *resumeFunction,
-                                  SerialExecutorRef newExecutor) SWIFT_OPTNONE {
+                                  SerialExecutorRef newExecutor) {
   auto task = swift_task_getCurrent();
   assert(task && "no current task!");
 


### PR DESCRIPTION
This reverts c07aa9c425ff96365683e8b3915f23452bb03b6b which was done to avoid a crash in optimnized caused by this PR:
https://github.com/apple/swift/pull/41088

Since this was almost 2 years ago, we probably don't have this issue anymore as far as I can see other resolved issues, so try to remove the workaround.

Resolves rdar://88711954
