### PR TITLE
[Index] Mark accessors as implicit in modules

### DIFF
--- a/test/Index/index_module_accessors.swift
+++ b/test/Index/index_module_accessors.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Mod.swiftmodule -module-name Mod %s
+// RUN: %target-swift-ide-test -print-indexed-symbols -module-to-print Mod -source-filename %s -I %t | %FileCheck %s
+
+// rdar://130775560 - Make sure the accessors are marked implicit in the index
+// data for the module.
+public struct S {
+  // CHECK-DAG: instance-property/Swift | x | s:3Mod1SV1xSivp | Def,RelChild
+  // CHECK-DAG: instance-method/acc-get/Swift | getter:x | s:3Mod1SV1xSivg | Def,Impl,RelChild,RelAcc
+  public let x = 0
+
+  // CHECK-DAG: instance-property/Swift | y | s:3Mod1SV1ySivp | Def,RelChild
+  // CHECK-DAG: instance-method/acc-get/Swift | getter:y | s:3Mod1SV1ySivg | Def,Impl,RelChild,RelAcc
+  public var y: Int {
+    0
+  }
+
+  // CHECK-DAG: instance-property/Swift | z | s:3Mod1SV1zSivp | Def,RelChild
+  // CHECK-DAG: instance-method/acc-get/Swift | getter:z | s:3Mod1SV1zSivg | Def,Impl,RelChild,RelAcc
+  // CHECK-DAG: instance-method/acc-set/Swift | setter:z | s:3Mod1SV1zSivs | Def,Impl,RelChild,RelAcc
+  public var z: Int {
+    get { 0 }
+    set {}
+  }
+
+  // CHECK-DAG: instance-property/Swift | a | s:3Mod1SV1aSivp | Def,RelChild
+  // CHECK-DAG: instance-method/acc-get/Swift | getter:a | s:3Mod1SV1aSivg | Def,Impl,RelChild,RelAcc
+  public var a: Int {
+    @inlinable
+    get { 0 }
+  }
+}

--- a/test/SourceKit/Indexing/Inputs/test_module.index.response
+++ b/test/SourceKit/Indexing/Inputs/test_module.index.response
@@ -94,15 +94,15 @@
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.name: "getter:value",
               key.usr: "s:11test_module16ComputedPropertyC5valueSivg",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.name: "setter:value",
               key.usr: "s:11test_module16ComputedPropertyC5valueSivs",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.public


### PR DESCRIPTION
These won't have bodies in generated interfaces, and generally aren't useful things to jump to. The property ought to be used instead.

rdar://130775560