### PR TITLE
[6.0 🍒][Dependency Scanning] Apply `-clang-scanner-module-cache-path` to header Clang module dependencies

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -485,11 +485,11 @@ bool ClangImporter::addHeaderDependencies(
           std::error_code(errno, std::generic_category()));
     }
     std::string workingDir = *optionalWorkingDir;
-    auto moduleCachePath = getModuleCachePathFromClang(getClangInstance());
+    auto moduleOutputPath = cache.getModuleOutputPath();
     auto lookupModuleOutput =
-        [moduleCachePath](const ModuleID &MID,
-                          ModuleOutputKind MOK) -> std::string {
-      return moduleCacheRelativeLookupModuleOutput(MID, MOK, moduleCachePath);
+        [moduleOutputPath](const ModuleID &MID,
+                           ModuleOutputKind MOK) -> std::string {
+      return moduleCacheRelativeLookupModuleOutput(MID, MOK, moduleOutputPath);
     };
     auto dependencies = clangScanningTool.getTranslationUnitDependencies(
         commandLineArgs, workingDir, cache.getAlreadySeenClangModules(),

--- a/test/ScanDependencies/separate_clang_scan_cache_bridging.swift
+++ b/test/ScanDependencies/separate_clang_scan_cache_bridging.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t.module-cache)
+// RUN: %empty-directory(%t.scanner-cache)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache -clang-scanner-module-cache-path %t.scanner-cache %s -o %t.deps.json -I %S/Inputs/SwiftDifferent -import-objc-header %S/Inputs/CHeaders/Bridging.h -dump-clang-diagnostics 2>&1 | %FileCheck %s --check-prefix=CHECK-CLANG-COMMAND
+// RUN: %validate-json %t.deps.json | %FileCheck %s --check-prefix=CHECK-DEPS
+
+// Ensure we prefer clang scanner module cache path
+// CHECK-CLANG-COMMAND: '-fmodules-cache-path={{.*}}.scanner-cache'
+
+// Ensure we the modules' output path is set to the module cache
+// CHECK-DEPS: "swift": "A"
+// CHECK-DEPS: "clang": "F"
+
+// CHECK-DEPS:            "clang": "F"
+// CHECK-DEPS-NEXT:     },
+// CHECK-DEPS-NEXT:     {
+// CHECK-DEPS-NEXT:       "modulePath": "{{.*}}separate_clang_scan_cache_bridging.swift.tmp.module-cache{{/|\\\\}}F-{{.*}}.pcm"
+
+// CHECK-DEPS:            "swift": "A"
+// CHECK-DEPS-NEXT:     },
+// CHECK-DEPS-NEXT:     {
+// CHECK-DEPS-NEXT:       "modulePath": "{{.*}}separate_clang_scan_cache_bridging.swift.tmp.module-cache{{/|\\\\}}A-{{.*}}.swiftmodule"
+
+
+
+import A


### PR DESCRIPTION
- **Explanation**: Clang module dependencies of (Bridging) headers incorrectly did not respect `-clang-scanner-module-cache-path`, and when it was set, were always output into the scanner cache directory. Whereas depending clients expected them in the non-scanner cache directory. This discrepancy caused missing `.pcm` compilation failures. This change fixes the discrepancy. 
 
- **Scope**: This change only affects Explicit Module Builds (opt-in) which also opt-in to using a separate `-clang-scanner-module-cache-path` setting. On such builds, it affects the ability to compile modular dependencies of Bridging Headers. 

- **Issue/Radar**: rdar://117024665

- **Original PR**: https://github.com/swiftlang/swift/pull/74872

- **Risk**: Low.  Previously, this configuration resulted in build failures 100% of the time when building modular dependencies of bridging headers with `-clang-scanner-module-cache-path`. Now such builds will succeed. Other dependency path code-paths are not affected.

- **Testing**: Automated test added to the compiler test suite.

- **Reviewers**: @owenv, @cachemeifyoucan 


