### PR TITLE
[SILGen] Fix assertion failure when opaque value is enabled

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -319,6 +319,9 @@ static ManagedValue emitManagedParameter(SILGenFunction &SGF, SILLocation loc,
     return ManagedValue::forLValue(value);
 
   case ParameterConvention::Indirect_In_Guaranteed:
+    if (!value->getType().isAddress())
+      return ManagedValue::forBorrowedObjectRValue(value);
+
     if (valueTL.isLoadable()) {
       return SGF.B.createLoadBorrow(
           loc, ManagedValue::forBorrowedAddressRValue(value));

--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -20,7 +20,15 @@ struct ARCStrong {
 void cfuncARCStrong(void (*_Nonnull)(ARCStrong));
 #endif
 
+struct ARCWeak {
+#if __OBJC__
+  __weak _Nullable id m;
+#endif
+};
+
 void cfuncReturnNonTrivial(NonTrivial (^_Nonnull)()) noexcept;
 void cfuncReturnNonTrivial2(NonTrivial (*_Nonnull)()) noexcept;
+
+void (*_Nonnull getFnPtr2() noexcept)(ARCWeak) noexcept;
 
 #endif // __CLOSURE__

--- a/test/Interop/Cxx/class/closure-thunk-opaque-values.swift
+++ b/test/Interop/Cxx/class/closure-thunk-opaque-values.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swiftxx-frontend -I %S/Inputs -enable-sil-opaque-values -emit-silgen %s | %FileCheck --dump-input-filter=all %s
+
+// REQUIRES: OS=macosx
+
+import Closure
+
+// CHECK: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSo7ARCWeakVIetCi_ABIegn_TR : $@convention(thin) (@in_guaranteed ARCWeak, @convention(c) (@in ARCWeak) -> ()) -> () {
+// CHECK: bb0(%[[V0:.*]] : @guaranteed $ARCWeak, %[[V1:.*]] : $@convention(c) (@in ARCWeak) -> ()):
+// CHECK: %[[V2:.*]] = copy_value %[[V0]] : $ARCWeak
+// CHECK: apply %[[V1]](%[[V2]]) : $@convention(c) (@in ARCWeak) -> ()
+
+public func testARCWeakFunctionPointer2() -> (ARCWeak) -> () {
+  return getFnPtr2()
+}


### PR DESCRIPTION
`emitManagedParameter` assumes the passed value has an address type and calls `forBorrowedAddressRValue` when the parameter convention is `Indirect_In_Guaranteed`.

Call `forBorrowedObjectRValue` instead when the type isn't an address type.

rdar://130456931