### PR TITLE
[6.0][ExplicitModule] Fix codegen target when using direct cc1 mode

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1135,6 +1135,10 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
     if (ctx.CASOpts.EnableCaching)
       CI->getCASOpts() = ctx.CASOpts.CASOpts;
 
+    // If clang target is ignored, using swift target.
+    if (ignoreClangTarget)
+      CI->getTargetOpts().Triple = ctx.LangOpts.Target.str();
+
     // Forward the index store path. That information is not passed to scanner
     // and it is cached invariant so we don't want to re-scan if that changed.
     CI->getFrontendOpts().IndexStorePath = ctx.ClangImporterOpts.IndexStorePath;

--- a/test/CAS/clang-target-codegen.swift
+++ b/test/CAS/clang-target-codegen.swift
@@ -1,0 +1,51 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -target arm64-apple-macos11 -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/test.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas \
+// RUN:   -I %t/include -clang-target arm64-apple-macos13
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/a.cmd
+// RUN: %swift_frontend_plain @%t/a.cmd
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Foo > %t/foo.cmd
+// RUN: %swift_frontend_plain @%t/foo.cmd
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+
+// RUN: %target-swift-frontend -c -o %t/test.o -target arm64-apple-macos11 \
+// RUN:   -clang-target arm64-apple-macos13 -cache-compile-job -cas-path %t/cas \
+// RUN:   -disable-implicit-swift-modules -swift-version 5 -parse-stdlib -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   %t/test.swift @%t/MyApp.cmd
+
+// RUN: llvm-objdump --macho --all-headers %t/test.o | %FileCheck %s
+
+// CHECK: cmd LC_BUILD_VERSION
+// CHECK-NEXT:   cmdsize
+// CHECK-NEXT:  platform macos
+// CHECK-NEXT:       sdk
+// CHECK-NEXT:     minos 11.0
+
+//--- include/module.modulemap
+module A {
+  header "a.h"
+  export *
+}
+//--- include/a.h
+void a(void);
+
+//--- include/Foo.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target arm64-apple-macos13 -enable-library-evolution -swift-version 5 -O -module-name Foo -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib
+import A
+public func foo()
+
+//--- test.swift
+import Foo


### PR DESCRIPTION
Explanation: Swift caching build that requires `-clang-target` will generate object file using the wrong deployment target.
Scope: Affect swift caching builds and can cause wrong code generation due to the wrong deployment target.
Original PR: https://github.com/swiftlang/swift/pull/74755
Issue: rdar://130547690
Reviewer: @artemcm 
Test: UnitTest

