### PR TITLE
Add new _foundation_unicode and _FoundationCShims c modules to windows build script

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1779,7 +1779,7 @@ function Install-Platform([Platform]$Platform, $Arch) {
   # Copy SDK header files
   Copy-Directory "$($Arch.SDKInstallRoot)\usr\include\swift\SwiftRemoteMirror" $SDKInstallRoot\usr\include\swift
   Copy-Directory "$($Arch.SDKInstallRoot)\usr\lib\swift\shims" $SDKInstallRoot\usr\lib\swift
-  foreach ($Module in ("Block", "dispatch", "os")) {
+  foreach ($Module in ("Block", "dispatch", "os", "_foundation_unicode", "_FoundationCShims")) {
     Copy-Directory "$($Arch.SDKInstallRoot)\usr\lib\swift\$Module" $SDKInstallRoot\usr\include
   }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1781,8 +1781,9 @@ function Install-Platform([Platform]$Platform, $Arch) {
   Copy-Directory "$($Arch.SDKInstallRoot)\usr\lib\swift\shims" $SDKInstallRoot\usr\lib\swift
   foreach ($Module in ("Block", "dispatch", "os", "_foundation_unicode", "_FoundationCShims")) {
     $ModuleDirectory = "$($Arch.SDKInstallRoot)\usr\lib\swift\$Module"
+    $DestinationDirectory = "$SDKInstallRoot\usr\include"
     if (Test-Path $ModuleDirectory) {
-      Copy-Directory $ModuleDirectory $SDKInstallRoot\usr\include
+      Copy-Directory $ModuleDirectory $DestinationDirectory
     }
   }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1780,7 +1780,10 @@ function Install-Platform([Platform]$Platform, $Arch) {
   Copy-Directory "$($Arch.SDKInstallRoot)\usr\include\swift\SwiftRemoteMirror" $SDKInstallRoot\usr\include\swift
   Copy-Directory "$($Arch.SDKInstallRoot)\usr\lib\swift\shims" $SDKInstallRoot\usr\lib\swift
   foreach ($Module in ("Block", "dispatch", "os", "_foundation_unicode", "_FoundationCShims")) {
-    Copy-Directory "$($Arch.SDKInstallRoot)\usr\lib\swift\$Module" $SDKInstallRoot\usr\include
+    $ModuleDirectory = "$($Arch.SDKInstallRoot)\usr\lib\swift\$Module"
+    if (Test-Path $ModuleDirectory) {
+      Copy-Directory $ModuleDirectory $SDKInstallRoot\usr\include
+    }
   }
 
   # Copy SDK share folder


### PR DESCRIPTION
Now that Foundation is producing new C modules (`_foundation_unicode` and `_FoundationCShims`) that clients depend upon because we do not enable library evolution for our modules, we need to ensure these modules are correctly installed into the just built SDK like the existing dispatch C modules.