### PR TITLE
[6.0] [Macros] Put the insertion location for freestanding macros at the beginning

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -289,7 +289,11 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
     switch (*macroRole) {
     case MacroRole::Expression:
     case MacroRole::Declaration:
-    case MacroRole::CodeItem:
+    case MacroRole::CodeItem: {
+      parentLoc = SF->getMacroInsertionRange().Start;
+      break;
+    }
+
     case MacroRole::Accessor:
     case MacroRole::MemberAttribute:
     case MacroRole::Conformance:

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -105,6 +105,20 @@ public struct StringifyAndTryMacro: ExpressionMacro {
   }
 }
 
+public struct TryCallThrowingFuncMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return """
+      try await {
+        print("let's throw")
+        return try await throwingFunc()
+      }()
+      """
+  }
+}
+
 struct SimpleDiagnosticMessage: DiagnosticMessage {
   let message: String
   let diagnosticID: MessageID

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -308,6 +308,16 @@ func testStringifyWithThrows() throws {
   _ = #stringifyAndTry(maybeThrowing())
 }
 
+func throwingFunc() async throws -> Int { 5 }
+
+@freestanding(expression) macro callThrowingFunc<T>(_ body: () -> T) -> T = #externalMacro(module: "MacroDefinition", type: "TryCallThrowingFuncMacro")
+
+func testThrowingCall() async throws -> Int {
+  #callThrowingFunc {
+    [1, 2, 3, 4, 5].map { $0 + 1 }.first!
+  }
+}
+
 func testStringifyWithLocalType() throws {
   _ =  #stringify({
     struct QuailError: Error {}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -308,10 +308,12 @@ func testStringifyWithThrows() throws {
   _ = #stringifyAndTry(maybeThrowing())
 }
 
+@available(SwiftStdlib 5.1, *)
 func throwingFunc() async throws -> Int { 5 }
 
 @freestanding(expression) macro callThrowingFunc<T>(_ body: () -> T) -> T = #externalMacro(module: "MacroDefinition", type: "TryCallThrowingFuncMacro")
 
+@available(SwiftStdlib 5.1, *)
 func testThrowingCall() async throws -> Int {
   #callThrowingFunc {
     [1, 2, 3, 4, 5].map { $0 + 1 }.first!


### PR DESCRIPTION
Explanation: Fixes an ASTScope-construction problem that resulted in incorrect resolution of catch nodes within freestanding macro expansions that involve trailing closures. In the issue, it manifest as an incorrect diagnostic about a thrown error type mismatch, but it could manifest in a number of other bugs with freestanding macro expansions.
Scope: Affects  only freestanding macro expansions.
Risk: Low
Testing: Added a new test case
Issue: rdar://130923190
Main branch PR: https://github.com/swiftlang/swift/pull/74925