### PR TITLE
[cxx-interop] NFC: update a couple outdated comments

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1235,7 +1235,7 @@ using ForeignClassMetadata = TargetForeignClassMetadata<InProcess>;
 /// The structure of metadata objects for foreign reference types.
 /// A foreign reference type is a non-Swift, non-Objective-C foreign type with
 /// reference semantics. Foreign reference types are pointers/reference to
-/// value types marked with the "import_as_ref" attribute.
+/// value types marked with the `swift_attr("import_reference")` attribute.
 ///
 /// Foreign reference types may have *custom* reference counting operations, or
 /// they may be immortal (and therefore trivial).

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -349,7 +349,7 @@ void simple_display(llvm::raw_ostream &out, CxxRecordSemanticsDescriptor desc);
 SourceLoc extractNearestSourceLoc(CxxRecordSemanticsDescriptor desc);
 
 /// What pattern does this C++ API fit? Uses attributes such as
-/// import_owned and import_as_reference to determine the pattern.
+/// import_owned and import_reference to determine the pattern.
 ///
 /// Do not evaluate this request before importing has started. For example, it
 /// is OK to invoke this request when importing a decl, but it is not OK to


### PR DESCRIPTION
`import_as_ref` attribute was renamed to `import_reference`.