### PR TITLE
SwiftCompilerSources: refactor `Function.mayBindDynamicSelf`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -643,8 +643,12 @@ extension Function {
     return nil
   }
 
+  /// True if this function has a dynamic-self metadata argument and any instruction is type dependent on it.
   var mayBindDynamicSelf: Bool {
-    self.bridged.mayBindDynamicSelf()
+    guard let dynamicSelf = self.dynamicSelfMetadata else {
+      return false
+    }
+    return dynamicSelf.uses.contains { $0.isTypeDependent }
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -278,6 +278,13 @@ extension Function {
 
   public var selfArgument: FunctionArgument { arguments[selfArgumentIndex] }
   
+  public var dynamicSelfMetadata: FunctionArgument? {
+    if bridged.hasDynamicSelfMetadata() {
+      return arguments.last!
+    }
+    return nil
+  }
+
   public var argumentTypes: ArgumentTypeArray { ArgumentTypeArray(function: self) }
 
   public var resultType: Type { bridged.getSILResultType().type }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -622,7 +622,7 @@ struct BridgedFunction {
   BRIDGED_INLINE bool isGeneric() const;
   BRIDGED_INLINE bool hasSemanticsAttr(BridgedStringRef attrName) const;
   BRIDGED_INLINE bool hasUnsafeNonEscapableResult() const;
-  bool mayBindDynamicSelf() const;
+  BRIDGED_INLINE bool hasDynamicSelfMetadata() const;
   BRIDGED_INLINE EffectsKind getEffectAttribute() const;
   BRIDGED_INLINE PerformanceConstraints getPerformanceConstraints() const;
   BRIDGED_INLINE InlineStrategy getInlineStrategy() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -687,6 +687,10 @@ bool BridgedFunction::hasUnsafeNonEscapableResult() const {
   return getFunction()->hasUnsafeNonEscapableResult();
 }
 
+bool BridgedFunction::hasDynamicSelfMetadata() const {
+  return getFunction()->hasDynamicSelfMetadata();
+}
+
 BridgedFunction::EffectsKind BridgedFunction::getEffectAttribute() const {
   return (EffectsKind)getFunction()->getEffectsKind();
 }

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1591,9 +1591,6 @@ SwiftPassInvocation::~SwiftPassInvocation() {}
 //===----------------------------------------------------------------------===//
 //                           SIL Bridging
 //===----------------------------------------------------------------------===//
-bool BridgedFunction::mayBindDynamicSelf() const {
-  return swift::mayBindDynamicSelf(getFunction());
-}
 
 bool BridgedFunction::isTrapNoReturn() const {
   return swift::isTrapNoReturnFunction(getFunction());


### PR DESCRIPTION
Instead of bridging the whole function, just bridge `hasDynamicSelfMetadata` and do the other work in swift.
