### PR TITLE
Fix SILBridging for GlobalAddr_getDecl

### DIFF
--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1362,11 +1362,11 @@ BridgedNullableVarDecl BridgedInstruction::AllocBox_getDecl() const {
 }
 
 BridgedNullableVarDecl BridgedInstruction::GlobalAddr_getDecl() const {
-  return {getAs<swift::DebugValueInst>()->getDecl()};
+  return {getAs<swift::GlobalAddrInst>()->getReferencedGlobal()->getDecl()};
 }
 
 BridgedNullableVarDecl BridgedInstruction::RefElementAddr_getDecl() const {
-  return {getAs<swift::DebugValueInst>()->getDecl()};
+  return {getAs<swift::RefElementAddrInst>()->getField()};
 }
 
 OptionalBridgedSILDebugVariable

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
@@ -64,3 +64,9 @@ func bv_incorrect_annotation2(_ w1: borrowing Wrapper, _ w2: borrowing Wrapper) 
   return w1.bv                                                                                        // expected-note @-1{{it depends on the lifetime of argument 'w1'}}
 }                                                                                                     // expected-note @-1{{this use causes the lifetime-dependent value to escape}}
 
+let ptr = UnsafeRawPointer(bitPattern: 1)!
+let nc = NC(ptr, 0) // expected-error {{lifetime-dependent variable 'nc' escapes its scope}}
+
+func bv_global(dummy: BV) -> BV {
+  nc.getBV()
+} // expected-note {{this use causes the lifetime-dependent value to escape}}


### PR DESCRIPTION
and RefElementAddr_getDecl.

Fixes:
Assertion failed: (isa<To>(Val) && "cast<Ty>() argument of incompatible type!"), function cast, file Casting.h

While running pass #224 SILFunctionTransform "LifetimeDependenceDiagnostics"
 #7 0x0000000102d3efcc decltype(auto) llvm::cast<swift::DebugValueInst, swift::SILInstruction>(swift::SILInstruction*)
 #8 0x0000000102d01e24 swift::DebugValueInst* BridgedInstruction::getAs<swift::DebugValueInst>() const
 #9 0x0000000102d01ee4 BridgedInstruction::GlobalAddr_getDecl() const
