### PR TITLE
[ClangImporter] Make sure the `-resource-dir` is checked before the `-sdk`, as done everywhere else in the compiler

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -35,10 +35,9 @@ static std::optional<Path> getActualModuleMapPath(
 
   Path result;
 
-  StringRef SDKPath = Opts.getSDKPath();
-  if (!SDKPath.empty()) {
-    result.append(SDKPath.begin(), SDKPath.end());
-    llvm::sys::path::append(result, "usr", "lib", "swift");
+  if (!Opts.RuntimeResourcePath.empty()) {
+    result.append(Opts.RuntimeResourcePath.begin(),
+                  Opts.RuntimeResourcePath.end());
     llvm::sys::path::append(result, platform);
     if (isArchSpecific) {
       llvm::sys::path::append(result, arch);
@@ -52,10 +51,11 @@ static std::optional<Path> getActualModuleMapPath(
       return result;
   }
 
-  if (!Opts.RuntimeResourcePath.empty()) {
+  StringRef SDKPath = Opts.getSDKPath();
+  if (!SDKPath.empty()) {
     result.clear();
-    result.append(Opts.RuntimeResourcePath.begin(),
-                  Opts.RuntimeResourcePath.end());
+    result.append(SDKPath.begin(), SDKPath.end());
+    llvm::sys::path::append(result, "usr", "lib", "swift");
     llvm::sys::path::append(result, platform);
     if (isArchSpecific) {
       llvm::sys::path::append(result, arch);


### PR DESCRIPTION
Otherwise, these module maps can be pulled from a system SDK instead when building a fresh Swift stdlib, fixes #74696.

I saw no regressions when I built the latest June 13 trunk source snapshot natively on Android with this change and it fixed not picking up an older 5.10.1 module map that I had installed in the Termux SDK.

@egorzhdan, if you would run the CI on this, let's make sure it doesn't break anything on other platforms first.