### PR TITLE
[PrunedLiveness] Branch summary merges to ending.

### DIFF
--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -402,7 +402,7 @@ public:
     bool isEnding() const { return value == Value::Ending; }
 
     LifetimeEnding meet(LifetimeEnding const other) const {
-      return value < other.value ? *this : other;
+      return std::min(value, other.value);
     }
     void meetInPlace(LifetimeEnding const other) { *this = meet(other); }
   };

--- a/test/SILOptimizer/liveness_unit.sil
+++ b/test/SILOptimizer/liveness_unit.sil
@@ -382,7 +382,7 @@ bb1(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
 // CHECK-LABEL: testSSAReborrowedPhi: ssa_liveness
 // CHECK: SSA lifetime analysis: %{{.*}} = begin_borrow
 // CHECK-NEXT: bb0: LiveWithin
-// CHECK-NEXT: regular user: br bb1
+// CHECK-NEXT: lifetime-ending user: br bb1
 // CHECK-NEXT: regular user: %{{.*}} = struct
 // CHECK-NEXT: last user: br bb1
 // CHECK-NEXT: end running

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -19,6 +19,7 @@ public enum FakeOptional<T> {
 
 sil @swift_asyncLet_finish : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> ()
 sil @swift_asyncLet_get : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> ()
+sil @getC : $@convention(thin) () -> (@owned C)
 
 protocol Error {}
 
@@ -723,4 +724,42 @@ bb0(%existential : @owned $any P):
   specify_test "liveness_partial_boundary_outside_users %opened"
   %ref_existential = init_existential_ref %opened : $@opened("00000000-0000-0000-0000-000000000000", any P) Self : $@opened("00000000-0000-0000-0000-000000000000", any P) Self, $AnyObject
   return %ref_existential : $AnyObject
+}
+
+// CHECK-LABEL: begin running test {{.*}} on root_of_reborrow: ossa_lifetime_completion
+// Verify that no instructions were inserted after backedge2's terminator.  (In
+// fact, if they were, the test would crash.)
+// CHECK-LABEL: sil [ossa] @root_of_reborrow : {{.*}} {
+// CHECK:       bb1([[C0:%[^,]+]] : @owned $C, [[B0:%[^,]+]] : @reborrow @guaranteed $C):
+// CHECK-NEXT:    [[B0F:%[^,]+]] = borrowed [[B0]] : $C from ([[C0]] : $C)
+// CHECK-NEXT:    end_borrow [[B0F]]
+// CHECK-NEXT:    destroy_value [[C0]]
+// CHECK-NEXT:    br
+// CHECK-LABEL: } // end sil function 'root_of_reborrow'
+// CHECK-LABEL: end running test {{.*}} on root_of_reborrow: ossa_lifetime_completion
+sil [ossa] @root_of_reborrow : $@convention(thin) () -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  %c = apply %getC() : $@convention(thin) () -> (@owned C)
+  %b = begin_borrow %c : $C
+  br header(%c : $C, %b : $C)
+header(%c0 : @owned $C, %b0 : @reborrow @guaranteed $C):
+  %b0f = borrowed %b0 : $C from (%c0 : $C)
+  end_borrow %b0f : $C
+  destroy_value %c0 : $C
+  br body
+body:
+  br latch
+latch:
+  cond_br undef, backedge, exit
+backedge:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  %b1 = begin_borrow %c1 : $C
+  br backedge2(%c1 : $C, %b1 : $C)
+backedge2(%c2 : @owned $C, %b2 : @reborrow @guaranteed $C):
+  %b2f = borrowed %b2 : $C from (%c2 : $C)
+  specify_test "ossa_lifetime_completion %c2 availability"
+  br header(%c2 : $C, %b2f : $C)
+exit:
+  unreachable
 }

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -606,7 +606,7 @@ bb1(%reborrow : @guaranteed $C):
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: bb0: LiveWithin
-// CHECK-NEXT: regular user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
+// CHECK-NEXT: lifetime-ending user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: Complete liveness
 // CHECK-NEXT: Unenclosed phis {


### PR DESCRIPTION
A branch instruction that is both a lifetime-ending user and also a non-lifetime-ending of a value should be regarded as a lifetime-ending user.

Without this, utilities that rely on PrunedLiveness such as `LinearLiveness` and `InteriorLiveness` both incorrectly report that a branch featuring a value and also a reborrow or guaranteed phi are non-ending.

rdar://130427564

