### PR TITLE
🍒[cxx-interop] Fix extra indirection when exporting CFData parameters

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -678,6 +678,12 @@ getCxxReferencePointeeTypeOrNone(const clang::Type *type);
 /// Returns true if the given type is a C++ `const` reference type.
 bool isCxxConstReferenceType(const clang::Type *type);
 
+/// Determine whether this typedef is a CF type.
+bool isCFTypeDecl(const clang::TypedefNameDecl *Decl);
+
+/// Determine the imported CF type for the given typedef-name, or the empty
+/// string if this is not an imported CF type name.
+llvm::StringRef getCFTypeName(const clang::TypedefNameDecl *decl);
 } // namespace importer
 
 struct ClangInvocationFileMapping {

--- a/lib/ClangImporter/CFTypeInfo.h
+++ b/lib/ClangImporter/CFTypeInfo.h
@@ -107,13 +107,6 @@ public:
     return Decl.get<const clang::TypedefNameDecl *>();
   }
 };
-
-/// Determine whether this typedef is a CF type.
-bool isCFTypeDecl(const clang::TypedefNameDecl *Decl);
-
-/// Determine the imported CF type for the given typedef-name, or the empty
-/// string if this is not an imported CF type name.
-llvm::StringRef getCFTypeName(const clang::TypedefNameDecl *decl);
 }
 }
 

--- a/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseCoreFoundation -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -emit-clang-header-path %t/UseCoreFoundation.h
+// RUN: %FileCheck %s < %t/UseCoreFoundation.h
+
+// REQUIRES: objc_interop
+
+import CoreFoundation
+
+public func foobar(_ a: CFData) -> Bool {
+    true
+}
+
+// CHECK: SWIFT_EXTERN bool $s17UseCoreFoundation6foobarySbSo9CFDataRefaF(CFDataRef _Nonnull a) SWIFT_NOEXCEPT SWIFT_CALL; // foobar(_:)


### PR DESCRIPTION
**Explanation**:
The clang nodes associated with Swift's Core Foundation types are already represented by a pointer. The interop code does not need to add an extra layer of indirection in those cases.
**Scope**: C++ Interop
**Risk**: Very targeted fix for a scenario that was broken before, the code change only affects that scenario.
Testing: Added a regression test.
Issue: rdar://119840281
Reviewer: @egorzhdan
Original PR: https://github.com/swiftlang/swift/pull/74330