### PR TITLE
Runtime: Fix runtime type resolution when mangled names refer to protocol extensions with Self same type constraints.

### DIFF
--- a/test/Runtime/protocol_self_same_type_extension.swift
+++ b/test/Runtime/protocol_self_same_type_extension.swift
@@ -1,0 +1,27 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// rdar://130168101: Make sure that we correctly resolve types in
+// the generic context of a protocol extension with a `Self` same
+// type constraint.
+
+
+protocol P { }
+
+struct P2: P { }
+
+extension P where Self == P2 {
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    dynamic func p2() -> some P {
+        return self
+    }
+}
+
+// CHECK: P2()
+if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+    print(P2().p2())
+} else {
+    print(P2())
+}


### PR DESCRIPTION
…ocol extensions with Self same type constraints.

If a type or opaque type descriptor appears inside of a protocol extension of the form:

```
extension P where Self == Nominal { ... }
```

then the runtime representation of the extension context was interpreted by the runtime demangler as a nominal type extension, even though the parameterization is on the `<Self>` generic signature of the protocol extension and not the generic signature of the nominal type. This would cause spurious rejection of mangled names referencing the extension context because we mistakenly thought that the type arguments mismatched with the nominal type signature rather than matching them to the extension context.

Add some code to `_findExtendedTypeContextDescriptor` to detect when an extension is a protocol extension with a `Self == SameType` constraint, and pass the extension along rather than treating it as a nominal type extension. Fixes rdar://130168101.