### PR TITLE
PoC of throwing checkIsolated

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -715,10 +715,17 @@ void swift_task_enqueue(Job *job, SerialExecutorRef executor);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueGlobal(Job *job);
 
+/// DEPRECATED. Use Error returning version instead.
+///
 /// Invoke an executor's `checkIsolated` or otherwise equivalent API,
 /// that will crash if the current executor is NOT the passed executor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_checkIsolated(SerialExecutorRef executor);
+
+/// Invoke an executor's `checkIsolated` or otherwise equivalent API,
+/// that will return an Error if the current executor is NOT the passed executor.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+SwiftError* swift_serialExecutor_checkIsolatedError(SerialExecutorRef executor);
 
 /// A count in nanoseconds.
 using JobDelay = unsigned long long;
@@ -789,10 +796,16 @@ SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_hook)(
     int clock, Job *job,
     swift_task_enqueueGlobalWithDeadline_original original);
 
+// Deprecated. Use swift_serialExecutor_checkIsolatedError instead.
 typedef SWIFT_CC(swift) void (*swift_task_checkIsolated_original)(SerialExecutorRef executor);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift) void (*swift_task_checkIsolated_hook)(
     SerialExecutorRef executor, swift_task_checkIsolated_original original);
+
+typedef SWIFT_CC(swift) SwiftError* (*swift_serialExecutor_checkIsolatedError_original)(SerialExecutorRef executor);
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift) SwiftError* (*swift_serialExecutor_checkIsolatedError_hook)(
+    SerialExecutorRef executor, swift_serialExecutor_checkIsolatedError_original original);
 
 
 typedef SWIFT_CC(swift) bool (*swift_task_isOnExecutor_original)(
@@ -971,8 +984,12 @@ SerialExecutorRef swift_task_getMainExecutor(void);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 TaskExecutorRef swift_task_getPreferredTaskExecutor(void);
 
+// DEPRECATED. Prefer swift_task_checkCurrentExecutor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 bool swift_task_isCurrentExecutor(SerialExecutorRef executor);
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+SwiftError* swift_task_checkCurrentExecutor(SerialExecutorRef executor);
 
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_reportUnexpectedExecutor(

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -136,6 +136,10 @@ OVERRIDE_ACTOR(task_isCurrentExecutor, bool,
                SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                swift::, (SerialExecutorRef executor), (executor))
 
+OVERRIDE_ACTOR(task_checkCurrentExecutor, SwiftError*,
+               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+               swift::, (SerialExecutorRef executor), (executor))
+
 OVERRIDE_ACTOR(task_switch, void,
                SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
                swift::, (SWIFT_ASYNC_CONTEXT AsyncContext *resumeToContext,

--- a/stdlib/public/Concurrency/CooperativeGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/CooperativeGlobalExecutor.inc
@@ -142,6 +142,13 @@ static void swift_task_checkIsolatedImpl(SerialExecutorRef executor) {
       executor.getSerialExecutorWitnessTable());
 }
 
+SWIFT_CC(swift)
+static SwiftError* swift_serialExecutor_checkIsolatedErrorImpl(SerialExecutorRef executor) {
+  return _task_serialExecutor_checkIsolatedError(
+      executor.getIdentity(), swift_getObjectType(executor.getIdentity()),
+      executor.getSerialExecutorWitnessTable());
+}
+
 /// Insert a job into the cooperative global queue with a delay.
 SWIFT_CC(swift)
 static void swift_task_enqueueGlobalWithDelayImpl(JobDelay delay,

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -18,7 +18,8 @@
 ///   swift_task_enqueueGlobalImpl
 ///   swift_task_enqueueGlobalWithDelayImpl
 ///   swift_task_enqueueMainExecutorImpl
-///   swift_task_checkIsolated
+///   swift_task_checkIsolatedImpl
+///   swift_serialExecutor_checkIsolatedErrorImpl
 /// as well as any Dispatch-specific functions for the runtime.
 ///
 ///===------------------------------------------------------------------===///
@@ -447,4 +448,30 @@ static void swift_task_checkIsolatedImpl(SerialExecutorRef executor) {
   // otherwise, we have no way to check, so report an error
   // TODO: can we swift_getTypeName(swift_getObjectType(executor.getIdentity()), false).data safely in the message here?
   swift_Concurrency_fatalError(0, "Incorrect actor executor assumption");
+}
+
+SWIFT_CC(swift)
+static SwiftError* swift_serialExecutor_checkIsolatedErrorImpl(SerialExecutorRef executor) {
+  // We're not able to special case the main executor; it must implement SerialExecutor and go through checkIsolated
+  // if (executor.isMainExecutor()) {
+  // dispatch_assert_queue(dispatch_get_main_queue());
+  //   return;
+  // }
+
+  // if able to, use the checkIsolated implementation in Swift
+  if (executor.hasSerialExecutorWitnessTable()) { // FIXME: what if it's not...
+    fprintf(stderr, "[%s:%d](%s) NO serial executor?\n", __FILE_NAME__, __LINE__, __FUNCTION__);
+    return _task_serialExecutor_checkIsolatedError(
+        executor.getIdentity(), swift_getObjectType(executor.getIdentity()),
+        executor.getSerialExecutorWitnessTable());
+  }
+
+  // We cannot write the code to check "is this the right queue" in Swift, we can only rely on SerialExecutor's checkIsolated error throwing
+  // if (auto queue = getAsDispatchSerialQueue(executor)) {
+  //   dispatch_assert_queue(queue);
+  //   return;
+  // }
+
+  // TODO: pass the expected executor here so error message can include it.
+  return swift_serialExecutor_makeUnexpectedExecutorError();
 }

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -90,16 +90,32 @@ SWIFT_CC(swift)
 void (*swift::swift_task_enqueueMainExecutor_hook)(
     Job *job, swift_task_enqueueMainExecutor_original original) = nullptr;
 
+// DEPRECATED. Replacing with Error returning version
 SWIFT_CC(swift)
 void (*swift::swift_task_checkIsolated_hook)(
     SerialExecutorRef executor,
     swift_task_checkIsolated_original original) = nullptr;
 
-extern "C" SWIFT_CC(swift)
-    void _task_serialExecutor_checkIsolated(
-        HeapObject *executor,
-        const Metadata *selfType,
-        const SerialExecutorWitnessTable *wtable);
+// DEPRECATED. Replacing with Error returning version
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+void _task_serialExecutor_checkIsolated(
+    HeapObject *executor,
+    const Metadata *selfType,
+    const SerialExecutorWitnessTable *wtable);
+
+SWIFT_CC(swift)
+SwiftError* (*swift::swift_serialExecutor_checkIsolatedError_hook)(
+    SerialExecutorRef executor,
+    swift_serialExecutor_checkIsolatedError_original original) = nullptr;
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+SwiftError* _task_serialExecutor_checkIsolatedError(
+    HeapObject *executor,
+    const Metadata *selfType,
+    const SerialExecutorWitnessTable *wtable);
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+    SwiftError* swift_serialExecutor_makeUnexpectedExecutorError();
 
 #if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
 #include "CooperativeGlobalExecutor.inc"
@@ -148,6 +164,13 @@ void swift::swift_task_checkIsolated(SerialExecutorRef executor) {
     swift_task_checkIsolated_hook(executor, swift_task_checkIsolatedImpl);
   else
     swift_task_checkIsolatedImpl(executor);
+}
+
+SwiftError* swift::swift_serialExecutor_checkIsolatedError(SerialExecutorRef executor) {
+  if (swift_serialExecutor_checkIsolatedError_hook)
+    return swift_serialExecutor_checkIsolatedError_hook(executor, swift_serialExecutor_checkIsolatedErrorImpl);
+  else
+    return swift_serialExecutor_checkIsolatedErrorImpl(executor);
 }
 
 // Implemented in Swift because we need to obtain the user-defined flags on the executor ref.

--- a/stdlib/public/Concurrency/NonDispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/NonDispatchGlobalExecutor.inc
@@ -62,9 +62,17 @@ static void swift_task_enqueueMainExecutorImpl(Job *job) {
                        "swift_task_enqueueMainExecutor");
 }
 
+// DEPRECATED. Replace with SwiftError returning version.
 SWIFT_CC(swift)
 static void swift_task_checkIsolatedImpl(SerialExecutorRef executor) {
   _task_serialExecutor_checkIsolated(
+      executor.getIdentity(), swift_getObjectType(executor.getIdentity()),
+      executor.getSerialExecutorWitnessTable());
+}
+
+SWIFT_CC(swift)
+static SwiftError* swift_serialExecutor_checkIsolatedErrorImpl(SerialExecutorRef executor) {
+  return _task_serialExecutor_checkIsolatedError(
       executor.getIdentity(), swift_getObjectType(executor.getIdentity()),
       executor.getSerialExecutorWitnessTable());
 }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -1275,6 +1275,11 @@ func _taskCreateNullaryContinuationJob(priority: Int, continuation: Builtin.RawU
 @_silgen_name("swift_task_isCurrentExecutor")
 func _taskIsCurrentExecutor(_ executor: Builtin.Executor) -> Bool
 
+@available(SwiftStdlib 6.0, *)
+@usableFromInline
+@_silgen_name("swift_task_checkCurrentExecutor")
+func _taskCheckCurrentExecutor(_ executor: Builtin.Executor) -> (any Error)?
+
 @available(SwiftStdlib 5.1, *)
 @usableFromInline
 @_silgen_name("swift_task_reportUnexpectedExecutor")

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -204,3 +204,8 @@ extension DistributedActor {
 @usableFromInline
 @_silgen_name("swift_task_isCurrentExecutor")
 func _taskIsCurrentExecutor(_ executor: Builtin.Executor) -> Bool
+
+@available(SwiftStdlib 6.0, *)
+@usableFromInline
+@_silgen_name("swift_task_checkCurrentExecutor")
+func _taskCheckCurrentExecutor(_ executor: Builtin.Executor) -> (any Error)?

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_bincompat_crash_swift_6_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_bincompat_crash_swift_6_mode.swift
@@ -27,7 +27,7 @@ final class NaiveQueueExecutor: SerialExecutor {
     UnownedSerialExecutor(ordinary: self)
   }
 
-  func checkIsolated() {
+  func checkIsolated() throws {
     print("checkIsolated: pretend it is ok!")
   }
 }

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_bincompat_nocrash_legacy_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_bincompat_nocrash_legacy_mode.swift
@@ -27,7 +27,7 @@ final class NaiveQueueExecutor: SerialExecutor {
     UnownedSerialExecutor(ordinary: self)
   }
 
-  func checkIsolated() {
+  func checkIsolated() throws {
     print("checkIsolated: pretend it is ok!")
   }
 }

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_bincompat_throw_swift_6_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_bincompat_throw_swift_6_mode.swift
@@ -1,0 +1,102 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking %import-libdispatch %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+// REQUIRES: libdispatch
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+import StdlibUnittest
+
+struct MyUnexpectedExecutorError: Sendable, Error {}
+
+final class NaiveQueueExecutor: SerialExecutor {
+  init() {}
+
+  public func enqueue(_ job: consuming ExecutorJob) {
+    job.runSynchronously(on: self.asUnownedSerialExecutor())
+  }
+
+  public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+
+  func checkIsolated() throws {
+    // Just always throw, we're testing if the throw propagates correctly
+    throw MyUnexpectedExecutorError()
+  }
+}
+
+actor DefaultActor {
+  nonisolated func nonisolatedCheck() async throws {
+    try self.checkIsolated()
+  }
+
+  func checkIt() async throws {
+    try self.checkIsolated()
+  }
+}
+
+actor QueueExecutorActor {
+  let executor: NaiveQueueExecutor
+
+  init(executor: NaiveQueueExecutor) {
+    self.executor = executor
+  }
+
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    self.executor.asUnownedSerialExecutor()
+  }
+
+  nonisolated func checkIt() async throws {
+    print("Before preconditionIsolated")
+    try self.checkIsolated()
+    print("After preconditionIsolated")
+  }
+}
+
+func getError(_ op: () async throws -> ()) async -> Error {
+  do {
+    try await op()
+    fatalError("Expected error!")
+  } catch {
+    return error
+  }
+}
+
+func assertExpectedError<Err: Error>(_ error: any Error, type: Err.Type) {
+  precondition(error is Err,
+    "Expected \(_Concurrency.UnexpectedSerialExecutorError.self) but got \(error)")
+  print("Got expected: \(error)")
+}
+
+// ==== ------------------------------------------------------------------------
+
+let tests = TestSuite("ThrowingCheckIsolated")
+
+let defaultActor = DefaultActor()
+
+tests.test("DefaultActor.checkIsolated() - should throw if off the actor") {
+  let error = await getError { try defaultActor.checkIsolated() }
+
+  assertExpectedError(error, type: _Concurrency.UnexpectedSerialExecutorError.self)
+}
+
+tests.test("DefaultActor.checkIsolated() - should not throw on the actor") {
+  try! await defaultActor.checkIt()
+}
+
+tests.test("DefaultActor.checkIsolated() - nonisolated func should throw, it is not on the actor") {
+  let error = await getError { try await defaultActor.nonisolatedCheck() }
+  assertExpectedError(error, type: _Concurrency.UnexpectedSerialExecutorError.self)
+}
+
+await runAllTestsAsync()

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_dispatch_swift6_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_dispatch_swift6_mode.swift
@@ -23,7 +23,7 @@ import Dispatch
 
 // FIXME(concurrency): Dispatch should provide such implementation
 extension DispatchQueue { // which includes DispatchSerialQueue, when a platform has it
-  public func checkIsolated() {
+  public func checkIsolated() throws {
     dispatchPrecondition(condition: .onQueue(self))
   }
 }
@@ -49,7 +49,7 @@ final class NaiveQueueExecutor: SerialExecutor {
     UnownedSerialExecutor(ordinary: self)
   }
 
-  func checkIsolated() {
+  func checkIsolated() throws {
     self.queue.checkIsolated()
   }
 }

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_main_customExecutorOnMain_swift6_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_main_customExecutorOnMain_swift6_mode.swift
@@ -40,7 +40,7 @@ final class NaiveOnMainQueueExecutor: SerialExecutor {
     UnownedSerialExecutor(complexEquality: self)
   }
 
-  public func checkIsolated() {
+  public func checkIsolated() throws {
     print("\(Self.self).checkIsolated...")
     dispatchPrecondition(condition: .onQueue(self.mainQueue))
   }

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_swift6_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_swift6_mode.swift
@@ -25,7 +25,7 @@ final class NaiveQueueExecutor: SerialExecutor {
     UnownedSerialExecutor(ordinary: self)
   }
 
-  func checkIsolated() {
+  func checkIsolated() throws {
     print("checkIsolated: pretend it is ok!")
   }
 }

--- a/test/Concurrency/Runtime/custom_executors_globalActor.swift
+++ b/test/Concurrency/Runtime/custom_executors_globalActor.swift
@@ -24,7 +24,7 @@ final class NaiveQueueExecutor: SerialExecutor {
     return UnownedSerialExecutor(ordinary: self)
   }
 
-  func checkIsolated() {
+  func checkIsolated() throws {
     // ok
   }
 }

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -316,6 +316,10 @@ Added: _$sScf13checkIsolatedyyFTj
 // method descriptor for Swift.SerialExecutor.checkIsolated() -> ()
 Added: _$sScf13checkIsolatedyyFTq
 
+// === 'SerialExecutor.checkIsolated() throws'
+Added: _swift_serialExecutor_checkIsolatedError
+Added: _swift_serialExecutor_checkIsolatedError_hook
+
 // #isolated adoption in multiple APIs
 // withTaskCancellationHandler gains #isolated
 Added: _$ss27withTaskCancellationHandler9operation8onCancel9isolationxxyYaKXE_yyYbXEScA_pSgYitYaKlF

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -316,6 +316,10 @@ Added: _$sScf13checkIsolatedyyFTj
 // method descriptor for Swift.SerialExecutor.checkIsolated() -> ()
 Added: _$sScf13checkIsolatedyyFTq
 
+// === 'SerialExecutor.checkIsolated() throws'
+Added: _swift_serialExecutor_checkIsolatedError
+Added: _swift_serialExecutor_checkIsolatedError_hook
+
 // #isolated adoption in multiple APis
 // withTaskCancellationHandler gains #isolated
 Added: _$ss27withTaskCancellationHandler9operation8onCancel9isolationxxyYaKXE_yyYbXEScA_pSgYitYaKlF

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -92,6 +92,13 @@ swift_task_checkIsolated_override(SerialExecutorRef executor,
 }
 
 SWIFT_CC(swift)
+static SwiftError*
+swift_serialExecutor_checkIsolatedError_override(SerialExecutorRef executor,
+                                       swift_serialExecutor_checkIsolatedError_original original) {
+  Ran = true;
+}
+
+SWIFT_CC(swift)
 static void swift_task_enqueueGlobalWithDelay_override(
     unsigned long long delay, Job *job,
     swift_task_enqueueGlobalWithDelay_original original) {
@@ -139,6 +146,8 @@ protected:
         swift_task_enqueueMainExecutor_override;
     swift_task_checkIsolated_hook =
         swift_task_checkIsolated_override;
+    swift_serialExecutor_checkIsolatedError_hook =
+        swift_serialExecutor_checkIsolatedError_override;
 #ifdef RUN_ASYNC_MAIN_DRAIN_QUEUE_TEST
     swift_task_asyncMainDrainQueue_hook =
         swift_task_asyncMainDrainQueue_override_fn;
@@ -194,6 +203,11 @@ TEST_F(CompatibilityOverrideConcurrencyTest,
 TEST_F(CompatibilityOverrideConcurrencyTest,
        test_swift_task_checkIsolated) {
   swift_task_checkIsolated(SerialExecutorRef::generic());
+}
+
+TEST_F(CompatibilityOverrideConcurrencyTest,
+       test_swift_serialExecutor_checkIsolatedError) {
+  swift_serialExecutor_checkIsolatedError(SerialExecutorRef::generic());
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest,


### PR DESCRIPTION
Proof of Concept that we can pull of a throws `checkIsolated` if we have enough time to do so.

The PR has not removed existing code supporting the crashing version. We need to make a decision if we want to pursue this or not.