### PR TITLE
[6.0][IRGen] Always load extra tag bits as full bytes in CVW to avoid elem…

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1685,11 +1685,22 @@ namespace {
       auto payload = EnumPayload::load(IGF, projectPayload(IGF, addr),
                                        PayloadSchema);
       if (ExtraTagBitCount > 0) {
-        extraTag = IGF.Builder.CreateLoad(projectExtraTagBits(IGF, addr));
         if (maskExtraTagBits) {
-          auto maskBits = llvm::NextPowerOf2(NumExtraTagValues) - 1;
+          auto projectedBits = projectExtraTagBits(IGF, addr);
+          // LLVM assumes that loads of fractional byte sizes have been stored
+          // with the same type, so all unused bits would be 0. Since we are
+          // re-using spare bits for tag storage, that assumption is wrong here.
+          // In CVW we have to mask the extra bits, which requires us to make
+          // this cast here, otherwise LLVM would optimize away the bit mask.
+          if (projectedBits.getElementType()->getIntegerBitWidth() < 8) {
+            projectedBits = IGF.Builder.CreateElementBitCast(addr, IGM.Int8Ty);
+          }
+          extraTag = IGF.Builder.CreateLoad(projectedBits);
+          auto maskBits = llvm::PowerOf2Ceil(NumExtraTagValues) - 1;
           auto mask = llvm::ConstantInt::get(extraTag->getType(), maskBits);
           extraTag = IGF.Builder.CreateAnd(extraTag, mask);
+        } else {
+          extraTag = IGF.Builder.CreateLoad(projectExtraTagBits(IGF, addr));
         }
       }
       return {std::move(payload), extraTag};

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -619,6 +619,16 @@ public enum MultiPayloadError {
     case error2(Int, Error)
 }
 
+public enum TwoPayloadInner {
+    case x(AnyObject)
+    case y(Int)
+}
+
+public enum TwoPayloadOuter {
+    case x(Int)
+    case y(TwoPayloadInner)
+}
+
 @inline(never)
 public func consume<T>(_ x: T.Type) {
     withExtendedLifetime(x) {}

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -I %S/Inputs/CTypes -enable-experimental-feature LayoutStringValueWitnesses -enable-layout-string-value-witnesses -parse-stdlib -emit-module -emit-module-path=%t/layout_string_witnesses_types.swiftmodule %S/Inputs/layout_string_witnesses_types.swift
+// RUN: %target-swift-frontend -O -I %S/Inputs/CTypes -enable-experimental-feature LayoutStringValueWitnesses -enable-layout-string-value-witnesses -parse-stdlib -emit-module -emit-module-path=%t/layout_string_witnesses_types.swiftmodule %S/Inputs/layout_string_witnesses_types.swift
 
 // NOTE: We have to build this as dylib to turn private external symbols into local symbols, so we can observe potential issues with linkage
-// RUN: %target-build-swift-dylib(%t/%target-library-name(layout_string_witnesses_types)) -I %S/Inputs/CTypes -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -parse-stdlib -parse-as-library %S/Inputs/layout_string_witnesses_types.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(layout_string_witnesses_types)) -O -I %S/Inputs/CTypes -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -parse-stdlib -parse-as-library %S/Inputs/layout_string_witnesses_types.swift
 // RUN: %target-codesign %t/%target-library-name(layout_string_witnesses_types)
-// RUN: %target-swift-frontend -enable-experimental-feature LayoutStringValueWitnesses -enable-layout-string-value-witnesses -enable-library-evolution -emit-module -emit-module-path=%t/layout_string_witnesses_types_resilient.swiftmodule %S/Inputs/layout_string_witnesses_types_resilient.swift
-// RUN: %target-build-swift -g -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -enable-library-evolution -c -parse-as-library -o %t/layout_string_witnesses_types_resilient.o %S/Inputs/layout_string_witnesses_types_resilient.swift
-// RUN: %target-build-swift -g -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -enable-type-layout -Xfrontend -parse-stdlib -module-name layout_string_witnesses_static -llayout_string_witnesses_types -L%t %t/layout_string_witnesses_types_resilient.o -I %t -o %t/main %s %target-rpath(%t)
+// RUN: %target-swift-frontend -O -enable-experimental-feature LayoutStringValueWitnesses -enable-layout-string-value-witnesses -enable-library-evolution -emit-module -emit-module-path=%t/layout_string_witnesses_types_resilient.swiftmodule %S/Inputs/layout_string_witnesses_types_resilient.swift
+// RUN: %target-build-swift -O -g -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -enable-library-evolution -c -parse-as-library -o %t/layout_string_witnesses_types_resilient.o %S/Inputs/layout_string_witnesses_types_resilient.swift
+// RUN: %target-build-swift -O -g -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -enable-type-layout -Xfrontend -parse-stdlib -module-name layout_string_witnesses_static -llayout_string_witnesses_types -L%t %t/layout_string_witnesses_types_resilient.o -I %t -o %t/main %s %target-rpath(%t)
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/%target-library-name(layout_string_witnesses_types) | %FileCheck %s --check-prefix=CHECK -check-prefix=CHECK-%target-os
 
@@ -1289,6 +1289,35 @@ func testCTypeUnderAligned() {
 }
 
 testCTypeUnderAligned()
+
+func testNestedTwoPayload() {
+    let ptr = UnsafeMutablePointer<TwoPayloadOuter>.allocate(capacity: 1)
+
+    do {
+        let x = TwoPayloadOuter.y(TwoPayloadInner.x(SimpleClass(x: 23)))
+        testInit(ptr, to: x)
+    }
+
+    do {
+        let y = TwoPayloadOuter.y(TwoPayloadInner.x(SimpleClass(x: 1)))
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testNestedTwoPayload()
 
 #if os(macOS)
 func testObjc() {


### PR DESCRIPTION
…ination of masking

**Explanation:** LLVM expects integer types of fractional byte sizes to have been written as those types as well, so it expects all unused bytes to be 0. Since we are using the unused extra tag bits to store tags of outer enums, that assumption does not hold here. In regular witnesses, the outer enum would mask out those bytes before checking the tag of the inner enum. In CVW we can't do that, so we have to apply the mask ourselves. To guarantee the mask does not get optimized out, we have to use full bytes instead of fractionals.
**Scope:** This change only affects compact value witnesses. 
**Risk:** Low. This feature is still experimental and the scope of the fix is very small.
**Testing:** Added unit test that observes the issue before the fix and passes afterwards.
**Original PR:** https://github.com/swiftlang/swift/pull/74952
**Issue:** rdar://129627898
**Reviewers:** @aschwaighofer 