### PR TITLE
[6.0] tests: add a missing codesign in devirtualize_existential.swift

### DIFF
--- a/test/SILOptimizer/devirtualize_existential.swift
+++ b/test/SILOptimizer/devirtualize_existential.swift
@@ -2,6 +2,7 @@
 
 // RUN: %empty-directory(%t) 
 // RUN: %target-build-swift -wmo -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -module-name=test %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
 // REQUIRES: executable_test
 


### PR DESCRIPTION
* **Explanation**: Fixes a test which was added in https://github.com/swiftlang/swift/pull/74653
* **Risk**: Zero. Just fixes a test
* **Issue**: rdar://130528110
* **Reviewer**:  @slavapestov 
* **Main branch PR**: https://github.com/swiftlang/swift/pull/74728
