### PR TITLE
Improve logging in `swift_build_support/shell.py`

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -88,7 +88,7 @@ def call(command, stderr=None, env=None, dry_run=None, echo=True):
         subprocess.check_call(command, env=_env, stderr=stderr)
     except subprocess.CalledProcessError as e:
         _fatal_error(
-            "command terminated with a non-zero exit status " +
+            "command `{0}` terminated with a non-zero exit status ".format(command) +
             str(e.returncode) + ", aborting")
     except OSError as e:
         _fatal_error(
@@ -138,7 +138,7 @@ def capture(command, stderr=None, env=None, dry_run=None, echo=True,
         if optional:
             return None
         _fatal_error(
-            "command terminated with a non-zero exit status " +
+            "command `{0}` terminated with a non-zero exit status ".format(command) +
             str(e.returncode) + ", aborting")
     except OSError as e:
         if optional:

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -88,8 +88,8 @@ def call(command, stderr=None, env=None, dry_run=None, echo=True):
         subprocess.check_call(command, env=_env, stderr=stderr)
     except subprocess.CalledProcessError as e:
         _fatal_error(
-            "command `{0}` terminated with a non-zero exit status ".format(command) +
-            str(e.returncode) + ", aborting")
+            f"command `{command}` terminated with a non-zero exit status "
+            f"{str(e.returncode)}, aborting")
     except OSError as e:
         _fatal_error(
             "could not execute '" + quote_command(command) +
@@ -138,8 +138,8 @@ def capture(command, stderr=None, env=None, dry_run=None, echo=True,
         if optional:
             return None
         _fatal_error(
-            "command `{0}` terminated with a non-zero exit status ".format(command) +
-            str(e.returncode) + ", aborting")
+            f"command `{command}` terminated with a non-zero exit status "
+            f"{str(e.returncode)}, aborting")
     except OSError as e:
         if optional:
             return None


### PR DESCRIPTION
Currently, when a command fails with this message 

```
ERROR: command terminated with a non-zero exit status 1, aborting
```

it's unclear at all which exact command terminated, which makes it very hard to debug issues in the build script.
