### PR TITLE
[cxx-interop] ensure destructors referenced only by the exception cle…

### DIFF
--- a/test/Interop/Cxx/class/throwing-constructor-destructor-cleanup-ref-irgen.swift
+++ b/test/Interop/Cxx/class/throwing-constructor-destructor-cleanup-ref-irgen.swift
@@ -1,0 +1,53 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swiftxx-frontend -emit-ir -I %t/Inputs -validate-tbd-against-ir=none %t/test.swift | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module ThrowingConstructorDestructorCleanupRef {
+  header "test.h"
+  requires cplusplus
+}
+//--- Inputs/test.h
+
+void testFunc(int x);
+
+template<class T>
+class HasDestructor {
+    T x = 0;
+public:
+
+    HasDestructor() { }
+    HasDestructor(const HasDestructor &other) : x(other.x) {}
+    inline ~HasDestructor() { testFunc(42); }
+};
+
+template<class T>
+class HasThrowingConstructor {
+    HasDestructor<T> m;
+public:
+    HasThrowingConstructor();
+    ~HasThrowingConstructor();
+    inline HasThrowingConstructor(const HasThrowingConstructor &f) : m(f.m) {
+        doSomethingThatMightThrow();
+    }
+
+    void doSomethingThatMightThrow();
+};
+
+inline void test33(const HasThrowingConstructor<int> x) {
+    
+}
+
+using HasThrowingConstructorInt = HasThrowingConstructor<int>;
+
+//--- test.swift
+
+import ThrowingConstructorDestructorCleanupRef
+
+public func test() {
+  let x = HasThrowingConstructorInt()
+  test33(x)
+}
+
+// Make sure we reach the destructor of 'HasDestructor'
+// CHECK: define linkonce_odr {{.*}} @{{_ZN13HasDestructorIiED2Ev|"\?\?1\?\$HasDestructor@H@@QEAA@XZ"}}


### PR DESCRIPTION
…anup landing pad in the constructor's initializer are picked up to be candidates for potential emission into one LLVM IR module

A C++ record destructor that is called implicitly in the landing pad cleanup code of a constructor after a field is initialized might only be referenced there, so the Clang decl finder should pick it up when scanning the AST for interesting Decls that might have to be emitted into one LLVM IR module.
