### PR TITLE
Fix a SourceKitCrash in the VTableSpecializer pass

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -374,6 +374,8 @@ ERROR(global_must_be_compile_time_const,none,
       "global variable must be a compile-time constant", ())
 ERROR(non_final_generic_class_function,none,
       "classes cannot have non-final generic fuctions in embedded Swift", ())
+ERROR(cannot_specialize_class,none,
+      "cannot specialize %0 because class definition is not available (make sure to build with -wmo)", (Type))
 ERROR(embedded_swift_existential_type,none,
       "cannot use a value of protocol type %0 in embedded Swift", (Type))
 ERROR(embedded_swift_existential,none,

--- a/lib/SILOptimizer/Transforms/VTableSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/VTableSpecializer.cpp
@@ -165,9 +165,12 @@ SILVTable *swift::specializeVTableForType(SILType classTy, SILModule &module,
   ClassDecl *classDecl = genClassTy->getDecl();
   SILVTable *origVtable = module.lookUpVTable(classDecl);
   if (!origVtable) {
-    llvm::errs() << "No vtable available for "
-                 << genClassTy->getDecl()->getName() << '\n';
-    llvm::report_fatal_error("no vtable");
+    // This cannot occur in regular builds - only if built without wmo, which
+    // can only happen in SourceKit.
+    // Not ideal, but better than a SourceKit crash.
+    module.getASTContext().Diags.diagnose(
+        SourceLoc(), diag::cannot_specialize_class, classTy.getASTType());
+    return nullptr;
   }
 
   SubstitutionMap subs = astType->getContextSubstitutionMap(

--- a/test/SourceKit/Misc/embedded_no_wmo.swift
+++ b/test/SourceKit/Misc/embedded_no_wmo.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// TODO: This test passes locally on my machine, but fails for an unknown reason in CI
+// REQUIRES: rdar130167087
+
+//--- secondary.swift
+
+final public class X<T> {
+  var x: T
+
+  init(_ t: T) { x = t}
+
+  public func foo() -> T { x }
+}
+
+//--- primary.swift
+
+// RUN: %sourcekitd-test  -req=diags %t/primary.swift -- %t/primary.swift %t/secondary.swift -enable-experimental-feature Embedded
+
+// check that SourceKit does not crash on this
+
+public func testit() -> X<Int> {
+  return X(27)
+}
+


### PR DESCRIPTION
Replace the assert-check if a vtable is available with a regular error message. This cannot occur in regular builds - only if built with embedded swift and without wmo. The command line compiler prevents this combination, but it  can happen in SourceKit.

rdar://130167087
