### PR TITLE
[stdlib] Prepare the standard library for Swift version 6

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/swift/shims/GlobalObjects.h
@@ -30,6 +30,8 @@ namespace swift {
 extern "C" {
 #endif
 
+#define SWIFT_NONISOLATED_UNSAFE __attribute__((__swift_attr__("nonisolated(unsafe)")))
+
 struct _SwiftArrayBodyStorage {
   __swift_intptr_t count;
   __swift_uintptr_t _capacityAndFlags;
@@ -40,7 +42,7 @@ struct _SwiftEmptyArrayStorage {
   struct _SwiftArrayBodyStorage body;
 };
 
-SWIFT_RUNTIME_STDLIB_API
+SWIFT_RUNTIME_STDLIB_API SWIFT_NONISOLATED_UNSAFE
 struct _SwiftEmptyArrayStorage _swiftEmptyArrayStorage;
 
 struct _SwiftDictionaryBodyStorage {
@@ -78,10 +80,10 @@ struct _SwiftEmptySetSingleton {
   __swift_uintptr_t metadata;
 };
 
-SWIFT_RUNTIME_STDLIB_API
+SWIFT_RUNTIME_STDLIB_API SWIFT_NONISOLATED_UNSAFE
 struct _SwiftEmptyDictionarySingleton _swiftEmptyDictionarySingleton;
 
-SWIFT_RUNTIME_STDLIB_API
+SWIFT_RUNTIME_STDLIB_API SWIFT_NONISOLATED_UNSAFE
 struct _SwiftEmptySetSingleton _swiftEmptySetSingleton;
 
 struct _SwiftHashingParameters {
@@ -91,7 +93,7 @@ struct _SwiftHashingParameters {
 };
   
 SWIFT_RUNTIME_STDLIB_API
-struct _SwiftHashingParameters _swift_stdlib_Hashing_parameters;
+const struct _SwiftHashingParameters _swift_stdlib_Hashing_parameters;
 
 #ifdef __cplusplus
 

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -120,12 +120,19 @@ internal func _connectNSBaseClasses() -> Bool
 
 
 private let _bridgeInitializedSuccessfully = _connectNSBaseClasses()
-internal var _orphanedFoundationSubclassesReparented: Bool = false
+
+// Note: This is marked nonisolated unsafe because we will only ever set this
+// value to true. Even if multiple threads race to call
+// _connectOrphanedFoundationSubclassesIfNeeded, all invocations will write the
+// same value. Readers of this variable should never see an in-between value
+// during a write since this is just a boolean.
+internal nonisolated(unsafe)
+var _orphanedFoundationSubclassesReparented: Bool = false
 
 /// Reparents the SwiftNativeNS*Base classes to be subclasses of their respective
 /// Foundation types, or is false if they couldn't be reparented. Must be run
 /// in order to bridge Swift Strings, Arrays, Dictionaries, Sets, or Enumerators to ObjC.
- internal func _connectOrphanedFoundationSubclassesIfNeeded() -> Void {
+internal func _connectOrphanedFoundationSubclassesIfNeeded() -> Void {
   let bridgeWorks = _bridgeInitializedSuccessfully
   _debugPrecondition(bridgeWorks)
   _orphanedFoundationSubclassesReparented = true

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -3574,7 +3574,8 @@ public enum EncodingError: Error {
   ///
   /// As associated values, this case contains the attempted value and context
   /// for debugging.
-  case invalidValue(Any, Context)
+  @preconcurrency
+  case invalidValue(Any & Sendable, Context)
 
   // MARK: - NSError Bridging
 

--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -26,7 +26,7 @@ extension CommandLine {
   /// The backing static variable for argument count may come either from the
   /// entry point or it may need to be computed e.g. if we're in the REPL.
   @usableFromInline
-  internal static var _argc: Int32 = 0
+  internal static nonisolated(unsafe) var _argc: Int32 = 0
 
   /// The backing static variable for arguments may come either from the
   /// entry point or it may need to be computed e.g. if we're in the REPL.
@@ -34,7 +34,7 @@ extension CommandLine {
   /// Care must be taken to ensure that `_swift_stdlib_getUnsafeArgvArgc` is
   /// not invoked more times than is necessary (at most once).
   @usableFromInline
-  internal static var _unsafeArgv:
+  internal static nonisolated(unsafe) var _unsafeArgv:
     UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>
       = _swift_stdlib_getUnsafeArgvArgc(&_argc)
 

--- a/stdlib/public/core/LegacyABI.swift
+++ b/stdlib/public/core/LegacyABI.swift
@@ -87,3 +87,40 @@ extension String.UTF16View {
   @inlinable @inline(__always)
   internal var _shortHeuristic: Int { return 32 }
 }
+
+// Note: These 4 functions are previous setters and modifies for
+// _EachFieldOptions.classType and _EachFieldOptions.ignoreUnknown. These were
+// defined as static vars which allow for shared mutable data when the intention
+// was just an option for an option set which should be constant static data.
+
+@available(SwiftStdlib 5.2, *)
+@usableFromInline
+@_silgen_name("$ss17_EachFieldOptionsV13ignoreUnknownABvsZ")
+@_spi(Reflection)
+internal func _eachFieldOptionsIgnoreUnknownSetter(_: _EachFieldOptions) {
+  fatalError()
+}
+
+@available(SwiftStdlib 5.2, *)
+@usableFromInline
+@_silgen_name("$ss17_EachFieldOptionsV13ignoreUnknownABvMZ")
+@_spi(Reflection)
+internal func _eachFieldOptionsIgnoreUnknownModify(_: UnsafeRawPointer) {
+  fatalError()
+}
+
+@available(SwiftStdlib 5.2, *)
+@usableFromInline
+@_silgen_name("$ss17_EachFieldOptionsV9classTypeABvsZ")
+@_spi(Reflection)
+internal func _eachFieldOptionsClassTypeSetter(_: _EachFieldOptions) {
+  fatalError()
+}
+
+@available(SwiftStdlib 5.2, *)
+@usableFromInline
+@_silgen_name("$ss17_EachFieldOptionsV9classTypeABvMZ")
+@_spi(Reflection)
+internal func _eachFieldOptionsClassTypeModify(_: UnsafeRawPointer) {
+  fatalError()
+}

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -620,7 +620,11 @@ extension Unicode.Scalar: TextOutputStreamable {
 }
 
 /// A hook for playgrounds to print through.
-public var _playgroundPrintHook: ((String) -> Void)? = nil
+///
+/// Note: This is marked nonisolated unsafe because we are not responisble for
+/// the synchronization needed to update this variable. Either a debugger or a
+/// playground environment is setting this hook up.
+public nonisolated(unsafe) var _playgroundPrintHook: ((String) -> Void)? = nil
 
 internal struct _TeeStream<L: TextOutputStream, R: TextOutputStream>
   : TextOutputStream

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -204,13 +204,17 @@ public struct _EachFieldOptions: OptionSet {
   ///
   /// If this is not set, the top-level type is required to be a struct or
   /// tuple.
-  public static var classType = _EachFieldOptions(rawValue: 1 << 0)
+  public static var classType: _EachFieldOptions {
+    _EachFieldOptions(rawValue: 1 << 0)
+  }
 
   /// Ignore fields that can't be introspected.
   ///
   /// If not set, the presence of things that can't be introspected causes
   /// the function to immediately return `false`.
-  public static var ignoreUnknown = _EachFieldOptions(rawValue: 1 << 1)
+  public static var ignoreUnknown: _EachFieldOptions {
+    _EachFieldOptions(rawValue: 1 << 1)
+  }
 }
 
 @available(SwiftStdlib 5.2, *)

--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -105,7 +105,7 @@ struct _RuntimeFunctionCounters {
 
   public static let runtimeFunctionNames =
     getRuntimeFunctionNames()
-  public static let runtimeFunctionCountersOffsets =
+  public static nonisolated(unsafe) let runtimeFunctionCountersOffsets =
     _RuntimeFunctionCounters.getRuntimeFunctionCountersOffsets()
   public static let numRuntimeFunctionCounters =
     Int(_RuntimeFunctionCounters.getNumRuntimeFunctionCounters())

--- a/stdlib/public/core/Shims.swift
+++ b/stdlib/public/core/Shims.swift
@@ -27,8 +27,14 @@ internal func _makeSwiftNSFastEnumerationState()
 
 /// A dummy value to be used as the target for `mutationsPtr` in fast
 /// enumeration implementations.
+///
+/// Note: This is marked nonisolated unsafe because we _never_ write to this
+/// value. It is unfortunate that this is not a let, but we need to take the
+/// address of this variable which is currently only possible with vars in
+/// Swift.
 @usableFromInline
-internal var _fastEnumerationStorageMutationsTarget: CUnsignedLong = 0
+internal nonisolated(unsafe)
+var _fastEnumerationStorageMutationsTarget: CUnsignedLong = 0
 
 /// A dummy pointer to be used as `mutationsPtr` in fast enumeration
 /// implementations.

--- a/stdlib/public/core/Shims.swift
+++ b/stdlib/public/core/Shims.swift
@@ -39,7 +39,8 @@ var _fastEnumerationStorageMutationsTarget: CUnsignedLong = 0
 /// A dummy pointer to be used as `mutationsPtr` in fast enumeration
 /// implementations.
 @usableFromInline
-internal let _fastEnumerationStorageMutationsPtr =
+internal nonisolated(unsafe)
+let _fastEnumerationStorageMutationsPtr =
   UnsafeMutablePointer<CUnsignedLong>(Builtin.addressof(&_fastEnumerationStorageMutationsTarget))
 #endif
 

--- a/stdlib/public/core/ThreadLocalStorage.swift
+++ b/stdlib/public/core/ThreadLocalStorage.swift
@@ -35,7 +35,7 @@ internal class _TLSAtomicInt {
   }
 }
 
-internal let _destroyTLSCounter = _TLSAtomicInt()
+internal nonisolated(unsafe) let _destroyTLSCounter = _TLSAtomicInt()
 
 public // @testable
 func _loadDestroyTLSCounter() -> Int {

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -720,7 +720,12 @@ final internal class __VaListBuilder {
   internal var retainer = [CVarArg]()
 #endif
 
-  internal static var alignedStorageForEmptyVaLists: Double = 0
+  /// Note: This is nonisolated unsafe because we will _never_ write to this
+  /// value. It is marked as a var because we need to take the address of it,
+  /// and that pointer may be passed to user code under the guise of a
+  /// CVaListPointer. We cannot enforce any synchronization guarantees if the
+  /// somehow writes to the underlying pointer value in that type.
+  internal static nonisolated(unsafe) var alignedStorageForEmptyVaLists: Double = 0
 }
 
 #endif

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -156,7 +156,7 @@ static swift::_SwiftHashingParameters initializeHashingParameters() {
 }
 
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
-swift::_SwiftHashingParameters swift::_swift_stdlib_Hashing_parameters =
+const swift::_SwiftHashingParameters swift::_swift_stdlib_Hashing_parameters =
   initializeHashingParameters();
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
 

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -813,4 +813,6 @@ Var UnsafeMutableBufferPointer.debugDescription is now with @_preInverseGenerics
 
 Func FixedWidthInteger.&*(_:_:) has been added as a protocol requirement
 
+EnumElement EncodingError.invalidValue has declared type change from (Swift.EncodingError.Type) -> (Any, Swift.EncodingError.Context) -> Swift.EncodingError to (Swift.EncodingError.Type) -> (any Swift.Sendable, Swift.EncodingError.Context) -> Swift.EncodingError
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
This is pulling out most of the changes made here: https://github.com/swiftlang/swift/pull/71290, but drops making the singletons constant because there are places in the stdlib that assume they can always mutate their underlying storage (which wouldn't be true anymore if the singletons are in read only memory). We'll tackle that in a subsequent PR, but this gets everything else.

Resolves: rdar://130611950