### PR TITLE
[6.0] Deserializer: flush the diag engine to see a function type mismatch error

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -430,10 +430,11 @@ SILFunction *SILDeserializer::getFuncForReference(StringRef name,
         if (auto *decl = dyn_cast_or_null<AbstractFunctionDecl>(dc->getAsDecl()))
           fnName = decl->getNameStr();
       }
-      fn->getModule().getASTContext().Diags.diagnose(
-        fn->getLocation().getSourceLoc(),
-        diag::deserialize_function_type_mismatch,
-        fnName, fnType.getASTType(), type.getASTType());
+      auto &diags = fn->getModule().getASTContext().Diags;
+      diags.diagnose(fn->getLocation().getSourceLoc(),
+                     diag::deserialize_function_type_mismatch,
+                     fnName, fnType.getASTType(), type.getASTType());
+      diags.flushConsumers();
       exit(1);
     }
     return fn;

--- a/test/embedded/functype-mismatch.swift
+++ b/test/embedded/functype-mismatch.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend %s -enable-experimental-feature Embedded -wmo -emit-sil -o /dev/null 2>&1 | %FileCheck %s
+
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+
+// This is a mismatch compared to what's in the embedded stdlib
+@_silgen_name("putchar")
+// CHECK: type mismatch of function 'putchar'
+public func putchar(_ value: CInt, _ x: Int) -> CInt {
+  return 0
+}
+
+print("hello")


### PR DESCRIPTION
* **Explanation**: Fixes a not-printed error message. When such an error occurs the compiler just terminated with an exit code but not with an error message.
* **Risk**: Very low. The change only affects how this specific error message in the de-serializer is printed.
* **Testing**: Tested by a test case
* **Issue**: rdar://127767886
* **Reviewer**:  @kubamracek
* **Main branch PR**: https://github.com/swiftlang/swift/pull/73565
