### PR TITLE
Improve RangeSet union performance

### DIFF
--- a/stdlib/public/core/RangeSet.swift
+++ b/stdlib/public/core/RangeSet.swift
@@ -251,10 +251,11 @@ extension RangeSet {
   /// Adds the contents of the given range set to this range set.
   ///
   /// - Parameter other: A range set to merge with this one.
+  ///
+  /// - Complexity: O(*m* + *n*), where *m* and *n* are the number of ranges in
+  ///   this and the other range set.
   public mutating func formUnion(_ other: __owned RangeSet<Bound>) {
-    for range in other._ranges {
-      insert(contentsOf: range)
-    }
+    self = self.union(other)
   }
   
   /// Removes the contents of this range set that aren't also in the given
@@ -293,9 +294,7 @@ extension RangeSet {
   public __consuming func union(
     _ other: __owned RangeSet<Bound>
   ) -> RangeSet<Bound> {
-    var result = self
-    result.formUnion(other)
-    return result
+    return RangeSet(_ranges: _ranges._union(other._ranges))
   }
   
   /// Returns a new range set containing the contents of both this set and the

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -163,6 +163,7 @@ Added: _$ss8RangeSetV6RangesV10startIndexSivpMV
 Added: _$ss8RangeSetV6RangesV11descriptionSSvg
 Added: _$ss8RangeSetV6RangesV11descriptionSSvpMV
 Added: _$ss8RangeSetV6RangesV13_intersectionyADyx_GAFF
+Added: _$ss8RangeSetV6RangesV6_unionyADyx_GAFF
 Added: _$ss8RangeSetV6RangesV2eeoiySbADyx_G_AFtFZ
 Added: _$ss8RangeSetV6RangesV5_gaps9boundedByADyx_GSnyxG_tF
 Added: _$ss8RangeSetV6RangesV5countSivg

--- a/validation-test/stdlib/RangeSet.swift
+++ b/validation-test/stdlib/RangeSet.swift
@@ -174,6 +174,55 @@ if #available(SwiftStdlib 6.0, *) {
     }
   }
 
+  RangeSetTests.test("union") {
+    func unionViaSet(
+      _ s1: RangeSet<Int>,
+      _ s2: RangeSet<Int>
+    ) -> RangeSet<Int> {
+      let set1 = Set(parent.indices[s1])
+      let set2 = Set(parent.indices[s2])
+      return RangeSet(set1.union(set2), within: parent)
+    }
+
+    func testUnion(
+      _ set1: RangeSet<Int>,
+      _ set2: RangeSet<Int>,
+      expect union: RangeSet<Int>
+    ) {
+      expectEqual(set1.union(set2), union)
+      expectEqual(set2.union(set1), union)
+
+      var set3 = set1
+      set3.formUnion(set2)
+      expectEqual(set3, union)
+
+      set3 = set2
+      set3.formUnion(set1)
+      expectEqual(set3, union)
+    }
+    
+    // Simple tests
+    testUnion([0..<5, 9..<14],
+              [1..<3, 4..<6, 8..<12],
+              expect: [0..<6, 8..<14])
+    
+    testUnion([10..<20, 50..<60],
+              [15..<55, 58..<65],
+              expect: [10..<65])
+
+    // Test with upper bound / lower bound equality
+    testUnion([10..<20, 30..<40],
+              [15..<30, 40..<50],
+              expect: [10..<50])
+    
+    for _ in 0..<100 {
+      let set1 = buildRandomRangeSet()
+      let set2 = buildRandomRangeSet()
+      testUnion(set1, set2,
+                expect: unionViaSet(set1, set2))
+    }
+  }
+  
   RangeSetTests.test("intersection") {
     func intersectionViaSet(
       _ s1: RangeSet<Int>,


### PR DESCRIPTION
The existing implementation of `RangeSet.formUnion` performs a naive insertion of each range of one range set into the other. This requires shuffling the array of ranges down with each insertion, which can have quadratic performance.

This change uses the known invariants of the ranges array to instead perform the merge in linear time. Each range in the resulting array is determined by finding the next lowest bound between the two range sets, and then searching for the first upper bound that isn't included in the merged range set contents.

rdar://129296438
