### PR TITLE
[AutoDiff] Ensure we are materializing adjoint value into buffer correctly for optionals

### DIFF
--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2617,7 +2617,7 @@ AllocStackInst *PullbackCloner::Implementation::createOptionalAdjoint(
   // Initialize an `Optional<T.TangentVector>` buffer from `wrappedAdjoint` as
   // the input for `Optional<T>.TangentVector.init`.
   auto *optArgBuf = builder.createAllocStack(pbLoc, optionalOfWrappedTanType);
-  if (optionalOfWrappedTanType.isLoadableOrOpaque(builder.getFunction())) {
+  if (optionalOfWrappedTanType.isObject()) {
     // %enum = enum $Optional<T.TangentVector>, #Optional.some!enumelt,
     //         %wrappedAdjoint : $T
     auto *enumInst = builder.createEnum(pbLoc, wrappedAdjoint, someEltDecl,

--- a/test/AutoDiff/compiler_crashers_fixed/issue-74841-optional-adjoint-buffer.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-74841-optional-adjoint-buffer.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// https://github.com/swiftlang/swift/issues/74841
+// We used to create invalid adjoint buffer for Optional<T>
+// if this buffer originated from unchecked_take_enum_data_addr
+// instruction
+import _Differentiation;
+
+struct F<I> {subscript(_ i: Int) -> S<I>? {get {nil} set {}}}
+struct S<I> {subscript(_ i: Int) -> I?    {get {nil} set {}}}
+extension F: Differentiable {}
+extension S: Differentiable {}
+struct A{@differentiable(reverse) func b(c: inout F<Double>, d: S<Double>) {c[0]![0] = 0}}


### PR DESCRIPTION
 - We use `enum $Optional<T.TangentVector>, #Optional.some!enumelt, %wrappedAdjoint : $T` for objects
 - We use `inject_enum_addr %optArgBuf : $*Optional<T.TangentVector>, #Optional.some!enumelt` for addresses

Fixes #74841