### PR TITLE
[AutoDiff] Implement active optional differentiation

### DIFF
--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -197,11 +197,8 @@ func checked_cast_addr_nonactive_result<T: Differentiable>(_ x: T) -> T {
 // CHECK:   checked_cast_addr_br take_always T in %3 : $*T to Float in %5 : $*Float, bb1, bb2
 // CHECK: }
 
-// expected-error @+1 {{function is not differentiable}}
 @differentiable(reverse)
-// expected-note @+1 {{when differentiating this function definition}}
 func checked_cast_addr_active_result<T: Differentiable>(x: T) -> T {
-  // expected-note @+1 {{expression is not differentiable}}
   if let y = x as? Float {
     // Use `y: Float?` value in an active way.
     return y as! T
@@ -777,12 +774,9 @@ func testClassModifyAccessor(_ c: inout C) {
 // Enum differentiation
 //===----------------------------------------------------------------------===//
 
-// expected-error @+1 {{function is not differentiable}}
 @differentiable(reverse)
-// expected-note @+1 {{when differentiating this function definition}}
 func testActiveOptional(_ x: Float) -> Float {
   var maybe: Float? = 10
-  // expected-note @+1 {{expression is not differentiable}}
   maybe = x
   return maybe!
 }

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -147,12 +147,9 @@ class C<T: Differentiable>: Differentiable {
 // Enum differentiation
 //===----------------------------------------------------------------------===//
 
-// expected-error @+1 {{function is not differentiable}}
 @differentiable(reverse)
-// expected-note @+1 {{when differentiating this function definition}}
 func usesOptionals(_ x: Float) -> Float {
   var maybe: Float? = 10
-  // expected-note @+1 {{expression is not differentiable}}
   maybe = x
   return maybe!
 }

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -21,6 +21,15 @@ func optional_nil_coalescing(_ maybeX: Float?) -> Float {
 }
 */
 
+OptionalTests.test("Active") {
+  @differentiable(reverse)
+  func square(y: Float) -> Float? {
+    return y * y
+  }
+
+  expectEqual(gradient(at: 10, of: {y in square(y:y)!}), .init(20.0))
+}
+
 OptionalTests.test("Let") {
   @differentiable(reverse)
   func optional_let(_ maybeX: Float?) -> Float {


### PR DESCRIPTION
Fixes #74972

Optionals of address-only types are already handled in https://github.com/swiftlang/swift/pull/68300