### PR TITLE
Sema: Change behavior of implied 'Sendable' conformance

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2714,6 +2714,9 @@ ProtocolConformance *
 ASTContext::getSpecializedConformance(Type type,
                                       NormalProtocolConformance *generic,
                                       SubstitutionMap substitutions) {
+  CONDITIONAL_ASSERT(substitutions.getGenericSignature().getCanonicalSignature()
+                     == generic->getGenericSignature().getCanonicalSignature());
+
   // If the specialization is a no-op, use the root conformance instead.
   if (collapseSpecializedConformance(type, generic, substitutions)) {
     ++NumCollapsedSpecializedProtocolConformances;

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -718,6 +718,12 @@ LookupConformanceInModuleRequest::evaluate(
       // specialized type.
       auto *normalConf = cast<NormalProtocolConformance>(conformance);
       auto *conformanceDC = normalConf->getDeclContext();
+
+      if (normalConf->getSourceKind() == ConformanceEntryKind::Implied &&
+          normalConf->getProtocol()->isSpecificProtocol(KnownProtocolKind::Sendable)) {
+        conformanceDC = conformanceDC->getSelfNominalTypeDecl();
+      }
+
       auto subMap = type->getContextSubstitutionMap(mod, conformanceDC);
       return ProtocolConformanceRef(
           ctx.getSpecializedConformance(type, normalConf, subMap));

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -231,6 +231,10 @@ GenericSignature ProtocolConformance::getGenericSignature() const {
   case ProtocolConformanceKind::Self:
     // If we have a normal or inherited protocol conformance, look for its
     // generic signature.
+    if (getSourceKind() == ConformanceEntryKind::Implied &&
+        getProtocol()->isSpecificProtocol(KnownProtocolKind::Sendable)) {
+      return getDeclContext()->getSelfNominalTypeDecl()->getGenericSignature();
+    }
     return getDeclContext()->getGenericSignatureOfContext();
 
   case ProtocolConformanceKind::Builtin:
@@ -406,7 +410,7 @@ ConditionalRequirementsRequest::evaluate(Evaluator &evaluator,
     return {};
   }
 
-  const auto extensionSig = ext->getGenericSignature();
+  const auto extensionSig = NPC->getGenericSignature();
 
   // The extension signature should be a superset of the type signature, meaning
   // every thing in the type signature either is included too or is implied by

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6055,6 +6055,8 @@ bool swift::checkSendableConformance(
     }
   }
 
+  if (conformance->getSourceKind() == ConformanceEntryKind::Implied)
+    conformanceDC = nominal;
   return checkSendableInstanceStorage(nominal, conformanceDC, check);
 }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2415,8 +2415,16 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
       ComplainLoc, diag::unchecked_conformance_not_special, ProtoType);
   }
 
+  bool allowImpliedConditionalConformance = false;
+  if (Proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
+    if (Context.LangOpts.StrictConcurrencyLevel != StrictConcurrency::Complete)
+      allowImpliedConditionalConformance = true;
+  } else if (Proto->isMarkerProtocol()) {
+    allowImpliedConditionalConformance = true;
+  }
+
   if (conformance->getSourceKind() == ConformanceEntryKind::Implied &&
-      !Proto->isMarkerProtocol()) {
+      !allowImpliedConditionalConformance) {
     // We've got something like:
     //
     //   protocol Foo : Proto {}

--- a/test/Concurrency/implied_sendable_conformance_swift5.swift
+++ b/test/Concurrency/implied_sendable_conformance_swift5.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-swift-emit-silgen %s -swift-version 5
+
+protocol P: Sendable {}
+protocol Q: Sendable {}
+
+struct One<T> {  // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+  var t: T  // expected-warning {{stored property 't' of 'Sendable'-conforming generic struct 'One' has non-sendable type 'T'; this is an error in the Swift 6 language mode}}
+}
+
+extension One: P where T: P {}
+
+struct Both<T> {  // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+  var t: T  // expected-warning {{stored property 't' of 'Sendable'-conforming generic struct 'Both' has non-sendable type 'T'; this is an error in the Swift 6 language mode}}
+}
+
+extension Both: P where T: P {}
+extension Both: Q where T: Q {}
+
+func takesSendable<T: Sendable>(_: T) {}
+
+takesSendable(One<Int>(t: 3))
+takesSendable(Both<Int>(t: 3))

--- a/test/Concurrency/implied_sendable_conformance_swift6.swift
+++ b/test/Concurrency/implied_sendable_conformance_swift6.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+protocol P: Sendable {}
+protocol Q: Sendable {}
+
+struct One<T> {  // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+  var t: T  // expected-error {{stored property 't' of 'Sendable'-conforming generic struct 'One' has non-sendable type 'T'}}
+}
+
+extension One: P where T: P {}
+// expected-error@-1 {{conditional conformance of type 'One<T>' to protocol 'P' does not imply conformance to inherited protocol 'Sendable'}}
+// expected-note@-2 {{did you mean to explicitly state the conformance like 'extension One: Sendable where ...'}}
+
+struct Both<T> { // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+  var t: T  // expected-error {{stored property 't' of 'Sendable'-conforming generic struct 'Both' has non-sendable type 'T'}}
+}
+
+extension Both: P where T: P {}
+// expected-error@-1 {{conditional conformance of type 'Both<T>' to protocol 'P' does not imply conformance to inherited protocol 'Sendable'}}
+// expected-note@-2 {{did you mean to explicitly state the conformance like 'extension Both: Sendable where ...'}}
+
+extension Both: Q where T: Q {}
+
+func takesSendable<T: Sendable>(_: T) {}
+
+takesSendable(One<Int>(t: 3))
+takesSendable(Both<Int>(t: 3))


### PR DESCRIPTION
Today, this gives you a conditional conformance to `Sendable` in Swift 5 and 6 language mode:

```
protocol P: Sendable {}
struct G<T> {}
extension G: P where T: P {}
// implied: extension G: Sendable where T: P {}
```

Change this so that in Swift 5 mode, the implied conformance is unconditional:

```
extension G: P where T: P {}
// implied: extension G: Sendable {}
```

And ban it outright in Swift 6 mode:

```
extension G: P where T: P {}  // error
```

Fixes rdar://95695543.
Fixes rdar://122754849.
Fixes https://github.com/swiftlang/swift/issues/71544.