### PR TITLE
PerformanceDiagnostic: give an error if a generic non-copyable value with a deinit is captured by an escaping closure.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -398,6 +398,8 @@ ERROR(embedded_swift_allocating_type,none,
       "cannot use allocating type %0 in -no-allocations mode", (Type))
 ERROR(embedded_swift_allocating,none,
       "cannot use allocating operation in -no-allocations mode", ())
+ERROR(embedded_capture_of_generic_value_with_deinit,none,
+      "capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift", ())
 NOTE(performance_called_from,none,
       "called from here", ())
 

--- a/test/embedded/noncopyable-captures.swift
+++ b/test/embedded/noncopyable-captures.swift
@@ -1,0 +1,112 @@
+// RUN: %target-swift-emit-ir %s -DIGNORE_FAILS -enable-experimental-feature Embedded -wmo -o /dev/null
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -wmo -verify
+
+struct MyStruct<Item> : ~Copyable {
+    var member = "42"
+
+    init() {}
+    deinit {}
+    mutating func foo() {}
+}
+
+var escape: (()->())?
+
+#if !IGNORE_FAILS
+
+public func test() {
+    var s = MyStruct<Int>() // expected-error {{capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift}}
+    s.foo()
+    escape = {
+        s.foo()
+    }
+}
+
+//
+
+struct Outer: ~Copyable {
+  var inner: MyStruct<Int>
+}
+
+public func testNested() {
+    var s = Outer(inner: MyStruct<Int>()) // expected-error {{capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift}}
+    s.inner.foo()
+    escape = {
+        s.inner.foo()
+    }
+}
+
+//
+
+enum E: ~Copyable {
+  case A(MyStruct<Int>)
+  case B
+
+  mutating func foo() {}
+}
+
+public func testEnum() {
+    var s = E.A(MyStruct<Int>()) // expected-error {{capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift}}
+    s.foo()
+    escape = {
+        s.foo()
+    }
+}
+
+#endif
+
+//
+
+struct StructWithoutDeinit<Item> {
+    var member = "42"
+
+    init() {}
+    mutating func foo() {}
+}
+
+public func testWithoutDeinit() {
+    var s = StructWithoutDeinit<Int>()
+    s.foo()
+    escape = {
+        s.foo()
+    }
+}
+
+//
+
+struct NonCopyableStructWithoutDeinit<Item>: ~Copyable {
+    var member = "42"
+
+    init() {}
+    mutating func foo() {}
+}
+
+public func testNonCopyableWithoutDeinit() {
+    var s = NonCopyableStructWithoutDeinit<Int>()
+    s.foo()
+    escape = {
+        s.foo()
+    }
+}
+
+//
+
+struct NonGenericStruct : ~Copyable {
+    var member = "42"
+
+    init() {
+    }
+
+    deinit {
+    }
+
+    mutating func foo() {
+    }
+}
+
+public func testNonGeneric() {
+    var s = NonGenericStruct()
+    s.foo()
+    escape = {
+        s.foo()
+    }
+}


### PR DESCRIPTION
Otherwise IRGen would crash.
It needs a bit of work to support alloc_box of generic non-copyable structs/enums with deinit, because we need to specialize the deinit functions, though they are not explicitly referenced in SIL. Until this is supported, give an error in such cases.

Fixes a compiler crash in IRGen
rdar://130283111
