### PR TITLE
[CachedDiagnostics] Optimize in case no diagnostics is emitted

### DIFF
--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -629,6 +629,11 @@ llvm::Error DiagnosticSerializer::deserializeDiagnosticInfo(
 
 llvm::Error
 DiagnosticSerializer::serializeEmittedDiagnostics(llvm::raw_ostream &os) {
+  // If no diagnostics is produced, do not write anything so output is smaller
+  // without referencing any files.
+  if (DiagInfos.empty())
+    return llvm::Error::success();
+
   // Convert all file backed source file into CASIDs.
   for (auto &File : Files) {
     if (!File.Content.empty() || !File.ContentCASID.empty())
@@ -822,12 +827,14 @@ CachingDiagnosticsProcessor::CachingDiagnosticsProcessor(
 
     // compress the YAML file.
     llvm::SmallVector<uint8_t, 512> Compression;
-    if (llvm::compression::zstd::isAvailable())
-      llvm::compression::zstd::compress(arrayRefFromStringRef(Output),
-                                        Compression);
-    else if (llvm::compression::zlib::isAvailable())
-      llvm::compression::zlib::compress(arrayRefFromStringRef(Output),
-                                        Compression);
+    if (!Output.empty()) {
+      if (llvm::compression::zstd::isAvailable())
+        llvm::compression::zstd::compress(arrayRefFromStringRef(Output),
+                                          Compression);
+      else if (llvm::compression::zlib::isAvailable())
+        llvm::compression::zlib::compress(arrayRefFromStringRef(Output),
+                                          Compression);
+    }
 
     // Write the uncompressed size in the end.
     if (!Compression.empty()) {
@@ -872,6 +879,10 @@ llvm::Error CachingDiagnosticsProcessor::serializeEmittedDiagnostics(
 
 llvm::Error
 CachingDiagnosticsProcessor::replayCachedDiagnostics(llvm::StringRef Buffer) {
+  // If empty buffer, no diagnostics to replay.
+  if (Buffer.empty())
+    return llvm::Error::success();
+
   SmallVector<uint8_t, 512> Uncompressed;
   if (llvm::compression::zstd::isAvailable() ||
       llvm::compression::zlib::isAvailable()) {


### PR DESCRIPTION
When no diagnostics is emitted from the compilation, just use an empty object as cached diagnostics. That is an optimization for storage to avoid emitting some supporting file to recreate source manager when not needed, also save a bit time from emitting YAML file.

rdar://128426132
