### PR TITLE
Option to disable printing package-name in public or private interface.

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -47,6 +47,11 @@ struct ModuleInterfaceOptions {
   /// back .swiftinterface and reconstructing .swiftmodule.
   std::string Flags;
 
+  /// Keep track of flags to be printed in package.swiftinterface only.
+  /// If -disable-print-package-name-for-non-package-interface is passed,
+  /// package-name flag should only be printed in package.swiftinterface.
+  std::string FlagsForPackageOnly;
+
   /// Flags that should be emitted to the .swiftinterface file but are OK to be
   /// ignored by the earlier version of the compiler.
   std::string IgnorableFlags;

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -62,6 +62,10 @@ struct ModuleInterfaceOptions {
   /// Print imports that are missing from the source and used in API.
   bool PrintMissingImports = true;
 
+  /// If true, package-name flag is not printed in either public or private
+  /// interface file.
+  bool DisablePackageNameForNonPackageInterface = false;
+
   /// Intentionally print invalid syntax into the file.
   bool DebugPrintInvalidSyntax = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -720,6 +720,11 @@ def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
   Flags<[HelpHidden]>,
   HelpText<"Disable automatic generation of bridging PCH files">;
 
+def disable_print_package_name_for_non_package_interface :
+  Flag<["-"], "disable-print-package-name-for-non-package-interface">,
+  Flags<[FrontendOption, NoDriverOption, ModuleInterfaceOption, HelpHidden]>,
+  HelpText<"Disable adding package name to public or private interface">;
+
 def lto : Joined<["-"], "lto=">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Specify the LTO type to either 'llvm-thin' or 'llvm-full'">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -459,6 +459,7 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     Args.hasArg(OPT_debug_emit_invalid_swiftinterface_syntax);
   Opts.PrintMissingImports =
     !Args.hasArg(OPT_disable_print_missing_imports_in_module_interface);
+  Opts.DisablePackageNameForNonPackageInterface |= Args.hasArg(OPT_disable_print_package_name_for_non_package_interface);
 
   if (const Arg *A = Args.getLastArg(OPT_library_level)) {
     StringRef contents = A->getValue();

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -485,6 +485,13 @@ static bool ShouldIncludeModuleInterfaceArg(const Arg *A) {
   return true;
 }
 
+static bool ShouldIncludeArgInPackageInterfaceOnly(const Arg *A,
+                                                   ArgList &Args) {
+  return A->getOption().matches(options::OPT_package_name) &&
+         Args.hasArg(
+             options::OPT_disable_print_package_name_for_non_package_interface);
+}
+
 /// Save a copy of any flags marked as ModuleInterfaceOption, if running
 /// in a mode that is going to emit a .swiftinterface file.
 static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
@@ -493,8 +500,10 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
   if (!FOpts.InputsAndOutputs.hasModuleInterfaceOutputPath())
     return;
   ArgStringList RenderedArgs;
+  ArgStringList RenderedArgsForPackageOnly;
   ArgStringList RenderedArgsIgnorable;
   ArgStringList RenderedArgsIgnorablePrivate;
+
   for (auto A : Args) {
     if (!ShouldIncludeModuleInterfaceArg(A))
       continue;
@@ -504,7 +513,10 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     } else if (A->getOption().hasFlag(options::ModuleInterfaceOptionIgnorable)) {
       A->render(Args, RenderedArgsIgnorable);
     } else if (A->getOption().hasFlag(options::ModuleInterfaceOption)) {
-      A->render(Args, RenderedArgs);
+      if (ShouldIncludeArgInPackageInterfaceOnly(A, Args))
+        A->render(Args, RenderedArgsForPackageOnly);
+      else
+        A->render(Args, RenderedArgs);
     }
   }
   {
@@ -512,6 +524,13 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     interleave(RenderedArgs,
                [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
                [&] { OS << " "; });
+  }
+  {
+    llvm::raw_string_ostream OS(Opts.FlagsForPackageOnly);
+    interleave(
+        RenderedArgsForPackageOnly,
+        [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
+        [&] { OS << " "; });
   }
   {
     llvm::raw_string_ostream OS(Opts.IgnorablePrivateFlags);

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -90,6 +90,13 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
   out << "// " SWIFT_MODULE_FLAGS_KEY ": "
       << flagsStr;
 
+  // Adding package-name can be disabled in non-package
+  // swiftinterfaces; add only to package.swiftinterface
+  // in such case.
+  if (Opts.printPackageInterface() &&
+      !Opts.FlagsForPackageOnly.empty())
+    out << " " << Opts.FlagsForPackageOnly;
+
   // Insert additional -module-alias flags
   if (Opts.AliasModuleNames) {
     StringRef moduleName = M->getNameStr();

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -60,8 +60,35 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
       << InterfaceFormatVersion << "\n";
   out << "// " SWIFT_COMPILER_VERSION_KEY ": "
       << ToolsVersion << "\n";
+
+  // Check if printing package-name is disabled for
+  // non-package interfaces (by default, it's printed
+  // in all interfaces).
+  std::string flagsStr = Opts.Flags;
+  if (Opts.DisablePackageNameForNonPackageInterface &&
+      !Opts.printPackageInterface()) {
+    size_t pkgIdx = 0;
+    size_t end = flagsStr.size();
+    auto pkgFlag = StringRef("-package-name ");
+    size_t pkgLen = pkgFlag.size();
+
+    // Find the package-name flag and its value and
+    // drop them. There can be multiple package-name
+    // flags passed, so drop them all.
+    while (pkgIdx < end) {
+      // First, find "-package-name "
+      pkgIdx = flagsStr.find(pkgFlag, 0);
+      if (pkgIdx == std::string::npos)
+        break;
+      // If found, find the next flag's starting pos.
+      auto next = flagsStr.find_first_of("-", pkgIdx + pkgLen + 1);
+      // Remove the substr in-place.
+      flagsStr.erase(pkgIdx, next - pkgIdx);
+    }
+  }
+
   out << "// " SWIFT_MODULE_FLAGS_KEY ": "
-      << Opts.Flags;
+      << flagsStr;
 
   // Insert additional -module-alias flags
   if (Opts.AliasModuleNames) {

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -60,35 +60,8 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
       << InterfaceFormatVersion << "\n";
   out << "// " SWIFT_COMPILER_VERSION_KEY ": "
       << ToolsVersion << "\n";
-
-  // Check if printing package-name is disabled for
-  // non-package interfaces (by default, it's printed
-  // in all interfaces).
-  std::string flagsStr = Opts.Flags;
-  if (Opts.DisablePackageNameForNonPackageInterface &&
-      !Opts.printPackageInterface()) {
-    size_t pkgIdx = 0;
-    size_t end = flagsStr.size();
-    auto pkgFlag = StringRef("-package-name ");
-    size_t pkgLen = pkgFlag.size();
-
-    // Find the package-name flag and its value and
-    // drop them. There can be multiple package-name
-    // flags passed, so drop them all.
-    while (pkgIdx < end) {
-      // First, find "-package-name "
-      pkgIdx = flagsStr.find(pkgFlag, 0);
-      if (pkgIdx == std::string::npos)
-        break;
-      // If found, find the next flag's starting pos.
-      auto next = flagsStr.find_first_of("-", pkgIdx + pkgLen + 1);
-      // Remove the substr in-place.
-      flagsStr.erase(pkgIdx, next - pkgIdx);
-    }
-  }
-
   out << "// " SWIFT_MODULE_FLAGS_KEY ": "
-      << flagsStr;
+      << Opts.Flags;
 
   // Adding package-name can be disabled in non-package
   // swiftinterfaces; add only to package.swiftinterface

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1060,6 +1060,12 @@ bool AttributeChecker::visitAbstractAccessControlAttr(
       D->getASTContext().LangOpts.PackageName.empty() &&
       File && File->Kind != SourceFileKind::Interface) {
     // `package` modifier used outside of a package.
+    // Error if a source file contains a package decl or `package import` but
+    // no package-name is passed.
+    // Note that if the file containing the package decl is a public (or private)
+    // interface file, the decl must be @usableFromInline (or "inlinable"),
+    // effectively getting "public" visibility; in such case, package-name is
+    // not needed, and typecheck on those decls are skipped.
     diagnose(attr->getLocation(), diag::access_control_requires_package_name,
              isa<ValueDecl>(D), D);
     return true;

--- a/test/ModuleInterface/package_interface_disable_package_name.swift
+++ b/test/ModuleInterface/package_interface_disable_package_name.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+
+/// Do not print package-name for public or private interfaces
+// RUN: %target-build-swift -emit-module %s -I %t \
+// RUN:   -module-name Bar -package-name foopkg \
+// RUN:   -enable-library-evolution -swift-version 6 \
+// RUN:   -package-name barpkg \
+// RUN:   -Xfrontend -disable-print-package-name-for-non-package-interface \
+// RUN:   -emit-module-interface-path %t/Bar.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Bar.private.swiftinterface \
+// RUN:   -emit-package-module-interface-path %t/Bar.package.swiftinterface
+
+// RUN: %FileCheck %s --check-prefix=CHECK-PUBLIC < %t/Bar.swiftinterface
+// RUN: %FileCheck %s --check-prefix=CHECK-PRIVATE < %t/Bar.private.swiftinterface
+// RUN: %FileCheck %s --check-prefix=CHECK-PACKAGE < %t/Bar.package.swiftinterface
+
+// CHECK-PUBLIC-NOT: -package-name foopkg
+// CHECK-PUBLIC-NOT: -package-name barpkg
+// CHECK-PRIVATE-NOT: -package-name foopkg
+// CHECK-PRIVATE-NOT: -package-name barpkg
+// CHECK-PACKAGE-NOT: -package-name foopkg
+// CHECK-PACKAGE: -package-name barpkg
+
+// CHECK-PUBLIC: -module-name Bar
+// CHECK-PRIVATE: -module-name Bar
+// CHECK-PACKAGE: -module-name Bar
+
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+// RUN: rm -rf %t/Bar.swiftmodule
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.private.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+// RUN: rm -rf %t/Bar.swiftmodule
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.package.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+
+// RUN: rm -rf %t/Bar.swiftmodule
+// RUN: rm -rf %t/Bar.swiftinterface
+// RUN: rm -rf %t/Bar.private.swiftinterface
+// RUN: rm -rf %t/Bar.package.swiftinterface
+
+/// By default, -package-name is printed in all interfaces.
+// RUN: %target-build-swift -emit-module %s -I %t \
+// RUN:   -module-name Bar -package-name barpkg \
+// RUN:   -enable-library-evolution -swift-version 6 \
+// RUN:   -emit-module-interface-path %t/Bar.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Bar.private.swiftinterface \
+// RUN:   -emit-package-module-interface-path %t/Bar.package.swiftinterface
+
+// RUN: %FileCheck %s < %t/Bar.swiftinterface
+// RUN: %FileCheck %s < %t/Bar.private.swiftinterface
+// RUN: %FileCheck %s < %t/Bar.package.swiftinterface
+
+// CHECK: -package-name barpkg
+// CHECK: -module-name Bar
+
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+// RUN: rm -rf %t/Bar.swiftmodule
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.private.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+// RUN: rm -rf %t/Bar.swiftmodule
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.package.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+
+public struct PubStruct {}
+@_spi(bar) public struct SPIStruct {}
+package struct PkgStruct {}

--- a/test/ModuleInterface/package_interface_disable_package_name.swift
+++ b/test/ModuleInterface/package_interface_disable_package_name.swift
@@ -19,12 +19,12 @@
 // CHECK-PRIVATE-NOT: -package-name foopkg
 // CHECK-PRIVATE-NOT: -package-name barpkg
 // CHECK-PACKAGE-NOT: -package-name foopkg
-// CHECK-PACKAGE: -package-name barpkg
 
-// CHECK-PUBLIC: -module-name Bar
-// CHECK-PRIVATE: -module-name Bar
-// CHECK-PACKAGE: -module-name Bar
+// CHECK-PUBLIC:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar
+// CHECK-PRIVATE:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar
+// CHECK-PACKAGE:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar -package-name barpkg
 
+/// Verify building modules from non-package interfaces succeeds without the package-name flag.
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.private.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
@@ -48,9 +48,9 @@
 // RUN: %FileCheck %s < %t/Bar.private.swiftinterface
 // RUN: %FileCheck %s < %t/Bar.package.swiftinterface
 
-// CHECK: -package-name barpkg
-// CHECK: -module-name Bar
+// CHECK: -enable-library-evolution -package-name barpkg -swift-version 6 -module-name Bar
 
+/// Building modules from non-package interfaces with package-name (default mode) should succeed.
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.private.swiftinterface -o %t/Bar.swiftmodule -module-name Bar


### PR DESCRIPTION
Having `-package-name` flag in non-package interfaces causes package-only dependencies to be built even for an external client, and causes a missing dependency module error. 

For example, when building X that depends on A with the following dependency chain, where A, B, and C are in the same package, and X is an external client (client outside of that package):
  X --> A --> B --(package-only)--> C

1. When dependency scanning X, and opening up A and B, because the scan target is in a different package domain, the scanner decides that B's package-only dependency on C is to be ignored.
2. When then finally building A itself, it will load its dependencies, but because the .private.swiftinterface of A still specifies `-package-name`, when it loads B, it will then examine its dependencies and deem that this package-only dependency on C is required.

Because (1) and (2) disagree, we get a `error: missing required module 'C'` now when building the private A textual interface.

This PR provides an option to disable printing package-name flag in public or private swiftinterface, so in the case of (2) above, it no longer requires package-only dependency module. 

rdar://130701866
