### PR TITLE
[cxx-interop] Ban ObjCBool from being substituted into C++ templates

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -897,6 +897,19 @@ ClangTypeConverter::getClangTemplateArguments(
     }
 
     auto replacement = genericArgs[templateParam->getIndex()];
+
+    // Ban ObjCBool type from being substituted into C++ templates.
+    if (auto nominal = replacement->getAs<NominalType>()) {
+      if (auto nominalDecl = nominal->getDecl()) {
+        if (nominalDecl->getName().is("ObjCBool") &&
+            nominalDecl->getModuleContext()->getName() ==
+                nominalDecl->getASTContext().Id_ObjectiveC) {
+          failedTypes.push_back(replacement);
+          continue;
+        }
+      }
+    }
+
     auto qualType = convert(replacement);
     if (qualType.isNull()) {
       failedTypes.push_back(replacement);

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -71,6 +71,8 @@ template <class T> struct Dep { using TT = T; };
 
 template <class T> void useDependentType(typename Dep<T>::TT) {}
 
+template <class T> void takesValue(T value) { }
+
 template <class T> void lvalueReference(T &ref) { ref = 42; }
 template <class T> void lvalueReferenceZero(T &ref) { ref = 0; }
 

--- a/test/Interop/Cxx/templates/function-template-objc-typechecker.swift
+++ b/test/Interop/Cxx/templates/function-template-objc-typechecker.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import FunctionTemplates
+import ObjectiveC
+
+// Verify that ObjCBool type is banned from C++ template parameters.
+
+takesValue(ObjCBool(true))
+// CHECK: error: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'takesValue' could not be converted: ObjCBool
+constLvalueReference(ObjCBool(true))
+// CHECK: error: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'constLvalueReference' could not be converted: ObjCBool


### PR DESCRIPTION
This fixes a compiler crash when calling a templated C++ function with a parameter of type `ObjCBool` from Swift. The compiler now emits an error for this.

Previously the following would happen:
1. Swift starts to emit SILGen for a call expression `takeTAsConstRef(ObjCBool(true))`.
2. `takeTAsConstRef` is a templated C++ function, so Swift asks Clang to instantiate a `takeTAsConstRef` with a built-in Obj-C boolean type.
3. Swift gets an instantiated function template back that looks like this: `void takeTAsConstRef(_Bool t) { ... }`.
4. Swift's ClangImporter begins to import that instantiated function.
5. Since the parameter type is not spelled as `BOOL`, the parameter is not imported as `ObjCBool`. Instead, it's imported as regular Swift `Bool`.
6. Swift realizes that the types don't match (`ObjCBool` vs `Bool`), tries to apply any of the known implicit conversions, fails to do so, crashes.

rdar://130424969