### PR TITLE
[6.0][region-isolation] Add 'inout sending' diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -939,6 +939,9 @@ NOTE(sil_referencebinding_inout_binding_here, none,
 
 NOTE(regionbasedisolation_maybe_race, none,
      "access can happen concurrently", ())
+NOTE(regionbasedisolation_inout_sending_must_be_reinitialized, none,
+     "'inout sending' parameter must be reinitialized before function exit with a non-actor isolated value",
+     ())
 ERROR(regionbasedisolation_unknown_pattern, none,
       "pattern that the region based isolation checker does not understand how to check. Please file a bug",
       ())
@@ -968,6 +971,9 @@ ERROR(regionbasedisolation_arg_passed_to_strongly_transferred_param, none,
 NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
      "value is %0 since it is in the same region as %1",
      (StringRef, DeclBaseName))
+NOTE(regionbasedisolation_isolated_since_in_same_region_string, none,
+     "%0 is %1since it is in the same region as %2",
+     (Identifier, StringRef, Identifier))
 
 //===---
 // New Transfer Non Sendable Diagnostics
@@ -976,6 +982,13 @@ NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
 ERROR(regionbasedisolation_named_transfer_yields_race, none,
       "sending %0 risks causing data races",
       (Identifier))
+
+ERROR(regionbasedisolation_inout_sending_cannot_be_actor_isolated, none,
+      "'inout sending' parameter %0 cannot be %1at end of function",
+      (Identifier, StringRef))
+NOTE(regionbasedisolation_inout_sending_cannot_be_actor_isolated_note, none,
+      "%1%0 risks causing races in between %1uses and caller uses since caller assumes value is not actor isolated",
+      (Identifier, StringRef))
 
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
      "sending %1%0 to %2 callee risks causing data races between %2 and local %3 uses",

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -410,6 +410,15 @@ enum class PartitionOpKind : uint8_t {
   ///
   /// This is used if we need to reject the program and do not want to assert.
   UnknownPatternError,
+
+  /// Require that a 'inout sending' parameter's region is not transferred and
+  /// disconnected at a specific function exiting term inst.
+  ///
+  /// This ensures that if users transfer away an inout sending parameter, the
+  /// parameter is reinitialized with a disconnected value.
+  ///
+  /// Takes one parameter, the inout parameter that we need to check.
+  RequireInOutSendingAtFunctionExit,
 };
 
 /// PartitionOp represents a primitive operation that can be performed on
@@ -492,6 +501,12 @@ public:
   static PartitionOp UnknownPatternError(Element elt,
                                          SILInstruction *sourceInst) {
     return PartitionOp(PartitionOpKind::UnknownPatternError, elt, sourceInst);
+  }
+
+  static PartitionOp
+  RequireInOutSendingAtFunctionExit(Element elt, SILInstruction *sourceInst) {
+    return PartitionOp(PartitionOpKind::RequireInOutSendingAtFunctionExit, elt,
+                       sourceInst);
   }
 
   bool operator==(const PartitionOp &other) const {
@@ -925,6 +940,21 @@ public:
                                                    isolationRegionInfo);
   }
 
+  /// Call our CRTP subclass.
+  void handleInOutSendingNotInitializedAtExitError(
+      const PartitionOp &op, Element elt, Operand *transferringOp) const {
+    return asImpl().handleInOutSendingNotInitializedAtExitError(op, elt,
+                                                                transferringOp);
+  }
+
+  /// Call our CRTP subclass.
+  void handleInOutSendingNotDisconnectedAtExitError(
+      const PartitionOp &op, Element elt,
+      SILDynamicMergedIsolationInfo isolation) const {
+    return asImpl().handleInOutSendingNotDisconnectedAtExitError(op, elt,
+                                                                 isolation);
+  }
+
   /// Call isActorDerived on our CRTP subclass.
   bool isActorDerived(Element elt) const {
     return asImpl().isActorDerived(elt);
@@ -959,8 +989,10 @@ public:
   }
 
   /// Overload of \p getIsolationRegionInfo without an Operand.
-  SILIsolationInfo getIsolationRegionInfo(Region region) const {
-    return getIsolationRegionInfo(region, nullptr).first;
+  SILDynamicMergedIsolationInfo getIsolationRegionInfo(Region region) const {
+    if (auto opt = getIsolationRegionInfo(region, nullptr))
+      return opt->first;
+    return SILDynamicMergedIsolationInfo();
   }
 
   bool isTaskIsolatedDerived(Element elt) const {
@@ -1150,6 +1182,41 @@ public:
         }
       }
       return;
+    case PartitionOpKind::RequireInOutSendingAtFunctionExit: {
+      assert(op.getOpArgs().size() == 1 &&
+             "Require PartitionOp should be passed 1 argument");
+      assert(p.isTrackingElement(op.getOpArgs()[0]) &&
+             "Require PartitionOp's argument should already be tracked");
+
+      // First check if the region of our 'inout sending' element has been
+      // transferred. In that case, we emit a special use after free error.
+      if (auto *transferredOperandSet = p.getTransferred(op.getOpArgs()[0])) {
+        for (auto transferredOperand : transferredOperandSet->data()) {
+          handleInOutSendingNotInitializedAtExitError(op, op.getOpArgs()[0],
+                                                      transferredOperand);
+        }
+        return;
+      }
+
+      // If we were not transferred, check if our region is actor isolated. If
+      // so, error since we need a disconnected value in the inout parameter.
+      Region inoutSendingRegion = p.getRegion(op.getOpArgs()[0]);
+      auto dynamicRegionIsolation = getIsolationRegionInfo(inoutSendingRegion);
+
+      // If we failed to merge emit an unknown pattern error so we fail.
+      if (!dynamicRegionIsolation) {
+        handleUnknownCodePattern(op);
+        return;
+      }
+
+      // Otherwise, emit the error if the dynamic region isolation is not
+      // disconnected.
+      if (!dynamicRegionIsolation.isDisconnected()) {
+        handleInOutSendingNotDisconnectedAtExitError(op, op.getOpArgs()[0],
+                                                     dynamicRegionIsolation);
+      }
+      return;
+    }
     case PartitionOpKind::UnknownPatternError:
       // Begin tracking the specified element in case we have a later use.
       p.trackNewElement(op.getOpArgs()[0]);
@@ -1336,6 +1403,16 @@ struct PartitionOpEvaluatorBaseImpl : PartitionOpEvaluator<Subclass> {
   /// DISCUSSION: Our dataflow cannot emit errors itself so this is a callback
   /// to our user so that we can emit that error as we process.
   void handleUnknownCodePattern(const PartitionOp &op) const {}
+
+  /// Called if we find an 'inout sending' parameter that is not live at exit.
+  void handleInOutSendingNotInitializedAtExitError(
+      const PartitionOp &op, Element elt, Operand *transferringOp) const {}
+
+  /// Called if we find an 'inout sending' parameter that is live at excit but
+  /// is actor isolated instead of disconnected.
+  void handleInOutSendingNotDisconnectedAtExitError(
+      const PartitionOp &op, Element elt,
+      SILDynamicMergedIsolationInfo actorIsolation) const {}
 
   /// This is used to determine if an element is actor derived. If we determine
   /// that a region containing such an element is transferred, we emit an error

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -81,6 +81,12 @@ public:
     return value.getPointer();
   }
 
+  SILValue maybeGetValue() const {
+    if (getKind() != Kind::Value)
+      return SILValue();
+    return getValue();
+  }
+
   bool isValue() const { return getKind() == Kind::Value; }
 
   bool isAccessorInit() const { return getKind() == Kind::ActorAccessorInit; }
@@ -389,7 +395,7 @@ class SILDynamicMergedIsolationInfo {
 
 public:
   SILDynamicMergedIsolationInfo() : innerInfo() {}
-  SILDynamicMergedIsolationInfo(SILIsolationInfo innerInfo)
+  explicit SILDynamicMergedIsolationInfo(SILIsolationInfo innerInfo)
       : innerInfo(innerInfo) {}
 
   /// Returns nullptr only if both this isolation info and \p other are actor
@@ -404,12 +410,20 @@ public:
 
   operator bool() const { return bool(innerInfo); }
 
+  SILIsolationInfo *operator->() { return &innerInfo; }
+
   SILIsolationInfo getIsolationInfo() const { return innerInfo; }
 
   bool isDisconnected() const { return innerInfo.isDisconnected(); }
 
   bool hasSameIsolation(SILIsolationInfo other) const {
     return innerInfo.hasSameIsolation(other);
+  }
+
+  static SILDynamicMergedIsolationInfo
+  getDisconnected(bool isUnsafeNonIsolated) {
+    return SILDynamicMergedIsolationInfo(
+        SILIsolationInfo::getDisconnected(isUnsafeNonIsolated));
   }
 
   SWIFT_DEBUG_DUMP { innerInfo.dump(); }

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -1568,7 +1568,7 @@ public:
   }
 
   void emitUnknownPatternError() {
-    if (AbortOnUnknownPatternMatchError) {
+    if (shouldAbortOnUnknownPatternMatchError()) {
       llvm::report_fatal_error(
           "RegionIsolation: Aborting on unknown pattern match error");
     }

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -425,6 +425,26 @@ void RequireLiveness::process(Collection requireInstList) {
 
 namespace {
 
+struct InOutSendingNotDisconnectedInfo {
+  /// The function exiting inst where the 'inout sending' parameter was actor
+  /// isolated.
+  TermInst *functionExitingInst;
+
+  /// The 'inout sending' param that we are emitting an error for.
+  SILValue inoutSendingParam;
+
+  /// The dynamic actor isolated region info of our 'inout sending' value's
+  /// region at the terminator inst.
+  SILDynamicMergedIsolationInfo actorIsolatedRegionInfo;
+
+  InOutSendingNotDisconnectedInfo(
+      SILInstruction *functionExitingInst, SILValue inoutSendingParam,
+      SILDynamicMergedIsolationInfo actorIsolatedRegionInfo)
+      : functionExitingInst(cast<TermInst>(functionExitingInst)),
+        inoutSendingParam(inoutSendingParam),
+        actorIsolatedRegionInfo(actorIsolatedRegionInfo) {}
+};
+
 struct TransferredNonTransferrableInfo {
   /// The use that actually caused the transfer.
   Operand *transferredOperand;
@@ -458,11 +478,13 @@ struct TransferredNonTransferrableInfo {
 /// dealing with an inout reinitialization needed or if it is just a normal
 /// use after transfer.
 class RequireInst {
+public:
   enum Kind {
     UseAfterTransfer,
     InOutReinitializationNeeded,
   };
 
+private:
   llvm::PointerIntPair<SILInstruction *, 1> instAndKind;
 
   RequireInst(SILInstruction *inst, Kind kind) : instAndKind(inst, kind) {}
@@ -489,6 +511,8 @@ class TransferNonSendableImpl {
       transferOpToRequireInstMultiMap;
   SmallVector<TransferredNonTransferrableInfo, 8>
       transferredNonTransferrableInfoList;
+  SmallVector<InOutSendingNotDisconnectedInfo, 8>
+      inoutSendingNotDisconnectedInfoList;
 
 public:
   TransferNonSendableImpl(RegionAnalysisFunctionInfo *regionInfo)
@@ -501,6 +525,7 @@ private:
 
   void emitUseAfterTransferDiagnostics();
   void emitTransferredNonTransferrableDiagnostics();
+  void emitInOutSendingNotDisconnectedInfoList();
 };
 
 } // namespace
@@ -745,8 +770,19 @@ private:
     // Now actually emit the require notes.
     while (!requireInsts.empty()) {
       auto require = requireInsts.pop_back_val();
-      diagnoseNote(*require, diag::regionbasedisolation_maybe_race)
-          .highlight(require->getLoc().getSourceRange());
+      switch (require.getKind()) {
+      case RequireInst::UseAfterTransfer:
+        diagnoseNote(*require, diag::regionbasedisolation_maybe_race)
+            .highlight(require->getLoc().getSourceRange());
+        continue;
+      case RequireInst::InOutReinitializationNeeded:
+        diagnoseNote(
+            *require,
+            diag::regionbasedisolation_inout_sending_must_be_reinitialized)
+            .highlight(require->getLoc().getSourceRange());
+        continue;
+      }
+      llvm_unreachable("Covered switch isn't covered?!");
     }
   }
 };
@@ -1506,6 +1542,125 @@ void TransferNonSendableImpl::emitTransferredNonTransferrableDiagnostics() {
 }
 
 //===----------------------------------------------------------------------===//
+//              MARK: InOutSendingNotDisconnected Error Emitter
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class InOutSendingNotDisconnectedDiagnosticEmitter {
+  InOutSendingNotDisconnectedInfo info;
+  bool emittedErrorDiagnostic = false;
+
+public:
+  InOutSendingNotDisconnectedDiagnosticEmitter(
+      InOutSendingNotDisconnectedInfo info)
+      : info(info) {}
+
+  ~InOutSendingNotDisconnectedDiagnosticEmitter() {
+    // If we were supposed to emit a diagnostic and didn't emit an unknown
+    // pattern error.
+    if (!emittedErrorDiagnostic)
+      emitUnknownPatternError();
+  }
+
+  std::optional<DiagnosticBehavior> getBehaviorLimit() const {
+    return getDiagnosticBehaviorLimitForValue(info.inoutSendingParam);
+  }
+
+  void emitUnknownPatternError() {
+    if (AbortOnUnknownPatternMatchError) {
+      llvm::report_fatal_error(
+          "RegionIsolation: Aborting on unknown pattern match error");
+    }
+
+    diagnoseError(info.functionExitingInst,
+                  diag::regionbasedisolation_unknown_pattern)
+        .limitBehaviorIf(getBehaviorLimit());
+  }
+
+  void emit();
+
+  ASTContext &getASTContext() const {
+    return info.functionExitingInst->getFunction()->getASTContext();
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseError(SourceLoc loc, Diag<T...> diag,
+                                   U &&...args) {
+    emittedErrorDiagnostic = true;
+    return std::move(getASTContext()
+                         .Diags.diagnose(loc, diag, std::forward<U>(args)...)
+                         .warnUntilSwiftVersion(6));
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseError(SILLocation loc, Diag<T...> diag,
+                                   U &&...args) {
+    return diagnoseError(loc.getSourceLoc(), diag, std::forward<U>(args)...);
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseError(SILInstruction *inst, Diag<T...> diag,
+                                   U &&...args) {
+    return diagnoseError(inst->getLoc(), diag, std::forward<U>(args)...);
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseNote(SourceLoc loc, Diag<T...> diag, U &&...args) {
+    return getASTContext().Diags.diagnose(loc, diag, std::forward<U>(args)...);
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseNote(SILLocation loc, Diag<T...> diag,
+                                  U &&...args) {
+    return diagnoseNote(loc.getSourceLoc(), diag, std::forward<U>(args)...);
+  }
+
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseNote(SILInstruction *inst, Diag<T...> diag,
+                                  U &&...args) {
+    return diagnoseNote(inst->getLoc(), diag, std::forward<U>(args)...);
+  }
+};
+
+} // namespace
+
+void InOutSendingNotDisconnectedDiagnosticEmitter::emit() {
+  // We should always be able to find a name for an inout sending param. If we
+  // do not, emit an unknown pattern error.
+  auto varName = VariableNameInferrer::inferName(info.inoutSendingParam);
+  if (!varName) {
+    return emitUnknownPatternError();
+  }
+
+  // Then emit the note with greater context.
+  SmallString<64> descriptiveKindStr;
+  {
+    llvm::raw_svector_ostream os(descriptiveKindStr);
+    info.actorIsolatedRegionInfo.printForDiagnostics(os);
+    os << ' ';
+  }
+
+  diagnoseError(
+      info.functionExitingInst,
+      diag::regionbasedisolation_inout_sending_cannot_be_actor_isolated,
+      *varName, descriptiveKindStr)
+      .limitBehaviorIf(getBehaviorLimit());
+
+  diagnoseNote(
+      info.functionExitingInst,
+      diag::regionbasedisolation_inout_sending_cannot_be_actor_isolated_note,
+      *varName, descriptiveKindStr);
+}
+
+void TransferNonSendableImpl::emitInOutSendingNotDisconnectedInfoList() {
+  for (auto &info : inoutSendingNotDisconnectedInfoList) {
+    InOutSendingNotDisconnectedDiagnosticEmitter emitter(info);
+    emitter.emit();
+  }
+}
+
+//===----------------------------------------------------------------------===//
 //                         MARK: Diagnostic Evaluator
 //===----------------------------------------------------------------------===//
 
@@ -1522,18 +1677,28 @@ struct DiagnosticEvaluator final
   /// is what is non-transferrable.
   SmallVectorImpl<TransferredNonTransferrableInfo> &transferredNonTransferrable;
 
+  /// A list of state that tracks specific 'inout sending' parameters that were
+  /// actor isolated on function exit with the necessary state to emit the
+  /// error.
+  SmallVectorImpl<InOutSendingNotDisconnectedInfo>
+      &inoutSendingNotDisconnectedInfoList;
+
   DiagnosticEvaluator(Partition &workingPartition,
                       RegionAnalysisFunctionInfo *info,
                       SmallFrozenMultiMap<Operand *, RequireInst, 8>
                           &transferOpToRequireInstMultiMap,
                       SmallVectorImpl<TransferredNonTransferrableInfo>
                           &transferredNonTransferrable,
+                      SmallVectorImpl<InOutSendingNotDisconnectedInfo>
+                          &inoutSendingNotDisconnectedInfoList,
                       TransferringOperandToStateMap &operandToStateMap)
       : PartitionOpEvaluatorBaseImpl(
             workingPartition, info->getOperandSetFactory(), operandToStateMap),
         info(info),
         transferOpToRequireInstMultiMap(transferOpToRequireInstMultiMap),
-        transferredNonTransferrable(transferredNonTransferrable) {}
+        transferredNonTransferrable(transferredNonTransferrable),
+        inoutSendingNotDisconnectedInfoList(
+            inoutSendingNotDisconnectedInfoList) {}
 
   void handleLocalUseAfterTransfer(const PartitionOp &partitionOp,
                                    Element transferredVal,
@@ -1587,6 +1752,27 @@ struct DiagnosticEvaluator final
         partitionOp.getSourceOp(), nonTransferrableValue, isolationRegionInfo);
   }
 
+  void handleInOutSendingNotDisconnectedAtExitError(
+      const PartitionOp &partitionOp, Element inoutSendingVal,
+      SILDynamicMergedIsolationInfo isolationRegionInfo) const {
+    LLVM_DEBUG(llvm::dbgs()
+                   << "    Emitting InOut Sending ActorIsolated at end of "
+                      "Function Error!\n"
+                   << "        ID:  %%" << inoutSendingVal << "\n"
+                   << "        Rep: "
+                   << *info->getValueMap().getRepresentative(inoutSendingVal)
+                   << "        Dynamic Isolation Region: ";
+               isolationRegionInfo.printForDiagnostics(llvm::dbgs());
+               llvm::dbgs() << '\n');
+    auto *self = const_cast<DiagnosticEvaluator *>(this);
+    auto nonTransferrableValue =
+        info->getValueMap().getRepresentative(inoutSendingVal);
+
+    self->inoutSendingNotDisconnectedInfoList.emplace_back(
+        partitionOp.getSourceInst(), nonTransferrableValue,
+        isolationRegionInfo);
+  }
+
   void handleTransferNonTransferrable(
       const PartitionOp &partitionOp, Element transferredVal,
       Element actualNonTransferrableValue,
@@ -1628,6 +1814,24 @@ struct DiagnosticEvaluator final
           info->getValueMap().getRepresentative(transferredVal),
           isolationRegionInfo);
     }
+  }
+
+  void
+  handleInOutSendingNotInitializedAtExitError(const PartitionOp &partitionOp,
+                                              Element inoutSendingVal,
+                                              Operand *transferringOp) const {
+    auto rep = info->getValueMap().getRepresentative(inoutSendingVal);
+    LLVM_DEBUG(llvm::dbgs()
+               << "    Emitting InOut Not Reinitialized At End Of Function!\n"
+               << "        Transferring Inst: " << *transferringOp->getUser()
+               << "        Transferring Op Value: " << transferringOp->get()
+               << "        Require Inst: " << *partitionOp.getSourceInst()
+               << "        ID:  %%" << inoutSendingVal << "\n"
+               << "        Rep: " << *rep << "        Transferring Op Num: "
+               << transferringOp->getOperandNumber() << '\n');
+    transferOpToRequireInstMultiMap.insert(
+        transferringOp, RequireInst::forInOutReinitializationNeeded(
+                            partitionOp.getSourceInst()));
   }
 
   void handleUnknownCodePattern(const PartitionOp &op) const {
@@ -1692,6 +1896,7 @@ void TransferNonSendableImpl::runDiagnosticEvaluator() {
     DiagnosticEvaluator eval(workingPartition, regionInfo,
                              transferOpToRequireInstMultiMap,
                              transferredNonTransferrableInfoList,
+                             inoutSendingNotDisconnectedInfoList,
                              regionInfo->getTransferringOpToStateMap());
 
     // And then evaluate all of our partition ops on the entry partition.
@@ -1724,6 +1929,7 @@ void TransferNonSendableImpl::emitDiagnostics() {
   runDiagnosticEvaluator();
   emitTransferredNonTransferrableDiagnostics();
   emitUseAfterTransferDiagnostics();
+  emitInOutSendingNotDisconnectedInfoList();
 }
 
 namespace {

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -347,9 +347,9 @@ void RequireLiveness::process(Collection requireInstList) {
 
   // Then put all of our requires into our allRequires set.
   BasicBlockWorklist initializingWorklist(transferInst->getFunction());
-  for (auto *require : requireInstList) {
-    LLVM_DEBUG(llvm::dbgs() << "        Require Inst: " << *require);
-    allRequires.insert(require);
+  for (auto require : requireInstList) {
+    LLVM_DEBUG(llvm::dbgs() << "        Require Inst: " << **require);
+    allRequires.insert(*require);
     initializingWorklist.pushIfNotVisited(require->getParent());
   }
 
@@ -454,9 +454,38 @@ struct TransferredNonTransferrableInfo {
         isolationRegionInfo(isolationRegionInfo) {}
 };
 
+/// Wrapper around a SILInstruction that internally specifies whether we are
+/// dealing with an inout reinitialization needed or if it is just a normal
+/// use after transfer.
+class RequireInst {
+  enum Kind {
+    UseAfterTransfer,
+    InOutReinitializationNeeded,
+  };
+
+  llvm::PointerIntPair<SILInstruction *, 1> instAndKind;
+
+  RequireInst(SILInstruction *inst, Kind kind) : instAndKind(inst, kind) {}
+
+public:
+  static RequireInst forUseAfterTransfer(SILInstruction *inst) {
+    return {inst, Kind::UseAfterTransfer};
+  }
+
+  static RequireInst forInOutReinitializationNeeded(SILInstruction *inst) {
+    return {inst, Kind::InOutReinitializationNeeded};
+  }
+
+  SILInstruction *getInst() const { return instAndKind.getPointer(); }
+  Kind getKind() const { return Kind(instAndKind.getInt()); }
+
+  SILInstruction *operator*() const { return getInst(); }
+  SILInstruction *operator->() const { return getInst(); }
+};
+
 class TransferNonSendableImpl {
   RegionAnalysisFunctionInfo *regionInfo;
-  SmallFrozenMultiMap<Operand *, SILInstruction *, 8>
+  SmallFrozenMultiMap<Operand *, RequireInst, 8>
       transferOpToRequireInstMultiMap;
   SmallVector<TransferredNonTransferrableInfo, 8>
       transferredNonTransferrableInfoList;
@@ -484,12 +513,12 @@ namespace {
 
 class UseAfterTransferDiagnosticEmitter {
   Operand *transferOp;
-  SmallVectorImpl<SILInstruction *> &requireInsts;
+  SmallVectorImpl<RequireInst> &requireInsts;
   bool emittedErrorDiagnostic = false;
 
 public:
-  UseAfterTransferDiagnosticEmitter(
-      Operand *transferOp, SmallVectorImpl<SILInstruction *> &requireInsts)
+  UseAfterTransferDiagnosticEmitter(Operand *transferOp,
+                                    SmallVectorImpl<RequireInst> &requireInsts)
       : transferOp(transferOp), requireInsts(requireInsts) {}
 
   ~UseAfterTransferDiagnosticEmitter() {
@@ -715,8 +744,8 @@ private:
   void emitRequireInstDiagnostics() {
     // Now actually emit the require notes.
     while (!requireInsts.empty()) {
-      auto *require = requireInsts.pop_back_val();
-      diagnoseNote(require, diag::regionbasedisolation_maybe_race)
+      auto require = requireInsts.pop_back_val();
+      diagnoseNote(*require, diag::regionbasedisolation_maybe_race)
           .highlight(require->getLoc().getSourceRange());
     }
   }
@@ -734,7 +763,7 @@ class UseAfterTransferDiagnosticInferrer {
 
 public:
   UseAfterTransferDiagnosticInferrer(
-      Operand *transferOp, SmallVectorImpl<SILInstruction *> &requireInsts,
+      Operand *transferOp, SmallVectorImpl<RequireInst> &requireInsts,
       RegionAnalysisValueMap &valueMap,
       TransferringOperandToStateMap &transferringOpToStateMap)
       : transferOp(transferOp), diagnosticEmitter(transferOp, requireInsts),
@@ -1037,17 +1066,17 @@ void TransferNonSendableImpl::emitUseAfterTransferDiagnostics() {
     ++blockLivenessInfoGeneration;
     liveness.process(requireInsts);
 
-    SmallVector<SILInstruction *, 8> requireInstsForError;
-    for (auto *require : requireInsts) {
+    SmallVector<RequireInst, 8> requireInstsForError;
+    for (auto require : requireInsts) {
       // We can have multiple of the same require insts if we had a require
       // and an assign from the same instruction. Our liveness checking
       // above doesn't care about that, but we still need to make sure we do
       // not emit twice.
-      if (!requireInstsUnique.insert(require))
+      if (!requireInstsUnique.insert(*require))
         continue;
 
       // If this was not a last require, do not emit an error.
-      if (!liveness.finalRequires.contains(require))
+      if (!liveness.finalRequires.contains(*require))
         continue;
 
       requireInstsForError.push_back(require);
@@ -1485,7 +1514,7 @@ namespace {
 struct DiagnosticEvaluator final
     : PartitionOpEvaluatorBaseImpl<DiagnosticEvaluator> {
   RegionAnalysisFunctionInfo *info;
-  SmallFrozenMultiMap<Operand *, SILInstruction *, 8>
+  SmallFrozenMultiMap<Operand *, RequireInst, 8>
       &transferOpToRequireInstMultiMap;
 
   /// First value is the operand that was transferred... second value is the
@@ -1495,7 +1524,7 @@ struct DiagnosticEvaluator final
 
   DiagnosticEvaluator(Partition &workingPartition,
                       RegionAnalysisFunctionInfo *info,
-                      SmallFrozenMultiMap<Operand *, SILInstruction *, 8>
+                      SmallFrozenMultiMap<Operand *, RequireInst, 8>
                           &transferOpToRequireInstMultiMap,
                       SmallVectorImpl<TransferredNonTransferrableInfo>
                           &transferredNonTransferrable,
@@ -1534,8 +1563,9 @@ struct DiagnosticEvaluator final
                << "        ID:  %%" << transferredVal << "\n"
                << "        Rep: " << *rep << "        Transferring Op Num: "
                << transferringOp->getOperandNumber() << '\n');
-    transferOpToRequireInstMultiMap.insert(transferringOp,
-                                           partitionOp.getSourceInst());
+    transferOpToRequireInstMultiMap.insert(
+        transferringOp,
+        RequireInst::forUseAfterTransfer(partitionOp.getSourceInst()));
   }
 
   void handleTransferNonTransferrable(

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -98,6 +98,13 @@ void PartitionOp::print(llvm::raw_ostream &os, bool extraSpace) const {
     os << "unknown pattern error ";
     os << "%%" << opArgs[0];
     break;
+  case PartitionOpKind::RequireInOutSendingAtFunctionExit:
+    constexpr static char extraSpaceLiteral[10] = "     ";
+    os << "require_inout_sending_at_function_exit ";
+    if (extraSpace)
+      os << extraSpaceLiteral;
+    os << "%%" << opArgs[0];
+    break;
   }
   os << ": " << *getSourceInst();
 }

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1158,11 +1158,11 @@ SILDynamicMergedIsolationInfo::merge(SILIsolationInfo other) const {
   // merging. These bits should not propagate through merging and should instead
   // always be associated with non-merged infos.
   if (other.isDisconnected() && other.isUnsafeNonIsolated()) {
-    return other.withUnsafeNonIsolated(false);
+    return SILDynamicMergedIsolationInfo(other.withUnsafeNonIsolated(false));
   }
 
   // Otherwise, just return other.
-  return other;
+  return SILDynamicMergedIsolationInfo(other);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Concurrency/transfernonsendable_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_sending_params.swift
@@ -7,11 +7,11 @@
 // MARK: Declarations //
 ////////////////////////
 
-class Klass {}
+class NonSendableKlass {}
 
 struct NonSendableStruct {
-  var first = Klass()
-  var second = Klass()
+  var first = NonSendableKlass()
+  var second = NonSendableKlass()
 }
 
 class KlassWithNonSendableStructPair {
@@ -50,53 +50,53 @@ struct CustomActor {
 @MainActor func transferToMain<T>(_ t: T) {}
 @CustomActor func transferToCustom<T>(_ t: T) {}
 
-func transferArg(_ x: sending Klass) {
+func transferArg(_ x: sending NonSendableKlass) {
 }
 
-func transferArgWithOtherParam(_ x: sending Klass, _ y: Klass) {
+func transferArgWithOtherParam(_ x: sending NonSendableKlass, _ y: NonSendableKlass) {
 }
 
-func transferArgWithOtherParam2(_ x: Klass, _ y: sending Klass) {
+func transferArgWithOtherParam2(_ x: NonSendableKlass, _ y: sending NonSendableKlass) {
 }
 
-func twoTransferArg(_ x: sending Klass, _ y: sending Klass) {}
+func twoTransferArg(_ x: sending NonSendableKlass, _ y: sending NonSendableKlass) {}
 
-@MainActor var globalKlass = Klass()
+@MainActor var globalKlass = NonSendableKlass()
 
 /////////////////
 // MARK: Tests //
 /////////////////
 
 func testSimpleTransferLet() {
-  let k = Klass()
+  let k = NonSendableKlass()
   transferArg(k) // expected-warning {{sending 'k' risks causing data races}}
   // expected-note @-1 {{'k' used after being passed as a 'sending' parameter}}
   useValue(k) // expected-note {{access can happen concurrently}}
 }
 
 func testSimpleTransferVar() {
-  var k = Klass()
-  k = Klass()
+  var k = NonSendableKlass()
+  k = NonSendableKlass()
   transferArg(k) // expected-warning {{sending 'k' risks causing data races}}
   // expected-note @-1 {{'k' used after being passed as a 'sending' parameter}}
   useValue(k) // expected-note {{access can happen concurrently}}
 }
 
 func testSimpleTransferUseOfOtherParamNoError() {
-  let k = Klass()
-  let k2 = Klass()
+  let k = NonSendableKlass()
+  let k2 = NonSendableKlass()
   transferArgWithOtherParam(k, k2)
   useValue(k2)
 }
 
 func testSimpleTransferUseOfOtherParamNoError2() {
-  let k = Klass()
-  let k2 = Klass()
+  let k = NonSendableKlass()
+  let k2 = NonSendableKlass()
   transferArgWithOtherParam2(k, k2)
   useValue(k)
 }
 
-@MainActor func transferToMain2(_ x: sending Klass, _ y: Klass, _ z: Klass) async {
+@MainActor func transferToMain2(_ x: sending NonSendableKlass, _ y: NonSendableKlass, _ z: NonSendableKlass) async {
 
 }
 
@@ -108,13 +108,13 @@ func testNonStrongTransferDoesntMerge() async {
 // MARK: Transferring Parameter //
 //////////////////////////////////
 
-func testTransferringParameter_canTransfer(_ x: sending Klass, _ y: Klass) async {
+func testTransferringParameter_canTransfer(_ x: sending NonSendableKlass, _ y: NonSendableKlass) async {
   await transferToMain(x)
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
-func testTransferringParameter_cannotTransferTwice(_ x: sending Klass, _ y: Klass) async {
+func testTransferringParameter_cannotTransferTwice(_ x: sending NonSendableKlass, _ y: NonSendableKlass) async {
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
 
@@ -122,28 +122,28 @@ func testTransferringParameter_cannotTransferTwice(_ x: sending Klass, _ y: Klas
   await transferToMain(x) // expected-note {{access can happen concurrently}}
 }
 
-func testTransferringParameter_cannotUseAfterTransfer(_ x: sending Klass, _ y: Klass) async {
+func testTransferringParameter_cannotUseAfterTransfer(_ x: sending NonSendableKlass, _ y: NonSendableKlass) async {
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-note {{access can happen concurrently}}
 }
 
 actor MyActor {
-  var field = Klass()
+  var field = NonSendableKlass()
 
-  func canTransferWithTransferringMethodArg(_ x: sending Klass, _ y: Klass) async {
+  func canTransferWithTransferringMethodArg(_ x: sending NonSendableKlass, _ y: NonSendableKlass) async {
     await transferToMain(x)
     await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
     // expected-note @-1 {{sending 'self'-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 
-  func getNormalErrorIfTransferTwice(_ x: sending Klass) async {
+  func getNormalErrorIfTransferTwice(_ x: sending NonSendableKlass) async {
     await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
     // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
     await transferToMain(x) // expected-note {{access can happen concurrently}}
   }
 
-  func getNormalErrorIfUseAfterTransfer(_ x: sending Klass) async {
+  func getNormalErrorIfUseAfterTransfer(_ x: sending NonSendableKlass) async {
     await transferToMain(x)  // expected-warning {{sending 'x' risks causing data races}}
     // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
     useValue(x) // expected-note {{access can happen concurrently}}
@@ -151,40 +151,40 @@ actor MyActor {
 
   // After assigning into the actor, we can still use x in the actor as long as
   // we don't transfer it.
-  func assignTransferringIntoActor(_ x: sending Klass) async {
+  func assignTransferringIntoActor(_ x: sending NonSendableKlass) async {
     field = x
     useValue(x)
   }
 
   // Once we assign into the actor, we cannot transfer further.
-  func assignTransferringIntoActor2(_ x: sending Klass) async {
+  func assignTransferringIntoActor2(_ x: sending NonSendableKlass) async {
     field = x
     await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
     // expected-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
 }
 
-@MainActor func canAssignTransferringIntoGlobalActor(_ x: sending Klass) async {
+@MainActor func canAssignTransferringIntoGlobalActor(_ x: sending NonSendableKlass) async {
   globalKlass = x
 }
 
-@MainActor func canAssignTransferringIntoGlobalActor2(_ x: sending Klass) async {
+@MainActor func canAssignTransferringIntoGlobalActor2(_ x: sending NonSendableKlass) async {
   globalKlass = x
   // TODO: This is incorrect! sending should be independent of @MainActor.
   await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
 
-@MainActor func canAssignTransferringIntoGlobalActor3(_ x: sending Klass) async {
-  await transferToCustom(globalKlass) // expected-warning {{sending main actor-isolated value of type 'Klass' with later accesses to global actor 'CustomActor'-isolated context risks causing data races}}
+@MainActor func canAssignTransferringIntoGlobalActor3(_ x: sending NonSendableKlass) async {
+  await transferToCustom(globalKlass) // expected-warning {{sending main actor-isolated value of type 'NonSendableKlass' with later accesses to global actor 'CustomActor'-isolated context risks causing data races}}
 }
 
-func canTransferAssigningIntoLocal(_ x: sending Klass) async {
+func canTransferAssigningIntoLocal(_ x: sending NonSendableKlass) async {
   let _ = x
   await transferToMain(x)
 }
 
-func canTransferAssigningIntoLocal2(_ x: sending Klass) async {
+func canTransferAssigningIntoLocal2(_ x: sending NonSendableKlass) async {
   let _ = x
   await transferToMain(x)
   // We do not error here since we just load the value and do not do anything
@@ -195,7 +195,7 @@ func canTransferAssigningIntoLocal2(_ x: sending Klass) async {
   let _ = x
 }
 
-func canTransferAssigningIntoLocal2a(_ x: sending Klass) async {
+func canTransferAssigningIntoLocal2a(_ x: sending NonSendableKlass) async {
   let _ = x
   await transferToMain(x)
   // We do not error here since we just load the value and do not do anything
@@ -206,7 +206,7 @@ func canTransferAssigningIntoLocal2a(_ x: sending Klass) async {
   _ = x
 }
 
-func canTransferAssigningIntoLocal3(_ x: sending Klass) async {
+func canTransferAssigningIntoLocal3(_ x: sending NonSendableKlass) async {
   let _ = x
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -219,8 +219,8 @@ func canTransferAssigningIntoLocal3(_ x: sending Klass) async {
 //////////////////////////////////////
 
 // Assigning into a 'sending' parameter is a merge.
-func assigningIsAMerge(_ x: sending Klass) async {
-  let y = Klass()
+func assigningIsAMerge(_ x: sending NonSendableKlass) async {
+  let y = NonSendableKlass()
 
   x = y
 
@@ -228,8 +228,8 @@ func assigningIsAMerge(_ x: sending Klass) async {
   await transferToMain(y)
 }
 
-func assigningIsAMergeError(_ x: sending Klass) async {
-  let y = Klass()
+func assigningIsAMergeError(_ x: sending NonSendableKlass) async {
+  let y = NonSendableKlass()
 
   x = y
 
@@ -306,7 +306,7 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: sending NonSendableStruct) async 
 
 
   // Ok, this is disconnected.
-  let y = Klass()
+  let y = NonSendableKlass()
 
   useValue(x)
 
@@ -322,7 +322,7 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: sending NonSendableStruct) async 
 
 func mergeDoesNotEliminateEarlierTransfer2(_ x: sending NonSendableStruct) async {
   // Ok, this is disconnected.
-  let y = Klass()
+  let y = NonSendableKlass()
 
   useValue(x)
 
@@ -334,24 +334,24 @@ func mergeDoesNotEliminateEarlierTransfer2(_ x: sending NonSendableStruct) async
 }
 
 func doubleArgument() async {
-  let x = Klass()
+  let x = NonSendableKlass()
   twoTransferArg(x, x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{'x' used after being passed as a 'sending' parameter}}
   // expected-note @-2 {{access can happen concurrently}}
 }
 
-func testTransferSrc(_ x: sending Klass) async {
-  let y = Klass()
+func testTransferSrc(_ x: sending NonSendableKlass) async {
+  let y = NonSendableKlass()
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   x = y // expected-note {{access can happen concurrently}}
 }
 
-func testTransferOtherParam(_ x: sending Klass, y: Klass) async {
+func testTransferOtherParam(_ x: sending NonSendableKlass, y: NonSendableKlass) async {
   x = y
 }
 
-func testTransferOtherParamTuple(_ x: sending Klass, y: (Klass, Klass)) async {
+func testTransferOtherParamTuple(_ x: sending NonSendableKlass, y: (NonSendableKlass, NonSendableKlass)) async {
   x = y.0
 }
 
@@ -382,14 +382,14 @@ func taskIsolatedInsideError(_ x: @escaping @MainActor () async -> ()) {
 
 // Make sure we error here on only the second since x by being assigned a part
 // of y becomes task-isolated
-func testMergeWithTaskIsolated(_ x: sending Klass, y: Klass) async {
+func testMergeWithTaskIsolated(_ x: sending NonSendableKlass, y: NonSendableKlass) async {
   await transferToMain(x)
   x = y
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
 }
 
-@MainActor func testMergeWithActorIsolated(_ x: sending Klass, y: Klass) async {
+@MainActor func testMergeWithActorIsolated(_ x: sending NonSendableKlass, y: NonSendableKlass) async {
   x = y
   await transferToCustom(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending main actor-isolated 'x' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
@@ -398,8 +398,8 @@ func testMergeWithTaskIsolated(_ x: sending Klass, y: Klass) async {
 
 @available(SwiftStdlib 5.1, *)
 actor NonSendableInit {
-  var first: Klass
-  var second: Klass? = nil {
+  var first: NonSendableKlass
+  var second: NonSendableKlass? = nil {
     @storageRestrictions(initializes: first)
     init(initialValue)  {
       transferArg(initialValue!) // expected-warning {{sending 'initialValue' risks causing data races}}
@@ -415,6 +415,6 @@ actor NonSendableInit {
 func testNoCrashWhenSendingNoEscapeClosure() async {
   func test(_ x: sending () -> ()) async {}
 
-  let c = Klass()
+  let c = NonSendableKlass()
   await test { print(c) }
 }


### PR DESCRIPTION
Explanation: This PR adds support for 'inout sending' diagnostics. Specifically:

1. We error now if one transfers an 'inout sending' parameter and does not
reinitialize it before the end of the function.

2. We error now if one merges an 'inout sending' parameter into an actor
isolated region and do not reinitialize it with a non-actor isolated value
before the end of the function.

Radars:

- rdar://126303739

Original PRs:

- https://github.com/swiftlang/swift/pull/74919
- https://github.com/swiftlang/swift/pull/74926

Risk: Low. This just adds 2 additional diagnostics to close a hole in the model.
Testing: Added/Ran tests
Reviewer: N/A