### PR TITLE
[6.0][ClangImporter/SILGen] A couple of fixes for ObjC and Sendable interaction

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7330,10 +7330,10 @@ std::optional<GenericParamList *> SwiftDeclConverter::importObjCGenericParams(
           TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()));
       }
     }
-    if (inherited.empty()) {
-      inherited.push_back(
-        TypeLoc::withoutLoc(Impl.SwiftContext.getAnyObjectConstraint()));
-    }
+
+    inherited.push_back(
+      TypeLoc::withoutLoc(Impl.SwiftContext.getAnyObjectConstraint()));
+
     genericParamDecl->setInherited(Impl.SwiftContext.AllocateCopy(inherited));
 
     genericParams.push_back(genericParamDecl);

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1170,8 +1170,8 @@ static ManagedValue emitCBridgedToNativeValue(
               .getAsSingleValue(SGF, loc);
     
     // Convert to the marker existential if necessary.
-    auto anyType = SGF.getASTContext().getAnyExistentialType();
-    if (nativeType != anyType) {
+    if (!v.isInContext()) {
+      auto anyType = SGF.getASTContext().getAnyExistentialType();
       v = SGF.emitTransformedValue(loc, v, anyType, nativeType);
     }
 

--- a/test/ClangImporter/objc_method_with_sendable_generic_requirement.swift
+++ b/test/ClangImporter/objc_method_with_sendable_generic_requirement.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-silgen %t/main.swift -import-objc-header %t/Test.h | %FileCheck %t/main.swift
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+
+// rdar://127520993
+
+//--- Test.h
+#import <Foundation/Foundation.h>
+
+#define SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+
+@interface Test<N : id SWIFT_SENDABLE> : NSObject
+- (void)luckWithNumber:(nullable N)number;
+@end
+
+//--- main.swift
+import Foundation
+
+Test<NSNumber>().luck(withNumber: 5)
+// CHECK-LABEL: sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32
+// CHECK: [[NS_NUMBER_INIT:%.*]] = function_ref @$sSo8NSNumberC10FoundationE14integerLiteralABSi_tcfC : $@convention(method) (Int, @thick NSNumber.Type) -> @owned NSNumber
+// CHECK-NEXT:  [[NS_NUMBER:%.*]] = apply [[NS_NUMBER_INIT]]({{.*}}) : $@convention(method) (Int, @thick NSNumber.Type) -> @owned NSNumber
+// CHECK-NEXT:  [[OPT_NS_NUMBER:%.*]] = enum $Optional<NSNumber>, #Optional.some!enumelt, [[NS_NUMBER]] : $NSNumber
+// CHECK-NEXT:  [[LUCK_METHOD_REF:%.*]] = objc_method %4 : $Test<NSNumber>, #Test.luck!foreign : <N where N : AnyObject, N : Sendable> (Test<N>) -> (N?) -> (), $@convention(objc_method) @pseudogeneric <τ_0_0 where τ_0_0 : AnyObject, τ_0_0 : Sendable> (Optional<τ_0_0>, Test<τ_0_0>) -> ()
+// CHECK-NEXT:  %14 = apply [[LUCK_METHOD_REF]]<NSNumber>([[OPT_NS_NUMBER]], {{.*}}) : $@convention(objc_method) @pseudogeneric <τ_0_0 where τ_0_0 : AnyObject, τ_0_0 : Sendable> (Optional<τ_0_0>, Test<τ_0_0>) -> ()

--- a/test/Interpreter/objc_method_with_sendable_generic_requirement.swift
+++ b/test/Interpreter/objc_method_with_sendable_generic_requirement.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-clang %t/Test.m -c -o %t/Test.o
+// RUN: %target-build-swift %t/main.swift -import-objc-header %t/Test.h %t/Test.o -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %t/main.swift
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+// rdar://127520993
+
+//--- Test.h
+#import <Foundation/Foundation.h>
+
+#define SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+
+@interface Test<N : id SWIFT_SENDABLE> : NSObject
+- (void)luckWithNumber:(nullable N)number;
+@end
+
+//--- Test.m
+#import "Test.h"
+
+static void NSPrint(NSString *format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    NSString *string = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+
+    fprintf(stdout, "%s\n", [string UTF8String]);
+
+#if !__has_feature(objc_arc)
+    [string release];
+#endif
+}
+
+@implementation Test
+
+- (void)luckWithNumber:(id)number
+{
+    NSPrint(@"Lucky number: %@", number);
+}
+
+@end
+
+//--- main.swift
+Test<NSNumber>().luck(withNumber: 5)
+// CHECK: Lucky number: 5

--- a/test/SILGen/Inputs/objc_bridging_sendable.h
+++ b/test/SILGen/Inputs/objc_bridging_sendable.h
@@ -2,5 +2,6 @@
 
 @interface NSBlah: NSObject
 - (void) takeSendable: (id __attribute__((swift_attr("@Sendable")))) x;
-@property (readonly) id __attribute__((swift_attr("@Sendable"))) x;
+@property(readonly) id __attribute__((swift_attr("@Sendable"))) x;
+- (nullable __attribute__((swift_attr("@Sendable"))) id)test:(NSError *_Nullable __autoreleasing * _Nullable)error;
 @end

--- a/test/SILGen/objc_bridging_sendable.swift
+++ b/test/SILGen/objc_bridging_sendable.swift
@@ -12,4 +12,25 @@ public func passSendableToObjC(_ s: Sendable) {
 
 public func useSendableProperty(_ ns: NSBlah) {
   _ = ns.x
+  let _: (Int, Any, String, [Any]) = (42, ns.x, "", [1, 2, 3])
+}
+
+// CHECK-LABEL: sil private [ossa] @$s22objc_bridging_sendable23test_use_of_buffer_inityyKFypSo6NSBlahCKXEfU_ : $@convention(thin) @substituted <τ_0_0> (@guaranteed NSBlah) -> (@out τ_0_0, @error any Error) for <Any>
+// CHECK: bb0(%0 : $*Any, %1 : @guaranteed $NSBlah):
+// CHECK: [[TEST_REF:%.*]] = objc_method %1 : $NSBlah, #NSBlah.test!foreign : (NSBlah) -> () throws -> any Sendable, $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, NSBlah) -> @autoreleased Optional<AnyObject>
+// CHECK: [[RESULT:%.*]] = apply [[TEST_REF]]({{.*}}, %1) : $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, NSBlah) -> @autoreleased Optional<AnyObject>
+// CHECK: switch_enum [[RESULT]] : $Optional<AnyObject>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+// CHECK: bb1([[SUCCESS:%.*]] : @owned $AnyObject)
+// CHECK-NEXT: [[OPT_RESULT_VALUE:%.*]] = unchecked_ref_cast [[SUCCESS]] : $AnyObject to $Optional<AnyObject>
+// CHECK-NEXT: // function_ref _bridgeAnyObjectToAny(_:)
+// CHECK-NEXT: [[BRIDGE_INTRINSIC_REF:%.*]] = function_ref @$ss018_bridgeAnyObjectToB0yypyXlSgF : $@convention(thin) (@guaranteed Optional<AnyObject>) -> @out Any
+// CHECK-NEXT:  apply [[BRIDGE_INTRINSIC_REF]](%0, [[OPT_RESULT_VALUE]]) : $@convention(thin) (@guaranteed Optional<AnyObject>) -> @out Any
+func test_use_of_buffer_init() throws {
+  func test<T: Sendable>(_: (NSBlah) throws -> T) rethrows -> T {
+    fatalError()
+  }
+
+  let _: Any = try test {
+      try $0.test()
+  }
 }


### PR DESCRIPTION
- Explanation:

  Fixes a couple of crashers recently discovered when ObjC API have been annotated with `@Sendable` attribute.

  - If the context indicates that the result of `id-to-Any` should be placed in some pre-allocated buffer, let's not attempt marker existential transformation because that would much the expected layout already.
  - `: AnyObject` was added only if there were no other constraints because all of them would imply it before, with introduction of `Sendable` this is no longer the case. Let's add `AnyObject` constraint unconditionally and let generic signature builder deal with the redundancy.

- Main Branch PRs: https://github.com/apple/swift/pull/74492, https://github.com/apple/swift/pull/74483

- Resolves: rdar://127520993

- Risk: Low

- Reviewed By: @jckarter   

- Testing: Existing test-cases were modified and new tests were added.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
