### PR TITLE
[Concurrency] Prevent potential for condfail with owned task executor parameter 

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -150,6 +150,7 @@ BASELINE_LANGUAGE_FEATURE(BuiltinBuildTaskExecutorRef, 0, "TaskExecutor-building
 BASELINE_LANGUAGE_FEATURE(BuiltinBuildExecutor, 0, "Executor-building builtins")
 BASELINE_LANGUAGE_FEATURE(BuiltinBuildComplexEqualityExecutor, 0, "Executor-building for 'complexEquality executor' builtins")
 BASELINE_LANGUAGE_FEATURE(BuiltinBuildMainExecutor, 0, "MainActor executor building builtin")
+BASELINE_LANGUAGE_FEATURE(BuiltinCreateAsyncTaskOwnedTaskExecutor, 0, "Task create with owned TaskExecutor")
 BASELINE_LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroup, 0, "Task create in task group builtin with extra flags")
 BASELINE_LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroupWithExecutor, 0, "Task create in task group builtin with extra flags")
 BASELINE_LANGUAGE_FEATURE(BuiltinCreateAsyncDiscardingTaskInGroup, 0, "Task create in discarding task group builtin, accounting for the Void return type")

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -60,6 +60,12 @@ else()
   list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS "-fswift-async-fp=never")
 endif()
 
+# Do not remove until IsolatedAny is on by default in all supported compilers.
+list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS
+  "-enable-experimental-feature"
+  "IsolatedAny"
+)
+
 list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
   "-D__STDC_WANT_LIB_EXT1__=1")
 

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -192,7 +192,6 @@ public struct DiscardingTaskGroup {
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
   #endif
@@ -234,7 +233,6 @@ public struct DiscardingTaskGroup {
   /// - Returns: `true` if the child task was added to the group;
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
   #endif
@@ -275,7 +273,6 @@ public struct DiscardingTaskGroup {
   }
 
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     operation: sending @escaping @isolated(any) () async -> Void
   ) {
@@ -304,7 +301,6 @@ public struct DiscardingTaskGroup {
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTaskUnlessCancelled(operation:)")
 #endif
-  @_allowFeatureSuppression(IsolatedAny)
   @_alwaysEmitIntoClient
   public mutating func addTaskUnlessCancelled(
     operation: sending @escaping @isolated(any) () async -> Void
@@ -756,7 +752,6 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
 #endif
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async throws -> Void
@@ -781,7 +776,6 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
 #endif
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async throws -> Void

--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -241,11 +241,13 @@ extension Task where Failure == Never {
       flags: flags,
       initialTaskExecutorConsuming: taskExecutor,
       operation: operation)
-
-    self._task = task
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+    let executorBuiltin: Builtin.Executor =
+      taskExecutor.asUnownedTaskExecutor().executor
+    let (task, _) = Builtin.createAsyncTaskWithExecutor(
+      flags, executorBuiltin, operation)
 #endif
+    self._task = task
   }
 }
 
@@ -301,11 +303,13 @@ extension Task where Failure == Error {
       flags: flags,
       initialTaskExecutorConsuming: taskExecutor,
       operation: operation)
-
-    self._task = task
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+    let executorBuiltin: Builtin.Executor =
+      taskExecutor.asUnownedTaskExecutor().executor
+    let (task, _) = Builtin.createAsyncTaskWithExecutor(
+      flags, executorBuiltin, operation)
 #endif
+    self._task = task
   }
 }
 
@@ -357,14 +361,15 @@ extension Task where Failure == Never {
 #if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     let (task, _) = Builtin.createTask(
       flags: flags,
-      // initialTaskExecutor: executorBuiltin, deprecated
       initialTaskExecutorConsuming: taskExecutor,
       operation: operation)
-
-    return Task(task)
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+    let executorBuiltin: Builtin.Executor =
+      taskExecutor.asUnownedTaskExecutor().executor
+    let (task, _) = Builtin.createAsyncTaskWithExecutor(
+      flags, executorBuiltin, operation)
 #endif
+    return Task(task)
   }
 }
 
@@ -418,11 +423,13 @@ extension Task where Failure == Error {
       flags: flags,
       initialTaskExecutorConsuming: taskExecutor,
       operation: operation)
-
-    return Task(task)
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+    let executorBuiltin: Builtin.Executor =
+      taskExecutor.asUnownedTaskExecutor().executor
+    let (task, _) = Builtin.createAsyncTaskWithExecutor(
+      flags, executorBuiltin, operation)
 #endif
+    return Task(task)
   }
 }
 

--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -236,12 +236,16 @@ extension Task where Failure == Never {
       addPendingGroupTaskUnconditionally: false,
       isDiscardingTask: false)
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     let (task, _) = Builtin.createTask(
       flags: flags,
       initialTaskExecutorConsuming: taskExecutor,
       operation: operation)
 
     self._task = task
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 }
 
@@ -292,12 +296,16 @@ extension Task where Failure == Error {
       addPendingGroupTaskUnconditionally: false,
       isDiscardingTask: false)
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     let (task, _) = Builtin.createTask(
       flags: flags,
       initialTaskExecutorConsuming: taskExecutor,
       operation: operation)
 
     self._task = task
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 }
 
@@ -346,6 +354,7 @@ extension Task where Failure == Never {
       addPendingGroupTaskUnconditionally: false,
       isDiscardingTask: false)
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     let (task, _) = Builtin.createTask(
       flags: flags,
       // initialTaskExecutor: executorBuiltin, deprecated
@@ -353,6 +362,9 @@ extension Task where Failure == Never {
       operation: operation)
 
     return Task(task)
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 }
 
@@ -401,12 +413,16 @@ extension Task where Failure == Error {
       addPendingGroupTaskUnconditionally: false,
       isDiscardingTask: false)
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     let (task, _) = Builtin.createTask(
       flags: flags,
       initialTaskExecutorConsuming: taskExecutor,
       operation: operation)
 
     return Task(task)
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 }
 

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -608,7 +608,6 @@ extension Task where Failure == Never {
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @discardableResult
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public init(
     priority: TaskPriority? = nil,
@@ -661,7 +660,6 @@ extension Task where Failure == Never {
   ///   - operation: The operation to perform.
   @discardableResult
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public init(
     priority: TaskPriority? = nil,
     @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async -> Success
@@ -692,7 +690,6 @@ extension Task where Failure == Error {
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @discardableResult
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public init(
     priority: TaskPriority? = nil,
@@ -745,7 +742,6 @@ extension Task where Failure == Error {
   ///   - operation: The operation to perform.
   @discardableResult
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public init(
     priority: TaskPriority? = nil,
     @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async throws -> Success
@@ -778,7 +774,6 @@ extension Task where Failure == Never {
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @discardableResult
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public static func detached(
     priority: TaskPriority? = nil,
@@ -828,7 +823,6 @@ extension Task where Failure == Never {
   /// - Returns: A reference to the task.
   @discardableResult
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public static func detached(
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async -> Success
@@ -859,7 +853,6 @@ extension Task where Failure == Error {
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @discardableResult
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public static func detached(
     priority: TaskPriority? = nil,
@@ -911,7 +904,6 @@ extension Task where Failure == Error {
   /// - Returns: A reference to the task.
   @discardableResult
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public static func detached(
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async throws -> Success

--- a/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
@@ -46,7 +46,6 @@ extension TaskGroup {
       addPendingGroupTaskUnconditionally: true,
       isDiscardingTask: false)
 
-    // Create the task in this group with an executor preference.
     let builtinSerialExecutor =
       Builtin.extractFunctionIsolation(operation)?.unownedExecutor.executor
 
@@ -57,7 +56,14 @@ extension TaskGroup {
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+    let executorBuiltin: Builtin.Executor =
+      taskExecutor.asUnownedTaskExecutor().executor
+
+    _ = Builtin.createTask(flags: flags,
+                           initialSerialExecutor: builtinSerialExecutor,
+                           taskGroup: _group,
+                           initialTaskExecutor: executorBuiltin,
+                           operation: operation)
 #endif
   }
 
@@ -107,10 +113,18 @@ extension TaskGroup {
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
-    return true
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+    let executorBuiltin: Builtin.Executor =
+      taskExecutor.asUnownedTaskExecutor().executor
+
+    _ = Builtin.createTask(flags: flags,
+                           initialSerialExecutor: builtinSerialExecutor,
+                           taskGroup: _group,
+                           initialTaskExecutor: executorBuiltin,
+                           operation: operation)
 #endif
+
+    return true
   }
 }
 
@@ -158,7 +172,14 @@ extension ThrowingTaskGroup {
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+    let executorBuiltin: Builtin.Executor =
+      taskExecutor.asUnownedTaskExecutor().executor
+
+    _ = Builtin.createTask(flags: flags,
+                           initialSerialExecutor: builtinSerialExecutor,
+                           taskGroup: _group,
+                           initialTaskExecutor: executorBuiltin,
+                           operation: operation)
 #endif
   }
 
@@ -204,10 +225,18 @@ extension ThrowingTaskGroup {
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
-    return true
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+    let executorBuiltin: Builtin.Executor =
+      taskExecutor.asUnownedTaskExecutor().executor
+
+    _ = Builtin.createTask(flags: flags,
+                           initialSerialExecutor: builtinSerialExecutor,
+                           taskGroup: _group,
+                           initialTaskExecutor: executorBuiltin,
+                           operation: operation)
 #endif
+
+    return true
   }
 }
 
@@ -255,7 +284,14 @@ extension DiscardingTaskGroup {
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+    let executorBuiltin: Builtin.Executor =
+      taskExecutor.asUnownedTaskExecutor().executor
+
+    _ = Builtin.createTask(flags: flags,
+                           initialSerialExecutor: builtinSerialExecutor,
+                           taskGroup: _group,
+                           initialTaskExecutor: executorBuiltin,
+                           operation: operation)
 #endif
   }
 
@@ -306,10 +342,18 @@ extension DiscardingTaskGroup {
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
-    return true
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+    let executorBuiltin: Builtin.Executor =
+      taskExecutor.asUnownedTaskExecutor().executor
+
+    _ = Builtin.createTask(flags: flags,
+                           initialSerialExecutor: builtinSerialExecutor,
+                           taskGroup: _group,
+                           initialTaskExecutor: executorBuiltin,
+                           operation: operation)
 #endif
+
+    return true
   }
 }
 
@@ -357,7 +401,14 @@ extension ThrowingDiscardingTaskGroup {
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+    let executorBuiltin: Builtin.Executor =
+      taskExecutor.asUnownedTaskExecutor().executor
+
+    _ = Builtin.createTask(flags: flags,
+                           initialSerialExecutor: builtinSerialExecutor,
+                           taskGroup: _group,
+                           initialTaskExecutor: executorBuiltin,
+                           operation: operation)
 #endif
   }
 
@@ -408,10 +459,18 @@ extension ThrowingDiscardingTaskGroup {
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
-    return true
 #else
-    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+  let executorBuiltin: Builtin.Executor =
+    taskExecutor.asUnownedTaskExecutor().executor
+
+  _ = Builtin.createTask(flags: flags,
+                         initialSerialExecutor: builtinSerialExecutor,
+                         taskGroup: _group,
+                         initialTaskExecutor: executorBuiltin,
+                         operation: operation)
 #endif
+
+    return true
   }
 }
 

--- a/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
@@ -31,7 +31,6 @@ extension TaskGroup {
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
@@ -82,7 +81,6 @@ extension TaskGroup {
   /// - Returns: `true` if the child task was added to the group;
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
@@ -146,7 +144,6 @@ extension ThrowingTaskGroup {
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
@@ -194,7 +191,6 @@ extension ThrowingTaskGroup {
   /// - Returns: `true` if the child task was added to the group;
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
@@ -258,7 +254,6 @@ extension DiscardingTaskGroup {
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
@@ -311,7 +306,6 @@ extension DiscardingTaskGroup {
   /// - Returns: `true` if the child task was added to the group;
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
@@ -375,7 +369,6 @@ extension ThrowingDiscardingTaskGroup {
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,
@@ -428,7 +421,6 @@ extension ThrowingDiscardingTaskGroup {
   /// - Returns: `true` if the child task was added to the group;
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     executorPreference taskExecutor: (any TaskExecutor)?,
     priority: TaskPriority? = nil,

--- a/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
@@ -50,11 +50,15 @@ extension TaskGroup {
     let builtinSerialExecutor =
       Builtin.extractFunctionIsolation(operation)?.unownedExecutor.executor
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     _ = Builtin.createTask(flags: flags,
                            initialSerialExecutor: builtinSerialExecutor,
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 
   /// Adds a child task to the group and enqueue it on the specified executor, unless the group has been canceled.
@@ -97,12 +101,16 @@ extension TaskGroup {
     let builtinSerialExecutor =
       Builtin.extractFunctionIsolation(operation)?.unownedExecutor.executor
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     _ = Builtin.createTask(flags: flags,
                            initialSerialExecutor: builtinSerialExecutor,
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
     return true
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 }
 
@@ -143,11 +151,15 @@ extension ThrowingTaskGroup {
     let builtinSerialExecutor =
       Builtin.extractFunctionIsolation(operation)?.unownedExecutor.executor
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     _ = Builtin.createTask(flags: flags,
                            initialSerialExecutor: builtinSerialExecutor,
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 
   /// Adds a child task to the group and enqueue it on the specified executor, unless the group has been canceled.
@@ -186,12 +198,16 @@ extension ThrowingTaskGroup {
     let builtinSerialExecutor =
       Builtin.extractFunctionIsolation(operation)?.unownedExecutor.executor
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     _ = Builtin.createTask(flags: flags,
                            initialSerialExecutor: builtinSerialExecutor,
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
     return true
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 }
 
@@ -232,11 +248,15 @@ extension DiscardingTaskGroup {
     let builtinSerialExecutor =
       Builtin.extractFunctionIsolation(operation)?.unownedExecutor.executor
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     _ = Builtin.createTask(flags: flags,
                            initialSerialExecutor: builtinSerialExecutor,
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 
   /// Adds a child task to the group and set it up with the passed in task executor preference,
@@ -280,12 +300,16 @@ extension DiscardingTaskGroup {
     let builtinSerialExecutor =
       Builtin.extractFunctionIsolation(operation)?.unownedExecutor.executor
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     _ = Builtin.createTask(flags: flags,
                            initialSerialExecutor: builtinSerialExecutor,
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
     return true
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 }
 
@@ -326,11 +350,15 @@ extension ThrowingDiscardingTaskGroup {
     let builtinSerialExecutor =
       Builtin.extractFunctionIsolation(operation)?.unownedExecutor.executor
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     _ = Builtin.createTask(flags: flags,
                            initialSerialExecutor: builtinSerialExecutor,
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 
   /// Adds a child task to the group and set it up with the passed in task executor preference,
@@ -374,12 +402,16 @@ extension ThrowingDiscardingTaskGroup {
     let builtinSerialExecutor =
       Builtin.extractFunctionIsolation(operation)?.unownedExecutor.executor
 
+#if $BuiltinCreateAsyncTaskOwnedTaskExecutor
     _ = Builtin.createTask(flags: flags,
                            initialSerialExecutor: builtinSerialExecutor,
                            taskGroup: _group,
                            initialTaskExecutorConsuming: taskExecutor,
                            operation: operation)
     return true
+#else
+    fatalError("Unsupported Swift compiler, missing support for BuiltinCreateAsyncTaskOwnedTaskExecutor")
+#endif
   }
 }
 

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -326,7 +326,6 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async -> ChildTaskResult
@@ -365,7 +364,6 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// - Returns: `true` if the child task was added to the group;
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async -> ChildTaskResult
@@ -461,7 +459,6 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
 #else // if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @available(SwiftStdlib 5.7, *)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async -> ChildTaskResult
@@ -474,7 +471,6 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// - Parameters:
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     operation: sending @escaping @isolated(any) () async -> ChildTaskResult
   ) {
@@ -509,7 +505,6 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// - Returns: `true` if the child task was added to the group;
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     operation: sending @escaping @isolated(any) () async -> ChildTaskResult
   ) -> Bool {
@@ -831,7 +826,6 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async throws -> ChildTaskResult
@@ -865,7 +859,6 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// - Returns: `true` if the child task was added to the group;
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
-  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async throws -> ChildTaskResult


### PR DESCRIPTION
We noticed this issue while checking https://github.com/swiftlang/swift/pull/74928 with @tshortli.

While the new parameter is added in a compatible way where code which
does not refer to it will get a defaulted nil value; since we refer to a
new parameter name in source, we need to guard it with a language
feature -- as old compilers will not have this new name available.

Fixes condfails that resulted from these recent PRs: https://github.com/swiftlang/swift/pull/74000, https://github.com/swiftlang/swift/pull/74543

Fixes rdar://131064807.
