### PR TITLE
[Docs] Update GettingStarted.md with workaround for icu error

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -135,6 +135,9 @@ toolchain as a one-off, there are a couple of differences:
 - Before running `update-checkout`, double-check that `swift` is the only
   repository inside the `swift-project` directory. Otherwise,
   `update-checkout` may not clone the necessary dependencies.
+- Running `update-checkout` may fail if the `git-lfs` dependency is not
+  installed. This may report as an error related to `icu`. A workaround is
+  passing `--skip-repository icu` to `update-checkout`.
 
 ## Installing dependencies
 


### PR DESCRIPTION
### Background

https://forums.swift.org/t/error-running-utils-update-checkout-clone-with-ssh/72696

This adds the workaround from https://github.com/swiftlang/swift/issues/70966 to the documentation to help engineers from running into this error again when building the toolchain locally.

### Test Plan

This is only a documentation change. No code is modified here.