### PR TITLE
[windows] Allow compiler and STL version mismatch

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -181,6 +181,13 @@ function(add_swift_compiler_modules_library name)
     # Workaround a crash in the LoadableByAddress pass
     # https://github.com/apple/swift/issues/73254
     list(APPEND swift_compile_options "-Xllvm" "-sil-disable-pass=loadable-address")
+
+    # The STL in VS 17.10 requires Clang 17 or higher, but bootstrapping generally uses toolchains with older versions
+    # versions of Clang. Swift 6 toolchains are the first to include Clang 17, so if we are on Windows and using an
+    # earlier toolchain, we need to relax to relax this requirement with ALLOW_COMPILER_AND_STL_VERSION_MISMATCH.
+    if (CMAKE_Swift_COMPILER_VERSION VERSION_LESS 6.0)
+      list(APPEND swift_compile_options "-Xcc" "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH")
+    endif()
   else()
     list(APPEND sdk_option "-I" "${swift_exec_bin_dir}/../lib" "-I" "${sdk_path}/usr/lib")
   endif()

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -152,6 +152,7 @@ if ($PinnedBuild -eq "") {
     "AMD64" {
       $PinnedBuild = "https://download.swift.org/swift-5.10.1-release/windows10/swift-5.10.1-RELEASE/swift-5.10.1-RELEASE-windows10.exe"
       $PinnedSHA256 = "3027762138ACFA1BBE3050FF6613BBE754332E84C9EFA5C23984646009297286"
+      $PinnedVersion = "5.10.1"
     }
     "ARM64" {
       # TODO(hjyamauchi) once we have an arm64 release, fill in PinnedBuild and PinnedSHA256.
@@ -739,6 +740,13 @@ function Get-PinnedToolchainRuntime() {
   return "$BinaryCache\toolchains\${PinnedToolchain}\PFiles64\Swift\runtime-development\usr\bin"
 }
 
+function Get-PinnedToolchainVersion() {
+  if (Test-Path variable:PinnedVersion) {
+    return $PinnedVersion
+  }
+  return "5.10.1"
+}
+
 function TryAdd-KeyValue([hashtable]$Hashtable, [string]$Key, [string]$Value) {
   if (-not $Hashtable.Contains($Key)) {
     $Hashtable.Add($Key, $Value)
@@ -1311,6 +1319,14 @@ function Build-Compilers() {
       }
     }
 
+    # The STL in VS 17.10 requires Clang 17 or higher, but Swift toolchains prior to version 6 include older versions
+    # of Clang. If bootstrapping with an older toolchain, we need to relax to relax this requirement with
+    # ALLOW_COMPILER_AND_STL_VERSION_MISMATCH.
+    $SwiftFlags = @();
+    if ([System.Version](Get-PinnedToolchainVersion) -lt [System.Version]"6.0") {
+      $SwiftFlags += @("-Xcc", "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH");
+    }
+
     Build-CMakeProject `
       -Src $SourceCache\llvm-project\llvm `
       -Bin $CompilersBinaryCache `
@@ -1323,7 +1339,7 @@ function Build-Compilers() {
       -Defines ($TestingDefines + @{
         CLANG_TABLEGEN = (Join-Path -Path $BuildTools -ChildPath "clang-tblgen.exe");
         CLANG_TIDY_CONFUSABLE_CHARS_GEN = (Join-Path -Path $BuildTools -ChildPath "clang-tidy-confusable-chars-gen.exe");
-        CMAKE_Swift_FLAGS = @("-Xcc", "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH");
+        CMAKE_Swift_FLAGS = $SwiftFlags;
         LLDB_PYTHON_EXE_RELATIVE_PATH = "python.exe";
         LLDB_PYTHON_EXT_SUFFIX = ".pyd";
         LLDB_PYTHON_RELATIVE_PATH = "lib/site-packages";

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1323,6 +1323,7 @@ function Build-Compilers() {
       -Defines ($TestingDefines + @{
         CLANG_TABLEGEN = (Join-Path -Path $BuildTools -ChildPath "clang-tblgen.exe");
         CLANG_TIDY_CONFUSABLE_CHARS_GEN = (Join-Path -Path $BuildTools -ChildPath "clang-tidy-confusable-chars-gen.exe");
+        CMAKE_Swift_FLAGS = @("-Xcc", "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH");
         LLDB_PYTHON_EXE_RELATIVE_PATH = "python.exe";
         LLDB_PYTHON_EXT_SUFFIX = ".pyd";
         LLDB_PYTHON_RELATIVE_PATH = "lib/site-packages";


### PR DESCRIPTION
VS 17.10 introduced a requirement on Clang 17, but the pinned Swift toolchain used to bootstrap the compilers (a 5.10 snapshot) uses Clang 16. We can relax this version requirement with `ALLOW_COMPILER_AND_STL_VERSION_MISMATCH` which needs to be set for all `CMAKE_Swift_FLAGS` when building the compilers, as well as explicitly in SwiftCompilerSources as the invocation of `swiftc` there is via `custom_command`

cc @compnerd 