### PR TITLE
Update TypeContextInfo.h

### DIFF
--- a/include/swift/IDE/TypeContextInfo.h
+++ b/include/swift/IDE/TypeContextInfo.h
@@ -36,7 +36,7 @@ public:
 /// An abstract base class for consumers of context info results.
 class TypeContextInfoConsumer {
 public:
-  virtual ~TypeContextInfoConsumer() {}
+  virtual ~TypeContextInfoConsumer() noexcept {}
   virtual void handleResults(ArrayRef<TypeContextInfoItem>) = 0;
 };
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Turning distructor to noxcept is a good practice nowadays for preventing different bugs.

