### PR TITLE
[6.0] SILGen: Fix emission of 'modify' witness when all generic params are concrete

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6054,6 +6054,11 @@ SILGenFunction::emitBeginApplyWithRethrow(SILLocation loc, SILValue fn,
                                           SubstitutionMap subs,
                                           ArrayRef<SILValue> args,
                                           SmallVectorImpl<SILValue> &yields) {
+  // We completely drop the generic signature if all generic parameters were
+  // concrete.
+  if (subs && subs.getGenericSignature()->areAllParamsConcrete())
+    subs = SubstitutionMap();
+
   // TODO: adjust this to create try_begin_apply when appropriate.
   assert(!substFnType.castTo<SILFunctionType>()->hasErrorResult());
 

--- a/test/SILGen/constrained_extensions.swift
+++ b/test/SILGen/constrained_extensions.swift
@@ -240,3 +240,22 @@ extension S<Int> {
     }
   }
 }
+
+// https://github.com/swiftlang/swift/issues/74648
+
+protocol HasX {
+  var x: Int { get set }
+}
+
+extension S: HasX where T == Int {
+  var x: Int {
+    get { 3 }
+    set { }
+  }
+}
+
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s22constrained_extensions1SVyxGAA4HasXAASiRszlAaEP1xSivMTW : $@yield_once @convention(witness_method: HasX) @substituted <τ_0_0> (@inout τ_0_0) -> @yields @inout Int for <S<Int>> {
+// CHECK: [[WITNESS_FN:%.*]] = function_ref @$s22constrained_extensions1SVAASiRszlE1xSivM : $@yield_once @convention(method) (@inout S<Int>) -> @yields @inout Int
+// CHECK: begin_apply [[WITNESS_FN]](%0) : $@yield_once @convention(method) (@inout S<Int>) -> @yields @inout Int
+// CHECK: yield
+// CHECK: unwind


### PR DESCRIPTION
* **Description:** Fixes an assertion failure when emitting a witness table for a conditional conformance making all generic parameters concrete.

* **Origination:** This is a regression in assert builds only, from https://github.com/swiftlang/swift/pull/74275. The assertion encodes an invariant that was not previously enforced.

* **Risk:** Very low.

* **Reviewed by:** @eeckstein 

* **Issue:** https://github.com/swiftlang/swift/issues/74648.