### PR TITLE
[Concurrency] Clear current task TSD before enqueuing task in swift_task_switch.

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -2139,8 +2139,8 @@ static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContex
       "switch failed, task %p enqueued on executor %p (task executor: %p)",
       task, newExecutor.getIdentity(), currentTaskExecutor.getIdentity());
 
-  task->flagAsAndEnqueueOnExecutor(newExecutor);
   _swift_task_clearCurrent();
+  task->flagAsAndEnqueueOnExecutor(newExecutor);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
The executor may execute and free the task while the enqueue code is still finishing up. If that code tries to get an async backtrace (for example, if it calls malloc/free with malloc stack logging enabled) then it will find a dangling pointer in the current task TSD, and dereferencing it may crash.

rdar://130125017