### PR TITLE
[6.0] Implement getSwiftRuntimeCompatibilityVersionForTarget for recent releases

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5626,8 +5626,6 @@ ERROR(isolated_parameter_combined_nonisolated,none,
 ERROR(isolated_parameter_isolated_attr_type,none,
       "function with 'isolated' parameter cannot also be '@isolated(%0)'",
       (StringRef))
-ERROR(isolated_any_experimental,none,
-      "attribute requires '-enable-experimental-feature IsolatedAny'", ())
 ERROR(isolated_attr_global_actor_type,none,
       "function type cannot have both a global actor and '@isolated(%0)'",
       (StringRef))

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -200,6 +200,8 @@ LANGUAGE_FEATURE(BuiltinAddressOfRawLayout, 0, "Builtin.addressOfRawLayout")
 LANGUAGE_FEATURE(TransferringArgsAndResults, 430, "Transferring args and results")
 SUPPRESSIBLE_LANGUAGE_FEATURE(SendingArgsAndResults, 430, "Sending arg and results")
 LANGUAGE_FEATURE(BorrowingSwitch, 432, "Noncopyable type pattern matching")
+CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE(IsolatedAny, 431, "@isolated(any) function types")
+LANGUAGE_FEATURE(IsolatedAny2, 431, "@isolated(any) function types")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
@@ -371,14 +373,8 @@ EXPERIMENTAL_FEATURE(GroupActorErrors, true)
 // Enable explicit isolation of closures.
 EXPERIMENTAL_FEATURE(ClosureIsolation, true)
 
-// Enable isolated(any) attribute on function types.
-CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE(IsolatedAny, true)
-
 // Whether lookup of members respects the enclosing file's imports.
 EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(MemberImportVisibility, true)
-
-// Alias for IsolatedAny
-EXPERIMENTAL_FEATURE(IsolatedAny2, true)
 
 // Enable @implementation on extensions of ObjC classes.
 EXPERIMENTAL_FEATURE(ObjCImplementation, true)

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -470,7 +470,13 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
         return floorFor64(llvm::VersionTuple(5, 5));
       return floorFor64(llvm::VersionTuple(5, 6));
     } else if (Major == 13) {
-      return floorFor64(llvm::VersionTuple(5, 7));
+      if (Minor <= 2)
+        return floorFor64(llvm::VersionTuple(5, 7));
+      return floorFor64(llvm::VersionTuple(5, 8));
+    } else if (Major == 14) {
+      if (Minor <= 3)
+        return floorFor64(llvm::VersionTuple(5, 9));
+      return floorFor64(llvm::VersionTuple(5, 10));
     }
   } else if (Triple.isiOS()) { // includes tvOS
     llvm::VersionTuple OSVersion = Triple.getiOSVersion();
@@ -510,7 +516,13 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
         return floorForArchitecture(llvm::VersionTuple(5, 5));
       return floorForArchitecture(llvm::VersionTuple(5, 6));
     } else if (Major <= 16) {
-      return floorForArchitecture(llvm::VersionTuple(5, 7));
+      if (Minor <= 3)
+        return floorForArchitecture(llvm::VersionTuple(5, 7));
+      return floorForArchitecture(llvm::VersionTuple(5, 8));
+    } else if (Major <= 17) {
+      if (Minor <= 3)
+        return floorForArchitecture(llvm::VersionTuple(5, 9));
+      return floorForArchitecture(llvm::VersionTuple(5, 10));
     }
   } else if (Triple.isWatchOS()) {
     llvm::VersionTuple OSVersion = Triple.getWatchOSVersion();
@@ -541,11 +553,25 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
         return floorFor64bits(llvm::VersionTuple(5, 5));
       return floorFor64bits(llvm::VersionTuple(5, 6));
     } else if (Major <= 9) {
-      return floorFor64bits(llvm::VersionTuple(5, 7));
+      if (Minor <= 3)
+        return floorFor64bits(llvm::VersionTuple(5, 7));
+      return floorFor64bits(llvm::VersionTuple(5, 8));
+    } else if (Major <= 10) {
+      if (Minor <= 3)
+        return floorFor64bits(llvm::VersionTuple(5, 9));
+      return floorFor64bits(llvm::VersionTuple(5, 10));
     }
   }
   else if (Triple.isXROS()) {
-    return std::nullopt;
+    llvm::VersionTuple OSVersion = Triple.getOSVersion();
+    unsigned Major = OSVersion.getMajor();
+    unsigned Minor = OSVersion.getMinor().value_or(0);
+
+    if (Major <= 1) {
+      if (Minor <= 0)
+        return llvm::VersionTuple(5, 9);
+      return llvm::VersionTuple(5, 10);
+    }
   }
 
   return std::nullopt;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3937,11 +3937,6 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     if (isolatedAttr && !isolatedAttr->isInvalid()) {
       switch (isolatedAttr->getIsolationKind()) {
       case IsolatedTypeAttr::IsolationKind::Dynamic:
-        if (!getASTContext().LangOpts.hasFeature(Feature::IsolatedAny)) {
-          diagnose(isolatedAttr->getAtLoc(), diag::isolated_any_experimental);
-          // Proceed as normal.
-        }
-
         if (representation != FunctionType::Representation::Swift) {
           assert(conventionAttr);
           diagnoseInvalid(repr, isolatedAttr->getAtLoc(),

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -60,11 +60,6 @@ else()
   list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS "-fswift-async-fp=never")
 endif()
 
-list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS
-  "-enable-experimental-feature"
-  "IsolatedAny2"
-)
-
 list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
   "-D__STDC_WANT_LIB_EXT1__=1")
 

--- a/test/Concurrency/isolated_any.swift
+++ b/test/Concurrency/isolated_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedAny -enable-upcoming-feature InferSendableFromCaptures %s
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -strict-concurrency=complete -enable-upcoming-feature InferSendableFromCaptures %s
 
 // REQUIRES: asserts
 

--- a/test/Distributed/distributed_actor_isolated_any.swift
+++ b/test/Distributed/distributed_actor_isolated_any.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
 
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature IsolatedAny %s -module-name test -swift-version 5 -disable-availability-checking -I %t | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 -disable-availability-checking -I %t | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/IRGen/isolated_any.sil
+++ b/test/IRGen/isolated_any.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature IsolatedAny | %IRGenFileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %IRGenFileCheck %s
 
 // REQUIRES: concurrency
 

--- a/test/IRGen/isolated_any_metadata.sil
+++ b/test/IRGen/isolated_any_metadata.sil
@@ -1,5 +1,5 @@
-// RUN: %swift -emit-ir %s -enable-experimental-feature IsolatedAny -target x86_64-apple-macosx10.10 -disable-legacy-type-info -parse-stdlib | %FileCheck -DINT=i64 %s -check-prefixes=CHECK,CHECK-ACCESSOR
-// RUN: %swift -emit-ir %s -enable-experimental-feature IsolatedAny -target x86_64-unknown-linux-gnu -disable-legacy-type-info -parse-stdlib | %FileCheck -DINT=i64 %s -check-prefixes=CHECK,CHECK-DEMANGLE
+// RUN: %swift -emit-ir %s -target x86_64-apple-macosx10.10 -disable-legacy-type-info -parse-stdlib | %FileCheck -DINT=i64 %s -check-prefixes=CHECK,CHECK-ACCESSOR
+// RUN: %swift -emit-ir %s -target x86_64-unknown-linux-gnu -disable-legacy-type-info -parse-stdlib | %FileCheck -DINT=i64 %s -check-prefixes=CHECK,CHECK-DEMANGLE
 
 // REQUIRES: concurrency
 

--- a/test/IRGen/reflection_metadata_isolated_any.swift
+++ b/test/IRGen/reflection_metadata_isolated_any.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos99.99 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-PRESENT %s
+// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos14.4 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-SUPPRESSED %s
+
+// REQUIRES: OS=macosx
+// UNSUPPORTED: CPU=arm64e
+
+public struct MyStruct {
+  let fn: @isolated(any) () -> ()
+}
+
+// Make sure that we only emit a demangling-based type description
+// for @isolated(any) types when deploying to runtimes that support it.
+// If we don't, we fall back on using a type metadata accessor, which
+// is fine.  Since this is for reflective metadata, we could go a step
+// further if we decide we really only care about layout equivalence for
+// these; if so, we could just suppress the @isolated(any) part of the
+// type completely, since it has the the same external layout as an
+// ordinary function type.
+// rdar://129861211
+
+// CHECK-LABEL: @"$s32reflection_metadata_isolated_any8MyStructVMF" = internal constant
+// CHECK-PRESENT-SAME: ptr @"symbolic yyYAc"
+// CHECK-SUPPRESSED-SAME: ptr @"get_type_metadata yyYAc.1"

--- a/test/ModuleInterface/isolated_any_suppression.swift
+++ b/test/ModuleInterface/isolated_any_suppression.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -module-name isolated_any -emit-module -o %t/isolated_any.swiftmodule -emit-module-interface-path -  -enable-experimental-feature IsolatedAny %s | %FileCheck %s
-// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -module-name isolated_any -emit-module -o %t/isolated_any.swiftmodule -emit-module-interface-path -  -enable-experimental-feature IsolatedAny2 %s | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -module-name isolated_any -emit-module -o %t/isolated_any.swiftmodule -emit-module-interface-path - %s | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -module-name isolated_any -emit-module -o %t/isolated_any.swiftmodule -emit-module-interface-path - %s | %FileCheck %s
 
 // CHECK:      #if compiler(>=5.3) && $IsolatedAny
 // CHECK-NEXT: {{^}}public func test1(fn: @isolated(any) @Sendable () -> ())

--- a/test/Parse/isolated_any.swift
+++ b/test/Parse/isolated_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature IsolatedAny -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
 
 // REQUIRES: asserts
 

--- a/test/Parse/isolated_any_forbidden.swift
+++ b/test/Parse/isolated_any_forbidden.swift
@@ -1,3 +1,3 @@
 // RUN: %target-typecheck-verify-swift 
 
-typealias FnType = @isolated(any) () -> () // expected-error {{attribute requires '-enable-experimental-feature IsolatedAny'}}
+typealias FnType = @isolated(any) () -> ()

--- a/test/SILGen/isolated_any.swift
+++ b/test/SILGen/isolated_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature IsolatedAny %s -module-name test -swift-version 6 -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 6 -disable-availability-checking | %FileCheck %s
 // REQUIRES: concurrency
 // REQUIRES: asserts
 

--- a/test/SILGen/isolated_any_conformance.swift
+++ b/test/SILGen/isolated_any_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature IsolatedAny %s -module-name test -swift-version 6 -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 6 -disable-availability-checking | %FileCheck %s
 // REQUIRES: concurrency
 // REQUIRES: asserts
 

--- a/test/SILGen/isolated_any_invalid.swift
+++ b/test/SILGen/isolated_any_invalid.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature IsolatedAny %s -module-name test -swift-version 6 -disable-availability-checking -verify
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 6 -disable-availability-checking -verify
 // REQUIRES: concurrency
 
 func takeSyncIsolatedAny(fn: @escaping @isolated(any) () -> ()) {}

--- a/test/Sema/availability_isolated_any.swift
+++ b/test/Sema/availability_isolated_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50 -enable-experimental-feature IsolatedAny
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50
 
 // REQUIRES: OS=macosx
 

--- a/test/decl/protocol/conforms/isolated_any.swift
+++ b/test/decl/protocol/conforms/isolated_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -enable-experimental-feature IsolatedAny -verify %s
+// RUN: %target-swift-frontend -typecheck -verify %s
 
 struct A<T> {
   // expected-note @+1 {{candidate has non-matching type}}


### PR DESCRIPTION
Explanation: We were relying on this function for `@isolated(any)` mangling suppression, but it actually doesn't generate correct results for recent deployment targets. As a result, we treated e.g. macOS 14.4 as if it were completely unconstrained in terms of runtime availability.

I took this data from availability-macros.def; it's unfortunate that we can't just generate the implementation directly from that.

For the 6.0 branch, I've also pulled in @hborla's #74543, which promotes `@isolated(any)` to being a full language feature and removes the diagnostic requiring an experimental feature flag.

Scope: Common code path for several different features, but shouldn't impact anything except `@isolated(any)`
Risk: Low
Testing: Added a new test case
Issue: rdar://129861211
Reviewer: Slava Pestov
Main branch PR: #74675, #74543