### PR TITLE
Sema: Suppress set accessor availability diagnostics in `LoadExpr`s

### DIFF
--- a/test/Sema/availability_accessors.swift
+++ b/test/Sema/availability_accessors.swift
@@ -72,14 +72,14 @@ struct BaseStruct<T: ValueProto> {
   var unavailableSetter: T {
     get { .defaultValue }
     @available(*, unavailable)
-    set { fatalError() } // expected-note 37 {{setter for 'unavailableSetter' has been explicitly marked unavailable here}}
+    set { fatalError() } // expected-note 27 {{setter for 'unavailableSetter' has been explicitly marked unavailable here}}
   }
 
   var unavailableGetterAndSetter: T {
     @available(*, unavailable)
     get { fatalError() } // expected-note 46 {{getter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
     @available(*, unavailable)
-    set { fatalError() } // expected-note 37 {{setter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
+    set { fatalError() } // expected-note 27 {{setter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
   }
 }
 
@@ -173,21 +173,15 @@ func testLValueAssignments_Class(_ someValue: ClassValue) {
   x.unavailableGetter[0].b = 1 // expected-error {{getter for 'unavailableGetter' is unavailable}}
 
   x.unavailableSetter = someValue // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  x.unavailableSetter.a = someValue.a // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  x.unavailableSetter[0] = someValue.a // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  x.unavailableSetter[0].b = 1 // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  x.unavailableSetter.a = someValue.a
+  x.unavailableSetter[0] = someValue.a
+  x.unavailableSetter[0].b = 1
 
   x.unavailableGetterAndSetter = someValue // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  x.unavailableGetterAndSetter.a = someValue.a // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  x.unavailableGetterAndSetter.a = someValue.a // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   // FIXME: missing diagnostic for getter
-  // FIXME: spurious unavailable setter error
-  x.unavailableGetterAndSetter[0] = someValue.a // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  x.unavailableGetterAndSetter[0].b = 1 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  x.unavailableGetterAndSetter[0] = someValue.a
+  x.unavailableGetterAndSetter[0].b = 1 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
 func testKeyPathLoads_Struct() {
@@ -245,17 +239,15 @@ func testKeyPathLoads_Class() {
   _ = x[keyPath: \.unavailableSetter.a]
   _ = x[keyPath: \.unavailableSetter[0]]
   _ = x[keyPath: \.unavailableSetter[0].b]
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableSetter.a.b)]] // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableSetter[0].b)]] // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  _ = a[keyPath: \.[takesIntInOut(&x.unavailableSetter.a.b)]]
+  _ = a[keyPath: \.[takesIntInOut(&x.unavailableSetter[0].b)]]
 
   _ = x[keyPath: \.unavailableGetterAndSetter] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetterAndSetter.a] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetterAndSetter[0]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetterAndSetter[0].b] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter.a.b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter[0].b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter.a.b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter[0].b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
 func testKeyPathAssignments_Struct(_ someValue: StructValue) {
@@ -318,20 +310,16 @@ func testKeyPathAssignments_Class(_ someValue: ClassValue) {
   x[keyPath: \.unavailableSetter[0]] = someValue.a // expected-error {{setter for 'unavailableSetter' is unavailable}}
   // FIXME: spurious unavailable setter error
   x[keyPath: \.unavailableSetter[0].b] = 1 // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  a[keyPath: \.[takesIntInOut(&x.unavailableSetter.a.b)]] = 0 // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  a[keyPath: \.[takesIntInOut(&x.unavailableSetter[0].b)]] = 0 // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  a[keyPath: \.[takesIntInOut(&x.unavailableSetter.a.b)]] = 0
+  a[keyPath: \.[takesIntInOut(&x.unavailableSetter[0].b)]] = 0
 
   x[keyPath: \.unavailableGetterAndSetter] = someValue // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
   x[keyPath: \.unavailableGetterAndSetter.a] = someValue.a // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
   x[keyPath: \.unavailableGetterAndSetter[0]] = someValue.a // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
   // FIXME: spurious unavailable setter error
   x[keyPath: \.unavailableGetterAndSetter[0].b] = 1 // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter.a.b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter[0].b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter.a.b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter[0].b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
 func testMutatingStructMember() {
@@ -405,20 +393,14 @@ func testPassAsInOutParameter_Class() {
   takesInOut(&x.unavailableGetter[0].b) // expected-error {{getter for 'unavailableGetter' is unavailable}}
 
   takesInOut(&x.unavailableSetter) // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  takesInOut(&x.unavailableSetter.a) // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  takesInOut(&x.unavailableSetter[0]) // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  takesInOut(&x.unavailableSetter[0].b) // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  takesInOut(&x.unavailableSetter.a)
+  takesInOut(&x.unavailableSetter[0])
+  takesInOut(&x.unavailableSetter[0].b)
 
   takesInOut(&x.unavailableGetterAndSetter) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  takesInOut(&x.unavailableGetterAndSetter.a) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  takesInOut(&x.unavailableGetterAndSetter[0]) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  // FIXME: spurious unavailable setter error
-  takesInOut(&x.unavailableGetterAndSetter[0].b) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  takesInOut(&x.unavailableGetterAndSetter.a) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  takesInOut(&x.unavailableGetterAndSetter[0]) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  takesInOut(&x.unavailableGetterAndSetter[0].b) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
 var global = BaseStruct<StructValue>()

--- a/test/Sema/availability_accessors.swift
+++ b/test/Sema/availability_accessors.swift
@@ -83,11 +83,11 @@ struct BaseStruct<T: ValueProto> {
   }
 }
 
-func takesIntInOut(_ i: inout Int) -> Int {
-  return 0
+@discardableResult func takesInOut<T>(_ t: inout T) -> T {
+  return t
 }
 
-func testRValueLoads_Struct() {
+func testDiscardedRValueLoads_Struct() {
   var x = BaseStruct<StructValue>() // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
 
   _ = x.available
@@ -111,7 +111,7 @@ func testRValueLoads_Struct() {
   _ = x.unavailableGetterAndSetter[0].b // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
-func testRValueLoads_Class() {
+func testDiscardedRValueLoads_Class() {
   var x = BaseStruct<ClassValue>() // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
 
   _ = x.available
@@ -184,7 +184,7 @@ func testLValueAssignments_Class(_ someValue: ClassValue) {
   x.unavailableGetterAndSetter[0].b = 1 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
-func testKeyPathLoads_Struct() {
+func testDiscardedKeyPathLoads_Struct() {
   let a = [0]
   var x = BaseStruct<StructValue>()
 
@@ -192,32 +192,32 @@ func testKeyPathLoads_Struct() {
   _ = x[keyPath: \.available.a]
   _ = x[keyPath: \.available[0]]
   _ = x[keyPath: \.available[0].b]
-  _ = a[keyPath: \.[takesIntInOut(&x.available.a.b)]]
-  _ = a[keyPath: \.[takesIntInOut(&x.available[0].b)]]
+  _ = a[keyPath: \.[takesInOut(&x.available.a.b)]]
+  _ = a[keyPath: \.[takesInOut(&x.available[0].b)]]
 
   _ = x[keyPath: \.unavailableGetter] // expected-error {{getter for 'unavailableGetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetter.a] // expected-error {{getter for 'unavailableGetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetter[0]] // expected-error {{getter for 'unavailableGetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetter[0].b] // expected-error {{getter for 'unavailableGetter' is unavailable}}
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetter.a.b)]] // expected-error {{getter for 'unavailableGetter' is unavailable}}
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetter[0].b)]] // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = a[keyPath: \.[takesInOut(&x.unavailableGetter.a.b)]] // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = a[keyPath: \.[takesInOut(&x.unavailableGetter[0].b)]] // expected-error {{getter for 'unavailableGetter' is unavailable}}
 
   _ = x[keyPath: \.unavailableSetter]
   _ = x[keyPath: \.unavailableSetter.a]
   _ = x[keyPath: \.unavailableSetter[0]]
   _ = x[keyPath: \.unavailableSetter[0].b]
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableSetter.a.b)]] // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableSetter[0].b)]] // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  _ = a[keyPath: \.[takesInOut(&x.unavailableSetter.a.b)]] // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  _ = a[keyPath: \.[takesInOut(&x.unavailableSetter[0].b)]] // expected-error {{setter for 'unavailableSetter' is unavailable}}
 
   _ = x[keyPath: \.unavailableGetterAndSetter] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetterAndSetter.a] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetterAndSetter[0]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetterAndSetter[0].b] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter.a.b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter[0].b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = a[keyPath: \.[takesInOut(&x.unavailableGetterAndSetter.a.b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = a[keyPath: \.[takesInOut(&x.unavailableGetterAndSetter[0].b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
-func testKeyPathLoads_Class() {
+func testDiscardedKeyPathLoads_Class() {
   let a = [0]
   var x = BaseStruct<ClassValue>() // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
 
@@ -225,29 +225,29 @@ func testKeyPathLoads_Class() {
   _ = x[keyPath: \.available.a]
   _ = x[keyPath: \.available[0]]
   _ = x[keyPath: \.available[0].b]
-  _ = a[keyPath: \.[takesIntInOut(&x.available.a.b)]]
-  _ = a[keyPath: \.[takesIntInOut(&x.available[0].b)]]
+  _ = a[keyPath: \.[takesInOut(&x.available.a.b)]]
+  _ = a[keyPath: \.[takesInOut(&x.available[0].b)]]
 
   _ = x[keyPath: \.unavailableGetter] // expected-error {{getter for 'unavailableGetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetter.a] // expected-error {{getter for 'unavailableGetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetter[0]] // expected-error {{getter for 'unavailableGetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetter[0].b] // expected-error {{getter for 'unavailableGetter' is unavailable}}
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetter.a.b)]] // expected-error {{getter for 'unavailableGetter' is unavailable}}
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetter[0].b)]] // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = a[keyPath: \.[takesInOut(&x.unavailableGetter.a.b)]] // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = a[keyPath: \.[takesInOut(&x.unavailableGetter[0].b)]] // expected-error {{getter for 'unavailableGetter' is unavailable}}
 
   _ = x[keyPath: \.unavailableSetter]
   _ = x[keyPath: \.unavailableSetter.a]
   _ = x[keyPath: \.unavailableSetter[0]]
   _ = x[keyPath: \.unavailableSetter[0].b]
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableSetter.a.b)]]
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableSetter[0].b)]]
+  _ = a[keyPath: \.[takesInOut(&x.unavailableSetter.a.b)]]
+  _ = a[keyPath: \.[takesInOut(&x.unavailableSetter[0].b)]]
 
   _ = x[keyPath: \.unavailableGetterAndSetter] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetterAndSetter.a] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetterAndSetter[0]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   _ = x[keyPath: \.unavailableGetterAndSetter[0].b] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter.a.b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
-  _ = a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter[0].b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = a[keyPath: \.[takesInOut(&x.unavailableGetterAndSetter.a.b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = a[keyPath: \.[takesInOut(&x.unavailableGetterAndSetter[0].b)]] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
 func testKeyPathAssignments_Struct(_ someValue: StructValue) {
@@ -259,29 +259,29 @@ func testKeyPathAssignments_Struct(_ someValue: StructValue) {
   x[keyPath: \.available[0]] = someValue.a
   x[keyPath: \.available[0].b] = 1
   x[keyPath: \.available] = someValue
-  a[keyPath: \.[takesIntInOut(&x.available.a.b)]] = 0
-  a[keyPath: \.[takesIntInOut(&x.available[0].b)]] = 0
+  a[keyPath: \.[takesInOut(&x.available.a.b)]] = 0
+  a[keyPath: \.[takesInOut(&x.available[0].b)]] = 0
 
   x[keyPath: \.unavailableGetter] = someValue
   x[keyPath: \.unavailableGetter.a] = someValue.a // FIXME: missing diagnostic for getter
   x[keyPath: \.unavailableGetter[0]] = someValue.a // FIXME: missing diagnostic for getter
   x[keyPath: \.unavailableGetter[0].b] = 1 // FIXME: missing diagnostic for getter
-  a[keyPath: \.[takesIntInOut(&x.unavailableGetter.a.b)]] = 0 // expected-error {{getter for 'unavailableGetter' is unavailable}}
-  a[keyPath: \.[takesIntInOut(&x.unavailableGetter[0].b)]] = 0 // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  a[keyPath: \.[takesInOut(&x.unavailableGetter.a.b)]] = 0 // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  a[keyPath: \.[takesInOut(&x.unavailableGetter[0].b)]] = 0 // expected-error {{getter for 'unavailableGetter' is unavailable}}
 
   x[keyPath: \.unavailableSetter] = someValue // expected-error {{setter for 'unavailableSetter' is unavailable}}
   x[keyPath: \.unavailableSetter.a] = someValue.a // expected-error {{setter for 'unavailableSetter' is unavailable}}
   x[keyPath: \.unavailableSetter[0]] = someValue.a // expected-error {{setter for 'unavailableSetter' is unavailable}}
   x[keyPath: \.unavailableSetter[0].b] = 1 // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  a[keyPath: \.[takesIntInOut(&x.unavailableSetter.a.b)]] = 0 // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  a[keyPath: \.[takesIntInOut(&x.unavailableSetter[0].b)]] = 0 // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  a[keyPath: \.[takesInOut(&x.unavailableSetter.a.b)]] = 0 // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  a[keyPath: \.[takesInOut(&x.unavailableSetter[0].b)]] = 0 // expected-error {{setter for 'unavailableSetter' is unavailable}}
 
   x[keyPath: \.unavailableGetterAndSetter] = someValue // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
   x[keyPath: \.unavailableGetterAndSetter.a] = someValue.a // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
   x[keyPath: \.unavailableGetterAndSetter[0]] = someValue.a // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
   x[keyPath: \.unavailableGetterAndSetter[0].b] = 1 // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter.a.b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter[0].b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  a[keyPath: \.[takesInOut(&x.unavailableGetterAndSetter.a.b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  a[keyPath: \.[takesInOut(&x.unavailableGetterAndSetter[0].b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
 func testKeyPathAssignments_Class(_ someValue: ClassValue) {
@@ -293,15 +293,15 @@ func testKeyPathAssignments_Class(_ someValue: ClassValue) {
   x[keyPath: \.available[0]] = someValue.a
   x[keyPath: \.available[0].b] = 1
   x[keyPath: \.available] = someValue
-  a[keyPath: \.[takesIntInOut(&x.available.a.b)]] = 0
-  a[keyPath: \.[takesIntInOut(&x.available[0].b)]] = 0
+  a[keyPath: \.[takesInOut(&x.available.a.b)]] = 0
+  a[keyPath: \.[takesInOut(&x.available[0].b)]] = 0
 
   x[keyPath: \.unavailableGetter] = someValue
   x[keyPath: \.unavailableGetter.a] = someValue.a // FIXME: missing diagnostic for getter
   x[keyPath: \.unavailableGetter[0]] = someValue.a // FIXME: missing diagnostic for getter
   x[keyPath: \.unavailableGetter[0].b] = 1 // FIXME: missing diagnostic for getter
-  a[keyPath: \.[takesIntInOut(&x.unavailableGetter.a.b)]] = 0 // expected-error {{getter for 'unavailableGetter' is unavailable}}
-  a[keyPath: \.[takesIntInOut(&x.unavailableGetter[0].b)]] = 0 // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  a[keyPath: \.[takesInOut(&x.unavailableGetter.a.b)]] = 0 // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  a[keyPath: \.[takesInOut(&x.unavailableGetter[0].b)]] = 0 // expected-error {{getter for 'unavailableGetter' is unavailable}}
 
   x[keyPath: \.unavailableSetter] = someValue // expected-error {{setter for 'unavailableSetter' is unavailable}}
   // FIXME: spurious unavailable setter error
@@ -310,16 +310,16 @@ func testKeyPathAssignments_Class(_ someValue: ClassValue) {
   x[keyPath: \.unavailableSetter[0]] = someValue.a // expected-error {{setter for 'unavailableSetter' is unavailable}}
   // FIXME: spurious unavailable setter error
   x[keyPath: \.unavailableSetter[0].b] = 1 // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  a[keyPath: \.[takesIntInOut(&x.unavailableSetter.a.b)]] = 0
-  a[keyPath: \.[takesIntInOut(&x.unavailableSetter[0].b)]] = 0
+  a[keyPath: \.[takesInOut(&x.unavailableSetter.a.b)]] = 0
+  a[keyPath: \.[takesInOut(&x.unavailableSetter[0].b)]] = 0
 
   x[keyPath: \.unavailableGetterAndSetter] = someValue // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
   x[keyPath: \.unavailableGetterAndSetter.a] = someValue.a // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
   x[keyPath: \.unavailableGetterAndSetter[0]] = someValue.a // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
   // FIXME: spurious unavailable setter error
   x[keyPath: \.unavailableGetterAndSetter[0].b] = 1 // expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter.a.b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
-  a[keyPath: \.[takesIntInOut(&x.unavailableGetterAndSetter[0].b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  a[keyPath: \.[takesInOut(&x.unavailableGetterAndSetter.a.b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  a[keyPath: \.[takesInOut(&x.unavailableGetterAndSetter[0].b)]] = 0 // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
 func testMutatingStructMember() {
@@ -351,9 +351,7 @@ func testMutatingStructMember() {
   _ = a[x.unavailableGetterAndSetter[0].setToZero()] // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
-func testPassAsInOutParameter_Struct() {
-  func takesInOut<T>(_ t: inout T) {}
-
+func testIgnoredApplyOfFuncWithInOutParam_Struct() {
   var x = BaseStruct<StructValue>()
 
   takesInOut(&x.available)
@@ -377,9 +375,7 @@ func testPassAsInOutParameter_Struct() {
   takesInOut(&x.unavailableGetterAndSetter[0].b) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
 }
 
-func testPassAsInOutParameter_Class() {
-  func takesInOut<T>(_ t: inout T) {}
-
+func testIgnoredApplyOfFuncWithInOutParam_Class() {
   var x = BaseStruct<ClassValue>()
 
   takesInOut(&x.available)

--- a/test/Sema/availability_accessors.swift
+++ b/test/Sema/availability_accessors.swift
@@ -65,21 +65,21 @@ struct BaseStruct<T: ValueProto> {
 
   var unavailableGetter: T {
     @available(*, unavailable)
-    get { fatalError() } // expected-note 46 {{getter for 'unavailableGetter' has been explicitly marked unavailable here}}
+    get { fatalError() } // expected-note 62 {{getter for 'unavailableGetter' has been explicitly marked unavailable here}}
     set {}
   }
 
   var unavailableSetter: T {
     get { .defaultValue }
     @available(*, unavailable)
-    set { fatalError() } // expected-note 27 {{setter for 'unavailableSetter' has been explicitly marked unavailable here}}
+    set { fatalError() } // expected-note 36 {{setter for 'unavailableSetter' has been explicitly marked unavailable here}}
   }
 
   var unavailableGetterAndSetter: T {
     @available(*, unavailable)
-    get { fatalError() } // expected-note 46 {{getter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
+    get { fatalError() } // expected-note 62 {{getter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
     @available(*, unavailable)
-    set { fatalError() } // expected-note 27 {{setter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
+    set { fatalError() } // expected-note 36 {{setter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
   }
 }
 
@@ -398,6 +398,89 @@ func testIgnoredApplyOfFuncWithInOutParam_Class() {
   takesInOut(&x.unavailableGetterAndSetter[0]) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   takesInOut(&x.unavailableGetterAndSetter[0].b) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
 }
+
+func testDiscardedApplyOfFuncWithInOutParam_Struct() {
+  var x = BaseStruct<StructValue>()
+
+  _ = takesInOut(&x.available)
+  _ = takesInOut(&x.available).a
+  _ = takesInOut(&x.available.a)
+  _ = takesInOut(&x.available.a).b
+  _ = takesInOut(&x.available[0])
+  _ = takesInOut(&x.available[0]).b
+  _ = takesInOut(&x.available[0].b)
+  _ = takesInOut(&x.available[0].b).magnitude
+
+  _ = takesInOut(&x.unavailableGetter) // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter).a // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter.a) // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter.a).b // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter[0]) // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter[0]).b // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter[0].b) // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter[0].b).magnitude // expected-error {{getter for 'unavailableGetter' is unavailable}}
+
+  _ = takesInOut(&x.unavailableSetter) // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableSetter).a // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableSetter.a) // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableSetter.a).b // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableSetter[0]) // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableSetter[0]).b // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableSetter[0].b) // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableSetter[0].b).magnitude // expected-error {{setter for 'unavailableSetter' is unavailable}}
+
+  _ = takesInOut(&x.unavailableGetterAndSetter) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter).a // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter.a) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter.a).b // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter[0]) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter[0]).b // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter[0].b) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter[0].b).magnitude // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+}
+
+func testDiscardedApplyOfFuncWithInOutParam_Class() {
+  var x = BaseStruct<ClassValue>()
+
+  _ = takesInOut(&x.available)
+  _ = takesInOut(&x.available).a
+  _ = takesInOut(&x.available.a)
+  _ = takesInOut(&x.available.a).b
+  _ = takesInOut(&x.available[0])
+  _ = takesInOut(&x.available[0]).b
+  _ = takesInOut(&x.available[0].b)
+  _ = takesInOut(&x.available[0].b).magnitude
+
+  _ = takesInOut(&x.unavailableGetter) // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter).a // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter.a) // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter.a).b // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter[0]) // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter[0]).b // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter[0].b) // expected-error {{getter for 'unavailableGetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetter[0].b).magnitude // expected-error {{getter for 'unavailableGetter' is unavailable}}
+
+  _ = takesInOut(&x.unavailableSetter) // expected-error {{setter for 'unavailableSetter' is unavailable}}
+  // FIXME: missing diagnostic for setter
+  _ = takesInOut(&x.unavailableSetter).a
+  _ = takesInOut(&x.unavailableSetter.a)
+  _ = takesInOut(&x.unavailableSetter.a).b
+  _ = takesInOut(&x.unavailableSetter[0])
+  _ = takesInOut(&x.unavailableSetter[0]).b
+  _ = takesInOut(&x.unavailableSetter[0].b)
+  _ = takesInOut(&x.unavailableSetter[0].b).magnitude
+
+  _ = takesInOut(&x.unavailableGetterAndSetter) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
+  // FIXME: missing diagnostic for setter
+  _ = takesInOut(&x.unavailableGetterAndSetter).a // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter.a) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter.a).b // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter[0]) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter[0]).b // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter[0].b) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter[0].b).magnitude // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+}
+
 
 var global = BaseStruct<StructValue>()
 

--- a/test/Sema/availability_accessors.swift
+++ b/test/Sema/availability_accessors.swift
@@ -72,14 +72,14 @@ struct BaseStruct<T: ValueProto> {
   var unavailableSetter: T {
     get { .defaultValue }
     @available(*, unavailable)
-    set { fatalError() } // expected-note 36 {{setter for 'unavailableSetter' has been explicitly marked unavailable here}}
+    set { fatalError() } // expected-note 37 {{setter for 'unavailableSetter' has been explicitly marked unavailable here}}
   }
 
   var unavailableGetterAndSetter: T {
     @available(*, unavailable)
     get { fatalError() } // expected-note 62 {{getter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
     @available(*, unavailable)
-    set { fatalError() } // expected-note 36 {{setter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
+    set { fatalError() } // expected-note 37 {{setter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
   }
 }
 
@@ -461,8 +461,7 @@ func testDiscardedApplyOfFuncWithInOutParam_Class() {
   _ = takesInOut(&x.unavailableGetter[0].b).magnitude // expected-error {{getter for 'unavailableGetter' is unavailable}}
 
   _ = takesInOut(&x.unavailableSetter) // expected-error {{setter for 'unavailableSetter' is unavailable}}
-  // FIXME: missing diagnostic for setter
-  _ = takesInOut(&x.unavailableSetter).a
+  _ = takesInOut(&x.unavailableSetter).a // expected-error {{setter for 'unavailableSetter' is unavailable}}
   _ = takesInOut(&x.unavailableSetter.a)
   _ = takesInOut(&x.unavailableSetter.a).b
   _ = takesInOut(&x.unavailableSetter[0])
@@ -471,8 +470,7 @@ func testDiscardedApplyOfFuncWithInOutParam_Class() {
   _ = takesInOut(&x.unavailableSetter[0].b).magnitude
 
   _ = takesInOut(&x.unavailableGetterAndSetter) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
-  // FIXME: missing diagnostic for setter
-  _ = takesInOut(&x.unavailableGetterAndSetter).a // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
+  _ = takesInOut(&x.unavailableGetterAndSetter).a // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}} expected-error {{setter for 'unavailableGetterAndSetter' is unavailable}}
   _ = takesInOut(&x.unavailableGetterAndSetter.a) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   _ = takesInOut(&x.unavailableGetterAndSetter.a).b // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}
   _ = takesInOut(&x.unavailableGetterAndSetter[0]) // expected-error {{getter for 'unavailableGetterAndSetter' is unavailable}}


### PR DESCRIPTION
This fixes a regression from https://github.com/swiftlang/swift/pull/72369. The compiler now incorrectly diagnoses use of an unavailable setter in this example:
    
```
func increaseBrightness(in window: UIWindow) {
  // warning: setter for 'screen' was deprecated in iOS 13.0
  window.screen.brightness = 1.0
}
```
    
While the setter is deprecated, it would not be called in the generated code since `screen` is a reference type and there is no writeback through the setter for `screen` after setting `brightness`.
    
Resolves rdar://129679658
