### PR TITLE
Allow TempRValueOpt of lexical alloc_stacks when base of copy source is @in_guaranteed

### DIFF
--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -528,7 +528,7 @@ void TempRValueOptPass::tryOptimizeCopyIntoTemp(CopyAddrInst *copyInst) {
     if (!storage.base)
       return;
     if (auto *arg = dyn_cast<SILFunctionArgument>(storage.base))
-      if (arg->getOwnershipKind() != OwnershipKind::Guaranteed)
+      if (!arg->getArgumentConvention().isGuaranteedConventionInCallee())
         return;
   }
 

--- a/test/SILOptimizer/assemblyvision_remark/cast_remarks_objc.swift
+++ b/test/SILOptimizer/assemblyvision_remark/cast_remarks_objc.swift
@@ -21,7 +21,6 @@ public func forcedCast2<NS, T>(_ ns: NS) -> T {
   let x = ns
   return x as! T  // expected-remark @:12 {{unconditional runtime cast of value with type 'NS' to 'T'}}
                   // expected-note @-4:34 {{of 'ns'}}
-                  // expected-note @-3:7 {{of 'x'}}
 }
 
 public func forcedCast3<NS, T>(_ ns: NS) -> T {
@@ -29,7 +28,6 @@ public func forcedCast3<NS, T>(_ ns: NS) -> T {
   var x = ns // expected-warning {{variable 'x' was never mutated}}
   return x as! T  // expected-remark @:12 {{unconditional runtime cast of value with type 'NS' to 'T'}}
                   // expected-note @-4:34 {{of 'ns'}}
-                  // expected-note @-3:7 {{of 'x'}}
 }
 
 public func forcedCast4<NS, T>(_ ns: NS, _ ns2: NS) -> T {
@@ -52,7 +50,6 @@ public func condCast2<NS, T>(_ ns: NS) -> T? {
   let x = ns
   return x as? T  // expected-remark @:12 {{conditional runtime cast of value with type 'NS' to 'T'}}
                   // expected-note @-4:32 {{of 'ns'}}
-                  // expected-note @-3:7 {{of 'x'}}
 }
 
 public func condCast3<NS, T>(_ ns: NS) -> T? {
@@ -60,7 +57,6 @@ public func condCast3<NS, T>(_ ns: NS) -> T? {
   var x = ns // expected-warning {{variable 'x' was never mutated}}
   return x as? T  // expected-remark @:12 {{conditional runtime cast of value with type 'NS' to 'T'}}
                   // expected-note @-4:32 {{of 'ns'}}
-                  // expected-note @-3:7 {{of 'x'}}
 }
 
 public func condCast4<NS, T>(_ ns: NS, _ ns2: NS) -> T? {

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -1804,6 +1804,19 @@ entry(%instance : @guaranteed $OtherClass):
   return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @copy_addr__lexical_alloc_stack_temporary_in_guaranteed_function_arg : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function 'copy_addr__lexical_alloc_stack_temporary_in_guaranteed_function_arg'
+sil [ossa] @copy_addr__lexical_alloc_stack_temporary_in_guaranteed_function_arg : $@convention(thin) (@in_guaranteed Klass) -> () {
+entry(%instance : $*Klass):
+  %addr = alloc_stack [lexical] $Klass
+  copy_addr %instance to [init] %addr : $*Klass
+  destroy_addr %addr : $*Klass
+  dealloc_stack %addr : $*Klass
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // Lexical alloc_stacks can't be eliminated even if their source is a function
 // argument if that function argument is inout.
 // CHECK-LABEL: sil [ossa] @copy_addr__lexical_alloc_stack_temporary__inout_function_arg : {{.*}} {


### PR DESCRIPTION
`@in_guaranteed` function argument is live for the duration of the function. It should be safe to allow TempRValueOpt when it is the base of the copy source of a lexical alloc_stack

