### PR TITLE
[Distributed] Avoid emitting distributed witness tbd visiting a protocol decl

### DIFF
--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -210,6 +210,10 @@ private:
     if (!thunk)
       return;
 
+    auto DC = AFD->getDeclContext();
+    if (isa<ProtocolDecl>(DC))
+      return;
+
     SILDeclRef declRef(thunk, kind);
     asDerived().addMethod(declRef.asDistributed());
   }


### PR DESCRIPTION
Seems that otherwise we end up in duplicate definitions like these

```
TBDGen duplicate symbol: _$s21...descriptionVG..._tYaKFTj
Assertion failed: (false && "TBDGen symbol appears twice"), function addSymbolInternal, file TBDGen.cpp, line 82.
```