### PR TITLE
[Sema] Raise impact of DefineMemberBasedOnUse to match RemoveInvalidCall

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11115,7 +11115,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
 
       auto instanceTy = baseObjTy->getMetatypeInstanceType();
 
-      auto impact = 2;
+      auto impact = 4;
       // Impact is higher if the base type is any function type
       // because function types can't have any members other than self
       if (instanceTy->is<AnyFunctionType>()) {
@@ -13392,7 +13392,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
     // Let's make this fix as high impact so if there is a function or member
     // overload with e.g. argument-to-parameter type mismatches it would take
     // a higher priority.
-    return recordFix(fix, /*impact=*/10) ? SolutionKind::Error
+    return recordFix(fix, /*impact=*/3) ? SolutionKind::Error
                                          : SolutionKind::Solved;
   }
 


### PR DESCRIPTION
RemoveInvalidCall has a fix impact of 10, which means that in this issue, the typechecker would rather invent a conformance and then a brand new member rather than find the actual problem. 

Raising the impact of DefineMemberBasedOnUse to be equivalent to RemoveInvalidCall seems reasonable, since it is better to diagnose a member that exists but has the wrong type rather than create a member that doesn't exist.

Resolves #74617 
