### PR TITLE
Skip macro-expanded code in the playground transform.

### DIFF
--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -949,7 +949,9 @@ void swift::performPlaygroundTransform(SourceFile &SF, PlaygroundOptionSet Opts)
 
     PreWalkAction walkToDeclPre(Decl *D) override {
       if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {
-        if (!FD->isImplicit() && !FD->isBodySkipped()) {
+        // Skip any functions that do not have user-written source code.
+        if (!FD->isImplicit() && !FD->isBodySkipped() &&
+            !FD->isInMacroExpansionInContext()) {
           if (BraceStmt *Body = FD->getBody()) {
             const ParameterList *PL = FD->getParameters();
             Instrumenter I(ctx, FD, RNG, Options, TmpNameIndex);


### PR DESCRIPTION
Playgrounds cannot display any macro expansions anyway and the @Observable macro can generate instrumentations that don't typecheck and/or reference missing functions.

rdar://112122752
(cherry picked from commit 388bd6e5f4cea63531b6c33584c7d6701814fbdc)
