### PR TITLE
[Concurrency] Infer protocol isolation from superclass requirements.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4603,13 +4603,15 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
 static std::optional<ActorIsolation>
 getIsolationFromInheritedProtocols(ProtocolDecl *protocol) {
   std::optional<ActorIsolation> foundIsolation;
-  for (auto inherited : protocol->getInheritedProtocols()) {
-    switch (auto protoIsolation = getActorIsolation(inherited)) {
+  bool conflict = false;
+
+  auto inferIsolation = [&](ValueDecl *decl) {
+    switch (auto protoIsolation = getActorIsolation(decl)) {
     case ActorIsolation::ActorInstance:
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
     case ActorIsolation::NonisolatedUnsafe:
-      break;
+      return;
 
     case ActorIsolation::Erased:
       llvm_unreachable("protocol cannot have erased isolation");
@@ -4617,15 +4619,26 @@ getIsolationFromInheritedProtocols(ProtocolDecl *protocol) {
     case ActorIsolation::GlobalActor:
       if (!foundIsolation) {
         foundIsolation = protoIsolation;
-        continue;
+        return;
       }
 
       if (*foundIsolation != protoIsolation)
-        return std::nullopt;
+        conflict = true;
 
-      break;
+      return;
     }
+  };
+
+  for (auto inherited : protocol->getInheritedProtocols()) {
+    inferIsolation(inherited);
   }
+
+  if (auto *superclass = protocol->getSuperclassDecl()) {
+    inferIsolation(superclass);
+  }
+
+  if (conflict)
+    return std::nullopt;
 
   return foundIsolation;
 }


### PR DESCRIPTION
Actor isolation on protocols was already inferred from inherited protocols, but we were missing inference from a required superclass.

Note that this is staged in behind the `GlobalActorIsolatedTypesUsability` upcoming feature, just like inference from refined protocols, because it's source breaking.

Resolves: https://github.com/swiftlang/swift/issues/63473, rdar://127152935