### PR TITLE
[6.0] [stdlib] (U)Int128 improvements

### DIFF
--- a/stdlib/public/core/Int128.swift
+++ b/stdlib/public/core/Int128.swift
@@ -21,24 +21,29 @@ public struct Int128: Sendable {
   //  of `Builtin.Int128`.
 #if _pointerBitWidth(_64) || arch(arm64_32)
   public var _value: Builtin.Int128
-  
+
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public init(_ _value: Builtin.Int128) {
     self._value = _value
   }
-  
-  @usableFromInline @_transparent
-  internal var _low: UInt64 {
-    UInt64(truncatingIfNeeded: self)
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var _low: UInt64 {
+    UInt64(Builtin.trunc_Int128_Int64(_value))
   }
-  
-  @usableFromInline @_transparent
-  internal var _high: Int64 {
-    Int64(truncatingIfNeeded: self &>> 64)
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var _high: Int64 {
+    let shifted: Int128 = self &>> 64
+    return Int64(Builtin.trunc_Int128_Int64(shifted._value))
   }
-  
-  @usableFromInline @_transparent
-  internal init(_low: UInt64, _high: Int64) {
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public init(_low: UInt64, _high: Int64) {
 #if _endian(little)
     self = unsafeBitCast((_low, _high), to: Int128.self)
 #else
@@ -53,30 +58,43 @@ public struct Int128: Sendable {
   //  out the type as two `UInt64` fields--note that we have to be careful
   //  about endianness in this case.
 #if _endian(little)
-  @usableFromInline internal var _low: UInt64
-  @usableFromInline internal var _high: Int64
+  public var _low: UInt64
+
+  public var _high: Int64
 #else
-  @usableFromInline internal var _high: Int64
-  @usableFromInline internal var _low: UInt64
+  public var _high: Int64
+
+  public var _low: UInt64
 #endif
-  
-  @usableFromInline @_transparent
-  internal init(_low: UInt64, _high: Int64) {
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public init(_low: UInt64, _high: Int64) {
     self._low = _low
     self._high = _high
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   public var _value: Builtin.Int128 {
-    @_transparent get { unsafeBitCast(self, to: Builtin.Int128.self) }
-    @_transparent set { self = Self(newValue) }
+    @_transparent
+    get {
+      unsafeBitCast(self, to: Builtin.Int128.self)
+    }
+
+    @_transparent
+    set {
+      self = Self(newValue)
+    }
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public init(_ _value: Builtin.Int128) {
     self = unsafeBitCast(_value, to: Self.self)
   }
 #endif
-  
+
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public init(bitPattern: UInt128) {
     self.init(bitPattern._value)
@@ -87,16 +105,19 @@ public struct Int128: Sendable {
 
 @available(SwiftStdlib 6.0, *)
 extension Int128 {
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public static var zero: Self {
     Self(Builtin.zeroInitializer())
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public static var min: Self {
     Self(_low: .zero, _high: .min)
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public static var max: Self {
     Self(_low: .max, _high: .max)
@@ -108,21 +129,24 @@ extension Int128 {
 @available(SwiftStdlib 6.0, *)
 extension Int128: ExpressibleByIntegerLiteral,
                   _ExpressibleByBuiltinIntegerLiteral {
-  
+  @available(SwiftStdlib 6.0, *)
   public typealias IntegerLiteralType = Self
-  
+
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public init(_builtinIntegerLiteral x: Builtin.IntLiteral) {
     self.init(Builtin.s_to_s_checked_trunc_IntLiteral_Int128(x).0)
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init?<T>(exactly source: T) where T: BinaryInteger {
     guard let high = Int64(exactly: source >> 64) else { return nil }
     let low = UInt64(truncatingIfNeeded: source)
     self.init(_low: low, _high: high)
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init<T>(_ source: T) where T: BinaryInteger {
     guard let value = Self(exactly: source) else {
@@ -130,7 +154,8 @@ extension Int128: ExpressibleByIntegerLiteral,
     }
     self = value
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init<T>(clamping source: T) where T: BinaryInteger {
     guard let value = Self(exactly: source) else {
@@ -139,15 +164,17 @@ extension Int128: ExpressibleByIntegerLiteral,
     }
     self = value
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init<T>(truncatingIfNeeded source: T) where T: BinaryInteger {
     let high = Int64(truncatingIfNeeded: source >> 64)
     let low = UInt64(truncatingIfNeeded: source)
     self.init(_low: low, _high: high)
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public init(_truncatingBits source: UInt) {
     self.init(_low: UInt64(source), _high: .zero)
   }
@@ -156,6 +183,7 @@ extension Int128: ExpressibleByIntegerLiteral,
 // MARK: - Conversions from Binary floating-point
 @available(SwiftStdlib 6.0, *)
 extension Int128 {
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init?<T>(exactly source: T) where T: BinaryFloatingPoint {
     if source.magnitude < 0x1.0p64 {
@@ -176,7 +204,8 @@ extension Int128 {
       self.init(_low: low, _high: high)
     }
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init<T>(_ source: T) where T: BinaryFloatingPoint {
     guard let value = Self(exactly: source.rounded(.towardZero)) else {
@@ -189,7 +218,8 @@ extension Int128 {
 // MARK: - Non-arithmetic utility conformances
 @available(SwiftStdlib 6.0, *)
 extension Int128: Equatable {
-  @inlinable
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func ==(a: Self, b: Self) -> Bool {
     Bool(Builtin.cmp_eq_Int128(a._value, b._value))
   }
@@ -197,7 +227,8 @@ extension Int128: Equatable {
 
 @available(SwiftStdlib 6.0, *)
 extension Int128: Comparable {
-  @inlinable
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func <(a: Self, b: Self) -> Bool {
     Bool(Builtin.cmp_slt_Int128(a._value, b._value))
   }
@@ -205,6 +236,7 @@ extension Int128: Comparable {
 
 @available(SwiftStdlib 6.0, *)
 extension Int128: Hashable {
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public func hash(into hasher: inout Hasher) {
     hasher.combine(_low)
@@ -215,6 +247,7 @@ extension Int128: Hashable {
 // MARK: - Overflow-reporting arithmetic
 @available(SwiftStdlib 6.0, *)
 extension Int128 {
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public func addingReportingOverflow(
     _ other: Self
@@ -224,7 +257,8 @@ extension Int128 {
     )
     return (Self(result), Bool(overflow))
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public func subtractingReportingOverflow(
     _ other: Self
@@ -234,8 +268,9 @@ extension Int128 {
     )
     return (Self(result), Bool(overflow))
   }
-  
-  @inline(__always)
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public func multipliedReportingOverflow(
     by other: Self
   ) -> (partialValue: Self, overflow: Bool) {
@@ -250,21 +285,23 @@ extension Int128 {
       return (partialValue, overflow || partialValue < 0)
     }
   }
-  
-  @inline(__always)
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public func dividedReportingOverflow(
     by other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    precondition(other != .zero, "Division by zero")
+    _precondition(other != .zero, "Division by zero")
     if self == .min && other == -1 { return (.min, true) }
     return (Self(Builtin.sdiv_Int128(self._value, other._value)), false)
   }
-  
-  @inline(__always)
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public func remainderReportingOverflow(
     dividingBy other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    precondition(other != .zero, "Remainder dividing by zero.")
+    _precondition(other != .zero, "Division by zero in remainder operation")
     if self == .min && other == -1 { return (0, true) }
     return (Self(Builtin.srem_Int128(self._value, other._value)), false)
   }
@@ -273,21 +310,29 @@ extension Int128 {
 // MARK: - AdditiveArithmetic conformance
 @available(SwiftStdlib 6.0, *)
 extension Int128: AdditiveArithmetic {
-  @inlinable
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func +(a: Self, b: Self) -> Self {
     let (result, overflow) = a.addingReportingOverflow(b)
     // On arm64, this check materializes the carryout in register, then does
     // a TBNZ, where we should get a b.cs instead. I filed rdar://115387277
     // to track this, but it only costs us one extra instruction, so we'll
     // keep it as is for now.
-    precondition(!overflow)
+    Builtin.condfail_message(
+      overflow._value,
+      StaticString("arithmetic overflow").unsafeRawPointer
+    )
     return result
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func -(a: Self, b: Self) -> Self {
     let (result, overflow) = a.subtractingReportingOverflow(b)
-    precondition(!overflow)
+    Builtin.condfail_message(
+      overflow._value,
+      StaticString("arithmetic overflow").unsafeRawPointer
+    )
     return result
   }
 }
@@ -295,36 +340,56 @@ extension Int128: AdditiveArithmetic {
 // MARK: - Multiplication and division
 @available(SwiftStdlib 6.0, *)
 extension Int128 {
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func *(a: Self, b: Self) -> Self {
     let (result, overflow) = a.multipliedReportingOverflow(by: b)
-    precondition(!overflow)
+    Builtin.condfail_message(
+      overflow._value,
+      StaticString("arithmetic overflow").unsafeRawPointer
+    )
     return result
   }
-  
-  @inlinable
-  public static func *=(a: inout Self, b: Self) { a = a * b }
-  
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public static func *=(a: inout Self, b: Self) {
+    a = a * b
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func /(a: Self, b: Self) -> Self {
-    return a.dividedReportingOverflow(by: b).partialValue
+    a.dividedReportingOverflow(by: b).partialValue
   }
-  
-  @inlinable
-  public static func /=(a: inout Self, b: Self) { a = a / b }
-  
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public static func /=(a: inout Self, b: Self) {
+    a = a / b
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func %(a: Self, b: Self) -> Self {
-    return a.remainderReportingOverflow(dividingBy: b).partialValue
+    a.remainderReportingOverflow(dividingBy: b).partialValue
   }
-  
-  @inlinable
-  public static func %=(a: inout Self, b: Self) { a = a % b }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public static func %=(a: inout Self, b: Self) {
+    a = a % b
+  }
 }
 
 // MARK: - Numeric conformance
 @available(SwiftStdlib 6.0, *)
 extension Int128: SignedNumeric {
+  @available(SwiftStdlib 6.0, *)
   public typealias Magnitude = UInt128
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public var magnitude: Magnitude {
     let unsignedSelf = UInt128(_value)
     return self < 0 ? 0 &- unsignedSelf : unsignedSelf
@@ -334,59 +399,90 @@ extension Int128: SignedNumeric {
 // MARK: - BinaryInteger conformance
 @available(SwiftStdlib 6.0, *)
 extension Int128: BinaryInteger {
-  
-  @inlinable
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public var words: UInt128.Words {
     Words(_value: UInt128(_value))
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func &=(a: inout Self, b: Self) {
     a._value = Builtin.and_Int128(a._value, b._value)
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func |=(a: inout Self, b: Self) {
     a._value = Builtin.or_Int128(a._value, b._value)
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func ^=(a: inout Self, b: Self) {
     a._value = Builtin.xor_Int128(a._value, b._value)
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func &>>=(a: inout Self, b: Self) {
     let masked = b & 127
     a._value = Builtin.ashr_Int128(a._value, masked._value)
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func &<<=(a: inout Self, b: Self) {
     let masked = b & 127
     a._value = Builtin.shl_Int128(a._value, masked._value)
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public var trailingZeroBitCount: Int {
     _low == 0 ? 64 + _high.trailingZeroBitCount : _low.trailingZeroBitCount
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var _lowWord: UInt {
+#if _pointerBitWidth(_64)
+    UInt(Builtin.trunc_Int128_Int64(_value))
+#elseif _pointerBitWidth(_32)
+    UInt(Builtin.trunc_Int128_Int32(_value))
+#else
+#error("Unsupported platform")
+#endif
   }
 }
 
 // MARK: - FixedWidthInteger conformance
 @available(SwiftStdlib 6.0, *)
 extension Int128: FixedWidthInteger, SignedInteger {
-  
+  @available(SwiftStdlib 6.0, *)
   @_transparent
-  static public var bitWidth: Int { 128 }
-  
+  public static var bitWidth: Int { 128 }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public var nonzeroBitCount: Int {
     _high.nonzeroBitCount &+ _low.nonzeroBitCount
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public var leadingZeroBitCount: Int {
     _high == 0 ? 64 + _low.leadingZeroBitCount : _high.leadingZeroBitCount
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public var byteSwapped: Self {
     return Self(_low: UInt64(bitPattern: _high.byteSwapped),
                 _high: Int64(bitPattern: _low.byteSwapped))
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public static func &*(lhs: Self, rhs: Self) -> Self {
     // The default &* on FixedWidthInteger calls multipliedReportingOverflow,

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -21,24 +21,29 @@ public struct UInt128: Sendable {
   //  32b pointers but HW-backed 64b integers), the layout is simply that
   //  of `Builtin.Int128`.
   public var _value: Builtin.Int128
-  
+
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public init(_ _value: Builtin.Int128) {
     self._value = _value
   }
-  
-  @usableFromInline @_transparent
-  internal var _low: UInt64 {
-    UInt64(truncatingIfNeeded: self)
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var _low: UInt64 {
+    UInt64(Builtin.trunc_Int128_Int64(_value))
   }
-  
-  @usableFromInline @_transparent
-  internal var _high: UInt64 {
-    UInt64(truncatingIfNeeded: self &>> 64)
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var _high: UInt64 {
+    let shifted: UInt128 = self &>> 64
+    return UInt64(Builtin.trunc_Int128_Int64(shifted._value))
   }
-  
-  @usableFromInline @_transparent
-  internal init(_low: UInt64, _high: UInt64) {
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public init(_low: UInt64, _high: UInt64) {
 #if _endian(little)
     self = unsafeBitCast((_low, _high), to: Self.self)
 #else
@@ -53,30 +58,42 @@ public struct UInt128: Sendable {
   //  out the type as two `UInt64` fields--note that we have to be careful
   //  about endianness in this case.
 #if _endian(little)
-  @usableFromInline internal var _low: UInt64
-  @usableFromInline internal var _high: UInt64
+  public var _low: UInt64
+
+  public var _high: UInt64
 #else
-  @usableFromInline internal var _high: UInt64
-  @usableFromInline internal var _low: UInt64
+  public var _high: UInt64
+
+  public var _low: UInt64
 #endif
-  
-  @usableFromInline @_transparent
-  internal init(_low: UInt64, _high: UInt64) {
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public init(_low: UInt64, _high: UInt64) {
     self._low = _low
     self._high = _high
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   public var _value: Builtin.Int128 {
-    @_transparent get { unsafeBitCast(self, to: Builtin.Int128.self) }
-    @_transparent set { self = Self(newValue) }
+    @_transparent
+    get {
+      unsafeBitCast(self, to: Builtin.Int128.self)
+    }
+
+    @_transparent
+    set {
+      self = Self(newValue)
+    }
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public init(_ _value: Builtin.Int128) {
     self = unsafeBitCast(_value, to: Self.self)
   }
 #endif
-  
+
+  @available(SwiftStdlib 6.0, *)
   @_transparent
   public init(bitPattern: Int128) {
     self.init(bitPattern._value)
@@ -86,15 +103,20 @@ public struct UInt128: Sendable {
 // MARK: - Constants
 @available(SwiftStdlib 6.0, *)
 extension UInt128 {
-  @inlinable
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static var zero: Self {
     Self(Builtin.zeroInitializer())
   }
-  
-  @inlinable
-  public static var min: Self { zero }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public static var min: Self {
+    zero
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static var max: Self {
     Self(_low: .max, _high: .max)
   }
@@ -104,21 +126,24 @@ extension UInt128 {
 @available(SwiftStdlib 6.0, *)
 extension UInt128: ExpressibleByIntegerLiteral,
                    _ExpressibleByBuiltinIntegerLiteral {
-  
+  @available(SwiftStdlib 6.0, *)
   public typealias IntegerLiteralType = Self
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public init(_builtinIntegerLiteral x: Builtin.IntLiteral) {
     self.init(Builtin.s_to_u_checked_trunc_IntLiteral_Int128(x).0)
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init?<T>(exactly source: T) where T: BinaryInteger {
     guard let high = UInt64(exactly: source >> 64) else { return nil }
     let low = UInt64(truncatingIfNeeded: source)
     self.init(_low: low, _high: high)
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init<T>(_ source: T) where T: BinaryInteger {
     guard let value = Self(exactly: source) else {
@@ -126,7 +151,8 @@ extension UInt128: ExpressibleByIntegerLiteral,
     }
     self = value
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init<T>(clamping source: T) where T: BinaryInteger {
     guard let value = Self(exactly: source) else {
@@ -135,15 +161,17 @@ extension UInt128: ExpressibleByIntegerLiteral,
     }
     self = value
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init<T>(truncatingIfNeeded source: T) where T: BinaryInteger {
     let high = UInt64(truncatingIfNeeded: source >> 64)
     let low = UInt64(truncatingIfNeeded: source)
     self.init(_low: low, _high: high)
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public init(_truncatingBits source: UInt) {
     self.init(_low: UInt64(source), _high: .zero)
   }
@@ -152,6 +180,7 @@ extension UInt128: ExpressibleByIntegerLiteral,
 // MARK: - Conversions from Binary floating-point
 @available(SwiftStdlib 6.0, *)
 extension UInt128 {
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init?<T>(exactly source: T) where T: BinaryFloatingPoint {
     let highAsFloat = (source * 0x1.0p-64).rounded(.towardZero)
@@ -161,7 +190,8 @@ extension UInt128 {
     ) else { return nil }
     self.init(_low: low, _high: high)
   }
-  
+
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public init<T>(_ source: T) where T: BinaryFloatingPoint {
     guard let value = Self(exactly: source.rounded(.towardZero)) else {
@@ -174,7 +204,8 @@ extension UInt128 {
 // MARK: - Non-arithmetic utility conformances
 @available(SwiftStdlib 6.0, *)
 extension UInt128: Equatable {
-  @inlinable
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func ==(a: Self, b: Self) -> Bool {
     Bool(Builtin.cmp_eq_Int128(a._value, b._value))
   }
@@ -182,7 +213,8 @@ extension UInt128: Equatable {
 
 @available(SwiftStdlib 6.0, *)
 extension UInt128: Comparable {
-  @inlinable
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func <(a: Self, b: Self) -> Bool {
     Bool(Builtin.cmp_ult_Int128(a._value, b._value))
   }
@@ -190,6 +222,7 @@ extension UInt128: Comparable {
 
 @available(SwiftStdlib 6.0, *)
 extension UInt128: Hashable {
+  @available(SwiftStdlib 6.0, *)
   @inlinable
   public func hash(into hasher: inout Hasher) {
     hasher.combine(_low)
@@ -200,7 +233,8 @@ extension UInt128: Hashable {
 // MARK: - Overflow-reporting arithmetic
 @available(SwiftStdlib 6.0, *)
 extension UInt128 {
-  @inlinable
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public func addingReportingOverflow(
     _ other: Self
   ) -> (partialValue: Self, overflow: Bool) {
@@ -209,8 +243,9 @@ extension UInt128 {
     )
     return (Self(result), Bool(overflow))
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public func subtractingReportingOverflow(
     _ other: Self
   ) -> (partialValue: Self, overflow: Bool) {
@@ -219,8 +254,9 @@ extension UInt128 {
     )
     return (Self(result), Bool(overflow))
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public func multipliedReportingOverflow(
     by other: Self
   ) -> (partialValue: Self, overflow: Bool) {
@@ -229,21 +265,23 @@ extension UInt128 {
     )
     return (Self(result), Bool(overflow))
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public func dividedReportingOverflow(
     by other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    precondition(other != .zero, "Division by zero.")
+    _precondition(other != .zero, "Division by zero")
     // Unsigned divide never overflows.
     return (Self(Builtin.udiv_Int128(self._value, other._value)), false)
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public func remainderReportingOverflow(
     dividingBy other: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    precondition(other != .zero, "Remainder dividing by zero.")
+    _precondition(other != .zero, "Division by zero in remainder operation")
     // Unsigned divide never overflows.
     return (Self(Builtin.urem_Int128(self._value, other._value)), false)
   }
@@ -252,21 +290,29 @@ extension UInt128 {
 // MARK: - AdditiveArithmetic conformance
 @available(SwiftStdlib 6.0, *)
 extension UInt128: AdditiveArithmetic {
-  @inlinable
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func +(a: Self, b: Self) -> Self {
     let (result, overflow) = a.addingReportingOverflow(b)
     // On arm64, this check materializes the carryout in register, then does
     // a TBNZ, where we should get a b.cs instead. I filed rdar://115387277
     // to track this, but it only costs us one extra instruction, so we'll
     // keep it as is for now.
-    precondition(!overflow)
+    Builtin.condfail_message(
+      overflow._value,
+      StaticString("arithmetic overflow").unsafeRawPointer
+    )
     return result
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func -(a: Self, b: Self) -> Self {
     let (result, overflow) = a.subtractingReportingOverflow(b)
-    precondition(!overflow)
+    Builtin.condfail_message(
+      overflow._value,
+      StaticString("arithmetic overflow").unsafeRawPointer
+    )
     return result
   }
 }
@@ -274,107 +320,189 @@ extension UInt128: AdditiveArithmetic {
 // MARK: - Multiplication and division
 @available(SwiftStdlib 6.0, *)
 extension UInt128 {
-  @inlinable
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func *(a: Self, b: Self) -> Self {
     let (result, overflow) = a.multipliedReportingOverflow(by: b)
-    precondition(!overflow)
+    Builtin.condfail_message(
+      overflow._value,
+      StaticString("arithmetic overflow").unsafeRawPointer
+    )
     return result
   }
-  
-  @inlinable
-  public static func *=(a: inout Self, b: Self) { a = a * b }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public static func *=(a: inout Self, b: Self) {
+    a = a * b
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func /(a: Self, b: Self) -> Self {
-    return a.dividedReportingOverflow(by: b).partialValue
+    a.dividedReportingOverflow(by: b).partialValue
   }
-  
-  @inlinable
-  public static func /=(a: inout Self, b: Self) { a = a / b }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public static func /=(a: inout Self, b: Self) {
+    a = a / b
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func %(a: Self, b: Self) -> Self {
-    return a.remainderReportingOverflow(dividingBy: b).partialValue
+    a.remainderReportingOverflow(dividingBy: b).partialValue
   }
-  
-  @inlinable
-  public static func %=(a: inout Self, b: Self) { a = a % b }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public static func %=(a: inout Self, b: Self) {
+    a = a % b
+  }
 }
 
 // MARK: - Numeric conformance
 @available(SwiftStdlib 6.0, *)
 extension UInt128: Numeric {
+  @available(SwiftStdlib 6.0, *)
   public typealias Magnitude = Self
-  
-  @inlinable
-  public var magnitude: Self { self }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var magnitude: Self {
+    self
+  }
 }
 
 // MARK: - BinaryInteger conformance
 @available(SwiftStdlib 6.0, *)
 extension UInt128: BinaryInteger {
+  @available(SwiftStdlib 6.0, *)
   @frozen
   public struct Words {
     @usableFromInline
     let _value: UInt128
-    @usableFromInline
-    init(_value: UInt128) { self._value = _value }
+
+    @available(SwiftStdlib 6.0, *)
+    @_transparent
+    public init(_value: UInt128) {
+      self._value = _value
+    }
   }
-  
-  @inlinable
-  public var words: Words { Words(_value: self) }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var words: Words {
+    Words(_value: self)
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func &=(a: inout Self, b: Self) {
     a._value = Builtin.and_Int128(a._value, b._value)
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func |=(a: inout Self, b: Self) {
     a._value = Builtin.or_Int128(a._value, b._value)
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func ^=(a: inout Self, b: Self) {
     a._value = Builtin.xor_Int128(a._value, b._value)
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func &>>=(a: inout Self, b: Self) {
     let masked = b & 127
     a._value = Builtin.lshr_Int128(a._value, masked._value)
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public static func &<<=(a: inout Self, b: Self) {
     let masked = b & 127
     a._value = Builtin.shl_Int128(a._value, masked._value)
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public var trailingZeroBitCount: Int {
     _low == 0 ? 64 + _high.trailingZeroBitCount : _low.trailingZeroBitCount
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var _lowWord: UInt {
+#if _pointerBitWidth(_64)
+    UInt(Builtin.trunc_Int128_Int64(_value))
+#elseif _pointerBitWidth(_32)
+    UInt(Builtin.trunc_Int128_Int32(_value))
+#else
+#error("Unsupported platform")
+#endif
   }
 }
 
 @available(SwiftStdlib 6.0, *)
 extension UInt128.Words: RandomAccessCollection {
+  @available(SwiftStdlib 6.0, *)
   public typealias Element = UInt
+
+  @available(SwiftStdlib 6.0, *)
   public typealias Index = Int
+
+  @available(SwiftStdlib 6.0, *)
   public typealias SubSequence = Slice<Self>
+
+  @available(SwiftStdlib 6.0, *)
   public typealias Indices = Range<Int>
-  
-  @inlinable public var count: Int { 128 / UInt.bitWidth }
-  @inlinable public var startIndex: Int { 0 }
-  @inlinable public var endIndex: Int { count }
-  @inlinable public var indices: Indices { startIndex ..< endIndex }
-  @inlinable public func index(after i: Int) -> Int { i + 1 }
-  @inlinable public func index(before i: Int) -> Int { i - 1 }
-  
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var count: Int {
+    128 / UInt.bitWidth
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var startIndex: Int {
+    0
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var endIndex: Int {
+    count
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public var indices: Indices {
+    startIndex ..< endIndex
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public func index(after i: Int) -> Int {
+    i + 1
+  }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public func index(before i: Int) -> Int {
+    i - 1
+  }
+
+  @available(SwiftStdlib 6.0, *)
   public subscript(position: Int) -> UInt {
     @inlinable
     get {
-      precondition(position >= 0 && position < count)
+      _precondition(position >= 0 && position < count, "Index out of bounds")
       var value = _value
 #if _endian(little)
       let index = position
@@ -391,21 +519,24 @@ extension UInt128.Words: RandomAccessCollection {
 // MARK: - FixedWidthInteger conformance
 @available(SwiftStdlib 6.0, *)
 extension UInt128: FixedWidthInteger, UnsignedInteger {
-  
-  @inlinable
-  static public var bitWidth: Int { 128 }
-  
-  @inlinable
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
+  public static var bitWidth: Int { 128 }
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public var nonzeroBitCount: Int {
     _high.nonzeroBitCount &+ _low.nonzeroBitCount
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public var leadingZeroBitCount: Int {
     _high == 0 ? 64 + _low.leadingZeroBitCount : _high.leadingZeroBitCount
   }
-  
-  @inlinable
+
+  @available(SwiftStdlib 6.0, *)
+  @_transparent
   public var byteSwapped: Self {
     return Self(_low: _high.byteSwapped, _high: _low.byteSwapped)
   }

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -313,7 +313,7 @@ extension UInt128: Numeric {
 // MARK: - BinaryInteger conformance
 @available(SwiftStdlib 6.0, *)
 extension UInt128: BinaryInteger {
-  
+  @frozen
   public struct Words {
     @usableFromInline
     let _value: UInt128

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -385,6 +385,8 @@ Added: _$ss6Int128Vs35_ExpressibleByBuiltinIntegerLiteralsWP
 Added: _$ss6Int128VyABBi128_cfC
 Added: _$ss6Int128VyABxcSBRzlufC
 Added: _$ss6Int128VyABxcSzRzlufC
+Added: _$ss6Int128V8_lowWordSuvg
+Added: _$ss6Int128V8_lowWordSuvpMV
 
 // UInt128
 Added: _$sSYsSeRzs7UInt128V8RawValueSYRtzrlE4fromxs7Decoder_p_tKcfC
@@ -547,6 +549,8 @@ Added: _$ss7UInt128Vs35_ExpressibleByBuiltinIntegerLiteralsWP
 Added: _$ss7UInt128VyABBi128_cfC
 Added: _$ss7UInt128VyABxcSBRzlufC
 Added: _$ss7UInt128VyABxcSzRzlufC
+Added: _$ss7UInt128V8_lowWordSuvg
+Added: _$ss7UInt128V8_lowWordSuvpMV
 
 // Fixed-width integer &* customization point
 Added: _$ss17FixedWidthIntegerP2amoiyxx_xtFZTj

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -385,6 +385,8 @@ Added: _$ss6Int128Vs35_ExpressibleByBuiltinIntegerLiteralsWP
 Added: _$ss6Int128VyABBi128_cfC
 Added: _$ss6Int128VyABxcSBRzlufC
 Added: _$ss6Int128VyABxcSzRzlufC
+Added: _$ss6Int128V8_lowWordSuvg
+Added: _$ss6Int128V8_lowWordSuvpMV
 
 // UInt128
 Added: _$sSYsSeRzs7UInt128V8RawValueSYRtzrlE4fromxs7Decoder_p_tKcfC
@@ -547,6 +549,8 @@ Added: _$ss7UInt128Vs35_ExpressibleByBuiltinIntegerLiteralsWP
 Added: _$ss7UInt128VyABBi128_cfC
 Added: _$ss7UInt128VyABxcSBRzlufC
 Added: _$ss7UInt128VyABxcSzRzlufC
+Added: _$ss7UInt128V8_lowWordSuvg
+Added: _$ss7UInt128V8_lowWordSuvpMV
 
 // Fixed-width integer &* customization point
 Added: _$ss17FixedWidthIntegerP2amoiyxx_xtFZTj


### PR DESCRIPTION
* **Explanation**: `UInt128.Words` wasn't correctly marked as `@frozen` hindering the optimizer's ability to help specialize uses of these types. This also applies `@_transparent` to most functionality of 128 bit integers (where necessary) and provides a specialized implementation of `_lowWord` as well.
* **Scope**: Stdlib
* **Risk**: Marking `UInt128.Words` as `@frozen` is ABI breaking, but hopefully we can land this before it becomes an actual issue. The rest of the changes are low risk.
* **Testing**: Tested by a test case
* **Issue**: https://github.com/swiftlang/swift/issues/74481
* **Reviewer**: @stephentyrone 
* **Main** **branch** PR: https://github.com/swiftlang/swift/pull/74523 and https://github.com/swiftlang/swift/pull/74507