### PR TITLE
[6.0] [Parse] Add fix-it for unknown isolation in `@isolated`

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4856,11 +4856,12 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
       kind = IsolatedTypeAttr::IsolationKind::Dynamic;
 
     // Add new kinds of isolation here; be sure to update the text for
-    // attr_isolated_expected_kind.
+    // attr_isolated_expected_kind, and change the associated fix-it below.
 
     } else {
       if (!justChecking) {
-        diagnose(Tok, diag::attr_isolated_expected_kind);
+        diagnose(Tok, diag::attr_isolated_expected_kind)
+          .fixItReplace(Tok.getLoc(), "any");
       }
       invalid = true;
       consumeIf(tok::identifier);

--- a/test/Parse/isolated_any.swift
+++ b/test/Parse/isolated_any.swift
@@ -10,3 +10,6 @@ func testLookahead() {
   let array = [@isolated(any) () -> ()]()
   _ = array
 }
+
+func testInvalidIsolation(_ x: @isolated(foo) () -> Void) {}
+// expected-error@-1 {{expected 'any' as the isolation kind}} {{42-45=any}}


### PR DESCRIPTION
*6.0 cherry-pick of #74892*

- Explanation: Adds a fix-it to the diagnostic for invalid isolation in `@isolated`
- Scope: Affects a diagnostic
- Issue: rdar://130287211
- Risk: Low
- Testing: Added tests to test suite
- Reviewer: Alex Hoppen, Konrad Malawski