### PR TITLE
Platform: add `sys_xattr` module for Android

### DIFF
--- a/stdlib/public/Platform/SwiftAndroidNDK.h
+++ b/stdlib/public/Platform/SwiftAndroidNDK.h
@@ -143,6 +143,7 @@
 #include <sys/user.h>
 #include <sys/utsname.h>
 #include <sys/wait.h>
+#include <sys/xattr.h>
 
 #include <android/api-level.h>
 #include <android/asset_manager_jni.h>

--- a/stdlib/public/Platform/android.modulemap
+++ b/stdlib/public/Platform/android.modulemap
@@ -282,6 +282,10 @@ module posix_filesystem [system] {
     header "sys/uio.h"
     export *
   }
+  explicit module sys_xattr {
+    header "sys/xattr.h"
+    export *
+  }
 }
 
 module dl [system] {


### PR DESCRIPTION
This module was left out from the modulariation pass. The declarations here are required for building swift-foundation for Android.