### PR TITLE
[sending] Add a reported test case that we used to crash on that we no longer do so.

### DIFF
--- a/test/Concurrency/sending_continuation.swift
+++ b/test/Concurrency/sending_continuation.swift
@@ -231,3 +231,16 @@ func withUnsafeContinuation_4a() async {
   }
   await useValueAsync(x)
 }
+
+public actor WithCheckedThrowingContinuationErrorAvoidance {
+  nonisolated func handle(reply: (Int) -> Void) {}
+
+  // make sure that we do not emit any errors on the following code.
+  func noError() async throws -> Int {
+    return try await withCheckedThrowingContinuation { continuation in 
+      handle { result in
+        continuation.resume(returning: result)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Just to validate we never break this code again.

rdar://130114727
