### PR TITLE
[6.0] Typed throws back-deployment fixes

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -83,6 +83,14 @@ protected:
   /// a critical role.
   bool AllowIsolatedAny = true;
 
+  /// If enabled, typed throws can be encoded in the mangled name.
+  /// Suppressing type attributes this way is generally questionable ---
+  /// for example, it does not interact properly with substitutions ---
+  /// and should only be done in situations where it is just going to be
+  /// interpreted as a type and the exact string value does not play
+  /// a critical role.
+  bool AllowTypedThrows = true;
+
   /// If enabled, declarations annotated with @_originallyDefinedIn are mangled
   /// as if they're part of their original module. Disabled for debug mangling,
   /// because lldb wants to find declarations in the modules they're currently

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6688,6 +6688,11 @@ ERROR(availability_isolated_any_only_version_newer, none,
       "%0 %1 or newer",
       (StringRef, llvm::VersionTuple))
 
+ERROR(availability_typed_throws_only_version_newer, none,
+      "runtime support for typed throws function types is only available in "
+      "%0 %1 or newer",
+      (StringRef, llvm::VersionTuple))
+
 ERROR(availability_variadic_type_only_version_newer, none,
       "parameter packs in generic types are only available in %0 %1 or newer",
       (StringRef, llvm::VersionTuple))

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3055,7 +3055,8 @@ void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
   if (fn->isSendable())
     appendOperator("Yb");
   if (auto thrownError = fn->getEffectiveThrownErrorType()) {
-    if ((*thrownError)->isEqual(fn->getASTContext().getErrorExistentialType())){
+    if ((*thrownError)->isEqual(fn->getASTContext().getErrorExistentialType())
+        || !AllowTypedThrows) {
       appendOperator("K");
     } else {
       appendType(*thrownError, sig);

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -161,18 +161,23 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
   llvm::SaveAndRestore<bool> savedConcurrencyStandardSubstitutions(
       AllowConcurrencyStandardSubstitutions);
   llvm::SaveAndRestore<bool> savedIsolatedAny(AllowIsolatedAny);
+  llvm::SaveAndRestore<bool> savedTypedThrows(AllowTypedThrows);
   if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget(
           ctx.LangOpts.Target)) {
+
     if (*runtimeCompatVersion < llvm::VersionTuple(5, 5))
       AllowConcurrencyStandardSubstitutions = false;
 
-    // Suppress @isolated(any) if we're mangling for pre-6.0 runtimes.
+    // Suppress @isolated(any) and typed throws if we're mangling for pre-6.0
+    // runtimes.
     // This is unprincipled but, because of the restrictions in e.g.
     // mangledNameIsUnknownToDeployTarget, should only happen when
     // mangling for certain reflective uses where we have to hope that
     // the exact type identity is generally unimportant.
-    if (*runtimeCompatVersion < llvm::VersionTuple(6, 0))
+    if (*runtimeCompatVersion < llvm::VersionTuple(6, 0)) {
       AllowIsolatedAny = false;
+      AllowTypedThrows = false;
+    }
   }
 
   llvm::SaveAndRestore<bool> savedAllowStandardSubstitutions(

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3031,6 +3031,15 @@ static bool diagnoseIsolatedAnyAvailability(
       ReferenceDC);
 }
 
+static bool diagnoseTypedThrowsAvailability(
+    SourceRange ReferenceRange, const DeclContext *ReferenceDC) {
+  return TypeChecker::checkAvailability(
+      ReferenceRange,
+      ReferenceDC->getASTContext().getTypedThrowsAvailability(),
+      diag::availability_typed_throws_only_version_newer,
+      ReferenceDC);
+}
+
 static bool checkTypeMetadataAvailabilityInternal(CanType type,
                                                   SourceRange refLoc,
                                                   const DeclContext *refDC) {
@@ -3041,6 +3050,8 @@ static bool checkTypeMetadataAvailabilityInternal(CanType type,
       auto isolation = fnType->getIsolation();
       if (isolation.isErased())
         return diagnoseIsolatedAnyAvailability(refLoc, refDC);
+      if (fnType.getThrownError())
+        return diagnoseTypedThrowsAvailability(refLoc, refDC);
     }
     return false;
   });

--- a/test/IRGen/reflection_metadata_typed_throws.swift
+++ b/test/IRGen/reflection_metadata_typed_throws.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos99.99 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-PRESENT %s
+// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos14.4 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-SUPPRESSED %s
+
+// REQUIRES: OS=macosx
+// UNSUPPORTED: CPU=arm64e
+
+// Make sure that a dangling-based type description involving typed throws is
+// only used when deploying to runtimes that support it.
+
+// Closure capture metadata:
+
+enum MyError: Error {
+  case fail
+}
+
+// CHECK-LABEL: @"\01l__swift5_reflection_descriptor" = private constant
+// CHECK-PRESENT-SAME: ptr @"symbolic Si_____Ieghdzo_ 32reflection_metadata_typed_throws7MyErrorO"
+// CHECK-SUPPRESSED-SAME: ptr @"symbolic Si_____Ieghdzo_ 32reflection_metadata_typed_throws7MyErrorO"
+// CHECK-LABEL: @metadata = private constant %swift.full_boxmetadata { {{.*}}, ptr @"\01l__swift5_reflection_descriptor" }, align
+func makeClosure(fn: @escaping @Sendable () throws(MyError) -> Int) -> (() throws(MyError)  -> Int) {
+  return { try fn() + 1 }
+}
+
+// Struct field metadata:
+
+public struct MyStruct {
+  let fn: () throws (MyError) -> ()
+}
+
+// CHECK-LABEL: @"$s32reflection_metadata_typed_throws8MyStructVMF" = internal constant
+// CHECK-PRESENT-SAME: ptr @"symbolic yy_____YKc 32reflection_metadata_typed_throws7MyErrorO"
+// CHECK-SUPPRESSED-SAME: ptr @"get_type_metadata yy32reflection_metadata_typed_throws7MyErrorOYKc.1"

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -13,11 +13,14 @@ public enum MyBigError: Error {
 
 
 // CHECK-MANGLE: @"$s12typed_throws1XVAA1PAAWP" = hidden global [2 x ptr] [ptr @"$s12typed_throws1XVAA1PAAMc", ptr getelementptr inbounds (i8, ptr @"symbolic ySi_____YKc 12typed_throws10MyBigErrorO", {{i32|i64}} 1)]
+@available(SwiftStdlib 6.0, *)
 struct X: P {
   typealias A = (Int) throws(MyBigError) -> Void
 }
 
 func requiresP<T: P>(_: T.Type) { }
+
+@available(SwiftStdlib 6.0, *)
 func createsP() {
   requiresP(X.self)
 }
@@ -27,6 +30,7 @@ func createsP() {
 
 
 // CHECK-LABEL: define {{.*}}hidden swiftcc ptr @"$s12typed_throws13buildMetatypeypXpyF"()
+@available(SwiftStdlib 6.0, *)
 func buildMetatype() -> Any.Type {
   typealias Fn = (Int) throws(MyBigError) -> Void
 

--- a/test/Parse/typed_throws.swift
+++ b/test/Parse/typed_throws.swift
@@ -20,6 +20,7 @@ func testClosures() {
   let _ = { (x: Int, y: Int) throws(MyError) -> Int in x + y }
 }
 
+@available(SwiftStdlib 6.0, *)
 func testTypes() {
   let _ = [(Int, Int) throws(MyError) -> Int]()
 }

--- a/test/decl/func/typed_throws_availability.swift
+++ b/test/decl/func/typed_throws_availability.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name test
+
+// REQUIRES: OS=macosx
+
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macos14.4
+
+enum MyError: Error {
+  case fail
+}
+
+func bad() -> Any.Type {
+  // expected-note@-1{{add @available attribute to enclosing global function}}
+  typealias Fn = () throws(MyError) -> ()
+  // expected-error@+2{{runtime support for typed throws function types is only available in macOS 15.0.0 or newer}}
+  // expected-note@+1{{add 'if #available' version check}}
+  return Fn.self
+}
+
+func good() -> Any.Type {
+  typealias Fn = () throws(any Error) -> ()
+  return Fn.self
+}


### PR DESCRIPTION
Explanation: Typed throws can be used when deploying to Swift runtimes prior to 6.0, but only when type metadata is not required. Enforce this via an availability check rather than emitting code that will crash on older runtimes.
Scope: Typed throws availability checking and mangling.
Risk: Low. This follows established mechanisms for back-deployment.
Testing: New tests for this behavior.
Issue: rdar://121530587
Original PR: https://github.com/swiftlang/swift/pull/74962
