### PR TITLE
[Runtime] Fix printing keypaths with LocalDeclName subscript types.

### DIFF
--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -3626,6 +3626,17 @@ std::string Demangle::keyPathSourceString(const char *MangledName,
             return argumentTypeNames[i];
           return std::string("<unknown>");
         };
+        auto getArgumentNodeName = [](NodePointer node) {
+          if (node->getKind() == Node::Kind::Identifier) {
+            return std::string(node->getText());
+          }
+          if (node->getKind() == Node::Kind::LocalDeclName) {
+            auto text = node->getChild(1)->getText();
+            auto index = node->getChild(0)->getIndex() + 1;
+            return std::string(text) + " #" + std::to_string(index);
+          }
+          return std::string("<unknown>");
+        };
         // Multiple arguments case
         NodePointer argList = matchSequenceOfKinds(
             child, {
@@ -3644,11 +3655,8 @@ std::string Demangle::keyPathSourceString(const char *MangledName,
             if (argumentType->getKind() == Node::Kind::TupleElement) {
               argumentType =
                   argumentType->getChild(0)->getChild(0)->getChild(1);
-              if (argumentType->getKind() == Node::Kind::Identifier) {
-                argumentTypeNames.push_back(
-                    std::string(argumentType->getText()));
-                continue;
-              }
+              argumentTypeNames.push_back(getArgumentNodeName(argumentType));
+              continue;
             }
             argumentTypeNames.push_back("<Unknown>");
           }
@@ -3663,7 +3671,7 @@ std::string Demangle::keyPathSourceString(const char *MangledName,
                      });
           if (argList != nullptr) {
             argumentTypeNames.push_back(
-                std::string(argList->getChild(0)->getChild(1)->getText()));
+                getArgumentNodeName(argList->getChild(0)->getChild(1)));
           }
         }
         child = child->getChild(1);

--- a/test/Interpreter/keypath.swift
+++ b/test/Interpreter/keypath.swift
@@ -149,3 +149,16 @@ do {
   // CHECK: 5
   print(Test(obj: "Hello").utf8.count)
 }
+
+do {
+  struct S1: Hashable {}
+  struct S2 {
+    subscript(param: S1) -> String { "Subscript with private type" }
+  }
+
+  let kp = \S2[S1()]
+  // CHECK: Subscript with private type
+  print(S2()[keyPath: kp])
+  // CHECK: {{\\S2\.subscript\(_: S1 #[0-9]+\)|\S2\.<computed 0x.* \(String\)>}}
+  print(kp)
+}


### PR DESCRIPTION
We assumed a bit too much about the structure of a single-argument subscript demangle tree and assumed that the argument identifier node was always in the same place. If it wasn't, we'd try to get text from the wrong node and get a bogus StringRef. Verify the node kind before trying to extract text, and handle LocalDeclName nodes as well as Identifier nodes.

rdar://129886558