### PR TITLE
Sema: Downgrade actor convenience initializer diagnostic to a warning in interfaces

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -379,8 +379,9 @@ static bool doesAccessorNeedDynamicAttribute(AccessorDecl *accessor) {
 CtorInitializerKind
 InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
   auto &diags = decl->getASTContext().Diags;
+  auto dc = decl->getDeclContext();
 
-  if (auto nominal = decl->getDeclContext()->getSelfNominalTypeDecl()) {
+  if (auto nominal = dc->getSelfNominalTypeDecl()) {
 
     // Convenience inits are only allowed on classes and in extensions thereof.
     if (auto convenAttr = decl->getAttrs().getAttribute<ConvenienceAttr>()) {
@@ -390,6 +391,7 @@ InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
           diags.diagnose(decl->getLoc(),
                 diag::no_convenience_keyword_init, "actors")
             .fixItRemove(convenAttr->getLocation())
+            .warnInSwiftInterface(dc)
             .warnUntilSwiftVersion(6);
 
         } else { // not an actor
@@ -447,7 +449,7 @@ InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
       // (or the same file) to add vtable entries, we can re-evaluate this
       // restriction.
       if (!decl->isSynthesized() &&
-          isa<ExtensionDecl>(decl->getDeclContext()->getImplementedObjCContext()) &&
+          isa<ExtensionDecl>(dc->getImplementedObjCContext()) &&
           !(decl->getAttrs().hasAttribute<DynamicReplacementAttr>())) {
 
         if (classDcl->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
@@ -476,7 +478,7 @@ InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
   } // end of Nominal context
 
   // initializers in protocol extensions must be convenience inits
-  if (decl->getDeclContext()->getExtendedProtocolDecl()) {
+  if (dc->getExtendedProtocolDecl()) {
     return CtorInitializerKind::Convenience;
   }
 

--- a/test/ModuleInterface/actor_init.swift
+++ b/test/ModuleInterface/actor_init.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s --check-prefixes=CHECK < %t/Library.swiftinterface
+
+// Re-verify with -swift-version 6
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -swift-version 6 -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s --check-prefixes=CHECK < %t/Library.swiftinterface
+
+// CHECK-LABEL: public actor TestActor {
+@available(SwiftStdlib 5.5, *)
+public actor TestActor {
+  // FIXME: The convenience keyword should be omitted (rdar://130926278)
+  // CHECK: public convenience init(convenience: Swift.Int)
+  public init(convenience: Int) {
+    self.init()
+  }
+  // CHECK: public init()
+  public init() {}
+}


### PR DESCRIPTION
The `convenience` keyword is not accepted on actor initializers because the compiler infers this status automatically and actors cannot be subclassed. However, internally the compiler still computes whether an actor init is a convenience init and this implicit status has been leaking through accidentally in printed `.swiftinterface` files. This was noticed because in Swift 6 the presence of the keyword is diagnosed as an error, making `.swiftinterface` files unparseable for modules containing actors with convenience inits.

For Swift 6, I'm just going to suppress the error in `.swiftinterface` files regardless of language mode. In future releases of the compiler, though, it can stop printing the `convenience` keyword on these inits altogether.

Resolves rdar://130857256.