### PR TITLE
[Sema] Add specialization constraints for func and variable types, then diagnose w/fixes.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4628,8 +4628,6 @@ NOTE(duplicated_key_declared_here, none,
 // Generic specializations
 ERROR(cannot_explicitly_specialize_generic_function,none,
       "cannot explicitly specialize a generic function", ())
-ERROR(not_a_generic_definition,none,
-      "cannot specialize a non-generic definition", ())
 ERROR(not_a_generic_type,none,
       "cannot specialize non-generic type %0", (Type))
 ERROR(protocol_declares_unknown_primary_assoc_type,none,

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -459,8 +459,11 @@ enum class FixKind : uint8_t {
   /// because its name doesn't appear in 'initializes' or 'accesses' attributes.
   AllowInvalidMemberReferenceInInitAccessor,
 
-  /// Ignore an attempt to specialize non-generic type.
+  /// Ignore an attempt to specialize a non-generic type.
   AllowConcreteTypeSpecialization,
+
+  /// Ignore an attempt to specialize a generic function.
+  AllowGenericFunctionSpecialization,
 
   /// Ignore an out-of-place \c then statement.
   IgnoreOutOfPlaceThenStmt,
@@ -3710,6 +3713,33 @@ public:
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowConcreteTypeSpecialization;
+  }
+};
+
+class AllowGenericFunctionSpecialization final : public ConstraintFix {
+  ValueDecl *Decl;
+
+  AllowGenericFunctionSpecialization(ConstraintSystem &cs, ValueDecl *decl,
+                                     ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowConcreteTypeSpecialization, locator),
+        Decl(decl) {}
+
+public:
+  std::string getName() const override {
+    return "allow generic function specialization";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static AllowGenericFunctionSpecialization *
+  create(ConstraintSystem &cs, ValueDecl *decl, ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowGenericFunctionSpecialization;
   }
 };
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1474,7 +1474,9 @@ static bool isGenericTypeDisambiguatingToken(Parser &P) {
   auto &tok = P.Tok;
   switch (tok.getKind()) {
   default:
-    return false;
+    // If this is the end of the expr (wouldn't match parseExprSequenceElement),
+    // prefer generic type list over an illegal unary postfix '>' operator.
+    return P.isStartOfSwiftDecl() || P.isStartOfStmt(/*prefer expr=*/true);
   case tok::r_paren:
   case tok::r_square:
   case tok::l_brace:

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9338,7 +9338,12 @@ bool InvalidMemberReferenceWithinInitAccessor::diagnoseAsError() {
 }
 
 bool ConcreteTypeSpecialization::diagnoseAsError() {
-  emitDiagnostic(diag::not_a_generic_type, ConcreteType);
+  emitDiagnostic(diag::not_a_generic_type, resolveType(ConcreteType));
+  return true;
+}
+
+bool GenericFunctionSpecialization::diagnoseAsError() {
+  emitDiagnostic(diag::cannot_explicitly_specialize_generic_function);
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3116,7 +3116,18 @@ public:
   ConcreteTypeSpecialization(const Solution &solution, Type concreteTy,
                              ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator),
-        ConcreteType(resolveType(concreteTy)) {}
+        ConcreteType(concreteTy) {}
+
+  bool diagnoseAsError() override;
+};
+
+class GenericFunctionSpecialization final : public FailureDiagnostic {
+  ValueDecl *Decl;
+
+public:
+  GenericFunctionSpecialization(const Solution &solution, ValueDecl *decl,
+                                ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), Decl(decl) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2604,6 +2604,18 @@ AllowConcreteTypeSpecialization::create(ConstraintSystem &cs, Type concreteTy,
       AllowConcreteTypeSpecialization(cs, concreteTy, locator);
 }
 
+bool AllowGenericFunctionSpecialization::diagnose(const Solution &solution,
+                                                  bool asNote) const {
+  GenericFunctionSpecialization failure(solution, Decl, getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowGenericFunctionSpecialization *AllowGenericFunctionSpecialization::create(
+    ConstraintSystem &cs, ValueDecl *decl, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowGenericFunctionSpecialization(cs, decl, locator);
+}
+
 bool IgnoreOutOfPlaceThenStmt::diagnose(const Solution &solution,
                                         bool asNote) const {
   OutOfPlaceThenStmtFailure failure(solution, getLocator());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1903,9 +1903,9 @@ namespace {
     /// introduce them as an explicit generic arguments constraint.
     ///
     /// \returns true if resolving any of the specialization types failed.
-    bool addSpecializationConstraint(
-        ConstraintLocator *locator, Type boundType,
-        ArrayRef<TypeRepr *> specializationArgs) {
+    void addSpecializationConstraint(ConstraintLocator *locator, Type boundType,
+                                     SourceLoc lAngleLoc,
+                                     ArrayRef<TypeRepr *> specializationArgs) {
       // Resolve each type.
       SmallVector<Type, 2> specializationArgTypes;
       auto options =
@@ -1916,61 +1916,36 @@ namespace {
           options |= TypeResolutionFlags::AllowPackReferences;
           elementEnv = OuterExpansions.back();
         }
-        const auto result = TypeResolution::resolveContextualType(
+        auto result = TypeResolution::resolveContextualType(
             specializationArg, CurDC, options,
             // Introduce type variables for unbound generics.
             OpenUnboundGenericType(CS, locator),
             HandlePlaceholderType(CS, locator),
             OpenPackElementType(CS, locator, elementEnv));
-        if (result->hasError())
-          return true;
-
+        if (result->hasError()) {
+          auto &ctxt = CS.getASTContext();
+          auto *repr = new (ctxt) PlaceholderTypeRepr(specializationArg->getLoc());
+          result = PlaceholderType::get(ctxt, repr);
+          ctxt.Diags.diagnose(lAngleLoc,
+                              diag::while_parsing_as_left_angle_bracket);
+        }
         specializationArgTypes.push_back(result);
       }
 
-      CS.addConstraint(
-          ConstraintKind::ExplicitGenericArguments, boundType,
-          PackType::get(CS.getASTContext(), specializationArgTypes),
-          locator);
-      return false;
+      auto constraint = Constraint::create(
+          CS, ConstraintKind::ExplicitGenericArguments, boundType,
+          PackType::get(CS.getASTContext(), specializationArgTypes), locator);
+      CS.addUnsolvedConstraint(constraint);
+      CS.activateConstraint(constraint);
     }
 
     Type visitUnresolvedSpecializeExpr(UnresolvedSpecializeExpr *expr) {
       auto baseTy = CS.getType(expr->getSubExpr());
-
-      if (baseTy->isTypeVariableOrMember()) {
-        return baseTy;
-      }
-
-      // We currently only support explicit specialization of generic types.
-      // FIXME: We could support explicit function specialization.
-      auto &de = CS.getASTContext().Diags;
-      if (baseTy->is<AnyFunctionType>()) {
-        de.diagnose(expr->getSubExpr()->getLoc(),
-                    diag::cannot_explicitly_specialize_generic_function);
-        de.diagnose(expr->getLAngleLoc(),
-                    diag::while_parsing_as_left_angle_bracket);
-        return Type();
-      }
-      
-      if (AnyMetatypeType *meta = baseTy->getAs<AnyMetatypeType>()) {
-        auto *overloadLocator = CS.getConstraintLocator(expr->getSubExpr());
-        if (addSpecializationConstraint(overloadLocator,
-                                        meta->getInstanceType(),
-                                        expr->getUnresolvedParams())) {
-          return Type();
-        }
-
-        return baseTy;
-      }
-
-      // FIXME: If the base type is a type variable, constrain it to a metatype
-      // of a bound generic type.
-      de.diagnose(expr->getSubExpr()->getLoc(),
-                  diag::not_a_generic_definition);
-      de.diagnose(expr->getLAngleLoc(),
-                  diag::while_parsing_as_left_angle_bracket);
-      return Type();
+      auto *overloadLocator = CS.getConstraintLocator(expr->getSubExpr());
+      addSpecializationConstraint(
+          overloadLocator, baseTy->getMetatypeInstanceType(),
+          expr->getLAngleLoc(), expr->getUnresolvedParams());
+      return baseTy;
     }
     
     Type visitSequenceExpr(SequenceExpr *expr) {
@@ -4082,10 +4057,9 @@ namespace {
 
       // Add explicit generic arguments, if there were any.
       if (expr->getGenericArgsRange().isValid()) {
-        if (addSpecializationConstraint(
-              CS.getConstraintLocator(expr), macroRefType,
-              expr->getGenericArgs()))
-          return Type();
+        addSpecializationConstraint(CS.getConstraintLocator(expr), macroRefType,
+                                    expr->getGenericArgsRange().Start,
+                                    expr->getGenericArgs());
       }
 
       // Form the applicable-function constraint. The result type

--- a/test/Constraints/ambiguous_specialized_name_diagnostics.swift
+++ b/test/Constraints/ambiguous_specialized_name_diagnostics.swift
@@ -42,7 +42,6 @@ func test() {
 
   S<Int>(t: 42).test() // expected-error {{ambiguous use of 'init(t:)'}}
 
-  // FIXME(diagnostics): This should produce ambiguity diagnostic too
   S<Int>.staticFn()
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{ambiguous use of 'staticFn()'}}
 }

--- a/test/Parse/enum_element_pattern_swift4.swift
+++ b/test/Parse/enum_element_pattern_swift4.swift
@@ -9,10 +9,13 @@ enum E {
 
   static func testE(e: E) {
     switch e {
-    case A<UndefinedTy>(): // expected-error {{cannot specialize a non-generic definition}}
+    case A<UndefinedTy>(): // expected-error {{cannot find type 'UndefinedTy' in scope}}
     // expected-note@-1 {{while parsing this '<' as a type parameter bracket}}
+    // expected-error@-2 {{cannot specialize non-generic type 'E'}}
+    // expected-error@-3 {{cannot call value of non-function type 'E'}}
       break
-    case B<Int>(): // expected-error {{cannot specialize a non-generic definition}} expected-note {{while parsing this '<' as a type parameter bracket}}
+    case B<Int>(): // expected-error {{cannot specialize non-generic type 'E'}}
+    // expected-error@-1 {{cannot call value of non-function type 'E'}}
       break
     default:
       break;
@@ -22,10 +25,13 @@ enum E {
 
 func testE(e: E) {
   switch e {
-  case E.A<UndefinedTy>(): // expected-error {{cannot specialize a non-generic definition}}
+  case E.A<UndefinedTy>(): // expected-error {{cannot find type 'UndefinedTy' in scope}}
   // expected-note@-1 {{while parsing this '<' as a type parameter bracket}}
+  // expected-error@-2 {{cannot specialize non-generic type 'E'}}
+  // expected-error@-3 {{cannot call value of non-function type 'E'}}
     break
-  case E.B<Int>(): // expected-error {{cannot specialize a non-generic definition}} expected-note {{while parsing this '<' as a type parameter bracket}}
+  case E.B<Int>(): // expected-error {{cannot specialize non-generic type 'E'}}
+  // expected-error@-1 {{cannot call value of non-function type 'E'}}
     break
   case .C(): // expected-error {{pattern with associated values does not match enum case 'C'}}
              // expected-note@-1 {{remove associated values to make the pattern match}} {{10-12=}} 

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -26,15 +26,21 @@ var a, b, c, d : Int
 _ = a < b
 _ = (a < b, c > d)
 // Parses as generic because of lparen after '>'
-(a < b, c > (d)) // expected-error{{cannot specialize a non-generic definition}}
-// expected-note@-1 {{while parsing this '<' as a type parameter bracket}}
+(a < b, c > (d)) // expected-error{{cannot find type 'b' in scope}}
+// expected-note@-1 2 {{while parsing this '<' as a type parameter bracket}}
+// expected-error@-2 {{cannot specialize non-generic type 'Int'}}
+// expected-error@-3 {{cannot call value of non-function type 'Int'}}
+// expected-error@-4 {{cannot find type 'c' in scope}}
 // Parses as generic because of lparen after '>'
-(a<b, c>(d)) // expected-error{{cannot specialize a non-generic definition}}
-// expected-note@-1 {{while parsing this '<' as a type parameter bracket}}
+(a<b, c>(d)) // expected-error{{cannot find type 'b' in scope}}
+// expected-note@-1 2 {{while parsing this '<' as a type parameter bracket}}
+// expected-error@-2 {{cannot specialize non-generic type 'Int'}}
+// expected-error@-3 {{cannot call value of non-function type 'Int'}}
+// expected-error@-4 {{cannot find type 'c' in scope}}
 _ = a>(b)
 _ = a > (b)
 
-generic<Int>(0) // expected-error{{cannot explicitly specialize a generic function}} expected-note{{while parsing this '<' as a type parameter bracket}}
+generic<Int>(0) // expected-error{{cannot explicitly specialize a generic function}}
 
 A<B>.c()
 A<A<B>>.c()

--- a/test/Sema/generic-arg-list.swift
+++ b/test/Sema/generic-arg-list.swift
@@ -1,0 +1,41 @@
+// RUN: %target-typecheck-verify-swift
+
+extension Int {
+  func foo() -> Int {}
+  var bar: Int {
+    get {}
+  }
+
+  func baz() -> Int {}
+  func baz(_ x: Int = 0) -> Int {}
+
+  func gen<T>() -> T {} // expected-note 2 {{in call to function 'gen()'}}
+}
+
+// https://github.com/swiftlang/swift/issues/74857
+func test(i: Int) {
+  let _ = i.foo<Int>() // expected-error {{cannot specialize non-generic type '() -> Int'}}
+
+  let _ = i.gen<Int>() // expected-error {{cannot explicitly specialize a generic function}}
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
+  let _ = 0.foo<Int>() // expected-error {{cannot specialize non-generic type '() -> Int'}}
+
+  let _ = i.gen<Int> // expected-error {{cannot explicitly specialize a generic function}}
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  let _ = i.bar<Int> // expected-error {{cannot specialize non-generic type 'Int'}}
+  let _ = 0.bar<Int> // expected-error {{cannot specialize non-generic type 'Int'}}
+}
+
+extension Bool {
+  func foo<T>() -> T {}
+}
+
+let _: () -> Bool = false.foo<Int> // expected-error {{cannot explicitly specialize a generic function}}
+
+func foo(_ x: Int) {
+  _ = {
+    _ = x<String> // expected-error {{cannot specialize non-generic type 'Int'}}
+  }
+}
+


### PR DESCRIPTION
Similar logic to the diagnoses already happening in visitUnresolvedSpecializeExpr in CSGen, but checking again after there are no more type variables resolves #74857.
