### PR TITLE
🍒[cxx-interop] Fix inadvertently renaming static method to Mutating

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2235,7 +2235,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   SmallString<16> newName;
   // Check if we need to rename the C++ method to disambiguate it.
   if (auto method = dyn_cast<clang::CXXMethodDecl>(D)) {
-    if (!method->isConst() && !method->isOverloadedOperator()) {
+    if (!method->isConst() && !method->isOverloadedOperator() && !method->isStatic()) {
       // See if any other methods within the same struct have the same name, but
       // differ in constness.
       auto otherDecls = dc->lookup(method->getDeclName());

--- a/test/Interop/Cxx/class/method/Inputs/methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/methods.h
@@ -14,7 +14,10 @@ struct __attribute__((swift_attr("import_unsafe"))) NonTrivialInWrapper {
 
 struct HasMethods {
   void nonConstMethod() { }
+  void nonConstMethod(int) { }
+  static void nonConstMethod(float) { } // checking name colisions: rdar://120858502
   void constMethod() const { }
+  static void constMethod(float) { } // checking name colisions: rdar://120858502
 
   int nonConstPassThrough(int a) { return a; }
   int constPassThrough(int a) const { return a; }

--- a/test/Interop/Cxx/class/method/methods.swift
+++ b/test/Interop/Cxx/class/method/methods.swift
@@ -11,7 +11,10 @@ CxxMethodTestSuite.test("() -> Void") {
   var instance = HasMethods()
 
   instance.nonConstMethod()
+  instance.nonConstMethod(5)
+  HasMethods.nonConstMethod(4.2) // Testing name collision
   instance.constMethod()
+  HasMethods.constMethod(4.2) // Testing name collision
 }
 
 CxxMethodTestSuite.test("(Int) -> Int") {


### PR DESCRIPTION
**Explanation:**
When we have both const and non-const version of a function, we import
the non-cont version with the "Mutating" suffix. This logic, however, is
redundant for static member functions as those can never be marked as
"const" since they don't have a "self" or "this" to mutate. Importing static
methods with the wrong name is confusing, the users thought that the
static methods are not visible to swift.
**Scope**: C++ Interop
**Risk**: Low, only affects C++ interop and the change is straightforward.
**Testing**: Added a regression test.
**Issue**: rdar://120858502
**Reviewer**: @egorzhdan 
**Original PR**: https://github.com/apple/swift/pull/74334