### PR TITLE
[cxx-interop] Conditionally re-enable a test for `std::function`

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -7,8 +7,11 @@
 
 // REQUIRES: executable_test
 
-// rdar://130527427
-// REQUIRES: rdar130527427
+// libstdc++11 declares a templated constructor of std::function with an rvalue-reference parameter,
+// which aren't yet supported in Swift. Therefore initializing a std::function from Swift closures
+// will not work on the platforms that are shipped with this version of libstdc++ (rdar://125816354).
+// XFAIL: LinuxDistribution=ubuntu-22.04
+// XFAIL: LinuxDistribution=rhel-9.4
 
 import StdlibUnittest
 import StdFunction


### PR DESCRIPTION
Let's re-enable the test on all platforms except Ubuntu 22.04 and UBI 9, which are shipped with libstdc++11.

rdar://130527427