### PR TITLE
[6.0] [SILOptimizer] Handle the mark_dependence chain when eliminating copies in ClosureLifetimeFixup

### DIFF
--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -733,6 +733,7 @@ static SILValue tryRewriteToPartialApplyStack(
   unsigned appliedArgStartIdx =
         newPA->getOrigCalleeType()->getNumParameters() - newPA->getNumArguments();
 
+  MarkDependenceInst *markDepChain = nullptr;
   for (unsigned i : indices(newPA->getArgumentOperands())) {
     auto &arg = newPA->getArgumentOperands()[i];
     SILValue copy = arg.get();
@@ -780,6 +781,20 @@ static SILValue tryRewriteToPartialApplyStack(
         continue;
       }
       if (auto mark = dyn_cast<MarkDependenceInst>(use->getUser())) {
+        // When we insert mark_dependence for non-trivial address operands, we
+        // emit a chain that looks like:
+        //    %md = mark_dependence %pai on %0
+        //    %md2 = mark_dependence %md on %1
+        // to tie all of those operands together on the same partial_apply.
+        //
+        // FIXME: Should we not be chaining like this and just emit independent
+        // mark_dependence?
+        if (markDepChain && mark->getValue() == markDepChain) {
+          markDep = mark;
+          markDepChain = mark;
+          continue;
+        }
+
         // If we're marking dependence of the current partial_apply on this
         // stack slot, that's fine.
         if (mark->getValue() != newPA
@@ -791,6 +806,11 @@ static SILValue tryRewriteToPartialApplyStack(
           break;
         }
         markDep = mark;
+
+        if (!markDepChain) {
+          markDepChain = mark;
+        }
+
         continue;
       }
       


### PR DESCRIPTION
* **Explanation**: The optimizer was not understanding certain patterns when eliminating copies of noncopyable arguments to non escaping closure arguments. This resolves that underlying issue so you can have 2+ noncopyable address only arguments.
* **Scope**: Compiler
* **Risk**: Low
* **Testing**: Added new test cases
* **Issue**: rdar://130205636
* **Reviewer**: NA
* **Main** **branch** **PR**: https://github.com/swiftlang/swift/pull/74593