### PR TITLE
[ClangImporter] Switch `lookupGlobalsAsMembers` to take a non-optional EffectiveClangContext

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -685,14 +685,13 @@ SwiftLookupTable::allGlobalsAsMembersInContext(StoredContext context) {
 }
 
 SmallVector<SwiftLookupTable::SingleEntry, 4>
-SwiftLookupTable::lookupGlobalsAsMembers(
-    SerializedSwiftName baseName,
-    std::optional<EffectiveClangContext> searchContext) {
+SwiftLookupTable::lookupGlobalsAsMembers(SerializedSwiftName baseName,
+                                         EffectiveClangContext searchContext) {
   // Propagate the null search context.
   if (!searchContext)
     return lookupGlobalsAsMembersImpl(baseName, std::nullopt);
 
-  std::optional<StoredContext> storedContext = translateContext(*searchContext);
+  std::optional<StoredContext> storedContext = translateContext(searchContext);
   if (!storedContext) return { };
 
   return lookupGlobalsAsMembersImpl(baseName, *storedContext);

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -549,7 +549,7 @@ public:
   /// entities should reside.
   SmallVector<SingleEntry, 4>
   lookupGlobalsAsMembers(SerializedSwiftName baseName,
-                         std::optional<EffectiveClangContext> searchContext);
+                         EffectiveClangContext searchContext);
 
   SmallVector<SingleEntry, 4>
   allGlobalsAsMembersInContext(EffectiveClangContext context);


### PR DESCRIPTION
The only caller is `loadNamedMembers`, and that passes in a non-optional EffectiveClangContext, meaning that we'd miss the case when `getEffectiveClangContext` returns `nullptr`, crashing in `translateContext`. No test case unfortunately as I haven't been able to come up with a reproducer.

rdar://129619711