### PR TITLE
[test] Wire libMockPlugin and swift-plugin-server as test dependencies

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,7 @@ function(get_test_dependencies SDK result_var_name)
 
   if (SWIFT_INCLUDE_TOOLS)
     list(APPEND deps_binaries
+      libMockPlugin
       lldb-moduleimport-test
       swift-frontend
       swift-demangle
@@ -63,6 +64,10 @@ function(get_test_dependencies SDK result_var_name)
 
     if(SWIFT_BUILD_SOURCEKIT)
       list(APPEND deps_binaries sourcekitd-test complete-test)
+    endif()
+
+    if(SWIFT_BUILD_SWIFT_SYNTAX)
+      list(APPEND deps_binaries swift-plugin-server)
     endif()
   endif()
 


### PR DESCRIPTION
The build script will build these pieces because they are wired to the tools and compiler components, but when using `ninja` or `cmake` directly to clean the build, and then later `check-swift-validation` and other test targets, it would not rebuild those targets, failing many of the macros/plugins tests.

