### PR TITLE
Remove TaskGroup backDeployed annotation typo that included *

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -64,7 +64,7 @@ import Swift
 /// For tasks that need to handle cancellation by throwing an error,
 /// use the `withThrowingTaskGroup(of:returning:body:)` method instead.
 @available(SwiftStdlib 5.1, *)
-@backDeployed(before: SwiftStdlib 6.0, *)
+@backDeployed(before: SwiftStdlib 6.0)
 @inlinable
 public func withTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,


### PR DESCRIPTION
Fix typo on a single task group backDeployed annotation.
