### PR TITLE
[6.0] Sema: Fix incorrect use of STL iterator in associated type inference

### DIFF
--- a/test/decl/protocol/req/rdar127575477.swift
+++ b/test/decl/protocol/req/rdar127575477.swift
@@ -1,0 +1,14 @@
+// RUN: not %target-typecheck-verify-swift
+
+// This is highly invalid, so just don't crash.
+
+struct G<T> {}
+
+extension G: Collection {
+  typealias SubSequence = DoesNotExist
+  typealias Index = DoesNotExist
+
+  subscript(position: Index) -> Element { fatalError() }
+}
+
+extension G: BidirectionalCollection where T: BidirectionalCollection {}


### PR DESCRIPTION
6.0 cherry-pick of https://github.com/swiftlang/swift/pull/74800

* **Description:** Crash-on-invalid from forgetting to compare STL iterator with `end()`.

* **Origination:** Regression in Swift 6 associated type inference implementation.

* **Risk:** Very low, because the old behavior was UB.

* **Radar:** rdar://problem/127575477.