### PR TITLE
Provide fixit for inferred property of opaque type (#69241)

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2544,6 +2544,8 @@ NOTE(opaque_of_optional_rewrite,none,
 ERROR(inferred_opaque_type,none,
       "property definition has inferred type %0, involving the 'some' "
       "return type of another declaration", (Type))
+NOTE(inferred_opaque_type_to_explicit,none,
+     "add explicit type annotation %0 in property declaration", (Type))
 
 // Inverse Constraints
 ERROR(inverse_type_not_invertible,none,

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -539,6 +539,10 @@ const PatternBindingEntry *PatternBindingEntryRequest::evaluate(
       // TODO: Check whether the type is the pattern binding's own opaque type.
       binding->diagnose(diag::inferred_opaque_type,
                         binding->getInit(entryNumber)->getType());
+      binding->diagnose(diag::inferred_opaque_type_to_explicit,
+                        binding->getInit(entryNumber)->getType())
+        .fixItInsertAfter(binding->getPattern(entryNumber)->getEndLoc(),
+                          ": " + binding->getInit(entryNumber)->getType()->getString());
     }
   } else {
     // Coerce the pattern to the computed type.

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -69,8 +69,11 @@ func zlop() -> some C & AnyObject & P {
 // types
 struct Test {
   let inferredOpaque = bar() // expected-error{{inferred type}}
+  // expected-note@-1 {{add explicit type annotation}} {{21-21=: some P}}
   let inferredOpaqueStructural = Optional(bar()) // expected-error{{inferred type}}
+  // expected-note@-1 {{add explicit type annotation}} {{31-31=: Optional<some P>}}
   let inferredOpaqueStructural2 = (bar(), bas()) // expected-error{{inferred type}}
+  // expected-note@-1 {{add explicit type annotation}} {{32-32=: (some P, some P & Q)}}
 }
 
 let zingle = {() -> some P in 1 } // expected-error{{'some' types are only permitted}}


### PR DESCRIPTION
When a pattern binding at top level attempts to pick up another declaration's opaque result type as its type by type inference, provide a fixit to explicitly declare the type. This is done to prevent opaque result types from propagating nontrivially into other declarations' types, see 6db0540b8a7ebe536c6c514d8df98b318e197d99

(First PR in this repo 🙏)

Added fix-it that annotates a top level declaration property declaration of inferred opaque type to be explicitly typed. Reasoning for this requirement in 6db0540b8a7ebe536c6c514d8df98b318e197d99.

Resolves #69241

## Tests
Reused the 3 existing cases covered in `test/type/opaque.swift`:

### Test case 1
```swift
let inferredOpaque = bar()
```
Is fixed to:
```swift
let inferredOpaque: some P = bar()
```
### Test case 2
```swift
let inferredOpaqueStructural = Optional(bar())
```
Is fixed to:
```swift
let inferredOpaqueStructural: Optional<some P> = Optional(bar())
```

### Test case 3
```swift
let inferredOpaqueStructural2 = (bar(), bas())
```
Is fixed to
```swift
let inferredOpaqueStructural2: (some P, some P & Q) = (bar(), bas())
```