### PR TITLE
SwiftCompilerSources: remove references to C's stderr

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -67,31 +67,6 @@ public extension NoReflectionChildren {
   var customMirror: Mirror { Mirror(self, children: []) }
 }
 
-#if !os(Windows)
-// TODO: https://github.com/apple/swift/issues/73252
-
-public var standardError = CFileStream(fp: stderr)
-
-#if os(Android) || canImport(Musl)
-  public typealias FILEPointer = OpaquePointer
-#else
-  public typealias FILEPointer = UnsafeMutablePointer<FILE>
-#endif
-
-public struct CFileStream: TextOutputStream {
-  var fp: FILEPointer
-
-  public func write(_ string: String) {
-    fputs(string, fp)
-  }
-
-  public func flush() {
-    fflush(fp)
-  }
-}
-
-#endif
-
 //===----------------------------------------------------------------------===//
 //                              StringRef
 //===----------------------------------------------------------------------===//

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -126,10 +126,7 @@ private struct DiagnoseDependence {
   }
 
   func reportUnknown(operand: Operand) {
-#if !os(Windows)
-    // TODO: https://github.com/apple/swift/issues/73252
-    standardError.write("Unknown use: \(operand)\n\(function)")
-#endif
+    log("Unknown use: \(operand)\n\(function)")
     reportEscaping(operand: operand)
   }
 


### PR DESCRIPTION
Fixes a linux build error.
The `var standardError` was only used in one place for logging, which can be done with `log` anyway. Instead of using such C library constructs directly we should bridge to higher level APIs. This is more platform independent.

Fixes https://github.com/swiftlang/swift/issues/73252
Fixes https://github.com/swiftlang/swift/issues/74701
