### PR TITLE
[6.0][Distributed] Adjust whenLocal impl to avoid potential ABI issues

### DIFF
--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -363,6 +363,9 @@ extension DistributedActor {
   ///
   /// When the actor is remote, the closure won't be executed and this function will return nil.
   @_alwaysEmitIntoClient
+  // we need to silgen_name here because the signature is the same as __abi_whenLocal,
+  // and even though this is @AEIC, the symbol name would conflict.
+  @_silgen_name("$s11Distributed0A5ActorPAAE20whenLocalTypedThrowsyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lF")
   public nonisolated func whenLocal<T: Sendable, E>(
     _ body: @Sendable (isolated Self) async throws(E) -> T
   ) async throws(E) -> T? {
@@ -372,6 +375,17 @@ extension DistributedActor {
     } else {
       return nil
     }
+  }
+
+  // ABI: This is a workaround when in Swift 6 this method was introduced
+  // in order to support typed-throws, but missed to add @_aeic.
+  // In practice, this method should not ever be used by anyone, ever.
+  @usableFromInline
+  @_silgen_name("$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lF")
+  internal nonisolated func __abi_whenLocal<T: Sendable, E>(
+    _ body: @Sendable (isolated Self) async throws(E) -> T
+  ) async throws(E) -> T? {
+    try await whenLocal(body)
   }
 
   // ABI: Historical whenLocal, rethrows was changed to typed throws `throws(E)`

--- a/test/abi/macOS/arm64/distributed.swift
+++ b/test/abi/macOS/arm64/distributed.swift
@@ -104,3 +104,9 @@ Added: _$s11Distributed0A5ActorPAAE22__actorUnownedExecutorScevpMV
 
 // Distributed._distributedStubFatalError(function: Swift.String) -> Swift.Never
 Added: _$s11Distributed26_distributedStubFatalError8functions5NeverOSS_tF
+
+// Bin compat for typed throws overload of whenLocal
+// (extension in Distributed):Distributed.DistributedActor.whenLocal<A, B where A1: Swift.Sendable, B1: Swift.Error>(@Sendable (isolated A) async throws(B1) -> A1) async throws(B1) -> A1?
+Added: _$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lF
+// async function pointer to (extension in Distributed):Distributed.DistributedActor.whenLocal<A, B where A1: Swift.Sendable, B1: Swift.Error>(@Sendable (isolated A) async throws(B1) -> A1) async throws(B1) -> A1?
+Added: _$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lFTu

--- a/test/abi/macOS/x86_64/distributed.swift
+++ b/test/abi/macOS/x86_64/distributed.swift
@@ -104,3 +104,9 @@ Added: _$s11Distributed0A5ActorPAAE22__actorUnownedExecutorScevpMV
 
 // Distributed._distributedStubFatalError(function: Swift.String) -> Swift.Never
 Added: _$s11Distributed26_distributedStubFatalError8functions5NeverOSS_tF
+
+// Bin compat for typed throws overload of whenLocal
+// (extension in Distributed):Distributed.DistributedActor.whenLocal<A, B where A1: Swift.Sendable, B1: Swift.Error>(@Sendable (isolated A) async throws(B1) -> A1) async throws(B1) -> A1?
+Added: _$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lF
+// async function pointer to (extension in Distributed):Distributed.DistributedActor.whenLocal<A, B where A1: Swift.Sendable, B1: Swift.Error>(@Sendable (isolated A) async throws(B1) -> A1) async throws(B1) -> A1?
+Added: _$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lFTu


### PR DESCRIPTION
**Description**: This is a follow up to https://github.com/swiftlang/swift/pull/74324 resolving rdar://129651474 where we added a missing `@AEIC` to the `whenLocal` function which adopted typed throws. This caused Distributed breakage in Beta 1. This PR here is a follow up to make the transition even safer, by introducing the "accidentally exposed symbol" (by not having made the new method AEIC from the beginning), such that applications which build against that we don't "remove" this symbol without replacement -- i.e. this patch doesn't "add" an API, but "keeps it" for ABI reasons, even if no new code against the new SDK should ever be touching that old symbol.

**Scope/Impact**: Distributed module users are impacted if they happened to build against an SDK with the non-`@AEIC` declaration of the whenLocal function.

**Risk:** Low, this only adds an "old" abi entrypoint which may have been used by someone in the brief beta 1 period.

To put it differently, this is "**strictly safer**" than the existing version.

**Testing**: CI testing and we verified manually with @xedin in a real reproducer project the AEIC approach is correct overall, and this only adds an "old" abi entrypoint.
**Reviewed by**: @xedin 

**Original PR:** https://github.com/swiftlang/swift/pull/74606
**Radar:** rdar://130610949 