### PR TITLE
[Runtime] Use dyld to find the image path when possible.

### DIFF
--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #if !defined(_WIN32) || defined(__CYGWIN__)
+
 #if __has_include(<sys/stat.h>)
 #  include <sys/stat.h>
 
@@ -42,12 +43,21 @@
  #include <dlfcn.h>
 #endif
 
+#if __has_include(<mach-o/dyld_priv.h>)
+#include <mach-o/dyld_priv.h>
+#define APPLE_OS_SYSTEM 1
 #else
+#define APPLE_OS_SYSTEM 0
+#endif
+
+#else // defined(_WIN32)
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
 #include <psapi.h>
-#endif
+
+#endif // defined(_WIN32)
 
 #include <cerrno>
 #include <cstdlib>
@@ -519,7 +529,9 @@ _swift_initRuntimePath(void *) {
 #if APPLE_OS_SYSTEM
   const char *path = dyld_image_path_containing_address(_swift_initRuntimePath);
 
-  runtimePath = ::strdup(path);
+  // No need to ::strdup() this, as the return value is guaranteed to remain
+  // valid as long as the library is loaded.
+  runtimePath = path;
 #elif SWIFT_STDLIB_HAS_DLADDR
   Dl_info dli;
   int ret = ::dladdr((void *)_swift_initRuntimePath, &dli);


### PR DESCRIPTION
For performance reasons, we want to avoid `dladdr()` when possible.

rdar://130954606
