### PR TITLE
🍒[cxx-interop] Ban ObjCBool from being substituted into C++ templates

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -896,6 +896,19 @@ ClangTypeConverter::getClangTemplateArguments(
     }
 
     auto replacement = genericArgs[templateParam->getIndex()];
+
+    // Ban ObjCBool type from being substituted into C++ templates.
+    if (auto nominal = replacement->getAs<NominalType>()) {
+      if (auto nominalDecl = nominal->getDecl()) {
+        if (nominalDecl->getName().is("ObjCBool") &&
+            nominalDecl->getModuleContext()->getName() ==
+                nominalDecl->getASTContext().Id_ObjectiveC) {
+          failedTypes.push_back(replacement);
+          continue;
+        }
+      }
+    }
+
     auto qualType = convert(replacement);
     if (qualType.isNull()) {
       failedTypes.push_back(replacement);

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -71,6 +71,8 @@ template <class T> struct Dep { using TT = T; };
 
 template <class T> void useDependentType(typename Dep<T>::TT) {}
 
+template <class T> void takesValue(T value) { }
+
 template <class T> void lvalueReference(T &ref) { ref = 42; }
 template <class T> void lvalueReferenceZero(T &ref) { ref = 0; }
 

--- a/test/Interop/Cxx/templates/function-template-objc-typechecker.swift
+++ b/test/Interop/Cxx/templates/function-template-objc-typechecker.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import FunctionTemplates
+import ObjectiveC
+
+// Verify that ObjCBool type is banned from C++ template parameters.
+
+takesValue(ObjCBool(true))
+// CHECK: error: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'takesValue' could not be converted: ObjCBool
+constLvalueReference(ObjCBool(true))
+// CHECK: error: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'constLvalueReference' could not be converted: ObjCBool


### PR DESCRIPTION
**Explanation**:  This fixes a compiler crash when calling a templated C++ function with a parameter of type `ObjCBool` from Swift. The compiler now emits an error for this.
**Scope**: Changes the logic that transforms Swift types to C++ types for the purpose of C++ template instantiation.
**Risk**: Low, only affects C++ templates.
**Testing**: Added a compile test.
**Issue**: rdar://130424969
**Reviewer**: @beccadax 

Original PR: https://github.com/swiftlang/swift/pull/74790
