### PR TITLE
[Macros] Put the insertion location for freestanding macros at the beginning

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -290,7 +290,11 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
     switch (*macroRole) {
     case MacroRole::Expression:
     case MacroRole::Declaration:
-    case MacroRole::CodeItem:
+    case MacroRole::CodeItem: {
+      parentLoc = SF->getMacroInsertionRange().Start;
+      break;
+    }
+
     case MacroRole::Accessor:
     case MacroRole::MemberAttribute:
     case MacroRole::Conformance:

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -105,6 +105,20 @@ public struct StringifyAndTryMacro: ExpressionMacro {
   }
 }
 
+public struct TryCallThrowingFuncMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return """
+      try await {
+        print("let's throw")
+        return try await throwingFunc()
+      }()
+      """
+  }
+}
+
 struct SimpleDiagnosticMessage: DiagnosticMessage {
   let message: String
   let diagnosticID: MessageID

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -308,6 +308,16 @@ func testStringifyWithThrows() throws {
   _ = #stringifyAndTry(maybeThrowing())
 }
 
+func throwingFunc() async throws -> Int { 5 }
+
+@freestanding(expression) macro callThrowingFunc<T>(_ body: () -> T) -> T = #externalMacro(module: "MacroDefinition", type: "TryCallThrowingFuncMacro")
+
+func testThrowingCall() async throws -> Int {
+  #callThrowingFunc {
+    [1, 2, 3, 4, 5].map { $0 + 1 }.first!
+  }
+}
+
 func testStringifyWithLocalType() throws {
   _ =  #stringify({
     struct QuailError: Error {}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -308,10 +308,12 @@ func testStringifyWithThrows() throws {
   _ = #stringifyAndTry(maybeThrowing())
 }
 
+@available(SwiftStdlib 5.1, *)
 func throwingFunc() async throws -> Int { 5 }
 
 @freestanding(expression) macro callThrowingFunc<T>(_ body: () -> T) -> T = #externalMacro(module: "MacroDefinition", type: "TryCallThrowingFuncMacro")
 
+@available(SwiftStdlib 5.1, *)
 func testThrowingCall() async throws -> Int {
   #callThrowingFunc {
     [1, 2, 3, 4, 5].map { $0 + 1 }.first!


### PR DESCRIPTION
When building the ASTScope tree, we set the insertion location for the macro expansion just before the end of the macro use. This is the right approach for attached macros, because we need to put the entities after the macro.

However, for freestanding macros, which can have trailing closures, this location is a problem, because the scope for the macro expansion ends up inside the scope for the trailing closure. Use the start location of the freestanding macro instead.

Fixes rdar://130923190.
