### PR TITLE
[6.0][Caching] Teach libSwiftScan to replay all diagnostics kinds

### DIFF
--- a/include/swift/Frontend/DiagnosticHelper.h
+++ b/include/swift/Frontend/DiagnosticHelper.h
@@ -1,0 +1,65 @@
+//===--- DiagnosticHelper.h - Diagnostic Helper -----------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file exposes helper class to emit diagnostics from swift-frontend.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FRONTEND_DIAGNOSTIC_HELPER_H
+#define SWIFT_FRONTEND_DIAGNOSTIC_HELPER_H
+
+#include "swift/Basic/LLVM.h"
+
+namespace swift {
+class CompilerInstance;
+class CompilerInvocation;
+
+class DiagnosticHelper {
+private:
+  class Implementation;
+  Implementation &Impl;
+
+public:
+  /// Create a DiagnosticHelper class to emit diagnostics from frontend actions.
+  static DiagnosticHelper create(CompilerInstance &instance,
+                                 bool useQuasiPID = false);
+
+  /// Initialized all DiagConsumers and add to the CompilerInstance.
+  void initDiagConsumers(CompilerInvocation &invocation);
+
+  /// Begin emitting the message, specifically the parseable output message.
+  void beginMessage(CompilerInvocation &invocation,
+                    ArrayRef<const char *> args);
+
+  /// End emitting all diagnostics. This has to be called if beginMessage() is
+  /// called.
+  void endMessage(int retCode);
+
+  /// Set if printing output should be suppressed.
+  void setSuppressOutput(bool suppressOutput);
+
+  /// Helper function to emit fatal error.
+  void diagnoseFatalError(const char *reason, bool shouldCrash);
+
+  DiagnosticHelper(const DiagnosticHelper &) = delete;
+  DiagnosticHelper(DiagnosticHelper &&) = delete;
+  DiagnosticHelper &operator=(const DiagnosticHelper &) = delete;
+  DiagnosticHelper &operator=(DiagnosticHelper &&) = delete;
+  ~DiagnosticHelper();
+
+private:
+  DiagnosticHelper(CompilerInstance &instance, bool useQuasiPID);
+};
+
+} // namespace swift
+
+#endif

--- a/include/swift/Frontend/DiagnosticHelper.h
+++ b/include/swift/Frontend/DiagnosticHelper.h
@@ -18,6 +18,7 @@
 #define SWIFT_FRONTEND_DIAGNOSTIC_HELPER_H
 
 #include "swift/Basic/LLVM.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace swift {
 class CompilerInstance;
@@ -30,7 +31,10 @@ private:
 
 public:
   /// Create a DiagnosticHelper class to emit diagnostics from frontend actions.
+  /// OS is the stream to print diagnostics. useQuasiPID determines if using
+  /// real PID when priting parseable output.
   static DiagnosticHelper create(CompilerInstance &instance,
+                                 llvm::raw_pwrite_stream &OS = llvm::errs(),
                                  bool useQuasiPID = false);
 
   /// Initialized all DiagConsumers and add to the CompilerInstance.
@@ -57,7 +61,8 @@ public:
   ~DiagnosticHelper();
 
 private:
-  DiagnosticHelper(CompilerInstance &instance, bool useQuasiPID);
+  DiagnosticHelper(CompilerInstance &instance, llvm::raw_pwrite_stream &OS,
+                   bool useQuasiPID);
 };
 
 } // namespace swift

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -10,6 +10,7 @@ add_swift_host_library(swiftFrontend STATIC
   CompileJobCacheResult.cpp
   CompilerInvocation.cpp
   DependencyVerifier.cpp
+  DiagnosticHelper.cpp
   DiagnosticVerifier.cpp
   Frontend.cpp
   FrontendInputsAndOutputs.cpp

--- a/lib/Frontend/DiagnosticHelper.cpp
+++ b/lib/Frontend/DiagnosticHelper.cpp
@@ -1,0 +1,522 @@
+//===--- DiagnosticHelper.cpp - Diagnostic Helper ---------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the DiagnosticHelper class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Frontend/DiagnosticHelper.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/Basic/Edit.h"
+#include "swift/Basic/ParseableOutput.h"
+#include "swift/Basic/SourceManager.h"
+#include "swift/Frontend/AccumulatingDiagnosticConsumer.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/Frontend/PrintingDiagnosticConsumer.h"
+#include "swift/Frontend/SerializedDiagnosticConsumer.h"
+#include "swift/Migrator/FixitFilter.h"
+
+#if __has_include(<unistd.h>)
+#include <unistd.h>
+#elif defined(_WIN32)
+#include <process.h>
+#endif
+
+using namespace swift;
+using namespace swift::parseable_output;
+
+class LLVM_LIBRARY_VISIBILITY DiagnosticHelper::Implementation {
+  friend class DiagnosticHelper;
+
+public:
+  Implementation(CompilerInstance &instance, bool useQuasiPID);
+
+  void initDiagConsumers(CompilerInvocation &invocation);
+
+  void beginMessage(CompilerInvocation &invocation,
+                    ArrayRef<const char *> args);
+  void endMessage(int retCode);
+  void setSuppressOutput(bool suppressOutput);
+
+  void diagnoseFatalError(const char *reason, bool shouldCrash);
+
+private:
+  ~Implementation() {
+    assert(!diagInProcess && "endMessage is not called after begin");
+  }
+
+  bool diagInProcess = false;
+  const int64_t OSPid;
+  const sys::TaskProcessInformation procInfo;
+
+  CompilerInstance &instance;
+
+  // potentially created diagnostic consumers.
+  PrintingDiagnosticConsumer PDC;
+  llvm::StringMap<std::vector<std::string>> FileSpecificDiagnostics;
+  std::unique_ptr<DiagnosticConsumer> FileSpecificAccumulatingConsumer;
+  std::unique_ptr<DiagnosticConsumer> SerializedConsumerDispatcher;
+  std::unique_ptr<DiagnosticConsumer> FixItsConsumer;
+};
+
+namespace {
+
+/// If there is an error with fixits it writes the fixits as edits in json
+/// format.
+class JSONFixitWriter : public DiagnosticConsumer,
+                        public migrator::FixitFilter {
+  std::string FixitsOutputPath;
+  std::unique_ptr<llvm::raw_ostream> OSPtr;
+  bool FixitAll;
+  SourceEdits AllEdits;
+
+public:
+  JSONFixitWriter(std::string fixitsOutputPath,
+                  const DiagnosticOptions &DiagOpts)
+      : FixitsOutputPath(std::move(fixitsOutputPath)),
+        FixitAll(DiagOpts.FixitCodeForAllDiagnostics) {}
+
+private:
+  void handleDiagnostic(SourceManager &SM,
+                        const DiagnosticInfo &Info) override {
+    if (!(FixitAll || shouldTakeFixit(Info)))
+      return;
+    for (const auto &Fix : Info.FixIts)
+      AllEdits.addEdit(SM, Fix.getRange(), Fix.getText());
+  }
+
+  bool finishProcessing() override {
+    std::error_code EC;
+    std::unique_ptr<llvm::raw_fd_ostream> OS;
+    OS.reset(
+        new llvm::raw_fd_ostream(FixitsOutputPath, EC, llvm::sys::fs::OF_None));
+    if (EC) {
+      // Create a temporary diagnostics engine to print the error to stderr.
+      SourceManager dummyMgr;
+      DiagnosticEngine DE(dummyMgr);
+      PrintingDiagnosticConsumer PDC;
+      DE.addConsumer(PDC);
+      DE.diagnose(SourceLoc(), diag::cannot_open_file, FixitsOutputPath,
+                  EC.message());
+      return true;
+    }
+
+    swift::writeEditsInJson(AllEdits, *OS);
+    return false;
+  }
+};
+
+} // anonymous namespace
+
+/// Creates a diagnostic consumer that handles dispatching diagnostics to
+/// multiple output files, based on the supplementary output paths specified by
+/// \p inputsAndOutputs.
+///
+/// If no output files are needed, returns null.
+static std::unique_ptr<DiagnosticConsumer>
+createDispatchingDiagnosticConsumerIfNeeded(
+    const FrontendInputsAndOutputs &inputsAndOutputs,
+    llvm::function_ref<std::unique_ptr<DiagnosticConsumer>(const InputFile &)>
+        maybeCreateConsumerForDiagnosticsFrom) {
+
+  // The "4" here is somewhat arbitrary. In practice we're going to have one
+  // sub-consumer for each diagnostic file we're trying to output, which (again
+  // in practice) is going to be 1 in WMO mode and equal to the number of
+  // primary inputs in batch mode. That in turn is going to be "the number of
+  // files we need to recompile in this build, divided by the number of jobs".
+  // So a value of "4" here means that there would be no heap allocation on a
+  // clean build of a module with up to 32 files on an 8-core machine, if the
+  // user doesn't customize anything.
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 4> subconsumers;
+
+  inputsAndOutputs.forEachInputProducingSupplementaryOutput(
+      [&](const InputFile &input) -> bool {
+        if (auto consumer = maybeCreateConsumerForDiagnosticsFrom(input))
+          subconsumers.emplace_back(input.getFileName(), std::move(consumer));
+        return false;
+      });
+  // For batch mode, the compiler must sometimes swallow diagnostics pertaining
+  // to non-primary files in order to avoid Xcode showing the same diagnostic
+  // multiple times. So, create a diagnostic "eater" for those non-primary
+  // files.
+  //
+  // This routine gets called in cases where no primary subconsumers are
+  // created. Don't bother to create non-primary subconsumers if there aren't
+  // any primary ones.
+  //
+  // To avoid introducing bugs into WMO or single-file modes, test for multiple
+  // primaries.
+  if (!subconsumers.empty() && inputsAndOutputs.hasMultiplePrimaryInputs()) {
+    inputsAndOutputs.forEachNonPrimaryInput(
+        [&](const InputFile &input) -> bool {
+          subconsumers.emplace_back(input.getFileName(), nullptr);
+          return false;
+        });
+  }
+
+  return FileSpecificDiagnosticConsumer::consolidateSubconsumers(subconsumers);
+}
+
+/// Creates a diagnostic consumer that handles serializing diagnostics, based on
+/// the supplementary output paths specified by \p inputsAndOutputs.
+///
+/// The returned consumer will handle producing multiple serialized diagnostics
+/// files if necessary, by using sub-consumers for each file and dispatching to
+/// the right one.
+///
+/// If no serialized diagnostics are being produced, returns null.
+static std::unique_ptr<DiagnosticConsumer>
+createSerializedDiagnosticConsumerIfNeeded(
+    const FrontendInputsAndOutputs &inputsAndOutputs,
+    bool emitMacroExpansionFiles) {
+  return createDispatchingDiagnosticConsumerIfNeeded(
+      inputsAndOutputs,
+      [emitMacroExpansionFiles](
+          const InputFile &input) -> std::unique_ptr<DiagnosticConsumer> {
+        auto serializedDiagnosticsPath = input.getSerializedDiagnosticsPath();
+        if (serializedDiagnosticsPath.empty())
+          return nullptr;
+        return serialized_diagnostics::createConsumer(serializedDiagnosticsPath,
+                                                      emitMacroExpansionFiles);
+      });
+}
+
+/// Creates a diagnostic consumer that accumulates all emitted diagnostics as
+/// compilation proceeds. The accumulated diagnostics are then emitted in the
+/// frontend's parseable-output.
+static std::unique_ptr<DiagnosticConsumer> createAccumulatingDiagnosticConsumer(
+    const FrontendInputsAndOutputs &InputsAndOutputs,
+    llvm::StringMap<std::vector<std::string>> &FileSpecificDiagnostics) {
+  return createDispatchingDiagnosticConsumerIfNeeded(
+      InputsAndOutputs,
+      [&](const InputFile &Input) -> std::unique_ptr<DiagnosticConsumer> {
+        FileSpecificDiagnostics.try_emplace(Input.getFileName(),
+                                            std::vector<std::string>());
+        auto &DiagBufferRef = FileSpecificDiagnostics[Input.getFileName()];
+        return std::make_unique<AccumulatingFileDiagnosticConsumer>(
+            DiagBufferRef);
+      });
+}
+
+/// Creates a diagnostic consumer that handles JSONFixIt diagnostics, based on
+/// the supplementary output paths specified in \p options.
+///
+/// If no json fixit diagnostics are being produced, returns null.
+static std::unique_ptr<DiagnosticConsumer>
+createJSONFixItDiagnosticConsumerIfNeeded(
+    const CompilerInvocation &invocation) {
+  return createDispatchingDiagnosticConsumerIfNeeded(
+      invocation.getFrontendOptions().InputsAndOutputs,
+      [&](const InputFile &input) -> std::unique_ptr<DiagnosticConsumer> {
+        auto fixItsOutputPath = input.getFixItsOutputPath();
+        if (fixItsOutputPath.empty())
+          return nullptr;
+        return std::make_unique<JSONFixitWriter>(
+            fixItsOutputPath.str(), invocation.getDiagnosticOptions());
+      });
+}
+
+DiagnosticHelper::Implementation::Implementation(CompilerInstance &instance,
+                                                 bool useQuasiPID)
+    : OSPid(useQuasiPID ? QUASI_PID_START : getpid()), procInfo(OSPid),
+      instance(instance) {
+  instance.addDiagnosticConsumer(&PDC);
+}
+
+void DiagnosticHelper::Implementation::initDiagConsumers(
+    CompilerInvocation &invocation) {
+  if (invocation.getFrontendOptions().FrontendParseableOutput) {
+    // We need a diagnostic consumer that will, per-file, collect all
+    // diagnostics to be reported in parseable-output
+    FileSpecificAccumulatingConsumer = createAccumulatingDiagnosticConsumer(
+        invocation.getFrontendOptions().InputsAndOutputs,
+        FileSpecificDiagnostics);
+    instance.addDiagnosticConsumer(FileSpecificAccumulatingConsumer.get());
+
+    // If we got this far, we need to suppress the output of the
+    // PrintingDiagnosticConsumer to ensure that only the parseable-output
+    // is emitted
+    PDC.setSuppressOutput(true);
+  }
+
+  // Because the serialized diagnostics consumer is initialized here,
+  // diagnostics emitted above, within CompilerInvocation::parseArgs, are never
+  // serialized. This is a non-issue because, in nearly all cases, frontend
+  // arguments are generated by the driver, not directly by a user. The driver
+  // is responsible for emitting diagnostics for its own errors.
+  // See https://github.com/apple/swift/issues/45288 for details.
+  SerializedConsumerDispatcher = createSerializedDiagnosticConsumerIfNeeded(
+      invocation.getFrontendOptions().InputsAndOutputs,
+      invocation.getDiagnosticOptions().EmitMacroExpansionFiles);
+  if (SerializedConsumerDispatcher)
+    instance.addDiagnosticConsumer(SerializedConsumerDispatcher.get());
+
+  FixItsConsumer = createJSONFixItDiagnosticConsumerIfNeeded(invocation);
+  if (FixItsConsumer)
+    instance.addDiagnosticConsumer(FixItsConsumer.get());
+
+  if (invocation.getDiagnosticOptions().UseColor)
+    PDC.forceColors();
+
+  PDC.setPrintEducationalNotes(
+      invocation.getDiagnosticOptions().PrintEducationalNotes);
+
+  PDC.setFormattingStyle(
+      invocation.getDiagnosticOptions().PrintedFormattingStyle);
+
+  PDC.setEmitMacroExpansionFiles(
+      invocation.getDiagnosticOptions().EmitMacroExpansionFiles);
+}
+
+static const char *
+mapFrontendInvocationToAction(const CompilerInvocation &Invocation) {
+  FrontendOptions::ActionType ActionType =
+      Invocation.getFrontendOptions().RequestedAction;
+  switch (ActionType) {
+  case FrontendOptions::ActionType::REPL:
+    return "repl";
+  case FrontendOptions::ActionType::MergeModules:
+    return "merge-module";
+  case FrontendOptions::ActionType::Immediate:
+    return "interpret";
+  case FrontendOptions::ActionType::TypecheckModuleFromInterface:
+    return "verify-module-interface";
+  case FrontendOptions::ActionType::EmitPCH:
+    return "generate-pch";
+  case FrontendOptions::ActionType::EmitIR:
+  case FrontendOptions::ActionType::EmitBC:
+  case FrontendOptions::ActionType::EmitAssembly:
+  case FrontendOptions::ActionType::EmitObject:
+    // Whether or not these actions correspond to a "compile" job or a
+    // "backend" job, depends on the input kind.
+    if (Invocation.getFrontendOptions().InputsAndOutputs.shouldTreatAsLLVM())
+      return "backend";
+    else
+      return "compile";
+  case FrontendOptions::ActionType::EmitModuleOnly:
+    return "emit-module";
+  default:
+    return "compile";
+  }
+  // The following Driver/Parseable-output actions do not correspond to
+  // possible Frontend invocations:
+  // ModuleWrapJob, AutolinkExtractJob, GenerateDSYMJob, VerifyDebugInfoJob,
+  // StaticLinkJob, DynamicLinkJob
+}
+
+// TODO: Apply elsewhere in the compiler
+static swift::file_types::ID computeFileTypeForPath(const StringRef Path) {
+  if (!llvm::sys::path::has_extension(Path))
+    return swift::file_types::ID::TY_INVALID;
+
+  auto Extension = llvm::sys::path::extension(Path).str();
+  auto FileType = file_types::lookupTypeForExtension(Extension);
+  if (FileType == swift::file_types::ID::TY_INVALID) {
+    auto PathStem = llvm::sys::path::stem(Path);
+    // If this path has a multiple '.' extension (e.g. .abi.json),
+    // then iterate over all preceeding possible extension variants.
+    while (llvm::sys::path::has_extension(PathStem)) {
+      auto NextExtension = llvm::sys::path::extension(PathStem);
+      PathStem = llvm::sys::path::stem(PathStem);
+      Extension = NextExtension.str() + Extension;
+      FileType = file_types::lookupTypeForExtension(Extension);
+      if (FileType != swift::file_types::ID::TY_INVALID)
+        break;
+    }
+  }
+
+  return FileType;
+}
+
+static DetailedTaskDescription constructDetailedTaskDescription(
+    const CompilerInvocation &Invocation, ArrayRef<InputFile> PrimaryInputs,
+    ArrayRef<const char *> Args, bool isEmitModuleOnly = false) {
+  // Command line and arguments
+  std::string Executable = Invocation.getFrontendOptions().MainExecutablePath;
+  SmallVector<std::string, 16> Arguments;
+  std::string CommandLine;
+  SmallVector<CommandInput, 4> Inputs;
+  SmallVector<OutputPair, 8> Outputs;
+  CommandLine += Executable;
+  for (const auto &A : Args) {
+    Arguments.push_back(A);
+    CommandLine += std::string(" ") + A;
+  }
+
+  // Primary Inputs
+  for (const auto &input : PrimaryInputs) {
+    Inputs.push_back(CommandInput(input.getFileName()));
+  }
+
+  for (const auto &input : PrimaryInputs) {
+    if (!isEmitModuleOnly) {
+      // Main per-input outputs
+      auto OutputFile = input.outputFilename();
+      if (!OutputFile.empty())
+        Outputs.push_back(
+            OutputPair(computeFileTypeForPath(OutputFile), OutputFile));
+    }
+
+    // Supplementary outputs
+    const auto &primarySpecificFiles = input.getPrimarySpecificPaths();
+    const auto &supplementaryOutputPaths =
+        primarySpecificFiles.SupplementaryOutputs;
+    supplementaryOutputPaths.forEachSetOutput([&](const std::string &output) {
+      Outputs.push_back(OutputPair(computeFileTypeForPath(output), output));
+    });
+  }
+  return DetailedTaskDescription{Executable, Arguments, CommandLine, Inputs,
+                                 Outputs};
+}
+
+void DiagnosticHelper::Implementation::beginMessage(
+    CompilerInvocation &invocation, ArrayRef<const char *> args) {
+  if (!invocation.getFrontendOptions().FrontendParseableOutput)
+    return;
+
+  diagInProcess = true;
+  const auto &IO = invocation.getFrontendOptions().InputsAndOutputs;
+  // Parseable output clients may not understand the idea of a batch
+  // compilation. We assign each primary in a batch job a quasi process id,
+  // making sure it cannot collide with a real PID (always positive). Non-batch
+  // compilation gets a real OS PID.
+  int64_t pid = IO.hasUniquePrimaryInput() ? OSPid : QUASI_PID_START;
+
+  if (IO.hasPrimaryInputs()) {
+    IO.forEachPrimaryInputWithIndex(
+        [&](const InputFile &Input, unsigned idx) -> bool {
+          ArrayRef<InputFile> Inputs(Input);
+          emitBeganMessage(
+              llvm::errs(), mapFrontendInvocationToAction(invocation),
+              constructDetailedTaskDescription(invocation, Inputs, args),
+              pid - idx, procInfo);
+          return false;
+        });
+  } else {
+    // If no primary inputs are present, we are in WMO or EmitModule.
+    bool isEmitModule = invocation.getFrontendOptions().RequestedAction ==
+                        FrontendOptions::ActionType::EmitModuleOnly;
+    emitBeganMessage(llvm::errs(), mapFrontendInvocationToAction(invocation),
+                     constructDetailedTaskDescription(
+                         invocation, IO.getAllInputs(), args, isEmitModule),
+                     OSPid, procInfo);
+  }
+}
+
+void DiagnosticHelper::Implementation::endMessage(int retCode) {
+  auto &invocation = instance.getInvocation();
+  if (!invocation.getFrontendOptions().FrontendParseableOutput)
+    return;
+
+  const auto &IO = invocation.getFrontendOptions().InputsAndOutputs;
+
+  // Parseable output clients may not understand the idea of a batch
+  // compilation. We assign each primary in a batch job a quasi process id,
+  // making sure it cannot collide with a real PID (always positive). Non-batch
+  // compilation gets a real OS PID.
+  int64_t pid = IO.hasUniquePrimaryInput() ? OSPid : QUASI_PID_START;
+
+  if (IO.hasPrimaryInputs()) {
+    IO.forEachPrimaryInputWithIndex([&](const InputFile &Input,
+                                        unsigned idx) -> bool {
+      assert(FileSpecificDiagnostics.count(Input.getFileName()) != 0 &&
+             "Expected diagnostic collection for input.");
+
+      // Join all diagnostics produced for this file into a single output.
+      auto PrimaryDiags = FileSpecificDiagnostics.lookup(Input.getFileName());
+      const char *const Delim = "";
+      std::ostringstream JoinedDiags;
+      std::copy(PrimaryDiags.begin(), PrimaryDiags.end(),
+                std::ostream_iterator<std::string>(JoinedDiags, Delim));
+
+      emitFinishedMessage(llvm::errs(),
+                          mapFrontendInvocationToAction(invocation),
+                          JoinedDiags.str(), retCode, pid - idx, procInfo);
+      return false;
+    });
+  } else {
+    // If no primary inputs are present, we are in WMO.
+    std::vector<std::string> AllDiagnostics;
+    for (const auto &FileDiagnostics : FileSpecificDiagnostics) {
+      AllDiagnostics.insert(AllDiagnostics.end(),
+                            FileDiagnostics.getValue().begin(),
+                            FileDiagnostics.getValue().end());
+    }
+    const char *const Delim = "";
+    std::ostringstream JoinedDiags;
+    std::copy(AllDiagnostics.begin(), AllDiagnostics.end(),
+              std::ostream_iterator<std::string>(JoinedDiags, Delim));
+    emitFinishedMessage(llvm::errs(), mapFrontendInvocationToAction(invocation),
+                        JoinedDiags.str(), retCode, OSPid, procInfo);
+  }
+
+  diagInProcess = false;
+}
+
+void DiagnosticHelper::Implementation::setSuppressOutput(bool suppressOutput) {
+  PDC.setSuppressOutput(suppressOutput);
+}
+
+void DiagnosticHelper::Implementation::diagnoseFatalError(const char *reason,
+                                                          bool shouldCrash) {
+  static const char *recursiveFatalError = nullptr;
+  if (recursiveFatalError) {
+    // Report the /original/ error through LLVM's default handler, not
+    // whatever we encountered.
+    llvm::remove_fatal_error_handler();
+    llvm::report_fatal_error(recursiveFatalError, shouldCrash);
+  }
+  recursiveFatalError = reason;
+
+  SourceManager dummyMgr;
+
+  DiagnosticInfo errorInfo(
+      DiagID(0), SourceLoc(), DiagnosticKind::Error,
+      "fatal error encountered during compilation; " SWIFT_BUG_REPORT_MESSAGE,
+      {}, StringRef(), SourceLoc(), {}, {}, {}, false);
+  DiagnosticInfo noteInfo(DiagID(0), SourceLoc(), DiagnosticKind::Note, reason,
+                          {}, StringRef(), SourceLoc(), {}, {}, {}, false);
+  PDC.handleDiagnostic(dummyMgr, errorInfo);
+  PDC.handleDiagnostic(dummyMgr, noteInfo);
+  if (shouldCrash)
+    abort();
+}
+
+DiagnosticHelper DiagnosticHelper::create(CompilerInstance &instance,
+                                          bool useQuasiPID) {
+  return DiagnosticHelper(instance, useQuasiPID);
+}
+
+DiagnosticHelper::DiagnosticHelper(CompilerInstance &instance, bool useQuasiPID)
+    : Impl(*new Implementation(instance, useQuasiPID)) {}
+
+DiagnosticHelper::~DiagnosticHelper() { delete &Impl; }
+
+void DiagnosticHelper::initDiagConsumers(CompilerInvocation &invocation) {
+  Impl.initDiagConsumers(invocation);
+}
+
+void DiagnosticHelper::beginMessage(CompilerInvocation &invocation,
+                                    ArrayRef<const char *> args) {
+  Impl.beginMessage(invocation, args);
+}
+
+void DiagnosticHelper::endMessage(int retCode) { Impl.endMessage(retCode); }
+
+void DiagnosticHelper::setSuppressOutput(bool suppressOutput) {
+  Impl.setSuppressOutput(suppressOutput);
+}
+
+void DiagnosticHelper::diagnoseFatalError(const char *reason,
+                                          bool shouldCrash) {
+  Impl.diagnoseFatalError(reason, shouldCrash);
+}

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -39,7 +39,6 @@
 #include "swift/Basic/Edit.h"
 #include "swift/Basic/FileSystem.h"
 #include "swift/Basic/LLVMInitialize.h"
-#include "swift/Basic/ParseableOutput.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/SourceManager.h"
@@ -49,15 +48,13 @@
 #include "swift/Basic/Version.h"
 #include "swift/ConstExtract/ConstExtract.h"
 #include "swift/DependencyScan/ScanDependencies.h"
-#include "swift/Frontend/AccumulatingDiagnosticConsumer.h"
 #include "swift/Frontend/CachedDiagnostics.h"
 #include "swift/Frontend/CachingUtils.h"
 #include "swift/Frontend/CompileJobCacheKey.h"
+#include "swift/Frontend/DiagnosticHelper.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Frontend/ModuleInterfaceSupport.h"
-#include "swift/Frontend/PrintingDiagnosticConsumer.h"
-#include "swift/Frontend/SerializedDiagnosticConsumer.h"
 #include "swift/IRGen/TBDGen.h"
 #include "swift/Immediate/Immediate.h"
 #include "swift/Index/IndexRecord.h"
@@ -81,15 +78,15 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IRReader/IRReader.h"
-#include "llvm/Option/Option.h"
 #include "llvm/Option/OptTable.h"
+#include "llvm/Option/Option.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualOutputBackend.h"
 #include "llvm/Support/VirtualOutputBackends.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/FileSystem.h"
 
 #if __has_include(<unistd.h>)
 #include <unistd.h>
@@ -102,7 +99,6 @@
 #include <utility>
 
 using namespace swift;
-using namespace swift::parseable_output;
 
 static std::string displayName(StringRef MainExecutablePath) {
   std::string Name = llvm::sys::path::stem(MainExecutablePath).str();
@@ -205,56 +201,6 @@ printModuleInterfaceIfNeeded(llvm::vfs::OutputBackend &outputBackend,
                           return swift::emitSwiftInterface(out, Opts, M);
                         });
 }
-
-namespace {
-
-/// If there is an error with fixits it writes the fixits as edits in json
-/// format.
-class JSONFixitWriter
-  : public DiagnosticConsumer, public migrator::FixitFilter {
-  std::string FixitsOutputPath;
-  std::unique_ptr<llvm::raw_ostream> OSPtr;
-  bool FixitAll;
-  SourceEdits AllEdits;
-
-public:
-  JSONFixitWriter(std::string fixitsOutputPath,
-                  const DiagnosticOptions &DiagOpts)
-      : FixitsOutputPath(std::move(fixitsOutputPath)),
-        FixitAll(DiagOpts.FixitCodeForAllDiagnostics) {}
-
-private:
-  void handleDiagnostic(SourceManager &SM,
-                        const DiagnosticInfo &Info) override {
-    if (!(FixitAll || shouldTakeFixit(Info)))
-      return;
-    for (const auto &Fix : Info.FixIts)
-      AllEdits.addEdit(SM, Fix.getRange(), Fix.getText());
-  }
-
-  bool finishProcessing() override {
-    std::error_code EC;
-    std::unique_ptr<llvm::raw_fd_ostream> OS;
-    OS.reset(new llvm::raw_fd_ostream(FixitsOutputPath,
-                                      EC,
-                                      llvm::sys::fs::OF_None));
-    if (EC) {
-      // Create a temporary diagnostics engine to print the error to stderr.
-      SourceManager dummyMgr;
-      DiagnosticEngine DE(dummyMgr);
-      PrintingDiagnosticConsumer PDC;
-      DE.addConsumer(PDC);
-      DE.diagnose(SourceLoc(), diag::cannot_open_file,
-                  FixitsOutputPath, EC.message());
-      return true;
-    }
-
-    swift::writeEditsInJson(AllEdits, *OS);
-    return false;
-  }
-};
-
-} // anonymous namespace
 
 // This is a separate function so that it shows up in stack traces.
 LLVM_ATTRIBUTE_NOINLINE
@@ -571,108 +517,6 @@ static bool emitReferenceDependencies(CompilerInstance &Instance,
                         Instance.getDiags());
         return hadError;
       });
-}
-
-static const char *
-mapFrontendInvocationToAction(const CompilerInvocation &Invocation) {
-  FrontendOptions::ActionType ActionType =
-  Invocation.getFrontendOptions().RequestedAction;
-  switch (ActionType) {
-    case FrontendOptions::ActionType::REPL:
-      return "repl";
-    case FrontendOptions::ActionType::MergeModules:
-      return "merge-module";
-    case FrontendOptions::ActionType::Immediate:
-      return "interpret";
-    case FrontendOptions::ActionType::TypecheckModuleFromInterface:
-      return "verify-module-interface";
-    case FrontendOptions::ActionType::EmitPCH:
-      return "generate-pch";
-    case FrontendOptions::ActionType::EmitIR:
-    case FrontendOptions::ActionType::EmitBC:
-    case FrontendOptions::ActionType::EmitAssembly:
-    case FrontendOptions::ActionType::EmitObject:
-      // Whether or not these actions correspond to a "compile" job or a
-      // "backend" job, depends on the input kind.
-      if (Invocation.getFrontendOptions().InputsAndOutputs.shouldTreatAsLLVM())
-        return "backend";
-      else
-        return "compile";
-    case FrontendOptions::ActionType::EmitModuleOnly:
-      return "emit-module";
-    default:
-      return "compile";
-  }
-  // The following Driver/Parseable-output actions do not correspond to
-  // possible Frontend invocations:
-  // ModuleWrapJob, AutolinkExtractJob, GenerateDSYMJob, VerifyDebugInfoJob,
-  // StaticLinkJob, DynamicLinkJob
-}
-
-// TODO: Apply elsewhere in the compiler
-static swift::file_types::ID computeFileTypeForPath(const StringRef Path) {
-  if (!llvm::sys::path::has_extension(Path))
-    return swift::file_types::ID::TY_INVALID;
-
-  auto Extension = llvm::sys::path::extension(Path).str();
-  auto FileType = file_types::lookupTypeForExtension(Extension);
-  if (FileType == swift::file_types::ID::TY_INVALID) {
-    auto PathStem = llvm::sys::path::stem(Path);
-    // If this path has a multiple '.' extension (e.g. .abi.json),
-    // then iterate over all preceeding possible extension variants.
-    while (llvm::sys::path::has_extension(PathStem)) {
-      auto NextExtension = llvm::sys::path::extension(PathStem);
-      PathStem = llvm::sys::path::stem(PathStem);
-      Extension = NextExtension.str() + Extension;
-      FileType = file_types::lookupTypeForExtension(Extension);
-      if (FileType != swift::file_types::ID::TY_INVALID)
-        break;
-    }
-  }
-
-  return FileType;
-}
-
-static DetailedTaskDescription
-constructDetailedTaskDescription(const CompilerInvocation &Invocation,
-                                 ArrayRef<InputFile> PrimaryInputs,
-                                 ArrayRef<const char *> Args,
-                                 bool isEmitModuleOnly = false) {
-  // Command line and arguments
-  std::string Executable = Invocation.getFrontendOptions().MainExecutablePath;
-  SmallVector<std::string, 16> Arguments;
-  std::string CommandLine;
-  SmallVector<CommandInput, 4> Inputs;
-  SmallVector<OutputPair, 8> Outputs;
-  CommandLine += Executable;
-  for (const auto &A : Args) {
-    Arguments.push_back(A);
-    CommandLine += std::string(" ") + A;
-  }
-
-  // Primary Inputs
-  for (const auto &input : PrimaryInputs) {
-    Inputs.push_back(CommandInput(input.getFileName()));
-  }
-
-  for (const auto &input : PrimaryInputs) {
-    if (!isEmitModuleOnly) {
-      // Main per-input outputs
-      auto OutputFile = input.outputFilename();
-      if (!OutputFile.empty())
-        Outputs.push_back(OutputPair(computeFileTypeForPath(OutputFile), OutputFile));
-    }
-
-    // Supplementary outputs
-    const auto &primarySpecificFiles = input.getPrimarySpecificPaths();
-    const auto &supplementaryOutputPaths =
-        primarySpecificFiles.SupplementaryOutputs;
-    supplementaryOutputPaths.forEachSetOutput([&](const std::string &output) {
-      Outputs.push_back(OutputPair(computeFileTypeForPath(output), output));
-    });
-  }
-  return DetailedTaskDescription{Executable, Arguments, CommandLine, Inputs,
-                                 Outputs};
 }
 
 static void emitSwiftdepsForAllPrimaryInputsIfNeeded(
@@ -2005,119 +1849,6 @@ static void emitIndexDataForSourceFile(SourceFile *PrimarySourceFile,
   }
 }
 
-/// Creates a diagnostic consumer that handles dispatching diagnostics to
-/// multiple output files, based on the supplementary output paths specified by
-/// \p inputsAndOutputs.
-///
-/// If no output files are needed, returns null.
-static std::unique_ptr<DiagnosticConsumer>
-createDispatchingDiagnosticConsumerIfNeeded(
-    const FrontendInputsAndOutputs &inputsAndOutputs,
-    llvm::function_ref<std::unique_ptr<DiagnosticConsumer>(const InputFile &)>
-        maybeCreateConsumerForDiagnosticsFrom) {
-
-  // The "4" here is somewhat arbitrary. In practice we're going to have one
-  // sub-consumer for each diagnostic file we're trying to output, which (again
-  // in practice) is going to be 1 in WMO mode and equal to the number of
-  // primary inputs in batch mode. That in turn is going to be "the number of
-  // files we need to recompile in this build, divided by the number of jobs".
-  // So a value of "4" here means that there would be no heap allocation on a
-  // clean build of a module with up to 32 files on an 8-core machine, if the
-  // user doesn't customize anything.
-  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 4> subconsumers;
-
-  inputsAndOutputs.forEachInputProducingSupplementaryOutput(
-      [&](const InputFile &input) -> bool {
-        if (auto consumer = maybeCreateConsumerForDiagnosticsFrom(input))
-          subconsumers.emplace_back(input.getFileName(), std::move(consumer));
-        return false;
-      });
-  // For batch mode, the compiler must sometimes swallow diagnostics pertaining
-  // to non-primary files in order to avoid Xcode showing the same diagnostic
-  // multiple times. So, create a diagnostic "eater" for those non-primary
-  // files.
-  //
-  // This routine gets called in cases where no primary subconsumers are created.
-  // Don't bother to create non-primary subconsumers if there aren't any primary
-  // ones.
-  //
-  // To avoid introducing bugs into WMO or single-file modes, test for multiple
-  // primaries.
-  if (!subconsumers.empty() && inputsAndOutputs.hasMultiplePrimaryInputs()) {
-    inputsAndOutputs.forEachNonPrimaryInput(
-        [&](const InputFile &input) -> bool {
-          subconsumers.emplace_back(input.getFileName(), nullptr);
-          return false;
-        });
-  }
-
-  return FileSpecificDiagnosticConsumer::consolidateSubconsumers(subconsumers);
-}
-
-/// Creates a diagnostic consumer that handles serializing diagnostics, based on
-/// the supplementary output paths specified by \p inputsAndOutputs.
-///
-/// The returned consumer will handle producing multiple serialized diagnostics
-/// files if necessary, by using sub-consumers for each file and dispatching to
-/// the right one.
-///
-/// If no serialized diagnostics are being produced, returns null.
-static std::unique_ptr<DiagnosticConsumer>
-createSerializedDiagnosticConsumerIfNeeded(
-    const FrontendInputsAndOutputs &inputsAndOutputs,
-    bool emitMacroExpansionFiles
-) {
-  return createDispatchingDiagnosticConsumerIfNeeded(
-      inputsAndOutputs,
-      [emitMacroExpansionFiles](
-          const InputFile &input
-      ) -> std::unique_ptr<DiagnosticConsumer> {
-        auto serializedDiagnosticsPath = input.getSerializedDiagnosticsPath();
-        if (serializedDiagnosticsPath.empty())
-          return nullptr;
-        return serialized_diagnostics::createConsumer(
-            serializedDiagnosticsPath, emitMacroExpansionFiles);
-      });
-}
-
-/// Creates a diagnostic consumer that accumulates all emitted diagnostics as compilation
-/// proceeds. The accumulated diagnostics are then emitted in the frontend's parseable-output.
-static std::unique_ptr<DiagnosticConsumer>
-createAccumulatingDiagnosticConsumer(
-    const FrontendInputsAndOutputs &InputsAndOutputs,
-    llvm::StringMap<std::vector<std::string>> &FileSpecificDiagnostics) {
-  return createDispatchingDiagnosticConsumerIfNeeded(
-      InputsAndOutputs,
-      [&](const InputFile &Input) -> std::unique_ptr<DiagnosticConsumer> {
-    FileSpecificDiagnostics.try_emplace(Input.getFileName(),
-                                        std::vector<std::string>());
-    auto &DiagBufferRef = FileSpecificDiagnostics[Input.getFileName()];
-    return std::make_unique<AccumulatingFileDiagnosticConsumer>(DiagBufferRef);
-  });
-}
-
-/// Creates a diagnostic consumer that handles serializing diagnostics, based on
-/// the supplementary output paths specified in \p options.
-///
-/// The returned consumer will handle producing multiple serialized diagnostics
-/// files if necessary, by using sub-consumers for each file and dispatching to
-/// the right one.
-///
-/// If no serialized diagnostics are being produced, returns null.
-static std::unique_ptr<DiagnosticConsumer>
-createJSONFixItDiagnosticConsumerIfNeeded(
-    const CompilerInvocation &invocation) {
-  return createDispatchingDiagnosticConsumerIfNeeded(
-      invocation.getFrontendOptions().InputsAndOutputs,
-      [&](const InputFile &input) -> std::unique_ptr<DiagnosticConsumer> {
-        auto fixItsOutputPath = input.getFixItsOutputPath();
-        if (fixItsOutputPath.empty())
-          return nullptr;
-        return std::make_unique<JSONFixitWriter>(
-            fixItsOutputPath.str(), invocation.getDiagnosticOptions());
-      });
-}
-
 /// A PrettyStackTraceEntry to print frontend information useful for debugging.
 class PrettyStackTraceFrontend : public llvm::PrettyStackTraceEntry {
   const CompilerInvocation &Invocation;
@@ -2147,50 +1878,22 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   llvm::setBugReportMsg(SWIFT_CRASH_BUG_REPORT_MESSAGE "\n");
   llvm::EnablePrettyStackTraceOnSigInfoForThisThread();
 
-  PrintingDiagnosticConsumer PDC;
+  std::unique_ptr<CompilerInstance> Instance =
+    std::make_unique<CompilerInstance>();
+
+  DiagnosticHelper DH = DiagnosticHelper::create(*Instance);
 
   // Hopefully we won't trigger any LLVM-level fatal errors, but if we do try
   // to route them through our usual textual diagnostics before crashing.
   //
   // Unfortunately it's not really safe to do anything else, since very
   // low-level operations in LLVM can trigger fatal errors.
-  auto diagnoseFatalError = [&PDC](const char *reason, bool shouldCrash) {
-    static const char *recursiveFatalError = nullptr;
-    if (recursiveFatalError) {
-      // Report the /original/ error through LLVM's default handler, not
-      // whatever we encountered.
-      llvm::remove_fatal_error_handler();
-      llvm::report_fatal_error(recursiveFatalError, shouldCrash);
-    }
-    recursiveFatalError = reason;
-
-    SourceManager dummyMgr;
-
-    DiagnosticInfo errorInfo(
-        DiagID(0), SourceLoc(), DiagnosticKind::Error,
-        "fatal error encountered during compilation; " SWIFT_BUG_REPORT_MESSAGE,
-        {}, StringRef(), SourceLoc(), {}, {}, {}, false);
-    DiagnosticInfo noteInfo(DiagID(0), SourceLoc(), DiagnosticKind::Note,
-                            reason, {}, StringRef(), SourceLoc(), {}, {}, {},
-                            false);
-    PDC.handleDiagnostic(dummyMgr, errorInfo);
-    PDC.handleDiagnostic(dummyMgr, noteInfo);
-    if (shouldCrash)
-      abort();
-  };
   llvm::ScopedFatalErrorHandler handler(
       [](void *rawCallback, const char *reason, bool shouldCrash) {
-        auto *callback =
-            static_cast<decltype(&diagnoseFatalError)>(rawCallback);
-        (*callback)(reason, shouldCrash);
+        auto *helper = static_cast<DiagnosticHelper *>(rawCallback);
+        helper->diagnoseFatalError(reason, shouldCrash);
       },
-      &diagnoseFatalError);
-
-  std::unique_ptr<CompilerInstance> Instance =
-    std::make_unique<CompilerInstance>();
-
-  // In parseable output, avoid printing diagnostics
-  Instance->addDiagnosticConsumer(&PDC);
+      &DH);
 
   struct FinishDiagProcessingCheckRAII {
     bool CalledFinishDiagProcessing = false;
@@ -2202,7 +1905,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   auto finishDiagProcessing = [&](int retValue, bool verifierEnabled) -> int {
     FinishDiagProcessingCheckRAII.CalledFinishDiagProcessing = true;
-    PDC.setSuppressOutput(false);
+    DH.setSuppressOutput(false);
     if (auto *CDP = Instance->getCachingDiagnosticsProcessor()) {
       // Don't cache if build failed.
       if (retValue)
@@ -2300,143 +2003,13 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     return finishDiagProcessing(1, /*verifierEnabled*/ false);
   }
 
-  llvm::StringMap<std::vector<std::string>> FileSpecificDiagnostics;
-  std::unique_ptr<DiagnosticConsumer> FileSpecificAccumulatingConsumer;
-  if (Invocation.getFrontendOptions().FrontendParseableOutput) {
-    // We need a diagnostic consumer that will, per-file, collect all
-    // diagnostics to be reported in parseable-output
-    FileSpecificAccumulatingConsumer = createAccumulatingDiagnosticConsumer(
-        Invocation.getFrontendOptions().InputsAndOutputs,
-        FileSpecificDiagnostics);
-    Instance->addDiagnosticConsumer(FileSpecificAccumulatingConsumer.get());
-
-    // If we got this far, we need to suppress the output of the
-    // PrintingDiagnosticConsumer to ensure that only the parseable-output
-    // is emitted
-    PDC.setSuppressOutput(true);
-  }
-
-  auto emitParseableBeganMessage = [&Invocation, &Args]() {
-    const auto &IO = Invocation.getFrontendOptions().InputsAndOutputs;
-    const auto OSPid = getpid();
-    const auto ProcInfo = sys::TaskProcessInformation(OSPid);
-
-    // Parseable output clients may not understand the idea of a batch
-    // compilation. We assign each primary in a batch job a quasi process id,
-    // making sure it cannot collide with a real PID (always positive). Non-batch
-    // compilation gets a real OS PID.
-    int64_t Pid = IO.hasUniquePrimaryInput() ? OSPid : QUASI_PID_START;
-
-    if (IO.hasPrimaryInputs()) {
-      IO.forEachPrimaryInputWithIndex([&](const InputFile &Input,
-                                          unsigned idx) -> bool {
-        ArrayRef<InputFile> Inputs(Input);
-        emitBeganMessage(llvm::errs(),
-                         mapFrontendInvocationToAction(Invocation),
-                         constructDetailedTaskDescription(Invocation,
-                                                          Inputs,
-                                                          Args), Pid - idx,
-                         ProcInfo);
-        return false;
-      });
-    } else {
-      // If no primary inputs are present, we are in WMO or EmitModule.
-      bool isEmitModule =
-        Invocation.getFrontendOptions().RequestedAction ==
-          FrontendOptions::ActionType::EmitModuleOnly;
-      emitBeganMessage(llvm::errs(),
-                       mapFrontendInvocationToAction(Invocation),
-                       constructDetailedTaskDescription(Invocation, IO.getAllInputs(),
-                                                        Args, isEmitModule),
-                       OSPid, ProcInfo);
-    }
-  };
-
-  auto emitParseableFinishedMessage = [&Invocation, &FileSpecificDiagnostics](
-                                          int ExitStatus) {
-    const auto &IO = Invocation.getFrontendOptions().InputsAndOutputs;
-    const auto OSPid = getpid();
-    const auto ProcInfo = sys::TaskProcessInformation(OSPid);
-
-    // Parseable output clients may not understand the idea of a batch
-    // compilation. We assign each primary in a batch job a quasi process id,
-    // making sure it cannot collide with a real PID (always positive). Non-batch
-    // compilation gets a real OS PID.
-    int64_t Pid = IO.hasUniquePrimaryInput() ? OSPid : QUASI_PID_START;
-
-    if (IO.hasPrimaryInputs()) {
-      IO.forEachPrimaryInputWithIndex([&](const InputFile &Input,
-                                          unsigned idx) -> bool {
-        assert(FileSpecificDiagnostics.count(Input.getFileName()) != 0 &&
-               "Expected diagnostic collection for input.");
-
-        // Join all diagnostics produced for this file into a single output.
-        auto PrimaryDiags = FileSpecificDiagnostics.lookup(Input.getFileName());
-        const char *const Delim = "";
-        std::ostringstream JoinedDiags;
-        std::copy(PrimaryDiags.begin(), PrimaryDiags.end(),
-                  std::ostream_iterator<std::string>(JoinedDiags, Delim));
-
-        emitFinishedMessage(llvm::errs(),
-                            mapFrontendInvocationToAction(Invocation),
-                            JoinedDiags.str(), ExitStatus, Pid - idx, ProcInfo);
-        return false;
-      });
-    } else {
-      // If no primary inputs are present, we are in WMO.
-      std::vector<std::string> AllDiagnostics;
-      for (const auto &FileDiagnostics : FileSpecificDiagnostics) {
-        AllDiagnostics.insert(AllDiagnostics.end(),
-                              FileDiagnostics.getValue().begin(),
-                              FileDiagnostics.getValue().end());
-      }
-      const char *const Delim = "";
-      std::ostringstream JoinedDiags;
-      std::copy(AllDiagnostics.begin(), AllDiagnostics.end(),
-                std::ostream_iterator<std::string>(JoinedDiags, Delim));
-      emitFinishedMessage(llvm::errs(),
-                          mapFrontendInvocationToAction(Invocation),
-                          JoinedDiags.str(), ExitStatus, OSPid, ProcInfo);
-    }
-  };
-
-  // Because the serialized diagnostics consumer is initialized here,
-  // diagnostics emitted above, within CompilerInvocation::parseArgs, are never
-  // serialized. This is a non-issue because, in nearly all cases, frontend
-  // arguments are generated by the driver, not directly by a user. The driver
-  // is responsible for emitting diagnostics for its own errors.
-  // See https://github.com/apple/swift/issues/45288 for details.
-  std::unique_ptr<DiagnosticConsumer> SerializedConsumerDispatcher =
-      createSerializedDiagnosticConsumerIfNeeded(
-        Invocation.getFrontendOptions().InputsAndOutputs,
-        Invocation.getDiagnosticOptions().EmitMacroExpansionFiles);
-  if (SerializedConsumerDispatcher)
-    Instance->addDiagnosticConsumer(SerializedConsumerDispatcher.get());
-
-  std::unique_ptr<DiagnosticConsumer> FixItsConsumer =
-      createJSONFixItDiagnosticConsumerIfNeeded(Invocation);
-  if (FixItsConsumer)
-    Instance->addDiagnosticConsumer(FixItsConsumer.get());
-
-  if (Invocation.getDiagnosticOptions().UseColor)
-    PDC.forceColors();
-
-  PDC.setPrintEducationalNotes(
-      Invocation.getDiagnosticOptions().PrintEducationalNotes);
-
-  PDC.setFormattingStyle(
-      Invocation.getDiagnosticOptions().PrintedFormattingStyle);
-
-  PDC.setEmitMacroExpansionFiles(
-      Invocation.getDiagnosticOptions().EmitMacroExpansionFiles);
+  DH.initDiagConsumers(Invocation);
 
   if (Invocation.getFrontendOptions().PrintStats) {
     llvm::EnableStatistics();
   }
 
-
-  if (Invocation.getFrontendOptions().FrontendParseableOutput)
-    emitParseableBeganMessage();
+  DH.beginMessage(Invocation, Args);
 
   const DiagnosticOptions &diagOpts = Invocation.getDiagnosticOptions();
   bool verifierEnabled = diagOpts.VerifyMode != DiagnosticOptions::NoVerify;
@@ -2444,8 +2017,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   std::string InstanceSetupError;
   if (Instance->setup(Invocation, InstanceSetupError, Args)) {
     int ReturnCode = 1;
-    if (Invocation.getFrontendOptions().FrontendParseableOutput)
-      emitParseableFinishedMessage(ReturnCode);
+    DH.endMessage(ReturnCode);
 
     return finishDiagProcessing(ReturnCode, /*verifierEnabled*/ false);
   }
@@ -2458,7 +2030,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   if (verifierEnabled) {
     // Suppress printed diagnostic output during the compile if the verifier is
     // enabled.
-    PDC.setSuppressOutput(true);
+    DH.setSuppressOutput(true);
   }
 
   CompilerInstance::HashingBackendPtrTy HashBackend = nullptr;
@@ -2486,7 +2058,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     if (diags.hasFatalErrorOccurred() &&
         !Invocation.getDiagnosticOptions().ShowDiagnosticsAfterFatalError) {
       diags.resetHadAnyError();
-      PDC.setSuppressOutput(false);
+      DH.setSuppressOutput(false);
       diags.diagnose(SourceLoc(), diag::verify_encountered_fatal);
       HadError = true;
     }
@@ -2534,9 +2106,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   if (auto *StatsReporter = Instance->getStatsReporter())
     StatsReporter->noteCurrentProcessExitStatus(r);
 
-  if (Invocation.getFrontendOptions().FrontendParseableOutput)
-    emitParseableFinishedMessage(r);
-
+  DH.endMessage(r);
   return r;
 }
 

--- a/test/CAS/swift-scan-diagnostics-batch.swift
+++ b/test/CAS/swift-scan-diagnostics-batch.swift
@@ -1,0 +1,63 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/a.swift %t/b.swift %t/c.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+
+// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- \
+// RUN:   %target-swift-frontend -cache-compile-job -primary-file %t/a.swift -primary-file %t/b.swift %t/c.swift \
+// RUN:   -c -emit-dependencies -module-name Test -o %t/a.o -o %t/b.o -cas-path %t/cas \
+// RUN:   @%t/MyApp.cmd > %t/key0.casid
+
+// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 1 -- \
+// RUN:   %target-swift-frontend -cache-compile-job -primary-file %t/a.swift -primary-file %t/b.swift %t/c.swift \
+// RUN:   -c -emit-dependencies -module-name Test -o %t/a.o -o %t/b.o -cas-path %t/cas \
+// RUN:   @%t/MyApp.cmd > %t/key1.casid
+
+// RUN: %target-swift-frontend -cache-compile-job \
+// RUN:  -primary-file %t/a.swift -primary-file %t/b.swift %t/c.swift \
+// RUN:  -c -emit-dependencies \
+// RUN:  -module-name Test -o %t/a.o -o %t/b.o -cas-path %t/cas @%t/MyApp.cmd
+
+// RUN: %target-swift-frontend -cache-compile-job \
+// RUN:  %t/a.swift %t/b.swift -primary-file %t/c.swift \
+// RUN:  -c -emit-dependencies \
+// RUN:  -module-name Test -o %t/c.o -cas-path %t/cas @%t/MyApp.cmd
+
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key0.casid -- %target-swift-frontend -cache-compile-job \
+// RUN:   -primary-file %t/a.swift -primary-file %t/b.swift  %t/c.swift \
+// RUN:   -c -emit-dependencies -module-name Test -o %t/a2.o -o %t/b2.o -cas-path %t/cas \
+// RUN:   -serialize-diagnostics -serialize-diagnostics-path %t/a2.dia -serialize-diagnostics-path %t/b2.dia \
+// RUN:   @%t/MyApp.cmd -frontend-parseable-output 2>&1 | %FileCheck %s --check-prefix=PARSEABLE
+
+// RUN: c-index-test -read-diagnostics %t/a2.dia 2>&1 | %FileCheck %s --check-prefix=A-WARN
+// RUN: c-index-test -read-diagnostics %t/b2.dia 2>&1 | %FileCheck %s --check-prefix=B-WARN
+
+// A-WARN: warning: This is a warning
+// B-WARN: warning: This is also a warning
+
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key1.casid -- %target-swift-frontend -cache-compile-job \
+// RUN:   -primary-file %t/a.swift -primary-file %t/b.swift  %t/c.swift \
+// RUN:   -c -emit-dependencies -module-name Test -o %t/a2.o -o %t/b2.o -cas-path %t/cas \
+// RUN:   -serialize-diagnostics -serialize-diagnostics-path %t/a2.dia -serialize-diagnostics-path %t/b2.dia \
+// RUN:   @%t/MyApp.cmd -frontend-parseable-output 2>&1 | %FileCheck %s --check-prefix=NO-OUTPUT --allow-empty
+
+// PARSEABLE-COUNT-1:   "kind": "began",
+// PARSEABLE-COUNT-1:   "kind": "finished",
+// PRASEABLE-NOT: "kind": "began",
+// PRASEABLE-NOT: "kind": "finished",
+
+// NO-OUTPUT-NOT: "kind": "began",
+
+//--- a.swift
+#warning("This is a warning")
+//--- b.swift
+#warning("This is also a warning")
+//--- c.swift
+#warning("This is another warning")

--- a/test/CAS/swift-scan-diagnostics.swift
+++ b/test/CAS/swift-scan-diagnostics.swift
@@ -9,11 +9,11 @@
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
 
-// RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- %target-swift-frontend -cache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd > %t/key.casid
 
-// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- %target-swift-frontend -cache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
 // RUN:   @%t/MyApp.cmd > %t/key1.casid
 
@@ -21,17 +21,20 @@
 
 // RUN: not %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=CHECK-QUERY-NOT-FOUND
 
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN: %target-swift-frontend -cache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN:  -serialize-diagnostics -serialize-diagnostics-path %t/test.dia \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd
 
 // RUN: %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas | %FileCheck %s --check-prefix=CHECK-QUERY
 
-// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- %target-swift-frontend -cache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test2.o -cas-path %t/cas \
+// RUN:   -serialize-diagnostics -serialize-diagnostics-path %t/test2.dia \
 // RUN:   @%t/MyApp.cmd
 
 // RUN: diff %t/Test.swiftmodule %t/Test2.swiftmodule
 // RUN: diff %t/test.o %t/test2.o
+// RUN: diff %t/test.dia %t/test2.dia
 
 // CHECK-QUERY-NOT-FOUND: cached output not found
 // CHECK-QUERY: Cached Compilation for key "llvmcas://{{.*}}" has 4 outputs:
@@ -40,4 +43,20 @@
 // CHECK-QUERY-NEXT: swiftmodule: llvmcas://
 // CHECK-QUERY-NEXT: cached-diagnostics: llvmcas://
 
-func testFunc() {}
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- %target-swift-frontend -cache-compile-job %s \
+// RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test2.o -cas-path %t/cas \
+// RUN:   -frontend-parseable-output -serialize-diagnostics -serialize-diagnostics-path %t/test3.dia \
+// RUN:   @%t/MyApp.cmd 2>&1 | %FileCheck %s --check-prefix=PARSEABLE
+
+// RUN: diff %t/test.dia %t/test3.dia
+
+// PARSEABLE: {{[1-9][0-9]*}}
+// PARSEABLE-NEXT: {
+// PARSEABLE-NEXT:   "kind": "began",
+// PARSEABLE-NEXT:   "name": "compile",
+
+// PARSEABLE:   "kind": "finished",
+// PARSEABLE-NEXT:   "name": "compile",
+
+
+#warning("This is a warning")

--- a/tools/swift-scan-test/swift-scan-test.cpp
+++ b/tools/swift-scan-test/swift-scan-test.cpp
@@ -145,8 +145,13 @@ static int action_replay_result(swiftscan_cas_t cas, const char *key,
                                 std::vector<const char *> &Args) {
   swiftscan_string_ref_t err_msg;
   auto comp = swiftscan_cache_query(cas, key, /*globally=*/false, &err_msg);
-  if (!comp)
-    return printError(err_msg);
+  if (!comp) {
+    if (err_msg.length != 0)
+      return printError(err_msg);
+
+    llvm::errs() << "key " << key << " not found for replay\n";
+    return EXIT_FAILURE;
+  }
 
   SWIFT_DEFER { swiftscan_cached_compilation_dispose(comp); };
   auto numOutput = swiftscan_cached_compilation_get_num_outputs(comp);


### PR DESCRIPTION
Explanation: Teach swift caching replay API to replay all diagnostics output kind, including parseable output and serialized diagnostics.
Scope: This allows build system to replay all diagnostics from scanner API in process.
Issue: rdar://129015959
Original PR: https://github.com/swiftlang/swift/pull/74128
Reviewer: @artemcm 
Risk: Low. Swift caching only change.
Test: Unit Tests