### PR TITLE
[Concurrency] Don't attempt to diagnose `GlobalConcurrency` issues wi…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5059,7 +5059,11 @@ ActorIsolation ActorIsolationRequest::evaluate(
   // isolated to a global actor.
   auto checkGlobalIsolation = [var = dyn_cast<VarDecl>(value)](
                                   ActorIsolation isolation) {
-    if (var && var->getLoc() &&
+    // Diagnose only declarations in the same module.
+    //
+    // TODO: This should be factored out from ActorIsolationRequest into
+    // either ActorIsolationChecker or DeclChecker.
+    if (var && var->getLoc(/*SerializedOK*/false) &&
         var->getASTContext().LangOpts.hasFeature(Feature::GlobalConcurrency) &&
         !isolation.isGlobalActor() &&
         (isolation != ActorIsolation::NonisolatedUnsafe)) {

--- a/test/Concurrency/global_actor_isolation_cross_module_reference.swift
+++ b/test/Concurrency/global_actor_isolation_cross_module_reference.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/lib)
+// RUN: split-file %s %t/src
+
+/// Build the library
+// RUN: %target-swift-frontend -emit-module %t/src/Lib.swift \
+// RUN:   -module-name Lib -swift-version 5 \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-interface-path %t/lib/Lib.swiftinterface \
+// RUN:   -emit-module-path %t/lib/Lib.swiftmodule \
+// RUN:   -emit-module-source-info-path %t/lib/Lib.swiftsourceinfo
+
+// Build the client
+// RUN: %target-swift-frontend -typecheck -primary-file %t/src/Client.swift \
+// RUN:   -module-name Client -I %t/lib \
+// RUN:   -swift-version 6
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+
+//--- Lib.swift
+
+public struct Test: Equatable {
+  public static let value = Test(x: 0)
+
+  public var x: UInt64
+
+  private init(x: UInt64) {
+    self.x = x
+  }
+}
+
+//--- Client.swift
+import Lib
+
+public func test() -> Test {
+  .value // Ok (no sendability errors)
+}


### PR DESCRIPTION
…th deserialized variable/properties

If the property comes from a different module the compiler shouldn't attempt to diagnose `GlobalIsolation` problems based in the current module flags otherwise it would create issues when i.e. a variable/property from a module built with `-swift-version 5` that gets referenced by a module that is built with `-swift-version 6` that has stricter local concurrency requirements.

See https://forums.swift.org/t/swift-6-language-mode-being-passed-to-dependencies/72622 for further discussion.

A better solution would be to move the check to `ActorIsolationChecker` or `DeclChecker` but that would be too risky for 6.0.

Fixes #73075.