### PR TITLE
[IRGen] Always use os version from swift invocation in IRGen

### DIFF
--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -240,7 +240,7 @@ namespace swift {
 
   /// Get the CPU, subtarget feature options, and triple to use when emitting code.
   std::tuple<llvm::TargetOptions, std::string, std::vector<std::string>,
-             std::string>
+             llvm::Triple>
   getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx);
 
   /// Turn the given Swift module into LLVM IR and return the generated module.

--- a/lib/Immediate/SwiftMaterializationUnit.cpp
+++ b/lib/Immediate/SwiftMaterializationUnit.cpp
@@ -146,14 +146,14 @@ llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>>
 SwiftJIT::CreateLLJIT(CompilerInstance &CI) {
   llvm::TargetOptions TargetOpt;
   std::string CPU;
-  std::string Triple;
+  llvm::Triple Triple;
   std::vector<std::string> Features;
   const auto &Invocation = CI.getInvocation();
   const auto &IRGenOpts = Invocation.getIRGenOptions();
   auto &Ctx = CI.getASTContext();
   std::tie(TargetOpt, CPU, Features, Triple) =
       getIRTargetOptions(IRGenOpts, Ctx);
-  auto JTMB = llvm::orc::JITTargetMachineBuilder(llvm::Triple(Triple))
+  auto JTMB = llvm::orc::JITTargetMachineBuilder(Triple)
                   .setRelocationModel(llvm::Reloc::PIC_)
                   .setOptions(std::move(TargetOpt))
                   .setCPU(std::move(CPU))

--- a/test/CAS/clang-target-codegen.swift
+++ b/test/CAS/clang-target-codegen.swift
@@ -1,0 +1,51 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -target arm64-apple-macos11 -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/test.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas \
+// RUN:   -I %t/include -clang-target arm64-apple-macos13
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/a.cmd
+// RUN: %swift_frontend_plain @%t/a.cmd
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Foo > %t/foo.cmd
+// RUN: %swift_frontend_plain @%t/foo.cmd
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+
+// RUN: %target-swift-frontend -c -o %t/test.o -target arm64-apple-macos11 \
+// RUN:   -cache-compile-job -cas-path %t/cas \
+// RUN:   -disable-implicit-swift-modules -swift-version 5 -parse-stdlib -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   %t/test.swift @%t/MyApp.cmd
+
+// RUN: llvm-objdump --macho --all-headers %t/test.o | %FileCheck %s
+
+// CHECK: cmd LC_BUILD_VERSION
+// CHECK-NEXT:   cmdsize
+// CHECK-NEXT:  platform macos
+// CHECK-NEXT:       sdk
+// CHECK-NEXT:     minos 11.0
+
+//--- include/module.modulemap
+module A {
+  header "a.h"
+  export *
+}
+//--- include/a.h
+void a(void);
+
+//--- include/Foo.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target arm64-apple-macos13 -enable-library-evolution -swift-version 5 -O -module-name Foo -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib
+import A
+public func foo()
+
+//--- test.swift
+import Foo


### PR DESCRIPTION
Do not infer IRGen target from clang importer. `-clang-target` can give it a different OS version for importing clang Decls and that triple should not be used to generate code.

rdar://130547690