### PR TITLE
ClangImporter: add support for Android API Notes

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -473,6 +473,11 @@ if("ANDROID" IN_LIST SWIFT_SDKS)
                                  COMPONENT sdk-overlay)
     endif()
   endforeach()
+
+  swift_install_in_component(FILES
+      posix_filesystem.apinotes
+    DESTINATION "share"
+    COMPONENT sdk-overlay)
 endif()
 add_custom_target(android_modulemap DEPENDS ${android_modulemap_target_list})
 set_property(TARGET android_modulemap PROPERTY FOLDER "Miscellaneous")

--- a/stdlib/public/Platform/posix_filesystem.apinotes
+++ b/stdlib/public/Platform/posix_filesystem.apinotes
@@ -1,0 +1,7 @@
+---
+Name: bionic
+Functions:
+- Name: fts_open
+  Parameters:
+  - Position: 0
+    Type: "char * const _Nullable * _Nonnull"


### PR DESCRIPTION
Introduce the first APINotes injection for the Android platform. This follows the VCRuntime pattern of permitting the SDK to provide API Notes that augment the system SDK. This adds a workaround for incorrect nullability on the `fts_open` function in bionic. The system library itself is fixed at:
https://android-review.googlesource.com/c/platform/bionic/+/3151616