### PR TITLE
[Runtime] Fix missing return in getMetadataFromPointerKeyedMap.

### DIFF
--- a/stdlib/public/runtime/LibPrespecialized.cpp
+++ b/stdlib/public/runtime/LibPrespecialized.cpp
@@ -408,8 +408,8 @@ getMetadataFromPointerKeyedMap(const LibPrespecializedState &state,
 #else
   LOG("Looking up description %p but dyld hash table call not available.",
       description);
-  return nullptr;
 #endif
+  return nullptr;
 }
 
 // When we have a pointer-keyed map from a debug library, it's not built as a


### PR DESCRIPTION
When DYLD_FIND_POINTER_HASH_TABLE_ENTRY_DEFINED is set but the function is not found at runtime, we're missing a return statement.