### PR TITLE
[embedded] Fix crash when using failable initializers on generic classes

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -916,6 +916,15 @@ bool irgen::isCompleteSpecializedNominalTypeMetadataStaticallyAddressable(
     IRGenModule &IGM, CanType type,
     SpecializedMetadataCanonicality canonicality) {
   if (isa<ClassType>(type) || isa<BoundGenericClassType>(type)) {
+    if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+      if (type->hasArchetype()) {
+        llvm::errs() << "Cannot get metadata of generic class for type "
+                     << type << "\n";
+        llvm::report_fatal_error("cannot get metadata");
+      }
+      return true;
+    }
+
     // TODO: On platforms without ObjC interop, we can do direct access to
     // class metadata.
     return false;

--- a/test/embedded/failable-crash.swift
+++ b/test/embedded/failable-crash.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-emit-ir %s -module-name=main -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public func test() {
+    _ = MyClass<String>(x: 42)
+}
+
+public class MyClass<T> {
+    private let member: Int
+
+    public init?(x: Int) {
+        guard x > 0 else { return nil }
+        self.member = 42
+    }
+}
+
+// CHECK: define {{.*}}@main(

--- a/test/embedded/init-failable-generic.swift
+++ b/test/embedded/init-failable-generic.swift
@@ -1,0 +1,78 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public struct FooError: Error {}
+
+public class PrintingClass {
+    init() { print("PrintingClass.init") }
+    deinit { print("PrintingClass.deinit") }
+}
+
+public class Foo<T> {
+    var a: PrintingClass
+    var b: PrintingClass
+    init?(shouldFail: Bool) {
+        a = PrintingClass()
+        if shouldFail { return nil }
+        b = PrintingClass()
+    }
+}
+
+public class Bar<T>: Foo<T> {
+  var value: Int = 17
+}
+
+public class Wibble<T>: Bar<T> {
+  var c: PrintingClass = .init()
+}
+
+_ = Wibble<Int>(shouldFail: true)
+print("OK 1")
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.deinit
+// CHECK: PrintingClass.deinit
+// CHECK: OK 1
+
+_ = Wibble<Int>(shouldFail: false)
+print("OK 2")
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.deinit
+// CHECK: PrintingClass.deinit
+// CHECK: PrintingClass.deinit
+// CHECK: OK 2
+
+public class Base<T> {
+    var baseMember: PrintingClass
+    init?(shouldFail: Bool) {
+        if shouldFail { return nil }
+        baseMember = PrintingClass()
+    }
+}
+
+class SubClass<T>: Base<T> {
+    var subClassMember: PrintingClass = PrintingClass()
+    override init?(shouldFail: Bool) {
+        super.init(shouldFail: shouldFail)
+    }
+}
+
+_ = SubClass<String>(shouldFail: true)
+print("OK 3")
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.deinit
+// CHECK: OK 3
+
+_ = SubClass<String>(shouldFail: false)
+print("OK 4")
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.deinit
+// CHECK: PrintingClass.deinit
+// CHECK: OK 4

--- a/test/embedded/init-failable.swift
+++ b/test/embedded/init-failable.swift
@@ -1,0 +1,78 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public struct FooError: Error {}
+
+public class PrintingClass {
+    init() { print("PrintingClass.init") }
+    deinit { print("PrintingClass.deinit") }
+}
+
+public class Foo {
+    var a: PrintingClass
+    var b: PrintingClass
+    init?(shouldFail: Bool) {
+        a = PrintingClass()
+        if shouldFail { return nil }
+        b = PrintingClass()
+    }
+}
+
+public class Bar: Foo {
+  var value: Int = 17
+}
+
+public class Wibble: Bar {
+  var c: PrintingClass = .init()
+}
+
+_ = Wibble(shouldFail: true)
+print("OK 1")
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.deinit
+// CHECK: PrintingClass.deinit
+// CHECK: OK 1
+
+_ = Wibble(shouldFail: false)
+print("OK 2")
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.deinit
+// CHECK: PrintingClass.deinit
+// CHECK: PrintingClass.deinit
+// CHECK: OK 2
+
+public class Base {
+    var baseMember: PrintingClass
+    init?(shouldFail: Bool) {
+        if shouldFail { return nil }
+        baseMember = PrintingClass()
+    }
+}
+
+class SubClass: Base {
+    var subClassMember: PrintingClass = PrintingClass()
+    override init?(shouldFail: Bool) {
+        super.init(shouldFail: shouldFail)
+    }
+}
+
+_ = SubClass(shouldFail: true)
+print("OK 3")
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.deinit
+// CHECK: OK 3
+
+_ = SubClass(shouldFail: false)
+print("OK 4")
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.deinit
+// CHECK: PrintingClass.deinit
+// CHECK: OK 4


### PR DESCRIPTION
Fixes a crash in `emitNominalPrespecializedGenericMetadataRef` when using failable initializers on generic classes in Embedded Swift, see the added test case (`failable-crash.swift`) which used to crash with:

```
Assertion failed: (isCompleteSpecializedNominalTypeMetadataStaticallyAddressable( IGF.IGM, theType, canonicality)), function emitNominalPrespecializedGenericMetadataRef, file MetadataRequest.cpp, line 649.
...
7  swift-frontend           0x00000001063da0dc swift::irgen::GenericArguments::collect(swift::irgen::IRGenFunction&, swift::SubstitutionMap) (.cold.1) + 0
8  swift-frontend           0x00000001014fcbdc swift::irgen::GenericArguments::collect(swift::irgen::IRGenFunction&, swift::SubstitutionMap) + 0
9  swift-frontend           0x00000001014fc64c emitNominalMetadataRef(swift::irgen::IRGenFunction&, swift::NominalTypeDecl*, swift::CanType, swift::irgen::DynamicMetadataRequest) + 256
10 swift-frontend           0x00000001014fce1c (anonymous namespace)::EmitTypeMetadataRef::visitBoundGenericType(swift::CanTypeWrapper<swift::BoundGenericType>, swift::irgen::DynamicMetadataRequest) + 144
11 swift-frontend           0x00000001014f7520 emitDirectTypeMetadataRef(swift::irgen::IRGenFunction&, swift::CanType, swift::irgen::DynamicMetadataRequest) + 1728
12 swift-frontend           0x00000001014f66f0 swift::irgen::IRGenFunction::emitTypeMetadataRef(swift::CanType, swift::irgen::DynamicMetadataRequest) + 384
13 swift-frontend           0x00000001014fbb9c swift::irgen::emitMetatypeRef(swift::irgen::IRGenFunction&, swift::CanTypeWrapper<swift::MetatypeType>, swift::irgen::Explosion&) + 96
14 swift-frontend           0x000000010148d284 (anonymous namespace)::IRGenSILFunction::visitSILBasicBlock(swift::SILBasicBlock*) + 7232
15 swift-frontend           0x000000010148a5d0 (anonymous namespace)::IRGenSILFunction::emitSILFunction() + 9296
```

rdar://130054499