### PR TITLE
[CMake] Exclude swift-syntax targets from 'all'

### DIFF
--- a/lib/CompilerSwiftSyntax/CMakeLists.txt
+++ b/lib/CompilerSwiftSyntax/CMakeLists.txt
@@ -25,6 +25,10 @@ function(includeSwiftSyntax)
   file(TO_CMAKE_PATH "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}" swift_syntax_path)
   FetchContent_Declare(CompilerSwiftSyntax SOURCE_DIR "${swift_syntax_path}")
   FetchContent_MakeAvailable(CompilerSwiftSyntax)
+
+  # FIXME: Use FetchContent_Declare's EXCLUDE_FROM_ALL after CMake 3.28
+  FetchContent_GetProperties(CompilerSwiftSyntax BINARY_DIR binary_dir)
+  set_property(DIRECTORY "${binary_dir}" PROPERTY EXCLUDE_FROM_ALL TRUE)
 endfunction()
 includeSwiftSyntax()
 

--- a/lib/SwiftSyntax/CMakeLists.txt
+++ b/lib/SwiftSyntax/CMakeLists.txt
@@ -24,6 +24,10 @@ file(TO_CMAKE_PATH "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}" swift_syntax_path)
 FetchContent_Declare(SwiftSyntax SOURCE_DIR "${swift_syntax_path}")
 FetchContent_MakeAvailable(SwiftSyntax)
 
+# FIXME: Use FetchContent_Declare's EXCLUDE_FROM_ALL after CMake 3.28
+FetchContent_GetProperties(SwiftSyntax BINARY_DIR binary_dir)
+set_property(DIRECTORY "${binary_dir}" PROPERTY EXCLUDE_FROM_ALL TRUE)
+
 # Install swift-syntax libraries.
 set(SWIFT_SYNTAX_MODULES
   SwiftBasicFormat


### PR DESCRIPTION
All targets in `swift-syntax` included via `FetchContent` are for some dependencies. They should not be included in `all`