### PR TITLE
[CursorInfo] Resolve solver-based in VarDecls

### DIFF
--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -175,7 +175,12 @@ private:
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override {
-    if (!rangeContainsLocToResolve(D->getSourceRangeIncludingAttrs())) {
+    // If the decl doesn't contain the location to resolve, we can skip walking
+    // it. One exception to this is for VarDecls, they can contain accessors
+    // which are not included in their SourceRange. For e.g `var x: Int { 0 }`,
+    // the VarDecl's range is just `x`, but the location may be in the accessor.
+    if (!isa<VarDecl>(D) &&
+        !rangeContainsLocToResolve(D->getSourceRangeIncludingAttrs())) {
       return Action::SkipNode();
     }
 

--- a/test/SourceKit/CursorInfo/rdar131135631.swift
+++ b/test/SourceKit/CursorInfo/rdar131135631.swift
@@ -1,0 +1,12 @@
+func foo(_ x: Int) -> Int {}
+func foo(_ x: String) -> Int {}
+
+// rdar://131135631 - Make sure we can resolve solver-based cursor info in a
+// VarDecl's accessor.
+var x: Int {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):3 %s -- %s | %FileCheck %s
+  foo()
+}
+
+// CHECK-DAG: source.lang.swift.ref.function.free (1:6-1:19)
+// CHECK-DAG: source.lang.swift.ref.function.free (2:6-2:22)


### PR DESCRIPTION
Previously we would skip resolving any solver-based cursor info in a VarDecl accessor as the VarDecl source range does not encompass the AccessorDecl. Avoid looking at the VarDecl source range in this case.

rdar://131135631