### PR TITLE
🍒[cxx-interop] Reenable exporting Foreign Reference Types to C++ 

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -282,25 +282,6 @@ public:
           os << " __strong";
         printInoutTypeModifier();
       }
-      if (isa<clang::CXXRecordDecl>(cd->getClangDecl())) {
-        if (std::find_if(
-                cd->getClangDecl()->getAttrs().begin(),
-                cd->getClangDecl()->getAttrs().end(), [](clang::Attr *attr) {
-                  if (auto *sa = dyn_cast<clang::SwiftAttrAttr>(attr)) {
-                    llvm::StringRef value = sa->getAttribute();
-                    if ((value.starts_with("retain:") ||
-                         value.starts_with("release:")) &&
-                        !value.endswith(":immortal"))
-                      return true;
-                  }
-                  return false;
-                }) != cd->getClangDecl()->getAttrs().end()) {
-          // This is a shared FRT. Do not bridge it back to
-          // C++ as its ownership is not managed automatically
-          // in C++ yet.
-          return ClangRepresentation::unsupported;
-        }
-      }
       // FIXME: Mark that this is only ObjC representable.
       return ClangRepresentation::representable;
     }

--- a/test/Interop/CxxToSwiftToCxx/allow-shared-frt-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/allow-shared-frt-back-to-cxx.swift
@@ -29,6 +29,6 @@ import CxxTest
 public func consumeSharedFRT(_ x: consuming SharedFRT) {}
 public func takeSharedFRT(_ x: SharedFRT) {}
 
-// CHECK: Unavailable in C++: Swift global function 'consumeSharedFRT(_:)'.
+// CHECK: SWIFT_EXTERN void $s8UseCxxTy16consumeSharedFRTyySo0eF0VnF(SharedFRT *_Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // consumeSharedFRT(_:)
 
-// CHECK: Unavailable in C++: Swift global function 'takeSharedFRT(_:)'.
+// CHECK: SWIFT_EXTERN void $s8UseCxxTy13takeSharedFRTyySo0eF0VF(SharedFRT *_Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // takeSharedFRT(_:)


### PR DESCRIPTION
Explanation:
This feature worked prior 5.10 but the semantics was undefined. This PR restores the behavior with the old semantics, and a separate PR will update the documentation to describe the behavior.
Scope: C++ Interop
Risk: Low, this PR restores previous behavior that used to work, added tests to validate the expected semantics.
Testing: Added a regression test.
Issue: rdar://129420670
Reviewer: @rjmccall
Original PR: https://github.com/swiftlang/swift/pull/74654