### PR TITLE
AST: Fix substitution map composition edge case

### DIFF
--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -200,6 +200,10 @@ operator()(CanType dependentType, Type conformingReplacementType,
 ProtocolConformanceRef LookUpConformanceInSubstitutionMap::
 operator()(CanType dependentType, Type conformingReplacementType,
            ProtocolDecl *conformedProtocol) const {
+  auto result = Subs.lookupConformance(dependentType, conformedProtocol);
+  if (!result.isInvalid())
+    return result;
+
   // Lookup conformances for archetypes that conform concretely
   // via a superclass.
   if (auto archetypeType = conformingReplacementType->getAs<ArchetypeType>()) {
@@ -207,7 +211,18 @@ operator()(CanType dependentType, Type conformingReplacementType,
         conformingReplacementType, conformedProtocol,
         /*allowMissing=*/true);
   }
-  return Subs.lookupConformance(dependentType, conformedProtocol);
+
+  // Otherwise, the original type might be fixed to a concrete type in
+  // the substitution map's input generic signature.
+  if (auto genericSig = Subs.getGenericSignature()) {
+    if (genericSig->isConcreteType(dependentType)) {
+      return conformedProtocol->getModuleContext()->lookupConformance(
+          conformingReplacementType, conformedProtocol,
+          /*allowMissing=*/true);
+    }
+  }
+
+  return ProtocolConformanceRef::forInvalid();
 }
 
 ProtocolConformanceRef MakeAbstractConformanceForGenericType::

--- a/test/SILGen/literal_expr_conditional_conformance.swift
+++ b/test/SILGen/literal_expr_conditional_conformance.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-emit-silgen %s
+
+public protocol P {
+  associatedtype A : Equatable
+}
+
+public struct G<A: Equatable>: P {}
+
+extension P where A == Int {
+  public init(integerLiteral: Int) {
+    fatalError()
+  }
+}
+
+extension G: ExpressibleByIntegerLiteral where A == Int {}
+
+public func f() -> G<Int> {
+  return 123
+}

--- a/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
+++ b/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
@@ -1,11 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-silgen
 
-// rdar://80395274 tracks getting this to pass with the requirement machine.
-// XFAIL: *
-
-// The test hangs in a noassert build:
-// REQUIRES: asserts
-
 import StdlibUnittest
 
 public struct MyRange<Bound : ForwardIndex> {


### PR DESCRIPTION
Adding `T == Int` to

    G1 := <T where T: Equatable>

gives us

    G2 := <T where T == Int>

which means that if I have this substitution map for G2:

    S2 := { Int }

then `SubstitutionMap::get(G1, S2)` should give me this substitution map for G1:

    S2 := { Int, [Int: Equatable] }

But it didn't, instead returning a substitution map with an invalid conformance.

The problem is that local conformance lookup alone cannot recover `[Int: Equatable]` in this case, because there is no "concrete conformance requirement" `[T == Int: Equatable]` recorded anywhere in G2.

This is of course a legacy of the GenericSignatureBuilder. It would have been better to not drop conformance requirements made concrete. But oh well.

Fixes https://github.com/swiftlang/swift/issues/74465
Fixes rdar://130404629.