### PR TITLE
SILGen: Skip function bodies with errors in lazy typechecking mode

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -647,7 +647,28 @@ static SILFunction *getFunctionToInsertAfter(SILGenModule &SGM,
 }
 
 static bool shouldEmitFunctionBody(const AbstractFunctionDecl *AFD) {
-  return AFD->hasBody() && !AFD->isBodySkipped();
+  if (!AFD->hasBody())
+    return false;
+
+  if (AFD->isBodySkipped())
+    return false;
+
+  auto &ctx = AFD->getASTContext();
+  if (ctx.TypeCheckerOpts.EnableLazyTypecheck) {
+    // Force the function body to be type-checked and then skip it if there
+    // have been any errors.
+    (void)AFD->getTypecheckedBody();
+
+    // FIXME: Only skip bodies that contain type checking errors.
+    // It would be ideal to only skip the function body if it is specifically
+    // the source of an error. However, that information isn't available today
+    // so instead we avoid emitting all function bodies as soon as any error is
+    // encountered.
+    if (ctx.hadError())
+      return false;
+  }
+
+  return true;
 }
 
 static bool isEmittedOnDemand(SILModule &M, SILDeclRef constant) {

--- a/test/SILGen/lazy_typecheck_errors.swift
+++ b/test/SILGen/lazy_typecheck_errors.swift
@@ -61,3 +61,8 @@ public class DerivedFromNonExistent: NonExistent {
 
   public func method() {}
 }
+
+@inlinable public func hasErrorInBody() {
+  nonExistent()
+  // expected-error@-1 {{cannot find 'nonExistent' in scope}}
+}


### PR DESCRIPTION
The SILGen pipeline expects function bodies to have been succesfully type checked and will usually crash if it attempts to emit SIL for a function that has errors. To avoid crashing, cause function body typechecking to happen earlier in lazy typechecking mode and then skip functions whenever any errors have been encountered.

Resolves rdar://130777647.

