### PR TITLE
[6.0 - stdlib] remove more deprecations added by SE-0426

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointerSlice.swift
+++ b/stdlib/public/core/UnsafeBufferPointerSlice.swift
@@ -389,9 +389,6 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   }
   @inlinable
   @_alwaysEmitIntoClient
-  @available(swift, deprecated: 6, message:
-    "Use the BitwiseCopyable-constrained overload"
-  )
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -629,9 +626,6 @@ extension Slice where Base == UnsafeRawBufferPointer {
   }
   @inlinable
   @_alwaysEmitIntoClient
-  @available(swift, deprecated: 6, message:
-    "Use the BitwiseCopyable-constrained overload"
-  )
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,
     as type: T.Type

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -450,9 +450,6 @@ extension Unsafe${Mutable}RawBufferPointer {
   }
 
   @_alwaysEmitIntoClient
-  @available(swift, deprecated: 6, message:
-    "Use the BitwiseCopyable-constrained overload"
-  )
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,
     as type: T.Type


### PR DESCRIPTION
Remove some deprecations introduced in [SE-0426](https://swiftlang.github.io/swift-evolution/#?proposal=SE-0426). Amendment was made to the proposal here: https://github.com/swiftlang/swift-evolution/pull/2469; this completes this completes https://github.com/swiftlang/swift/pull/73947 (cherry-picked in https://github.com/swiftlang/swift/pull/74015).

Addresses rdar://128709914
Original PR: https://github.com/swiftlang/swift/pull/74710
Risk: Very low. This only removes some newly-added deprecations.
Reviewer: @Azoy 