### PR TITLE
6.0: [PrunedLiveness] Branch summary merges to ending.

### DIFF
--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -399,7 +399,7 @@ public:
         : value(lifetimeEnding ? Value::Ending : Value::NonEnding) {}
     operator Value() const { return value; }
     LifetimeEnding meet(LifetimeEnding const other) const {
-      return value < other.value ? *this : other;
+      return std::min(value, other.value);
     }
     void meetInPlace(LifetimeEnding const other) { *this = meet(other); }
     bool isEnding() const { return value == Value::Ending; }

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -192,6 +192,43 @@ static FunctionTest
 //                              PrunedLiveRange
 //===----------------------------------------------------------------------===//
 
+static PrunedLiveness::LifetimeEnding
+branchMeet(PrunedLiveness::LifetimeEnding const lhs,
+           PrunedLiveness::LifetimeEnding const rhs) {
+  enum BranchLifetimeEnding {
+    Ending,
+    NonEnding,
+    NonUse,
+  };
+  auto toBranch =
+      [](PrunedLiveness::LifetimeEnding const ending) -> BranchLifetimeEnding {
+    switch (ending) {
+    case PrunedLiveness::LifetimeEnding::Value::NonEnding:
+      return NonEnding;
+    case PrunedLiveness::LifetimeEnding::Value::Ending:
+      return Ending;
+    case PrunedLiveness::LifetimeEnding::Value::NonUse:
+      return NonUse;
+    }
+  };
+  auto toRegular =
+      [](BranchLifetimeEnding const ending) -> PrunedLiveness::LifetimeEnding {
+    switch (ending) {
+    case NonEnding:
+      return PrunedLiveness::LifetimeEnding::Value::NonEnding;
+    case Ending:
+      return PrunedLiveness::LifetimeEnding::Value::Ending;
+    case NonUse:
+      return PrunedLiveness::LifetimeEnding::Value::NonUse;
+    }
+  };
+  return toRegular(std::min(toBranch(lhs), toBranch(rhs)));
+}
+static void branchMeetInPlace(PrunedLiveness::LifetimeEnding &that,
+                              PrunedLiveness::LifetimeEnding const other) {
+  that = branchMeet(that, other);
+}
+
 template <typename LivenessWithDefs>
 void PrunedLiveRange<LivenessWithDefs>::updateForUse(
     SILInstruction *user,
@@ -210,8 +247,13 @@ void PrunedLiveRange<LivenessWithDefs>::updateForUse(
   // This call is not considered the end of %val's lifetime. The @owned
   // argument must be copied.
   auto iterAndSuccess = users.insert({user, lifetimeEnding});
-  if (!iterAndSuccess.second)
-    iterAndSuccess.first->second.meetInPlace(lifetimeEnding);
+  if (!iterAndSuccess.second) {
+    if (isa<BranchInst>(user)) {
+      branchMeetInPlace(iterAndSuccess.first->second, lifetimeEnding);
+    } else {
+      iterAndSuccess.first->second.meetInPlace(lifetimeEnding);
+    }
+  }
 }
 template <typename LivenessWithDefs>
 void PrunedLiveRange<LivenessWithDefs>::updateForUse(SILInstruction *user,

--- a/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
@@ -169,6 +169,15 @@ void MoveOnlyChecker::completeObjectLifetimes(
         }
       }
     }
+    for (SILArgument *arg : block->getArguments()) {
+      assert(!arg->isReborrow() && "reborrows not legal at this SIL stage");
+      if (!transitiveValues.isVisited(arg))
+        continue;
+      if (completion.completeOSSALifetime(arg) ==
+          LifetimeCompletion::WasCompleted) {
+        madeChange = true;
+      }
+    }
   }
 }
 

--- a/test/SILOptimizer/liveness_unit.sil
+++ b/test/SILOptimizer/liveness_unit.sil
@@ -378,7 +378,7 @@ bb1(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
 // CHECK-LABEL: testSSAReborrowedPhi: ssa_liveness
 // CHECK: SSA lifetime analysis: %{{.*}} = begin_borrow
 // CHECK-NEXT: bb0: LiveWithin
-// CHECK-NEXT: regular user: br bb1
+// CHECK-NEXT: lifetime-ending user: br bb1
 // CHECK-NEXT: regular user: %{{.*}} = struct
 // CHECK-NEXT: last user: br bb1
 // CHECK-NEXT: end running

--- a/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
@@ -21,6 +21,8 @@ struct M4: ~Copyable {
   let s4: M
 }
 
+class C {}
+
 sil @get_M4 : $@convention(thin) () -> @owned M4
 sil @end_2 : $@convention(thin) (@owned M, @owned M) -> ()
 sil @see_addr : $@convention(thin) (@in_guaranteed M) -> ()
@@ -28,6 +30,7 @@ sil @see_addr_2 : $@convention(thin) (@in_guaranteed M, @in_guaranteed M) -> ()
 sil @replace_2 : $@convention(thin) (@inout M, @inout M) -> ()
 sil @get_out_2 : $@convention(thin) () -> (@out M, @out M)
 sil @take_addr_2 : $@convention(thin) (@in M, @in M) -> ()
+sil @getC : $@convention(thin) () -> (@owned C)
 
 /// Two non-contiguous fields (#M4.s2, #M4.s4) are borrowed by @see_addr_2.
 /// Two non-contiguous fields (#M4.s1, #M$.s3) are consumed by @end_2.
@@ -253,3 +256,37 @@ bb0(%0 : @guaranteed $M):
   return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @rdar130427564 : {{.*}} {
+// Verify that no instructions were inserted after backedge2's terminator.  (In
+// fact, if they were, the test would crash.)
+// CHECK:       bb2([[C0:%[^,]+]] : @owned $C, [[B0:%[^,]+]] : @reborrow @guaranteed $C):
+// CHECK-NEXT:    end_borrow [[B0]]
+// CHECK-NEXT:    destroy_value [[C0]]
+// CHECK-NEXT:    br
+// CHECK-LABEL: } // end sil function 'rdar130427564'
+sil [ossa] @rdar130427564 : $@convention(thin) (@in_guaranteed M) -> () {
+entry(%ignore_me : $*M):
+  %ignore_me_2 = mark_unresolved_non_copyable_value [no_consume_or_assign] %ignore_me : $*M
+  br fn
+fn:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  %c = apply %getC() : $@convention(thin) () -> (@owned C)
+  %b = begin_borrow %c : $C
+  br header(%c : $C, %b : $C)
+header(%c0 : @owned $C, %b0 : @reborrow @guaranteed $C):
+  end_borrow %b0 : $C
+  destroy_value %c0 : $C
+  br body
+body:
+  br latch
+latch:
+  cond_br undef, backedge, ecit
+backedge:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  %b1 = begin_borrow %c1 : $C
+  br backedge2(%c1 : $C, %b1 : $C)
+backedge2(%c2 : @owned $C, %b2 : @reborrow @guaranteed $C):
+  br header(%c2 : $C, %b2 : $C)
+ecit:
+  unreachable
+}

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -11,6 +11,8 @@ public enum FakeOptional<T> {
   case some(T)
 }
 
+sil @getC : $@convention(thin) () -> (@owned C)
+
 // CHECK-LABEL: begin running test 1 of 1 on eagerConsumneOwnedArg: ossa-lifetime-completion with: @argument
 // CHECK-LABEL: OSSA lifetime completion: %0 = argument of bb0 : $C
 // CHECK: sil [ossa] @eagerConsumneOwnedArg : $@convention(thin) (@owned C) -> () {
@@ -394,4 +396,39 @@ die:
 exit:
   %retval = tuple ()
   return %retval : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on root_of_reborrow: ossa-lifetime-completion
+// Verify that no instructions were inserted after backedge2's terminator.  (In
+// fact, if they were, the test would crash.)
+// CHECK-LABEL: sil [ossa] @root_of_reborrow : {{.*}} {
+// CHECK:       bb1([[C0:%[^,]+]] : @owned $C, [[B0:%[^,]+]] : @reborrow @guaranteed $C):
+// CHECK-NEXT:    end_borrow [[B0]]
+// CHECK-NEXT:    destroy_value [[C0]]
+// CHECK-NEXT:    br
+// CHECK-LABEL: } // end sil function 'root_of_reborrow'
+// CHECK-LABEL: end running test {{.*}} on root_of_reborrow: ossa-lifetime-completion
+sil [ossa] @root_of_reborrow : $@convention(thin) () -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  %c = apply %getC() : $@convention(thin) () -> (@owned C)
+  %b = begin_borrow %c : $C
+  br header(%c : $C, %b : $C)
+header(%c0 : @owned $C, %b0 : @reborrow @guaranteed $C):
+  end_borrow %b0 : $C
+  destroy_value %c0 : $C
+  br body
+body:
+  br latch
+latch:
+  cond_br undef, backedge, exit
+backedge:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  %b1 = begin_borrow %c1 : $C
+  br backedge2(%c1 : $C, %b1 : $C)
+backedge2(%c2 : @owned $C, %b2 : @reborrow @guaranteed $C):
+  specify_test "ossa-lifetime-completion %c2"
+  br header(%c2 : $C, %b2 : $C)
+exit:
+  unreachable
 }

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -386,7 +386,7 @@ bb1(%reborrow : @guaranteed $C):
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
 // CHECK-NEXT: Inner scope:   %{{.*}} = begin_borrow %{{.*}} : $D
 // CHECK-NEXT: bb0: LiveWithin
-// CHECK-NEXT: regular user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
+// CHECK-NEXT: lifetime-ending user:   br bb1(%{{.*}} : $C, %{{.*}} : $D)
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
 // CHECK-NEXT: Complete liveness
 // CHECK-NEXT: Unenclosed phis {


### PR DESCRIPTION
**Explanation**: Fix underlying utility and reinstate lifetime completion during move checking.

To address a compiler crash, move-checking's lifetime completion was partially disabled.  Here, it is reenabled now that the compiler crash will no longer occur.

The move-only address checker depends on complete lifetimes; without them, it miscompiles code.  So, if the checker determines that it will have to transform the function, it completes all (non-reborrow) lifetimes before transforming.  That completion was temporarily partially disabled because it was producing invalid SIL.  Here, the underlying issue which caused completion to produce invalid SIL is fixed and lifetime completion is reinstated to run as before.

The underlying issue was an incorrect summary calculation done by the `PrunedLiveness` utility.  Specifically, it determined that branch instructions (e.g. `br bbN(%x, %y)`) were not lifetime-ending if they had both an owned value and a guaranteed value derived from that owned value as their operands`†`.  The result was ending lifetimes of the value actually consumed by the branch in the block that it branched to.  This was invalid in a couple of ways: the value was overconsumed, the destroy might not dominate the def.  In noasserts builds, this resulted in a compiler crash during LLVM.

Now that the underlying issue is fixed, lifetime completion doesn't produce invalid SIL, and the compiler doesn't crash during LLVM.

`†` In OSSA, in the target block, the guaranteed block argument is understood to be derived from the owned block argument.
**Scope**: Affects noncopyable code.
**Issue**: rdar://130427564
**Original PR**: https://github.com/swiftlang/swift/pull/74815 , https://github.com/swiftlang/swift/pull/74835
**Risk**: Low.
**Testing**: Added and updated tests.  Rebuilt project exhibiting compiler crash without fix.
**Reviewer**: Andrew Trick ( @atrick ), Meghana Gupta ( @meg-gupta )
