### PR TITLE
Improve pattern matching range check in ArrayBoundsCheck optimizations

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -357,6 +357,11 @@ static bool isSignedLessEqual(SILValue Start, SILValue End, SILBasicBlock &BB) {
                                         m_Specific(End)),
                             m_One())))
         return true;
+      // Try to match a cond_fail on "SLT End, Start".
+      if (match(CF->getOperand(),
+                m_ApplyInst(BuiltinValueKind::ICMP_SLT, m_Specific(End),
+                            m_Specific(Start))))
+        return true;
       // Inclusive ranges will have a check on the upper value (before adding
       // one).
       if (PreInclusiveEnd) {
@@ -366,6 +371,11 @@ static bool isSignedLessEqual(SILValue Start, SILValue End, SILBasicBlock &BB) {
                                           m_Specific(Start),
                                           m_Specific(PreInclusiveEnd)),
                               m_One())))
+          IsPreInclusiveEndLEQ = true;
+        if (match(CF->getOperand(),
+                  m_ApplyInst(BuiltinValueKind::ICMP_SLT,
+                              m_Specific(PreInclusiveEnd),
+                              m_Specific(Start))))
           IsPreInclusiveEndLEQ = true;
         if (match(CF->getOperand(),
                   m_ApplyInst(BuiltinValueKind::Xor,
@@ -497,10 +507,7 @@ static bool isRangeChecked(SILValue Start, SILValue End,
   if (!PreheaderPred)
     return false;
   auto *CondBr = dyn_cast<CondBranchInst>(PreheaderPred->getTerminator());
-  if (!CondBr)
-    return false;
-
-  if (isLessThanCheck(Start, End, CondBr, Preheader))
+  if (CondBr && isLessThanCheck(Start, End, CondBr, Preheader))
     return true;
 
   // Walk up the dominator tree looking for a range check ("SLE Start, End").
@@ -1197,7 +1204,6 @@ bool ABCOpt::processLoop(SILLoop *Loop) {
 
   LLVM_DEBUG(llvm::dbgs() << "Attempting to remove redundant checks in "
                           << *Loop);
-  LLVM_DEBUG(Header->getParent()->dump());
 
   // Collect safe arrays. Arrays are safe if there is no function call that
   // could mutate their size in the loop.
@@ -1242,8 +1248,6 @@ bool ABCOpt::processLoop(SILLoop *Loop) {
       LLVM_DEBUG(llvm::dbgs() << "Found a latch ...\n");
     } else return Changed;
   }
-
-  LLVM_DEBUG(Preheader->getParent()->dump());
 
   // Find canonical induction variables.
   InductionAnalysis IndVars(DT, *IVs, Preheader, Header, ExitingBlk, ExitBlk);
@@ -1314,8 +1318,6 @@ bool ABCOpt::processLoop(SILLoop *Loop) {
       }
     }
   }
-
-  LLVM_DEBUG(Preheader->getParent()->dump());
 
   // Hoist bounds checks.
   Changed |= hoistChecksInLoop(DT->getNode(Header), ABC, IndVars, Preheader,
@@ -1429,7 +1431,6 @@ bool ABCOpt::hoistChecksInLoop(DominanceInfoNode *DTNode, ABCAnalysis &ABC,
     Changed = true;
   }
 
-  LLVM_DEBUG(Preheader->getParent()->dump());
   // Traverse the children in the dominator tree.
   for (auto Child : *DTNode)
     Changed |= hoistChecksInLoop(Child, ABC, IndVars, Preheader, Header,

--- a/test/SILOptimizer/abcopts_ossa_guaranteed.sil
+++ b/test/SILOptimizer/abcopts_ossa_guaranteed.sil
@@ -742,7 +742,7 @@ bb2:
   return %23 : $Int32
 }
 
-// CHECK-LABEL: sil [ossa] @hoist_rangechecked :
+// CHECK-LABEL: sil [ossa] @hoist_rangechecked1 :
 // CHECK: bb0
 // CHECK:  cond_br {{.*}}, bb2, bb1
 // CHECK: bb1:
@@ -759,8 +759,8 @@ bb2:
 // CHECK:   br bb6
 // CHECK: bb6{{.*}}:
 // CHECK:  return
-// CHECK-LABEL: } // end sil function 'hoist_rangechecked'
-sil [ossa] @hoist_rangechecked : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
+// CHECK-LABEL: } // end sil function 'hoist_rangechecked1'
+sil [ossa] @hoist_rangechecked1 : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
 bb0(%0 : $Int32, %1 : $*ArrayInt):
   %2 = integer_literal $Builtin.Int1, -1
   %3 = struct $Bool (%2 : $Builtin.Int1)
@@ -808,6 +808,70 @@ bb6(%36 : $Builtin.Int32):
   return %37 : $Int32
 }
 
+// CHECK-LABEL: sil [ossa] @hoist_rangechecked2 :
+// CHECK: bb0
+// CHECK:  cond_br {{.*}}, bb2, bb1
+// CHECK: bb1:
+// CHECK:   [[CB:%[0-9]+]] = function_ref @checkbounds
+// CHECK:    apply [[CB]]
+// CHECK:   br bb3{{.*}}
+// CHECK: bb3{{.*}}:
+// CHECK-NOT: function_ref @checkbounds
+// CHECK-NOT:    apply [[CB]]
+// CHECK:   cond_br {{.*}}, bb5, bb4
+// CHECK: bb4
+// CHECK:   br bb3
+// CHECK: bb5
+// CHECK:   br bb6
+// CHECK: bb6{{.*}}:
+// CHECK:  return
+// CHECK-LABEL: } // end sil function 'hoist_rangechecked2'
+sil [ossa] @hoist_rangechecked2 : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
+bb0(%0 : $Int32, %1 : $*ArrayInt):
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = struct $Bool (%2 : $Builtin.Int1)
+  %4 = struct_extract %0 : $Int32, #Int32._value
+  %5 = integer_literal $Builtin.Int32, 0
+  %6 = integer_literal $Builtin.Int1, -1
+  %7 = builtin "cmp_slt_Int32"(%4 : $Builtin.Int32, %5 : $Builtin.Int32) : $Builtin.Int1
+  cond_fail %7 : $Builtin.Int1, ""
+  %10 = builtin "cmp_eq_Int32"(%5 : $Builtin.Int32, %4 : $Builtin.Int32) : $Builtin.Int1
+  %17 = load [copy] %1 : $*ArrayInt
+  cond_br %10, bb2, bb1
+
+bb1:
+  br bb3(%5 : $Builtin.Int32)
+
+bb2:
+  br bb6(%5 : $Builtin.Int32)
+
+bb3(%14 : $Builtin.Int32):
+  %15 = struct $Int32 (%14 : $Builtin.Int32)
+  %16 = function_ref @checkbounds : $@convention(method) (Int32, Bool, @guaranteed ArrayInt) -> _DependenceToken
+  %21 = apply %16(%15, %3, %17) : $@convention(method) (Int32, Bool, @guaranteed ArrayInt) -> _DependenceToken
+  %22 = integer_literal $Builtin.Int32, 1
+  %23 = integer_literal $Builtin.Int1, -1
+  %24 = builtin "sadd_with_overflow_Int32"(%14 : $Builtin.Int32, %22 : $Builtin.Int32, %23 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %25 = tuple_extract %24 : $(Builtin.Int32, Builtin.Int1), 0
+  %26 = function_ref @getElementAddr : $@convention(method) (Int32, @guaranteed ArrayInt) -> UnsafeMutablePointerInt
+  %28 = apply %26(%15, %17) : $@convention(method) (Int32, @guaranteed ArrayInt) -> UnsafeMutablePointerInt
+  %29 = struct_extract %28 : $UnsafeMutablePointerInt, #UnsafeMutablePointerInt._rawValue
+  %30 = pointer_to_address %29 : $Builtin.RawPointer to [strict] $*Int32
+  store %0 to [trivial] %30 : $*Int32
+  %32 = builtin "cmp_eq_Int32"(%25 : $Builtin.Int32, %4 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %32, bb5, bb4
+
+bb4:
+  br bb3(%25 : $Builtin.Int32)
+
+bb5:
+  br bb6(%25 : $Builtin.Int32)
+
+bb6(%36 : $Builtin.Int32):
+  destroy_value %17 : $ArrayInt
+  %37 = struct $Int32 (%36 : $Builtin.Int32)
+  return %37 : $Int32
+}
 // CHECK-LABEL: sil [ossa] @hoist_rangechecked_ref_tail_addr :
 // CHECK: bb0
 // CHECK:  cond_br {{.*}}, bb2, bb1
@@ -1049,7 +1113,7 @@ bb6(%38 : $Builtin.Int32):
   return %39 : $Int32
 }
 
-// CHECK-LABEL: sil [ossa] @hoist_inclusive_rangechecked :
+// CHECK-LABEL: sil [ossa] @hoist_inclusive_rangechecked1 :
 // CHECK: bb0
 // CHECK:  cond_br {{.*}}, bb2, bb1
 // CHECK: bb1:
@@ -1065,8 +1129,8 @@ bb6(%38 : $Builtin.Int32):
 // CHECK: bb5:
 // CHECK:  br bb6
 // CHECK: bb6{{.*}}:
-// CHECK-LABEL: } // end sil function 'hoist_inclusive_rangechecked'
-sil [ossa] @hoist_inclusive_rangechecked : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
+// CHECK-LABEL: } // end sil function 'hoist_inclusive_rangechecked1'
+sil [ossa] @hoist_inclusive_rangechecked1 : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
 bb0(%0 : $Int32, %1 : $*ArrayInt):
   %2 = integer_literal $Builtin.Int1, -1
   %3 = struct $Bool (%2 : $Builtin.Int1)
@@ -1116,6 +1180,71 @@ bb6(%37 : $Builtin.Int32):
   return %38 : $Int32
 }
 
+// CHECK-LABEL: sil [ossa] @hoist_inclusive_rangechecked2 :
+// CHECK: bb0
+// CHECK:  cond_br {{.*}}, bb2, bb1
+// CHECK: bb1:
+// CHECK:   [[CB:%[0-9]+]] = function_ref @checkbounds
+// CHECK:    apply [[CB]]
+// CHECK:   br bb3{{.*}}
+// CHECK: bb3{{.*}}:
+// CHECK-NOT: function_ref @checkbounds
+// CHECK-NOT:    apply [[CB]]
+// CHECK:   cond_br {{.*}}, bb5, bb4
+// CHECK: bb4:
+// CHECK:  br bb3
+// CHECK: bb5:
+// CHECK:  br bb6
+// CHECK: bb6{{.*}}:
+// CHECK-LABEL: } // end sil function 'hoist_inclusive_rangechecked2'
+sil [ossa] @hoist_inclusive_rangechecked2 : $@convention(thin) (Int32, @inout ArrayInt) -> Int32 {
+bb0(%0 : $Int32, %1 : $*ArrayInt):
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = struct $Bool (%2 : $Builtin.Int1)
+  %4 = struct_extract %0 : $Int32, #Int32._value
+  %5 = integer_literal $Builtin.Int32, 0
+  %6 = integer_literal $Builtin.Int1, -1
+  %7 = builtin "cmp_slt_Int32"(%4 : $Builtin.Int32, %5 : $Builtin.Int32) : $Builtin.Int1
+  cond_fail %7 : $Builtin.Int1, ""
+  %10 = integer_literal $Builtin.Int32, 1
+  %11 = integer_literal $Builtin.Int1, 0
+  %12 = builtin "sadd_with_overflow_Int32"(%4 : $Builtin.Int32, %10 : $Builtin.Int32, %11 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %13 = tuple_extract %12 : $(Builtin.Int32, Builtin.Int1), 0
+  %14 = builtin "cmp_sgt_Int32"(%13 : $Builtin.Int32, %4 : $Builtin.Int32) : $Builtin.Int1
+  %15 = builtin "xor_Int1"(%14 : $Builtin.Int1, %6 : $Builtin.Int1) : $Builtin.Int1
+  cond_fail %15 : $Builtin.Int1, ""
+  %17 = builtin "cmp_eq_Int32"(%5 : $Builtin.Int32, %13 : $Builtin.Int32) : $Builtin.Int1
+  %24 = load [copy] %1 : $*ArrayInt
+  cond_br %17, bb2, bb1
+
+bb1:
+  br bb3(%5 : $Builtin.Int32)
+
+bb2:
+  br bb6(%5 : $Builtin.Int32)
+
+bb3(%21 : $Builtin.Int32):
+  %22 = struct $Int32 (%21 : $Builtin.Int32)
+  %23 = function_ref @checkbounds : $@convention(method) (Int32, Bool, @guaranteed ArrayInt) -> _DependenceToken
+  %28 = apply %23(%22, %3, %24) : $@convention(method) (Int32, Bool, @guaranteed ArrayInt) -> _DependenceToken
+  %29 = integer_literal $Builtin.Int32, 1
+  %30 = integer_literal $Builtin.Int1, -1
+  %31 = builtin "sadd_with_overflow_Int32"(%21 : $Builtin.Int32, %29 : $Builtin.Int32, %30 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %32 = tuple_extract %31 : $(Builtin.Int32, Builtin.Int1), 0
+  %33 = builtin "cmp_eq_Int32"(%32 : $Builtin.Int32, %13 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %33, bb5, bb4
+
+bb4:
+  br bb3(%32 : $Builtin.Int32)
+
+bb5:
+  br bb6(%32 : $Builtin.Int32)
+
+bb6(%37 : $Builtin.Int32):
+  destroy_value %24 : $ArrayInt
+  %38 = struct $Int32 (%37 : $Builtin.Int32)
+  return %38 : $Int32
+}
 // Don't hoist arrays that are variant.
 // CHECK-LABEL: sil [ossa] @dont_hoist_variant_array :
 // CHECK: bb0


### PR DESCRIPTION
Current pattern matching misses when range checks are of the form:
```
%cond = %end < %start
cond_fail %cond, "Range requires lowerBound <= upperBound"
```

instead of
```
%cond =  (%start <= %end) ^ 1
cond_fail %cond, "Range requires lowerBound <= upperBound"
```

This PR adds this pattern.


