### PR TITLE
[6.0] Suppress `@isolated(any)` in reflective metadata strings on old targets

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -75,6 +75,14 @@ protected:
   /// If enabled, inverses will not be mangled into generic signatures.
   bool AllowInverses = true;
 
+  /// If enabled, @isolated(any) can be encoded in the mangled name.
+  /// Suppressing type attributes this way is generally questionable ---
+  /// for example, it does not interact properly with substitutions ---
+  /// and should only be done in situations where it is just going to be
+  /// interpreted as a type and the exact string value does not play
+  /// a critical role.
+  bool AllowIsolatedAny = true;
+
   /// If enabled, declarations annotated with @_originallyDefinedIn are mangled
   /// as if they're part of their original module. Disabled for debug mangling,
   /// because lldb wants to find declarations in the modules they're currently

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2056,7 +2056,8 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn,
   case SILFunctionTypeIsolation::Unknown:
     break;
   case SILFunctionTypeIsolation::Erased:
-    OpArgs.push_back('A');
+    if (AllowIsolatedAny)
+      OpArgs.push_back('A');
     break;
   }
 
@@ -3090,7 +3091,8 @@ void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
     appendOperator("Yc");
     break;
   case FunctionTypeIsolation::Kind::Erased:
-    appendOperator("YA");
+    if (AllowIsolatedAny)
+      appendOperator("YA");
     break;
   }
 

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -160,10 +160,19 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
   ASTContext &ctx = Ty->getASTContext();
   llvm::SaveAndRestore<bool> savedConcurrencyStandardSubstitutions(
       AllowConcurrencyStandardSubstitutions);
+  llvm::SaveAndRestore<bool> savedIsolatedAny(AllowIsolatedAny);
   if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget(
           ctx.LangOpts.Target)) {
     if (*runtimeCompatVersion < llvm::VersionTuple(5, 5))
       AllowConcurrencyStandardSubstitutions = false;
+
+    // Suppress @isolated(any) if we're mangling for pre-6.0 runtimes.
+    // This is unprincipled but, because of the restrictions in e.g.
+    // mangledNameIsUnknownToDeployTarget, should only happen when
+    // mangling for certain reflective uses where we have to hope that
+    // the exact type identity is generally unimportant.
+    if (*runtimeCompatVersion < llvm::VersionTuple(6, 0))
+      AllowIsolatedAny = false;
   }
 
   llvm::SaveAndRestore<bool> savedAllowStandardSubstitutions(

--- a/test/IRGen/reflection_metadata_isolated_any.swift
+++ b/test/IRGen/reflection_metadata_isolated_any.swift
@@ -4,10 +4,6 @@
 // REQUIRES: OS=macosx
 // UNSUPPORTED: CPU=arm64e
 
-public struct MyStruct {
-  let fn: @isolated(any) () -> ()
-}
-
 // Make sure that we only emit a demangling-based type description
 // for @isolated(any) types when deploying to runtimes that support it.
 // If we don't, we fall back on using a type metadata accessor, which
@@ -18,6 +14,22 @@ public struct MyStruct {
 // ordinary function type.
 // rdar://129861211
 
+// Closure capture metadata:
+
+// CHECK-LABEL: @"\01l__swift5_reflection_descriptor" = private constant
+// CHECK-PRESENT-SAME: ptr @"symbolic SiIeAgd_"
+// CHECK-SUPPRESSED-SAME: ptr @"symbolic SiIegd_"
+// CHECK-LABEL: @metadata = private constant %swift.full_boxmetadata { {{.*}}, ptr @"\01l__swift5_reflection_descriptor" }, align
+func makeClosure(fn: @escaping @isolated(any) () -> Int) -> (() async -> Int) {
+  return { await fn() + 1 }
+}
+
+// Struct field metadata:
+
+public struct MyStruct {
+  let fn: @isolated(any) () -> ()
+}
+
 // CHECK-LABEL: @"$s32reflection_metadata_isolated_any8MyStructVMF" = internal constant
 // CHECK-PRESENT-SAME: ptr @"symbolic yyYAc"
-// CHECK-SUPPRESSED-SAME: ptr @"get_type_metadata yyYAc.1"
+// CHECK-SUPPRESSED-SAME: ptr @"get_type_metadata yyYAc.{{[0-9]+}}"


### PR DESCRIPTION
Explanation: The previous fix for rdar://129861211 (#74702) failed to comprehend that it was important to also fix closure capture metadata, which is designed to be consumed by low-level, compiler-integrated tools from outside of the process, but apparently is sometimes being dynamically inspected and used to construct type metadata (!) in must-not-break code.
Scope: Touches common mangling paths in a way that should be isolated to the intended metadata generation
Risk: Low
Testing: Added a new test case
Issue: rdar://129861211
Reviewer: Doug Gregor
Main branch PR: https://github.com/swiftlang/swift/pull/74916