### PR TITLE
test: Fix test/IRGen/moveonly_value_functions.sil for 32-bit targets

### DIFF
--- a/test/IRGen/moveonly_value_functions.sil
+++ b/test/IRGen/moveonly_value_functions.sil
@@ -14,7 +14,10 @@ import Swift
   @_alwaysEmitIntoClient @inlinable deinit
 }
 
-sil @$sSp12deinitialize5countSvSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, UnsafeMutablePointer<τ_0_0>) -> UnsafeMutableRawPointer
+struct Int {
+  var _value: Builtin.Int64
+}
+sil @deinit_count : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (moveonly_value_functions.Int, UnsafeMutablePointer<τ_0_0>) -> UnsafeMutableRawPointer
 
 // CHECK-LABEL: define{{.*}} @"$s15Synchronization5_CellVAARi_zrlEfD"(
 // CHECK-SAME:      ptr %"_Cell<Value>", 
@@ -22,20 +25,20 @@ sil @$sSp12deinitialize5countSvSi_tF : $@convention(method) <τ_0_0 where τ_0_0
 // CHECK-SAME:  ) 
 // CHECK-SAME:  {
 // CHECK:       entry:
-// CHECK:         [[CELL_VWT_ADDR:%[^,]+]] = getelementptr inbounds ptr, ptr %"_Cell<Value>", i64 -1
+// CHECK:         [[CELL_VWT_ADDR:%[^,]+]] = getelementptr inbounds ptr, ptr %"_Cell<Value>", [[INT]] -1
 // CHECK:         %"_Cell<Value>.valueWitnesses" = load ptr, ptr [[CELL_VWT_ADDR]]
 // CHECK:         [[CELL_SIZE_ADDR:%[^,]+]] = getelementptr inbounds %swift.vwtable, ptr %"_Cell<Value>.valueWitnesses", i32 0, i32 8
-// CHECK:         %size = load i64, ptr [[CELL_SIZE_ADDR]]
-// CHECK:         [[DEST:%[^,]+]] = alloca i8, i64 %size
+// CHECK:         %size = load [[INT]], ptr [[CELL_SIZE_ADDR]]
+// CHECK:         [[DEST:%[^,]+]] = alloca i8, [[INT]] %size
 // CHECK:         call void @llvm.lifetime.start.p0(i64 -1, ptr [[DEST]])
-// CHECK:         [[VALUE_METADATA_ADDR:%[^,]+]] = getelementptr inbounds ptr, ptr %"_Cell<Value>", i64 2
+// CHECK:         [[VALUE_METADATA_ADDR:%[^,]+]] = getelementptr inbounds ptr, ptr %"_Cell<Value>", [[INT]] 2
 // CHECK:         %Value = load ptr, ptr [[VALUE_METADATA_ADDR]]
-// CHECK:         [[VALUE_VWT_ADDR:%[^,]+]] = getelementptr inbounds ptr, ptr %Value, i64 -1
+// CHECK:         [[VALUE_VWT_ADDR:%[^,]+]] = getelementptr inbounds ptr, ptr %Value, [[INT]] -1
 // CHECK:         %Value.valueWitnesses = load ptr, ptr [[VALUE_VWT_ADDR]]
 // CHECK:         [[VALUE_INIT_WITH_TAKE_ADDR:%[^,]+]] = getelementptr inbounds ptr, ptr %Value.valueWitnesses, i32 4
 // CHECK:         %InitializeWithTake = load ptr, ptr [[VALUE_INIT_WITH_TAKE_ADDR]]
 // CHECK:         call ptr %InitializeWithTake(ptr noalias [[DEST]], ptr noalias [[SOURCE]], ptr %Value)
-// CHECK:         call swiftcc ptr @"$sSp12deinitialize5countSvSi_tF"(i64 1, ptr [[DEST]], ptr %Value)
+// CHECK:         call swiftcc ptr @deinit_count(i64 1, ptr [[DEST]], ptr %Value)
 // CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[DEST]])
 // CHECK:       }
 sil @$s15Synchronization5_CellVAARi_zrlEfD : $@convention(method) <Value where Value : ~Copyable> (@in _Cell<Value>) -> () {
@@ -46,8 +49,8 @@ bb0(%0 : $*_Cell<Value>):
   %8 = struct $UnsafeMutablePointer<Value> (%7 : $Builtin.RawPointer)
   %9 = integer_literal $Builtin.Int64, 1
   %10 = struct $Int (%9 : $Builtin.Int64)
-  %11 = function_ref @$sSp12deinitialize5countSvSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, UnsafeMutablePointer<τ_0_0>) -> UnsafeMutableRawPointer
-  %12 = apply %11<Value>(%10, %8) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, UnsafeMutablePointer<τ_0_0>) -> UnsafeMutableRawPointer
+  %11 = function_ref @deinit_count : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (moveonly_value_functions.Int, UnsafeMutablePointer<τ_0_0>) -> UnsafeMutableRawPointer
+  %12 = apply %11<Value>(%10, %8) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (moveonly_value_functions.Int, UnsafeMutablePointer<τ_0_0>) -> UnsafeMutableRawPointer
   %13 = tuple ()
   dealloc_stack %1 : $*_Cell<Value>
   return %13 : $()


### PR DESCRIPTION
We cannot assume Int is backed by BuiltIn.Int64 and ptr offset is i64. Function declaration names are renamed to avoid signature mismatch with the real imported declaration.

```
--
Exit Code: 2

Command Output (stderr):
--
SIL verification failed: struct operand type does not match field type
  $Builtin.Int64
  $Builtin.Int32
Verifying instruction:
     %5 = integer_literal $Builtin.Int64, 1       // user: %6
->   %6 = struct $Int (%5 : $Builtin.Int64)       // user: %8
     %8 = apply %7<Value>(%6, %4) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, UnsafeMutablePointer<τ_0_0>) -> UnsafeMutableRawPointer
In function:
// _Cell<>.deinit
sil @$s15Synchronization5_CellVAARi_zrlEfD : $@convention(method) <Value where Value : ~Copyable> (@in _Cell<Value>) -> () {
// %0                                             // user: %2
bb0(%0 : $*_Cell<Value>):
  %1 = alloc_stack $_Cell<Value>                  // users: %10, %3, %2
  copy_addr [take] %0 to [init] %1 : $*_Cell<Value> // id: %2
  %3 = builtin "addressOfRawLayout"<_Cell<Value>>(%1 : $*_Cell<Value>) : $Builtin.RawPointer // user: %4
  %4 = struct $UnsafeMutablePointer<Value> (%3 : $Builtin.RawPointer) // user: %8
  %5 = integer_literal $Builtin.Int64, 1          // user: %6
  %6 = struct $Int (%5 : $Builtin.Int64)          // user: %8
  // function_ref UnsafeMutablePointer.deinitialize(count:)
  %7 = function_ref @$sSp12deinitialize5countSvSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, UnsafeMutablePointer<τ_0_0>) -> UnsafeMutableRawPointer // user: %8
  %8 = apply %7<Value>(%6, %4) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, UnsafeMutablePointer<τ_0_0>) -> UnsafeMutableRawPointer
  %9 = tuple ()                                   // user: %11
  dealloc_stack %1 : $*_Cell<Value>               // id: %10
  return %9 : $()                                 // id: %11
} // end sil function '$s15Synchronization5_CellVAARi_zrlEfD'
```

https://ci.swift.org/job/oss-swift-pr-test-crosscompile-wasm-ubuntu-20_04/1034/console