### PR TITLE
[cxx-interop] Do not expose enums with optional generic cases

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2914,6 +2914,9 @@ static bool isEnumExposableToCxx(const ValueDecl *VD,
       if (auto *params = elementDecl->getParameterList()) {
         for (const auto *param : *params) {
           auto paramType = param->getInterfaceType();
+          // TODO: properly support exporting these optionals. rdar://131112273 
+          if (paramType->isOptional() && paramType->getOptionalObjectType()->isTypeParameter())
+            return false;
           if (DeclAndTypeClangFunctionPrinter::getTypeRepresentation(
                   printer.getTypeMapping(), printer.getInteropContext(),
                   printer, enumDecl->getModuleContext(), paramType)

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -89,6 +89,11 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
     }
 }
 
+@frozen public enum GenericCustomType<T> {
+    case success(T?)
+    case failure
+}
+
 // CHECK: namespace Generics SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Generics") {
 
 // CHECK: template<class T_0_0>


### PR DESCRIPTION
Unfortunately, we cannot generate the C++ code for them just yet. There will be a follow-up PR to actually fix the underlying issue and expose such enums correctly.

rdar://129250756
