### PR TITLE
Improve support in Swift for program address space N in llvm DataLayout

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1595,11 +1595,10 @@ FUNCTION(GetEnumTagSinglePayloadGeneric,
          ARGS(OpaquePtrTy, Int32Ty, TypeMetadataPtrTy,
               llvm::FunctionType::get(Int32Ty, {OpaquePtrTy, Int32Ty,
                                                 TypeMetadataPtrTy},
-                                      false)->getPointerTo()),
+                                      false)->getPointerTo(DataLayout.getProgramAddressSpace())),
          ATTRS(NoUnwind, WillReturn),
          EFFECT(NoEffect),
          MEMEFFECTS(ReadOnly))
-
 
 // void swift_storeEnumTagSinglePayloadGeneric(opaque_t *obj,
 //                                             unsigned case_index,
@@ -1616,7 +1615,7 @@ FUNCTION(StoreEnumTagSinglePayloadGeneric,
          ARGS(OpaquePtrTy, Int32Ty, Int32Ty, TypeMetadataPtrTy,
               llvm::FunctionType::get(VoidTy, {OpaquePtrTy, Int32Ty, Int32Ty,
                                                TypeMetadataPtrTy},
-                                      false)->getPointerTo()),
+                                      false)->getPointerTo(DataLayout.getProgramAddressSpace())),
          ATTRS(NoUnwind, WillReturn),
          EFFECT(NoEffect),
          UNKNOWN_MEMEFFECTS)
@@ -1890,7 +1889,7 @@ FUNCTION(IsOptionalType,
 //                 void *context);
 FUNCTION(Once, swift_once, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
-         ARGS(OnceTy->getPointerTo(), Int8PtrTy, Int8PtrTy),
+         ARGS(OnceTy->getPointerTo(), Int8ProgramSpacePtrTy, Int8PtrTy),
          ATTRS(NoUnwind),
          EFFECT(Locking),
          UNKNOWN_MEMEFFECTS)

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1861,7 +1861,7 @@ static llvm::Value *emitPartialApplicationForwarder(
   }
 
   // Derive the callee function pointer.
-  auto fnTy = origSig.getType()->getPointerTo();
+  auto fnTy = origSig.getType()->getPointerTo(IGM.DataLayout.getProgramAddressSpace());
   FunctionPointer fnPtr = [&]() -> FunctionPointer {
     // If we found a function pointer statically, great.
     if (staticFnPtr) {
@@ -2353,7 +2353,7 @@ std::optional<StackAddress> irgen::emitFunctionPartialApplication(
       IGF.IGM, staticFn, fnContext != nullptr, origSig, origType, substType,
       outType, subs, &layout, argConventions);
   forwarder = emitPointerAuthSign(IGF, forwarder, outAuthInfo);
-  forwarder = IGF.Builder.CreateBitCast(forwarder, IGF.IGM.Int8PtrTy);
+  forwarder = IGF.Builder.CreateBitCast(forwarder, IGF.IGM.Int8ProgramSpacePtrTy);
   out.add(forwarder);
   out.add(data);
   return stackAddr;

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -875,7 +875,7 @@ static void emitUnaryRefCountCall(IRGenFunction &IGF,
                         ? IGF.IGM.VoidTy
                         : value->getType();
     fnType = llvm::FunctionType::get(resultTy, value->getType(), false);
-    fn = llvm::ConstantExpr::getBitCast(fn, fnType->getPointerTo());
+    fn = llvm::ConstantExpr::getBitCast(fn, fnType->getPointerTo(fn->getType()->getPointerAddressSpace()));
   }
 
   // Emit the call.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1567,7 +1567,7 @@ public:
               IGM.getDeletedMethodErrorFn(), IGM.FunctionPtrTy);
         }
       }
-      witness = llvm::ConstantExpr::getBitCast(witness, IGM.Int8PtrTy);
+      witness = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(witness, IGM.Int8PtrTy);
 
       if (isRelative) {
         Table.addRelativeAddress(witness);

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1028,7 +1028,7 @@ static void addValueWitness(IRGenModule &IGM, ConstantStructBuilder &B,
                             const std::optional<BoundGenericTypeCharacteristics>
                                 boundGenericCharacteristics = std::nullopt) {
   auto addFunction = [&](llvm::Constant *fn) {
-    fn = llvm::ConstantExpr::getBitCast(fn, IGM.Int8PtrTy);
+    fn = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(fn, IGM.Int8PtrTy);
     B.addSignedPointer(fn, IGM.getOptions().PointerAuth.ValueWitnesses, index);
   };
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -717,8 +717,11 @@ public:
     llvm::PointerType *Int8PtrTy;      /// i8*
     llvm::PointerType *WitnessTableTy;
     llvm::PointerType *ObjCSELTy;
-    llvm::PointerType *FunctionPtrTy;
     llvm::PointerType *CaptureDescriptorPtrTy;
+  };
+  union {
+    llvm::PointerType *FunctionPtrTy;
+    llvm::PointerType *Int8ProgramSpacePtrTy; /// i8* in same address space as programs
   };
   union {
     llvm::PointerType *Int8PtrPtrTy;   /// i8**
@@ -1622,7 +1625,7 @@ public:
   llvm::Constant *getBool(bool condition);
 
   /// Cast the given constant to i8*.
-  llvm::Constant *getOpaquePtr(llvm::Constant *pointer);
+  llvm::Constant *getOpaquePtrToFn(llvm::Constant *fnPointer);
 
   llvm::Constant *getAddrOfAsyncFunctionPointer(LinkEntity entity);
   llvm::Constant *getAddrOfAsyncFunctionPointer(SILFunction *function);


### PR DESCRIPTION
<!-- What's in this pull request? -->
@rauhul @phausler @kubamracek 

[AVR Harvard Architecture fixes]: Update Swift, at least partially, to be aware of address spaces for functions:

I think the AVR target might struggle to produce code without these fixes in many cases. Simple code is OK on AVR but things like function pointers will probably need this. I'm completely open to any other way of supporting this too.

- For closures, allow round trip via opaque ptr in pgmspace.
- Fix for mapping program space functions into protocol witness tables and value witness tables.
- Fixed in SIL function lowering, addPointerParameter should only create pointers in address space 1 when the parameter is a function (e.g. working with closures).
- Fix coroutine/yield emission.
- More program address space fixes.
- Fix pointer wrangling between address spaces (or not) in coroutine emission.
- Fix pointer parameter wrangling between namespaces in call site emission.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
