### PR TITLE
Fix two problems with `-cross-module-optimization`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -355,6 +355,9 @@ private extension Value {
 private extension Function {
   /// Analyzes the global initializer function and returns global it initializes (from `alloc_global` instruction).
   func getInitializedGlobal() -> GlobalVariable? {
+    if !isDefinition {
+      return nil
+    }
     for inst in self.entryBlock.instructions {
       switch inst {
       case let agi as AllocGlobalInst:

--- a/test/SILOptimizer/Inputs/cross-module/cross-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/cross-module.swift
@@ -287,6 +287,12 @@ public func callCImplementationOnly<T>(_ t: T) -> Int {
 
 public let globalLet = 529387
 
+private var privateVar = Int.random(in: 0..<100)
+
+public func getRandom() -> Int {
+  return privateVar
+}
+
 public struct StructWithClosure {
   public static let c = { (x: Int) -> Int in return x }
 }

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -165,6 +165,12 @@ func testImplementationOnly() {
   // CHECK-SIL2: } // end sil function '$s4Main22testImplementationOnlyyyF'
 }
 
+@inline(never)
+func testPrivateVar() {
+  // CHECK-OUTPUT: {{[0-9]+}}
+  print(getRandom())
+}
+
 testNestedTypes()
 testClass()
 testError()
@@ -175,4 +181,5 @@ testKeypath()
 testMisc()
 testGlobal()
 testImplementationOnly()
+testPrivateVar()
 

--- a/test/SILOptimizer/mandatory_performance_optimizations.sil
+++ b/test/SILOptimizer/mandatory_performance_optimizations.sil
@@ -167,6 +167,11 @@ bb0:
   return %6 : $()
 }
 
+// Check that we don't crash on global init-once declarations.
+
+// CHECK-LABEL: sil [global_init_once_fn] [no_locks] @external_global_init_once : $@convention(c) () -> ()
+sil [global_init_once_fn] [no_locks] @external_global_init_once : $@convention(c) () -> ()
+
 sil @yield_int_value : $@convention(thin) @yield_once () -> (@yields Int32) {
 bb0:
   %0 = integer_literal $Builtin.Int32, 10


### PR DESCRIPTION
* MandatoryPerformanceOptimizations: don't crash with empty global-init-once functions

Instead ignore empty global-init-once functions

* Deserializer: fix a crash with global variables and cross-module-optimization

In case of cross-module-optimizations it can happen that a private global variable is changed to public,
but it's declaration is not available in the module file.

Fixes https://github.com/swiftlang/swift/issues/73487
rdar://130406651