### PR TITLE
[region-isolation] Given a .none #isolation parameter, infer the isolation from the callee rather than the isolated parameter.

### DIFF
--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1767,3 +1767,30 @@ extension MyActor {
     }
   }
 }
+
+public struct TimeoutError: Error, CustomStringConvertible {
+  public var description: String { "Timed out" }
+}
+
+// We used to not merge the isolation below correctly causing us to emit a crash
+// due to undefined behavior. Make sure we do not crash or emit an unhandled
+// pattern error.
+public func doNotCrashOrEmitUnhandledPatternErrors<T: Sendable>(
+  _ duration: Duration,
+  _ body: @escaping @Sendable () async throws -> T
+) async throws -> T {
+  try await withThrowingTaskGroup(of: T.self) { taskGroup in
+    taskGroup.addTask {
+      try await Task.sleep(for: duration)
+      throw TimeoutError()
+    }
+    taskGroup.addTask {
+      return try await body()
+    }
+    for try await value in taskGroup {
+      taskGroup.cancelAll()
+      return value
+    }
+    throw CancellationError()
+  }
+}


### PR DESCRIPTION
Otherwise, we will have differing isolation from other parameters since the isolations will look different since one will have the .none value as an instance and the other will not have one and instead will rely on the AST isolation info. That is the correct behavior here since we do not actually have an actor here.

I also removed some undefined behavior in the merging code. The way the code should work is that we should check if the merge fails and in such a case emit an unknown pattern error... instead of not checking appropriately on the next iteration and hitting undefined behavior.

rdar://130396399
