### PR TITLE
[6.0] Sema: Downgrade actor convenience initializer diagnostic to a warning in interfaces.

### DIFF
--- a/test/ModuleInterface/actor_init.swift
+++ b/test/ModuleInterface/actor_init.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s --check-prefixes=CHECK < %t/Library.swiftinterface
+
+// Re-verify with -swift-version 6
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -swift-version 6 -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s --check-prefixes=CHECK < %t/Library.swiftinterface
+
+// CHECK-LABEL: public actor TestActor {
+@available(SwiftStdlib 5.1, *)
+public actor TestActor {
+  // FIXME: The convenience keyword should be omitted (rdar://130926278)
+  // CHECK: public convenience init(convenience: Swift.Int)
+  public init(convenience: Int) {
+    self.init()
+  }
+  // CHECK: public init()
+  public init() {}
+}


### PR DESCRIPTION
- **Explanation:** The `convenience` keyword is not accepted on actor initializers because the compiler infers this status automatically and actors cannot be subclassed. However, internally the compiler still computes whether an actor init is a convenience init and this implicit status has been leaking through accidentally in printed `.swiftinterface` files. This was noticed because in Swift 6 the presence of the keyword is diagnosed as an error, making `.swiftinterface` files unparseable for modules containing actors with convenience inits.
- **Scope:** The fix changes the behavior of building modules from interfaces by relaxing a type checking constraint. This fix is important for the owners of resilient libraries who want to adopt Swift 6 because their adoption could be blocked by this bug.
- **Issue/Radar:** rdar://130857256
- **Original PR:** https://github.com/swiftlang/swift/pull/74877
- **Risk:** Very low. This just relaxes a type checking constraint when checking `.swiftinterface` files to continue allowing syntax in Swift 6 that was already allowed in modules compiled with the Swift 5 language mode.
- **Testing:** Added a new test to the compiler test suite.
- **Reviewer:** @kavon 
