### PR TITLE
[6.0 🍒][Parseable Output] Make Emit-Module tasks indicate their name accordingly, instead of `compile`

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -598,6 +598,8 @@ mapFrontendInvocationToAction(const CompilerInvocation &Invocation) {
         return "backend";
       else
         return "compile";
+    case FrontendOptions::ActionType::EmitModuleOnly:
+      return "emit-module";
     default:
       return "compile";
   }
@@ -634,7 +636,8 @@ static swift::file_types::ID computeFileTypeForPath(const StringRef Path) {
 static DetailedTaskDescription
 constructDetailedTaskDescription(const CompilerInvocation &Invocation,
                                  ArrayRef<InputFile> PrimaryInputs,
-                                 ArrayRef<const char *> Args) {
+                                 ArrayRef<const char *> Args,
+                                 bool isEmitModuleOnly = false) {
   // Command line and arguments
   std::string Executable = Invocation.getFrontendOptions().MainExecutablePath;
   SmallVector<std::string, 16> Arguments;
@@ -653,10 +656,12 @@ constructDetailedTaskDescription(const CompilerInvocation &Invocation,
   }
 
   for (const auto &input : PrimaryInputs) {
-    // Main outputs
-    auto OutputFile = input.outputFilename();
-    if (!OutputFile.empty())
-      Outputs.push_back(OutputPair(computeFileTypeForPath(OutputFile), OutputFile));
+    if (!isEmitModuleOnly) {
+      // Main per-input outputs
+      auto OutputFile = input.outputFilename();
+      if (!OutputFile.empty())
+        Outputs.push_back(OutputPair(computeFileTypeForPath(OutputFile), OutputFile));
+    }
 
     // Supplementary outputs
     const auto &primarySpecificFiles = input.getPrimarySpecificPaths();
@@ -2335,10 +2340,14 @@ int swift::performFrontend(ArrayRef<const char *> Args,
         return false;
       });
     } else {
-      // If no primary inputs are present, we are in WMO.
+      // If no primary inputs are present, we are in WMO or EmitModule.
+      bool isEmitModule =
+        Invocation.getFrontendOptions().RequestedAction ==
+          FrontendOptions::ActionType::EmitModuleOnly;
       emitBeganMessage(llvm::errs(),
                        mapFrontendInvocationToAction(Invocation),
-                       constructDetailedTaskDescription(Invocation, IO.getAllInputs(), Args),
+                       constructDetailedTaskDescription(Invocation, IO.getAllInputs(),
+                                                        Args, isEmitModule),
                        OSPid, ProcInfo);
     }
   };

--- a/test/Frontend/parseable_output.swift
+++ b/test/Frontend/parseable_output.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.json -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -c -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.json -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
 // Check without primary files (WMO):
-// RUN: %target-swift-frontend %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.json -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -c %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.json -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {

--- a/test/Frontend/parseable_output_batch.swift
+++ b/test/Frontend/parseable_output_batch.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: touch %t/test.swift
 // RUN: echo 'func foo() {}' > %t/test.swift
-// RUN: %target-swift-frontend -primary-file %s -primary-file %t/test.swift -o %t.out -o test.tmp.out -module-name parseable_output_batch -emit-module -emit-module-path %t.swiftmodule -module-name test -emit-module -emit-module-path test.tmp.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -c -primary-file %s -primary-file %t/test.swift -o %t.out -o test.tmp.out -module-name parseable_output_batch -emit-module -emit-module-path %t.swiftmodule -module-name test -emit-module -emit-module-path test.tmp.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
 
 // Despite only one frontend invocation, two compile jobs are "begin" and "finish", using quasi-PIDs, on per-primary and its outputs.
 

--- a/test/Frontend/parseable_output_early.swift
+++ b/test/Frontend/parseable_output_early.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %/S/../ModuleInterface/Inputs/BadStdlib.sdk -module-cache-path %/t/module-cache -resource-dir %/S/../ModuleInterface/Inputs/BadStdlib.sdk) -primary-file %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -module-name parseable_output_early -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %/S/../ModuleInterface/Inputs/BadStdlib.sdk -module-cache-path %/t/module-cache -resource-dir %/S/../ModuleInterface/Inputs/BadStdlib.sdk) -c -primary-file %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -module-name parseable_output_early -frontend-parseable-output 2>&1 | %FileCheck %s
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {

--- a/test/Frontend/parseable_output_emit_module.swift
+++ b/test/Frontend/parseable_output_emit_module.swift
@@ -1,0 +1,56 @@
+// RUN: %target-swift-frontend -emit-module %s %S/Inputs/filelist-other.swift -module-name parseable_output_emit_module -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.json -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
+
+// CHECK: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "began",
+// CHECK-NEXT:   "name": "emit-module",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}} {{.*}} -emit-module {{.*[\\/]}}parseable_output_emit_module.swift {{.*[\\/]}}filelist-other.swift -module-name parseable_output_emit_module -empty-abi-descriptor -emit-abi-descriptor-path {{.*[\\/]}}parseable_output_emit_module.swift.tmp.abi.json -emit-module -emit-module-path {{.*[\\/]}}parseable_output_emit_module.swift.tmp.swiftmodule -serialize-diagnostics -serialize-diagnostics-path {{.*[\\/]}}parseable_output_emit_module.swift.tmp.dia -frontend-parseable-output",
+// CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{(-frontend|c)?(\.exe)?}}",
+// CHECK-NEXT:   "command_arguments": [
+// CHECK:          "{{.*[\\/]}}parseable_output_emit_module.swift",
+// CHECK-NEXT:     "{{.*[\\/]}}filelist-other.swift",
+// CHECK-NEXT:     "-module-name",
+// CHECK-NEXT:     "parseable_output_emit_module",
+// CHECK-NEXT:     "-empty-abi-descriptor",
+// CHECK-NEXT:     "-emit-abi-descriptor-path",
+// CHECK-NEXT:     "{{.*[\\/]}}parseable_output_emit_module.swift.tmp.abi.json",
+// CHECK-NEXT:     "-emit-module",
+// CHECK-NEXT:     "-emit-module-path",
+// CHECK-NEXT:     "{{.*[\\/]}}parseable_output_emit_module.swift.tmp.swiftmodule",
+// CHECK-NEXT:     "-serialize-diagnostics",
+// CHECK-NEXT:     "-serialize-diagnostics-path"
+// CHECK-NEXT:     "{{.*[\\/]}}parseable_output_emit_module.swift.tmp.dia",
+// CHECK-NEXT:     "-frontend-parseable-output"
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "inputs": [
+// CHECK-NEXT:       "{{.*[\\/]}}parseable_output_emit_module.swift"
+// CHECK:        "outputs": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "swiftmodule",
+// CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output_emit_module.swift.tmp.swiftmodule"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "diagnostics",
+// CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output_emit_module.swift.tmp.dia"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "abi-baseline-json",
+// CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output_emit_module.swift.tmp.abi.json"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "pid": [[PID:[0-9]*]]
+// CHECK-NEXT:     "process": {
+// CHECK-NEXT:       "real_pid": [[PID]]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+
+// CHECK-NEXT: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "finished",
+// CHECK-NEXT:   "name": "emit-module",
+// CHECK-NEXT:   "pid": [[PID]],
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": [[PID]]
+// CHECK-NEXT:   },
+// CHECK-NEXT:   "exit-status": 0
+// CHECK-NEXT: }

--- a/test/Frontend/parseable_output_error.swift
+++ b/test/Frontend/parseable_output_error.swift
@@ -1,6 +1,6 @@
-// RUN: not %target-swift-frontend -primary-file %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -c -primary-file %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
 // Check without primary files (WMO):
-// RUN: not %target-swift-frontend %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -c %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
 
 func foo() {
     return 11;

--- a/test/Frontend/parseable_output_unknown_file_type.swift
+++ b/test/Frontend/parseable_output_unknown_file_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.weird_file_extension -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -c -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.weird_file_extension -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/74401
--------------------------------------

**Explanation**: Frontend-emitted parsable output labels each `swift-frontend` invocation according to the action it performs. Up until now, it mistakenly classified module-emission tasks as `compile`. This change makes it so that such tasks are identified as `emit-module`. 

**Risk**: Low. This change affects only the task titles in frontend-emitted parsable output commands for emit-module tasks.

**Testing**: Automated test added to the compiler test suite.