### PR TITLE
[windows] Temporarily guard lifetime dependence diagnostics

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -29,6 +29,11 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let lifetimeDependenceDiagnosticsPass = FunctionPass(
   name: "lifetime-dependence-diagnostics")
 { (function: Function, context: FunctionPassContext) in
+#if os(Windows)
+  if !context.options.hasFeature(.NonescapableTypes) {
+    return
+  }
+#endif
   log(prefix: false, "\n--- Diagnosing lifetime dependence in \(function.name)")
   log("\(function)")
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
@@ -31,6 +31,11 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let lifetimeDependenceInsertionPass = FunctionPass(
   name: "lifetime-dependence-insertion")
 { (function: Function, context: FunctionPassContext) in
+#if os(Windows)
+  if !context.options.hasFeature(.NonescapableTypes) {
+    return
+  }
+#endif
   log(prefix: false, "\n--- Inserting lifetime dependence markers in \(function.name)")
 
   for instruction in function.instructions {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -31,6 +31,11 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let lifetimeDependenceScopeFixupPass = FunctionPass(
   name: "lifetime-dependence-scope-fixup")
 { (function: Function, context: FunctionPassContext) in
+#if os(Windows)
+  if !context.options.hasFeature(.NonescapableTypes) {
+    return
+  }
+#endif
   log(prefix: false, "\n--- Scope fixup for lifetime dependence in \(function.name)")
 
   let localReachabilityCache = LocalVariableReachabilityCache()


### PR DESCRIPTION
by -enable-experimental-feature NonescapableTypes
on the Windows platform

These passes do nothing unless the above feature flag is enabled, so the only reason to run the pass is to exercise SwiftCompilerSources and catch invalid SIL.

These passes rely on fundamental SwiftCompilerSources abstractions which have not yet been tested outside of the passes. They don't yet handle all SIL patterns, and SIL continues to evolve. We would like to can these issues quickly as we hit them, but only if we have a way of reproducing the failure. Currently, we don't have a way of reproducing Windows-arm64 failures.

Workaround for:
rdar://128434000 ([nonescapable] [LifetimeDependenceInsertion] Package resolution fails with arm64 Windows toolchain)
