### PR TITLE
[6.0 🍒][Compile Time Constant Extraction] Ensure macro-expanded declarations are visited in WMO

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -549,6 +549,13 @@ gatherConstValuesForModule(const std::unordered_set<std::string> &Protocols,
   NominalTypeConformanceCollector ConformanceCollector(Protocols,
                                                        ConformanceDecls);
   Module->walk(ConformanceCollector);
+  // Visit macro expanded extensions
+  for (auto *FU : Module->getFiles())
+    if (auto *synthesizedSF = FU->getSynthesizedFile())
+      for (auto D : synthesizedSF->getTopLevelDecls())
+        if (isa<ExtensionDecl>(D))
+          D->walk(ConformanceCollector);
+
   for (auto *CD : ConformanceDecls)
     Result.emplace_back(evaluateOrDefault(CD->getASTContext().evaluator,
                                           ConstantValueInfoRequest{CD, Module},

--- a/test/ConstExtraction/ExtractFromMacroExpansion.swift
+++ b/test/ConstExtraction/ExtractFromMacroExpansion.swift
@@ -7,6 +7,10 @@
 // RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractFromMacroExpansion.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s -load-plugin-library %t/%target-library-name(MacroDefinition)
 // RUN: cat %t/ExtractFromMacroExpansion.swiftconstvalues 2>&1 | %FileCheck %s
 
+// Do the same, but ensure the WMO compilation flow produces the same result
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractFromMacroExpansionWMO.swiftconstvalues -const-gather-protocols-file %t/protocols.json -O %s -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: cat %t/ExtractFromMacroExpansionWMO.swiftconstvalues 2>&1 | %FileCheck %s
+
 protocol MyProto { }
 
 @freestanding(declaration, names: named(MacroAddedStruct))


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/74708
------------------
**Explanation**: When support for macro-expanded declarations was added to ConstExtract, it only ever applied to single-file compilation on a per-primary basis. Which means that the same code, when compiled in WMO, did not handle macro-generated extension declarations. This change brings WMO code-path in line with the per-primary extraction code path.

**Risk**: Low. WMO compilation will now match what happens per-primary in single-file compiles. 

**Testing**: Automated test added to the compiler test suite.

Resolves rdar://130036855
