### PR TITLE
[6.0] Add new _foundation_unicode and _FoundationCShims c modules to windows build script

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1512,8 +1512,12 @@ function Install-Platform([Platform]$Platform, $Arch) {
   # Copy SDK header files
   Copy-Directory "$($Arch.SDKInstallRoot)\usr\include\swift\SwiftRemoteMirror" $SDKInstallRoot\usr\include\swift
   Copy-Directory "$($Arch.SDKInstallRoot)\usr\lib\swift\shims" $SDKInstallRoot\usr\lib\swift
-  foreach ($Module in ("Block", "dispatch", "os")) {
-    Copy-Directory "$($Arch.SDKInstallRoot)\usr\lib\swift\$Module" $SDKInstallRoot\usr\include
+  foreach ($Module in ("Block", "dispatch", "os", "_foundation_unicode", "_FoundationCShims")) {
+    $ModuleDirectory = "$($Arch.SDKInstallRoot)\usr\lib\swift\$Module"
+    $DestinationDirectory = "$SDKInstallRoot\usr\include"
+    if (Test-Path $ModuleDirectory) {
+      Copy-Directory $ModuleDirectory $DestinationDirectory
+    }
   }
 
   # Copy SDK share folder


### PR DESCRIPTION
Cherry pick of https://github.com/swiftlang/swift/pull/74796

Explanation: Updates the Windows build script to copy _foundation_unicode and _FoundationCShims (if they exist) like dispatch, os, and Block
Scope: Affects building toolchains on Windows
Original PR: https://github.com/swiftlang/swift/pull/74796
Risk: Minimal - these directories do not yet exist so the change should be inert until we add the directories to the Foundation build
Testing: Testing done via swift-ci testing and toolchain builds
Reviewer: @compnerd 