### PR TITLE
[cxx-interop] Conditionally re-enable a test for `std::function`, pt 3

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -13,6 +13,7 @@
 // XFAIL: LinuxDistribution=ubuntu-22.04
 // XFAIL: LinuxDistribution=rhel-9.3
 // XFAIL: LinuxDistribution=rhel-9.4
+// XFAIL: LinuxDistribution=fedora-39
 
 import StdlibUnittest
 import StdFunction


### PR DESCRIPTION
This also disables the test on Fedora.

rdar://125816354
