### PR TITLE
[6.0][region-isolation] Change capturing a value into an async let that is not further sent into an actor isolated function to use a new style error.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -990,6 +990,10 @@ NOTE(regionbasedisolation_named_transfer_non_transferrable, none,
 NOTE(regionbasedisolation_named_transfer_non_transferrable_callee, none,
       "sending %1%0 to %2 %3 %4 risks causing data races between %2 and %5 uses",
       (Identifier, StringRef, ActorIsolation, DescriptiveDeclKind, DeclName, StringRef))
+NOTE(regionbasedisolation_named_nonisolated_asynclet_name, none,
+      "sending %0 into async let risks causing data races between async let uses and local uses",
+      (Identifier))
+
 NOTE(regionbasedisolation_named_transfer_into_sending_param, none,
      "%0%1 is passed as a 'sending' parameter; Uses in callee may race with later %0uses",
      (StringRef, Identifier))

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -28,6 +28,12 @@ class RegionAnalysisValueMap;
 
 namespace regionanalysisimpl {
 
+#ifndef NDEBUG
+/// Global bool set only when asserts are enabled to ease debugging by causing
+/// unknown pattern errors to cause an assert so we drop into the debugger.
+extern bool AbortOnUnknownPatternMatchError;
+#endif
+
 using TransferringOperandSetFactory = Partition::TransferringOperandSetFactory;
 using Element = PartitionPrimitives::Element;
 using Region = PartitionPrimitives::Region;

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -34,6 +34,14 @@ namespace regionanalysisimpl {
 extern bool AbortOnUnknownPatternMatchError;
 #endif
 
+static inline bool shouldAbortOnUnknownPatternMatchError() {
+#ifndef NDEBUG
+  return AbortOnUnknownPatternMatchError;
+#else
+  return false;
+#endif
+}
+
 using TransferringOperandSetFactory = Partition::TransferringOperandSetFactory;
 using Element = PartitionPrimitives::Element;
 using Region = PartitionPrimitives::Region;

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -47,11 +47,19 @@ using namespace swift::PartitionPrimitives;
 using namespace swift::PatternMatch;
 using namespace swift::regionanalysisimpl;
 
-static llvm::cl::opt<bool> AbortOnUnknownPatternMatchError(
+#ifndef NDEBUG
+
+bool swift::regionanalysisimpl::AbortOnUnknownPatternMatchError = false;
+
+static llvm::cl::opt<bool, true> AbortOnUnknownPatternMatchErrorCmdLine(
     "sil-region-isolation-assert-on-unknown-pattern",
     llvm::cl::desc("Abort if SIL region isolation detects an unknown pattern. "
                    "Intended only to be used when debugging the compiler!"),
-    llvm::cl::init(false), llvm::cl::Hidden);
+    llvm::cl::Hidden,
+    llvm::cl::location(
+        swift::regionanalysisimpl::AbortOnUnknownPatternMatchError));
+
+#endif
 
 //===----------------------------------------------------------------------===//
 //                              MARK: Utilities

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1205,7 +1205,7 @@ struct PartitionOpBuilder {
   }
 
   void addUnknownPatternError(SILValue value) {
-    if (AbortOnUnknownPatternMatchError) {
+    if (shouldAbortOnUnknownPatternMatchError()) {
       llvm::report_fatal_error(
           "RegionIsolation: Aborting on unknown pattern match error");
     }

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -664,6 +664,11 @@ public:
   }
 
   void emitUnknownPatternError() {
+    if (AbortOnUnknownPatternMatchError) {
+      llvm::report_fatal_error(
+          "RegionIsolation: Aborting on unknown pattern match error");
+    }
+
     diagnoseError(transferOp->getUser(),
                   diag::regionbasedisolation_unknown_pattern)
         .limitBehaviorIf(getBehaviorLimit());
@@ -1058,6 +1063,11 @@ void TransferNonSendableImpl::emitUseAfterTransferDiagnostics() {
     // tells the user to file a bug. This importantly ensures that we can
     // guarantee that we always find the require if we successfully compile.
     if (!didEmitRequireNote) {
+      if (AbortOnUnknownPatternMatchError) {
+        llvm::report_fatal_error(
+            "RegionIsolation: Aborting on unknown pattern match error");
+      }
+
       diagnoseError(transferOp, diag::regionbasedisolation_unknown_pattern);
       continue;
     }
@@ -1116,6 +1126,11 @@ public:
   }
 
   void emitUnknownPatternError() {
+    if (AbortOnUnknownPatternMatchError) {
+      llvm::report_fatal_error(
+          "RegionIsolation: Aborting on unknown pattern match error");
+    }
+
     diagnoseError(getOperand()->getUser(),
                   diag::regionbasedisolation_unknown_pattern)
         .limitBehaviorIf(getBehaviorLimit());
@@ -1601,6 +1616,11 @@ struct DiagnosticEvaluator final
   }
 
   void handleUnknownCodePattern(const PartitionOp &op) const {
+    if (AbortOnUnknownPatternMatchError) {
+      llvm::report_fatal_error(
+          "RegionIsolation: Aborting on unknown pattern match error");
+    }
+
     diagnoseError(op.getSourceInst(),
                   diag::regionbasedisolation_unknown_pattern);
   }

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -574,6 +574,19 @@ public:
     emitRequireInstDiagnostics();
   }
 
+  void emitNamedAsyncLetNoIsolationCrossingError(SILLocation loc,
+                                                 Identifier name) {
+    // Emit the short error.
+    diagnoseError(loc, diag::regionbasedisolation_named_transfer_yields_race,
+                  name)
+        .highlight(loc.getSourceRange())
+        .limitBehaviorIf(getBehaviorLimit());
+
+    diagnoseNote(
+        loc, diag::regionbasedisolation_named_nonisolated_asynclet_name, name);
+    emitRequireInstDiagnostics();
+  }
+
   void emitTypedIsolationCrossing(SILLocation loc, Type inferredType,
                                   ApplyIsolationCrossing isolationCrossing) {
     diagnoseError(
@@ -843,7 +856,7 @@ struct UseAfterTransferDiagnosticInferrer::AutoClosureWalker : ASTWalker {
       : foundTypeInfo(foundTypeInfo), targetDecl(targetDecl),
         targetDeclIsolationInfo(targetDeclIsolationInfo) {}
 
-  Expr *lookThroughExpr(Expr *expr) {
+  Expr *lookThroughArgExpr(Expr *expr) {
     while (true) {
       if (auto *memberRefExpr = dyn_cast<MemberRefExpr>(expr)) {
         expr = memberRefExpr->getBase();
@@ -871,67 +884,85 @@ struct UseAfterTransferDiagnosticInferrer::AutoClosureWalker : ASTWalker {
 
   PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
     if (auto *declRef = dyn_cast<DeclRefExpr>(expr)) {
-      // If this decl ref expr was not visited as part of a callExpr, add it as
-      // something without isolation crossing.
+      // If this decl ref expr was not visited as part of a callExpr and is our
+      // target decl... emit a simple async let error.
       if (!visitedCallExprDeclRefExprs.count(declRef)) {
         if (declRef->getDecl() == targetDecl) {
-          visitedCallExprDeclRefExprs.insert(declRef);
           foundTypeInfo.diagnosticEmitter
-              .emitTypedRaceWithUnknownIsolationCrossing(
-                  foundTypeInfo.baseLoc, declRef->findOriginalType());
+              .emitNamedAsyncLetNoIsolationCrossingError(
+                  foundTypeInfo.baseLoc, targetDecl->getBaseIdentifier());
           return Action::Continue(expr);
         }
       }
     }
 
+    // If we have a call expr, see if any of its arguments will cause our sent
+    // value to be transferred into another isolation domain.
     if (auto *callExpr = dyn_cast<CallExpr>(expr)) {
-      if (auto isolationCrossing = callExpr->getIsolationCrossing()) {
-        // Search callExpr's arguments to see if we have our targetDecl.
-        auto *argList = callExpr->getArgs();
-        for (auto pair : llvm::enumerate(argList->getArgExprs())) {
-          auto *arg = lookThroughExpr(pair.value());
-          if (auto *declRef = dyn_cast<DeclRefExpr>(arg)) {
-            if (declRef->getDecl() == targetDecl) {
-              // Found our target!
-              visitedCallExprDeclRefExprs.insert(declRef);
+      // Search callExpr's arguments to see if we have our targetDecl.
+      auto *argList = callExpr->getArgs();
+      for (auto pair : llvm::enumerate(argList->getArgExprs())) {
+        auto *arg = lookThroughArgExpr(pair.value());
+        auto *declRef = dyn_cast<DeclRefExpr>(arg);
+        if (!declRef)
+          continue;
 
-              // See if we can find a valueDecl/name for our callee so we can
-              // emit a nicer error.
-              ConcreteDeclRef concreteDecl =
-                  callExpr->getDirectCallee()->getReferencedDecl();
+        if (declRef->getDecl() != targetDecl)
+          continue;
 
-              // If we do not find a direct one, see if we are calling a method
-              // on a nominal type.
-              if (!concreteDecl) {
-                if (auto *dot = dyn_cast<DotSyntaxCallExpr>(
-                        callExpr->getDirectCallee())) {
-                  concreteDecl = dot->getSemanticFn()->getReferencedDecl();
-                }
-              }
+        // Found our target!
+        visitedCallExprDeclRefExprs.insert(declRef);
 
-              if (concreteDecl) {
-                auto *valueDecl = concreteDecl.getDecl();
-                assert(valueDecl &&
-                       "Should be non-null if concreteDecl is valid");
-                if (valueDecl->hasName()) {
-                  foundTypeInfo.diagnosticEmitter
-                      .emitNamedIsolationCrossingError(
-                          foundTypeInfo.baseLoc,
-                          targetDecl->getBaseIdentifier(),
-                          targetDeclIsolationInfo, *isolationCrossing,
-                          valueDecl->getName(),
-                          valueDecl->getDescriptiveKind());
-                  return Action::Continue(expr);
-                }
-              }
+        auto isolationCrossing = callExpr->getIsolationCrossing();
 
-              // Otherwise default back to the "callee" error.
-              foundTypeInfo.diagnosticEmitter.emitNamedIsolationCrossingError(
-                  foundTypeInfo.baseLoc, targetDecl->getBaseIdentifier(),
-                  targetDeclIsolationInfo, *isolationCrossing);
-              return Action::Continue(expr);
-            }
+        // If we do not have an isolation crossing, then we must be just sending
+        // a value in a nonisolated fashion into an async let. So emit the
+        // simple async let error.
+        if (!isolationCrossing) {
+          foundTypeInfo.diagnosticEmitter
+              .emitNamedAsyncLetNoIsolationCrossingError(
+                  foundTypeInfo.baseLoc, targetDecl->getBaseIdentifier());
+          continue;
+        }
+
+        // Otherwise, we are calling an actor isolated function in the async
+        // let. Emit a better error.
+
+        // See if we can find a valueDecl/name for our callee so we can
+        // emit a nicer error.
+        ConcreteDeclRef concreteDecl =
+            callExpr->getDirectCallee()->getReferencedDecl();
+
+        // If we do not find a direct one, see if we are calling a method
+        // on a nominal type.
+        if (!concreteDecl) {
+          if (auto *dot =
+                  dyn_cast<DotSyntaxCallExpr>(callExpr->getDirectCallee())) {
+            concreteDecl = dot->getSemanticFn()->getReferencedDecl();
           }
+        }
+
+        if (!concreteDecl)
+          continue;
+
+        auto *valueDecl = concreteDecl.getDecl();
+        assert(valueDecl && "Should be non-null if concreteDecl is valid");
+
+        if (auto isolationCrossing = callExpr->getIsolationCrossing()) {
+          // If we have an isolation crossing, use that information.
+          if (valueDecl->hasName()) {
+            foundTypeInfo.diagnosticEmitter.emitNamedIsolationCrossingError(
+                foundTypeInfo.baseLoc, targetDecl->getBaseIdentifier(),
+                targetDeclIsolationInfo, *isolationCrossing,
+                valueDecl->getName(), valueDecl->getDescriptiveKind());
+            continue;
+          }
+
+          // Otherwise default back to the "callee" error.
+          foundTypeInfo.diagnosticEmitter.emitNamedIsolationCrossingError(
+              foundTypeInfo.baseLoc, targetDecl->getBaseIdentifier(),
+              targetDeclIsolationInfo, *isolationCrossing);
+          continue;
         }
       }
     }

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -677,7 +677,7 @@ public:
   }
 
   void emitUnknownPatternError() {
-    if (AbortOnUnknownPatternMatchError) {
+    if (shouldAbortOnUnknownPatternMatchError()) {
       llvm::report_fatal_error(
           "RegionIsolation: Aborting on unknown pattern match error");
     }
@@ -1094,7 +1094,7 @@ void TransferNonSendableImpl::emitUseAfterTransferDiagnostics() {
     // tells the user to file a bug. This importantly ensures that we can
     // guarantee that we always find the require if we successfully compile.
     if (!didEmitRequireNote) {
-      if (AbortOnUnknownPatternMatchError) {
+      if (shouldAbortOnUnknownPatternMatchError()) {
         llvm::report_fatal_error(
             "RegionIsolation: Aborting on unknown pattern match error");
       }
@@ -1157,7 +1157,7 @@ public:
   }
 
   void emitUnknownPatternError() {
-    if (AbortOnUnknownPatternMatchError) {
+    if (shouldAbortOnUnknownPatternMatchError()) {
       llvm::report_fatal_error(
           "RegionIsolation: Aborting on unknown pattern match error");
     }
@@ -1647,7 +1647,7 @@ struct DiagnosticEvaluator final
   }
 
   void handleUnknownCodePattern(const PartitionOp &op) const {
-    if (AbortOnUnknownPatternMatchError) {
+    if (shouldAbortOnUnknownPatternMatchError()) {
       llvm::report_fatal_error(
           "RegionIsolation: Aborting on unknown pattern match error");
     }

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -8,8 +8,8 @@
 ////////////////////////
 
 /// Classes are always non-sendable, so this is non-sendable
-class NonSendableKlass { // expected-complete-note 96{{}}
-  // expected-tns-note @-1 {{}}
+class NonSendableKlass {
+  // expected-note @-1 {{}}
   var field: NonSendableKlass? = nil
   var field2: NonSendableKlass? = nil
 
@@ -53,7 +53,7 @@ struct SingleFieldKlassBox {
   var k = NonSendableKlass()
 }
 
-struct TwoFieldKlassBox { // expected-complete-note 24{{}}
+struct TwoFieldKlassBox {
   var k1 = NonSendableKlass()
   var k2 = NonSendableKlass()
 }
@@ -64,30 +64,26 @@ struct TwoFieldKlassBox { // expected-complete-note 24{{}}
 
 func asyncLet_Let_ActorIsolated_Simple1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_Simple2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+
   let _ = await y
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
 }
 
 func asyncLet_Let_ActorIsolated_Simple3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // TODO: We shouldn't emit the 2nd error here given the current implementation
   // since it is only accessible along the else path but we already hit
@@ -97,36 +93,34 @@ func asyncLet_Let_ActorIsolated_Simple3() async {
   if await booleanFlag {
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{access can happen concurrently}}
+    useValue(x) // expected-note {{access can happen concurrently}}
   }
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
 }
 
 func asyncLet_Let_ActorIsolated_Simple4() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
   if await booleanFlag {
-    useValue(x) // expected-tns-note {{access can happen concurrently}}
+    useValue(x) // expected-note {{access can happen concurrently}}
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{access can happen concurrently}}
+    useValue(x) // expected-note {{access can happen concurrently}}
   }
 }
 
 func asyncLet_Let_ActorIsolated_Simple5() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
   if await booleanFlag {
     let _ = await y
-    useValue(x) // expected-tns-note {{access can happen concurrently}}
+    useValue(x) // expected-note {{access can happen concurrently}}
   } else {
-    useValue(x) // expected-tns-note {{access can happen concurrently}}
+    useValue(x) // expected-note {{access can happen concurrently}}
   }
 }
 
@@ -134,31 +128,28 @@ func asyncLet_Let_ActorIsolated_Simple5() async {
 // async let rather than the base class.
 func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x.field) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x.field) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x.field) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x.field) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x.field2) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x.field) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x.field2) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
@@ -166,41 +157,37 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x.k1) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x.k1) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x.k2) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x.k2) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x.k1.field) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x.k2.field2) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x.k1.field) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
@@ -208,45 +195,37 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x.0.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.1) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x.0.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x.1) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.1.k2) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x.0.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x.1.k2) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.0.k2.field) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToMainInt(x.1.k1.field2) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x.0.k2.field) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
@@ -254,34 +233,28 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr1() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{sending 'x2' risks causing data races}}
-  // expected-tns-note @-3 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-2 {{sending 'x2' risks causing data races}}
+  // expected-note @-3 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
-  useValue(x2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x2) // expected-note {{access can happen concurrently}}
 }
 
 func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{sending 'x2' risks causing data races}}
-  // expected-tns-note @-3 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x2) // expected-tns-note {{access can happen concurrently}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-2 {{sending 'x2' risks causing data races}}
+  // expected-note @-3 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(x2) // expected-note {{access can happen concurrently}}
   let _ = await y
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
 }
 
 // Make sure we emit separate errors for x and x2.
@@ -289,19 +262,15 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{sending 'x2' risks causing data races}}
-  // expected-tns-note @-3 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-2 {{sending 'x2' risks causing data races}}
+  // expected-note @-3 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   // We only error on the first value captured if multiple values are captured
   // since we track a single partial_apply as a transfer instruction.
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
-  useValue(x2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
+  useValue(x2) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
@@ -310,13 +279,20 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
 func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-note @-2:67 {{access can happen concurrently}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x))
 
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  let _ = await y
+}
+
+// Make sure that we do emit an error since we are sending the value to two
+// different isolation domains in the async let.
+func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr5() async {
+  let x = NonSendableKlass()
+
+  async let y = useValue(transferToMainInt(x) + transferToCustomInt(x))
+  // expected-warning @-1 {{sending 'x' risks causing data races}}
+  // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-3:49 {{access can happen concurrently}}
 
   let _ = await y
 }
@@ -326,14 +302,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-note @-2:53 {{access can happen concurrently}}
-
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-note @-2:53 {{access can happen concurrently}}
 
   let _ = await y
   let _ = await z
@@ -345,10 +316,6 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet2() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-3 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let _ = await y
   let _ = await z
@@ -359,15 +326,10 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{sending 'x2' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-1 {{sending 'x2' risks causing data races}}
+  // expected-note @-2 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
 
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-
-  useValue(x2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x2) // expected-note {{access can happen concurrently}}
   let _ = await y
   let _ = await z
 }
@@ -377,19 +339,15 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{sending 'x2' risks causing data races}}
-  // expected-tns-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}  
-  // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-7 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-8 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-warning @-1 {{sending 'x' risks causing data races}}
+  // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-3 {{sending 'x2' risks causing data races}}
+  // expected-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   let _ = await y
   let _ = await z
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
-  useValue(x2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
+  useValue(x2) // expected-note {{access can happen concurrently}}
 }
 
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
@@ -397,19 +355,15 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{sending 'x2' risks causing data races}}
-  // expected-tns-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-7 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-8 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-warning @-1 {{sending 'x' risks causing data races}}
+  // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-3 {{sending 'x2' risks causing data races}}
+  // expected-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   let _ = await y
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await z
-  useValue(x2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x2) // expected-note {{access can happen concurrently}}
 }
 
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
@@ -417,19 +371,14 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{sending 'x2' risks causing data races}}
-  // expected-tns-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-
-  // expected-complete-warning @-6 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-8 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-9 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-warning @-1 {{sending 'x' risks causing data races}}
+  // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-warning @-3 {{sending 'x2' risks causing data races}}
+  // expected-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   let _ = await y
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
-  useValue(x2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
+  useValue(x2) // expected-note {{access can happen concurrently}}
   let _ = await z
 }
 
@@ -439,18 +388,16 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
 
 func asyncLet_Let_NonIsolated_Simple1() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x)  // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x)  // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_NonIsolated_Simple2() async {
   let x = NonSendableKlass()
   async let y = transferToNonIsolatedInt(x)
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   let _ = await y
   useValue(x)
@@ -458,9 +405,8 @@ func asyncLet_Let_NonIsolated_Simple2() async {
 
 func asyncLet_Let_NonIsolated_Simple3() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
   // TODO: We shouldn't emit the 2nd error here given the current implementation
   // since it is only accessible along the else path but we already hit
@@ -470,36 +416,34 @@ func asyncLet_Let_NonIsolated_Simple3() async {
   if await booleanFlag {
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{access can happen concurrently}}
+    useValue(x) // expected-note {{access can happen concurrently}}
   }
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
 }
 
 func asyncLet_Let_NonIsolated_Simple4() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
   if await booleanFlag {
-    useValue(x) // expected-tns-note {{access can happen concurrently}}
+    useValue(x) // expected-note {{access can happen concurrently}}
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{access can happen concurrently}}
+    useValue(x) // expected-note {{access can happen concurrently}}
   }
 }
 
 func asyncLet_Let_NonIsolated_Simple5() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
   if await booleanFlag {
     let _ = await y
     useValue(x)
   } else {
-    useValue(x) // expected-tns-note {{access can happen concurrently}}
+    useValue(x) // expected-note {{access can happen concurrently}}
   }
 }
 
@@ -507,31 +451,28 @@ func asyncLet_Let_NonIsolated_Simple5() async {
 // async let rather than the base class.
 func asyncLet_Let_NonIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_NonIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
-  useValue(x.field) // expected-tns-note {{access can happen concurrently}}
+  useValue(x.field) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_NonIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
-  useValue(x.field2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x.field2) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
@@ -539,41 +480,37 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass3() async {
 // async let rather than the base struct.
 func asyncLet_Let_NonIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
-  useValue(x.k1) // expected-tns-note {{access can happen concurrently}}
+  useValue(x.k1) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
-  useValue(x.k2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x.k2) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k2.field2) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x.k2.field2) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
-  useValue(x.k1.field) // expected-tns-note {{access can happen concurrently}}
+  useValue(x.k1.field) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
@@ -581,43 +518,37 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct4() async {
 // async let rather than the base struct.
 func asyncLet_Let_NonIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.1) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
+
+  useValue(x.1) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
-  useValue(x.1.k2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x.1.k2) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.1.k1.field2) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.0.k2.field) // expected-tns-note {{access can happen concurrently}}
+  async let y = transferToNonIsolatedInt(x.1.k1.field2) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
+
+  useValue(x.0.k2.field) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
@@ -625,11 +556,10 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr1() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
+
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
   useValue(x2)
 }
@@ -638,11 +568,10 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr2() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending 'x2' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  useValue(x2) // expected-tns-note {{access can happen concurrently}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-warning {{sending 'x2' risks causing data races}}
+  // expected-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
+
+  useValue(x2) // expected-note {{access can happen concurrently}}
   let _ = await y
   useValue(x)
 }
@@ -652,18 +581,15 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending 'x2' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
-  // expected-tns-warning @-2 {{sending 'x' risks causing data races}}
-  // expected-tns-note @-3 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-warning {{sending 'x2' risks causing data races}}
+  // expected-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
+  // expected-warning @-2 {{sending 'x' risks causing data races}}
+  // expected-note @-3 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
   // We only error on the first value captured if multiple values are captured
   // since we track a single partial_apply as a transfer instruction.
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
-  useValue(x2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x) // expected-note {{access can happen concurrently}}
+  useValue(x2) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
 
@@ -673,7 +599,6 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr4() async {
   let x = NonSendableKlass()
 
   async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x))
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   let _ = await y
 }
@@ -683,12 +608,9 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr4() async {
 func asyncLet_Let_NonIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x)) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-tns-note @-2:60 {{access can happen concurrently}}
-
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x)) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
+  // expected-note @-2:60 {{access can happen concurrently}}
 
   let _ = await y
   let _ = await z
@@ -700,8 +622,6 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet2() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   let _ = await y
   let _ = await z
@@ -711,13 +631,10 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending 'x2' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2)) // expected-warning {{sending 'x2' risks causing data races}}
+  // expected-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
 
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-
-  useValue(x2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x2) // expected-note {{access can happen concurrently}}
   let _ = await y
   let _ = await z
 }
@@ -727,8 +644,6 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet4() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   let _ = await y
   let _ = await z
@@ -741,8 +656,6 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet5() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   let _ = await y
   useValue(x)
@@ -754,15 +667,12 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet6() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending 'x2' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
-
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2)) // expected-warning {{sending 'x2' risks causing data races}}
+  // expected-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
 
   let _ = await y
   useValue(x)
-  useValue(x2) // expected-tns-note {{access can happen concurrently}}
+  useValue(x2) // expected-note {{access can happen concurrently}}
   let _ = await z
 }
 
@@ -772,18 +682,17 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet6() async {
 
 func asyncLet_Let_NormalUse_Simple1() async {
   let x = NonSendableKlass()
-  async let y = x // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
-  let _ = await y
+  async let y = x // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
+  useValue(x) // expected-note {{access can happen concurrently}}
+  let _ = await y
 }
 
 func asyncLet_Let_NormalUse_Simple2() async {
   let x = NonSendableKlass()
   async let y = x
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
   let _ = await y
   useValue(x)
 }
@@ -795,19 +704,18 @@ func asyncLetWithoutCapture() async {
   async let x: NonSendableKlass = await returnValueFromMain()
   // expected-warning @-1 {{non-sendable type 'NonSendableKlass' returned by implicitly asynchronous call to main actor-isolated function cannot cross actor boundary}}
   let y = await x
-  await transferToMain(y) // expected-tns-warning {{sending 'y' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(y) // expected-tns-note {{access can happen concurrently}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  useValue(y) // expected-note {{access can happen concurrently}}
 }
 
 func asyncLet_Let_ActorIsolated_Method() async {
   let a = Actor()
   let x = NonSendableKlass()
-  async let y = a.useKlass(x) // expected-tns-warning {{sending 'x' risks causing data races}}
-  // expected-tns-note @-1 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{access can happen concurrently}}
+  async let y = a.useKlass(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+
+  useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
 }

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -439,7 +439,8 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
 
 func asyncLet_Let_NonIsolated_Simple1() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x)  // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x) // expected-tns-note {{access can happen concurrently}}
@@ -457,7 +458,8 @@ func asyncLet_Let_NonIsolated_Simple2() async {
 
 func asyncLet_Let_NonIsolated_Simple3() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   // TODO: We shouldn't emit the 2nd error here given the current implementation
@@ -475,7 +477,8 @@ func asyncLet_Let_NonIsolated_Simple3() async {
 
 func asyncLet_Let_NonIsolated_Simple4() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   if await booleanFlag {
@@ -488,7 +491,8 @@ func asyncLet_Let_NonIsolated_Simple4() async {
 
 func asyncLet_Let_NonIsolated_Simple5() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   if await booleanFlag {
@@ -503,7 +507,8 @@ func asyncLet_Let_NonIsolated_Simple5() async {
 // async let rather than the base class.
 func asyncLet_Let_NonIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x) // expected-tns-note {{access can happen concurrently}}
@@ -512,7 +517,8 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass1() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x.field) // expected-tns-note {{access can happen concurrently}}
@@ -521,7 +527,8 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass2() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x.field2) // expected-tns-note {{access can happen concurrently}}
@@ -532,7 +539,8 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass3() async {
 // async let rather than the base struct.
 func asyncLet_Let_NonIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x) // expected-tns-note {{access can happen concurrently}}
@@ -541,7 +549,8 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct1() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x.k1) // expected-tns-note {{access can happen concurrently}}
@@ -550,7 +559,8 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct2() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x.k2) // expected-tns-note {{access can happen concurrently}}
@@ -559,7 +569,8 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct3() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k2.field2) // expected-tns-warning {{sending value of non-Sendable type 'TwoFieldKlassBox' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x.k2.field2) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x.k1.field) // expected-tns-note {{access can happen concurrently}}
@@ -570,7 +581,8 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct4() async {
 // async let rather than the base struct.
 func asyncLet_Let_NonIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -580,7 +592,8 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple1() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   useValue(x.1) // expected-tns-note {{access can happen concurrently}}
@@ -589,7 +602,8 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple2() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
 
@@ -599,7 +613,8 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple3() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.1.k1.field2) // expected-tns-warning {{sending value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' with later accesses risks causing data races}}
+  async let y = transferToNonIsolatedInt(x.1.k1.field2) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   useValue(x.0.k2.field) // expected-tns-note {{access can happen concurrently}}
@@ -610,7 +625,8 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr1() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   useValue(x) // expected-tns-note {{access can happen concurrently}}
@@ -622,7 +638,8 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr2() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending 'x2' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   useValue(x2) // expected-tns-note {{access can happen concurrently}}
@@ -635,8 +652,10 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
-  // expected-tns-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending 'x2' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
+  // expected-tns-warning @-2 {{sending 'x' risks causing data races}}
+  // expected-tns-note @-3 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -664,8 +683,9 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr4() async {
 func asyncLet_Let_NonIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x)) // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
-  // expected-tns-note @-1:60 {{access can happen concurrently}}
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x)) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
+  // expected-tns-note @-2:60 {{access can happen concurrently}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -691,8 +711,8 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
-  // expected-tns-warning @-1:60 {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending 'x2' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -734,8 +754,8 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet6() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
-  // expected-tns-warning @-1 {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2)) // expected-tns-warning {{sending 'x2' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x2' into async let risks causing data races between async let uses and local uses}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -752,7 +772,8 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet6() async {
 
 func asyncLet_Let_NormalUse_Simple1() async {
   let x = NonSendableKlass()
-  async let y = x // expected-tns-warning {{sending value of non-Sendable type 'NonSendableKlass' with later accesses risks causing data races}}
+  async let y = x // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{sending 'x' into async let risks causing data races between async let uses and local uses}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   useValue(x) // expected-tns-note {{access can happen concurrently}}
   let _ = await y


### PR DESCRIPTION
Explanation: This PR cleans up the async let diagnostic so that we emit a new style "named" error instead of a type based error.

Radars:

- rdar://130915737

Original PRs:

- https://github.com/swiftlang/swift/pull/74869
- https://github.com/swiftlang/swift/pull/74911

Risk: Low. Just modifies a diagnostic to improve readability and quality of implementation.
Testing: Added tests to the compiler.
Reviewer: @ktoso 