### PR TITLE
[6.0][concurrency] Standardize sending of non-isolated -> nonisolated to match the keyword 'nonisolated'.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -687,14 +687,14 @@ WARNING(warning_int_to_fp_inexact, none,
 
 // Flow-isolation diagnostics
 ERROR(isolated_after_nonisolated, none,
-      "cannot access %1 %2 here in %select{non-isolated initializer|deinitializer}0",
+      "cannot access %1 %2 here in %select{nonisolated initializer|deinitializer}0",
       (bool, DescriptiveDeclKind, DeclName))
 NOTE(nonisolated_blame, none, "after %1%2 %3, "
-     "only non-isolated properties of 'self' can be accessed from "
+     "only nonisolated properties of 'self' can be accessed from "
      "%select{this init|a deinit}0", (bool, StringRef, StringRef, DeclName))
 ERROR(isolated_property_mutation_in_nonisolated_context,none,
       "actor-isolated %kind0 can not be %select{referenced|mutated}1 "
-      "from a non-isolated context",
+      "from a nonisolated context",
       (const ValueDecl *, bool))
 
 // Yield usage errors

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5431,16 +5431,16 @@ ERROR(actor_isolated_non_self_reference,none,
         "%4 %kind0 can not be "
         "%select{referenced|mutated|used 'inout'}1 "
         "%select{from outside the actor|on a different actor instance|"
-        "on a non-isolated actor instance|"
+        "on a nonisolated actor instance|"
         "from a Sendable function|from a Sendable closure|"
         "from an 'async let' initializer|from global actor %3|"
-        "from the main actor|from a non-isolated context|"
-        "from a non-isolated autoclosure}2",
+        "from the main actor|from a nonisolated context|"
+        "from a nonisolated autoclosure}2",
         (const ValueDecl *, unsigned, unsigned, Type,
          ActorIsolation))
 ERROR(distributed_actor_isolated_non_self_reference,none,
       "distributed actor-isolated %kind0 can not be accessed from a "
-      "non-isolated context",
+      "nonisolated context",
       (const ValueDecl *))
 ERROR(conflicting_stored_property_isolation,none,
       "%select{default|memberwise}0 initializer for %1 cannot be both %2 and %3",
@@ -5581,7 +5581,7 @@ ERROR(shared_mutable_state_access,none,
       "reference to %kind0 is not concurrency-safe because it involves shared "
       "mutable state", (const ValueDecl *))
 ERROR(shared_mutable_state_decl,none,
-      "%kind0 is not concurrency-safe because it is non-isolated global shared "
+      "%kind0 is not concurrency-safe because it is nonisolated global shared "
       "mutable state", (const ValueDecl *))
 ERROR(shared_immutable_state_decl,none,
       "%kind1 is not concurrency-safe because non-'Sendable' type %0 may have "
@@ -5641,7 +5641,7 @@ NOTE(in_derived_witness, none,
      (DescriptiveDeclKind, DeclName, Type))
 ERROR(non_sendable_param_type,none,
       "non-sendable type %0 %select{passed in call to %3 %kind2|"
-      "exiting %3 context in call to non-isolated %kind2|"
+      "exiting %3 context in call to nonisolated %kind2|"
       "passed in implicitly asynchronous call to %3 %kind2|"
       "in parameter of the protocol requirement satisfied by %3 %kind2|"
       "in parameter of superclass method overridden by %3 %kind2|"
@@ -5653,7 +5653,7 @@ ERROR(non_sendable_call_argument,none,
       (Type, bool, ActorIsolation))
 ERROR(non_sendable_result_type,none,
       "non-sendable type %0 returned by %select{call to %3 %kind2|"
-      "call from %4 context to non-isolated %kind2|"
+      "call from %4 context to nonisolated %kind2|"
       "implicitly asynchronous call to %3 %kind2|"
       "%3 %kind2 satisfying protocol requirement|"
       "%3 overriding %kind2|"
@@ -5666,7 +5666,7 @@ ERROR(non_sendable_call_result_type,none,
 ERROR(non_sendable_property_type,none,
       "non-sendable type %0 in %select{"
       "%select{asynchronous access to %4 %kind1|"
-      "asynchronous access from %4 context to non-isolated %kind1|"
+      "asynchronous access from %4 context to nonisolated %kind1|"
       "implicitly asynchronous access to %4 %kind1|"
       "conformance of %4 %kind1 to protocol requirement|"
       "%4 overriding %kind1|"
@@ -5769,7 +5769,7 @@ ERROR(nonisolated_wrapped_property,none,
       ())
 
 ERROR(non_sendable_from_deinit,none,
-        "cannot access %1 %2 with a non-sendable type %0 from non-isolated deinit",
+        "cannot access %1 %2 with a non-sendable type %0 from nonisolated deinit",
         (Type, DescriptiveDeclKind, DeclName))
 
 ERROR(actor_instance_property_wrapper,none,

--- a/test/ClangImporter/objc_isolation_complete.swift
+++ b/test/ClangImporter/objc_isolation_complete.swift
@@ -12,7 +12,7 @@ func unsatisfiedPreconcurrencyIsolation(view: MyView) {
   // expected-warning@+1 {{call to main actor-isolated instance method 'display()' in a synchronous nonisolated context}}
   view.display()
 
-  // expected-warning@+1 {{main actor-isolated property 'isVisible' can not be referenced from a non-isolated context}}
+  // expected-warning@+1 {{main actor-isolated property 'isVisible' can not be referenced from a nonisolated context}}
   _ = view.isVisible
 }
 
@@ -21,7 +21,7 @@ class IsolatedSub: NXSender {
   var mainActorState = 0 // expected-note {{property declared here}}
   override func sendAny(_: any Sendable) -> any Sendable {
     return mainActorState
-    // expected-warning@-1 {{main actor-isolated property 'mainActorState' can not be referenced from a non-isolated context}}
+    // expected-warning@-1 {{main actor-isolated property 'mainActorState' can not be referenced from a nonisolated context}}
   }
 
   @MainActor

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -232,7 +232,7 @@ func anotherAsyncFunc() async {
 
   _ = b.balance // expected-error {{actor-isolated instance method 'balance()' can not be partially applied}}
 
-  a.owner = "cat" // expected-error{{actor-isolated property 'owner' can not be mutated from a non-isolated context}}
+  a.owner = "cat" // expected-error{{actor-isolated property 'owner' can not be mutated from a nonisolated context}}
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
   _ = b.owner
   _ = await b.owner == "cat"
@@ -454,7 +454,7 @@ func tryEffPropsFromSync() {
   _ = effPropA // expected-error{{'async' property access in a function that does not support concurrency}}
 
   // expected-error@+1 {{property access can throw, but it is not marked with 'try' and the error is not handled}}
-  _ = effPropT // expected-error{{global actor 'BananaActor'-isolated var 'effPropT' can not be referenced from a non-isolated context}}
+  _ = effPropT // expected-error{{global actor 'BananaActor'-isolated var 'effPropT' can not be referenced from a nonisolated context}}
   // NOTE: that we don't complain about async access on `effPropT` because it's not declared async, and we're not in an async context!
 
   // expected-error@+1 {{property access can throw, but it is not marked with 'try' and the error is not handled}}

--- a/test/Concurrency/actor_defer.swift
+++ b/test/Concurrency/actor_defer.swift
@@ -91,7 +91,7 @@ actor Actor {
 #if NEGATIVES
   nonisolated func testActor_negative() {
     defer {
-      // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from a non-isolated context}}
+      // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from a nonisolated context}}
       actorProperty += 1
     }
     doSomething()
@@ -99,7 +99,7 @@ actor Actor {
 
   nonisolated func testActor_task_negative() {
     Task {
-      // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from a non-isolated context}}
+      // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from a nonisolated context}}
       defer { actorProperty += 1 }
       doSomething()
     }
@@ -168,7 +168,7 @@ func testIsolatedActor_positive(actor: isolated Actor) {
 @available(SwiftStdlib 5.1, *)
 func testIsolatedActor_negative(actor: Actor) {
   defer {
-    // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from a non-isolated context}}
+    // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from a nonisolated context}}
     actor.actorProperty += 1
   }
   doSomething()
@@ -213,7 +213,7 @@ func testIsolatedActor_closure_positive() {
 @available(SwiftStdlib 5.1, *)
 func testIsolatedActor_closure_negative() {
   takeClosureWithNotIsolatedParam { actor in
-    // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from a non-isolated context}}
+    // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from a nonisolated context}}
     defer { actor.actorProperty += 1 }
     doSomething()
   }

--- a/test/Concurrency/actor_existentials.swift
+++ b/test/Concurrency/actor_existentials.swift
@@ -30,13 +30,13 @@ func from_isolated_existential2(_ x: isolated any P) async {
 
 func from_nonisolated(_ x: any P) async {
   await x.f()
-  x.prop += 1 // expected-error {{actor-isolated property 'prop' can not be mutated from a non-isolated context}}
-  x.prop = 100 // expected-error {{actor-isolated property 'prop' can not be mutated from a non-isolated context}}
+  x.prop += 1 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
+  x.prop = 100 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
 }
 
 func from_concrete(_ x: A) async {
-  x.prop += 1 // expected-error {{actor-isolated property 'prop' can not be mutated from a non-isolated context}}
-  x.prop = 100 // expected-error {{actor-isolated property 'prop' can not be mutated from a non-isolated context}}
+  x.prop += 1 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
+  x.prop = 100 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
 }
 
 func from_isolated_concrete(_ x: isolated A) async {
@@ -53,7 +53,7 @@ nonisolated let act = Act()
 
 func bad() async {
     // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}
-    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a non-isolated context}}
+    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
     await act.i = 666
 }
 
@@ -64,11 +64,11 @@ extension Act: Proto {}
 
 func good() async {
     // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}
-    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a non-isolated context}}
+    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
     await (act as any Proto).i = 42
     let aIndirect: any Proto = act
 
     // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}
-    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a non-isolated context}}
+    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
     await aIndirect.i = 777
 }

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -119,7 +119,7 @@ extension TestActor {
   func passStateIntoDifferentClassMethod() async {
     let other = NonAsyncClass()
     let otherCurry = other.modifyOtherAsync
-    // expected-targeted-complete-tns-warning @-1 {{non-sendable type 'NonAsyncClass' exiting actor-isolated context in call to non-isolated instance method 'modifyOtherAsync' cannot cross actor boundary}}
+    // expected-targeted-complete-tns-warning @-1 {{non-sendable type 'NonAsyncClass' exiting actor-isolated context in call to nonisolated instance method 'modifyOtherAsync' cannot cross actor boundary}}
     await other.modifyOtherAsync(&value2)
     // expected-error @-1 {{actor-isolated property 'value2' cannot be passed 'inout' to 'async' function call}}
 
@@ -194,7 +194,7 @@ actor MyActor {
 
     // expected-error@+1{{cannot pass immutable value of type 'Int' as inout argument}}
     await modifyAsynchronously(&(maybePoint?.z)!)
-    // expected-error@+2{{actor-isolated property 'position' can not be used 'inout' on a non-isolated actor instance}}
+    // expected-error@+2{{actor-isolated property 'position' can not be used 'inout' on a nonisolated actor instance}}
     // expected-error@+1{{actor-isolated property 'myActor' cannot be passed 'inout' to 'async' function call}}
     await modifyAsynchronously(&myActor.position.x)
   }
@@ -219,8 +219,8 @@ struct MyGlobalActor {
 if #available(SwiftStdlib 5.1, *) {
   let _ = Task.detached { await { (_ foo: inout Int) async in foo += 1 }(&number) }
   // expected-error @-1 {{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
-  // expected-minimal-error @-2 {{global actor 'MyGlobalActor'-isolated var 'number' can not be used 'inout' from a non-isolated context}}
-  // expected-complete-tns-error @-3 {{main actor-isolated var 'number' can not be used 'inout' from a non-isolated context}}
+  // expected-minimal-error @-2 {{global actor 'MyGlobalActor'-isolated var 'number' can not be used 'inout' from a nonisolated context}}
+  // expected-complete-tns-error @-3 {{main actor-isolated var 'number' can not be used 'inout' from a nonisolated context}}
 }
 
 // attempt to pass global state owned by the global actor to another async function
@@ -288,11 +288,11 @@ actor ProtectArray {
   func test() async {
     // FIXME: this is invalid too!
     _ = await array.mutateAsynchronously
-    // expected-targeted-complete-tns-warning@-1 {{non-sendable type '@lvalue [Int]' exiting actor-isolated context in call to non-isolated property 'mutateAsynchronously' cannot cross actor boundary}}
+    // expected-targeted-complete-tns-warning@-1 {{non-sendable type '@lvalue [Int]' exiting actor-isolated context in call to nonisolated property 'mutateAsynchronously' cannot cross actor boundary}}
 
     _ = await array[mutateAsynchronously: 0]
     // expected-error@-1 {{actor-isolated property 'array' cannot be passed 'inout' to 'async' function call}}
-    // expected-targeted-complete-tns-warning@-2 {{non-sendable type 'inout Array<Int>' exiting actor-isolated context in call to non-isolated subscript 'subscript(mutateAsynchronously:)' cannot cross actor boundary}}
+    // expected-targeted-complete-tns-warning@-2 {{non-sendable type 'inout Array<Int>' exiting actor-isolated context in call to nonisolated subscript 'subscript(mutateAsynchronously:)' cannot cross actor boundary}}
 
     await passToAsync(array[0])
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -97,19 +97,19 @@ actor Camera {
 func checkAsyncPropertyAccess() async {
   let act = MyActor()
   let _ : Int = await act.mutable + act.mutable
-  act.mutable += 1  // expected-error {{actor-isolated property 'mutable' can not be mutated from a non-isolated context}}
+  act.mutable += 1  // expected-error {{actor-isolated property 'mutable' can not be mutated from a nonisolated context}}
 
-  act.superState += 1 // expected-error {{actor-isolated property 'superState' can not be mutated from a non-isolated context}}
+  act.superState += 1 // expected-error {{actor-isolated property 'superState' can not be mutated from a nonisolated context}}
 
-  act.text[0].append("hello") // expected-error{{actor-isolated property 'text' can not be mutated from a non-isolated context}}
+  act.text[0].append("hello") // expected-error{{actor-isolated property 'text' can not be mutated from a nonisolated context}}
 
   // this is not the same as the above, because Array is a value type
   var arr = await act.text
   arr[0].append("hello")
 
-  act.text.append("no") // expected-error{{actor-isolated property 'text' can not be mutated from a non-isolated context}}
+  act.text.append("no") // expected-error{{actor-isolated property 'text' can not be mutated from a nonisolated context}}
 
-  act.text[0] += "hello" // expected-error{{actor-isolated property 'text' can not be mutated from a non-isolated context}}
+  act.text[0] += "hello" // expected-error{{actor-isolated property 'text' can not be mutated from a nonisolated context}}
 
   _ = act.point  // expected-warning{{non-sendable type 'Point' in implicitly asynchronous access to actor-isolated property 'point' cannot cross actor boundary}}
   // expected-warning@-1 {{expression is 'async' but is not marked with 'await'}}
@@ -190,8 +190,8 @@ extension MyActor {
 
   nonisolated func actorIndependentFunc(otherActor: MyActor) -> Int {
     _ = immutable
-    _ = mutable // expected-error{{actor-isolated property 'mutable' can not be referenced from a non-isolated}}
-    _ = text[0] // expected-error{{actor-isolated property 'text' can not be referenced from a non-isolated context}}
+    _ = mutable // expected-error{{actor-isolated property 'mutable' can not be referenced from a nonisolated}}
+    _ = text[0] // expected-error{{actor-isolated property 'text' can not be referenced from a nonisolated context}}
     _ = synchronous() // expected-error{{call to actor-isolated instance method 'synchronous()' in a synchronous nonisolated context}}
 
     // nonisolated
@@ -224,9 +224,9 @@ extension MyActor {
 
     // FIXME: The reference here isn't strictly a call
     _ = super.superMethod // expected-error{{call to actor-isolated instance method 'superMethod()' in a synchronous nonisolated context}}
-    acceptClosure(synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from a non-isolated context}}
-    acceptClosure(self.synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from a non-isolated context}}
-    acceptClosure(otherActor.synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from a non-isolated context}}
+    acceptClosure(synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from a nonisolated context}}
+    acceptClosure(self.synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from a nonisolated context}}
+    acceptClosure(otherActor.synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from a nonisolated context}}
     acceptEscapingClosure(synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be partially applied}}
     acceptEscapingClosure(self.synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be partially applied}}
     acceptEscapingClosure(otherActor.synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be partially applied}}
@@ -266,9 +266,9 @@ extension MyActor {
     _ = otherActor.mutable  // expected-error{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
     // expected-note@-1{{property access is 'async'}}
     _ = await otherActor.mutable
-    otherActor.mutable = 0  // expected-error{{actor-isolated property 'mutable' can not be mutated on a non-isolated actor instance}}
-    acceptInout(&otherActor.mutable)  // expected-error{{actor-isolated property 'mutable' can not be used 'inout' on a non-isolated actor instance}}
-    // expected-error@+2{{actor-isolated property 'mutable' can not be mutated on a non-isolated actor instance}}
+    otherActor.mutable = 0  // expected-error{{actor-isolated property 'mutable' can not be mutated on a nonisolated actor instance}}
+    acceptInout(&otherActor.mutable)  // expected-error{{actor-isolated property 'mutable' can not be used 'inout' on a nonisolated actor instance}}
+    // expected-error@+2{{actor-isolated property 'mutable' can not be mutated on a nonisolated actor instance}}
     // expected-warning@+1{{no 'async' operations occur within 'await' expression}}
     await otherActor.mutable = 0
 
@@ -362,7 +362,7 @@ extension MyActor {
 
     @Sendable func localFn2() {
       acceptClosure {
-        _ = text[0]  // expected-error{{actor-isolated property 'text' can not be referenced from a non-isolated context}}
+        _ = text[0]  // expected-error{{actor-isolated property 'text' can not be referenced from a nonisolated context}}
         _ = self.synchronous() // expected-error{{call to actor-isolated instance method 'synchronous()' in a synchronous nonisolated context}}
         _ = localVar // expected-warning{{reference to captured var 'localVar' in concurrently-executing code}}
         localVar = 25 // expected-warning{{mutation of captured var 'localVar' in concurrently-executing code}}
@@ -382,7 +382,7 @@ extension MyActor {
     _ = super.superMethod
     acceptClosure(synchronous)
     acceptClosure(self.synchronous)
-    acceptClosure(otherActor.synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced on a non-isolated actor instance}}
+    acceptClosure(otherActor.synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced on a nonisolated actor instance}}
     acceptEscapingClosure(synchronous)
     acceptEscapingClosure(self.synchronous)
     acceptEscapingClosure(otherActor.synchronous) // expected-error{{actor-isolated instance method 'synchronous()' can not be partially applied}}
@@ -591,7 +591,7 @@ var number: Int = 42 // expected-note {{var declared here}}
 
 // expected-note@+1 {{add '@SomeGlobalActor' to make global function 'badNumberUser()' part of global actor 'SomeGlobalActor'}}
 func badNumberUser() {
-  //expected-error@+1{{global actor 'SomeGlobalActor'-isolated var 'number' can not be referenced from a non-isolated context}}
+  //expected-error@+1{{global actor 'SomeGlobalActor'-isolated var 'number' can not be referenced from a nonisolated context}}
   print("The protected number is: \(number)")
 }
 
@@ -695,7 +695,7 @@ actor AnActorWithClosures {
           self.counter += 1 // expected-error{{actor-isolated property 'counter' can not be mutated from a Sendable closure}}
 
           acceptEscapingClosure {
-            self.counter += 1 // expected-error{{actor-isolated property 'counter' can not be mutated from a non-isolated context}}
+            self.counter += 1 // expected-error{{actor-isolated property 'counter' can not be mutated from a nonisolated context}}
           }
         }
       }
@@ -852,26 +852,26 @@ actor SomeActorWithInits {
     self.mutableState = 42
     self.otherMutableState = 17
 
-    self.isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
+    self.isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.nonisolated()
 
     defer {
-      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
+      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
       mutableState += 1 // okay through typechecking, since flow-isolation will verify it.
       nonisolated()
     }
 
     func local() {
-      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
-      mutableState += 1 // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
+      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+      mutableState += 1 // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
       nonisolated()
     }
     local()
 
     let _ = {
       defer {
-        isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
-        mutableState += 1  // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
+        isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+        mutableState += 1  // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
         nonisolated()
       }
       nonisolated()
@@ -888,7 +888,7 @@ actor SomeActorWithInits {
 
   convenience init(i3: Bool) { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in the Swift 6 language mode}}{{3-15=}}
     self.init(i1: i3)
-    _ = mutableState    // expected-error{{actor-isolated property 'mutableState' can not be referenced from a non-isolated context}}
+    _ = mutableState    // expected-error{{actor-isolated property 'mutableState' can not be referenced from a nonisolated context}}
     self.isolated()     // expected-error{{call to actor-isolated instance method 'isolated()' in a synchronous nonisolated context}}
     self.nonisolated()
   }
@@ -947,15 +947,15 @@ actor SomeActorWithInits {
     let _ = self.nonSendable // OK only through typechecking, not SIL.
 
     defer {
-      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
+      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
       mutableState += 1 // okay
       nonisolated()
     }
 
     let _ = {
       defer {
-        isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
-        mutableState += 1  // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
+        isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+        mutableState += 1  // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
         nonisolated()
       }
       nonisolated()
@@ -984,7 +984,7 @@ class SomeClassWithInits {
 
   deinit {
     print(mutableState) // Okay, we're actor-isolated
-    print(SomeClassWithInits.shared) // expected-error{{main actor-isolated static property 'shared' can not be referenced from a non-isolated context}}
+    print(SomeClassWithInits.shared) // expected-error{{main actor-isolated static property 'shared' can not be referenced from a nonisolated context}}
     beets_ma() //expected-error{{call to main actor-isolated global function 'beets_ma()' in a synchronous nonisolated context}}
   }
 
@@ -1010,7 +1010,7 @@ class SomeClassWithInits {
 @available(SwiftStdlib 5.1, *)
 func outsideSomeClassWithInits() { // expected-note 3 {{add '@MainActor' to make global function 'outsideSomeClassWithInits()' part of global actor 'MainActor'}}
   _ = SomeClassWithInits() // expected-error{{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context}}
-  _ = SomeClassWithInits.shared // expected-error{{main actor-isolated static property 'shared' can not be referenced from a non-isolated context}}
+  _ = SomeClassWithInits.shared // expected-error{{main actor-isolated static property 'shared' can not be referenced from a nonisolated context}}
   SomeClassWithInits.staticIsolated() // expected-error{{call to main actor-isolated static method 'staticIsolated()' in a synchronous nonisolated context}}
 }
 
@@ -1047,10 +1047,10 @@ extension OtherModuleActor {
 
 actor CrossModuleFromInitsActor {
   init(v1 actor: OtherModuleActor) {
-    _ = actor.a   // expected-error {{actor-isolated property 'a' can not be referenced from a non-isolated context}}
+    _ = actor.a   // expected-error {{actor-isolated property 'a' can not be referenced from a nonisolated context}}
     _ = actor.b   // okay
 
-    _ = actor.c   // expected-error {{actor-isolated property 'c' can not be referenced from a non-isolated context}}
+    _ = actor.c   // expected-error {{actor-isolated property 'c' can not be referenced from a nonisolated context}}
   }
 
   init(v2 actor: OtherModuleActor) async {
@@ -1260,11 +1260,11 @@ actor Counter {
   }
 
   init() {
-    _ = self.next() // expected-warning {{actor-isolated instance method 'next()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
-    defer { _ = self.next() } // expected-warning {{actor-isolated instance method 'next()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
+    _ = self.next() // expected-warning {{actor-isolated instance method 'next()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    defer { _ = self.next() } // expected-warning {{actor-isolated instance method 'next()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
 
-    _ = computedProp  // expected-warning {{actor-isolated property 'computedProp' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
-    computedProp = 1  // expected-warning {{actor-isolated property 'computedProp' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
+    _ = computedProp  // expected-warning {{actor-isolated property 'computedProp' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    computedProp = 1  // expected-warning {{actor-isolated property 'computedProp' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
 
   }
 
@@ -1306,17 +1306,17 @@ actor Butterfly {
 
   nonisolated init(icecream: Void) { // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in the Swift 6 language mode}} {{3-15=}}
     self.init()
-    self.flapsPerSec += 1 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a non-isolated context}}
+    self.flapsPerSec += 1 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a nonisolated context}}
   }
 
   nonisolated init(cookies: Void) async {
     self.init()
-    self.flapsPerSec += 1 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a non-isolated context}}
+    self.flapsPerSec += 1 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a nonisolated context}}
   }
 
   init(brownies: Void) {
     self.init()
-    self.flapsPerSec = 0 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a non-isolated context}}
+    self.flapsPerSec = 0 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a nonisolated context}}
   }
 }
 
@@ -1428,7 +1428,7 @@ actor DunkTracker {
   private var curry: Int? // expected-note {{property declared here}}
 
   deinit {
-    // expected-warning@+1 {{actor-isolated property 'curry' can not be referenced from a non-isolated autoclosure; this is an error in the Swift 6 language mode}}
+    // expected-warning@+1 {{actor-isolated property 'curry' can not be referenced from a nonisolated autoclosure; this is an error in the Swift 6 language mode}}
     if lebron != nil || curry != nil {
       
     }
@@ -1539,12 +1539,12 @@ class OverridesNonsiolatedInit: SuperWithNonisolatedInit {
   override nonisolated init() {
     super.init()
 
-    // expected-error@+1 {{main actor-isolated property 'x' can not be mutated from a non-isolated context}}
+    // expected-error@+1 {{main actor-isolated property 'x' can not be mutated from a nonisolated context}}
     super.x = 10
   }
 
   nonisolated func f() {
-    // expected-error@+1 {{main actor-isolated property 'x' can not be mutated from a non-isolated context}}
+    // expected-error@+1 {{main actor-isolated property 'x' can not be mutated from a nonisolated context}}
     super.x = 10
   }
 }
@@ -1595,7 +1595,7 @@ actor AnotherActor {
   init() {
     self.a = ProtectNonSendable()
 
-    // expected-warning@+1 {{actor-isolated property 'ns' can not be referenced from a non-isolated context}}
+    // expected-warning@+1 {{actor-isolated property 'ns' can not be referenced from a nonisolated context}}
     _ = a.ns
   }
 }
@@ -1609,7 +1609,7 @@ class MainActorIsolated {
 }
 
 nonisolated func accessAcrossActors() {
-  // expected-warning@+1 {{main actor-isolated static property 'shared' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
+  // expected-warning@+1 {{main actor-isolated static property 'shared' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
   let _ = MainActorIsolated.shared
 }
 

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -92,6 +92,6 @@ class MainActorIsolated {
 }
 
 nonisolated func accessAcrossActors() {
-  // expected-error@+1 {{main actor-isolated static property 'shared' can not be referenced from a non-isolated context}}
+  // expected-error@+1 {{main actor-isolated static property 'shared' can not be referenced from a nonisolated context}}
   let _ = MainActorIsolated.shared
 }

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -294,7 +294,7 @@ typealias CF = @Sendable () -> NotConcurrent?
 typealias BadGenericCF<T> = @Sendable () -> T?
 typealias GoodGenericCF<T: Sendable> = @Sendable () -> T? // okay
 
-var concurrentFuncVar: (@Sendable (NotConcurrent) -> Void)? = nil // expected-warning{{var 'concurrentFuncVar' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
+var concurrentFuncVar: (@Sendable (NotConcurrent) -> Void)? = nil // expected-warning{{var 'concurrentFuncVar' is not concurrency-safe because it is nonisolated global shared mutable state; this is an error in the Swift 6 language mode}}
 // expected-note@-1 {{annotate 'concurrentFuncVar' with '@MainActor' if property should only be accessed from the main actor}}
 // expected-note@-2 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
 // expected-note@-3 {{convert 'concurrentFuncVar' to a 'let' constant to make 'Sendable' shared state immutable}}

--- a/test/Concurrency/derived_conformances_nonisolated.swift
+++ b/test/Concurrency/derived_conformances_nonisolated.swift
@@ -31,7 +31,7 @@ extension NonSendable: Equatable {
   }
 }
 
-// expected-warning@+3 2{{main actor-isolated property 'x' can not be referenced from a non-isolated context}}
+// expected-warning@+3 2{{main actor-isolated property 'x' can not be referenced from a nonisolated context}}
 // expected-note@+2 2{{in static method '==' for derived conformance to 'Equatable'}}
 @MainActor
 struct X2NonSendable: Equatable {

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -44,28 +44,28 @@ actor Bob {
 
   init(v0 initial: Int) {
     self.x = 0
-    speak()    // expected-note {{after calling instance method 'speak()', only non-isolated properties of 'self' can be accessed from this init}}
+    speak()    // expected-note {{after calling instance method 'speak()', only nonisolated properties of 'self' can be accessed from this init}}
     speak()
-    self.x = 1 // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    self.x = 1 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     speak()
   }
 
   init(v1 _: Void) {
     self.x = 0
-    _ = cherry  // expected-note {{after accessing property 'cherry', only non-isolated properties of 'self' can be accessed from this init}}
-    self.x = 1  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    _ = cherry  // expected-note {{after accessing property 'cherry', only nonisolated properties of 'self' can be accessed from this init}}
+    self.x = 1  // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   init(v2 callBack: (Bob) -> Void) {
     self.x = 0
-    callBack(self)  // expected-note {{after a call involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
-    self.x = 1      // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    callBack(self)  // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
+    self.x = 1      // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   init(v3 _: Void) {
     self.x = 1
-    takeBob(self)   // expected-note {{after calling global function 'takeBob', only non-isolated properties of 'self' can be accessed from this init}}
-    self.x = 1  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    takeBob(self)   // expected-note {{after calling global function 'takeBob', only nonisolated properties of 'self' can be accessed from this init}}
+    self.x = 1  // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
 
@@ -94,24 +94,24 @@ actor Casey {
 
   init() {
     money = Money(dollars: 100)
-    defer { logTransaction(money.euros) } // expected-warning {{cannot access property 'money' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
-    self.speak("Yay, I have $\(money.dollars)!") // expected-note {{after calling instance method 'speak', only non-isolated properties of 'self' can be accessed from this init}}
+    defer { logTransaction(money.euros) } // expected-warning {{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
+    self.speak("Yay, I have $\(money.dollars)!") // expected-note {{after calling instance method 'speak', only nonisolated properties of 'self' can be accessed from this init}}
   }
 
   init(with start: Int) {
     money = Money(dollars: start)
 
     if (money.dollars < 0) {
-      self.speak("Oh no, I'm in debt!") // expected-note 3 {{after calling instance method 'speak', only non-isolated properties of 'self' can be accessed from this init}}
+      self.speak("Oh no, I'm in debt!") // expected-note 3 {{after calling instance method 'speak', only nonisolated properties of 'self' can be accessed from this init}}
     }
-    logTransaction(money.euros) // expected-warning {{cannot access property 'money' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    logTransaction(money.euros) // expected-warning {{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
 
-    // expected-warning@+1 2 {{cannot access property 'money' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    // expected-warning@+1 2 {{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     money.dollars = money.dollars + 1
 
     if randomBool() {
-      // expected-note@+2 {{after calling instance method 'cashUnderMattress()', only non-isolated properties of 'self' can be accessed from this init}}
-      // expected-warning@+1 {{cannot access property 'money' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+      // expected-note@+2 {{after calling instance method 'cashUnderMattress()', only nonisolated properties of 'self' can be accessed from this init}}
+      // expected-warning@+1 {{cannot access property 'money' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
       money.dollars += cashUnderMattress()
     }
   }
@@ -126,7 +126,7 @@ actor Demons {
   }
 
   deinit {
-    let _ = self.ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in the Swift 6 language mode}}
+    let _ = self.ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -147,11 +147,11 @@ actor ExampleFromProposal {
     _ = self.nonSendable        // ok
     _ = self.unsafeNonSendable
 
-    f() // expected-note 2 {{after calling instance method 'f()', only non-isolated properties of 'self' can be accessed from this init}}
+    f() // expected-note 2 {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
 
     _ = self.immutableSendable  // ok
-    _ = self.mutableSendable    // expected-warning {{cannot access property 'mutableSendable' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
-    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    _ = self.mutableSendable    // expected-warning {{cannot access property 'mutableSendable' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
+    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     _ = self.unsafeNonSendable // ok
   }
 
@@ -159,13 +159,13 @@ actor ExampleFromProposal {
   deinit {
     _ = self.immutableSendable  // ok
     _ = self.mutableSendable    // ok
-    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in the Swift 6 language mode}}
+    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
 
-    f() // expected-note {{after calling instance method 'f()', only non-isolated properties of 'self' can be accessed from a deinit}}
+    f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from a deinit}}
 
     _ = self.immutableSendable  // ok
     _ = self.mutableSendable    // expected-warning {{cannot access property 'mutableSendable' here in deinitializer; this is an error in the Swift 6 language mode}}
-    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in the Swift 6 language mode}}
+    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated func f() {}
@@ -189,16 +189,16 @@ class CheckGAIT1 {
           silly += 1
           continue
         case .blue:
-          f() // expected-note {{after calling instance method 'f()', only non-isolated properties of 'self' can be accessed from this init}}
+          f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
       }
       break
     } while true
-    silly += 2 // expected-warning {{cannot access property 'silly' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    silly += 2 // expected-warning {{cannot access property 'silly' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   deinit {
-    _ = ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in the Swift 6 language mode}}
-    f()     // expected-note {{after calling instance method 'f()', only non-isolated properties of 'self' can be accessed from a deinit}}
+    _ = ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    f()     // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from a deinit}}
     _ = silly // expected-warning {{cannot access property 'silly' here in deinitializer; this is an error in the Swift 6 language mode}}
 
   }
@@ -213,8 +213,8 @@ actor ControlFlowTester {
   nonisolated func noniso() {}
 
   init(v1: Void) {
-    noniso()                 // expected-note {{after calling instance method 'noniso()', only non-isolated properties of 'self' can be accessed from this init}}
-    takeNonSendable(self.ns) // expected-warning {{cannot access property 'ns' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    noniso()                 // expected-note {{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
+    takeNonSendable(self.ns) // expected-warning {{cannot access property 'ns' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     takeSendable(self.s)
   }
 
@@ -231,7 +231,7 @@ actor ControlFlowTester {
 
   init(v3 c: Color) {
     do {
-      defer { noniso() } // expected-note 3 {{after calling instance method 'noniso()', only non-isolated properties of 'self' can be accessed from this init}}
+      defer { noniso() } // expected-note 3 {{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
       switch c {
       case .red:
         throw Color.red
@@ -242,17 +242,17 @@ actor ControlFlowTester {
         throw Color.yellow
       }
     } catch Color.blue {
-      count += 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+      count += 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     } catch {
-      count += 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+      count += 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     }
-    count = 42 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    count = 42 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
 
   init(v4 c: Color) {
-    defer { count += 1 } // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
-    noniso() // expected-note 1 {{after calling instance method 'noniso()', only non-isolated properties of 'self' can be accessed from this init}}
+    defer { count += 1 } // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
+    noniso() // expected-note 1 {{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
   }
 
   init?(v5 c: Color) throws {
@@ -261,35 +261,35 @@ actor ControlFlowTester {
       return nil
     }
     count += 1
-    noniso()  // expected-note {{after calling instance method 'noniso()', only non-isolated properties of 'self' can be accessed from this init}}
+    noniso()  // expected-note {{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
     if c == .blue {
       throw c
     }
-    count += 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    count += 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   init(v5 c: Color?) {
     if let c = c {
       switch c {
       case .red:
-        defer { noniso() } // expected-note 5 {{after calling instance method 'noniso()', only non-isolated properties of 'self' can be accessed from this init}}
+        defer { noniso() } // expected-note 5 {{after calling instance method 'noniso()', only nonisolated properties of 'self' can be accessed from this init}}
         count = 0 // OK
         fallthrough
       case .blue:
-        count = 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+        count = 1 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
         fallthrough
       case .yellow:
-        count = 2 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+        count = 2 // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
         break
       }
     }
     switch c {
     case .some(.red):
-      count += 1  // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+      count += 1  // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     case .some(.blue):
-      count += 2  // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+      count += 2  // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     case .some(.yellow):
-      count += 3  // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+      count += 3  // expected-warning {{cannot access property 'count' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     case .none:
       break
     }
@@ -409,30 +409,30 @@ actor MyActor {
         _ = self.x
         self.y = self.x
 
-        Task { self } // expected-note 2 {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
+        Task { self } // expected-note 2 {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
-        self.x = randomInt()  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+        self.x = randomInt()  // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
 
-        callMethod(self) // expected-note 5 {{after calling global function 'callMethod', only non-isolated properties of 'self' can be accessed from this init}}
+        callMethod(self) // expected-note 5 {{after calling global function 'callMethod', only nonisolated properties of 'self' can be accessed from this init}}
 
-        passInout(&self.x) // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+        passInout(&self.x) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
 
         if c {
-          // expected-warning@+2 {{cannot access property 'y' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
-          // expected-warning@+1 {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+          // expected-warning@+2 {{cannot access property 'y' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
+          // expected-warning@+1 {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
           self.x = self.y
         }
 
-        // expected-warning@+2 {{cannot access property 'y' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
-        // expected-warning@+1 {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+        // expected-warning@+2 {{cannot access property 'y' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
+        // expected-warning@+1 {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
         (_, _) = (self.x, self.y)
-        _ = self.x == 0 // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+        _ = self.x == 0 // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
 
         while c {
-          // expected-warning@+2 {{cannot access property 'hax' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
-          // expected-note@+1 2 {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
+          // expected-warning@+2 {{cannot access property 'hax' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
+          // expected-note@+1 2 {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
           self.hax = self
-          _ = self.hax  // expected-warning {{cannot access property 'hax' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+          _ = self.hax  // expected-warning {{cannot access property 'hax' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
         }
 
         Task {
@@ -448,11 +448,11 @@ actor MyActor {
         self.x = 0
         self.y = self.x
 
-        Task { self } // expected-note {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
+        Task { self } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
         callMethod(self)
 
-        passInout(&self.x) // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+        passInout(&self.x) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     }
 
     init(i3 c:  Bool) async {
@@ -486,11 +486,11 @@ actor MyActor {
       self.x = 0
       self.y = self.x
 
-      Task { self } // expected-note {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
+      Task { self } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
       callMethod(self)
 
-      passInout(&self.x) // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+      passInout(&self.x) // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     }
 }
 
@@ -501,9 +501,9 @@ actor X {
 
     init(v1 start: Int) {
         self.counter = start
-        Task { await self.setCounter(start + 1) } // expected-note {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
+        Task { await self.setCounter(start + 1) } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
-        if self.counter != start { // expected-warning {{cannot access property 'counter' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+        if self.counter != start { // expected-warning {{cannot access property 'counter' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
             fatalError("where's my protection?")
         }
     }
@@ -519,7 +519,7 @@ struct CardboardBox<T> {
 
 
 @available(SwiftStdlib 5.1, *)
-var globalVar: EscapeArtist? // expected-warning {{var 'globalVar' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
+var globalVar: EscapeArtist? // expected-warning {{var 'globalVar' is not concurrency-safe because it is nonisolated global shared mutable state; this is an error in the Swift 6 language mode}}
 // expected-note@-1 {{annotate 'globalVar' with '@MainActor' if property should only be accessed from the main actor}}
 // expected-note@-2 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
 // expected-note@-3 {{convert 'globalVar' to a 'let' constant to make 'Sendable' shared state immutable}}
@@ -531,12 +531,12 @@ actor EscapeArtist {
     init(attempt1: Bool) {
         self.x = 0
 
-        // expected-note@+1 {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
+        // expected-note@+1 {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
         globalVar = self
 
         Task { await globalVar!.isolatedMethod() }
 
-        if self.x == 0 {  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+        if self.x == 0 {  // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
             fatalError("race detected.")
         }
     }
@@ -544,11 +544,11 @@ actor EscapeArtist {
     init(attempt2: Bool) {
         self.x = 0
 
-        let wrapped: EscapeArtist? = .some(self)    // expected-note {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
+        let wrapped: EscapeArtist? = .some(self)    // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
         let selfUnchained = wrapped!
 
         Task { await selfUnchained.isolatedMethod() }
-        if self.x == 0 {  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+        if self.x == 0 {  // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
             fatalError("race detected.")
         }
     }
@@ -597,32 +597,32 @@ actor Ahmad {
   var computedProp: Int { 10 } // expected-note {{property declared here}}
 
   init(v1: Void) {
-    Task.detached { self.f() } // expected-note {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
+    Task.detached { self.f() } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
     f()
-    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init(v2: Void) async {
-    Task.detached { self.f() } // expected-note {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
+    Task.detached { self.f() } // expected-note {{after making a copy of 'self', only nonisolated properties of 'self' can be accessed from this init}}
     f()
-    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init(v3: Void) async {
     prop = 10
-    f()       // expected-note {{after calling instance method 'f()', only non-isolated properties of 'self' can be accessed from this init}}
-    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    f()       // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
+    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v4: Void) async {
     prop = 10
-    f()       // expected-note {{after calling instance method 'f()', only non-isolated properties of 'self' can be accessed from this init}}
-    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    f()       // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from this init}}
+    prop += 1 // expected-warning {{cannot access property 'prop' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   deinit {
-    // expected-warning@+2 {{actor-isolated property 'computedProp' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
-    // expected-note@+1 {{after accessing property 'computedProp', only non-isolated properties of 'self' can be accessed from a deinit}}
+    // expected-warning@+2 {{actor-isolated property 'computedProp' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-note@+1 {{after accessing property 'computedProp', only nonisolated properties of 'self' can be accessed from a deinit}}
     let x = computedProp
 
     prop = x // expected-warning {{cannot access property 'prop' here in deinitializer; this is an error in the Swift 6 language mode}}
@@ -637,11 +637,11 @@ actor Rain {
   init(_ hollerBack: (Rain) -> () -> Void) {
     defer { self.f() }
 
-    defer { _ = self.x }  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    defer { _ = self.x }  // expected-warning {{cannot access property 'x' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
 
     defer { Task { self.f() } }
 
-    defer { _ = hollerBack(self) } // expected-note {{after a call involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
+    defer { _ = hollerBack(self) } // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
   }
 
   init(_ hollerBack: (Rain) -> () -> Void) async {
@@ -668,8 +668,8 @@ actor DeinitExceptionForSwift5 {
   }
 
   deinit {
-    // expected-warning@+2 {{actor-isolated instance method 'cleanup()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
-    // expected-note@+1 {{after calling instance method 'cleanup()', only non-isolated properties of 'self' can be accessed from a deinit}}
+    // expected-warning@+2 {{actor-isolated instance method 'cleanup()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-note@+1 {{after calling instance method 'cleanup()', only nonisolated properties of 'self' can be accessed from a deinit}}
     cleanup()
 
     x = 1 // expected-warning {{cannot access property 'x' here in deinitializer; this is an error in the Swift 6 language mode}}
@@ -693,18 +693,18 @@ actor OhBrother {
 
     // make sure we don't call this a closure, which is the more common situation.
 
-    _ = giver(self) // expected-note {{after a call involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
+    _ = giver(self) // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
-    whatever = 1 // expected-warning {{cannot access property 'whatever' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    whatever = 1 // expected-warning {{cannot access property 'whatever' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   init(v3: Void) {
     let blah = { (x: OhBrother) -> Int in 0 }
     giver = blah
 
-    _ = blah(self) // expected-note {{after a call involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
+    _ = blah(self) // expected-note {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
-    whatever = 2 // expected-warning {{cannot access property 'whatever' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    whatever = 2 // expected-warning {{cannot access property 'whatever' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -715,8 +715,8 @@ actor OhBrother {
 class CheckDeinitFromClass: AwesomeUIView {
   var ns: NonSendableType?
   deinit {
-    ns?.f() // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in the Swift 6 language mode}}
-    ns = nil // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in the Swift 6 language mode}}
+    ns?.f() // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    ns = nil // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -724,8 +724,8 @@ class CheckDeinitFromClass: AwesomeUIView {
 actor CheckDeinitFromActor {
   var ns: NonSendableType?
   deinit {
-    ns?.f() // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in the Swift 6 language mode}}
-    ns = nil // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in the Swift 6 language mode}}
+    ns?.f() // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    ns = nil // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -760,7 +760,7 @@ func testActorWithInitAccessorInit() {
       escapingSelf(self)
 
       self.radians = 0
-      // expected-warning@-1 {{actor-isolated property 'radians' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
+      // expected-warning@-1 {{actor-isolated property 'radians' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     }
   }
 
@@ -782,10 +782,10 @@ func testActorWithInitAccessorInit() {
       let escapingSelf: (EscapeBeforeFullInit) -> Void = { _ in }
 
       escapingSelf(self) // expected-error {{'self' used before all stored properties are initialized}}
-      // expected-note@-1 {{after a call involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
+      // expected-note@-1 {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
       self.a = v
-      // expected-warning@-1 {{cannot access property '_a' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+      // expected-warning@-1 {{cannot access property '_a' here in nonisolated initializer; this is an error in the Swift 6 language mode}}
     }
   }
 

--- a/test/Concurrency/freestanding_top_level.swift
+++ b/test/Concurrency/freestanding_top_level.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -concurrency-model=task-to-thread -typecheck  -verify %s
 // RUN: %target-swift-frontend -concurrency-model=task-to-thread -typecheck  -verify -verify-additional-prefix complete- -strict-concurrency=complete %s
 
-// expected-complete-warning@+4 {{var 'global' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
+// expected-complete-warning@+4 {{var 'global' is not concurrency-safe because it is nonisolated global shared mutable state; this is an error in the Swift 6 language mode}}
 // expected-complete-note@+3 {{annotate 'global' with '@MainActor' if property should only be accessed from the main actor}}{{1-1=@MainActor }}
 // expected-complete-note@+2 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}{{1-1=nonisolated(unsafe) }}
 // expected-complete-note@+1 {{convert 'global' to a 'let' constant to make 'Sendable' shared state immutable}}{{1-4=let}}

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -41,7 +41,7 @@ func referenceGlobalActor() async {
 
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
   _ = a[1]  // expected-note{{subscript access is 'async'}}
-  a[0] = 1  // expected-error{{global actor 'SomeGlobalActor'-isolated subscript 'subscript(_:)' can not be mutated from a non-isolated context}}
+  a[0] = 1  // expected-error{{global actor 'SomeGlobalActor'-isolated subscript 'subscript(_:)' can not be mutated from a nonisolated context}}
 
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
   _ = 32 + a[1] // expected-note@:12{{subscript access is 'async'}}
@@ -128,7 +128,7 @@ func fromAsync() async {
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
   _ = a[1]  // expected-note{{subscript access is 'async'}}
   _ = await a[1]
-  a[0] = 1  // expected-error{{global actor 'SomeGlobalActor'-isolated subscript 'subscript(_:)' can not be mutated from a non-isolated context}}
+  a[0] = 1  // expected-error{{global actor 'SomeGlobalActor'-isolated subscript 'subscript(_:)' can not be mutated from a nonisolated context}}
 }
 
 // expected-minimal-and-targeted-note @+2 {{mutation of this var is only permitted within the actor}}
@@ -136,7 +136,7 @@ func fromAsync() async {
 @SomeGlobalActor var value: Int = 42
 
 func topLevelSyncFunction(_ number: inout Int) { }
-// expected-minimal-and-targeted-error @+1 {{global actor 'SomeGlobalActor'-isolated var 'value' can not be used 'inout' from a non-isolated context}}
+// expected-minimal-and-targeted-error @+1 {{global actor 'SomeGlobalActor'-isolated var 'value' can not be used 'inout' from a nonisolated context}}
 topLevelSyncFunction(&value)
 
 // Strict checking based on inferred Sendable/async/etc.

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -330,7 +330,7 @@ public struct WrapperOnMainActor<Wrapped> {
   public var accessCount: Int
 
   nonisolated public init(wrappedValue: Wrapped) {
-    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.wrappedValue = wrappedValue
   }
 }
@@ -341,7 +341,7 @@ public struct WrapperOnMainActorNonSendable<Wrapped> {
   @MainActor public var wrappedValue: Wrapped
 
   public init(wrappedValue: Wrapped) {
-    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.wrappedValue = wrappedValue
   }
 }
@@ -380,8 +380,8 @@ struct HasWrapperOnActor {
 
   // expected-note@+1 2{{to make instance method 'testErrors()'}}
   func testErrors() {
-    _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
-    _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
+    _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced from a nonisolated context}}
+    _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a nonisolated context}}
     _ = _synced // okay
   }
 
@@ -495,7 +495,7 @@ class WrappedContainsNonisolatedAttr {
 
   nonisolated func test() {
     _ = value
-    _ = $value // expected-error {{main actor-isolated property '$value' can not be referenced from a non-isolated context}}
+    _ = $value // expected-error {{main actor-isolated property '$value' can not be referenced from a nonisolated context}}
   }
 }
 
@@ -572,14 +572,14 @@ struct HasWrapperOnUnsafeActor {
   func testUnsafeOkay() {
     // expected-complete-tns-note @-1 {{add '@SomeGlobalActor' to make instance method 'testUnsafeOkay()' part of global actor 'SomeGlobalActor'}}
     // expected-complete-tns-note @-2 {{add '@MainActor' to make instance method 'testUnsafeOkay()' part of global actor 'MainActor'}}
-    _ = synced // expected-complete-tns-warning {{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
-    _ = $synced // expected-complete-tns-warning {{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
+    _ = synced // expected-complete-tns-warning {{main actor-isolated property 'synced' can not be referenced from a nonisolated context}}
+    _ = $synced // expected-complete-tns-warning {{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a nonisolated context}}
     _ = _synced // okay
   }
 
   nonisolated func testErrors() {
-    _ = synced // expected-warning{{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
-    _ = $synced // expected-warning{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
+    _ = synced // expected-warning{{main actor-isolated property 'synced' can not be referenced from a nonisolated context}}
+    _ = $synced // expected-warning{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a nonisolated context}}
     _ = _synced // okay
   }
 
@@ -692,7 +692,7 @@ class Butter {
   var a = useFooInADefer() // expected-minimal-targeted-error {{call to main actor-isolated global function 'useFooInADefer()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
   // expected-complete-tns-warning@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context; this is an error in the Swift 6 language mode}}
 
-  nonisolated let b = statefulThingy // expected-minimal-targeted-error {{main actor-isolated var 'statefulThingy' can not be referenced from a non-isolated context}}
+  nonisolated let b = statefulThingy // expected-minimal-targeted-error {{main actor-isolated var 'statefulThingy' can not be referenced from a nonisolated context}}
   // expected-complete-tns-warning@-1 {{main actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
 
   var c: Int = {

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -73,7 +73,7 @@ public struct WrapperOnMainActor<Wrapped> {
   public var accessCount: Int
 
   nonisolated public init(wrappedValue: Wrapped) {
-    // expected-error@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a non-isolated context}}
+    // expected-error@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a nonisolated context}}
     self.wrappedValue = wrappedValue
   }
 }
@@ -86,8 +86,8 @@ struct HasMainActorWrappedProp {
   var computedProp: Int { 0 }
 
   nonisolated func testErrors() {
-    _ = thing // expected-error {{main actor-isolated property 'thing' can not be referenced from a non-isolated context}}
-    _ = _thing.wrappedValue // expected-error {{main actor-isolated property 'wrappedValue' can not be referenced from a non-isolated context}}
+    _ = thing // expected-error {{main actor-isolated property 'thing' can not be referenced from a nonisolated context}}
+    _ = _thing.wrappedValue // expected-error {{main actor-isolated property 'wrappedValue' can not be referenced from a nonisolated context}}
 
     _ = _thing
     _ = _thing.accessCount
@@ -104,10 +104,10 @@ struct HasWrapperOnActor {
 
   // expected-note@+1 3{{to make instance method 'testErrors()'}}
   func testErrors() {
-    _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
-    _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
+    _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced from a nonisolated context}}
+    _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a nonisolated context}}
     _ = _synced
-    _ = _synced.wrappedValue // expected-error{{main actor-isolated property 'wrappedValue' can not be referenced from a non-isolated context}}
+    _ = _synced.wrappedValue // expected-error{{main actor-isolated property 'wrappedValue' can not be referenced from a nonisolated context}}
   }
 
   @MainActor mutating func testOnMain() {
@@ -128,7 +128,7 @@ struct Carbon {
   @IntWrapper var atomicWeight: Int // expected-note {{property declared here}}
 
   nonisolated func getWeight() -> Int {
-    return atomicWeight // expected-error {{main actor-isolated property 'atomicWeight' can not be referenced from a non-isolated context}}
+    return atomicWeight // expected-error {{main actor-isolated property 'atomicWeight' can not be referenced from a nonisolated context}}
   }
 }
 

--- a/test/Concurrency/global_variables.swift
+++ b/test/Concurrency/global_variables.swift
@@ -14,7 +14,7 @@ actor TestGlobalActor {
 @TestGlobalActor
 var mutableIsolatedGlobal = 1
 
-var mutableNonisolatedGlobal = 1 // expected-error{{var 'mutableNonisolatedGlobal' is not concurrency-safe because it is non-isolated global shared mutable state}}
+var mutableNonisolatedGlobal = 1 // expected-error{{var 'mutableNonisolatedGlobal' is not concurrency-safe because it is nonisolated global shared mutable state}}
 // expected-note@-1{{annotate 'mutableNonisolatedGlobal' with '@MainActor' if property should only be accessed from the main actor}}{{1-1=@MainActor }}
 // expected-note@-2{{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}{{1-1=nonisolated(unsafe) }}
 // expected-note@-3{{convert 'mutableNonisolatedGlobal' to a 'let' constant to make 'Sendable' shared state immutable}}{{1-4=let}}
@@ -58,12 +58,12 @@ struct TestStatics {
   static nonisolated(unsafe) let immutableNonisolatedUnsafeSendable = TestSendable()
   // expected-warning@-1 {{'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'TestSendable', consider removing it}} {{10-30=}}
   static let immutableInferredSendable = 0
-  static var mutable = 0 // expected-error{{static property 'mutable' is not concurrency-safe because it is non-isolated global shared mutable state}}
+  static var mutable = 0 // expected-error{{static property 'mutable' is not concurrency-safe because it is nonisolated global shared mutable state}}
   // expected-note@-1{{convert 'mutable' to a 'let' constant to make 'Sendable' shared state immutable}}
   // expected-note@-2{{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
   // expected-note@-3{{annotate 'mutable' with '@MainActor' if property should only be accessed from the main actor}}
   static var computedProperty: Int { 0 } // computed property that, though static, has no storage so is not a global
-  @TestWrapper static var wrapped: Int // expected-error{{static property 'wrapped' is not concurrency-safe because it is non-isolated global shared mutable state}}
+  @TestWrapper static var wrapped: Int // expected-error{{static property 'wrapped' is not concurrency-safe because it is nonisolated global shared mutable state}}
   // expected-note@-1{{convert 'wrapped' to a 'let' constant to make 'Sendable' shared state immutable}}{{23-26=let}}
   // expected-note@-2{{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}{{16-16=nonisolated(unsafe) }}
   // expected-note@-3{{annotate 'wrapped' with '@MainActor' if property should only be accessed from the main actor}}{{3-3=@MainActor }}
@@ -99,5 +99,5 @@ func testImportedGlobals() { // expected-note{{add '@MainActor' to make global f
   let _ = Globals.integerMutable
   let _ = Globals.nonisolatedUnsafeIntegerConstant
   let _ = Globals.nonisolatedUnsafeIntegerMutable
-  let _ = Globals.actorInteger // expected-error{{main actor-isolated static property 'actorInteger' can not be referenced from a non-isolated context}}
+  let _ = Globals.actorInteger // expected-error{{main actor-isolated static property 'actorInteger' can not be referenced from a nonisolated context}}
 }

--- a/test/Concurrency/grouped_actor_isolation_diagnostics.swift
+++ b/test/Concurrency/grouped_actor_isolation_diagnostics.swift
@@ -89,17 +89,17 @@ struct HasWrapperOnActor {
   // expected-error@+2{{calls to '@MainActor'-isolated' code in instance method 'testWrapped()'}}
   // expected-note@+1{{add '@MainActor' to make instance method 'testWrapped()' part of global actor 'MainActor'}}
   func testWrapped() {
-    _ = x // expected-note{{main actor-isolated property 'x' can not be referenced from a non-isolated context}}
-    _ = y // expected-note{{main actor-isolated property 'y' can not be referenced from a non-isolated context}}
-    _ = z // expected-note{{main actor-isolated property 'z' can not be referenced from a non-isolated context}}
+    _ = x // expected-note{{main actor-isolated property 'x' can not be referenced from a nonisolated context}}
+    _ = y // expected-note{{main actor-isolated property 'y' can not be referenced from a nonisolated context}}
+    _ = z // expected-note{{main actor-isolated property 'z' can not be referenced from a nonisolated context}}
   }
 
   // expected-error@+2{{calls to '@SomeGlobalActor'-isolated' code in instance method 'testProjected()'}}
   // expected-note@+1{{add '@SomeGlobalActor' to make instance method 'testProjected()' part of global actor 'SomeGlobalActor'}}
   func testProjected(){
-    _ = $x // expected-note{{global actor 'SomeGlobalActor'-isolated property '$x' can not be referenced from a non-isolated context}}
-    _ = $y // expected-note{{global actor 'SomeGlobalActor'-isolated property '$y' can not be referenced from a non-isolated context}}
-    _ = $z // expected-note{{global actor 'SomeGlobalActor'-isolated property '$z' can not be referenced from a non-isolated context}}
+    _ = $x // expected-note{{global actor 'SomeGlobalActor'-isolated property '$x' can not be referenced from a nonisolated context}}
+    _ = $y // expected-note{{global actor 'SomeGlobalActor'-isolated property '$y' can not be referenced from a nonisolated context}}
+    _ = $z // expected-note{{global actor 'SomeGlobalActor'-isolated property '$z' can not be referenced from a nonisolated context}}
   }
 
   @MainActor

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -70,7 +70,7 @@ struct OtherValue : @preconcurrency TestSendability {
 // expected-note@+1 2 {{add '@MainActor' to make global function 'test(value:)' part of global actor 'MainActor'}}
 func test(value: Value) {
   _ = value.x
-  // expected-error@-1 {{main actor-isolated property 'x' can not be referenced from a non-isolated context}}
+  // expected-error@-1 {{main actor-isolated property 'x' can not be referenced from a nonisolated context}}
   _ = value.test(nil)
   // expected-error@-1 {{call to main actor-isolated instance method 'test' in a synchronous nonisolated context}}
 }
@@ -88,7 +88,7 @@ extension MyActor : @preconcurrency TestSendability {
 
   func test_ref_diagnostics() {
     _ = value?.x
-    // expected-error@-1 {{main actor-isolated property 'x' can not be referenced on a non-isolated actor instance}}
+    // expected-error@-1 {{main actor-isolated property 'x' can not be referenced on a nonisolated actor instance}}
     _ = value?.test(nil)
     // expected-error@-1 {{call to main actor-isolated instance method 'test' in a synchronous actor-isolated context}}
   }

--- a/test/Concurrency/predates_concurrency_import_deinit.swift
+++ b/test/Concurrency/predates_concurrency_import_deinit.swift
@@ -17,6 +17,6 @@ actor ActorWithDeinit {
 
   deinit {
     print(ns)
-    print(ss) // expected-warning{{cannot access property 'ss' with a non-sendable type 'StrictStruct' from non-isolated deinit}}
+    print(ss) // expected-warning{{cannot access property 'ss' with a non-sendable type 'StrictStruct' from nonisolated deinit}}
   }
 }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -398,7 +398,7 @@ extension SynthesizedConformances.NotSendable: Sendable {}
 enum SynthesizedConformances {
   struct NotSendable: Equatable {}
 
-  // expected-warning@+2 2{{main actor-isolated property 'x' can not be referenced from a non-isolated context}}
+  // expected-warning@+2 2{{main actor-isolated property 'x' can not be referenced from a nonisolated context}}
   // expected-note@+1 2{{in static method '==' for derived conformance to 'Equatable'}}
   @MainActor struct Isolated: Equatable {
     let x: NotSendable // expected-note 2{{property declared here}}

--- a/test/Concurrency/toplevel/async-5-top-level.swift
+++ b/test/Concurrency/toplevel/async-5-top-level.swift
@@ -22,7 +22,7 @@ func isolatedSync() {
 func nonIsolatedAsync() async {
     await print(a)
     a = a + 10
-    // expected-warning@-1:5 {{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
+    // expected-warning@-1:5 {{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
     // expected-warning@-2:9 {{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
     // expected-note@-3:9 {{property access is 'async'}}
 }

--- a/test/Concurrency/toplevel/async-6-top-level.swift
+++ b/test/Concurrency/toplevel/async-6-top-level.swift
@@ -5,10 +5,10 @@ var a = 10
 // expected-note@-2 2 {{mutation of this var is only permitted within the actor}}
 
 func nonIsolatedSync() { //expected-note 3 {{add '@MainActor' to make global function 'nonIsolatedSync()' part of global actor 'MainActor'}}
-    print(a)    // expected-error {{main actor-isolated var 'a' can not be referenced from a non-isolated context}}
+    print(a)    // expected-error {{main actor-isolated var 'a' can not be referenced from a nonisolated context}}
     a = a + 10
-    // expected-error@-1:9 {{main actor-isolated var 'a' can not be referenced from a non-isolated context}}
-    // expected-error@-2:5 {{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
+    // expected-error@-1:9 {{main actor-isolated var 'a' can not be referenced from a nonisolated context}}
+    // expected-error@-2:5 {{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
 
 }
 
@@ -21,7 +21,7 @@ func isolatedSync() {
 func nonIsolatedAsync() async {
     await print(a)
     a = a + 10
-    // expected-error@-1:5 {{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
+    // expected-error@-1:5 {{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
     // expected-error@-2:9 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@-3:9 {{property access is 'async'}}
 }

--- a/test/Concurrency/toplevel/main.swift
+++ b/test/Concurrency/toplevel/main.swift
@@ -9,10 +9,10 @@ var b = 14
 
 func nonIsolatedSynchronous() {
     print(a)
-// Swift6-CHECK: main actor-isolated var 'a' can not be referenced from a non-isolated context
+// Swift6-CHECK: main actor-isolated var 'a' can not be referenced from a nonisolated context
 // Swift6-CHECK: add '@MainActor' to make global function 'nonIsolatedSynchronous()' part of global actor 'MainActor'
 
-// Swift5-CHECK-NOT: main actor-isolated var 'a' can not be referenced from a non-isolated context
+// Swift5-CHECK-NOT: main actor-isolated var 'a' can not be referenced from a nonisolated context
 // Swift5-CHECK-NOT: add '@MainActor' to make global function 'nonIsolatedSynchronous()' part of global actor 'MainActor'
 }
 
@@ -24,11 +24,11 @@ func nonIsolatedAsync() async {
 
 await nonIsolatedAsync()
 
-// Swift6-CHECK: foo.swift{{.*}}main actor-isolated var 'a' can not be referenced from a non-isolated context
+// Swift6-CHECK: foo.swift{{.*}}main actor-isolated var 'a' can not be referenced from a nonisolated context
 // Swift6-CHECK-DAG: var declared here
 // Swift6-CHECK-DAG: add '@MainActor' to make global function 'foo()' part of global actor 'MainActor'
 
-// Swift5-CHECK-NOT: foo.swift{{.*}}main actor-isolated var 'a' can not be referenced from a non-isolated context
+// Swift5-CHECK-NOT: foo.swift{{.*}}main actor-isolated var 'a' can not be referenced from a nonisolated context
 // Swift5-CHECK-NOT: var declared here
 // Swift5-CHECK-NOT: add '@MainActor' to make global function 'foo()' part of global actor 'MainActor'
 

--- a/test/Concurrency/toplevel/no-async-6-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-6-top-level.swift
@@ -10,9 +10,9 @@ var a = 10 // expected-note 2 {{var declared here}}
 
 // expected-note@+1 3{{add '@MainActor' to make global function 'nonIsolatedSync()' part of global actor 'MainActor'}}
 func nonIsolatedSync() {
-    print(a) // expected-error {{main actor-isolated var 'a' can not be referenced from a non-isolated context}}
-    a = a + 10 // expected-error{{main actor-isolated var 'a' can not be referenced from a non-isolated context}}
-  // expected-error@-1{{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
+    print(a) // expected-error {{main actor-isolated var 'a' can not be referenced from a nonisolated context}}
+    a = a + 10 // expected-error{{main actor-isolated var 'a' can not be referenced from a nonisolated context}}
+  // expected-error@-1{{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
 }
 
 @MainActor
@@ -23,7 +23,7 @@ func isolatedSync() {
 
 func nonIsolatedAsync() async {
   await print(a)
-  a = a + 10 // expected-error{{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
+  a = a + 10 // expected-error{{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
   // expected-note@-1{{property access is 'async'}}
   // expected-error@-2{{expression is 'async' but is not marked with 'await'}}
 }

--- a/test/Concurrency/toplevel/synchronous_mainactor.swift
+++ b/test/Concurrency/toplevel/synchronous_mainactor.swift
@@ -6,7 +6,7 @@ var a = 10 // expected-note{{var declared here}}
 var b = 15 // expected-error{{top-level code variables cannot have a global actor}}
 
 func unsafeAccess() { // expected-note{{add '@MainActor' to make global function 'unsafeAccess()' part of global actor 'MainActor'}}
-    print(a) // expected-error@:11{{main actor-isolated var 'a' can not be referenced from a non-isolated context}}
+    print(a) // expected-error@:11{{main actor-isolated var 'a' can not be referenced from a nonisolated context}}
 }
 
 func unsafeAsyncAccess() async {

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -231,7 +231,7 @@ func closureNonInOut(_ a: MyActor) async {
 func transferNonIsolatedNonAsyncClosureTwice() async {
   let a = MyActor()
 
-  // This is non-isolated and non-async... we can transfer it safely.
+  // This is nonisolated and non-async... we can transfer it safely.
   var actorCaptureClosure = { print(a) }
   await transferToMain(actorCaptureClosure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -385,11 +385,11 @@ extension MyActor {
   func simpleClosureCaptureSelfThroughTupleWithFieldAccess() async {
     // In this case, we erase that we accessed self so we hit a type checker
     // error. We could make this a SNS error, but since in the other cases where
-    // we have a non-isolated non-async we are probably going to change it to be
+    // we have a nonisolated non-async we are probably going to change it to be
     // async as well making these errors go away.
     let x = (self, 1)
     let closure: () -> () = {
-      print(x.0.klass) // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+      print(x.0.klass) // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
     }
     await transferToMain(closure)
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
@@ -443,7 +443,7 @@ func testSimpleLetClosureCaptureActor() async {
 
 func testSimpleLetClosureCaptureActorField() async {
   let a = MyActor()
-  let closure = { print(a.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  let closure = { print(a.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -451,7 +451,7 @@ func testSimpleLetClosureCaptureActorField() async {
 
 func testSimpleLetClosureCaptureActorFieldThroughTuple() async {
   let a = (MyActor(), 0)
-  let closure = { print(a.0.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  let closure = { print(a.0.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -459,7 +459,7 @@ func testSimpleLetClosureCaptureActorFieldThroughTuple() async {
 
 func testSimpleLetClosureCaptureActorFieldThroughOptional() async {
   let a: MyActor? = MyActor()
-  let closure = { print(a!.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  let closure = { print(a!.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -480,7 +480,7 @@ func testSimpleVarClosureCaptureActor() async {
 func testSimpleVarClosureCaptureActorField() async {
   let a = MyActor()
   var closure = {}
-  closure = { print(a.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  closure = { print(a.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -489,7 +489,7 @@ func testSimpleVarClosureCaptureActorField() async {
 func testSimpleVarClosureCaptureActorFieldThroughTuple() async {
   let a = (MyActor(), 0)
   var closure = {}
-  closure = { print(a.0.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  closure = { print(a.0.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -498,7 +498,7 @@ func testSimpleVarClosureCaptureActorFieldThroughTuple() async {
 func testSimpleVarClosureCaptureActorFieldThroughOptional() async {
   let a: MyActor? = MyActor()
   var closure = {}
-  closure = { print(a!.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  closure = { print(a!.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -161,8 +161,8 @@ func test_outside(
 
   _ = local.name // ok, special case that let constants are okey
   let _: String = local.mutable // ok, special case that let constants are okey
-  _ = distributed.name // expected-error{{distributed actor-isolated property 'name' can not be accessed from a non-isolated context}}
-  _ = distributed.mutable // expected-error{{distributed actor-isolated property 'mutable' can not be accessed from a non-isolated context}}
+  _ = distributed.name // expected-error{{distributed actor-isolated property 'name' can not be accessed from a nonisolated context}}
+  _ = distributed.mutable // expected-error{{distributed actor-isolated property 'mutable' can not be accessed from a nonisolated context}}
 
   // ==== special properties (nonisolated, implicitly replicated)
   // the distributed actor's special fields may always be referred to

--- a/test/Distributed/distributed_actor_isolation_and_tasks.swift
+++ b/test/Distributed/distributed_actor_isolation_and_tasks.swift
@@ -63,7 +63,7 @@ distributed actor Philosopher {
 
 func test_outside(system: FakeActorSystem) async throws {
   _ = try await Philosopher(system: system).dist()
-  _ = Philosopher(system: system).log // expected-error{{distributed actor-isolated property 'log' can not be accessed from a non-isolated context}}
+  _ = Philosopher(system: system).log // expected-error{{distributed actor-isolated property 'log' can not be accessed from a nonisolated context}}
 
   _ = Philosopher(system: system).id
   _ = Philosopher(system: system).actorSystem

--- a/test/Distributed/distributed_actor_nonisolated.swift
+++ b/test/Distributed/distributed_actor_nonisolated.swift
@@ -21,7 +21,7 @@ distributed actor DA {
 
   nonisolated var computedNonisolated: Int {
     // nonisolated computed properties are outside of the actor and as such cannot access local
-    _ = self.local // expected-error{{distributed actor-isolated property 'local' can not be accessed from a non-isolated context}}
+    _ = self.local // expected-error{{distributed actor-isolated property 'local' can not be accessed from a nonisolated context}}
 
     _ = self.id // ok, special handled and always available
     _ = self.actorSystem // ok, special handled and always available
@@ -34,7 +34,7 @@ distributed actor DA {
     _ = self.actorSystem // ok
     
     // self is a distributed actor self is NOT isolated
-    _ = self.local // expected-error{{distributed actor-isolated property 'local' can not be accessed from a non-isolated context}}
+    _ = self.local // expected-error{{distributed actor-isolated property 'local' can not be accessed from a nonisolated context}}
     _ = try await self.dist() // ok, was made implicitly throwing and async
     _ = self.computedNonisolated // it's okay, only the body of computedNonisolated is wrong
   }
@@ -58,7 +58,7 @@ func invalidIsolatedCall<DA: DistributedActor> (
   Task {
     // expected-note@+1 {{let declared here}}
     for await closure in queue {
-      // expected-warning@+1 {{distributed actor-isolated let 'closure' can not be accessed from a non-isolated context; this is an error in the Swift 6 language mode}}
+      // expected-warning@+1 {{distributed actor-isolated let 'closure' can not be accessed from a nonisolated context; this is an error in the Swift 6 language mode}}
       await closure(actor)
     }
   }

--- a/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
@@ -75,9 +75,9 @@ distributed actor D {
 
 func test_outside(distributed: D) async throws {
   _ = distributed.normal
-  // expected-error@-1{{distributed actor-isolated property 'normal' can not be accessed from a non-isolated context}}
+  // expected-error@-1{{distributed actor-isolated property 'normal' can not be accessed from a nonisolated context}}
 
   _ = distributed.computed
-  // expected-error@-1{{distributed actor-isolated property 'computed' can not be accessed from a non-isolated context}}
+  // expected-error@-1{{distributed actor-isolated property 'computed' can not be accessed from a nonisolated context}}
 }
 

--- a/test/Distributed/distributed_property_must_be_throws.swift
+++ b/test/Distributed/distributed_property_must_be_throws.swift
@@ -29,7 +29,7 @@ func test(da: MyDistributedActor) async throws {
 }
 
 func testSyncFunc(da: MyDistributedActor) throws {
-  _ = da.accessMe // expected-error{{actor-isolated distributed property 'accessMe' can not be referenced from a non-isolated context}}
+  _ = da.accessMe // expected-error{{actor-isolated distributed property 'accessMe' can not be referenced from a nonisolated context}}
   // expected-error@-1{{property access can throw but is not marked with 'try'}}
   // expected-note@-2{{did you mean to use 'try'?}}
   // expected-note@-3{{did you mean to handle error as optional value?}}


### PR DESCRIPTION
Starting the testing.

rdar://130827967
(cherry picked from commit 474aa47732f0de33115d877ac809d388c0682ded)
