### PR TITLE
[cxx-interop] ensure that the body of implicit virtual destructor is …

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -688,14 +688,7 @@ namespace {
         return;
       }
 
-      if (!destructor->isUserProvided() &&
-          !destructor->doesThisDeclarationHaveABody()) {
-        assert(!destructor->isDeleted() &&
-               "Swift cannot handle a type with no known destructor.");
-        // Make sure we define the destructor so we have something to call.
-        auto &sema = IGF.IGM.Context.getClangModuleLoader()->getClangSema();
-        sema.DefineImplicitDestructor(clang::SourceLocation(), destructor);
-      }
+      IGF.IGM.ensureImplicitCXXDestructorBodyIsDefined(destructor);
 
       clang::GlobalDecl destructorGlobalDecl(destructor, clang::Dtor_Complete);
       auto *destructorFnAddr =

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -77,6 +77,7 @@ namespace clang {
   class ASTContext;
   template <class> class CanQual;
   class CodeGenerator;
+  class CXXDestructorDecl;
   class Decl;
   class GlobalDecl;
   class Type;
@@ -1614,6 +1615,9 @@ public:
                                       llvm::AttributeList &attrs,
                                       ForeignFunctionInfo *foreignInfo=nullptr);
   ForeignFunctionInfo getForeignFunctionInfo(CanSILFunctionType type);
+
+  void
+  ensureImplicitCXXDestructorBodyIsDefined(clang::CXXDestructorDecl *cxxDtor);
 
   llvm::ConstantInt *getInt32(uint32_t value);
   llvm::ConstantInt *getSize(Size size);

--- a/test/Interop/Cxx/class/virtual-destructor-vtable-ref-irgen.swift
+++ b/test/Interop/Cxx/class/virtual-destructor-vtable-ref-irgen.swift
@@ -1,0 +1,106 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swiftxx-frontend -emit-ir -I %t/Inputs -validate-tbd-against-ir=none %t/test.swift | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module VtableDestructorRef {
+  header "test.h"
+  requires cplusplus
+}
+//--- Inputs/test.h
+
+
+namespace impl {
+
+template<class T>
+class BaseClass
+{
+public:
+    virtual ~BaseClass() {}
+};
+
+template<class Fp, class T>
+class Func: public BaseClass<T>
+{
+   Fp x;
+public:
+    
+    inline explicit Func(Fp x) : x(x) {}
+};
+
+
+template <class _Fp> class ValueFunc;
+
+template <class _Rp, class... _ArgTypes> class ValueFunc<_Rp(_ArgTypes...)>
+{
+    typedef impl::BaseClass<_Rp(_ArgTypes...)> FuncTy;
+    FuncTy* _Nullable f;
+  public:
+
+    template <class _Fp>
+    ValueFunc(_Fp fp) {
+        typedef impl::Func<_Fp, _Rp(_ArgTypes...)> _Fun;
+        f = ::new _Fun(fp);
+    }
+
+    ValueFunc(ValueFunc&& other) {
+        if (other.f == nullptr)
+            f = nullptr;
+        else
+        {
+            f = other.f;
+            other.f = nullptr;
+        }
+    }
+};
+
+template<class _Rp>
+class Function;
+
+template<class _Rp, class ..._ArgTypes>
+class Function<_Rp(_ArgTypes...)> {
+    ValueFunc<_Rp(_ArgTypes...)> f;
+public:
+  template<class _Fp>
+  Function(_Fp);
+};
+
+template <class _Rp, class... _ArgTypes>
+template <class _Fp>
+Function<_Rp(_ArgTypes...)>::Function(_Fp f) : f(f) {}
+
+}
+
+class MyFutureBase {
+public:
+  void OnCompletion(impl::Function<void(const MyFutureBase&)> callback) const;
+};
+
+template<class T>
+class MyFuture : public MyFutureBase {
+public:
+    void OnCompletion(
+      void (* _Nonnull completion)(void * _Nullable),
+       void * _Nullable user_data) const {
+    MyFutureBase::OnCompletion(
+        [completion, user_data](const MyFutureBase&) {
+          completion(user_data);
+        });
+  }
+};
+
+using MyFutureInt = MyFuture<int>;
+
+//--- test.swift
+
+import VtableDestructorRef
+
+public func test() {
+  let f = MyFutureInt()
+  f.OnCompletion({ _ in
+    print("done")
+  }, nil)
+}
+
+// Make sure we reach the virtual destructor of 'Func'.
+// CHECK: define linkonce_odr {{.*}} @{{_ZN4impl4FuncIZNK8MyFutureIiE12OnCompletionEPFvPvES3_EUlRK12MyFutureBaseE_FvS8_EED2Ev|\?\?1\?\$BaseClass@\$\$A6AXAEBVMyFutureBase@@@Z@impl@@UEAA@XZ}}


### PR DESCRIPTION
…defined before emitting the clang decl for it

This ensures that the destructor definition is emitted into the module's LLVM IR, fixing a linker error. The failure can be observed only on a Linux target, like Android, and Darwin/MSVC handle this case just fine.