### PR TITLE
Revert "Disable test Runtime/issue-51181.swift"

### DIFF
--- a/validation-test/Runtime/issue-51181.swift
+++ b/validation-test/Runtime/issue-51181.swift
@@ -1,6 +1,5 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: rdar126151157
 
 // https://github.com/apple/swift/issues/51181
 


### PR DESCRIPTION
I think we can bring back this test now.

This reverts commit dfcdf16a721c518d0652504b3c59f3f4b8774b3d.
