### PR TITLE
[Sema] Penalize type mismatches that lead to @dynamicMemberLookup types

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2375,6 +2375,10 @@ private:
   llvm::SmallMapVector<ConstraintLocator *, ArrayRef<OpenedType>, 4>
       OpenedTypes;
 
+  /// A set of type variables representing opened generic types that have been
+  /// involved in type mismatch fixes.
+  llvm::SmallVector<TypeVariableType *, 4> MismatchedOpenedTypes;
+
   /// A dictionary of all conformances that have been looked up by the solver.
   llvm::DenseMap<std::pair<TypeBase *, ProtocolDecl *>, ProtocolConformanceRef>
       Conformances;
@@ -2890,6 +2894,9 @@ public:
 
     /// The length of \c OpenedTypes.
     unsigned numOpenedTypes;
+
+    /// The length of \c MismatchedOpenedTypes.
+    unsigned numMismatchedOpenedTypes;
 
     /// The length of \c OpenedExistentialTypes.
     unsigned numOpenedExistentialTypes;
@@ -4315,6 +4322,27 @@ public:
                 ConstraintLocatorBuilder locator);
 
 private:
+  /// Record mismatch in opened generic  type parameter.
+  void recordMismatchedOpenedType(TypeVariableType *type) {
+    MismatchedOpenedTypes.push_back(type);
+  }
+
+  /// Check whether type involves  any mismatched opened generic type parameters..
+  bool typeHasMismatchedOpenedType(Type type) {
+    if (MismatchedOpenedTypes.empty())
+      return false;
+    SmallPtrSet<TypeVariableType *, 2> variables;
+    type->getTypeVariables(variables);
+    for (auto tv : variables) {
+      auto rep = tv->getImpl().getRepresentative(nullptr);
+      for (auto mismatch : MismatchedOpenedTypes) {
+        if (mismatch->getImpl().getRepresentative(nullptr) == rep)
+          return true;
+      }
+    }
+    return false;
+  }
+
   /// "Open" an opaque archetype type, similar to \c openType.
   Type openOpaqueType(OpaqueTypeArchetypeType *type,
                       ConstraintLocatorBuilder locator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10413,7 +10413,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     if ((candidates.empty() ||
          allFromConditionalConformances(*this, instanceTy, candidates)) &&
         !isSelfRecursiveKeyPathDynamicMemberLookup(*this, baseTy,
-                                                   memberLocator)) {
+                                                   memberLocator) &&
+        !typeHasMismatchedOpenedType(instanceTy)) {
       auto &ctx = getASTContext();
 
       // Recursively look up `subscript(dynamicMember:)` methods in this type.
@@ -15291,6 +15292,14 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
 
       if (type2->getAnyNominal() == getASTContext().getOpaquePointerDecl())
         impact += 1;
+    }
+
+    // Record any opened generic types mismatched
+    SmallPtrSet<TypeVariableType *, 2> variables;
+    type2->getTypeVariables(variables);
+    for (auto tv : variables) {
+      if (tv->getImpl().getGenericParameter())
+        recordMismatchedOpenedType(tv);
     }
 
     return recordFix(fix, impact) ? SolutionKind::Error : SolutionKind::Solved;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -669,6 +669,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numAppliedDisjunctions = cs.AppliedDisjunctions.size();
   numArgumentMatchingChoices = cs.argumentMatchingChoices.size();
   numOpenedTypes = cs.OpenedTypes.size();
+  numMismatchedOpenedTypes = cs.MismatchedOpenedTypes.size();
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
   numOpenedPackExpansionTypes = cs.OpenedPackExpansionTypes.size();
   numPackExpansionEnvironments = cs.PackExpansionEnvironments.size();
@@ -748,6 +749,9 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any opened types.
   truncate(cs.OpenedTypes, numOpenedTypes);
+
+  // Remove any mismatched opened types.
+  truncate(cs.MismatchedOpenedTypes, numMismatchedOpenedTypes);
 
   // Remove any conformances solver had to fix along
   // the current path.

--- a/test/Constraints/issue-74700.swift
+++ b/test/Constraints/issue-74700.swift
@@ -1,0 +1,64 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Idable<ID> {
+  associatedtype ID
+  var id: ID { get }
+}
+
+@dynamicMemberLookup struct Binding<C> {
+  subscript(dynamicMember member: String) -> String { "" }
+}
+
+struct ForEach<Data, ID, Content> where Data : RandomAccessCollection, ID: Hashable {
+  init(_ data: Data, content: (Data.Element) -> Content) where ID == Data.Element.ID, Data.Element : Idable {}
+  // expected-note@-1 {{where 'Data.Element' = 'User'}}
+  init<C>(_ data: Binding<C>, content: (Binding<C.Element>) -> Content) where Data == Array<C>, ID == C.Element.ID, C : MutableCollection, C : RandomAccessCollection, C.Element : Idable, C.Index : Hashable {}
+}
+
+struct User {
+  let name: String // expected-note 3 {{'name' declared here}}
+  func member() {}
+}
+
+struct ContentView {
+  let users: [User] = []
+  func body() -> Void {
+    ForEach(users) { user in // expected-error {{initializer 'init(_:content:)' requires that 'User' conform to 'Idable'}}
+      return user.nam // expected-error {{value of type 'User' has no member 'nam'; did you mean 'name'?}}
+    }
+  }
+}
+
+
+@dynamicMemberLookup struct BindingB {
+  subscript(dynamicMember member: String) -> String { "" }
+}
+func test(_: String) {} // expected-note {{candidate expects value of type 'String' for parameter #1 (got 'Int')}}
+func test(_: BindingB) {} // expected-note {{candidate expects value of type 'BindingB' for parameter #1 (got 'Int')}}
+test(42) // expected-error {{no exact matches in call to global function 'test'}}
+
+
+func passThrough<T>(_ :T, _: (T) -> Void) {}
+func passThrough<T>(_ :Binding<T>, _: (Binding<T>) -> Void) {}
+func passThrough2<T>(_ : T, _: (T) -> Void) {}
+func takeString(_: String) {}
+func two<T>(_: T, _: T, _: (T) -> Void) {}
+func two<T>(_: Binding<T>, _: Binding<T>, _: (Binding<T>) -> Void) {}
+
+func f(s: String, i: Int, u: User, b: Binding<User>) {
+  passThrough(u) {
+    takeString($0.nam) // expected-error {{value of type 'User' has no member 'nam'}}
+    passThrough(b) { takeString($0.a) }
+  }
+  passThrough(u) {
+    passThrough2($0) { takeString($0.nam) }  // expected-error {{value of type 'User' has no member 'nam'}}
+  }
+  passThrough(b) {
+    takeString($0.name)
+    passThrough(s) { takeString($0) }
+    passThrough(i) { takeString($0) } // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+  }
+
+  two(u, b) { takeString($0.b) } // expected-error {{cannot convert value of type 'User' to expected argument type 'Binding<User>'}}
+  two(u, b) { $0.member() } // expected-error {{cannot convert value of type 'Binding<User>' to expected argument type 'User'}}
+}


### PR DESCRIPTION
Resolves #74700 

The problem with this issue is that the overload with a `Binding` parameter seems better because `Binding` has `@dynamicMemberLookup`, so the argument fix seems lower impact than the missing member error.

The change here is to use the same idea from param/argument fixes where if you get a second param fix on the same call, it is very unlikely to be the correct overload. Here, do the same thing for defaulting a generic parameter to Any. If we're defaulting a generic parameter in a call that already has an argument fix, it's not likely to be the correct overload.

The increase by `6` is the lowest amount that will give the correct diagnosis in the original issue code IF pull request <https://github.com/swiftlang/swift/pull/74692> gets merged (which raises the cost of inventing a member). Otherwise an increase by `4` would be enough.
