### PR TITLE
[6.0 🍒][Dependency Scanning] Resolve cross-import overlays relative to defining interface for prebuilt binary Swift dependencies

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -367,13 +367,15 @@ public:
       const std::string &sourceInfoPath,
       const std::vector<ScannerImportStatementInfo> &moduleImports,
       const std::vector<ScannerImportStatementInfo> &optionalModuleImports,
-      const std::string &headerImport, const bool isFramework,
+      const std::string &headerImport,
+      const std::string &definingModuleInterface, const bool isFramework,
       const std::string &moduleCacheKey)
       : ModuleDependencyInfoStorageBase(ModuleDependencyKind::SwiftBinary,
                                         moduleImports, optionalModuleImports,
                                         moduleCacheKey),
         compiledModulePath(compiledModulePath), moduleDocPath(moduleDocPath),
         sourceInfoPath(sourceInfoPath), headerImport(headerImport),
+        definingModuleInterfacePath(definingModuleInterface),
         isFramework(isFramework) {}
 
   ModuleDependencyInfoStorageBase *clone() const override {
@@ -392,6 +394,10 @@ public:
   /// The path of the .h dependency of this module.
   const std::string headerImport;
 
+  /// The path of the defining .swiftinterface that this
+  /// binary .swiftmodule was built from, if one exists.
+  const std::string definingModuleInterfacePath;
+
   /// Source files on which the header inputs depend.
   std::vector<std::string> headerSourceFiles;
 
@@ -400,6 +406,15 @@ public:
 
   /// A flag that indicates this dependency is a framework
   const bool isFramework;
+
+  /// Return the path to the defining .swiftinterface of this module
+  /// of one was determined. Otherwise, return the .swiftmodule path
+  /// itself.
+  std::string getDefiningModulePath() const {
+    if (definingModuleInterfacePath.empty())
+      return compiledModulePath;
+    return definingModuleInterfacePath;
+  }
 
   static bool classof(const ModuleDependencyInfoStorageBase *base) {
     return base->dependencyKind == ModuleDependencyKind::SwiftBinary;
@@ -560,12 +575,13 @@ public:
       const std::vector<ScannerImportStatementInfo> &moduleImports,
       const std::vector<ScannerImportStatementInfo> &optionalModuleImports,
       const std::string &headerImport,
+      const std::string &definingModuleInterface,
       bool isFramework, const std::string &moduleCacheKey) {
     return ModuleDependencyInfo(
         std::make_unique<SwiftBinaryModuleDependencyStorage>(
           compiledModulePath, moduleDocPath, sourceInfoPath,
-          moduleImports, optionalModuleImports,
-          headerImport, isFramework, moduleCacheKey));
+          moduleImports, optionalModuleImports, headerImport,
+          definingModuleInterface, isFramework, moduleCacheKey));
   }
 
   /// Describe the main Swift module.

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -222,7 +222,7 @@ ModuleDependencyInfo::collectCrossImportOverlayNames(
     }
     case swift::ModuleDependencyKind::SwiftBinary: {
       auto *swiftBinaryDep = getAsSwiftBinaryModule();
-      modulePath = swiftBinaryDep->compiledModulePath;
+      modulePath = swiftBinaryDep->getDefiningModulePath();
       assert(modulePath.has_value());
       StringRef parentDir = llvm::sys::path::parent_path(*modulePath);
       if (llvm::sys::path::extension(parentDir) == ".swiftmodule") {

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -508,11 +508,12 @@ bool ModuleDependenciesCacheDeserializer::readGraph(SwiftDependencyScanningServi
       if (!headerImport)
         llvm::report_fatal_error("Bad binary direct dependencies: no header import");
 
+      // TODO: DefiningModulePath
       // Form the dependencies storage object
       auto moduleDep = ModuleDependencyInfo::forSwiftBinaryModule(
            *compiledModulePath, *moduleDocPath, *moduleSourceInfoPath,
            currentModuleImports, currentOptionalModuleImports,
-           *headerImport, isFramework, *moduleCacheKey);
+           *headerImport, "", isFramework, *moduleCacheKey);
 
       auto headerModuleDependencies = getStringArray(headerModuleDependenciesArrayID);
       if (!headerModuleDependencies)

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -91,19 +91,6 @@ static bool isTargetTooNew(const llvm::Triple &moduleTarget,
   return ctxTarget.isOSVersionLT(moduleTarget);
 }
 
-std::string ModuleFile::resolveModuleDefiningFilename(const ASTContext &ctx) {
-  if (!Core->ModuleInterfacePath.empty()) {
-    std::string interfacePath = Core->ModuleInterfacePath.str();
-    if (llvm::sys::path::is_relative(interfacePath)) {
-      SmallString<128> absoluteInterfacePath(ctx.SearchPathOpts.getSDKPath());
-      llvm::sys::path::append(absoluteInterfacePath, interfacePath);
-      return absoluteInterfacePath.str().str();
-    } else
-      return interfacePath;
-  } else
-    return getModuleLoadedFilename().str();
-}
-
 namespace swift {
 namespace serialization {
 bool areCompatible(const llvm::Triple &moduleTarget,
@@ -271,7 +258,8 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
 
   ASTContext &ctx = getContext();
   // Resolve potentially-SDK-relative module-defining .swiftinterface path
-  ResolvedModuleDefiningFilename = resolveModuleDefiningFilename(ctx);
+  ResolvedModuleDefiningFilename =
+       Core->resolveModuleDefiningFilePath(ctx.SearchPathOpts.getSDKPath());
 
   llvm::Triple moduleTarget(llvm::Triple::normalize(Core->TargetTriple));
   if (!areCompatible(moduleTarget, ctx.LangOpts.Target)) {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -285,10 +285,6 @@ private:
   ArrayRef<ProtocolConformanceID>
   claimLazyConformanceLoaderToken(uint64_t token);
 
-  /// If the module-defining `.swiftinterface` file is an SDK-relative path,
-  /// resolve it to be absolute to the context's SDK.
-  std::string resolveModuleDefiningFilename(const ASTContext &ctx);
-
   /// Represents an identifier that may or may not have been deserialized yet.
   ///
   /// If \c Ident is empty, the identifier has not been loaded yet.

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1773,6 +1773,19 @@ bool ModuleFileSharedCore::hasSourceInfo() const {
   return !!DeclUSRsTable;
 }
 
+std::string ModuleFileSharedCore::resolveModuleDefiningFilePath(const StringRef SDKPath) const {
+  if (!ModuleInterfacePath.empty()) {
+    std::string interfacePath = ModuleInterfacePath.str();
+    if (llvm::sys::path::is_relative(interfacePath)) {
+      SmallString<128> absoluteInterfacePath(SDKPath);
+      llvm::sys::path::append(absoluteInterfacePath, interfacePath);
+      return absoluteInterfacePath.str().str();
+    } else
+      return interfacePath;
+  } else
+    return ModuleInputBuffer->getBufferIdentifier().str();
+}
+
 ModuleLoadingBehavior
 ModuleFileSharedCore::getTransitiveLoadingBehavior(
                                           const Dependency &dependency,

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -605,6 +605,10 @@ public:
     return Dependencies;
   }
 
+  /// If the module-defining `.swiftinterface` file is an SDK-relative path,
+  /// resolve it to be absolute to the specified SDK.
+  std::string resolveModuleDefiningFilePath(const StringRef SDKPath) const;
+
   /// Returns \c true if this module file contains a section with incremental
   /// information.
   bool hasIncrementalInfo() const { return HasIncrementalInfo; }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -494,11 +494,15 @@ SerializedModuleLoaderBase::scanModuleFile(Twine modulePath, bool isFramework,
       optionalModuleImports.push_back(
           ScannerImportStatementInfo(optionalImportedModule.str()));
 
+  // Attempt to resolve the module's defining .swiftinterface path
+  std::string definingModulePath =
+       loadedModuleFile->resolveModuleDefiningFilePath(Ctx.SearchPathOpts.getSDKPath());
+
   // Map the set of dependencies over to the "module dependencies".
   auto dependencies = ModuleDependencyInfo::forSwiftBinaryModule(
       modulePath.str(), moduleDocPath, sourceInfoPath, moduleImports,
-      optionalModuleImports, importedHeader, isFramework,
-      /*module-cache-key*/ "");
+      optionalModuleImports, importedHeader, definingModulePath,
+      isFramework, /*module-cache-key*/ "");
 
   return std::move(dependencies);
 }

--- a/test/ScanDependencies/module_deps_cross_import_of_binary_module.swift
+++ b/test/ScanDependencies/module_deps_cross_import_of_binary_module.swift
@@ -1,0 +1,85 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/inputs)
+// RUN: %empty-directory(%t/binaryInputs)
+// RUN: %empty-directory(%t/separateModules)
+// RUN: %empty-directory(%t/inputs/Foo.swiftcrossimport)
+// RUN: split-file %s %t
+
+// - Fixup the input module file map
+// RUN: sed -e "s|INPUTSDIR|%/t/inputs|g" %t/map.json.template > %t/map.json.template1
+// RUN: sed -e "s|STDLIBMOD|%/stdlib_module|g" %t/map.json.template1 > %t/map.json.template2
+// RUN: sed -e "s|ONONEMOD|%/ononesupport_module|g" %t/map.json.template2 > %t/map.json.template3
+// RUN: sed -e "s|SWIFTLIBDIR|%swift-lib-dir|g" %t/map.json.template3 > %t/map.json
+
+// - Pre-compile explicit module dependency inputs
+// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
+
+// - Pre-compile the Foo module into a separately-stored binary module
+// RUN: %target-swift-frontend -compile-module-from-interface %t/separateModules/Foo.swiftinterface -o %t/binaryInputs/Foo.swiftmodule -module-name Foo -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -disable-implicit-swift-modules -Xcc -fno-implicit-modules -Xcc -fno-implicit-module-maps -explicit-swift-module-map-file %t/map.json
+
+// - Run a dependency scan on test.swift which will pick-up the ready-made binary dependency on Foo.swiftmodule
+//   and use the binary module's serialized originating defining .swiftinterface path to be able to
+//   discover the cross-import overlay _Foo_Bar.
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %t/inputs -I %t/binaryInputs -module-name test -enable-cross-import-overlays -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+
+// CHECK: "mainModuleName": "test"
+// CHECK:        "swift": "test"
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   "modulePath": "test.swiftmodule"
+// CHECK-NEXT:   "sourceFiles": [
+// CHECK-NEXT:   "{{.*}}{{/|\\}}module_deps_cross_import_of_binary_module.swift.tmp{{/|\\}}test.swift"
+// CHECK-NEXT:   ]
+// CHECK-NEXT:   "directDependencies": [
+// CHECK-DAG:      "swiftPrebuiltExternal": "Swift"
+// CHECK-DAG:      "swiftPrebuiltExternal": "SwiftOnoneSupport"
+// CHECK-DAG:      "swiftPrebuiltExternal": "Foo"
+// CHECK-DAG:      "swift": "Bar"
+// CHECK-DAG:      "swift": "_Foo_Bar"
+
+//--- map.json.template
+[
+  {
+      "moduleName": "Swift",
+      "modulePath": "STDLIBMOD",
+      "isFramework": false
+  },
+  {
+      "moduleName": "SwiftOnoneSupport",
+      "modulePath": "ONONEMOD",
+      "isFramework": false
+  },
+  {
+      "moduleName": "SwiftShims",
+      "isFramework": false,
+      "clangModuleMapPath": "SWIFTLIBDIR/swift/shims/module.modulemap",
+      "clangModulePath": "INPUTSDIR/SwiftShims.pcm"
+}]
+
+//--- test.swift
+import Foo
+import Bar
+
+//--- separateModules/Foo.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Foo
+public func foo() {}
+
+//--- inputs/Bar.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Bar
+public func bar() {}
+
+//--- inputs/_Foo_Bar.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name _Foo_Bar
+public func foobar() {}
+
+//--- separateModules/Foo.swiftcrossimport/Bar.swiftoverlay
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: _Foo_Bar


### PR DESCRIPTION
- **Explanation:** When the dependency scanner picks a pre-built binary module candidate for a given dependency, it needs to be able to attempt to resolve its cross-import overlays relative to the textual interface that the binary module was built from. For example, if a collection of binary modules are located in, and resolved as dependencies from, a pre-built module directory, the scanner must lookup their corresponding cross-import overlays relative to the defining interface as read out from the binary module's MODULE_INTERFACE_PATH. https://github.com/swiftlang/swift/pull/70817 ensures that binary modules serialize the path to their defining textual interface.

- **Scope:** This change affects Explicit Module Builds (opt-in) which rely on binary module dependencies that are placed separately from textual interface files they were built from. (e.g. prebuilt module cache)

- **Risk:** Low. This change is additive to the logic of cross-import lookup and predominantly affects the code-path that would previously fail to correctly identify cross-import overlays. It does not affect lookup of cross-import overlays that otherwise succeeds relative to the path of the `.swiftmodule` dependency itself.

- **Original PR:** https://github.com/swiftlang/swift/pull/74945

- **Issue/Radar:** rdar://130778577

- **Reviewers:** @cachemeifyoucan 