### PR TITLE
Implement getSwiftRuntimeCompatibilityVersionForTarget for recent releases

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -471,7 +471,13 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
         return floorFor64(llvm::VersionTuple(5, 5));
       return floorFor64(llvm::VersionTuple(5, 6));
     } else if (Major == 13) {
-      return floorFor64(llvm::VersionTuple(5, 7));
+      if (Minor <= 2)
+        return floorFor64(llvm::VersionTuple(5, 7));
+      return floorFor64(llvm::VersionTuple(5, 8));
+    } else if (Major == 14) {
+      if (Minor <= 3)
+        return floorFor64(llvm::VersionTuple(5, 9));
+      return floorFor64(llvm::VersionTuple(5, 10));
     }
   } else if (Triple.isiOS()) { // includes tvOS
     llvm::VersionTuple OSVersion = Triple.getiOSVersion();
@@ -511,7 +517,13 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
         return floorForArchitecture(llvm::VersionTuple(5, 5));
       return floorForArchitecture(llvm::VersionTuple(5, 6));
     } else if (Major <= 16) {
-      return floorForArchitecture(llvm::VersionTuple(5, 7));
+      if (Minor <= 3)
+        return floorForArchitecture(llvm::VersionTuple(5, 7));
+      return floorForArchitecture(llvm::VersionTuple(5, 8));
+    } else if (Major <= 17) {
+      if (Minor <= 3)
+        return floorForArchitecture(llvm::VersionTuple(5, 9));
+      return floorForArchitecture(llvm::VersionTuple(5, 10));
     }
   } else if (Triple.isWatchOS()) {
     llvm::VersionTuple OSVersion = Triple.getWatchOSVersion();
@@ -542,11 +554,25 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
         return floorFor64bits(llvm::VersionTuple(5, 5));
       return floorFor64bits(llvm::VersionTuple(5, 6));
     } else if (Major <= 9) {
-      return floorFor64bits(llvm::VersionTuple(5, 7));
+      if (Minor <= 3)
+        return floorFor64bits(llvm::VersionTuple(5, 7));
+      return floorFor64bits(llvm::VersionTuple(5, 8));
+    } else if (Major <= 10) {
+      if (Minor <= 3)
+        return floorFor64bits(llvm::VersionTuple(5, 9));
+      return floorFor64bits(llvm::VersionTuple(5, 10));
     }
   }
   else if (Triple.isXROS()) {
-    return std::nullopt;
+    llvm::VersionTuple OSVersion = Triple.getOSVersion();
+    unsigned Major = OSVersion.getMajor();
+    unsigned Minor = OSVersion.getMinor().value_or(0);
+
+    if (Major <= 1) {
+      if (Minor <= 0)
+        return llvm::VersionTuple(5, 9);
+      return llvm::VersionTuple(5, 10);
+    }
   }
 
   return std::nullopt;

--- a/test/IRGen/reflection_metadata_isolated_any.swift
+++ b/test/IRGen/reflection_metadata_isolated_any.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos99.99 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-PRESENT %s
+// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos14.4 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-SUPPRESSED %s
+
+// REQUIRES: OS=macosx
+// UNSUPPORTED: CPU=arm64e
+
+public struct MyStruct {
+  let fn: @isolated(any) () -> ()
+}
+
+// Make sure that we only emit a demangling-based type description
+// for @isolated(any) types when deploying to runtimes that support it.
+// If we don't, we fall back on using a type metadata accessor, which
+// is fine.  Since this is for reflective metadata, we could go a step
+// further if we decide we really only care about layout equivalence for
+// these; if so, we could just suppress the @isolated(any) part of the
+// type completely, since it has the the same external layout as an
+// ordinary function type.
+// rdar://129861211
+
+// CHECK-LABEL: @"$s32reflection_metadata_isolated_any8MyStructVMF" = internal constant
+// CHECK-PRESENT-SAME: ptr @"symbolic yyYAc"
+// CHECK-SUPPRESSED-SAME: ptr @"get_type_metadata yyYAc.1"


### PR DESCRIPTION
We were relying on this for `@isolated(any)` mangling suppression, but it actually doesn't generate correct results for recent deployment targets. As a result, we treated e.g. macOS 14.4 as if it were completely unconstrained in terms of runtime availability.

I took this data from availability-macros.def; it's unfortunate that we can't just generate the implementation directly from that.

Fixes rdar://129861211