### PR TITLE
[6.0] Change behavior of implied 'Sendable' conformance

### DIFF
--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -717,6 +717,12 @@ LookupConformanceInModuleRequest::evaluate(
       // specialized type.
       auto *normalConf = cast<NormalProtocolConformance>(conformance);
       auto *conformanceDC = normalConf->getDeclContext();
+
+      if (normalConf->getSourceKind() == ConformanceEntryKind::Implied &&
+          normalConf->getProtocol()->isSpecificProtocol(KnownProtocolKind::Sendable)) {
+        conformanceDC = conformanceDC->getSelfNominalTypeDecl();
+      }
+
       auto subMap = type->getContextSubstitutionMap(mod, conformanceDC);
       return ProtocolConformanceRef(
           ctx.getSpecializedConformance(type, normalConf, subMap));

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -718,6 +718,10 @@ LookupConformanceInModuleRequest::evaluate(
       auto *normalConf = cast<NormalProtocolConformance>(conformance);
       auto *conformanceDC = normalConf->getDeclContext();
 
+      // In -swift-version 5 mode, a conditional conformance to a protocol can imply
+      // a Sendable conformance. The implied conformance is unconditional so it uses
+      // the generic signature of the nominal type and not the generic signature of
+      // the extension that declared the (implying) conditional conformance.
       if (normalConf->getSourceKind() == ConformanceEntryKind::Implied &&
           normalConf->getProtocol()->isSpecificProtocol(KnownProtocolKind::Sendable)) {
         conformanceDC = conformanceDC->getSelfNominalTypeDecl();

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -230,6 +230,10 @@ GenericSignature ProtocolConformance::getGenericSignature() const {
   case ProtocolConformanceKind::Self:
     // If we have a normal or inherited protocol conformance, look for its
     // generic signature.
+    if (getSourceKind() == ConformanceEntryKind::Implied &&
+        getProtocol()->isSpecificProtocol(KnownProtocolKind::Sendable)) {
+      return getDeclContext()->getSelfNominalTypeDecl()->getGenericSignature();
+    }
     return getDeclContext()->getGenericSignatureOfContext();
 
   case ProtocolConformanceKind::Builtin:
@@ -405,7 +409,7 @@ ConditionalRequirementsRequest::evaluate(Evaluator &evaluator,
     return {};
   }
 
-  const auto extensionSig = ext->getGenericSignature();
+  const auto extensionSig = NPC->getGenericSignature();
 
   // The extension signature should be a superset of the type signature, meaning
   // every thing in the type signature either is included too or is implied by

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -230,10 +230,16 @@ GenericSignature ProtocolConformance::getGenericSignature() const {
   case ProtocolConformanceKind::Self:
     // If we have a normal or inherited protocol conformance, look for its
     // generic signature.
+
+    // In -swift-version 5 mode, a conditional conformance to a protocol can imply
+    // a Sendable conformance. The implied conformance is unconditional so it uses
+    // the generic signature of the nominal type and not the generic signature of
+    // the extension that declared the (implying) conditional conformance.
     if (getSourceKind() == ConformanceEntryKind::Implied &&
         getProtocol()->isSpecificProtocol(KnownProtocolKind::Sendable)) {
       return getDeclContext()->getSelfNominalTypeDecl()->getGenericSignature();
     }
+
     return getDeclContext()->getGenericSignatureOfContext();
 
   case ProtocolConformanceKind::Builtin:
@@ -409,6 +415,10 @@ ConditionalRequirementsRequest::evaluate(Evaluator &evaluator,
     return {};
   }
 
+  // In -swift-version 5 mode, a conditional conformance to a protocol can imply
+  // a Sendable conformance. We ask the conformance for its generic signature,
+  // which will always be the generic signature of `ext` except in this case,
+  // where it's the generic signature of the extended nominal.
   const auto extensionSig = NPC->getGenericSignature();
 
   // The extension signature should be a superset of the type signature, meaning

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6040,6 +6040,10 @@ bool swift::checkSendableConformance(
     }
   }
 
+  // In -swift-version 5 mode, a conditional conformance to a protocol can imply
+  // a Sendable conformance. The implied conformance is unconditional, so check
+  // the storage for sendability as if the conformance was declared on the nominal,
+  // and not some (possibly constrained) extension.
   if (conformance->getSourceKind() == ConformanceEntryKind::Implied)
     conformanceDC = nominal;
   return checkSendableInstanceStorage(nominal, conformanceDC, check);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6040,6 +6040,8 @@ bool swift::checkSendableConformance(
     }
   }
 
+  if (conformance->getSourceKind() == ConformanceEntryKind::Implied)
+    conformanceDC = nominal;
   return checkSendableInstanceStorage(nominal, conformanceDC, check);
 }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2414,8 +2414,16 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
       ComplainLoc, diag::unchecked_conformance_not_special, ProtoType);
   }
 
+  bool allowImpliedConditionalConformance = false;
+  if (Proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
+    if (Context.LangOpts.StrictConcurrencyLevel != StrictConcurrency::Complete)
+      allowImpliedConditionalConformance = true;
+  } else if (Proto->isMarkerProtocol()) {
+    allowImpliedConditionalConformance = true;
+  }
+
   if (conformance->getSourceKind() == ConformanceEntryKind::Implied &&
-      !Proto->isMarkerProtocol()) {
+      !allowImpliedConditionalConformance) {
     // We've got something like:
     //
     //   protocol Foo : Proto {}

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2416,7 +2416,9 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
 
   bool allowImpliedConditionalConformance = false;
   if (Proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
-    if (Context.LangOpts.StrictConcurrencyLevel != StrictConcurrency::Complete)
+    // In -swift-version 5 mode, a conditional conformance to a protocol can imply
+    // a Sendable conformance.
+    if (!Context.LangOpts.isSwiftVersionAtLeast(6))
       allowImpliedConditionalConformance = true;
   } else if (Proto->isMarkerProtocol()) {
     allowImpliedConditionalConformance = true;

--- a/test/Concurrency/implied_sendable_conformance_swift5.swift
+++ b/test/Concurrency/implied_sendable_conformance_swift5.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-swift-emit-silgen %s -swift-version 5
+
+protocol P: Sendable {}
+protocol Q: Sendable {}
+
+struct One<T> {  // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+  var t: T  // expected-warning {{stored property 't' of 'Sendable'-conforming generic struct 'One' has non-sendable type 'T'; this is an error in the Swift 6 language mode}}
+}
+
+extension One: P where T: P {}
+
+struct Both<T> {  // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+  var t: T  // expected-warning {{stored property 't' of 'Sendable'-conforming generic struct 'Both' has non-sendable type 'T'; this is an error in the Swift 6 language mode}}
+}
+
+extension Both: P where T: P {}
+extension Both: Q where T: Q {}
+
+func takesSendable<T: Sendable>(_: T) {}
+
+takesSendable(One<Int>(t: 3))
+takesSendable(Both<Int>(t: 3))

--- a/test/Concurrency/implied_sendable_conformance_swift5.swift
+++ b/test/Concurrency/implied_sendable_conformance_swift5.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
-// RUN: %target-swift-emit-silgen %s -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -strict-concurrency=complete
+// RUN: %target-swift-emit-silgen %s -swift-version 5 -strict-concurrency=complete
 
 protocol P: Sendable {}
 protocol Q: Sendable {}

--- a/test/Concurrency/implied_sendable_conformance_swift6.swift
+++ b/test/Concurrency/implied_sendable_conformance_swift6.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+protocol P: Sendable {}
+protocol Q: Sendable {}
+
+struct One<T> {  // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+  var t: T  // expected-error {{stored property 't' of 'Sendable'-conforming generic struct 'One' has non-sendable type 'T'}}
+}
+
+extension One: P where T: P {}
+// expected-error@-1 {{conditional conformance of type 'One<T>' to protocol 'P' does not imply conformance to inherited protocol 'Sendable'}}
+// expected-note@-2 {{did you mean to explicitly state the conformance like 'extension One: Sendable where ...'}}
+
+struct Both<T> { // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+  var t: T  // expected-error {{stored property 't' of 'Sendable'-conforming generic struct 'Both' has non-sendable type 'T'}}
+}
+
+extension Both: P where T: P {}
+// expected-error@-1 {{conditional conformance of type 'Both<T>' to protocol 'P' does not imply conformance to inherited protocol 'Sendable'}}
+// expected-note@-2 {{did you mean to explicitly state the conformance like 'extension Both: Sendable where ...'}}
+
+extension Both: Q where T: Q {}
+
+func takesSendable<T: Sendable>(_: T) {}
+
+takesSendable(One<Int>(t: 3))
+takesSendable(Both<Int>(t: 3))


### PR DESCRIPTION
6.0 cherry-pick of https://github.com/swiftlang/swift/pull/74908

* **Description:** If a type conditionally conforms to two protocols that both adopt Sendable retroactively, we would attempt to synthesize two conditional conformances to Sendable with incompatible requirements. Instead, change it so that the implied Sendable conformance is unconditional in `-swift-version 5` mode, and ban it outright in `-swift-version 6`.

* **Origination:** This is a long-standing issue with conditional conformances, where the original Sendable carveout never quite worked right.

* **Reviewed by:** @DougGregor 

* **Risk:** Low. We might now diagnose a non-Sendable stored property in more cases, because the Sendable conformance is unconditional, but in `-swift-version 5` this was a warning, so this should not be a source break. In `-swift-version 6`, the new behavior is source breaking because the implied Sendable conformance must be declared explicitly. However, this matches the intent of `-swift-version 6`.

* **Radar:** rdar://95695543, rdar://122754849.