### PR TITLE
[6.0] Temporarily turn off completing lifetimes of block arguments

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
@@ -169,15 +169,6 @@ void MoveOnlyChecker::completeObjectLifetimes(
         }
       }
     }
-    for (SILArgument *arg : block->getArguments()) {
-      assert(!arg->isReborrow() && "reborrows not legal at this SIL stage");
-      if (!transitiveValues.isVisited(arg))
-        continue;
-      if (completion.completeOSSALifetime(arg) ==
-          LifetimeCompletion::WasCompleted) {
-        madeChange = true;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Explanation: Fixes a compiler crash due to calling complete lifetimes from the move-only address checker. 
Scope: Affects compiler diagnostics for move-only values
Risk: Low. 
Testing: Passes unit tests
Issue: rdar://130077346
Reviewer: @nate-chandler 
Main branch PR: https://github.com/swiftlang/swift/pull/74660