### PR TITLE
[6.0] [Sema] Pass down ProtocolConformance to DerivedConformance

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2488,9 +2488,8 @@ AssociatedTypeInference::computeDefaultTypeWitness(
 }
 
 static std::pair<Type, TypeDecl *>
-deriveTypeWitness(DeclContext *DC,
-                  NominalTypeDecl *TypeDecl,
-                  AssociatedTypeDecl *AssocType) {
+deriveTypeWitness(const NormalProtocolConformance *Conformance,
+                  NominalTypeDecl *TypeDecl, AssociatedTypeDecl *AssocType) {
   auto *protocol = cast<ProtocolDecl>(AssocType->getDeclContext());
 
   auto knownKind = protocol->getKnownProtocolKind();
@@ -2498,10 +2497,7 @@ deriveTypeWitness(DeclContext *DC,
   if (!knownKind)
     return std::make_pair(nullptr, nullptr);
 
-  auto Decl = DC->getInnermostDeclarationDeclContext();
-
-  DerivedConformance derived(TypeDecl->getASTContext(), Decl, TypeDecl,
-                             protocol);
+  DerivedConformance derived(Conformance, TypeDecl, protocol);
   switch (*knownKind) {
   case KnownProtocolKind::RawRepresentable:
     return std::make_pair(derived.deriveRawRepresentable(AssocType), nullptr);
@@ -2535,7 +2531,7 @@ AssociatedTypeInference::computeDerivedTypeWitness(
     return std::make_pair(Type(), nullptr);
 
   // Try to derive the type witness.
-  auto result = deriveTypeWitness(dc, derivingTypeDecl, assocType);
+  auto result = deriveTypeWitness(conformance, derivingTypeDecl, assocType);
   if (!result.first)
     return std::make_pair(Type(), nullptr);
 

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -984,19 +984,17 @@ void DerivedConformance::tryDiagnoseFailedHashableDerivation(
 }
 
 ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
-  ASTContext &C = ConformanceDecl->getASTContext();
-
   // var hashValue: Int
-  if (requirement->getBaseName() == C.Id_hashValue) {
+  if (requirement->getBaseName() == Context.Id_hashValue) {
     // We always allow hashValue to be synthesized; invalid cases are diagnosed
     // during hash(into:) synthesis.
     return deriveHashable_hashValue(*this);
   }
 
   // Hashable.hash(into:)
-  if (requirement->getBaseName() == C.Id_hash) {
+  if (requirement->getBaseName() == Context.Id_hash) {
     // Start by resolving hashValue conformance.
-    auto hashValueReq = getHashValueRequirement(C);
+    auto hashValueReq = getHashValueRequirement(Context);
     auto conformance = getHashableConformance(ConformanceDecl);
     auto hashValueDecl = conformance->getWitnessDecl(hashValueReq);
     if (!hashValueDecl) {
@@ -1010,7 +1008,7 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
       
       // Refuse to synthesize Hashable if type isn't a struct or enum, or if it
       // has non-Hashable stored properties/associated values.
-      auto hashableProto = C.getProtocol(KnownProtocolKind::Hashable);
+      auto hashableProto = Context.getProtocol(KnownProtocolKind::Hashable);
       if (!canDeriveConformance(getConformanceContext(), Nominal,
                                 hashableProto)) {
         ConformanceDecl->diagnose(diag::type_does_not_conform,

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -952,20 +952,6 @@ getHashValueRequirement(ASTContext &C) {
   return nullptr;
 }
 
-static ProtocolConformance *
-getHashableConformance(const Decl *parentDecl) {
-  ASTContext &C = parentDecl->getASTContext();
-  const auto IDC = cast<IterableDeclContext>(parentDecl);
-  auto hashableProto = C.getProtocol(KnownProtocolKind::Hashable);
-  for (auto conformance: IDC->getLocalConformances(
-           ConformanceLookupKind::NonStructural)) {
-    if (conformance->getProtocol() == hashableProto) {
-      return conformance;
-    }
-  }
-  return nullptr;
-}
-
 bool DerivedConformance::canDeriveHashable(NominalTypeDecl *type) {
   // FIXME: This is not actually correct. We cannot promise to always
   // provide a witness here in all cases. Unfortunately, figuring out
@@ -995,8 +981,7 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
   if (requirement->getBaseName() == Context.Id_hash) {
     // Start by resolving hashValue conformance.
     auto hashValueReq = getHashValueRequirement(Context);
-    auto conformance = getHashableConformance(ConformanceDecl);
-    auto hashValueDecl = conformance->getWitnessDecl(hashValueReq);
+    auto hashValueDecl = Conformance->getWitnessDecl(hashValueReq);
     if (!hashValueDecl) {
       // We won't derive hash(into:) if hashValue cannot be resolved.
       // The hashValue failure will produce a diagnostic elsewhere.

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -279,7 +279,7 @@ void DerivedConformance::diagnoseIfSynthesisUnsupportedForDecl(
 ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
                                                        ValueDecl *requirement) {
   // Note: whenever you update this function, also update
-  // TypeChecker::deriveProtocolRequirement.
+  // deriveProtocolRequirement.
   ASTContext &ctx = nominal->getASTContext();
   const auto name = requirement->getName();
 

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -28,20 +28,23 @@ using namespace swift;
 
 enum NonconformingMemberKind { AssociatedValue, StoredProperty };
 
-DerivedConformance::DerivedConformance(ASTContext &ctx, Decl *conformanceDecl,
-                                       NominalTypeDecl *nominal,
-                                       ProtocolDecl *protocol)
-    : Context(ctx), ConformanceDecl(conformanceDecl), Nominal(nominal),
-      Protocol(protocol) {
-  assert(getConformanceContext()->getSelfNominalTypeDecl() == nominal);
+DerivedConformance::DerivedConformance(
+    const NormalProtocolConformance *conformance, NominalTypeDecl *nominal,
+    ProtocolDecl *protocol)
+    : Context(nominal->getASTContext()), Conformance(conformance),
+      Nominal(nominal), Protocol(protocol) {
+  auto *DC = Conformance->getDeclContext();
+  ConformanceDecl = DC->getInnermostDeclarationDeclContext();
+  assert(ConformanceDecl);
+  assert(DC->getSelfNominalTypeDecl() == nominal);
 }
 
 DeclContext *DerivedConformance::getConformanceContext() const {
-  return cast<DeclContext>(ConformanceDecl);
+  return Conformance->getDeclContext();
 }
 
 ModuleDecl *DerivedConformance::getParentModule() const {
-  return cast<DeclContext>(ConformanceDecl)->getParentModule();
+  return getConformanceContext()->getParentModule();
 }
 
 void DerivedConformance::addMembersToConformanceContext(

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -55,11 +55,12 @@ public:
 
 public:
   ASTContext &Context;
+  const NormalProtocolConformance *Conformance;
   Decl *ConformanceDecl;
   NominalTypeDecl *Nominal;
   ProtocolDecl *Protocol;
 
-  DerivedConformance(ASTContext &ctx, Decl *conformanceDecl,
+  DerivedConformance(const NormalProtocolConformance *conformance,
                      NominalTypeDecl *nominal, ProtocolDecl *protocol);
 
   /// Retrieve the context in which the conformance is declared (either the

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4499,9 +4499,9 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   return ResolveWitnessResult::ExplicitFailed;
 }
 
-static ValueDecl *deriveProtocolRequirement(DeclContext *DC,
-                                            NominalTypeDecl *TypeDecl,
-                                            ValueDecl *Requirement) {
+static ValueDecl *
+deriveProtocolRequirement(const NormalProtocolConformance *Conformance,
+                          NominalTypeDecl *TypeDecl, ValueDecl *Requirement) {
   // Note: whenever you update this function, also update
   // DerivedConformance::getDerivableRequirement.
   const auto protocol = cast<ProtocolDecl>(Requirement->getDeclContext());
@@ -4510,12 +4510,12 @@ static ValueDecl *deriveProtocolRequirement(DeclContext *DC,
   if (!derivableKind)
     return nullptr;
 
+  auto *DC = Conformance->getDeclContext();
   const auto Decl = DC->getInnermostDeclarationDeclContext();
   if (Decl->isInvalid())
     return nullptr;
 
-  DerivedConformance derived(TypeDecl->getASTContext(), Decl, TypeDecl,
-                             protocol);
+  DerivedConformance derived(Conformance, TypeDecl, protocol);
 
   switch (*derivableKind) {
   case KnownDerivableProtocolKind::RawRepresentable:
@@ -4596,7 +4596,8 @@ ResolveWitnessResult ConformanceChecker::resolveWitnessViaDerivation(
   }
 
   // Attempt to derive the witness.
-  auto derived = deriveProtocolRequirement(DC, derivingTypeDecl, requirement);
+  auto derived =
+      deriveProtocolRequirement(Conformance, derivingTypeDecl, requirement);
 
   if (!derived) {
     return ResolveWitnessResult::ExplicitFailed;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -826,21 +826,6 @@ void checkConformancesInContext(IterableDeclContext *idc);
 /// Check that the type of the given property conforms to NSCopying.
 ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var);
 
-/// Derive an implicit declaration to satisfy a requirement of a derived
-/// protocol conformance.
-///
-/// \param DC           The declaration context where the conformance was
-///                     defined, either the type itself or an extension
-/// \param TypeDecl     The type for which the requirement is being derived.
-/// \param Requirement  The protocol requirement.
-///
-/// \returns nullptr if the derivation failed, or the derived declaration
-///          if it succeeded. If successful, the derived declaration is added
-///          to TypeDecl's body.
-ValueDecl *deriveProtocolRequirement(DeclContext *DC,
-                                     NominalTypeDecl *TypeDecl,
-                                     ValueDecl *Requirement);
-
 /// \name Name lookup
 ///
 /// Routines that perform name lookup.


### PR DESCRIPTION
*6.0 cherry-pick of #74680 (minus the last commit)*

- Explanation: Fixes a crash that could occur when attempting to synthesize a Hashable conformance
- Scope: Affects Hashable conformance synthesis
- Issue: rdar://129620291
- Risk: Low, the fix is fairly straightforward
- Testing: No test unfortunately as haven't been able to come up with a reproducer, passes the existing test suite
- Reviewer: Pavel Yaskevich