### PR TITLE
Minor improvements to new ASSERT macros

### DIFF
--- a/include/swift/Basic/Assertions.h
+++ b/include/swift/Basic/Assertions.h
@@ -17,8 +17,6 @@
 #ifndef SWIFT_BASIC_ASSERTIONS_H
 #define SWIFT_BASIC_ASSERTIONS_H
 
-#include <stdint.h>
-
 // Only for use in this header
 #if __has_builtin(__builtin_expect)
 #define ASSERT_UNLIKELY(expression) (__builtin_expect(!!(expression), 0))
@@ -46,7 +44,7 @@
 #define ASSERT(expr) \
   do { \
     if (ASSERT_UNLIKELY(!expr)) {			   \
-      ASSERT_failure(#expr, __FILE__, __LINE__, __func__); \
+      ASSERT_failure(#expr, __FILE_NAME__, __LINE__, __func__); \
     } \
   } while (0)
 

--- a/lib/Basic/Assertions.cpp
+++ b/lib/Basic/Assertions.cpp
@@ -35,16 +35,7 @@ int CONDITIONAL_ASSERT_Global_enable_flag =
   0; // TODO: Default to `on` in debug builds
 #endif
 
-void ASSERT_failure(const char *expr, const char *file, int line, const char *func) {
-  // Only print the last component of `file`
-  const char *f = file;
-  for (const char *p = file; *p != '\0'; p++) {
-    if ((p[0] == '/' || p[0] == '\\')
-	&& p[1] != '/' && p[1] != '\\' && p[1] != '\0') {
-      f = p + 1;
-    }
-  }
-
+void ASSERT_failure(const char *expr, const char *filename, int line, const char *func) {
   if (AssertHelp) {
     ASSERT_help();
   } else {
@@ -56,9 +47,9 @@ void ASSERT_failure(const char *expr, const char *file, int line, const char *fu
   std::cerr
     << "Assertion failed: "
     << "(" << expr << "), "
-    << "function " << func << ", "
-    << "file " << f << ", "
-    << "line " << line << "."
+    << "function " << func << " at "
+    << filename << ":"
+    << line << "."
     << std::endl;
 
   if (AssertContinue) {


### PR DESCRIPTION
Three minor changes on top of #73675:
* Remove unneeded stdint.h inclusion
* Use `__FILE_NAME__` instead of `__FILE__` to reduce code size
* Write location as "file:line" for better compatibility with existing tools
