### PR TITLE
[Parse] Add fix-it for unknown isolation in `@isolated`

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4850,11 +4850,12 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
       kind = IsolatedTypeAttr::IsolationKind::Dynamic;
 
     // Add new kinds of isolation here; be sure to update the text for
-    // attr_isolated_expected_kind.
+    // attr_isolated_expected_kind, and change the associated fix-it below.
 
     } else {
       if (!justChecking) {
-        diagnose(Tok, diag::attr_isolated_expected_kind);
+        diagnose(Tok, diag::attr_isolated_expected_kind)
+          .fixItReplace(Tok.getLoc(), "any");
       }
       invalid = true;
       consumeIf(tok::identifier);

--- a/test/Parse/isolated_any.swift
+++ b/test/Parse/isolated_any.swift
@@ -10,3 +10,6 @@ func testLookahead() {
   let array = [@isolated(any) () -> ()]()
   _ = array
 }
+
+func testInvalidIsolation(_ x: @isolated(foo) () -> Void) {}
+// expected-error@-1 {{expected 'any' as the isolation kind}} {{42-45=any}}


### PR DESCRIPTION
Currently `any` is the only supported kind, so we can suggest that.

rdar://130287211