### PR TITLE
Do not require overriding this method

### DIFF
--- a/include/swift/RemoteInspection/DescriptorFinder.h
+++ b/include/swift/RemoteInspection/DescriptorFinder.h
@@ -126,7 +126,7 @@ struct DescriptorFinder {
   getFieldDescriptor(const TypeRef *TR) = 0;
 
   virtual std::unique_ptr<MultiPayloadEnumDescriptorBase>
-  getMultiPayloadEnumDescriptor(const TypeRef *TR) = 0;
+  getMultiPayloadEnumDescriptor(const TypeRef *TR) { abort(); };
 };
 
 } // namespace reflection


### PR DESCRIPTION
I'm working to fully remove this method, but because it's used and/or implemented in a few places, I'm backing it out incrementally. This just changes the abstract method so I can delete the implementors in a subsequent PR without breaking anything.
