### PR TITLE
[siloptimizer] Teach VariableNameInference how to look through convert_escape_to_no_escape.

### DIFF
--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -627,7 +627,8 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
         isa<MoveOnlyWrapperToCopyableAddrInst>(searchValue) ||
         isa<MoveOnlyWrapperToCopyableValueInst>(searchValue) ||
         isa<CopyableToMoveOnlyWrapperValueInst>(searchValue) ||
-        isa<EndInitLetRefInst>(searchValue)) {
+        isa<EndInitLetRefInst>(searchValue) ||
+        isa<ConvertEscapeToNoEscapeInst>(searchValue)) {
       searchValue = cast<SingleValueInstruction>(searchValue)->getOperand(0);
       continue;
     }

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -102,7 +102,10 @@ func test_closure_capture(a : A) async {
   print(ns3)
 
   // this should consume ns0
-  await a.run_closure(captures0) // expected-tns-warning {{sending value of non-Sendable type '() -> ()' with later accesses from nonisolated context to actor-isolated context risks causing data races}}
+  await a.run_closure(captures0)
+  // expected-tns-warning @-1 {{sending 'captures0' risks causing data races}}
+  // expected-tns-note @-2 {{sending 'captures0' to actor-isolated instance method 'run_closure' risks causing data races between actor-isolated and local nonisolated uses}}
+
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -112,7 +115,9 @@ func test_closure_capture(a : A) async {
   print(ns3)
 
   // this should consume ns1 and ns2
-  await a.run_closure(captures12) // expected-tns-warning {{sending value of non-Sendable type '() -> ()' with later accesses from nonisolated context to actor-isolated context risks causing data races}}
+  await a.run_closure(captures12)
+  // expected-tns-warning @-1 {{sending 'captures12' risks causing data races}}
+  // expected-tns-note @-2 {{sending 'captures12' to actor-isolated instance method 'run_closure' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -123,7 +128,9 @@ func test_closure_capture(a : A) async {
   print(ns3)
 
   // this should consume ns3
-  await a.run_closure(captures3indirect) // expected-tns-warning {{sending value of non-Sendable type '() -> ()' with later accesses from nonisolated context to actor-isolated context risks causing data races}}
+  await a.run_closure(captures3indirect)
+  // expected-tns-warning @-1 {{sending 'captures3indirect' risks causing data races}}
+  // expected-tns-note @-2 {{sending 'captures3indirect' to actor-isolated instance method 'run_closure' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -897,3 +897,25 @@ bb0(%0 : @owned $Klass):
   debug_value [trace] %1 : $Klass
   return %1 : $Klass
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on infer_for_closure: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %5 = convert_escape_to_noescape [not_guaranteed] %4 : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK: Name: 'closure1'
+// CHECK: Root:   %2 = move_value [lexical] [var_decl] %1 : $@callee_guaranteed () -> ()
+// CHECK: end running test 1 of 1 on infer_for_closure: variable-name-inference with: @trace[0]
+sil [ossa] @infer_for_closure : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = function_ref @sideEffect : $@convention(thin) () -> ()
+  %1 = partial_apply [callee_guaranteed] %0() : $@convention(thin) () -> ()
+  %2 = move_value [lexical] [var_decl] %1 : $@callee_guaranteed () -> ()
+  debug_value %2 : $@callee_guaranteed () -> (), let, name "closure1"
+  %3 = copy_value %2 : $@callee_guaranteed () -> ()
+  %4 = convert_escape_to_noescape [not_guaranteed] %3 : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+  debug_value [trace] %4 : $@noescape @callee_guaranteed () -> ()
+  destroy_value %4 : $@noescape @callee_guaranteed () -> ()
+  destroy_value %3 : $@callee_guaranteed () -> ()
+  destroy_value %2 : $@callee_guaranteed () -> ()
+  %9999 = tuple ()
+  return %9999 : $()
+}


### PR DESCRIPTION
This was causing us to emit old style diagnostics in TransferNonSendable in certain cases.

Just doing a walk through of the diagnostics and fixing issues while I am here sprucing up sending diagnostics.

rdar://130915737
