### PR TITLE
[cxx-interop] Conditionally re-enable a test for `std::function`, pt 2

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -11,6 +11,7 @@
 // which aren't yet supported in Swift. Therefore initializing a std::function from Swift closures
 // will not work on the platforms that are shipped with this version of libstdc++ (rdar://125816354).
 // XFAIL: LinuxDistribution=ubuntu-22.04
+// XFAIL: LinuxDistribution=rhel-9.3
 // XFAIL: LinuxDistribution=rhel-9.4
 
 import StdlibUnittest


### PR DESCRIPTION
The post-commit CI uses a slightly different version of UBI.

rdar://125816354