### PR TITLE
[cxx-interop] Instantiate the `std::function` constructor with a const pointer argument

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1058,7 +1058,7 @@ void swift::conformToCxxFunctionIfNeeded(
 
   auto funcPointerType = clangCtx.getPointerType(clangCtx.getFunctionType(
       operatorCallDecl->getReturnType(), operatorCallParamTypes,
-      clang::FunctionProtoType::ExtProtoInfo()));
+      clang::FunctionProtoType::ExtProtoInfo())).withConst();
 
   // Create a fake variable with a function type that matches the type of
   // `operator()`.


### PR DESCRIPTION
We were trying to instantiate a constructor for `std::function` from a C function pointer with a non-const function pointer type. That worked well on most platforms, where `std::function` defines a single constructor for const and non-const function pointers, but failed on UBI 9.

This fixes a test (`Interop/Cxx/stdlib/use-std-function.swift`) on UBI Linux.

rdar://118026392