### PR TITLE
[6.0] Fix two problems with `-cross-module-optimization`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -355,6 +355,9 @@ private extension Value {
 private extension Function {
   /// Analyzes the global initializer function and returns global it initializes (from `alloc_global` instruction).
   func getInitializedGlobal() -> GlobalVariable? {
+    if !isDefinition {
+      return nil
+    }
     for inst in self.entryBlock.instructions {
       switch inst {
       case let agi as AllocGlobalInst:

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -3642,11 +3642,23 @@ SILGlobalVariable *SILDeserializer::readGlobalVar(StringRef Name) {
     return nullptr;
   }
 
+  VarDecl *globalDecl = nullptr;
+  if (dID) {
+    llvm::Expected<Decl *> d = MF->getDeclChecked(dID);
+    if (d) {
+      globalDecl = cast<VarDecl>(d.get());
+    } else {
+      // This can happen with cross-module-optimizations, if the linkage of a
+      // private global variable is changed to public.
+      consumeError(d.takeError());
+    }
+  }
+
   auto Ty = MF->getType(TyID);
   SILGlobalVariable *v = SILGlobalVariable::create(
       SILMod, linkage.value(), SerializedKind_t(serializedKind),
       Name.str(), getSILType(Ty, SILValueCategory::Object, nullptr),
-      std::nullopt, dID ? cast<VarDecl>(MF->getDecl(dID)) : nullptr);
+      std::nullopt, globalDecl);
   v->setLet(IsLet);
   globalVarOrOffset.set(v, true /*isFullyDeserialized*/);
   v->setDeclaration(IsDeclaration);

--- a/test/SILOptimizer/Inputs/cross-module/cross-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/cross-module.swift
@@ -287,6 +287,12 @@ public func callCImplementationOnly<T>(_ t: T) -> Int {
 
 public let globalLet = 529387
 
+private var privateVar = Int.random(in: 0..<100)
+
+public func getRandom() -> Int {
+  return privateVar
+}
+
 public struct StructWithClosure {
   public static let c = { (x: Int) -> Int in return x }
 }

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -165,6 +165,12 @@ func testImplementationOnly() {
   // CHECK-SIL2: } // end sil function '$s4Main22testImplementationOnlyyyF'
 }
 
+@inline(never)
+func testPrivateVar() {
+  // CHECK-OUTPUT: {{[0-9]+}}
+  print(getRandom())
+}
+
 testNestedTypes()
 testClass()
 testError()
@@ -175,4 +181,5 @@ testKeypath()
 testMisc()
 testGlobal()
 testImplementationOnly()
+testPrivateVar()
 

--- a/test/SILOptimizer/mandatory_performance_optimizations.sil
+++ b/test/SILOptimizer/mandatory_performance_optimizations.sil
@@ -167,6 +167,11 @@ bb0:
   return %6 : $()
 }
 
+// Check that we don't crash on global init-once declarations.
+
+// CHECK-LABEL: sil [global_init_once_fn] [no_locks] @external_global_init_once : $@convention(c) () -> ()
+sil [global_init_once_fn] [no_locks] @external_global_init_once : $@convention(c) () -> ()
+
 sil @yield_int_value : $@convention(thin) @yield_once () -> (@yields Int32) {
 bb0:
   %0 = integer_literal $Builtin.Int32, 10


### PR DESCRIPTION
* **Explanation**: Fixes two compiler crashes when building projects with `-cross-module-optimization`: one problem in MandatoryPerformanceOptimizations (it needs to consider empty global-init-once functions) and one problem in the Deserializer (handle the case that for de-serialized globals there might not be a var-declaration available in the module file)
* **Scope**: Affects projects built with `-cross-module-optimization`
* **Risk**: Low. The changes are trivial and only handle cases, which would otherwise run into compiler crashes
* **Testing**: Tested by a test case
* **Issue**: rdar://130406651, https://github.com/swiftlang/swift/issues/73487
* **Reviewer**:  @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/74893
