### PR TITLE
[Build][Linux] Set `--build-id=sha1` for the linker.

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -297,6 +297,12 @@ function(add_pure_swift_host_library name)
     endif()
   endif()
 
+  # Enable build IDs
+  if(SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_USE_BUILD_ID)
+    target_link_options(${name} PRIVATE
+      "SHELL:-Xlinker --build-id=sha1")
+  endif()
+
   # Export this target.
   set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
 endfunction()
@@ -396,6 +402,12 @@ function(add_pure_swift_host_tool name)
     target_link_options(${name} PRIVATE
       "-use-ld=${LLVM_USE_LINKER}"
     )
+  endif()
+
+  # Enable build IDs
+  if(SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_USE_BUILD_ID)
+    target_link_options(${name} PRIVATE
+      "SHELL:-Xlinker --build-id=sha1")
   endif()
 
   # Workaround to touch the library and its objects so that we don't

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -447,6 +447,12 @@ function(_add_host_variant_link_flags target)
       "SHELL:-Xlinker -no_warn_duplicate_libraries")
   endif()
 
+  # Enable build IDs
+  if(SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_USE_BUILD_ID)
+    target_link_options(${target} PRIVATE
+      "SHELL:-Xlinker --build-id=sha1")
+  endif()
+
 endfunction()
 
 function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -168,6 +168,7 @@ endfunction()
 #   SWIFT_SDK_${prefix}_IS_SIMULATOR              Whether this is a simulator target.
 #   SWIFT_SDK_${prefix}_ARCH_${ARCH}_TRIPLE       Triple name
 #   SWIFT_SDK_${prefix}_ARCH_${ARCH}_MODULE       Module triple name for this SDK
+#   SWIFT_SDK_${prefix}_USE_BUILD_ID              Whether to pass --build-id to the linker
 macro(configure_sdk_darwin
     prefix name deployment_version xcrun_name
     triple_name module_name architectures)
@@ -215,6 +216,9 @@ macro(configure_sdk_darwin
   set(SWIFT_SDK_${prefix}_STATIC_LINKING_SUPPORTED FALSE)
   set(SWIFT_SDK_${prefix}_STATIC_ONLY FALSE)
   get_threading_package(${prefix} "darwin" SWIFT_SDK_${prefix}_THREADING_PACKAGE)
+
+  # On Darwin we get UUIDs automatically, without the --build-id flag
+  set(SWIFT_SDK_${prefix}_USE_BUILD_ID FALSE)
 
   set(SWIFT_SDK_${prefix}_ARCHITECTURES ${architectures})
   if(SWIFT_DARWIN_SUPPORTED_ARCHS)
@@ -333,6 +337,15 @@ macro(configure_sdk_unix name architectures)
     set(SWIFT_SDK_${prefix}_STATIC_ONLY TRUE)
   else()
     set(SWIFT_SDK_${prefix}_STATIC_ONLY FALSE)
+  endif()
+
+  if("${prefix}" STREQUAL "LINUX"
+      OR "${prefix}" STREQUAL "ANDROID"
+      OR "${prefix}" STREQUAL "FREEBSD"
+      OR "${prefix}" STREQUAL "OPENBSD")
+    set(SWIFT_SDK_${prefix}_USE_BUILD_ID TRUE)
+  else()
+    set(SWIFT_SDK_${prefix}_USE_BUILD_ID FALSE)
   endif()
 
   # GCC on Linux is usually located under `/usr`.
@@ -494,6 +507,7 @@ macro(configure_sdk_windows name environment architectures)
   set(SWIFT_SDK_${prefix}_IMPORT_LIBRARY_SUFFIX ".lib")
   set(SWIFT_SDK_${prefix}_STATIC_LINKING_SUPPORTED FALSE)
   set(SWIFT_SDK_${prefix}_STATIC_ONLY FALSE)
+  set(SWIFT_SDK_${prefix}_USE_BUILD_ID FALSE)
   get_threading_package(${prefix} "win32" SWIFT_SDK_${prefix}_THREADING_PACKAGE)
 
   foreach(arch ${architectures})

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -595,6 +595,11 @@ function(_add_target_variant_link_flags)
     endif()
   endif()
 
+  # Enable build-ids on non-Windows non-Darwin platforms
+  if(SWIFT_SDK_${LFLAGS_SDK}_USE_BUILD_ID)
+    list(APPEND result "-Wl,--build-id=sha1")
+  endif()
+
   # Enable dead stripping. Portions of this logic were copied from llvm's
   # `add_link_opts` function (which, perhaps, should have been used here in the
   # first place, but at this point it's hard to say whether that's feasible).


### PR DESCRIPTION
This means we will get build IDs in the tools and standard library, which is useful for debugging (it lets us associate debug symbols with the binaries later on, as well as allowing us to reliably identify exactly which binary we are looking at).

rdar://116525111
