### PR TITLE
[6.0] AST: Fix substitution map composition edge case

### DIFF
--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -220,6 +220,10 @@ operator()(CanType dependentType, Type conformingReplacementType,
 ProtocolConformanceRef LookUpConformanceInSubstitutionMap::
 operator()(CanType dependentType, Type conformingReplacementType,
            ProtocolDecl *conformedProtocol) const {
+  auto result = Subs.lookupConformance(dependentType, conformedProtocol);
+  if (!result.isInvalid())
+    return result;
+
   // Lookup conformances for archetypes that conform concretely
   // via a superclass.
   if (auto archetypeType = conformingReplacementType->getAs<ArchetypeType>()) {
@@ -227,7 +231,18 @@ operator()(CanType dependentType, Type conformingReplacementType,
         conformingReplacementType, conformedProtocol,
         /*allowMissing=*/true);
   }
-  return Subs.lookupConformance(dependentType, conformedProtocol);
+
+  // Otherwise, the original type might be fixed to a concrete type in
+  // the substitution map's input generic signature.
+  if (auto genericSig = Subs.getGenericSignature()) {
+    if (genericSig->isConcreteType(dependentType)) {
+      return conformedProtocol->getModuleContext()->lookupConformance(
+          conformingReplacementType, conformedProtocol,
+          /*allowMissing=*/true);
+    }
+  }
+
+  return ProtocolConformanceRef::forInvalid();
 }
 
 ProtocolConformanceRef MakeAbstractConformanceForGenericType::

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -220,10 +220,6 @@ operator()(CanType dependentType, Type conformingReplacementType,
 ProtocolConformanceRef LookUpConformanceInSubstitutionMap::
 operator()(CanType dependentType, Type conformingReplacementType,
            ProtocolDecl *conformedProtocol) const {
-  auto result = Subs.lookupConformance(dependentType, conformedProtocol);
-  if (!result.isInvalid())
-    return result;
-
   // Lookup conformances for archetypes that conform concretely
   // via a superclass.
   if (auto archetypeType = conformingReplacementType->getAs<ArchetypeType>()) {
@@ -232,10 +228,15 @@ operator()(CanType dependentType, Type conformingReplacementType,
         /*allowMissing=*/true);
   }
 
+  auto result = Subs.lookupConformance(dependentType, conformedProtocol);
+  if (!result.isInvalid())
+    return result;
+
   // Otherwise, the original type might be fixed to a concrete type in
   // the substitution map's input generic signature.
   if (auto genericSig = Subs.getGenericSignature()) {
-    if (genericSig->isConcreteType(dependentType)) {
+    if (genericSig->isValidTypeParameter(dependentType) &&
+        genericSig->isConcreteType(dependentType)) {
       return conformedProtocol->getModuleContext()->lookupConformance(
           conformingReplacementType, conformedProtocol,
           /*allowMissing=*/true);

--- a/test/SILGen/literal_expr_conditional_conformance.swift
+++ b/test/SILGen/literal_expr_conditional_conformance.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-emit-silgen %s
+
+public protocol P {
+  associatedtype A : Equatable
+}
+
+public struct G<A: Equatable>: P {}
+
+extension P where A == Int {
+  public init(integerLiteral: Int) {
+    fatalError()
+  }
+}
+
+extension G: ExpressibleByIntegerLiteral where A == Int {}
+
+public func f() -> G<Int> {
+  return 123
+}

--- a/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
+++ b/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
@@ -1,11 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-silgen
 
-// rdar://80395274 tracks getting this to pass with the requirement machine.
-// XFAIL: *
-
-// The test hangs in a noassert build:
-// REQUIRES: asserts
-
 import StdlibUnittest
 
 public struct MyRange<Bound : ForwardIndex> {


### PR DESCRIPTION
6.0 cherry-pick of https://github.com/swiftlang/swift/pull/74828

* **Description:** If a type parameter was subject to a conformance requirement `T: P` and then becomes concrete `T == S` in a constrained extension, we would sometimes crash.

* **Origination:** Issue has been there forever, but introduction of noncopyable generics regressed the reported test case by introducing `Copyable` requirements everywhere.

* **Reviewed by:** @kavon 

* **Risk:** Low.

* **Radar:** Fixes rdar://130404629.