### PR TITLE
Invoke foundation tests via SwiftPM

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1653,8 +1653,6 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
       $Targets = @("default", "install")
       $InstallPath = "$($Arch.SDKInstallRoot)\usr"
 
-
-    $env:CTEST_OUTPUT_ON_FAILURE = 1
     Build-CMakeProject `
       -Src $SourceCache\swift-corelibs-foundation `
       -Bin $FoundationBinaryCache `

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -672,6 +672,10 @@ class BuildScriptInvocation(object):
 
         builder.add_product(products.SwiftPM,
                             is_enabled=self.args.build_swiftpm)
+        builder.add_product(products.SwiftFoundationTests,
+                            is_enabled=self.args.build_foundation)
+        builder.add_product(products.FoundationTests,
+                            is_enabled=self.args.build_foundation)
         builder.add_product(products.SwiftSyntax,
                             is_enabled=self.args.build_swiftsyntax)
         builder.add_product(products.SwiftFormat,

--- a/utils/swift_build_support/swift_build_support/products/__init__.py
+++ b/utils/swift_build_support/swift_build_support/products/__init__.py
@@ -15,6 +15,7 @@ from .cmark import CMark
 from .curl import LibCurl
 from .earlyswiftdriver import EarlySwiftDriver
 from .foundation import Foundation
+from .foundationtests import FoundationTests
 from .indexstoredb import IndexStoreDB
 from .libcxx import LibCXX
 from .libdispatch import LibDispatch
@@ -33,6 +34,7 @@ from .swiftdocc import SwiftDocC
 from .swiftdoccrender import SwiftDocCRender
 from .swiftdriver import SwiftDriver
 from .swiftformat import SwiftFormat
+from .swiftfoundationtests import SwiftFoundationTests
 from .swiftinspect import SwiftInspect
 from .swiftpm import SwiftPM
 from .swiftsyntax import SwiftSyntax
@@ -47,6 +49,8 @@ from .zlib import Zlib
 __all__ = [
     'CMark',
     'Foundation',
+    'FoundationTests',
+    'SwiftFoundationTests',
     'LibCXX',
     'LibDispatch',
     'LibXML2',

--- a/utils/swift_build_support/swift_build_support/products/foundationtests.py
+++ b/utils/swift_build_support/swift_build_support/products/foundationtests.py
@@ -1,0 +1,97 @@
+# swift_build_support/products/foundationtests.py -----------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2024 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+import os
+
+from . import cmark
+from . import foundation
+from . import libcxx
+from . import libdispatch
+from . import llbuild
+from . import llvm
+from . import product
+from . import swift
+from . import swiftpm
+from . import swiftsyntax
+from . import xctest
+from .. import shell
+
+
+class FoundationTests(product.Product):
+    @classmethod
+    def is_build_script_impl_product(cls):
+        return False
+
+    @classmethod
+    def is_before_build_script_impl_product(cls):
+        return False
+
+    @classmethod
+    def is_ignore_install_all_product(cls):
+        return True
+
+    @classmethod
+    def is_nondarwin_only_build_product(cls):
+        return True
+
+    def should_build(self, host_target):
+        return False
+
+    def should_install(self, host_target):
+        return False
+
+    def should_test(self, host_target):
+        return True
+
+    def configuration(self):
+        return 'release' if self.is_release() else 'debug'
+
+    def test(self, host_target):
+        swift_exec = os.path.join(
+            self.install_toolchain_path(host_target),
+            'bin',
+            'swift'
+        )
+        package_path = os.path.join(self.source_dir, '..', 'swift-corelibs-foundation')
+        package_path = os.path.abspath(package_path)
+        include_path = os.path.join(
+            self.install_toolchain_path(host_target),
+            'lib',
+            'swift'
+        )
+        cmd = [
+            swift_exec,
+            'test',
+            '--toolchain', self.install_toolchain_path(host_target),
+            '--configuration', self.configuration(),
+            '--scratch-path', self.build_dir,
+            '--package-path', package_path
+        ]
+        if self.args.verbose_build:
+            cmd.append('--verbose')
+        shell.call(cmd, env={
+            'SWIFTCI_USE_LOCAL_DEPS': '1',
+            'DISPATCH_INCLUDE_PATH': include_path
+        })
+
+    @classmethod
+    def get_dependencies(cls):
+        return [cmark.CMark,
+                llvm.LLVM,
+                libcxx.LibCXX,
+                swift.Swift,
+                libdispatch.LibDispatch,
+                foundation.Foundation,
+                xctest.XCTest,
+                llbuild.LLBuild,
+                swiftpm.SwiftPM,
+                swiftsyntax.SwiftSyntax]

--- a/utils/swift_build_support/swift_build_support/products/swiftfoundationtests.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftfoundationtests.py
@@ -1,0 +1,89 @@
+# swift_build_support/products/foundationtests.py -----------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2024 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+import os
+
+from . import cmark
+from . import foundation
+from . import libcxx
+from . import libdispatch
+from . import llbuild
+from . import llvm
+from . import product
+from . import swift
+from . import swiftpm
+from . import swiftsyntax
+from . import xctest
+from .. import shell
+
+
+class SwiftFoundationTests(product.Product):
+    @classmethod
+    def is_build_script_impl_product(cls):
+        return False
+
+    @classmethod
+    def is_before_build_script_impl_product(cls):
+        return False
+
+    @classmethod
+    def is_ignore_install_all_product(cls):
+        return True
+
+    @classmethod
+    def is_nondarwin_only_build_product(cls):
+        return True
+
+    def should_build(self, host_target):
+        return False
+
+    def should_install(self, host_target):
+        return False
+
+    def should_test(self, host_target):
+        return True
+
+    def configuration(self):
+        return 'release' if self.is_release() else 'debug'
+
+    def test(self, host_target):
+        swift_exec = os.path.join(
+            self.install_toolchain_path(host_target),
+            'bin',
+            'swift'
+        )
+        package_path = os.path.join(self.source_dir, '..', 'swift-foundation')
+        package_path = os.path.abspath(package_path)
+        cmd = [
+            swift_exec,
+            'test',
+            '--toolchain', self.install_toolchain_path(host_target),
+            '--configuration', self.configuration(),
+            '--scratch-path', self.build_dir,
+            '--package-path', package_path
+        ]
+        if self.args.verbose_build:
+            cmd.append('--verbose')
+        shell.call(cmd, env={'SWIFTCI_USE_LOCAL_DEPS': '1'})
+
+    @classmethod
+    def get_dependencies(cls):
+        return [cmark.CMark,
+                llvm.LLVM,
+                libcxx.LibCXX,
+                swift.Swift,
+                libdispatch.LibDispatch,
+                foundation.Foundation,
+                xctest.XCTest,
+                llbuild.LLBuild,
+                swiftpm.SwiftPM,
+                swiftsyntax.SwiftSyntax]


### PR DESCRIPTION
This adds new phases to the build script that will build and run swift-foundation unit tests and swift-corelibs-foundation unit tests via swiftpm. On platforms that use the `build-script`, this will take place later than before after the SwiftPM build has finished. On platforms that use `build.ps1` the tests will happen as they did previously but will build with SwiftPM instead. We set the `SWIFTCI_USE_LOCAL_DEPS` environment variable when building these projects so that they find dependencies in the local checkout rather than fetching them from GitHub.