### PR TITLE
[swift-syntax] Update for underscored product names

### DIFF
--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -57,7 +57,7 @@ let package = Package(
     .target(
       name: "swiftASTGen",
       dependencies: [
-        .product(name: "SwiftCompilerPluginMessageHandling", package: "swift-syntax"),
+        .product(name: "_SwiftCompilerPluginMessageHandling", package: "swift-syntax"),
         .product(name: "SwiftDiagnostics", package: "swift-syntax"),
         .product(name: "SwiftOperators", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),

--- a/tools/swift-plugin-server/Package.swift
+++ b/tools/swift-plugin-server/Package.swift
@@ -18,15 +18,15 @@ let package = Package(
     .executableTarget(
       name: "swift-plugin-server",
       dependencies: [
-        .product(name: "SwiftCompilerPluginMessageHandling", package: "swift-syntax"),
-        .product(name: "SwiftLibraryPluginProvider", package: "swift-syntax"),
+        .product(name: "_SwiftCompilerPluginMessageHandling", package: "swift-syntax"),
+        .product(name: "_SwiftLibraryPluginProvider", package: "swift-syntax"),
       ]
     ),
     .target(
       name: "SwiftInProcPluginServer",
       dependencies: [
-        .product(name: "SwiftCompilerPluginMessageHandling", package: "swift-syntax"),
-        .product(name: "SwiftLibraryPluginProvider", package: "swift-syntax"),
+        .product(name: "_SwiftCompilerPluginMessageHandling", package: "swift-syntax"),
+        .product(name: "_SwiftLibraryPluginProvider", package: "swift-syntax"),
       ]
     ),
   ],


### PR DESCRIPTION
`SwiftCompilerPluginMessageHandling ` and `SwiftLibraryPluginProvider` _product_ are going to be underscored
Update for https://github.com/swiftlang/swift-syntax/pull/2703

NFC for CMake builds because SwiftPM's product names are only used for local development.