### PR TITLE
IRGen: don't stack promote classes for which the layout has not a fixed size

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -781,6 +781,8 @@ static llvm::Value *stackPromote(IRGenFunction &IGF,
     return nullptr;
   if (!FieldLayout.isFixedLayout())
     return nullptr;
+  if (!FieldLayout.isFixedSize())
+    return nullptr;
 
   // Calculate the total size needed.
   // The first part is the size of the class itself.

--- a/test/SILOptimizer/stack-promotion-crash.swift
+++ b/test/SILOptimizer/stack-promotion-crash.swift
@@ -1,0 +1,53 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-build-swift -O -wmo -parse-as-library -emit-module -emit-module-path=%t/XMod.swiftmodule -module-name=XMod %t/xmod.swift -I%t -c -o %t/xmod.o
+// RUN: %target-build-swift -O -wmo -module-name=Main -I%t %t/main.swift -c -o %t/main.o
+// RUN: %target-swiftc_driver %t/main.o %t/xmod.o -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+//--- module.modulemap
+
+module CModule {
+  header "c-header.h"
+  export *
+}
+
+
+//--- c-header.h
+
+struct CS {
+  int x;
+};
+
+//--- xmod.swift
+
+@_implementationOnly import CModule
+
+// The layout of this class does not include the C-imported CS field.
+// Therefore it must not be stack-promoted in `testit`. Otherwise the reserved stack space
+// would be wrong and the executable would crash.
+final public class X {
+  public var i: Int
+  var cs: CS? = nil
+
+  public init(_ i: Int) { self.i = i }
+}
+
+//--- main.swift
+
+import XMod
+
+@inline(never)
+func getit(_ x: X, _ y: X) -> Int {
+  return x.i + y.i
+}
+
+@inline(never)
+public func testit() -> Int {
+  return getit(X(27), X(11))
+}
+
+// CHECK: 38
+print(testit())
+


### PR DESCRIPTION
In most cases this was already checked with `ClassLayout::isFixedLayout`. But for classes which are imported from another module and contain implementation-only C-imported stored properties, those properties don't show up in the class layout. Stack promoting such classes will reserve too less space on the stack which leads to all kind of memory corruption problems. The fix is to also check `ClassLayout::isFixedSize`, which returns false for such classes.

Fixes a miscompile
rdar://131067105
(https://github.com/duckdb/duckdb/issues/11289)
