### PR TITLE
16 bit pointer fixes

### DIFF
--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -109,6 +109,7 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name)
   if (GYB_ARCH)
     set_if_arch_bitness(ptr_size
       ARCH "${GYB_ARCH}"
+      CASE_16_BIT "2"
       CASE_32_BIT "4"
       CASE_64_BIT "8")
     set(extra_gyb_flags "-DCMAKE_SIZEOF_VOID_P=${ptr_size}")

--- a/cmake/modules/SwiftSetIfArchBitness.cmake
+++ b/cmake/modules/SwiftSetIfArchBitness.cmake
@@ -2,7 +2,7 @@ function(set_if_arch_bitness var_name)
   cmake_parse_arguments(
       SIA # prefix
       "" # options
-      "ARCH;CASE_32_BIT;CASE_64_BIT" # single-value args
+      "ARCH;CASE_16_BIT;CASE_32_BIT;CASE_64_BIT" # single-value args
       "" # multi-value args
       ${ARGN})
 

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -109,6 +109,7 @@ static const SupportedConditionalValue SupportedConditionalCompilationEndianness
 };
 
 static const SupportedConditionalValue SupportedConditionalCompilationPointerBitWidths[] = {
+  "_16",
   "_32",
   "_64"
 };
@@ -564,7 +565,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   }
 
   // Set the "_pointerBitWidth" platform condition.
-  if (Target.isArch32Bit()) {
+  if (Target.isArch16Bit()) {
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_16");
+  } else if (Target.isArch32Bit()) {
     addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_32");
   } else if (Target.isArch64Bit()) {
     addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_64");

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -397,6 +397,10 @@ void LangOptions::setHasAtomicBitWidth(llvm::Triple triple) {
     // case please update the switch with your flavor of arch. Otherwise assume
     // every arch supports at least word atomics.
 
+    if (triple.isArch16Bit()) {
+      setMaxAtomicBitWidth(16);
+    }
+
     if (triple.isArch32Bit()) {
       setMaxAtomicBitWidth(32);
     }

--- a/lib/IRGen/ExtraInhabitants.cpp
+++ b/lib/IRGen/ExtraInhabitants.cpp
@@ -165,7 +165,7 @@ llvm::Value *PointerInfo::getExtraInhabitantIndex(IRGenFunction &IGF,
 
     // Truncate down to i32 if necessary.
     if (index->getType() != IGF.IGM.Int32Ty) {
-      index = IGF.Builder.CreateTrunc(index, IGF.IGM.Int32Ty);
+      index = IGF.Builder.CreateZExtOrTrunc(index, IGF.IGM.Int32Ty);
     }
 
     phiValues.push_back({IGF.Builder.GetInsertBlock(), index});
@@ -195,7 +195,7 @@ void PointerInfo::storeExtraInhabitant(IRGenFunction &IGF,
                                        llvm::Value *index,
                                        Address dest) const {
   if (index->getType() != IGF.IGM.SizeTy) {
-    index = IGF.Builder.CreateZExt(index, IGF.IGM.SizeTy);
+    index = IGF.Builder.CreateZExtOrTrunc(index, IGF.IGM.SizeTy);
   }
 
   if (Nullable) {

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -3028,14 +3028,14 @@ irgen::emitClassResilientInstanceSizeAndAlignMask(IRGenFunction &IGF,
   slot = IGF.Builder.CreateElementBitCast(slot, IGF.IGM.Int32Ty);
   llvm::Value *size = IGF.Builder.CreateLoad(slot);
   if (IGF.IGM.SizeTy != IGF.IGM.Int32Ty)
-    size = IGF.Builder.CreateZExt(size, IGF.IGM.SizeTy);
+    size = IGF.Builder.CreateZExtOrTrunc(size, IGF.IGM.SizeTy);
 
   slot = IGF.Builder.CreateConstByteArrayGEP(
       metadataAsBytes,
       layout.getInstanceAlignMaskOffset());
   slot = IGF.Builder.CreateElementBitCast(slot, IGF.IGM.Int16Ty);
   llvm::Value *alignMask = IGF.Builder.CreateLoad(slot);
-  alignMask = IGF.Builder.CreateZExt(alignMask, IGF.IGM.SizeTy);
+  alignMask = IGF.Builder.CreateZExtOrTrunc(alignMask, IGF.IGM.SizeTy);
 
   return {size, alignMask};
 }

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1037,7 +1037,11 @@ llvm::Type *LinkEntity::getDefaultDeclarationType(IRGenModule &IGM) const {
   case Kind::NoncanonicalSpecializedGenericTypeMetadataCacheVariable:
     return IGM.TypeMetadataPtrTy;
   case Kind::TypeMetadataDemanglingCacheVariable:
-    return llvm::StructType::get(IGM.Int32Ty, IGM.Int32Ty);
+    if (IGM.getModule()->getDataLayout().isBigEndian()) {
+      return llvm::StructType::get(IGM.Int32Ty, IGM.RelativeAddressTy);
+    } else {
+      return llvm::StructType::get(IGM.RelativeAddressTy, IGM.Int32Ty);
+    }
   case Kind::TypeMetadataSingletonInitializationCache:
     // TODO: put a cache variable on IGM
     return llvm::StructType::get(IGM.getLLVMContext(),

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3228,8 +3228,8 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
 
     auto stringAddrOffset = subIGF.Builder.CreateTrunc(load,
                                                        IGM.Int32Ty);
-    stringAddrOffset = subIGF.Builder.CreateSExtOrBitCast(stringAddrOffset,
-                                                          IGM.SizeTy);
+    stringAddrOffset = subIGF.Builder.CreateSExtOrTrunc(stringAddrOffset,
+                                                        IGM.SizeTy);
     auto stringAddrBase = subIGF.Builder.CreatePtrToInt(cache, IGM.SizeTy);
     if (IGM.getModule()->getDataLayout().isBigEndian()) {
       stringAddrBase = subIGF.Builder.CreateAdd(stringAddrBase,


### PR DESCRIPTION
<!-- What's in this pull request? -->
These changes fix some crashes when trying to build programs for 16-bit targets.

Note: I'm not sure if there are any 16-bit pointer targets yet for Swift. I hope to add AVR in the near future.

The AVR architecture is extremely space constrained and will use the "embedded" compiler mode, which makes some of the fixes here not important for that platform, but they're included for completeness, in case someone wants to add other 16-bit platforms in the future where embedded mode is not used and where metadata is still important.