### PR TITLE
[PackageCMO] Don't allow modifying AST

### DIFF
--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -829,6 +829,21 @@ void CrossModuleOptimization::makeDeclUsableFromInline(ValueDecl *decl) {
   if (decl->getEffectiveAccess() >= AccessLevel::Package)
     return;
 
+  // FIXME: rdar://130456707
+  // Currently not all types are visited in canSerialize* calls, sometimes
+  // resulting in an internal type getting @usableFromInline, which is
+  // incorrect.
+  // For example, for `let q = P() as? Q`, where Q is an internal class
+  // inherting a public class P, Q is not visited in the canSerialize*
+  // checks, thus resulting in `@usableFromInline class Q`; this is not
+  // the intended behavior in the conservative mode as it modifies AST.
+  //
+  // To properly fix, instruction visitor needs to be refactored to do
+  // both the "canSerialize" check (that visits all types) and serialize
+  // or update visibility (modify AST in non-conservative modes). 
+  if (isPackageCMOEnabled(M.getSwiftModule()))
+    return;
+
   // We must not modify decls which are defined in other modules.
   if (M.getSwiftModule() != decl->getDeclContext()->getParentModule())
     return;

--- a/test/SILOptimizer/package-cmo-swiftinterface.swift
+++ b/test/SILOptimizer/package-cmo-swiftinterface.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+
+/// First Test: Check `@_usableFromInline` is not added to types in PackageCMO mode.
+// RUN: %target-swift-frontend -parse-as-library %s -O -wmo -enable-library-evolution -experimental-allow-non-resilient-access -experimental-package-cmo -module-name=Lib -package-name pkg -emit-module -o %t/Lib-package-cmo.swiftmodule
+// RUN: %target-sil-opt -module-name Lib -enable-sil-verify-all %t/Lib-package-cmo.swiftmodule -o %t/Lib-package-cmo.sil
+// RUN: %FileCheck %s < %t/Lib-package-cmo.sil
+
+/// Second Test: Check .swiftinterface files with and without PackageCMO have the same decl signatures without `@_usableFromInline`.
+// RUN: %target-swift-frontend -emit-module %s -I %t \
+// RUN:   -module-name Lib -package-name pkg \
+// RUN:   -enable-library-evolution -swift-version 6 \
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Lib.private.swiftinterface \
+// RUN:   -emit-package-module-interface-path %t/Lib.package.swiftinterface
+// RUN: %FileCheck %s --check-prefixes=CHECK-PKG-INTERFACE,CHECK-INTERFACE < %t/Lib.package.swiftinterface
+// RUN: %FileCheck %s --check-prefix=CHECK-INTERFACE < %t/Lib.swiftinterface
+
+// RUN: rm -rf %t/Lib.swiftmodule
+// RUN: rm -rf %t/Lib.swiftinterface
+// RUN: rm -rf %t/Lib.private.swiftinterface
+// RUN: rm -rf %t/Lib.package.swiftinterface
+
+// RUN: %target-swift-frontend -emit-module %s -I %t \
+// RUN:   -module-name Lib -package-name pkg \
+// RUN:   -enable-library-evolution -swift-version 6 \
+// RUN:   -O -wmo \
+// RUN:   -experimental-allow-non-resilient-access -experimental-package-cmo \
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Lib.private.swiftinterface \
+// RUN:   -emit-package-module-interface-path %t/Lib.package.swiftinterface
+// RUN: %FileCheck %s --check-prefixes=CHECK-PKG-INTERFACE,CHECK-INTERFACE < %t/Lib.package.swiftinterface
+// RUN: %FileCheck %s --check-prefix=CHECK-INTERFACE < %t/Lib.swiftinterface
+
+// REQUIRES: swift_in_compiler
+
+// CHECK-NOT: @usableFromInline
+final class InternalKlass: PkgKlass {
+    @inline(never)
+    override func bar() -> Int { return 13 }
+}
+
+package class PkgKlass {
+    @inline(never)
+    package func bar() -> Int { return 11 }
+}
+
+// CHECK-NOT: sil package [serialized_for_package] [noinline] [canonical] @$s3Lib3fooySiSgAA8PkgKlassCF : $@convention(thin) (@guaranteed PkgKlass) -> Optional<Int> {
+// CHECK-NOT: checked_cast_br PkgKlass in {{.*}} : $PkgKlass to InternalKlass
+@inline(never)
+package func foo(_ arg: PkgKlass) -> Int? {
+    let x = arg as? InternalKlass
+    return x?.bar()
+}
+
+public func run() -> Int {
+  return PkgKlass().bar()
+}
+
+// CHECK-PKG-INTERFACE-NOT: @usableFromInline
+// CHECK-INTERFACE-NOT: @usableFromInline
+// CHECK-PKG-INTERFACE: package class PkgKlass {
+// CHECK-PKG-INTERFACE:   @inline(never) package func bar() -> Swift.Int
+// CHECK-PKG-INTERFACE:   @inline(never) package func foo(_ arg: Lib.PkgKlass) -> Swift.Int?
+// CHECK-INTERFACE: public func run() -> Swift.Int


### PR DESCRIPTION
Currently not all types are visited in canSerialize* calls, sometimes
resulting in an internal type getting @usableFromInline, which is
incorrect.

For example, for `let q = P() as? Q`, where Q is an internal class
inherting a public class P, Q is not visited in the canSerialize*
checks, thus resulting in `@usableFromInline class Q`; this is not
the intended behavior in the conservative mode used by PackageCMO
as it modifies AST.

To properly fix, instruction visitor needs to be refactored to do
both the "canSerialize" check (that visits all types) and serialize
or update visibility (modify AST in non-conservative modes).

This PR provides a short-term fix that prevents modifying AST, and
also ensures that the generated interfaces with PackageCMO flags
are not affected by the optimization or contain modified AST.

rdar://130292190