### PR TITLE
[6.0] [ClangImporter] Switch `lookupGlobalsAsMembers` to take a non-optional EffectiveClangContext

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -684,14 +684,13 @@ SwiftLookupTable::allGlobalsAsMembersInContext(StoredContext context) {
 }
 
 SmallVector<SwiftLookupTable::SingleEntry, 4>
-SwiftLookupTable::lookupGlobalsAsMembers(
-    SerializedSwiftName baseName,
-    std::optional<EffectiveClangContext> searchContext) {
+SwiftLookupTable::lookupGlobalsAsMembers(SerializedSwiftName baseName,
+                                         EffectiveClangContext searchContext) {
   // Propagate the null search context.
   if (!searchContext)
     return lookupGlobalsAsMembersImpl(baseName, std::nullopt);
 
-  std::optional<StoredContext> storedContext = translateContext(*searchContext);
+  std::optional<StoredContext> storedContext = translateContext(searchContext);
   if (!storedContext) return { };
 
   return lookupGlobalsAsMembersImpl(baseName, *storedContext);

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -549,7 +549,7 @@ public:
   /// entities should reside.
   SmallVector<SingleEntry, 4>
   lookupGlobalsAsMembers(SerializedSwiftName baseName,
-                         std::optional<EffectiveClangContext> searchContext);
+                         EffectiveClangContext searchContext);
 
   SmallVector<SingleEntry, 4>
   allGlobalsAsMembersInContext(EffectiveClangContext context);


### PR DESCRIPTION
*6.0 cherry-pick of #74683*

- Explanation: Fixes a crash that could occur when looking up a member in the ClangImporter
- Scope: Affects name lookup for imported decls
- Issue: rdar://129619711
- Risk: Low, the fix is very straightforward
- Testing: No test unfortunately as haven't been able to come up with a reproducer, passes the existing test suite
- Reviewer: Becca Royal-Gordon