### PR TITLE
fix a crash when de-virtualizing class or actor methods with typed throws

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -741,6 +741,11 @@ public:
     return getArguments().slice(0, getNumIndirectSILResults());
   }
 
+  OperandValueArrayRef getIndirectSILErrorResults() const {
+    return getArguments().slice(getNumIndirectSILResults(),
+                                getNumIndirectSILErrorResults());
+  }
+
   OperandValueArrayRef getArgumentsWithoutIndirectResults() const {
     return getArguments().slice(getNumIndirectSILResults() +
                                 getNumIndirectSILErrorResults());

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -510,7 +510,7 @@ static OperandOwnership getFunctionArgOwnership(SILArgumentConvention argConv,
   case SILArgumentConvention::Indirect_Out:
   case SILArgumentConvention::Indirect_Inout:
   case SILArgumentConvention::Indirect_InoutAliasable:
-    llvm_unreachable("Illegal convention for non-address types");
+    ASSERT(false && "Illegal convention for non-address types");
   }
   llvm_unreachable("covered switch");
 }

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -799,6 +799,17 @@ swift::devirtualizeClassMethod(SILPassManager *pm, FullApplySite applySite,
     ++indirectResultArgIter;
   }
 
+  if (SILType errorTy = substConv.getIndirectErrorResultType(applySite.getFunction()->getTypeExpansionContext())) {
+    auto errorArgs = applySite.getIndirectSILErrorResults();
+    assert(errorArgs.size() == 1);
+    SILValue errorArg = errorArgs[0];
+    auto castRes = castValueToABICompatibleType(
+        &builder, pm, loc, errorArg, errorArg->getType(),
+        errorTy, {applySite.getInstruction()});
+    newArgs.push_back(castRes.first);
+    changedCFG |= castRes.second;
+  }
+
   auto paramArgIter = applySite.getArgumentsWithoutIndirectResults().begin();
   // Skip the last parameter, which is `self`. Add it below.
   for (auto param : substConv.getParameters()) {

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -801,7 +801,7 @@ swift::devirtualizeClassMethod(SILPassManager *pm, FullApplySite applySite,
 
   if (SILType errorTy = substConv.getIndirectErrorResultType(applySite.getFunction()->getTypeExpansionContext())) {
     auto errorArgs = applySite.getIndirectSILErrorResults();
-    assert(errorArgs.size() == 1);
+    ASSERT(errorArgs.size() == 1);
     SILValue errorArg = errorArgs[0];
     auto castRes = castValueToABICompatibleType(
         &builder, pm, loc, errorArg, errorArg->getType(),

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -1503,3 +1503,39 @@ entry(%executor: $Builtin.Executor):
   %r = tuple ()
   return %r : $()
 }
+
+private class X {
+  func foo<E>(_ e: E.Type) throws(E) where E : Error
+}
+
+sil private [ossa] @X_foo : $@convention(method) <E where E : Error> (@thick E.Type, @guaranteed X) -> @error_indirect E {
+bb0(%0 : $*E, %1 : $@thick E.Type, %2 : @guaranteed $X):
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @class_method_with_typed_throw
+// CHECK:         function_ref
+// CHECK:       } // end sil function 'class_method_with_typed_throw'
+sil [ossa] @class_method_with_typed_throw : $@convention(thin) <E where E : Error> (@guaranteed X, @thick E.Type) -> () {
+bb0(%0 : @guaranteed $X, %1 : $@thick E.Type):
+  %4 = alloc_stack $E
+  %5 = class_method %0 : $X, #X.foo : <E where E : Error> (X) -> (E.Type) throws(E) -> (), $@convention(method) <τ_0_0 where τ_0_0 : Error> (@thick τ_0_0.Type, @guaranteed X) -> @error_indirect τ_0_0
+  %6 = alloc_stack $E
+  try_apply %5<E>(%6, %1, %0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@thick τ_0_0.Type, @guaranteed X) -> @error_indirect τ_0_0, normal bb1, error bb2
+
+bb1(%8 : $()):
+  dealloc_stack %6 : $*E
+  dealloc_stack %4 : $*E
+  %11 = tuple ()
+  return %11 : $()
+
+bb2:
+  unreachable
+}
+
+
+sil_vtable X {
+  #X.foo: <E where E : Error> (X) -> (E.Type) throws(E) -> () : @X_foo
+}
+

--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -203,3 +203,14 @@ func switchLoopWithPartialApplyCaller() {
       print(error)
   }
 }
+
+private class Cl {
+  func foo<E: Error>(_ e: E.Type) throws(E) {
+  }
+}
+
+
+private func devirtualizeClassMethodWithTypedThrow<E: Error>(_ x: Cl, e: E.Type) {
+  try! x.foo(e)
+}
+


### PR DESCRIPTION
The de-virtualizer utility didn't handle indirect error results when de-virtualizing class or actor methods. This resulted in a missing argument for the indirect error result in the new try_apply instruction.

rdar://130545338
