### PR TITLE
🍒[cxx-interop] Always instantiate the default destructor

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -263,6 +263,10 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
     // Unfortunately, implicitly defined CXXDestructorDecls don't have a real
     // body, so we need to traverse these manually.
     if (auto *dtor = dyn_cast<clang::CXXDestructorDecl>(next)) {
+      if (dtor->isImplicit() && dtor->isDefaulted() && !dtor->isDeleted() &&
+          !dtor->doesThisDeclarationHaveABody())
+        clangSema.DefineImplicitDestructor(dtor->getLocation(), dtor);
+
       if (dtor->isImplicit() || dtor->hasBody()) {
         auto cxxRecord = dtor->getParent();
 

--- a/test/Interop/Cxx/class/Inputs/destructors.h
+++ b/test/Interop/Cxx/class/Inputs/destructors.h
@@ -28,4 +28,16 @@ struct HasNonTrivialImplicitDestructor {
   HasUserProvidedDestructor member;
 };
 
+template <typename T>
+struct TemplatedHasVirtualDestructor {
+  T value;
+  virtual ~TemplatedHasVirtualDestructor() {}
+};
+
+template <typename T>
+struct DerivedTemplatedHasVirtualDestructor : TemplatedHasVirtualDestructor<T> {
+};
+
+using DerivedTemplatedHasVirtualDestructorChar = DerivedTemplatedHasVirtualDestructor<char>;
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_DESTRUCTORS_H

--- a/test/Interop/Cxx/class/destructors-templated-irgen.swift
+++ b/test/Interop/Cxx/class/destructors-templated-irgen.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swiftxx-frontend -emit-ir -I %S/Inputs -validate-tbd-against-ir=none %s | %FileCheck %s
+
+import Destructors
+
+let _ = DerivedTemplatedHasVirtualDestructorChar()
+
+// CHECK: define {{.*}} @{{_ZN36DerivedTemplatedHasVirtualDestructorIcED2Ev|"\?\?1\?\$DerivedTemplatedHasVirtualDestructor@D@@UEAA@XZ"}}
+// CHECK: entry:
+// CHECK:   call {{.*}} @{{_ZN29TemplatedHasVirtualDestructorIcED2Ev|"\?\?1\?\$TemplatedHasVirtualDestructor@D@@UEAA@XZ"}}


### PR DESCRIPTION
**Explanation**: This fixes a linker error when using `std::function` from Swift. In libc++ `std::function` inherits from `std::__function::__func`, which doesn't explicitly define a destructor but inherits from `std::__function::__base` which defines a virtual destructor.
**Scope**: Changes IRGen of destructors of C++ structs.
**Risk**: Low, only affects C++ types.
**Testing**: Added a compiler test.
**Issue**: rdar://124061505