### PR TITLE
MandatoryPerformanceOptimizations: prevent inlining of dynamic-self class methods

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -204,6 +204,12 @@ private func shouldInline(apply: FullApplySite, callee: Function, alreadyInlined
     return true
   }
 
+  if callee.mayBindDynamicSelf {
+    // We don't support inlining a function that binds dynamic self into a global-init function
+    // because the global-init function cannot provide the self metadata.
+    return false
+  }
+
   if apply.parentFunction.isGlobalInitOnceFunction && callee.inlineStrategy == .always {
     // Some arithmetic operations, like integer conversions, are not transparent but `inline(__always)`.
     // Force inlining them in global initializers so that it's possible to statically initialize the global.

--- a/test/embedded/classes.swift
+++ b/test/embedded/classes.swift
@@ -43,6 +43,16 @@ func testCasting(_ title: StaticString, _ c: MyClass) {
   }
 }
 
+public class DynamicSelfClass {
+  public static let ds = DynamicSelfClass()
+  public static let i: Int = 42
+  var x: Int
+
+  public init() {
+    self.x = Self.i
+  }
+}
+
 @main
 struct Main {
   static var o: (MyClass?, MyClass?, MyClass?) = (nil, nil, nil)
@@ -95,5 +105,8 @@ struct Main {
     testCasting("subsub: ", MySubSubClass())
     // CHECK: other: -
     testCasting("other: ", OtherSubClass())
+
+    // CHECK: 42
+    print(DynamicSelfClass.ds.x)
   }
 }


### PR DESCRIPTION
This fixes a compiler crash in embedded swift.
When a static/global variable is initialized with a class where the initializer uses dynamic `Self` the MandatoryPerformanceOptimizations crashed while trying to inline the initializer. Such initializer must not be inlined, because the caller (= the global-init function) cannot provide the dynamic-self metadata.

rdar://129241915
