### PR TITLE
Warn about sending on Sendable type in function parameters (#74616)

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7952,8 +7952,11 @@ ERROR(sending_unsupported_param_specifier, none,
       "'%0' cannot be applied to a 'sending' parameter", (StringRef))
 ERROR(sending_only_on_parameters_and_results, none,
       "'sending' may only be used on parameters and results", ())
-WARNING(sending_applied_to_sendable, none,
+WARNING(sending_applied_to_sendable_parameter, none,
         "'sending' has no effect on Sendable parameter %0",
+        (Type))
+WARNING(sending_applied_to_sendable_result, none,
+        "'sending' has no effect on Sendable function result type %0",
         (Type))
 ERROR(sending_cannot_be_applied_to_tuple_elt, none,
       "'sending' cannot be applied to tuple elements", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7952,6 +7952,9 @@ ERROR(sending_unsupported_param_specifier, none,
       "'%0' cannot be applied to a 'sending' parameter", (StringRef))
 ERROR(sending_only_on_parameters_and_results, none,
       "'sending' may only be used on parameters and results", ())
+WARNING(sending_applied_to_sendable, none,
+        "'sending' has no effect on Sendable parameter %0",
+        (Type))
 ERROR(sending_cannot_be_applied_to_tuple_elt, none,
       "'sending' cannot be applied to tuple elements", ())
 ERROR(sending_function_wrong_sending,none,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4976,8 +4976,29 @@ TypeResolver::resolveSendingTypeRepr(SendingTypeRepr *repr,
     return ErrorType::get(getASTContext());
   }
 
+  NeverNullType resolvedType = resolveType(repr->getBase(), options);
+  
+  // If resolved type is Sendable, warn about unnecessary 'sending' annotation.
+  if (options.is(TypeResolverContext::FunctionInput)) {
+    if(!resolvedType->hasTypeParameter()) {
+      if (resolvedType->isSendableType()) {
+        diagnose(repr->getSpecifierLoc(),
+                 diag::sending_applied_to_sendable,
+                 resolvedType.get())
+        .fixItRemove(repr->getSpecifierLoc());
+      }
+    } else {
+      if (resolvedType->getASTContext().getProtocol(KnownProtocolKind::Sendable)) {
+        diagnose(repr->getSpecifierLoc(),
+                 diag::sending_applied_to_sendable,
+                 resolvedType.get())
+        .fixItRemove(repr->getSpecifierLoc());
+      };
+    }
+  }
+
   // Return the type.
-  return resolveType(repr->getBase(), options);
+  return resolvedType;
 }
 
 NeverNullType

--- a/test/Parse/parameter_specifier_before_param_name.swift
+++ b/test/Parse/parameter_specifier_before_param_name.swift
@@ -20,4 +20,4 @@ func foo(isolated x b: MyActor) {} // expected-warning {{'isolated' before a par
 func foo(_const x b: MyClass) {} // expected-warning {{'_const' before a parameter name is not allowed, place it before the parameter type instead; this is an error in the Swift 6 language mode}}
 
 @available(SwiftStdlib 5.1, *)
-func foo(sending x b: MyActor) {} // expected-warning {{'sending' before a parameter name is not allowed, place it before the parameter type instead}}
+func foo(sending x b: MyClass) {} // expected-warning {{'sending' before a parameter name is not allowed, place it before the parameter type instead}}

--- a/test/Parse/sending.swift
+++ b/test/Parse/sending.swift
@@ -2,32 +2,36 @@
 
 // REQUIRES: asserts
 
-func testArg(_ x: sending String) {
+class NonSendable {
+  init(){}
 }
 
-func testResult() -> sending String {
-  ""
+func testArg(_ x: sending NonSendable) {
 }
 
-func testArgResult(_ x: sending String) -> sending String {
+func testResult() -> sending NonSendable {
+  return NonSendable()
+}
+
+func testArgResult(_ x: sending NonSendable) -> sending NonSendable {
 }
 
 func testVarDeclDoesntWork() {
-  var x: sending String // expected-error {{'sending' may only be used on parameter}}
+  var x: sending NonSendable // expected-error {{'sending' may only be used on parameter}}
 }
 
-func testVarDeclTupleElt() -> (sending String, String) {} // expected-error {{'sending' cannot be applied to tuple elements}}
+func testVarDeclTupleElt() -> (sending NonSendable, NonSendable) {} // expected-error {{'sending' cannot be applied to tuple elements}}
 
-func testVarDeclTuple2(_ x: (sending String)) {}
-func testVarDeclTuple2(_ x: (sending String, String)) {} // expected-error {{'sending' cannot be applied to tuple elements}}
+func testVarDeclTuple2(_ x: (sending NonSendable)) {}
+func testVarDeclTuple2(_ x: (sending NonSendable, NonSendable)) {} // expected-error {{'sending' cannot be applied to tuple elements}}
 
-func testArgWithConsumingWrongOrder(_ x: sending consuming String, _ y: sending inout String) {}
+func testArgWithConsumingWrongOrder(_ x: sending consuming NonSendable, _ y: sending inout NonSendable) {}
 // expected-error @-1 {{'sending' must be placed after specifier 'consuming'}}
 // expected-error @-2 {{'sending' must be placed after specifier 'inout'}}
 
-func testArgWithConsumingWrongOrderType(_ x: (sending consuming String, sending inout String) -> ()) {}
+func testArgWithConsumingWrongOrderType(_ x: (sending consuming NonSendable, sending inout NonSendable) -> ()) {}
 // expected-error @-1 {{'sending' must be placed after specifier 'consuming'}}
 // expected-error @-2 {{'sending' must be placed after specifier 'inout'}}
 
-func testBorrowSending(_ x: borrowing sending String) {}
+func testBorrowSending(_ x: borrowing sending NonSendable) {}
 // expected-error @-1 {{'sending' cannot be used together with 'borrowing'}}

--- a/test/Sema/consume_operator_noop_warning.swift
+++ b/test/Sema/consume_operator_noop_warning.swift
@@ -43,6 +43,7 @@ func proofOfUseAfterConsume() -> Int {
 func moreProofs(_ share: __shared Int,
                 _ own: __owned Int,
                 _ snd: sending Int, // expected-error {{'snd' used after consume}}
+                // expected-warning @-1 {{'sending' has no effect on Sendable parameter}}
                 _ ino: inout Int, // expected-error {{'ino' used after consume}}
                 _ brw: borrowing Int, // expected-error {{'brw' is borrowed and cannot be consumed}}
                 _ csm: consuming Int // expected-error {{'csm' consumed more than once}}

--- a/test/Sema/sending.swift
+++ b/test/Sema/sending.swift
@@ -6,19 +6,23 @@
 // README: This test makes sure that we error when sending is placed in the
 // wrong place with respect to ownership modifiers.
 
-func test_good(_ x: sending Int) {}
+class NonSendable {
+	init(){}
+}
 
-func test_consuming_after_sending(_ x: sending consuming Int) {} // expected-error {{'sending' must be placed after specifier 'consuming'}}
+func test_good(_ x: sending NonSendable) {}
 
-func test_inout_after_sending(_ x: sending inout Int) {} // expected-error {{'sending' must be placed after specifier 'inout'}}
+func test_consuming_after_sending(_ x: sending consuming NonSendable) {} // expected-error {{'sending' must be placed after specifier 'consuming'}}
 
-func test_repeated_sending(_ x: sending sending Int) {} // expected-error {{parameter may have at most one 'sending' specifier}}
+func test_inout_after_sending(_ x: sending inout NonSendable) {} // expected-error {{'sending' must be placed after specifier 'inout'}}
 
-func test_repeated_sending_mixed(_ x: sending consuming sending inout Int) {}
+func test_repeated_sending(_ x: sending sending NonSendable) {} // expected-error {{parameter may have at most one 'sending' specifier}}
+
+func test_repeated_sending_mixed(_ x: sending consuming sending inout NonSendable) {}
 // expected-error @-1 {{'sending' must be placed after specifier 'consuming'}}
 // expected-error @-2 {{parameter may have at most one 'sending' specifier}}
 // expected-error @-3 {{parameter may have at most one of the 'inout', 'borrowing', or 'consuming' specifiers}}
 
 // Just until we get the results setup.
-func test_sending_result_in_tuple() -> (sending Int, Int) {}
+func test_sending_result_in_tuple() -> (sending NonSendable, NonSendable) {}
 // expected-error @-1 {{'sending' cannot be applied to tuple elements}}

--- a/test/Serialization/Inputs/sending.swift
+++ b/test/Serialization/Inputs/sending.swift
@@ -1,4 +1,7 @@
 
 public func testSending(_ x: sending String) -> sending String { x }
+// expected-warning @-1 {{'sending' has no effect on Sendable parameter}}
 public func testSendingFunc(_ x: (sending String) -> ()) { fatalError() }
+// expected-warning @-1 {{'sending' has no effect on Sendable parameter}}
 public func testSendingResultFunc(_ x: () -> sending String) { fatalError() }
+// expected-warning @-1 {{'sending' has no effect on Sendable parameter}}

--- a/test/type/function/sending_sendable_parameter.swift
+++ b/test/type/function/sending_sendable_parameter.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -module-name TestModule -typecheck -verify %s
+
+struct SendableType {}
+class NonSendableType {}
+
+func testSendingOnNonSendable(input: sending NonSendableType) {
+    // okay
+}
+
+func testSendingOnSendable(input: sending SendableType) {
+    // expected-warning@-1{{'sending' has no effect}}{{35-43=}}
+}
+
+func testSendingOnSendable(input: sending some Sendable) {
+    // expected-warning@-1{{'sending' has no effect}}{{35-43=}}
+}
+
+func testSendingOnSendable(input: sending any Sendable) {
+    // expected-warning@-1{{'sending' has no effect}}{{35-43=}}
+}

--- a/test/type/function/sending_sendable_parameter.swift
+++ b/test/type/function/sending_sendable_parameter.swift
@@ -1,20 +1,32 @@
 // RUN: %target-swift-frontend -module-name TestModule -typecheck -verify %s
 
 struct SendableType {}
-class NonSendableType {}
+class NonSendableType {
+    init() {}
+}
+struct SendableTypeWithTypeParam<SendableType> {}
 
-func testSendingOnNonSendable(input: sending NonSendableType) {
-    // okay
+func testSendingOnNonSendable(input: sending NonSendableType) -> sending NonSendableType {
+    return NonSendableType() // okay
 }
 
-func testSendingOnSendable(input: sending SendableType) {
+func testSendingOnSendableParam(input: sending SendableType) {
+    // expected-warning@-1{{'sending' has no effect}}{{40-48=}}
+}
+
+func testSendingOnSendable(input: sending SendableTypeWithTypeParam<SendableType>) {
     // expected-warning@-1{{'sending' has no effect}}{{35-43=}}
 }
 
-func testSendingOnSendable(input: sending some Sendable) {
-    // expected-warning@-1{{'sending' has no effect}}{{35-43=}}
+func testSendingOnSendableParam(input: sending some Sendable) {
+    // expected-warning@-1{{'sending' has no effect}}{{40-48=}}
 }
 
-func testSendingOnSendable(input: sending any Sendable) {
-    // expected-warning@-1{{'sending' has no effect}}{{35-43=}}
+func testSendingOnSendableParam(input: sending any Sendable) {
+    // expected-warning@-1{{'sending' has no effect}}{{40-48=}}
+}
+
+func testSendingOnSendableResult() -> sending SendableType {
+    // expected-warning@-1{{'sending' has no effect}}{{39-47=}}
+    return SendableType()
 }


### PR DESCRIPTION
When a function parameter is Sendable, adding 'sending' annotation does nothing, as the value is safe to be sent across isolation boundaries. SE-0430 seems to imply that 'sending' is intended to be used for non-Sendable types only.

Includes fix-it to remove 'sending' from parameter.

Addresses #74616 .