### PR TITLE
[Sema/SilGen] Refactor key path component kinds

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -5712,9 +5712,9 @@ public:
   /// - a code completion token
   class Component {
   public:
-    enum class Kind: unsigned {
+    enum class Kind : unsigned {
       Invalid,
-      UnresolvedProperty,
+      UnresolvedMember,
       UnresolvedSubscript,
       Property,
       Subscript,
@@ -5726,7 +5726,7 @@ public:
       DictionaryKey,
       CodeCompletion,
     };
-  
+
   private:
     union DeclNameOrRef {
       DeclNameRef UnresolvedName;
@@ -5750,10 +5750,11 @@ public:
                        ArrayRef<ProtocolConformanceRef> indexHashables,
                        Kind kind, Type type, SourceLoc loc);
 
-    // Private constructor for property or #keyPath dictionary key.
+    // Private constructor for unresolved member, property or #keyPath
+    // dictionary key.
     explicit Component(DeclNameOrRef decl, Kind kind, Type type, SourceLoc loc)
         : Component(kind, type, loc) {
-      assert(kind == Kind::Property || kind == Kind::UnresolvedProperty ||
+      assert(kind == Kind::Property || kind == Kind::UnresolvedMember ||
              kind == Kind::DictionaryKey);
       Decl = decl;
     }
@@ -5772,11 +5773,11 @@ public:
     Component() : Component(Kind::Invalid, Type(), SourceLoc()) {}
 
     /// Create an unresolved component for a property.
-    static Component forUnresolvedProperty(DeclNameRef UnresolvedName,
-                                           SourceLoc Loc) {
-      return Component(UnresolvedName, Kind::UnresolvedProperty, Type(), Loc);
+    static Component forUnresolvedMember(DeclNameRef UnresolvedName,
+                                         SourceLoc Loc) {
+      return Component(UnresolvedName, Kind::UnresolvedMember, Type(), Loc);
     }
-    
+
     /// Create an unresolved component for a subscript.
     static Component forUnresolvedSubscript(ASTContext &ctx,
                                             ArgumentList *argList);
@@ -5878,7 +5879,7 @@ public:
         return true;
 
       case Kind::UnresolvedSubscript:
-      case Kind::UnresolvedProperty:
+      case Kind::UnresolvedMember:
       case Kind::Invalid:
       case Kind::CodeCompletion:
         return false;
@@ -5896,7 +5897,7 @@ public:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
       case Kind::OptionalForce:
-      case Kind::UnresolvedProperty:
+      case Kind::UnresolvedMember:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
@@ -5925,7 +5926,7 @@ public:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
       case Kind::OptionalForce:
-      case Kind::UnresolvedProperty:
+      case Kind::UnresolvedMember:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
@@ -5938,7 +5939,7 @@ public:
 
     DeclNameRef getUnresolvedDeclName() const {
       switch (getKind()) {
-      case Kind::UnresolvedProperty:
+      case Kind::UnresolvedMember:
       case Kind::DictionaryKey:
         return Decl.UnresolvedName;
 
@@ -5964,7 +5965,7 @@ public:
         return true;
 
       case Kind::Invalid:
-      case Kind::UnresolvedProperty:
+      case Kind::UnresolvedMember:
       case Kind::UnresolvedSubscript:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
@@ -5985,7 +5986,7 @@ public:
         return Decl.ResolvedDecl;
 
       case Kind::Invalid:
-      case Kind::UnresolvedProperty:
+      case Kind::UnresolvedMember:
       case Kind::UnresolvedSubscript:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
@@ -6005,7 +6006,7 @@ public:
           return TupleIndex;
                 
         case Kind::Invalid:
-        case Kind::UnresolvedProperty:
+        case Kind::UnresolvedMember:
         case Kind::UnresolvedSubscript:
         case Kind::OptionalChain:
         case Kind::OptionalWrap:

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -5716,7 +5716,7 @@ public:
       Invalid,
       UnresolvedMember,
       UnresolvedApply,
-      Property,
+      Member,
       Subscript,
       OptionalForce,
       OptionalChain,
@@ -5750,11 +5750,11 @@ public:
                        ArrayRef<ProtocolConformanceRef> indexHashables,
                        Kind kind, Type type, SourceLoc loc);
 
-    // Private constructor for unresolved member, property or #keyPath
+    // Private constructor for unresolved member, member or #keyPath
     // dictionary key.
     explicit Component(DeclNameOrRef decl, Kind kind, Type type, SourceLoc loc)
         : Component(kind, type, loc) {
-      assert(kind == Kind::Property || kind == Kind::UnresolvedMember ||
+      assert(kind == Kind::Member || kind == Kind::UnresolvedMember ||
              kind == Kind::DictionaryKey);
       Decl = decl;
     }
@@ -5793,12 +5793,11 @@ public:
     static Component forUnresolvedOptionalChain(SourceLoc QuestionLoc) {
       return Component(Kind::OptionalChain, Type(), QuestionLoc);
     }
-    
-    /// Create a component for a property.
-    static Component forProperty(ConcreteDeclRef property,
-                                 Type propertyType,
-                                 SourceLoc loc) {
-      return Component(property, Kind::Property, propertyType, loc);
+
+    /// Create a component for a member.
+    static Component forMember(ConcreteDeclRef member, Type memberType,
+                               SourceLoc loc) {
+      return Component(member, Kind::Member, memberType, loc);
     }
 
     /// Create a component for a dictionary key (#keyPath only).
@@ -5874,7 +5873,7 @@ public:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
       case Kind::OptionalForce:
-      case Kind::Property:
+      case Kind::Member:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
@@ -5900,7 +5899,7 @@ public:
       case Kind::OptionalWrap:
       case Kind::OptionalForce:
       case Kind::UnresolvedMember:
-      case Kind::Property:
+      case Kind::Member:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
@@ -5929,7 +5928,7 @@ public:
       case Kind::OptionalWrap:
       case Kind::OptionalForce:
       case Kind::UnresolvedMember:
-      case Kind::Property:
+      case Kind::Member:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
@@ -5951,7 +5950,7 @@ public:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
       case Kind::OptionalForce:
-      case Kind::Property:
+      case Kind::Member:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::CodeCompletion:
@@ -5962,7 +5961,7 @@ public:
 
     bool hasDeclRef() const {
       switch (getKind()) {
-      case Kind::Property:
+      case Kind::Member:
       case Kind::Subscript:
         return true;
 
@@ -5983,7 +5982,7 @@ public:
 
     ConcreteDeclRef getDeclRef() const {
       switch (getKind()) {
-      case Kind::Property:
+      case Kind::Member:
       case Kind::Subscript:
         return Decl.ResolvedDecl;
 
@@ -6014,7 +6013,7 @@ public:
         case Kind::OptionalWrap:
         case Kind::OptionalForce:
         case Kind::Identity:
-        case Kind::Property:
+        case Kind::Member:
         case Kind::Subscript:
         case Kind::DictionaryKey:
         case Kind::CodeCompletion:

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -5717,6 +5717,7 @@ public:
       UnresolvedMember,
       UnresolvedApply,
       Member,
+      Apply,
       Subscript,
       OptionalForce,
       OptionalChain,
@@ -5806,7 +5807,14 @@ public:
                                       SourceLoc loc) {
       return Component(UnresolvedName, Kind::DictionaryKey, valueType, loc);
     }
-    
+
+    /// Create a component for resolved application.
+    static Component forApply(ArgumentList *argList,
+                              ArrayRef<ProtocolConformanceRef> indexHashables) {
+      return Component({}, argList, indexHashables, Kind::Apply, Type(),
+                       argList->getLParenLoc());
+    }
+
     /// Create a component for a subscript.
     static Component
     forSubscript(ASTContext &ctx, ConcreteDeclRef subscript,
@@ -5870,6 +5878,7 @@ public:
 
       switch (getKind()) {
       case Kind::Subscript:
+      case Kind::Apply:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
       case Kind::OptionalForce:
@@ -5891,6 +5900,7 @@ public:
     ArgumentList *getArgs() const {
       switch (getKind()) {
       case Kind::Subscript:
+      case Kind::Apply:
       case Kind::UnresolvedApply:
         return ArgList;
 
@@ -5918,6 +5928,7 @@ public:
     getSubscriptIndexHashableConformances() const {
       switch (getKind()) {
       case Kind::Subscript:
+      case Kind::Apply:
         if (!ArgHashableConformancesData)
           return {};
         return {ArgHashableConformancesData, ArgList->size()};
@@ -5947,6 +5958,7 @@ public:
       case Kind::Invalid:
       case Kind::Subscript:
       case Kind::UnresolvedApply:
+      case Kind::Apply:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
       case Kind::OptionalForce:
@@ -5968,6 +5980,7 @@ public:
       case Kind::Invalid:
       case Kind::UnresolvedMember:
       case Kind::UnresolvedApply:
+      case Kind::Apply:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
       case Kind::OptionalForce:
@@ -5989,6 +6002,7 @@ public:
       case Kind::Invalid:
       case Kind::UnresolvedMember:
       case Kind::UnresolvedApply:
+      case Kind::Apply:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
       case Kind::OptionalForce:
@@ -6009,6 +6023,7 @@ public:
         case Kind::Invalid:
         case Kind::UnresolvedMember:
         case Kind::UnresolvedApply:
+        case Kind::Apply:
         case Kind::OptionalChain:
         case Kind::OptionalWrap:
         case Kind::OptionalForce:

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3133,8 +3133,8 @@ public:
                              IdentifierColor);
             break;
 
-          case KeyPathExpr::Component::Kind::UnresolvedSubscript:
-            printHead("unresolved_subscript", ASTNodeColor);
+          case KeyPathExpr::Component::Kind::UnresolvedApply:
+            printHead("unresolved_apply", ASTNodeColor);
             break;
           case KeyPathExpr::Component::Kind::Identity:
             printHead("identity", ASTNodeColor);
@@ -3154,7 +3154,7 @@ public:
             break;
           }
           printFieldQuoted(GetTypeOfKeyPathComponent(E, i), "type");
-          if (auto *args = component.getSubscriptArgs()) {
+          if (auto *args = component.getArgs()) {
             printRec(args);
           }
           printFoot();

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3136,6 +3136,9 @@ public:
           case KeyPathExpr::Component::Kind::UnresolvedApply:
             printHead("unresolved_apply", ASTNodeColor);
             break;
+          case KeyPathExpr::Component::Kind::Apply:
+            printHead("apply", ASTNodeColor);
+            break;
           case KeyPathExpr::Component::Kind::Identity:
             printHead("identity", ASTNodeColor);
             break;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3117,7 +3117,7 @@ public:
             printHead("optional_wrap", ASTNodeColor);
             break;
 
-          case KeyPathExpr::Component::Kind::Property:
+          case KeyPathExpr::Component::Kind::Member:
             printHead("property", ASTNodeColor);
             printDeclRefField(component.getDeclRef(), "decl");
             break;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3127,7 +3127,7 @@ public:
             printDeclRefField(component.getDeclRef(), "decl");
             break;
 
-          case KeyPathExpr::Component::Kind::UnresolvedProperty:
+          case KeyPathExpr::Component::Kind::UnresolvedMember:
             printHead("unresolved_property", ASTNodeColor);
             printFieldQuoted(component.getUnresolvedDeclName(), "decl_name",
                              IdentifierColor);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4953,7 +4953,7 @@ void PrintAST::printKeyPathComponents(KeyPathExpr *expr, ArrayRef<KeyPathExpr::C
         case ComponentKind::Invalid: {
           break;
         }
-        case ComponentKind::UnresolvedProperty: {
+        case ComponentKind::UnresolvedMember: {
           Printer << component.getUnresolvedDeclName();
           break;
         }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4962,7 +4962,7 @@ void PrintAST::printKeyPathComponents(KeyPathExpr *expr, ArrayRef<KeyPathExpr::C
           printArgumentList(args);
           break;
         }
-        case ComponentKind::Property: {
+        case ComponentKind::Member: {
           Printer << component.getUnresolvedDeclName();
           break;
         }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4966,6 +4966,11 @@ void PrintAST::printKeyPathComponents(KeyPathExpr *expr, ArrayRef<KeyPathExpr::C
           Printer << component.getUnresolvedDeclName();
           break;
         }
+        case ComponentKind::Apply: {
+          auto args = component.getArgs();
+          printArgumentList(args);
+          break;
+        }
         case ComponentKind::Subscript: {
           auto args = component.getArgs();
           printArgumentList(args);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4957,9 +4957,9 @@ void PrintAST::printKeyPathComponents(KeyPathExpr *expr, ArrayRef<KeyPathExpr::C
           Printer << component.getUnresolvedDeclName();
           break;
         }
-        case ComponentKind::UnresolvedSubscript: {
-          auto args = component.getSubscriptArgs();
-          printArgumentList(args, /*forSubscript*/ true);
+        case ComponentKind::UnresolvedApply: {
+          auto args = component.getArgs();
+          printArgumentList(args);
           break;
         }
         case ComponentKind::Property: {
@@ -4967,8 +4967,8 @@ void PrintAST::printKeyPathComponents(KeyPathExpr *expr, ArrayRef<KeyPathExpr::C
           break;
         }
         case ComponentKind::Subscript: {
-          auto args = component.getSubscriptArgs();
-          printArgumentList(args, /*forSubscript*/ true);
+          auto args = component.getArgs();
+          printArgumentList(args);
           break;
         }
         case ComponentKind::OptionalForce: {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1302,7 +1302,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       case KeyPathExpr::Component::Kind::OptionalWrap:
       case KeyPathExpr::Component::Kind::OptionalForce:
       case KeyPathExpr::Component::Kind::Property:
-      case KeyPathExpr::Component::Kind::UnresolvedProperty:
+      case KeyPathExpr::Component::Kind::UnresolvedMember:
       case KeyPathExpr::Component::Kind::Invalid:
       case KeyPathExpr::Component::Kind::Identity:
       case KeyPathExpr::Component::Kind::TupleElement:

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1289,6 +1289,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       auto component = origComponent;
       switch (auto kind = component.getKind()) {
       case KeyPathExpr::Component::Kind::Subscript:
+      case KeyPathExpr::Component::Kind::Apply:
       case KeyPathExpr::Component::Kind::UnresolvedApply: {
         if (auto *newArgs = doIt(component.getArgs())) {
           component.setArgs(newArgs);

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1289,15 +1289,15 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       auto component = origComponent;
       switch (auto kind = component.getKind()) {
       case KeyPathExpr::Component::Kind::Subscript:
-      case KeyPathExpr::Component::Kind::UnresolvedSubscript: {
-        if (auto *newArgs = doIt(component.getSubscriptArgs())) {
-          component.setSubscriptArgs(newArgs);
+      case KeyPathExpr::Component::Kind::UnresolvedApply: {
+        if (auto *newArgs = doIt(component.getArgs())) {
+          component.setArgs(newArgs);
         } else {
           return nullptr;
         }
         break;
       }
-        
+
       case KeyPathExpr::Component::Kind::OptionalChain:
       case KeyPathExpr::Component::Kind::OptionalWrap:
       case KeyPathExpr::Component::Kind::OptionalForce:

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1301,7 +1301,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       case KeyPathExpr::Component::Kind::OptionalChain:
       case KeyPathExpr::Component::Kind::OptionalWrap:
       case KeyPathExpr::Component::Kind::OptionalForce:
-      case KeyPathExpr::Component::Kind::Property:
+      case KeyPathExpr::Component::Kind::Member:
       case KeyPathExpr::Component::Kind::UnresolvedMember:
       case KeyPathExpr::Component::Kind::Invalid:
       case KeyPathExpr::Component::Kind::Identity:

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2446,9 +2446,9 @@ KeyPathExpr::setComponents(ASTContext &C,
   Components = Components.slice(0, newComponents.size());
 }
 
-std::optional<unsigned> KeyPathExpr::findComponentWithSubscriptArg(Expr *arg) {
+std::optional<unsigned> KeyPathExpr::findComponentWithArg(Expr *arg) {
   for (auto idx : indices(getComponents())) {
-    if (auto *args = getComponents()[idx].getSubscriptArgs()) {
+    if (auto *args = getComponents()[idx].getArgs()) {
       if (args->findArgumentExpr(arg))
         return idx;
     }
@@ -2492,24 +2492,17 @@ KeyPathExpr::Component KeyPathExpr::Component::forSubscript(
                    elementType, argList->getLParenLoc());
 }
 
-KeyPathExpr::Component
-KeyPathExpr::Component::forUnresolvedSubscript(ASTContext &ctx,
-                                               ArgumentList *argList) {
-  return Component({}, argList, {}, Kind::UnresolvedSubscript, Type(),
-                   argList->getLParenLoc());
-}
-
 KeyPathExpr::Component::Component(
     DeclNameOrRef decl, ArgumentList *argList,
     ArrayRef<ProtocolConformanceRef> indexHashables, Kind kind, Type type,
     SourceLoc loc)
-    : Decl(decl), SubscriptArgList(argList), KindValue(kind),
-      ComponentType(type), Loc(loc) {
-  assert(kind == Kind::Subscript || kind == Kind::UnresolvedSubscript);
+    : Decl(decl), ArgList(argList), KindValue(kind), ComponentType(type),
+      Loc(loc) {
+  assert(kind == Kind::Subscript || kind == Kind::UnresolvedApply);
   assert(argList);
   assert(argList->size() == indexHashables.size() || indexHashables.empty());
-  SubscriptHashableConformancesData = indexHashables.empty()
-    ? nullptr : indexHashables.data();
+  ArgHashableConformancesData =
+      indexHashables.empty() ? nullptr : indexHashables.data();
 }
 
 SingleValueStmtExpr *SingleValueStmtExpr::create(ASTContext &ctx, Stmt *S,

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2498,7 +2498,8 @@ KeyPathExpr::Component::Component(
     SourceLoc loc)
     : Decl(decl), ArgList(argList), KindValue(kind), ComponentType(type),
       Loc(loc) {
-  assert(kind == Kind::Subscript || kind == Kind::UnresolvedApply);
+  assert(kind == Kind::Subscript || kind == Kind::Apply ||
+         kind == Kind::UnresolvedApply);
   assert(argList);
   assert(argList->size() == indexHashables.size() || indexHashables.empty());
   ArgHashableConformancesData =

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -490,7 +490,7 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       case KeyPathExpr::Component::Kind::TupleElement:
       case KeyPathExpr::Component::Kind::Invalid:
       case KeyPathExpr::Component::Kind::UnresolvedMember:
-      case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+      case KeyPathExpr::Component::Kind::UnresolvedApply:
       case KeyPathExpr::Component::Kind::OptionalChain:
       case KeyPathExpr::Component::Kind::OptionalWrap:
       case KeyPathExpr::Component::Kind::OptionalForce:

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -471,7 +471,7 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
   } else if (auto *KPE = dyn_cast<KeyPathExpr>(E)) {
     for (auto &component : KPE->getComponents()) {
       switch (component.getKind()) {
-      case KeyPathExpr::Component::Kind::Property:
+      case KeyPathExpr::Component::Kind::Member:
       case KeyPathExpr::Component::Kind::Subscript: {
         auto *decl = component.getDeclRef().getDecl();
         auto loc = component.getLoc();

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -489,7 +489,7 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
 
       case KeyPathExpr::Component::Kind::TupleElement:
       case KeyPathExpr::Component::Kind::Invalid:
-      case KeyPathExpr::Component::Kind::UnresolvedProperty:
+      case KeyPathExpr::Component::Kind::UnresolvedMember:
       case KeyPathExpr::Component::Kind::UnresolvedSubscript:
       case KeyPathExpr::Component::Kind::OptionalChain:
       case KeyPathExpr::Component::Kind::OptionalWrap:

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -491,6 +491,7 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       case KeyPathExpr::Component::Kind::Invalid:
       case KeyPathExpr::Component::Kind::UnresolvedMember:
       case KeyPathExpr::Component::Kind::UnresolvedApply:
+      case KeyPathExpr::Component::Kind::Apply:
       case KeyPathExpr::Component::Kind::OptionalChain:
       case KeyPathExpr::Component::Kind::OptionalWrap:
       case KeyPathExpr::Component::Kind::OptionalForce:

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -817,8 +817,8 @@ ParserResult<Expr> Parser::parseExprKeyPathObjC() {
     }
 
     // Record the name we parsed.
-    auto component = KeyPathExpr::Component::forUnresolvedProperty(name,
-                                                      nameLoc.getBaseNameLoc());
+    auto component = KeyPathExpr::Component::forUnresolvedMember(
+        name, nameLoc.getBaseNameLoc());
     components.push_back(component);
 
     // After the first component, we can start parsing keywords.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4474,7 +4474,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
       continue;
         
     case KeyPathExpr::Component::Kind::Invalid:
-    case KeyPathExpr::Component::Kind::UnresolvedProperty:
+    case KeyPathExpr::Component::Kind::UnresolvedMember:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:
     case KeyPathExpr::Component::Kind::CodeCompletion:
       llvm_unreachable("not resolved");

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4395,7 +4395,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
 
   for (auto &component : E->getComponents()) {
     switch (auto kind = component.getKind()) {
-    case KeyPathExpr::Component::Kind::Property:
+    case KeyPathExpr::Component::Kind::Member:
     case KeyPathExpr::Component::Kind::Subscript: {
       auto decl = cast<AbstractStorageDecl>(component.getDeclRef().getDecl());
 
@@ -4413,7 +4413,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
                             SGF.FunctionDC,
                             /*for descriptor*/ false));
       baseTy = loweredComponents.back().getComponentType();
-      if (kind == KeyPathExpr::Component::Kind::Property)
+      if (kind == KeyPathExpr::Component::Kind::Member)
         break;
 
       auto subscript = cast<SubscriptDecl>(decl);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4396,6 +4396,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
   for (auto &component : E->getComponents()) {
     switch (auto kind = component.getKind()) {
     case KeyPathExpr::Component::Kind::Member:
+    case KeyPathExpr::Component::Kind::Apply:
     case KeyPathExpr::Component::Kind::Subscript: {
       auto decl = cast<AbstractStorageDecl>(component.getDeclRef().getDecl());
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4418,9 +4418,8 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
 
       auto subscript = cast<SubscriptDecl>(decl);
       auto loweredArgs = SGF.emitKeyPathSubscriptOperands(
-          E, subscript,
-          component.getDeclRef().getSubstitutions(),
-          component.getSubscriptArgs());
+          E, subscript, component.getDeclRef().getSubstitutions(),
+          component.getArgs());
 
       for (auto &arg : loweredArgs) {
         operands.push_back(arg.forward(SGF));
@@ -4475,7 +4474,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
         
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::UnresolvedMember:
-    case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+    case KeyPathExpr::Component::Kind::UnresolvedApply:
     case KeyPathExpr::Component::Kind::CodeCompletion:
       llvm_unreachable("not resolved");
       break;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -328,6 +328,7 @@ static bool buildObjCKeyPathString(KeyPathExpr *E,
     }
     case KeyPathExpr::Component::Kind::TupleElement:
     case KeyPathExpr::Component::Kind::Subscript:
+    case KeyPathExpr::Component::Kind::Apply:
       // Subscripts and tuples aren't generally represented in KVC.
       // TODO: There are some subscript forms we could map to KVC, such as
       // when indexing a Dictionary or NSDictionary by string, or when applying
@@ -5193,6 +5194,7 @@ namespace {
         }
         case KeyPathExpr::Component::Kind::Member:
         case KeyPathExpr::Component::Kind::Subscript:
+        case KeyPathExpr::Component::Kind::Apply:
         case KeyPathExpr::Component::Kind::OptionalWrap:
         case KeyPathExpr::Component::Kind::TupleElement:
           llvm_unreachable("already resolved");

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -334,7 +334,7 @@ static bool buildObjCKeyPathString(KeyPathExpr *E,
       // a mapping subscript operation to Array/Set or NSArray/NSSet.
       return false;
     case KeyPathExpr::Component::Kind::Invalid:
-    case KeyPathExpr::Component::Kind::UnresolvedProperty:
+    case KeyPathExpr::Component::Kind::UnresolvedMember:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:
     case KeyPathExpr::Component::Kind::CodeCompletion:
       // Don't bother building the key path string if the key path didn't even
@@ -2478,7 +2478,7 @@ namespace {
         assert(kpElt && "no keypath component node");
         auto &comp = KPE->getComponents()[kpElt->getIndex()];
 
-        if (comp.getKind() == Component::Kind::UnresolvedProperty) {
+        if (comp.getKind() == Component::Kind::UnresolvedMember) {
           buildKeyPathPropertyComponent(overload, comp.getLoc(), componentLoc,
                                         components);
         } else if (comp.getKind() == Component::Kind::UnresolvedSubscript) {
@@ -5116,7 +5116,7 @@ namespace {
 
         bool isDynamicMember = false;
         // If this is an unresolved link, make sure we resolved it.
-        if (kind == KeyPathExpr::Component::Kind::UnresolvedProperty ||
+        if (kind == KeyPathExpr::Component::Kind::UnresolvedMember ||
             kind == KeyPathExpr::Component::Kind::UnresolvedSubscript) {
           auto foundDecl = solution.getOverloadChoiceIfAvailable(calleeLoc);
           if (!foundDecl) {
@@ -5136,7 +5136,7 @@ namespace {
         }
 
         switch (kind) {
-        case KeyPathExpr::Component::Kind::UnresolvedProperty: {
+        case KeyPathExpr::Component::Kind::UnresolvedMember: {
           buildKeyPathPropertyComponent(solution.getOverloadChoice(calleeLoc),
                                         origComponent.getLoc(), calleeLoc,
                                         resolvedComponents);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -315,7 +315,7 @@ static bool buildObjCKeyPathString(KeyPathExpr *E,
     case KeyPathExpr::Component::Kind::Member: {
       if (auto subscript =
               isa<SubscriptDecl>(component.getDeclRef().getDecl())) {
-        // Subscripts and tuples aren't generally represented in KVC.
+        // Subscripts aren't generally represented in KVC.
         // TODO: There are some subscript forms we could map to KVC, such as
         // when indexing a Dictionary or NSDictionary by string, or when
         // applying a mapping subscript operation to Array/Set or NSArray/NSSet.
@@ -339,10 +339,7 @@ static bool buildObjCKeyPathString(KeyPathExpr *E,
     case KeyPathExpr::Component::Kind::TupleElement:
     case KeyPathExpr::Component::Kind::Subscript:
     case KeyPathExpr::Component::Kind::Apply:
-      // Subscripts and tuples aren't generally represented in KVC.
-      // TODO: There are some subscript forms we could map to KVC, such as
-      // when indexing a Dictionary or NSDictionary by string, or when applying
-      // a mapping subscript operation to Array/Set or NSArray/NSSet.
+      // Tuples aren't generally represented in KVC.
       return false;
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::UnresolvedMember:

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3779,7 +3779,7 @@ namespace {
               resultLocator,
               TVO_CanBindToLValue | TVO_CanBindToNoEscape | TVO_CanBindToHole);
           break;
-        case KeyPathExpr::Component::Kind::UnresolvedProperty:
+        case KeyPathExpr::Component::Kind::UnresolvedMember:
         // This should only appear in resolved ASTs, but we may need to
         // re-type-check the constraints during failure diagnosis.
         case KeyPathExpr::Component::Kind::Property: {
@@ -3787,10 +3787,13 @@ namespace {
                                                 TVO_CanBindToLValue |
                                                 TVO_CanBindToNoEscape);
           componentTypeVars.push_back(memberTy);
-          auto lookupName = kind == KeyPathExpr::Component::Kind::UnresolvedProperty
-            ? DeclNameRef(component.getUnresolvedDeclName()) // FIXME: type change needed
-            : component.getDeclRef().getDecl()->createNameRef();
-          
+          auto lookupName =
+              kind == KeyPathExpr::Component::Kind::UnresolvedMember
+                  ? DeclNameRef(
+                        component.getUnresolvedDeclName()) // FIXME: type change
+                                                           // needed
+                  : component.getDeclRef().getDecl()->createNameRef();
+
           auto refKind = lookupName.isSimpleName()
             ? FunctionRefKind::Unapplied
             : FunctionRefKind::Compound;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3808,6 +3808,7 @@ namespace {
         }
 
         case KeyPathExpr::Component::Kind::UnresolvedApply:
+        case KeyPathExpr::Component::Kind::Apply:
         // Subscript should only appear in resolved ASTs, but we may need to
         // re-type-check the constraints during failure diagnosis.
         case KeyPathExpr::Component::Kind::Subscript: {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3782,7 +3782,7 @@ namespace {
         case KeyPathExpr::Component::Kind::UnresolvedMember:
         // This should only appear in resolved ASTs, but we may need to
         // re-type-check the constraints during failure diagnosis.
-        case KeyPathExpr::Component::Kind::Property: {
+        case KeyPathExpr::Component::Kind::Member: {
           auto memberTy = CS.createTypeVariable(resultLocator,
                                                 TVO_CanBindToLValue |
                                                 TVO_CanBindToNoEscape);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3806,12 +3806,12 @@ namespace {
           base = memberTy;
           break;
         }
-          
-        case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+
+        case KeyPathExpr::Component::Kind::UnresolvedApply:
         // Subscript should only appear in resolved ASTs, but we may need to
         // re-type-check the constraints during failure diagnosis.
         case KeyPathExpr::Component::Kind::Subscript: {
-          auto *args = component.getSubscriptArgs();
+          auto *args = component.getArgs();
           base = addSubscriptConstraints(E, base, /*decl*/ nullptr, args,
                                          memberLocator, &componentTypeVars);
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3796,13 +3796,11 @@ namespace {
         // This should only appear in resolved ASTs, but we may need to
         // re-type-check the constraints during failure diagnosis.
         case KeyPathExpr::Component::Kind::Member: {
-          if (auto *path = E->getParsedPath()) {
-            if (auto SE = isa<SubscriptExpr>(path)) {
-              subscriptMemberTy = addSubscriptConstraints(
-                  E, base, /*decl*/ nullptr, /*args*/ nullptr, memberLocator,
-                  &componentTypeVars);
-              base = subscriptMemberTy;
-            }
+          if (!component.hasUnresolvedDeclName()) {
+            subscriptMemberTy = addSubscriptConstraints(
+                E, base, /*decl*/ nullptr, /*args*/ nullptr, memberLocator,
+                &componentTypeVars);
+            base = subscriptMemberTy;
           } else {
             auto memberTy = CS.createTypeVariable(resultLocator,
                                                   TVO_CanBindToLValue |

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -601,7 +601,7 @@ bool ConstraintLocator::isKeyPathSubscriptComponent() const {
     auto index = keyPathElt->getIndex();
     auto &component = KPE->getComponents()[index];
     return component.getKind() == ComponentKind::Subscript ||
-           component.getKind() == ComponentKind::UnresolvedSubscript;
+           component.getKind() == ComponentKind::UnresolvedApply;
   });
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -642,8 +642,8 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
       return getConstraintLocator(
                                   anchor, {*componentElt, ConstraintLocator::SubscriptMember});
     case ComponentKind::UnresolvedMember:
-    case ComponentKind::Property:
-      // For a property, the choice is just given by the component.
+    case ComponentKind::Member:
+      // For a member, the choice is just given by the component.
       return getConstraintLocator(anchor, *componentElt);
     case ComponentKind::TupleElement:
       llvm_unreachable("Not implemented by CSGen");
@@ -7842,7 +7842,7 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
       }
       LLVM_FALLTHROUGH;
     }
-    case KeyPathExpr::Component::Kind::Property:
+    case KeyPathExpr::Component::Kind::Member:
     case KeyPathExpr::Component::Kind::UnresolvedMember: {
       auto *componentLoc =
           getConstraintLocator(keyPath, LocatorPathElt::KeyPathComponent(i));

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -641,7 +641,7 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
       // For a subscript the callee is given by 'component -> subscript member'.
       return getConstraintLocator(
                                   anchor, {*componentElt, ConstraintLocator::SubscriptMember});
-    case ComponentKind::UnresolvedProperty:
+    case ComponentKind::UnresolvedMember:
     case ComponentKind::Property:
       // For a property, the choice is just given by the component.
       return getConstraintLocator(anchor, *componentElt);
@@ -7843,7 +7843,7 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
       LLVM_FALLTHROUGH;
     }
     case KeyPathExpr::Component::Kind::Property:
-    case KeyPathExpr::Component::Kind::UnresolvedProperty: {
+    case KeyPathExpr::Component::Kind::UnresolvedMember: {
       auto *componentLoc =
           getConstraintLocator(keyPath, LocatorPathElt::KeyPathComponent(i));
       auto *calleeLoc = getCalleeLocator(componentLoc);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -637,6 +637,7 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
     using ComponentKind = KeyPathExpr::Component::Kind;
     switch (component.getKind()) {
     case ComponentKind::UnresolvedApply:
+    case ComponentKind::Apply:
     case ComponentKind::Subscript:
       // For a subscript the callee is given by 'component -> subscript member'.
       return getConstraintLocator(
@@ -7814,6 +7815,7 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
     }
 
     case KeyPathExpr::Component::Kind::UnresolvedApply:
+    case KeyPathExpr::Component::Kind::Apply:
     case KeyPathExpr::Component::Kind::Subscript: {
       if (Context.LangOpts.hasFeature(Feature::InferSendableFromCaptures)) {
         // Key path is sendable only when all of its captures are sendable.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7851,10 +7851,6 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
     }
     case KeyPathExpr::Component::Kind::Member:
     case KeyPathExpr::Component::Kind::UnresolvedMember: {
-      if (!component.hasUnresolvedDeclName()) {
-        continue;
-      }
-
       auto *componentLoc =
           getConstraintLocator(keyPath, LocatorPathElt::KeyPathComponent(i));
       auto *calleeLoc = getCalleeLocator(componentLoc);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7846,6 +7846,10 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
     }
     case KeyPathExpr::Component::Kind::Member:
     case KeyPathExpr::Component::Kind::UnresolvedMember: {
+      if (!component.hasUnresolvedDeclName()) {
+        continue;
+      }
+
       auto *componentLoc =
           getConstraintLocator(keyPath, LocatorPathElt::KeyPathComponent(i));
       auto *calleeLoc = getCalleeLocator(componentLoc);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -5799,7 +5799,7 @@ static void diagnoseDeprecatedWritableKeyPath(const Expr *E,
 
         assert(keyPathExpr->getComponents().size() > 0);
         auto &component = keyPathExpr->getComponents().back();
-        if (component.getKind() == KeyPathExpr::Component::Kind::Property) {
+        if (component.getKind() == KeyPathExpr::Component::Kind::Member) {
           auto *storage =
             cast<AbstractStorageDecl>(component.getDeclRef().getDecl());
           if (!storage->isSettable(nullptr) ||
@@ -5885,7 +5885,7 @@ static void maybeDiagnoseCallToKeyValueObserveMethod(const Expr *E,
       }
       for (auto *keyPathArg : keyPathArgs) {
         auto lastComponent = keyPathArg->getComponents().back();
-        if (lastComponent.getKind() != KeyPathExpr::Component::Kind::Property)
+        if (lastComponent.getKind() != KeyPathExpr::Component::Kind::Member)
           continue;
         auto property = lastComponent.getDeclRef().getDecl();
         if (!property)

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -2293,6 +2293,9 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
         // .[0] or just plain [0]
         components.push_back(
             KeyPathExpr::Component::forUnresolvedApply(SE->getArgs()));
+        components.push_back(
+            KeyPathExpr::Component::forUnresolvedMember({}, SE->getLoc()));
+        
 
         expr = SE->getBase();
       } else if (auto BOE = dyn_cast<BindOptionalExpr>(expr)) {

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -2276,7 +2276,7 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
         expr = SE->getSubExpr();
       } else if (auto UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
         // .foo
-        components.push_back(KeyPathExpr::Component::forUnresolvedProperty(
+        components.push_back(KeyPathExpr::Component::forUnresolvedMember(
             UDE->getName(), UDE->getLoc()));
 
         expr = UDE->getBase();

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -2291,8 +2291,8 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
         }
       } else if (auto SE = dyn_cast<SubscriptExpr>(expr)) {
         // .[0] or just plain [0]
-        components.push_back(KeyPathExpr::Component::forUnresolvedSubscript(
-            getASTContext(), SE->getArgs()));
+        components.push_back(
+            KeyPathExpr::Component::forUnresolvedApply(SE->getArgs()));
 
         expr = SE->getBase();
       } else if (auto BOE = dyn_cast<BindOptionalExpr>(expr)) {

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -2293,9 +2293,8 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
         // .[0] or just plain [0]
         components.push_back(
             KeyPathExpr::Component::forUnresolvedApply(SE->getArgs()));
-        components.push_back(
-            KeyPathExpr::Component::forUnresolvedMember({}, SE->getLoc()));
-        
+        components.push_back(KeyPathExpr::Component::forUnresolvedMember(
+            {}, SE->getLoc(), /*hasName*/ false));
 
         expr = SE->getBase();
       } else if (auto BOE = dyn_cast<BindOptionalExpr>(expr)) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3627,7 +3627,7 @@ private:
         break;
 
       case KeyPathExpr::Component::Kind::Invalid:
-      case KeyPathExpr::Component::Kind::UnresolvedProperty:
+      case KeyPathExpr::Component::Kind::UnresolvedMember:
       case KeyPathExpr::Component::Kind::UnresolvedSubscript:
       case KeyPathExpr::Component::Kind::OptionalChain:
       case KeyPathExpr::Component::Kind::OptionalWrap:

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3612,7 +3612,7 @@ private:
 
     for (auto &component : KP->getComponents()) {
       switch (component.getKind()) {
-      case KeyPathExpr::Component::Kind::Property:
+      case KeyPathExpr::Component::Kind::Member:
       case KeyPathExpr::Component::Kind::Subscript: {
         auto decl = component.getDeclRef();
         auto loc = component.getLoc();

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3628,7 +3628,7 @@ private:
 
       case KeyPathExpr::Component::Kind::Invalid:
       case KeyPathExpr::Component::Kind::UnresolvedMember:
-      case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+      case KeyPathExpr::Component::Kind::UnresolvedApply:
       case KeyPathExpr::Component::Kind::OptionalChain:
       case KeyPathExpr::Component::Kind::OptionalWrap:
       case KeyPathExpr::Component::Kind::OptionalForce:

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3629,6 +3629,7 @@ private:
       case KeyPathExpr::Component::Kind::Invalid:
       case KeyPathExpr::Component::Kind::UnresolvedMember:
       case KeyPathExpr::Component::Kind::UnresolvedApply:
+      case KeyPathExpr::Component::Kind::Apply:
       case KeyPathExpr::Component::Kind::OptionalChain:
       case KeyPathExpr::Component::Kind::OptionalWrap:
       case KeyPathExpr::Component::Kind::OptionalForce:

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -319,7 +319,7 @@ getTypeOfCompletionContextExpr(DeclContext *DC, CompletionTypeCheckKind kind,
       if (!components.empty()) {
         auto &last = components.back();
         if (last.isResolved()) {
-          if (last.getKind() == KeyPathExpr::Component::Kind::Property)
+          if (last.getKind() == KeyPathExpr::Component::Kind::Member)
             referencedDecl = last.getDeclRef();
           Type lookupTy = last.getComponentType();
           ASTContext &Ctx = DC->getASTContext();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3901,7 +3901,7 @@ namespace {
           // Captured values in a path component must conform to Sendable.
           // These captured values appear in Subscript, such as \Type.dict[k]
           // where k is a captured dictionary key.
-          if (auto *args = component.getSubscriptArgs()) {
+          if (auto *args = component.getArgs()) {
             for (auto arg : *args) {
               auto type = getType(arg.getExpr());
               if (type && shouldDiagnoseExistingDataRaces(getDeclContext()) &&

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -177,8 +177,7 @@ bool TypeVariableType::Implementation::isSubscriptResultType() const {
 
   auto &component = KP->getComponents()[componentLoc->getIndex()];
   return component.getKind() == KeyPathExpr::Component::Kind::Subscript ||
-         component.getKind() ==
-             KeyPathExpr::Component::Kind::UnresolvedSubscript;
+         component.getKind() == KeyPathExpr::Component::Kind::UnresolvedApply;
 }
 
 bool TypeVariableType::Implementation::isParameterPack() const {

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -208,7 +208,7 @@ std::optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     case KeyPathExpr::Component::Kind::CodeCompletion:
       continue;
 
-    case KeyPathExpr::Component::Kind::UnresolvedProperty:
+    case KeyPathExpr::Component::Kind::UnresolvedMember:
       break;
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:
     case KeyPathExpr::Component::Kind::OptionalChain:

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -210,7 +210,7 @@ std::optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
     case KeyPathExpr::Component::Kind::UnresolvedMember:
       break;
-    case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+    case KeyPathExpr::Component::Kind::UnresolvedApply:
     case KeyPathExpr::Component::Kind::OptionalChain:
     case KeyPathExpr::Component::Kind::OptionalForce:
     case KeyPathExpr::Component::Kind::TupleElement:

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -219,7 +219,7 @@ std::optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
                      (unsigned)kind);
       continue;
     case KeyPathExpr::Component::Kind::OptionalWrap:
-    case KeyPathExpr::Component::Kind::Property:
+    case KeyPathExpr::Component::Kind::Member:
     case KeyPathExpr::Component::Kind::Subscript:
     case KeyPathExpr::Component::Kind::DictionaryKey:
       llvm_unreachable("already resolved!");
@@ -330,8 +330,8 @@ std::optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
       // Updates currentType
       updateState(/*isProperty=*/true, varTy);
 
-      auto resolved = KeyPathExpr::Component::forProperty(varRef, currentType,
-                                                          componentNameLoc);
+      auto resolved = KeyPathExpr::Component::forMember(varRef, currentType,
+                                                        componentNameLoc);
       resolvedComponents.push_back(resolved);
 
       // Check that the property is @objc.
@@ -388,8 +388,8 @@ std::optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
       // Resolve this component to the type we found.
       auto typeRef = ConcreteDeclRef(type);
-      auto resolved = KeyPathExpr::Component::forProperty(typeRef, currentType,
-                                                          componentNameLoc);
+      auto resolved = KeyPathExpr::Component::forMember(typeRef, currentType,
+                                                        componentNameLoc);
       resolvedComponents.push_back(resolved);
 
       continue;

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -221,6 +221,7 @@ std::optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     case KeyPathExpr::Component::Kind::OptionalWrap:
     case KeyPathExpr::Component::Kind::Member:
     case KeyPathExpr::Component::Kind::Subscript:
+    case KeyPathExpr::Component::Kind::Apply:
     case KeyPathExpr::Component::Kind::DictionaryKey:
       llvm_unreachable("already resolved!");
     }


### PR DESCRIPTION
These changes refactor and generalize key path component kinds to make them extendable to other potential key path component kinds, eg. method keypaths.

`UnresolvedProperty` is renamed to `UnresolvedMember` to handle all members, including properties and subscripts. `UnresolvedSubscript` is renamed to `UnresolvedApply` and handles unresolved application of arguments, including subscript index arguments.

An `Apply` component kind has been added to deal with the resolved application of arguments and the 'Subscript' component kind has been generalized to `Member`.