### PR TITLE
[NFC] Adjust CODEOWNERS after transfer to `swiftlang`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -144,7 +144,7 @@
 # TODO: /localization
 
 # stdlib
-/stdlib/                                  @apple/standard-librarians
+/stdlib/                                  @swiftlang/standard-librarians
 /stdlib/public/Backtracing/               @al45tair
 /stdlib/public/Concurrency/               @ktoso
 /stdlib/public/Cxx/                       @zoecarver @hyp @egorzhdan
@@ -181,14 +181,14 @@
 /test/Sema/moveonly*                                @kavon
 /test/SourceKit/                                    @ahoppen @bnbarham @hamishknight @rintaro
 /test/SymbolGraph/                                  @QuietMisdreavus
-/test/abi/                                          @apple/standard-librarians
+/test/abi/                                          @swiftlang/standard-librarians
 /test/decl/                                         @hborla @slavapestov
 /test/decl/protocol/                                @AnthonyLatsis @hborla @slavapestov
 # FIXME: This file could have a dedicated directory.
 /test/decl/protocol/special/DistributedActor.swift  @ktoso
 /test/expr/                                         @hborla @slavapestov @xedin
 /test/refactoring/                                  @ahoppen @bnbarham @hamishknight @rintaro
-/test/stdlib/                                       @apple/standard-librarians
+/test/stdlib/                                       @swiftlang/standard-librarians
 /test/stmt/                                         @hborla @xedin
 /test/type/                                         @hborla @slavapestov @xedin
 
@@ -232,4 +232,4 @@
 # TODO: /validation-test/SILGen/
 # TODO: /validation-test/SILOptimizer/
 /validation-test/Sema/                    @hborla @slavapestov @xedin
-/validation-test/stdlib/                  @apple/standard-librarians
+/validation-test/stdlib/                  @swiftlang/standard-librarians


### PR DESCRIPTION
...assuming this team made it to `swiftlang` together with the repository.