### PR TITLE
Fix isTriviallyDuplicatable to handle open_pack_element

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1418,8 +1418,10 @@ bool SILInstruction::isTriviallyDuplicatable() const {
 
   if (isa<OpenExistentialAddrInst>(this) || isa<OpenExistentialRefInst>(this) ||
       isa<OpenExistentialMetatypeInst>(this) ||
-      isa<OpenExistentialValueInst>(this) || isa<OpenExistentialBoxInst>(this) ||
-      isa<OpenExistentialBoxValueInst>(this)) {
+      isa<OpenExistentialValueInst>(this) ||
+      isa<OpenExistentialBoxInst>(this) ||
+      isa<OpenExistentialBoxValueInst>(this) ||
+      isa<OpenPackElementInst>(this)) {
     // Don't know how to duplicate these properly yet. Inst.clone() per
     // instruction does not work. Because the follow-up instructions need to
     // reuse the same archetype uuid which would only work if we used a

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -280,9 +280,9 @@ bool swift::canDuplicateLoopInstruction(SILLoop *L, SILInstruction *I) {
 
   // We can't have a phi of two openexistential instructions of different UUID.
   if (isa<OpenExistentialAddrInst>(I) || isa<OpenExistentialRefInst>(I) ||
-      isa<OpenExistentialMetatypeInst>(I) ||
-      isa<OpenExistentialValueInst>(I) || isa<OpenExistentialBoxInst>(I) ||
-      isa<OpenExistentialBoxValueInst>(I)) {
+      isa<OpenExistentialMetatypeInst>(I) || isa<OpenExistentialValueInst>(I) ||
+      isa<OpenExistentialBoxInst>(I) || isa<OpenExistentialBoxValueInst>(I) ||
+      isa<OpenPackElementInst>(I)) {
     SingleValueInstruction *OI = cast<SingleValueInstruction>(I);
     for (auto *UI : OI->getUses())
       if (!L->contains(UI->getUser()))

--- a/test/SILOptimizer/looprotate.sil
+++ b/test/SILOptimizer/looprotate.sil
@@ -465,3 +465,39 @@ bb3:
  %1 = tuple ()
  return %1 : $()
 }
+
+struct Wrapper : Sendable {
+  let id: Int
+}
+ 
+// CHECK-LABEL: sil @test_open_pack_element :
+// CHECK: bb0{{.*}}:
+// CHECK-NOT: open_pack_element
+// CHECK: br bb2
+// CHECK:  } // end sil function 'test_open_pack_element'
+sil @test_open_pack_element : $@convention(thin) (@pack_guaranteed Pack{KeyPath<Wrapper, Wrapper>}) -> () {
+bb0(%0 : $*Pack{KeyPath<Wrapper, Wrapper>}):
+  %5 = alloc_stack $KeyPath<Wrapper, Wrapper>
+  %6 = integer_literal $Builtin.Word, 0           // user: %8
+  br bb2(%6 : $Builtin.Word)
+
+bb1:
+  dealloc_stack %5 : $*KeyPath<Wrapper, Wrapper>
+  %35 = tuple ()
+  return %35 : $()
+
+bb2(%37 : $Builtin.Word):
+  %38 = dynamic_pack_index %37 of $Pack{KeyPath<Wrapper, Wrapper>}
+  %39 = open_pack_element %38 of <Topic, each Value where Topic : AnyObject, repeat each Value : Sendable> at <Wrapper, Pack{Wrapper}>, shape $each Value, uuid "94218A22-3595-11EF-8496-4EA2A866E4C5"
+  %40 = pack_element_get %38 of %0 : $*Pack{KeyPath<Wrapper, Wrapper>} as $*KeyPath<Wrapper, @pack_element("94218A22-3595-11EF-8496-4EA2A866E4C5") each Value>
+  %41 = unchecked_addr_cast %5 : $*KeyPath<Wrapper, Wrapper> to $*KeyPath<Wrapper, @pack_element("94218A22-3595-11EF-8496-4EA2A866E4C5") each Value>
+  %42 = load %40 : $*KeyPath<Wrapper, @pack_element("94218A22-3595-11EF-8496-4EA2A866E4C5") each Value>
+  store %42 to %41 : $*KeyPath<Wrapper, @pack_element("94218A22-3595-11EF-8496-4EA2A866E4C5") each Value>
+  %7 = integer_literal $Builtin.Word, 1           // users: %45, %44
+  %44 = builtin "add_Word"(%37 : $Builtin.Word, %7 : $Builtin.Word) : $Builtin.Word // users: %48, %45
+  cond_br undef, bb1, bb3
+
+bb3:
+  strong_retain %42 : $KeyPath<Wrapper, @pack_element("94218A22-3595-11EF-8496-4EA2A866E4C5") each Value>
+  br bb2(%44 : $Builtin.Word)
+}


### PR DESCRIPTION
Just like other instructions that produce archetype uuid: `open_existential_addr` and `open_existential_metatype`, `open_pack_element` is not trivially duplicatable. 

`SILInstruction::clone` doesn't know how to clone instructions that produce the archetype uuid. `SILCloner` is equipped to handle such instructions. Optimizations like LoopRotate use  `SILInstruction::clone` and will be incorrect for such instructions.

rdar://130047619

