### PR TITLE
SILGen: Ignore invalid associated conformances

### DIFF
--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -33,6 +33,12 @@ void SILGenModule::useConformance(ProtocolConformanceRef conformanceRef) {
   // If the conformance is invalid, crash deterministically even in noassert
   // builds.
   if (conformanceRef.isInvalid()) {
+    // When lazy type checking is enabled, a conformance may only be diagnosed
+    // as invalid during SILGen. Ignore it instead of asserting.
+    auto &ctx = getASTContext();
+    if (ctx.TypeCheckerOpts.EnableLazyTypecheck && ctx.hadError())
+      return;
+
     llvm::report_fatal_error("Invalid conformance in type-checked AST");
   }
 

--- a/test/SILGen/lazy_typecheck_errors.swift
+++ b/test/SILGen/lazy_typecheck_errors.swift
@@ -25,6 +25,14 @@ public struct ConformsToProtoWithAssociatedType_MissingTypeRequirement: ProtoWit
   // expected-error@-1 {{type 'ConformsToProtoWithAssociatedType_MissingTypeRequirement' does not conform to protocol 'ProtoWithAssociatedType'}}
 }
 
+public protocol ProtoWithConstrainedAssociatedType {
+  associatedtype A: Proto
+}
+
+public struct ConformsToProtoWithConstrainedAssociatedType_MissingTypeRequirement: ProtoWithConstrainedAssociatedType {
+  // expected-error@-1 {{type 'ConformsToProtoWithConstrainedAssociatedType_MissingTypeRequirement' does not conform to protocol 'ProtoWithConstrainedAssociatedType'}}
+}
+
 public struct GenericStruct<T> {
   public var t: T
 }

--- a/test/SILGen/lazy_typecheck_errors.swift
+++ b/test/SILGen/lazy_typecheck_errors.swift
@@ -7,12 +7,12 @@ public protocol Proto {
   func req()
 }
 
-public struct ConformsToProtoMissingRequirement: Proto {
-  // expected-error@-1 {{type 'ConformsToProtoMissingRequirement' does not conform to protocol 'Proto'}}
+public struct ConformsToProto_MissingRequirement: Proto {
+  // expected-error@-1 {{type 'ConformsToProto_MissingRequirement' does not conform to protocol 'Proto'}}
 }
 
-public struct ConformsToProtoNearMiss: Proto {
-  // expected-error@-1 {{type 'ConformsToProtoNearMiss' does not conform to protocol 'Proto'}}
+public struct ConformsToProto_NearMiss: Proto {
+  // expected-error@-1 {{type 'ConformsToProto_NearMiss' does not conform to protocol 'Proto'}}
 
   public func req(x: Int) {}
 }
@@ -21,8 +21,8 @@ public protocol ProtoWithAssociatedType {
   associatedtype A
 }
 
-public struct ConformsToProtoProtoWithAssociatedType: ProtoWithAssociatedType {
-  // expected-error@-1 {{type 'ConformsToProtoProtoWithAssociatedType' does not conform to protocol 'ProtoWithAssociatedType'}}
+public struct ConformsToProtoWithAssociatedType_MissingTypeRequirement: ProtoWithAssociatedType {
+  // expected-error@-1 {{type 'ConformsToProtoWithAssociatedType_MissingTypeRequirement' does not conform to protocol 'ProtoWithAssociatedType'}}
 }
 
 public struct GenericStruct<T> {


### PR DESCRIPTION
With lazy type checking, invalid conformances can make it all the way to SILGen. As a result, `SILGenModule::useConformance()` needs to handle invalid conformances more gracefully by ignoring them instead of asserting.

Resolves rdar://128286622