### PR TITLE
[Sema] Let protocols define getter requirements for @_staticExclusiveOnly types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1995,6 +1995,8 @@ ERROR(attr_static_exclusive_only_let_only_param,none,
       "parameter of type %0 must be declared as either 'borrowing' or 'consuming'", (Type))
 ERROR(attr_static_exclusive_only_mutating,none,
       "type %0 cannot have mutating function %1", (Type, ValueDecl *))
+ERROR(attr_static_exclusive_no_setters,none,
+      "varaible of type %0 must not have a setter", (Type))
 
 // @extractConstantsFromMembers
 ERROR(attr_extractConstantsFromMembers_experimental,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1996,7 +1996,7 @@ ERROR(attr_static_exclusive_only_let_only_param,none,
 ERROR(attr_static_exclusive_only_mutating,none,
       "type %0 cannot have mutating function %1", (Type, ValueDecl *))
 ERROR(attr_static_exclusive_no_setters,none,
-      "varaible of type %0 must not have a setter", (Type))
+      "variable of type %0 must not have a setter", (Type))
 
 // @extractConstantsFromMembers
 ERROR(attr_extractConstantsFromMembers_experimental,none,

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2589,13 +2589,14 @@ public:
 
     TypeChecker::checkDeclAttributes(VD);
 
+    auto DC = VD->getDeclContext();
+
     if (!checkOverrides(VD)) {
       // If a property has an override attribute but does not override
       // anything, complain.
       auto overridden = VD->getOverriddenDecl();
       if (auto *OA = VD->getAttrs().getAttribute<OverrideAttr>()) {
         if (!overridden) {
-          auto DC = VD->getDeclContext();
           auto isClassContext = DC->getSelfClassDecl() != nullptr;
           auto isStructOrEnumContext = DC->getSelfEnumDecl() != nullptr ||
                                        DC->getSelfStructDecl() != nullptr;
@@ -2650,10 +2651,22 @@ public:
 
     // @_staticExclusiveOnly types cannot be put into 'var's, only 'let'.
     if (auto SD = VD->getInterfaceType()->getStructOrBoundGenericStruct()) {
-      if (SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
-          !VD->isLet()) {
+      if (SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>()) {
+        auto isProtocolContext = DC->getSelfProtocolDecl() != nullptr;
+
+        if (isProtocolContext && !VD->supportsMutation()) {
+          return;
+        }
+
+        if (VD->isLet()) {
+          return;
+        }
+
+        auto diagMsg = isProtocolContext ? diag::attr_static_exclusive_no_setters
+                                      : diag::attr_static_exclusive_only_let_only;
+
         Ctx.Diags.diagnoseWithNotes(
-          VD->diagnose(diag::attr_static_exclusive_only_let_only,
+          VD->diagnose(diagMsg,
                        VD->getInterfaceType()),
           [&]() {
             SD->diagnose(diag::attr_static_exclusive_only_type_nonmutating,

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2652,7 +2652,7 @@ public:
     // @_staticExclusiveOnly types cannot be put into 'var's, only 'let'.
     if (auto SD = VD->getInterfaceType()->getStructOrBoundGenericStruct()) {
       if (SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>()) {
-        auto isProtocolContext = DC->getSelfProtocolDecl() != nullptr;
+        auto isProtocolContext = isa<ProtocolDecl>(DC);
 
         if (isProtocolContext && !VD->supportsMutation()) {
           return;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2662,16 +2662,15 @@ public:
           return;
         }
 
-        auto diagMsg = isProtocolContext ? diag::attr_static_exclusive_no_setters
-                                      : diag::attr_static_exclusive_only_let_only;
+        auto diagMsg = isProtocolContext
+                           ? diag::attr_static_exclusive_no_setters
+                           : diag::attr_static_exclusive_only_let_only;
 
         Ctx.Diags.diagnoseWithNotes(
-          VD->diagnose(diagMsg,
-                       VD->getInterfaceType()),
-          [&]() {
-            SD->diagnose(diag::attr_static_exclusive_only_type_nonmutating,
-                       SD->getDeclaredInterfaceType());
-          });
+            VD->diagnose(diagMsg, VD->getInterfaceType()), [&]() {
+              SD->diagnose(diag::attr_static_exclusive_only_type_nonmutating,
+                           SD->getDeclaredInterfaceType());
+            });
       }
     }
   }

--- a/test/attr/attr_static_exclusive_only.swift
+++ b/test/attr/attr_static_exclusive_only.swift
@@ -9,6 +9,8 @@ struct B: ~Copyable { // expected-note {{'B' is a non-mutable type}}
                       // expected-note@-2 {{'B' is a non-mutable type}}
                       // expected-note@-3 {{'B' is a non-mutable type}}
                       // expected-note@-4 {{'B' is a non-mutable type}}
+                      // expected-note@-5 {{'B' is a non-mutable type}}
+                      // expected-note@-6 {{'B' is a non-mutable type}}
   mutating func change() { // expected-error {{type 'B' cannot have mutating function 'change()'}}
     print("123")
   }
@@ -68,3 +70,25 @@ func p(_: (consuming B) -> ()) {} // OK
 struct Q<T>: ~Copyable {} // expected-note {{'Q<T>' is a non-mutable type}}
 
 var r0 = Q<Int>() // expected-error {{variable of type 'Q<Int>' must be declared with a 'let'}}
+
+protocol S {
+  var t0: B { get } // OK
+
+  var t1: B { get set } // expected-error {{varaible of type 'B' must not have a setter}}
+}
+
+protocol U: ~Copyable {
+  var v: B { get } // OK
+}
+
+struct W: ~Copyable {}
+
+extension W: U {
+  var v: B { // expected-error {{variable of type 'B' must be declared with a 'let'}}
+    B()
+  }
+}
+
+struct X: ~Copyable, U {
+  let v: B // OK
+}

--- a/test/attr/attr_static_exclusive_only.swift
+++ b/test/attr/attr_static_exclusive_only.swift
@@ -11,6 +11,7 @@ struct B: ~Copyable { // expected-note {{'B' is a non-mutable type}}
                       // expected-note@-4 {{'B' is a non-mutable type}}
                       // expected-note@-5 {{'B' is a non-mutable type}}
                       // expected-note@-6 {{'B' is a non-mutable type}}
+                      // expected-note@-7 {{'B' is a non-mutable type}}
   mutating func change() { // expected-error {{type 'B' cannot have mutating function 'change()'}}
     print("123")
   }
@@ -91,4 +92,10 @@ extension W: U {
 
 struct X: ~Copyable, U {
   let v: B // OK
+}
+
+extension U {
+  var y: B { // expected-error {{variable of type 'B' must be declared with a 'let'}}
+    B()
+  }
 }

--- a/test/attr/attr_static_exclusive_only.swift
+++ b/test/attr/attr_static_exclusive_only.swift
@@ -75,7 +75,7 @@ var r0 = Q<Int>() // expected-error {{variable of type 'Q<Int>' must be declared
 protocol S {
   var t0: B { get } // OK
 
-  var t1: B { get set } // expected-error {{varaible of type 'B' must not have a setter}}
+  var t1: B { get set } // expected-error {{variable of type 'B' must not have a setter}}
 }
 
 protocol U: ~Copyable {


### PR DESCRIPTION
Variable requirements in protocols must always be spelled out with `var`, so we weren't allowing types like `Atomic` to be a protocol requirement even if the protocol only requires a getter. Lets allow protocol contexts to define getter requirements and error if they have a setter.

Resolves: rdar://130447812