### PR TITLE
[Macros] In-process plugin server library tied to compiler host, not target

### DIFF
--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -253,6 +253,9 @@ protected:
                       const InvocationInfo &invocationInfo,
                       const JobContext &context) const;
 
+  void addPluginArguments(const llvm::opt::ArgList &Args,
+                          llvm::opt::ArgStringList &Arguments) const;
+
 public:
   virtual ~ToolChain() = default;
 
@@ -340,9 +343,6 @@ public:
   void addLinkRuntimeLib(const llvm::opt::ArgList &Args,
                          llvm::opt::ArgStringList &Arguments,
                          StringRef LibName) const;
-
-  virtual void addPluginArguments(const llvm::opt::ArgList &Args,
-                                  llvm::opt::ArgStringList &Arguments) const {}
 
   /// Validates arguments passed to the toolchain.
   ///

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -129,37 +129,6 @@ std::string toolchains::Darwin::sanitizerRuntimeLibName(StringRef Sanitizer,
       .str();
 }
 
-void
-toolchains::Darwin::addPluginArguments(const ArgList &Args,
-                                       ArgStringList &Arguments) const {
-  SmallString<64> pluginPath;
-  auto programPath = getDriver().getSwiftProgramPath();
-  CompilerInvocation::computeRuntimeResourcePathFromExecutablePath(
-      programPath, /*shared=*/true, pluginPath);
-
-  // In-process plugin server path.
-  auto inProcPluginServerPath = pluginPath;
-  llvm::sys::path::append(inProcPluginServerPath, "host",
-                          "libSwiftInProcPluginServer.dylib");
-  Arguments.push_back("-in-process-plugin-server-path");
-  Arguments.push_back(Args.MakeArgString(inProcPluginServerPath));
-
-  // Default plugin path.
-  auto defaultPluginPath = pluginPath;
-  llvm::sys::path::append(defaultPluginPath, "host", "plugins");
-  Arguments.push_back("-plugin-path");
-  Arguments.push_back(Args.MakeArgString(defaultPluginPath));
-
-  // Local plugin path.
-  llvm::sys::path::remove_filename(pluginPath); // Remove "swift"
-  llvm::sys::path::remove_filename(pluginPath); // Remove "lib"
-  llvm::sys::path::append(pluginPath, "local", "lib");
-  llvm::sys::path::append(pluginPath, "swift");
-  llvm::sys::path::append(pluginPath, "host", "plugins");
-  Arguments.push_back("-plugin-path");
-  Arguments.push_back(Args.MakeArgString(pluginPath));
-}
-
 static void addLinkRuntimeLibRPath(const ArgList &Args,
                                    ArgStringList &Arguments,
                                    StringRef DarwinLibName,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1468,6 +1468,68 @@ void ToolChain::addLinkRuntimeLib(const ArgList &Args, ArgStringList &Arguments,
   Arguments.push_back(Args.MakeArgString(P));
 }
 
+static void appendInProcPluginServerPath(StringRef PluginPathRoot,
+                                         llvm::SmallVectorImpl<char> &InProcPluginServerPath) {
+  InProcPluginServerPath.append(PluginPathRoot.begin(), PluginPathRoot.end());
+#if defined(_WIN32)
+  llvm::sys::path::append(InProcPluginServerPath, "bin", "SwiftInProcPluginServer.dll");
+#elif defined(__APPLE__)
+  llvm::sys::path::append(InProcPluginServerPath, "lib", "swift", "host", "libSwiftInProcPluginServer.dylib");
+#elif defined(__unix__)
+  llvm::sys::path::append(InProcPluginServerPath, "lib", "swift", "host", "libSwiftInProcPluginServer.so");
+#else
+#error Unknown compiler host
+#endif
+}
+
+static void appendPluginsPath(StringRef PluginPathRoot,
+                              llvm::SmallVectorImpl<char> &PluginsPath) {
+  PluginsPath.append(PluginPathRoot.begin(), PluginPathRoot.end());
+#if defined(_WIN32)
+  llvm::sys::path::append(PluginsPath, "bin");
+#elif defined(__APPLE__) || defined(__unix__)
+  llvm::sys::path::append(PluginsPath, "lib", "swift", "host", "plugins");
+#else
+#error Unknown compiler host
+#endif
+}
+
+#if defined(__APPLE__) || defined(__unix__)
+static void appendLocalPluginsPath(StringRef PluginPathRoot,
+                                   llvm::SmallVectorImpl<char> &LocalPluginsPath) {
+  SmallString<261> localPluginPathRoot = PluginPathRoot;
+  llvm::sys::path::append(localPluginPathRoot, "local");
+  appendPluginsPath(localPluginPathRoot, LocalPluginsPath);
+}
+#endif
+
+void ToolChain::addPluginArguments(const ArgList &Args,
+                                   ArgStringList &Arguments) const {
+  SmallString<261> pluginPathRoot = StringRef(getDriver().getSwiftProgramPath());
+  llvm::sys::path::remove_filename(pluginPathRoot); // Remove `swift`
+  llvm::sys::path::remove_filename(pluginPathRoot); // Remove `bin`
+
+  // In-process plugin server path.
+  SmallString<261> inProcPluginServerPath;
+  appendInProcPluginServerPath(pluginPathRoot, inProcPluginServerPath);
+  Arguments.push_back("-in-process-plugin-server-path");
+  Arguments.push_back(Args.MakeArgString(inProcPluginServerPath));
+
+  // Default plugin path.
+  SmallString<261> defaultPluginPath;
+  appendPluginsPath(pluginPathRoot, defaultPluginPath);
+  Arguments.push_back("-plugin-path");
+  Arguments.push_back(Args.MakeArgString(defaultPluginPath));
+
+  // Local plugin path.
+#if defined(__APPLE__) || defined(__unix__)
+  SmallString<261> localPluginPath;
+  appendLocalPluginsPath(pluginPathRoot, localPluginPath);
+  Arguments.push_back("-plugin-path");
+  Arguments.push_back(Args.MakeArgString(localPluginPath));
+#endif
+}
+
 void ToolChain::getClangLibraryPath(const ArgList &Args,
                                     SmallString<128> &LibPath) const {
   const llvm::Triple &T = getTriple();

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -66,9 +66,6 @@ protected:
   InvocationInfo constructInvocation(const StaticLinkJobAction &job,
                                      const JobContext &context) const override;
 
-  void addPluginArguments(const llvm::opt::ArgList &Args,
-                          llvm::opt::ArgStringList &Arguments) const override;
-
   void validateArguments(DiagnosticEngine &diags,
                          const llvm::opt::ArgList &args,
                          StringRef defaultTarget) const override;
@@ -117,9 +114,6 @@ public:
 
   std::string sanitizerRuntimeLibName(StringRef Sanitizer,
                                       bool shared = true) const override;
-
-  void addPluginArguments(const llvm::opt::ArgList &Args,
-                          llvm::opt::ArgStringList &Arguments) const override;
 };
 
 class LLVM_LIBRARY_VISIBILITY WebAssembly : public ToolChain {
@@ -173,9 +167,6 @@ public:
   ~GenericUnix() = default;
   std::string sanitizerRuntimeLibName(StringRef Sanitizer,
                                       bool shared = true) const override;
-
-  void addPluginArguments(const llvm::opt::ArgList &Args,
-                          llvm::opt::ArgStringList &Arguments) const override;
 };
 
 class LLVM_LIBRARY_VISIBILITY Android : public GenericUnix {

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -50,37 +50,6 @@ toolchains::GenericUnix::sanitizerRuntimeLibName(StringRef Sanitizer,
       .str();
 }
 
-void
-toolchains::GenericUnix::addPluginArguments(const ArgList &Args,
-                                            ArgStringList &Arguments) const {
-  SmallString<64> pluginPath;
-  auto programPath = getDriver().getSwiftProgramPath();
-  CompilerInvocation::computeRuntimeResourcePathFromExecutablePath(
-      programPath, /*shared=*/true, pluginPath);
-
-  // In-process plugin server path.
-  auto inProcPluginServerPath = pluginPath;
-  llvm::sys::path::append(inProcPluginServerPath, "host",
-                          "libSwiftInProcPluginServer.so");
-  Arguments.push_back("-in-process-plugin-server-path");
-  Arguments.push_back(Args.MakeArgString(inProcPluginServerPath));
-
-  // Default plugin path.
-  auto defaultPluginPath = pluginPath;
-  llvm::sys::path::append(defaultPluginPath, "host", "plugins");
-  Arguments.push_back("-plugin-path");
-  Arguments.push_back(Args.MakeArgString(defaultPluginPath));
-
-  // Local plugin path.
-  llvm::sys::path::remove_filename(pluginPath); // Remove "swift"
-  llvm::sys::path::remove_filename(pluginPath); // Remove "lib"
-  llvm::sys::path::append(pluginPath, "local", "lib");
-  llvm::sys::path::append(pluginPath, "swift");
-  llvm::sys::path::append(pluginPath, "host", "plugins");
-  Arguments.push_back("-plugin-path");
-  Arguments.push_back(Args.MakeArgString(pluginPath));
-}
-
 ToolChain::InvocationInfo
 toolchains::GenericUnix::constructInvocation(const InterpretJobAction &job,
                                              const JobContext &context) const {

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -44,24 +44,6 @@ std::string toolchains::Windows::sanitizerRuntimeLibName(StringRef Sanitizer,
       .str();
 }
 
-void
-toolchains::Windows::addPluginArguments(const ArgList &Args,
-                                        ArgStringList &Arguments) const {
-  SmallString<261> LibraryPath = StringRef(getDriver().getSwiftProgramPath());
-  llvm::sys::path::remove_filename(LibraryPath); // Remove `swift`
-
-  // In-process plugin server path.
-  SmallString<261> InProcPluginServerPath = LibraryPath;
-  llvm::sys::path::append(InProcPluginServerPath,
-                          "SwiftInProcPluginServer.dll");
-  Arguments.push_back("-in-process-plugin-server-path");
-  Arguments.push_back(Args.MakeArgString(InProcPluginServerPath));
-
-  // Default plugin path.
-  Arguments.push_back("-plugin-path");
-  Arguments.push_back(Args.MakeArgString(LibraryPath));
-}
-
 ToolChain::InvocationInfo
 toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
                                          const JobContext &context) const {

--- a/test/Driver/compiler_plugin_path.swift
+++ b/test/Driver/compiler_plugin_path.swift
@@ -1,7 +1,6 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>^1 | %FileCheck %s
 
-// CHECK: -plugin-path
-// CHECK-SAME: {{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins
+// REQUIRES: OS=macosx || OS=linux-gnu
 
-// CHECK-SAME: -plugin-path
-// CHECK-SAME: {{(/|\\\\)}}local{{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins
+// CHECK: -plugin-path {{[^ ]+}}/lib/swift/host/plugins
+// CHECK-SAME: -plugin-path {{[^ ]+}}/local/lib/swift/host/plugins

--- a/test/Driver/compiler_plugin_path_windows.swift
+++ b/test/Driver/compiler_plugin_path_windows.swift
@@ -1,0 +1,5 @@
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>^1 | %FileCheck %s
+
+// REQUIRES: OS=windows
+
+// CHECK: -plugin-path {{[^ ]+}}\bin


### PR DESCRIPTION
PR #73725 introduced the in-process plugin server library, but the selection of the library depends on the selected toolchain, which depends on the compiler target, not the host. When cross-compiling (for example from macOS to a embedded Unix target), the compiler will incorrectly chose the `.so` file, not find it, and fail to compile things like the `@debugDescription` macro.

Move the in-process plugin server library code from the platform toolchains into the parent type, and code it so it uses the right name depending on the compiler host at compilation time. This discards the target and only relies on the compiler host for selecting the right library.
