### PR TITLE
[cxx-interop] Emit Swift StdLib dependencies when all public decls emitted

### DIFF
--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -624,7 +624,9 @@ bool swift::printAsClangHeader(raw_ostream &os, ModuleDecl *M,
         !frontendOpts.ClangHeaderExposedDecls.has_value() ||
         *frontendOpts.ClangHeaderExposedDecls ==
             FrontendOptions::ClangHeaderExposeBehavior::
-                HasExposeAttrOrImplicitDeps;
+                HasExposeAttrOrImplicitDeps ||
+        *frontendOpts.ClangHeaderExposedDecls ==
+            FrontendOptions::ClangHeaderExposeBehavior::AllPublic;
 
     std::string moduleContentsBuf;
     llvm::raw_string_ostream moduleContents{moduleContentsBuf};

--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
 // RUN: %FileCheck %s < %t/class.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/class.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/class.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // UNSUPPORTED: CPU=arm64e
 

--- a/test/Interop/SwiftToCxx/class/swift-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-resilient-class-virtual-method-dispatch.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %S/swift-class-virtual-method-dispatch.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h -enable-library-evolution
 // RUN: %FileCheck %s < %t/class.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/class.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/class.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // note: implemented in swift-class-virtual-method-dispatch.swift
 

--- a/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
@@ -9,7 +9,7 @@
 // RUN: echo '#include "class.h"' > %t/fixed-useclass.h
 // RUN: cat %t/useclass.h     >> %t/fixed-useclass.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/fixed-useclass.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/fixed-useclass.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // rdar://105396625
 // UNSUPPORTED: CPU=arm64e

--- a/test/Interop/SwiftToCxx/cross-module-refs/do-not-expose-imported-api-by-default.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/do-not-expose-imported-api-by-default.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-structs.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/uses-structs.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/uses-structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 // RUN: %FileCheck %s < %t/uses-structs.h
 
 import Structs

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
@@ -4,10 +4,10 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-structs.h -clang-header-expose-module Structs=structs.h
 
 // RUN: %FileCheck %s < %t/uses-structs.h
-// RUN: %check-interop-cxx-header-in-clang(-I %t %t/uses-structs.h)
+// RUN: %check-interop-cxx-header-in-clang(-I %t %t/uses-structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -cxx-interoperability-mode=default -emit-clang-header-path %t/uses-structs-default.h -clang-header-expose-module Structs=structs.h
-// RUN: %check-interop-cxx-header-in-clang(-I %t %t/uses-structs-default.h)
+// RUN: %check-interop-cxx-header-in-clang(-I %t %t/uses-structs-default.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 import Structs
 

--- a/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // rdar://124466216
 // UNSUPPORTED: OS=watchos

--- a/test/Interop/SwiftToCxx/enums/enum-element-method-name-clash.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-element-method-name-clash.swift
@@ -25,6 +25,7 @@ extension Foo {
 
 // CHECK-NOT:   Foo bar(swift::Int version)
 
+// CHECK: class SWIFT_SYMBOL("s:5Enums3FooO") Foo final {
 // CHECK:    switch (_getEnumTag()) {
 // CHECK-NEXT:      case 0: return cases::bar;
 // CHECK-NEXT:      default: abort();

--- a/test/Interop/SwiftToCxx/enums/enum-member-param-no-shadow-case.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-member-param-no-shadow-case.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public enum E {
     case a

--- a/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public struct IntTuple {
     let values: (Int64, Int64, Int64, Int64, Int64, Int64)

--- a/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
@@ -6,8 +6,8 @@
 // RUN: %target-swift-frontend %s -enable-library-evolution -D NEW_CASE -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums_new_case.h
 // RUN: %FileCheck --check-prefixes=CHECK,NEW_CASE %s < %t/enums_new_case.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
-// RUN: %check-interop-cxx-header-in-clang(%t/enums_new_case.h -Wno-unused-private-field -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+// RUN: %check-interop-cxx-header-in-clang(%t/enums_new_case.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public enum Foo {
     case a(Double)

--- a/test/Interop/SwiftToCxx/enums/small-enums-generated-stub-64bit.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-generated-stub-64bit.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // REQUIRES: PTRSIZE=64
 

--- a/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
 // RUN: %FileCheck %s < %t/enums.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %target-swift-frontend %s -typecheck -module-name Enums -enable-experimental-cxx-interop -emit-clang-header-path %t/enums-default.h
 // RUN: %FileCheck %s < %t/enums-default.h

--- a/test/Interop/SwiftToCxx/extension/struct-extension-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/extension/struct-extension-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -Wno-unused-private-field -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -Wno-unused-private-field -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 
 public struct TypeAfterArray {

--- a/test/Interop/SwiftToCxx/functions/cdecl.swift
+++ b/test/Interop/SwiftToCxx/functions/cdecl.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name CdeclFunctions -clang-header-expose-decls=all-public -emit-clang-header-path %t/cdecl.h
 // RUN: %FileCheck %s < %t/cdecl.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/cdecl.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/cdecl.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // CHECK-LABEL: namespace CdeclFunctions SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("CdeclFunctions") {
 

--- a/test/Interop/SwiftToCxx/functions/swift-function-argument-keyword-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-argument-keyword-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // CHECK: SWIFT_INLINE_THUNK void testKeywordArgument(swift::Int register_) noexcept
 // CHECK-NEXT: _impl::$s9Functions19testKeywordArgument8registerySi_tF(register_);

--- a/test/Interop/SwiftToCxx/functions/swift-function-overloads.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-overloads.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public func overloadedFunc(_ x: Int) { }
 public func overloadedFunc(_ y: Float) { }

--- a/test/Interop/SwiftToCxx/functions/swift-function-unsupported-cxx-type.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-unsupported-cxx-type.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public func a() { }
 public func b(_ x: @escaping (Int) -> ()) { }

--- a/test/Interop/SwiftToCxx/functions/swift-functions.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions.swift
@@ -4,7 +4,7 @@
 
 import CxxStdlib
 
-// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 @_cdecl("cdeclFunction") public func cdeclFunction(_ x: CInt) {}
 

--- a/test/Interop/SwiftToCxx/functions/swift-operators.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-operators.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Operators -clang-header-expose-decls=all-public -emit-clang-header-path %t/operators.h
 // RUN: %FileCheck %s < %t/operators.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/operators.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/operators.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // CHECK-LABEL: namespace Operators SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Operators") {
 

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-abi < %t/functions.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // CHECK:      SWIFT_INLINE_THUNK float passThrougCFloat(float x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: return _impl::$s9Functions16passThrougCFloatyS2fF(x);

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-cxx-bridging.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // CHECK: SWIFT_EXTERN void $s9Functions8inOutIntyySizF(ptrdiff_t * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // inOutInt(_:)
 // CHECK: SWIFT_EXTERN void $s9Functions11inOutTwoIntyySiz_SiztF(ptrdiff_t * _Nonnull x, ptrdiff_t * _Nonnull y) SWIFT_NOEXCEPT SWIFT_CALL; // inOutTwoInt(_:_:)

--- a/test/Interop/SwiftToCxx/functions/swift-transparent-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-transparent-functions-cxx-bridging.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // CHECK: SWIFT_EXTERN ptrdiff_t $s9Functions24transparentPrimitiveFuncyS2iF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // transparentPrimitiveFunc(_:)
 

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // FIXME: remove the need for -Wno-reserved-identifier
 
@@ -88,6 +88,8 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
         break
     }
 }
+
+// CHECK: namespace Generics SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Generics") {
 
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts

--- a/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
@@ -2,12 +2,12 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -enable-library-evolution -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions-evo.h
 // RUN: %FileCheck %s < %t/functions-evo.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/functions-evo.h -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/functions-evo.h -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public func genericPrintFunctionTwoArg<T>(_ x: T, _ y: Int) {
     print("X:", x)

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -1,16 +1,16 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // Check that an instantiation compiles too.
 // RUN: echo "constexpr int x = sizeof(Generics::GenericPair<int, int>);" >> %t/generics.h
-// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // FIXME: remove the need for -Wno-reserved-identifier
 

--- a/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
@@ -1,13 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
+// CHECK: namespace Generics SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Generics") {
 // CHECK: // Stub struct to be used to pass/return values to/from Swift functions.
 // CHECK-NEXT: struct swift_interop_passStub_Generics_[[PTRPTRENC:void_ptr_[0-9]_[0-9]_void_ptr_[0-9]_[0-9]+]] {
 // CHECK-NEXT:  void * _Nullable _1;

--- a/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-indirect-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-indirect-in-cxx.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift  -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+// RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // CHECK: SWIFT_EXTERN void $s8Generics11GenericPairV1yq_vg(SWIFT_INDIRECT_RESULT void * _Nonnull, void * _Nonnull , SWIFT_CONTEXT const void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // _
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV1yq_vs(const void * _Nonnull newValue, void * _Nonnull , SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // _

--- a/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Init -clang-header-expose-decls=all-public -emit-clang-header-path %t/inits.h
 // RUN: %FileCheck %s < %t/inits.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/inits.h -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/inits.h -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %target-swift-frontend %s -typecheck -module-name Init -clang-header-expose-decls=all-public -swift-version 5 -emit-clang-header-path %t/inits2.h
 // RUN: %FileCheck %s < %t/inits2.h

--- a/test/Interop/SwiftToCxx/initializers/swift-init-availability-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/swift-init-availability-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
 // RUN: %FileCheck %s < %t/methods.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/methods.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/methods.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public struct Struct {
   var field: Int16

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
 // RUN: %FileCheck %s < %t/methods.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/methods.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/methods.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public struct LargeStruct {
     let x1, x2, x3, x4, x5, x6: Int

--- a/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
 // RUN: %FileCheck %s < %t/methods.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/methods.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/methods.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public struct LargeStruct {
     var x1, x2, x3, x4, x5, x6: Int

--- a/test/Interop/SwiftToCxx/methods/swift-method-availability-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/swift-method-availability-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
 // RUN: %FileCheck %s < %t/methods.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/methods.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/methods.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public struct Struct {
   var field: Int16

--- a/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -typecheck -module-name Init -clang-header-expose-decls=all-public -emit-clang-header-path %t/inits.h
 // RUN: %FileCheck --check-prefixes=CHECK,CHECK-NON_EVO %s < %t/inits.h
-// RUN: %check-interop-cxx-header-in-clang(%t/inits.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/inits.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %target-swift-frontend %s -typecheck -module-name Init -clang-header-expose-decls=all-public -emit-clang-header-path %t/inits-evo.h -enable-library-evolution
 // RUN: %FileCheck %s < %t/inits-evo.h
-// RUN: %check-interop-cxx-header-in-clang(%t/inits-evo.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/inits-evo.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public final class AKlass {
     public init() {}

--- a/test/Interop/SwiftToCxx/properties/bool-is-has-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/bool-is-has-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Properties -clang-header-expose-decls=all-public -emit-clang-header-path %t/properties.h
 // RUN: %FileCheck %s < %t/properties.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/properties.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/properties.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public struct IsHasProperties {
     public var isEmpty: Bool { return true }

--- a/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Properties -clang-header-expose-decls=all-public -emit-clang-header-path %t/properties.h
 // RUN: %FileCheck %s < %t/properties.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/properties.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/properties.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public struct FirstSmallStruct {
     public let x: UInt32

--- a/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Properties -clang-header-expose-decls=all-public -emit-clang-header-path %t/properties.h
 // RUN: %FileCheck %s < %t/properties.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/properties.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/properties.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public struct FirstSmallStruct {
     public var x: UInt32

--- a/test/Interop/SwiftToCxx/properties/swift-property-availability-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/swift-property-availability-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Methods -clang-header-expose-decls=all-public -emit-clang-header-path %t/methods.h
 // RUN: %FileCheck %s < %t/methods.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/methods.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/methods.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public struct Struct {
   public var field: Int16

--- a/test/Interop/SwiftToCxx/stdlib/optional/optional-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/optional/optional-in-cxx.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseOptional -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/useopt.h
+// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseOptional -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -emit-clang-header-path %t/useopt.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/useopt.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: %FileCheck %s < %t/useopt.h
 
-@_expose(Cxx)
 public struct SmallStruct {
     let x: Int16
 }
 
-@_expose(Cxx)
 public class Klass {
     let x: Int16
 
@@ -18,37 +18,30 @@ public class Klass {
     }
 }
 
-@_expose(Cxx)
 public func createCIntOpt(_ val: CInt) -> Optional<CInt> {
     return val
 }
 
-@_expose(Cxx)
 public func takeCIntOpt(_ val: Optional<CInt>) {
     print(String(describing: val))
 }
 
-@_expose(Cxx)
 public func createSmallStructOpt(_ val: Int16) -> SmallStruct? {
     return SmallStruct(x: val)
 }
 
-@_expose(Cxx)
 public func takeSmallStructOpt(_ val: Optional<SmallStruct>) {
     print(String(describing: val))
 }
 
-@_expose(Cxx)
 public func createKlassOpt(_ val: Int16) -> Klass? {
     return Klass(val)
 }
 
-@_expose(Cxx)
 public func takeKlassOpt(_ val: Klass?) {
     print(String(describing: val))
 }
 
-@_expose(Cxx)
 public func resetOpt<T>(_ val: inout Optional<T>) {
     val = .none
 }

--- a/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/structs.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public struct StructSeveralI64 {
     var x1, x2, x3, x4, x5: Int64

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/structs.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public struct FirstSmallStruct {
     public var x: UInt32

--- a/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/structs.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // RUN: sed -e 's/^public struct/@frozen public struct/' %s > %t/small-structs-frozen.swift
 // RUN: %target-swift-frontend %t/small-structs-frozen.swift -enable-library-evolution -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/small-structs-frozen.h -D RESILIENT

--- a/test/Interop/SwiftToCxx/structs/struct-with-refcounted-member.swift
+++ b/test/Interop/SwiftToCxx/structs/struct-with-refcounted-member.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -Wno-unused-function -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 class RefCountedClass {
     init() {

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Decls -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/decls.h
 // RUN: %FileCheck %s < %t/decls.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/decls.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/decls.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public protocol Proto { init() }
 

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 public func takeFloat(_ x: Float) {}
 


### PR DESCRIPTION
The generated header would not compile without these dependencies. Moreover users probably expect all-public option to be the most permissive filter including the maximal amount of declarations.

