### PR TITLE
[stdlib] Refactor implementation of `firstIndex(of element: Element)`

### DIFF
--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -62,15 +62,7 @@ extension Collection where Element: Equatable {
     if let result = _customIndexOfEquatableElement(element) {
       return result
     }
-
-    var i = self.startIndex
-    while i != self.endIndex {
-      if self[i] == element {
-        return i
-      }
-      self.formIndex(after: &i)
-    }
-    return nil
+    return firstIndex(where: { $0 == element })
   }
 }
 


### PR DESCRIPTION
Resolves #74650

In the Swift Collection Algorithms logic, `lastIndex(of element: Element)`
utilises a helper function, whereas, `firstIndex(of element: Element)` does not.