### PR TITLE
[android] Enable several C++ Interop and other tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,9 +414,9 @@ set(SWIFT_STDLIB_MSVC_RUNTIME_LIBRARY
 
 
 if(BRIDGING_MODE STREQUAL "DEFAULT" OR NOT BRIDGING_MODE)
-  if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR "${SWIFT_HOST_VARIANT_SDK}" MATCHES "WINDOWS|ANDROID" OR (CMAKE_Swift_COMPILER AND CMAKE_Swift_COMPILER_VERSION VERSION_LESS 5.8))
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS" OR (CMAKE_Swift_COMPILER AND CMAKE_Swift_COMPILER_VERSION VERSION_LESS 5.8))
     # In debug builds, to workaround a problem with LLDB's `po` command (rdar://115770255).
-    # On Windows and Android, to workaround a build problem.
+    # On Windows, to workaround a build problem.
     # If the host Swift version is less than 5.8, use pure mode to workaround a C++ interop compiler crash.
     set(BRIDGING_MODE "PURE")
   else()

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -31,12 +31,12 @@ Swift-to-Java bridging.
 To follow along with this guide, you'll need:
 
 1. A Linux environment capable of building Swift from source, preferably
-   Ubuntu 20.04 or Ubuntu 18.04. Before attempting to build for Android,
+   Ubuntu 22.04 or Ubuntu 20.04. Before attempting to build for Android,
    please make sure you are able to build for Linux by following the
    instructions in the Swift project README.
 2. The latest build of the Swift compiler for your Linux distro, available at
    https://www.swift.org/download/ or sometimes your distro package manager.
-3. The latest version of the Android LTS NDK (r26c at the time of this writing),
+3. The latest version of the Android LTS NDK (r26d at the time of this writing),
    available to download here:
    https://developer.android.com/ndk/downloads
 4. An Android device with remote debugging enabled or the emulator. We require
@@ -54,9 +54,9 @@ and the prebuilt Swift toolchain (add --skip-early-swift-driver if you already
 have a Swift toolchain in your path):
 
 ```
-$ NDK_PATH=path/to/android-ndk-r26c
-$ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2023-09-30-a-ubuntu20.04/usr/bin
-$ git checkout swift-DEVELOPMENT-SNAPSHOT-2023-09-30-a
+$ NDK_PATH=path/to/android-ndk-r26d
+$ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2024-07-09-a-ubuntu22.04/usr/bin
+$ git checkout swift-DEVELOPMENT-SNAPSHOT-2024-07-09-a
 $ utils/build-script \
     -R \                                       # Build in ReleaseAssert mode.
     --android \                                # Build for Android.
@@ -83,8 +83,8 @@ Then use the standalone Swift stdlib from the previous step to compile a Swift
 source file, targeting Android:
 
 ```
-$ NDK_PATH="path/to/android-ndk-r26c"
-$ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2023-09-30-a-ubuntu20.04/usr/bin
+$ NDK_PATH="path/to/android-ndk-r26d"
+$ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2024-07-09-a-ubuntu22.04/usr/bin
 $ $SWIFT_PATH/swiftc \                                               # The prebuilt Swift compiler you downloaded
                                                                      # The location of the tools used to build Android binaries
     -tools-directory ${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/ \
@@ -133,7 +133,7 @@ $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libBlo
 In addition, you'll also need to copy the Android NDK's libc++:
 
 ```
-$ adb push /path/to/android-ndk-r26c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so /data/local/tmp
+$ adb push /path/to/android-ndk-r26d/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so /data/local/tmp
 ```
 
 Finally, you'll need to copy the `hello` executable you built in the
@@ -176,8 +176,8 @@ $ utils/build-script \
   -R \                               # Build in ReleaseAssert mode.
   -T \                               # Run all tests, including on the Android device (add --host-test to only run Android tests on the Linux host).
   --android \                        # Build for Android.
-  --android-ndk ~/android-ndk-r26c \  # Path to an Android NDK.
-  --android-arch aarch64 \           # Optionally specify Android architecture, alternately armv7
+  --android-ndk ~/android-ndk-r26d \  # Path to an Android NDK.
+  --android-arch aarch64 \           # Optionally specify Android architecture, alternately armv7 or x86_64
   --android-api-level 21
 ```
 

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_dispatch_dispatchMain_swift_6_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_dispatch_dispatchMain_swift_6_mode.swift
@@ -22,6 +22,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 @main struct Main {

--- a/test/Interop/Cxx/class/custom-new-operator-irgen.swift
+++ b/test/Interop/Cxx/class/custom-new-operator-irgen.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir | %FileCheck %s
 
-// XFAIL: OS=linux-android, OS=linux-androideabi
-
 import CustomNewOperator
 
 var x = callsCustomNew()

--- a/test/Interop/Cxx/class/memory-layout-silgen.swift
+++ b/test/Interop/Cxx/class/memory-layout-silgen.swift
@@ -1,8 +1,5 @@
 // RUN: %target-swiftxx-frontend -I %S/Inputs -emit-ir -o - %s | %FileCheck %s
 
-// XFAIL: OS=linux-android
-// XFAIL: OS=linux-androideabi
-
 import MemoryLayout
 
 var v = PrivateMemberLayout()

--- a/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import MoveOnly
 

--- a/test/Interop/Cxx/foreign-reference/move-only-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-module-interface.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnly -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // CHECK: class MoveOnly {
 // CHECK-NOT: init

--- a/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import MoveOnly
 

--- a/test/Interop/Cxx/foreign-reference/nullable-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/nullable-module-interface.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=Nullable -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // CHECK: class Empty {
 // CHECK:   func test() -> Int32

--- a/test/Interop/Cxx/foreign-reference/pod-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-irgen.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import POD
 

--- a/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=POD -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // CHECK: class Empty {
 // CHECK-NOT: init

--- a/test/Interop/Cxx/foreign-reference/pod-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-silgen.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import POD
 

--- a/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-irgen.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-irgen %s -I %S/Inputs -cxx-interoperability-mode=default -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
-// XFAIL: OS=linux-android, OS=linux-androideabi
 // XFAIL: OS=windows-msvc
 
 import ReferenceCounted

--- a/test/Interop/Cxx/foreign-reference/reference-counted-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-silgen.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import POD
 import ReferenceCounted

--- a/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import Singleton
 

--- a/test/Interop/Cxx/foreign-reference/singleton-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-module-interface.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=Singleton -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // CHECK: class DeletedDtor {
 // CHECK-NOT: init

--- a/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import Singleton
 

--- a/test/Interop/SwiftToCxx/core/unsigned-return-type-no-zext.cpp
+++ b/test/Interop/SwiftToCxx/core/unsigned-return-type-no-zext.cpp
@@ -4,7 +4,6 @@
 // RUN: %FileCheck %s < %t/ir.ll
 
 // UNSUPPORTED: OS=windows-msvc
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 unsigned char getEnumTagi8(void *p);
 unsigned getEnumTagi32(void *p);

--- a/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
@@ -7,8 +7,6 @@
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -fsyntax-only -c %t/test-stdlib.cpp -I %t -Wall -Werror -Werror=ignored-attributes -Wno-error=unused-command-line-argument
 
-// XFAIL: OS=linux-android, OS=linux-androideabi
-
 //--- print-string.swift
 
 public func printString(_ s: String) {

--- a/test/Interop/SwiftToCxxToSwift/hide-swift-module-namespace-in-swift.swift
+++ b/test/Interop/SwiftToCxxToSwift/hide-swift-module-namespace-in-swift.swift
@@ -11,8 +11,6 @@
 
 // RUN: %target-swift-ide-test -print-module -module-to-print=SwiftToCxxTest -I %t -source-filename=x -enable-experimental-cxx-interop -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR | %FileCheck --check-prefix=INTERFACE %s
 
-// XFAIL: OS=linux-android, OS=linux-androideabi
-
 //--- header.h
 #ifndef FIRSTPASS
 #include "swiftMod.h"

--- a/test/Interop/SwiftToCxxToSwift/import-swift-class-back-to-swift.swift
+++ b/test/Interop/SwiftToCxxToSwift/import-swift-class-back-to-swift.swift
@@ -10,7 +10,6 @@
 // RUN: %target-swift-frontend -typecheck %t/swiftMod.swift -typecheck -module-name SwiftMod -I %t -enable-experimental-cxx-interop -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR -DSECOND_PASS -emit-sil -o - | %FileCheck --check-prefix=SIL %s
 
 // UNSUPPORTED: OS=windows-msvc
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 //--- header.h
 #ifndef FIRSTPASS

--- a/test/Interpreter/llvm_link_time_opt.swift
+++ b/test/Interpreter/llvm_link_time_opt.swift
@@ -1,8 +1,6 @@
 // UNSUPPORTED: OS=windows-msvc
 // static library is not well supported yet on Windows
 
-// XFAIL: OS=linux-android, OS=linux-androideabi
-
 // UNSUPPORTED: OS=xros
 
 // For LTO, the linker dlopen()'s the libLTO library, which is a scenario that

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -177,6 +177,10 @@ if platform.system() == 'Darwin':
 # NOTE: this mirrors the kIsWindows from lit.lit.TestRunner in LLVM
 kIsWindows = platform.system() == 'Windows'
 
+# The global environment in Android sets ANDROID_DATA, so if that variable is
+# set, we are probably running in Android.
+kIsAndroid = 'ANDROID_DATA' in os.environ
+
 # testFormat: The test format to use to interpret tests.
 
 # Choose between lit's internal shell pipeline runner and a real shell.  If
@@ -422,6 +426,11 @@ if run_os.startswith('wasi'):
 
 # Parse the host triple
 (host_cpu, host_vendor, host_os, host_vers) = re.match('([^-]+)-([^-]+)-([^0-9-]+)(.*)', config.host_triple).groups()
+
+# Manually set the host OS on Android, because the host OS from the triple says
+# `linux`.
+if kIsAndroid:
+    host_os = 'android'
 
 if f"{host_cpu}-{host_vendor}-{host_os}" == f"{run_cpu}-{run_vendor}-{run_os}":
     # Ignore the version on purpose, to account for scenario
@@ -1123,10 +1132,6 @@ if platform.system() == 'Darwin' and (run_os == 'macosx' or run_os == 'darwin'):
 elif platform.system() == 'Linux':
     if swift_test_mode != 'only_non_executable':
       config.available_features.add('swift_interpreter')
-
-# The global environment in Android sets ANDROID_DATA, so if that variable is
-# set, we are probably running in Android.
-kIsAndroid = 'ANDROID_DATA' in os.environ
 
 # swift-remoteast-test requires the ability to compile and run code
 # for the system we compiled the swift-remoteast-test executable on.
@@ -2465,8 +2470,12 @@ elif not kIsWindows and not run_os == 'wasi':
         lit_config.note('Testing with the just-built libraries')
 
     lit_config.note('Library load path: {0}'.format(os.path.pathsep.join(target_stdlib_path)))
+    env_path = "/usr/bin/env "
+    # Android doesn't have /usr/bin/
+    if kIsAndroid:
+      env_path = "/bin/env "
     config.target_run = (
-        "/usr/bin/env " +
+        env_path +
         construct_library_path_env(target_stdlib_path) +
         config.target_run)
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1393,7 +1393,7 @@ def create_argument_parser():
 
     option('--android-arch', store,
            choices=['armv7', 'aarch64', 'x86_64'],
-           default='armv7',
+           default='aarch64',
            help='The target architecture when building for Android. '
                 'Currently, only armv7, aarch64, and x86_64 are supported. '
                 '%(default)s is the default.')

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -41,7 +41,7 @@ EXPECTED_DEFAULTS = {
     'android_api_level': '21',
     'android_deploy_device_path': '/data/local/tmp',
     'android_ndk': None,
-    'android_arch': 'armv7',
+    'android_arch': 'aarch64',
     'assertions': True,
     'benchmark': False,
     'benchmark_num_o_iterations': 3,
@@ -764,7 +764,7 @@ EXPECTED_OPTIONS = [
     ChoicesOption('--swift-analyze-code-coverage',
                   choices=['false', 'not-merged', 'merged']),
     ChoicesOption('--android-arch',
-                  choices=['armv7', 'aarch64']),
+                  choices=['armv7', 'aarch64', 'x86_64']),
 
     StrOption('--android-api-level'),
     StrOption('--build-args'),


### PR DESCRIPTION
Also, update NDK and Ubuntu versions to the latest in the Android doc, enable inline bridging when building the compiler for Android, and update the default arch set by `build-script` to AArch64, as that is by far the most commonly used now.

These C++ Interop tests were all disabled over the years because of build errors with the Android NDK, but @hyp's recent pull #72161 adding a modularized Bionic module map fixed them and the inline bridging issue in the compiler itself. Alex, let me know if these tests all pass for you too.

@drodriguez, perhaps you'd like to take a look at this pull too.