### PR TITLE
[test] Retrieve Linux distro and version from `/etc/os-release`

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2883,8 +2883,30 @@ def linux_get_lsb_release():
         return (distributor, release)
     return ('', '')
 
+def linux_get_os_release():
+    try:
+        os_release_path = '/etc/os-release'
+        os_release_file = open(os_release_path)
+    except FileNotFoundError:
+        return '', ''
+    os_id = ''
+    os_release = ''
+    for line in os_release_file:
+        line = line.rstrip()
+        if not line or line.startswith('#'):
+            continue
+        if line.startswith('ID='):
+            os_id = line[len('ID='):].strip('\"')
+        if line.startswith('VERSION_ID='):
+            os_release = line[len('VERSION_ID='):].strip('\"')
+    return os_id, os_release
+
 if platform.system() == 'Linux':
-    (distributor, release) = linux_get_lsb_release()
+    # Retrieve the Linux distro and version from `/etc/os-release`. 
+    (distributor, release) = linux_get_os_release()
+    if distributor == '' or release == '':
+        # If `/etc/os-release` does not provide full results, fallback to `lsb_release`.
+        (distributor, release) = linux_get_lsb_release()
     if distributor != '' and release != '':
         config.available_features.add("LinuxDistribution=" + distributor + '-' + release)
         lit_config.note('Running tests on %s-%s' % (distributor, release))


### PR DESCRIPTION
Certain Linux distributions like UBI9 don't include `lsb_release`. Let's use `/etc/os-release` to detect the Linux distro and version by default, and fall back to `lsb_release` if `/etc/os-release` is not available.

This makes it possible to mark C++ interop tests that require C++20 as unsupported on distros that bundle an older libstdc++ version.