### PR TITLE
[region-isolation] Treat sendable return values as Sendable when the returning function has a known actor isolation.

### DIFF
--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3475,6 +3475,14 @@ RegionAnalysisValueMap::initializeTrackableValue(
 
   // If we did not insert, just return the already stored value.
   self->stateIndexToEquivalenceClass[iter.first->second.getID()] = value;
+
+  // Before we do anything, see if we have a Sendable value.
+  if (!SILIsolationInfo::isNonSendableType(value->getType(), fn)) {
+    iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
+    return {{iter.first->first, iter.first->second}, true};
+  }
+
+  // Otherwise, we have a non-Sendable type... so wire up the isolation.
   iter.first->getSecond().setIsolationRegionInfo(newInfo);
 
   return {{iter.first->first, iter.first->second}, true};

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -23,10 +23,8 @@ actor MyActor {
     async let z = synchronous()
 
     var localText = text
-    // TODO: We should allow this since text is Sendable and localText is a
-    // separate box. localText should be disconnected.
+
     async let w = localText.removeLast() // expected-without-transferring-warning {{mutation of captured var 'localText' in concurrently-executing code}}
-    // expected-tns-warning @-1 {{task or actor isolated value cannot be sent}}
 
     _ = await x
     _ = await y

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1794,3 +1794,18 @@ public func doNotCrashOrEmitUnhandledPatternErrors<T: Sendable>(
     throw CancellationError()
   }
 }
+
+/// The following makes sure that when we have a function like test2 with an
+/// assigned isolation that returns a Sendable value... we treat the value as
+/// actually Sendable. This occurs in this example via the result of the default
+/// parameter function for string.
+///
+/// We shouldn't emit any diagnostic here.
+actor FunctionWithSendableResultAndIsolationActor {
+    func foo() -> String {
+        return string()
+    }
+    func string(someCondition: Bool = false) -> String {
+        return ""
+    }
+}


### PR DESCRIPTION
rdar://130544081
