### PR TITLE
caches: add `clang-features-file` to the install components

### DIFF
--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -124,6 +124,7 @@ set(CLANG_TOOLS
       clang
       clangd
       clang-deps-launcher
+      clang-features-file
       clang-format
       clang-resource-headers
       clang-scan-deps

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -129,6 +129,7 @@ set(CLANG_TOOLS
       clang
       clangd
       clang-deps-launcher
+      clang-features-file
       clang-format
       clang-resource-headers
       clang-scan-deps


### PR DESCRIPTION
This ensures that we distribute the features.json for clang in the toolchain distribution image which is used for building the image.