### PR TITLE
[6.0] [Completion] Complete `.isolation` for `@isolated(any)` functions

### DIFF
--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -510,6 +510,9 @@ public:
 
   bool tryTupleExprCompletions(Type ExprType);
 
+  /// Try add the completion for '.isolation' for @isolated(any) function types.
+  void tryFunctionIsolationCompletion(Type ExprType);
+
   bool tryFunctionCallCompletions(
       Type ExprType, const ValueDecl *VD,
       std::optional<SemanticContextKind> SemanticContext = std::nullopt);

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -441,6 +441,10 @@ public:
 
   void addPrecedenceGroupRef(PrecedenceGroupDecl *PGD);
 
+  /// Add a builtin member reference pattern. This is used for members that
+  /// do not have associated decls, e.g tuple access and '.isolation'.
+  void addBuiltinMemberRef(StringRef Name, Type TypeAnnotation);
+
   void addEnumElementRef(const EnumElementDecl *EED, DeclVisibilityKind Reason,
                          DynamicLookupInfo dynamicLookupInfo,
                          bool HasTypeContext);

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1764,6 +1764,15 @@ void CompletionLookup::addPrecedenceGroupRef(PrecedenceGroupDecl *PGD) {
   builder.setAssociatedDecl(PGD);
 }
 
+void CompletionLookup::addBuiltinMemberRef(StringRef Name,
+                                           Type TypeAnnotation) {
+  CodeCompletionResultBuilder Builder = makeResultBuilder(
+      CodeCompletionResultKind::Pattern, SemanticContextKind::CurrentNominal);
+  addLeadingDot(Builder);
+  Builder.addBaseName(Name);
+  addTypeAnnotation(Builder, TypeAnnotation);
+}
+
 void CompletionLookup::addEnumElementRef(const EnumElementDecl *EED,
                                          DeclVisibilityKind Reason,
                                          DynamicLookupInfo dynamicLookupInfo,
@@ -2276,20 +2285,17 @@ bool CompletionLookup::tryTupleExprCompletions(Type ExprType) {
 
   unsigned Index = 0;
   for (auto TupleElt : TT->getElements()) {
-    CodeCompletionResultBuilder Builder = makeResultBuilder(
-        CodeCompletionResultKind::Pattern, SemanticContextKind::CurrentNominal);
-    addLeadingDot(Builder);
+    auto Ty = TupleElt.getType();
     if (TupleElt.hasName()) {
-      Builder.addBaseName(TupleElt.getName().str());
+      addBuiltinMemberRef(TupleElt.getName().str(), Ty);
     } else {
       llvm::SmallString<4> IndexStr;
       {
         llvm::raw_svector_ostream OS(IndexStr);
         OS << Index;
       }
-      Builder.addBaseName(IndexStr.str());
+      addBuiltinMemberRef(IndexStr, Ty);
     }
-    addTypeAnnotation(Builder, TupleElt.getType());
     ++Index;
   }
   return true;

--- a/test/IDE/complete_function_isolation.swift
+++ b/test/IDE/complete_function_isolation.swift
@@ -1,0 +1,24 @@
+// RUN: %batch-code-completion
+
+// REQUIRES: concurrency
+
+func test1(_ x: () -> Void) {
+  x.#^NORMAL_FN^#
+  // NORMAL_FN:     Begin completions, 2 items
+  // NORMAL_FN-DAG: Keyword[self]/CurrNominal: self[#() -> Void#]; name=self
+  // NORMAL_FN-DAG: Pattern/CurrModule/Flair[ArgLabels]/Erase[1]: ()[#Void#]; name=()
+}
+
+func test2(_ x: @isolated(any) () -> Void) {
+  x.#^ISOLATED_ANY_FN^#
+  // ISOLATED_ANY_FN:     Begin completions, 3 items
+  // ISOLATED_ANY_FN-DAG: Pattern/CurrNominal: isolation[#(any Actor)?#]; name=isolation
+  // ISOLATED_ANY_FN-DAG: Keyword[self]/CurrNominal: self[#@isolated(any) () -> Void#]; name=self
+  // ISOLATED_ANY_FN-DAG: Pattern/CurrModule/Flair[ArgLabels]/Erase[1]: ()[#Void#]; name=()
+}
+
+func test3(_ x: (@isolated(any) () -> Void)?) {
+  x.#^ISOLATED_ANY_OPTIONAL_FN^#
+  // ISOLATED_ANY_OPTIONAL_FN-DAG: Pattern/CurrNominal/Erase[1]: ?.isolation[#(any Actor)?#]; name=isolation
+  // ISOLATED_ANY_OPTIONAL_FN-DAG: Keyword[self]/CurrNominal: self[#(@isolated(any) () -> Void)?#]; name=self
+}


### PR DESCRIPTION
*6.0 cherry-pick of #74860*

- Explanation: Adds completion support for `.isolation` on `@isolated(any)` functions
- Scope: Affects code completion
- Issue: rdar://124615036
- Risk: Low, only affects completion, and is fairly straightforward
- Testing: Added tests to test suite
- Reviewer: Alex Hoppen