### PR TITLE
Fix a thinko.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -1615,7 +1615,7 @@ public:
   }
 
   void emitUnknownPatternError() {
-    if (AbortOnUnknownPatternMatchError) {
+    if (shouldAbortOnUnknownPatternMatchError()) {
       llvm::report_fatal_error(
           "RegionIsolation: Aborting on unknown pattern match error");
     }


### PR DESCRIPTION
I was working on c20abe570d5a163805f01dce4991b32834e208c5 and 03bfadea60278281b9f1a641109d87e8614cc0eb at the same time and I forgot to update to use the new API in 03bfadea60278281b9f1a641109d87e8614cc0eb before I commited c20abe570d5a163805f01dce4991b32834e208c5. Sorry!

To be clear the thinko was just I used something that is only around in asserts builds in code that also builds without asserts. = /.