### PR TITLE
AST: Functions nested in exportable functions are also exportable

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -784,20 +784,6 @@ bool SILGenModule::shouldSkipDecl(Decl *D) {
   if (D->isExposedToClients())
     return false;
 
-  if (isa<AbstractFunctionDecl>(D)) {
-    // If this function is nested within another function that is exposed to
-    // clients then it should be emitted.
-    auto dc = D->getDeclContext();
-    do {
-      if (auto afd = dyn_cast<AbstractFunctionDecl>(dc))
-        if (afd->isExposedToClients())
-          return false;
-    } while ((dc = dc->getParent()));
-
-    // We didn't find a parent function that is exposed.
-    return true;
-  }
-
   return true;
 }
 

--- a/test/Serialization/Safety/unsafe-decls.swift
+++ b/test/Serialization/Safety/unsafe-decls.swift
@@ -70,11 +70,20 @@ public struct PublicStruct {
 // SAFETY-PRIVATE: Serialization safety, unsafe: 'init(fileprivateInit:)'
 
     @inlinable public func inlinableFunc() {
-        typealias localTypealias = Int
-    }
 // SAFETY-PRIVATE: Serialization safety, safe: 'inlinableFunc()'
-    public func publicFunc() {}
+        typealias localTypealias = Int
+
+        func inlinableFunc_nested() {}
+// SAFETY-PRIVATE-NOT: inlinableFunc_nested()
+        inlinableFunc_nested()
+    }
+
+    public func publicFunc() {
 // SAFETY-PRIVATE: Serialization safety, safe: 'publicFunc()'
+        func publicFunc_nested() {}
+// SAFETY-PRIVATE-NOT: publicFunc_nested()
+        publicFunc_nested()
+    }
 
     @available(SwiftStdlib 5.1, *) // for the `some` keyword.
     public func opaqueTypeFunc() -> some PublicProto {


### PR DESCRIPTION
Centralize the exportability checking logic for nested functions in the `DeclExportabilityVisitor` utility. This logic was previously added to SILGen but there should not be special casing for nested functions at that layer.