### PR TITLE
[SILOptimizer] Handle existential_metatype in moveonlytype eliminator

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -198,6 +198,7 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   NO_UPDATE_NEEDED(ClassMethod)
   NO_UPDATE_NEEDED(FixLifetime)
   NO_UPDATE_NEEDED(AddressToPointer)
+  NO_UPDATE_NEEDED(ExistentialMetatype)
 #undef NO_UPDATE_NEEDED
 
   bool eliminateIdentityCast(SingleValueInstruction *svi) {

--- a/test/SILOptimizer/moveonly_type_eliminator.sil
+++ b/test/SILOptimizer/moveonly_type_eliminator.sil
@@ -36,6 +36,8 @@ struct KlassPair {
 
 sil @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
 
+protocol Error {}
+
 ///////////
 // Tests //
 ///////////
@@ -598,4 +600,16 @@ bb0(%x : @owned $Klass):
   dealloc_box %box : ${ var @moveOnly Klass }
   %retval = tuple ()
   return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @existential_metatype : $@convention(thin) (@guaranteed any Error) -> @thick any Error.Type {
+// CHECK:         [[EM:%.*]] = existential_metatype $@thick any Error.Type, {{%.*}} : $any Error
+// CHECK:         return [[EM]] : $@thick any Error.Type
+// CHECK-LABEL: } // end sil function 'existential_metatype'
+sil [ossa] @existential_metatype : $@convention(thin) (@guaranteed any Error) -> @thick any Error.Type {
+bb0(%x : @guaranteed $any Error):
+  %y = copyable_to_moveonlywrapper [guaranteed] %x : $any Error
+  %em = existential_metatype $@thick any Error.Type, %y : $@moveOnly (any Error)
+  debug_value %em : $@thick any Error.Type, var, name "s", argno 1, expr op_deref
+  return %em : $@thick any Error.Type
 }


### PR DESCRIPTION
Resolves: https://github.com/swiftlang/swift/issues/74628