### PR TITLE
[test] Fix test for cases where TMPDIR shares a prefix with CWD

### DIFF
--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -167,7 +167,7 @@ func testFileID(a: Int, b: Int) {
     // CHECK-IR-DAG: ![[L1:[0-9]+]] = distinct !DILocation(line: [[@LINE+4]], column: 5
     // CHECK-IR-DAG: ![[L2:[0-9]+]] = distinct !DILocation({{.*}}inlinedAt: ![[L1]])
     // CHECK-IR-DAG: !DIFile(filename: "{{.*}}@__swiftmacro_9MacroUser0023macro_expandswift_elFCffMX{{.*}}_12customFileIDfMf_.swift", {{.*}}source: "{{.*}}MacroUser/macro_expand.swift{{.*}}// original-source-range: {{.*}}")
-    // CHECK-IR-DWARF4: {{(target triple = .*-unknown-windows-msvc)|(!DIFile\(filename: ".*generated-.*@__swiftmacro_9MacroUser0023macro_expandswift_elFCffMX.*_12customFileIDfMf_.swift", directory: ""\))}}
+    // CHECK-IR-DWARF4: {{(target triple = .*-unknown-windows-msvc)|(!DIFile\(filename: ".*generated-.*@__swiftmacro_9MacroUser0023macro_expandswift_elFCffMX.*_12customFileIDfMf_.swift", directory: "[^"]*"\))}}
     #addBlocker(
       #stringify(a - b)
       )


### PR DESCRIPTION
There is code in `IRGenDebugInfo.cpp` ([1]) that tries to move the common part of the `filename` into the `directory`. If this test is build with a temporary directory that shares a prefix with the current working directory, the common part of the path will be moved into `directory`, but since the test checks for an empty directory, it will fail the test, even if the results are correct. This situation is not uncommon in CI setups where each job might have an isolated temporary directory sharing a prefix with the current working directory (example: `/ci/build/XXX/tmp` and `/ci/build/XXX/cwd`).

Modify the regex to allow anything in the `directory` value, since it is not really important to test the exact value of `directory` to prove that the debug information is generated.

[1]: https://github.com/swiftlang/swift/blob/9c4232c89d8adf9068efb53105e95d14a00b2505/lib/IRGen/IRGenDebugInfo.cpp?fbclid=IwZXh0bgNhZW0CMTEAAR1eg4aiepWRUGYPzTe4KnjDId-PmyM0CYsG6wHOKTgXwvPKDP46BFWOU4U_aem_1A9mSFYy41hgN1V6RijBKA#L564-L585