### PR TITLE
Frontend: Only print `-project-name` in private and package interfaces

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -55,6 +55,10 @@ struct ModuleInterfaceOptions {
   /// Flags which appear in all .swiftinterface files.
   InterfaceFlags PublicFlags = {};
 
+  /// Flags which appear in both the private and package .swiftinterface files,
+  /// but not the public interface.
+  InterfaceFlags PrivateFlags = {};
+
   /// Flags which appear only in the .package.swiftinterface.
   InterfaceFlags PackageFlags = {};
 

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -21,7 +21,6 @@
 #define SWIFT_COMPILER_VERSION_KEY "swift-compiler-version"
 #define SWIFT_MODULE_FLAGS_KEY "swift-module-flags"
 #define SWIFT_MODULE_FLAGS_IGNORABLE_KEY "swift-module-flags-ignorable"
-#define SWIFT_MODULE_FLAGS_IGNORABLE_PRIVATE_KEY "swift-module-flags-ignorable-private"
 
 namespace swift {
 
@@ -55,10 +54,6 @@ struct ModuleInterfaceOptions {
   /// Flags that should be emitted to the .swiftinterface file but are OK to be
   /// ignored by the earlier version of the compiler.
   std::string IgnorableFlags;
-
-  /// Ignorable flags that should only be printed in .private.swiftinterface file;
-  /// e.g. -package-name PACKAGE_ID
-  std::string IgnorablePrivateFlags;
 
   /// Print imports with both @_implementationOnly and @_spi, only applies
   /// when PrintSPIs is true.

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -41,19 +41,22 @@ struct ModuleInterfaceOptions {
   /// [TODO: Clang-type-plumbing] This check should go away.
   bool PrintFullConvention = false;
 
-  /// Copy of all the command-line flags passed at .swiftinterface
-  /// generation time, re-applied to CompilerInvocation when reading
-  /// back .swiftinterface and reconstructing .swiftmodule.
-  std::string Flags;
+  struct InterfaceFlags {
+    /// Copy of all the command-line flags passed at .swiftinterface
+    /// generation time, re-applied to CompilerInvocation when reading
+    /// back .swiftinterface and reconstructing .swiftmodule.
+    std::string Flags = "";
 
-  /// Keep track of flags to be printed in package.swiftinterface only.
-  /// If -disable-print-package-name-for-non-package-interface is passed,
-  /// package-name flag should only be printed in package.swiftinterface.
-  std::string FlagsForPackageOnly;
+    /// Flags that should be emitted to the .swiftinterface file but are OK to
+    /// be ignored by the earlier version of the compiler.
+    std::string IgnorableFlags = "";
+  };
 
-  /// Flags that should be emitted to the .swiftinterface file but are OK to be
-  /// ignored by the earlier version of the compiler.
-  std::string IgnorableFlags;
+  /// Flags which appear in all .swiftinterface files.
+  InterfaceFlags PublicFlags = {};
+
+  /// Flags which appear only in the .package.swiftinterface.
+  InterfaceFlags PackageFlags = {};
 
   /// Print imports with both @_implementationOnly and @_spi, only applies
   /// when PrintSPIs is true.

--- a/include/swift/Option/Options.h
+++ b/include/swift/Option/Options.h
@@ -41,9 +41,8 @@ namespace options {
     SwiftAPIDigesterOption = (1 << 16),
     NewDriverOnlyOption = (1 << 17),
     ModuleInterfaceOptionIgnorable = (1 << 18),
-    ModuleInterfaceOptionIgnorablePrivate = (1 << 19),
-    ArgumentIsFileList = (1 << 20),
-    CacheInvariant = (1 << 21),
+    ArgumentIsFileList = (1 << 19),
+    CacheInvariant = (1 << 20),
   };
 
   enum ID {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -56,12 +56,6 @@ def ModuleInterfaceOption : OptionFlag;
 // The option can be safely ignored by the older compiler.
 def ModuleInterfaceOptionIgnorable : OptionFlag;
 
-// The option should be written into a .private.swiftinterface or
-// .package.swiftinterface module interface file, and read/parsed from
-// there when reconstituting a .swiftmodule from it.
-// The option can be safely ignored by the older compiler.
-def ModuleInterfaceOptionIgnorablePrivate : OptionFlag;
-
 // The option causes the output of a supplementary output, or is the path option
 // for a supplementary output. E.g., `-emit-module` and `-emit-module-path`.
 def SupplementaryOutput : OptionFlag;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -499,18 +499,16 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
                                     ArgList &Args, DiagnosticEngine &Diags) {
   if (!FOpts.InputsAndOutputs.hasModuleInterfaceOutputPath())
     return;
+  
   ArgStringList RenderedArgs;
   ArgStringList RenderedArgsForPackageOnly;
   ArgStringList RenderedArgsIgnorable;
-  ArgStringList RenderedArgsIgnorablePrivate;
 
   for (auto A : Args) {
     if (!ShouldIncludeModuleInterfaceArg(A))
       continue;
 
-    if (A->getOption().hasFlag(options::ModuleInterfaceOptionIgnorablePrivate)) {
-      A->render(Args, RenderedArgsIgnorablePrivate);
-    } else if (A->getOption().hasFlag(options::ModuleInterfaceOptionIgnorable)) {
+    if (A->getOption().hasFlag(options::ModuleInterfaceOptionIgnorable)) {
       A->render(Args, RenderedArgsIgnorable);
     } else if (A->getOption().hasFlag(options::ModuleInterfaceOption)) {
       if (ShouldIncludeArgInPackageInterfaceOnly(A, Args))
@@ -531,12 +529,6 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
         RenderedArgsForPackageOnly,
         [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
         [&] { OS << " "; });
-  }
-  {
-    llvm::raw_string_ostream OS(Opts.IgnorablePrivateFlags);
-    interleave(RenderedArgsIgnorablePrivate,
-               [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
-               [&] { OS << " "; });
   }
   {
     llvm::raw_string_ostream OS(Opts.IgnorableFlags);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -489,11 +489,14 @@ static bool ShouldIncludeModuleInterfaceArg(const Arg *A) {
   return true;
 }
 
-static bool ShouldIncludeArgInPackageInterfaceOnly(const Arg *A,
-                                                   ArgList &Args) {
+static bool IsPackageInterfaceFlag(const Arg *A, ArgList &Args) {
   return A->getOption().matches(options::OPT_package_name) &&
          Args.hasArg(
              options::OPT_disable_print_package_name_for_non_package_interface);
+}
+
+static bool IsPrivateInterfaceFlag(const Arg *A, ArgList &Args) {
+  return A->getOption().matches(options::OPT_project_name);
 }
 
 /// Save a copy of any flags marked as ModuleInterfaceOption, if running
@@ -510,13 +513,17 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
   };
 
   RenderedInterfaceArgs PublicArgs{};
+  RenderedInterfaceArgs PrivateArgs{};
   RenderedInterfaceArgs PackageArgs{};
 
   auto interfaceArgListForArg = [&](Arg *A) -> ArgStringList & {
     bool ignorable =
         A->getOption().hasFlag(options::ModuleInterfaceOptionIgnorable);
-    if (ShouldIncludeArgInPackageInterfaceOnly(A, Args))
+    if (IsPackageInterfaceFlag(A, Args))
       return ignorable ? PackageArgs.Ignorable : PackageArgs.Standard;
+
+    if (IsPrivateInterfaceFlag(A, Args))
+      return ignorable ? PrivateArgs.Ignorable : PrivateArgs.Standard;
 
     return ignorable ? PublicArgs.Ignorable : PublicArgs.Standard;
   };
@@ -543,6 +550,7 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
   };
 
   updateInterfaceOpts(Opts.PublicFlags, PublicArgs);
+  updateInterfaceOpts(Opts.PrivateFlags, PrivateArgs);
   updateInterfaceOpts(Opts.PackageFlags, PackageArgs);
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -475,6 +475,10 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
 /// Checks if an arg is generally allowed to be included
 /// in a module interface
 static bool ShouldIncludeModuleInterfaceArg(const Arg *A) {
+  if (!A->getOption().hasFlag(options::ModuleInterfaceOption) &&
+      !A->getOption().hasFlag(options::ModuleInterfaceOptionIgnorable))
+    return false;
+
   if (!A->getOption().matches(options::OPT_enable_experimental_feature))
     return true;
 
@@ -499,43 +503,47 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
                                     ArgList &Args, DiagnosticEngine &Diags) {
   if (!FOpts.InputsAndOutputs.hasModuleInterfaceOutputPath())
     return;
-  
-  ArgStringList RenderedArgs;
-  ArgStringList RenderedArgsForPackageOnly;
-  ArgStringList RenderedArgsIgnorable;
+
+  struct RenderedInterfaceArgs {
+    ArgStringList Standard = {};
+    ArgStringList Ignorable = {};
+  };
+
+  RenderedInterfaceArgs PublicArgs{};
+  RenderedInterfaceArgs PackageArgs{};
+
+  auto interfaceArgListForArg = [&](Arg *A) -> ArgStringList & {
+    bool ignorable =
+        A->getOption().hasFlag(options::ModuleInterfaceOptionIgnorable);
+    if (ShouldIncludeArgInPackageInterfaceOnly(A, Args))
+      return ignorable ? PackageArgs.Ignorable : PackageArgs.Standard;
+
+    return ignorable ? PublicArgs.Ignorable : PublicArgs.Standard;
+  };
 
   for (auto A : Args) {
     if (!ShouldIncludeModuleInterfaceArg(A))
       continue;
 
-    if (A->getOption().hasFlag(options::ModuleInterfaceOptionIgnorable)) {
-      A->render(Args, RenderedArgsIgnorable);
-    } else if (A->getOption().hasFlag(options::ModuleInterfaceOption)) {
-      if (ShouldIncludeArgInPackageInterfaceOnly(A, Args))
-        A->render(Args, RenderedArgsForPackageOnly);
-      else
-        A->render(Args, RenderedArgs);
-    }
+    ArgStringList &ArgList = interfaceArgListForArg(A);
+    A->render(Args, ArgList);
   }
-  {
-    llvm::raw_string_ostream OS(Opts.Flags);
-    interleave(RenderedArgs,
-               [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
-               [&] { OS << " "; });
-  }
-  {
-    llvm::raw_string_ostream OS(Opts.FlagsForPackageOnly);
-    interleave(
-        RenderedArgsForPackageOnly,
-        [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
-        [&] { OS << " "; });
-  }
-  {
-    llvm::raw_string_ostream OS(Opts.IgnorableFlags);
-    interleave(RenderedArgsIgnorable,
-               [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
-               [&] { OS << " "; });
-  }
+
+  auto updateInterfaceOpts = [](ModuleInterfaceOptions::InterfaceFlags &Flags,
+                                RenderedInterfaceArgs &RenderedArgs) {
+    auto printFlags = [](std::string &str, ArgStringList argList) {
+      llvm::raw_string_ostream OS(str);
+      interleave(
+          argList,
+          [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
+          [&] { OS << " "; });
+    };
+    printFlags(Flags.Flags, RenderedArgs.Standard);
+    printFlags(Flags.IgnorableFlags, RenderedArgs.Ignorable);
+  };
+
+  updateInterfaceOpts(Opts.PublicFlags, PublicArgs);
+  updateInterfaceOpts(Opts.PackageFlags, PackageArgs);
 }
 
 enum class CxxCompatMode {

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -60,15 +60,12 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
       << InterfaceFormatVersion << "\n";
   out << "// " SWIFT_COMPILER_VERSION_KEY ": "
       << ToolsVersion << "\n";
-  out << "// " SWIFT_MODULE_FLAGS_KEY ": "
-      << Opts.Flags;
+  out << "// " SWIFT_MODULE_FLAGS_KEY ": " << Opts.PublicFlags.Flags;
 
-  // Adding package-name can be disabled in non-package
-  // swiftinterfaces; add only to package.swiftinterface
-  // in such case.
-  if (Opts.printPackageInterface() &&
-      !Opts.FlagsForPackageOnly.empty())
-    out << " " << Opts.FlagsForPackageOnly;
+  // Append flags that are for the package interface only (e.g. -package-name
+  // when -disable-print-package-name-for-non-package-interface is specified).
+  if (Opts.printPackageInterface() && !Opts.PackageFlags.Flags.empty())
+    out << " " << Opts.PackageFlags.Flags;
 
   // Insert additional -module-alias flags
   if (Opts.AliasModuleNames) {
@@ -104,10 +101,14 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
   }
   out << "\n";
 
-  if (!Opts.IgnorableFlags.empty()) {
+  if (!Opts.PublicFlags.IgnorableFlags.empty()) {
     out << "// " SWIFT_MODULE_FLAGS_IGNORABLE_KEY ": "
-        << Opts.IgnorableFlags << "\n";
+        << Opts.PublicFlags.IgnorableFlags << "\n";
   }
+
+  // Append ignorable flags that are for the package interface only.
+  if (Opts.printPackageInterface() && !Opts.PackageFlags.IgnorableFlags.empty())
+    out << " " << Opts.PackageFlags.IgnorableFlags;
 }
 
 std::string

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -108,12 +108,6 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
     out << "// " SWIFT_MODULE_FLAGS_IGNORABLE_KEY ": "
         << Opts.IgnorableFlags << "\n";
   }
-
-  auto hasPrivateIgnorableFlags = !Opts.printPublicInterface() && !Opts.IgnorablePrivateFlags.empty();
-  if (hasPrivateIgnorableFlags) {
-    out << "// " SWIFT_MODULE_FLAGS_IGNORABLE_PRIVATE_KEY ": "
-        << Opts.IgnorablePrivateFlags << "\n";
-  }
 }
 
 std::string

--- a/test/ModuleInterface/project-name.swift
+++ b/test/ModuleInterface/project-name.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module %s -I %t \
+// RUN:   -module-name Library -project-name ProjectName \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module-interface-path %t/Library.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Library.private.swiftinterface \
+// RUN:   -emit-package-module-interface-path %t/Library.package.swiftinterface
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.private.swiftinterface) -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.package.swiftinterface) -module-name Library
+
+// RUN: %FileCheck %s < %t/Library.swiftinterface --check-prefix CHECK-PUBLIC
+// RUN: %FileCheck %s < %t/Library.private.swiftinterface --check-prefix CHECK-NONPUBLIC
+// RUN: %FileCheck %s < %t/Library.package.swiftinterface --check-prefix CHECK-NONPUBLIC
+
+// CHECK-PUBLIC-NOT: -project-name
+
+// CHECK-NONPUBLIC: swift-module-flags-ignorable:
+// CHECK-NONPUBLIC-SAME: -project-name ProjectName
+
+public func foo() {}


### PR DESCRIPTION
Exclude the `-project-name` flag from the public `.swiftinterface` file for a module. In order to accomplish this, some refactoring was necessary. There are two axes on which a saved frontend flag can be categorized for printing in a `.swiftinterface` file:
    
1. Whether the flag is "ignorable" or not.
2. Which levels of interface the flag should be in (public, private, package).
    
The refactor ensures that those two axes are modeled independently which should make it easier to reason about and extend in the future.

Resolves rdar://130992944.