### PR TITLE
AST: Stop pretending that conformance lookup takes the module into account

### DIFF
--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -118,7 +118,7 @@ getDistributedActorAsActorConformanceRef(ASTContext &C);
 /// the DistributedActor-as-Actor conformance.
 ExtensionDecl *
 findDistributedActorAsActorExtension(
-    ProtocolDecl *distributedActorProto, ModuleDecl *module);
+    ProtocolDecl *distributedActorProto);
 
 bool isDistributedActorAsLocalActorComputedProperty(VarDecl *var);
 

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -322,12 +322,6 @@ public:
       SmallVector<Requirement, 2> &reqs,
       SmallVector<InverseRequirement, 2> &inverses) const;
 
-  /// Look up a stored conformance in the generic signature. These are formed
-  /// from same-type constraints placed on associated types of generic
-  /// parameters which have conformance constraints on them.
-  ProtocolConformanceRef lookupConformance(CanType depTy,
-                                           ProtocolDecl *proto) const;
-
   /// Iterate over all generic parameters, passing a flag to the callback
   /// indicating if the generic parameter is canonical or not.
   void forEachParam(

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -886,8 +886,8 @@ public:
   ///
   /// \returns An invalid conformance if the search failed, otherwise an
   /// abstract, concrete or pack conformance, depending on the lookup type.
-  ProtocolConformanceRef lookupConformance(Type type, ProtocolDecl *protocol,
-                                           bool allowMissing = false);
+  static ProtocolConformanceRef lookupConformance(Type type, ProtocolDecl *protocol,
+                                                  bool allowMissing = false);
 
   /// Global conformance lookup, checks conditional requirements.
   /// Requires a contextualized type.
@@ -903,9 +903,10 @@ public:
   ///
   /// \returns An invalid conformance if the search failed, otherwise an
   /// abstract, concrete or pack conformance, depending on the lookup type.
-  ProtocolConformanceRef checkConformance(Type type, ProtocolDecl *protocol,
-                              // Note: different default from lookupConformance
-                              bool allowMissing = true);
+  static ProtocolConformanceRef checkConformance(Type type, ProtocolDecl *protocol,
+                                                 // Note: different default from
+                                                 // lookupConformance
+                                                 bool allowMissing = true);
 
   /// Global conformance lookup, checks conditional requirements.
   /// Accepts interface types without context. If the conformance cannot be
@@ -925,22 +926,23 @@ public:
   /// if the search succeeded. `std::nullopt` if the type could have
   /// conditionally conformed depending on the context of the interface types.
   std::optional<ProtocolConformanceRef>
-  checkConformanceWithoutContext(Type type,
-                                 ProtocolDecl *protocol,
-                                 // Note: different default from lookupConformance
-                                 bool allowMissing = true);
+  static checkConformanceWithoutContext(Type type,
+                                        ProtocolDecl *protocol,
+                                        // Note: different default from
+                                        // lookupConformance
+                                        bool allowMissing = true);
 
 
   /// Look for the conformance of the given existential type to the given
   /// protocol.
-  ProtocolConformanceRef lookupExistentialConformance(Type type,
-                                                      ProtocolDecl *protocol);
+  static ProtocolConformanceRef lookupExistentialConformance(Type type,
+                                                             ProtocolDecl *protocol);
 
   /// Collect the conformances of \c fromType to each of the protocols of an
   /// existential type's layout.
   ArrayRef<ProtocolConformanceRef>
-  collectExistentialConformances(CanType fromType, CanType existential,
-                                 bool allowMissing = false);
+  static collectExistentialConformances(CanType fromType, CanType existential,
+                                        bool allowMissing = false);
 
   /// Find a member named \p name in \p container that was declared in this
   /// module.

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -732,21 +732,18 @@ public:
 
 class LookupConformanceDescriptor final {
 public:
-  ModuleDecl *Mod;
   Type Ty;
   ProtocolDecl *PD;
 
-  LookupConformanceDescriptor(ModuleDecl *Mod, Type Ty, ProtocolDecl *PD)
-      : Mod(Mod), Ty(Ty), PD(PD) {}
+  LookupConformanceDescriptor(Type Ty, ProtocolDecl *PD) : Ty(Ty), PD(PD) {}
 
   friend llvm::hash_code hash_value(const LookupConformanceDescriptor &desc) {
-    return llvm::hash_combine(desc.Mod, desc.Ty.getPointer(), desc.PD);
+    return llvm::hash_combine(desc.Ty.getPointer(), desc.PD);
   }
 
   friend bool operator==(const LookupConformanceDescriptor &lhs,
                          const LookupConformanceDescriptor &rhs) {
-    return lhs.Mod == rhs.Mod && lhs.Ty.getPointer() == rhs.Ty.getPointer() &&
-           lhs.PD == rhs.PD;
+    return lhs.Ty.getPointer() == rhs.Ty.getPointer() && lhs.PD == rhs.PD;
   }
 
   friend bool operator!=(const LookupConformanceDescriptor &lhs,

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -241,8 +241,7 @@ checkRequirementsWithoutContext(ArrayRef<Requirement> requirements);
 /// Check if each requirement is satisfied after applying the given
 /// substitutions. The substitutions must replace all type parameters that
 /// appear in the requirement with concrete types or archetypes.
-CheckRequirementsResult checkRequirements(ModuleDecl *module,
-                                          ArrayRef<Requirement> requirements,
+CheckRequirementsResult checkRequirements(ArrayRef<Requirement> requirements,
                                           TypeSubstitutionFn substitutions,
                                           SubstOptions options = std::nullopt);
 

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -114,17 +114,6 @@ public:
                                     Type conformingReplacementType,
                                     ProtocolDecl *conformedProtocol) const;
 };
-
-/// Functor class suitable for use as a \c LookupConformanceFn that fetches
-/// conformances from a generic signature.
-class LookUpConformanceInSignature {
-public:
-  LookUpConformanceInSignature(const GenericSignatureImpl *Sig) {}
-
-  ProtocolConformanceRef operator()(CanType dependentType,
-                                    Type conformingReplacementType,
-                                    ProtocolDecl *conformedProtocol) const;
-};
   
 /// Flags that can be passed when substituting into a type.
 enum class SubstFlags {

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -97,10 +97,8 @@ using LookupConformanceFn = llvm::function_ref<GenericFunction>;
 /// Functor class suitable for use as a \c LookupConformanceFn to look up a
 /// conformance through a module.
 class LookUpConformanceInModule {
-  ModuleDecl *M;
 public:
-  explicit LookUpConformanceInModule(ModuleDecl *M)
-    : M(M) {}
+  explicit LookUpConformanceInModule() {}
 
   ProtocolConformanceRef operator()(CanType dependentType,
                                     Type conformingReplacementType,
@@ -120,16 +118,12 @@ public:
 /// Functor class suitable for use as a \c LookupConformanceFn that fetches
 /// conformances from a generic signature.
 class LookUpConformanceInSignature {
-  const GenericSignatureImpl *Sig;
 public:
-  LookUpConformanceInSignature(const GenericSignatureImpl *Sig)
-    : Sig(Sig) {
-      assert(Sig && "Cannot lookup conformance in null signature!");
-    }
+  LookUpConformanceInSignature(const GenericSignatureImpl *Sig) {}
 
-    ProtocolConformanceRef operator()(CanType dependentType,
-                                      Type conformingReplacementType,
-                                      ProtocolDecl *conformedProtocol) const;
+  ProtocolConformanceRef operator()(CanType dependentType,
+                                    Type conformingReplacementType,
+                                    ProtocolDecl *conformedProtocol) const;
 };
   
 /// Flags that can be passed when substituting into a type.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1309,8 +1309,7 @@ public:
   /// \param genericEnv If non-null and the type is nested inside of a
   /// generic function, generic parameters of the outer context are
   /// mapped to context archetypes of this generic environment.
-  SubstitutionMap getContextSubstitutionMap(ModuleDecl *module,
-                                            const DeclContext *dc,
+  SubstitutionMap getContextSubstitutionMap(const DeclContext *dc,
                                             GenericEnvironment *genericEnv=nullptr);
 
   /// Deprecated version of the above.
@@ -1322,8 +1321,7 @@ public:
   ///
   /// \param genericEnv If non-null, generic parameters of the member are
   /// mapped to context archetypes of this generic environment.
-  SubstitutionMap getMemberSubstitutionMap(ModuleDecl *module,
-                                           const ValueDecl *member,
+  SubstitutionMap getMemberSubstitutionMap(const ValueDecl *member,
                                            GenericEnvironment *genericEnv=nullptr);
 
   /// Deprecated version of the above.
@@ -1340,7 +1338,7 @@ public:
   /// \param member The property whose type we are substituting.
   ///
   /// \returns The resulting property type.
-  Type getTypeOfMember(ModuleDecl *module, const VarDecl *member);
+  Type getTypeOfMember(const VarDecl *member);
 
   /// Retrieve the type of the given member as seen through the given base
   /// type, substituting generic arguments where necessary.
@@ -1371,8 +1369,7 @@ public:
   /// method's generic parameters.
   ///
   /// \returns The resulting member type.
-  Type getTypeOfMember(ModuleDecl *module, const ValueDecl *member,
-                       Type memberType);
+  Type getTypeOfMember(const ValueDecl *member, Type memberType);
 
   /// Get the type of a superclass member as seen from the subclass,
   /// substituting generic parameters, dynamic Self return, and the
@@ -7075,7 +7072,7 @@ public:
   /// Substitute the base type, looking up our associated type in it if it is
   /// non-dependent. Returns null if the member could not be found in the new
   /// base.
-  Type substBaseType(ModuleDecl *M, Type base);
+  Type substBaseType(Type base);
 
   /// Substitute the base type, looking up our associated type in it if it is
   /// non-dependent. Returns null if the member could not be found in the new

--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -109,14 +109,14 @@ void emitIndirectConditionalCastWithScalar(
     ProfileCounter FalseCount = ProfileCounter());
 
 /// Does the type conform to the _ObjectiveCBridgeable protocol.
-bool isObjectiveCBridgeable(ModuleDecl *M, CanType Ty);
+bool isObjectiveCBridgeable(CanType Ty);
 
 /// Get the bridged NS class of a CF class if it exists. Returns
 /// an empty CanType if such class does not exist.
-CanType getNSBridgedClassOfCFClass(ModuleDecl *M, CanType type);
+CanType getNSBridgedClassOfCFClass(CanType type);
 
 /// Does the type conform to Error.
-bool isError(ModuleDecl *M, CanType Ty);
+bool isError(CanType Ty);
 
 struct SILDynamicCastKind {
   enum innerty : std::underlying_type<SILInstructionKind>::type {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -50,7 +50,7 @@ struct SubstitutionMapWithLocalArchetypes {
                                     Type substType,
                                     ProtocolDecl *proto) {
     if (isa<LocalArchetypeType>(origType))
-      return proto->getParentModule()->lookupConformance(substType, proto);
+      return ModuleDecl::lookupConformance(substType, proto);
     if (SubsMap)
       return SubsMap->lookupConformance(origType, proto);
 

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -331,7 +331,7 @@ protected:
                 remappedOrigFnType->getDifferentiabilityResultIndices(),
                 dfei->getDerivativeFunctionKind(),
                 getBuilder().getModule().Types,
-                LookUpConformanceInModule(SwiftMod))
+                LookUpConformanceInModule())
             ->getWithoutDifferentiability();
     SILType remappedDerivativeFnType = getOpType(dfei->getType());
     // If remapped derivative type and derivative remapped type are equal, do

--- a/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
@@ -139,8 +139,7 @@ private:
           type->mapTypeOutOfContext());
     }
     // Look up conformance in the current module.
-    auto lookupConformance =
-        LookUpConformanceInModule(getFunction().getModule().getSwiftModule());
+    auto lookupConformance = LookUpConformanceInModule();
     return type->getAutoDiffTangentSpace(lookupConformance).has_value();
   }
 

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -416,8 +416,7 @@ void BridgedPassContext::loadFunction(BridgedFunction function, bool loadCallees
 BridgedSubstitutionMap BridgedPassContext::getContextSubstitutionMap(BridgedType type) const {
   swift::SILType ty = type.unbridged();
   auto *ntd = ty.getASTType()->getAnyNominal();
-  auto *mod = invocation->getPassManager()->getModule()->getSwiftModule();
-  return ty.getASTType()->getContextSubstitutionMap(mod, ntd);
+  return ty.getASTType()->getContextSubstitutionMap(ntd);
 }
 
 BridgedType BridgedPassContext::getBuiltinIntegerType(SwiftInt bitWidth) const {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1561,7 +1561,7 @@ ConcreteDeclRef ASTContext::getRegexInitDecl(Type regexType) const {
                             results);
   assert(results.size() == 1);
   auto *foundDecl = cast<ConstructorDecl>(results[0]);
-  auto subs = regexType->getMemberSubstitutionMap(spModule, foundDecl);
+  auto subs = regexType->getMemberSubstitutionMap(foundDecl);
   return ConcreteDeclRef(foundDecl, subs);
 }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1531,7 +1531,7 @@ ASTContext::getBuiltinInitDecl(NominalTypeDecl *decl,
 
   auto type = decl->getDeclaredInterfaceType();
   auto builtinProtocol = getProtocol(builtinProtocolKind);
-  auto builtinConformance = getStdlibModule()->lookupConformance(
+  auto builtinConformance = ModuleDecl::lookupConformance(
       type, builtinProtocol);
   if (builtinConformance.isInvalid()) {
     assert(false && "Missing required conformance");
@@ -5671,7 +5671,7 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
     if (nominal != dc->getASTContext().getOptionalDecl()) {
       if (auto objcBridgeable
             = getProtocol(KnownProtocolKind::ObjectiveCBridgeable)) {
-        auto conformance = dc->getParentModule()->lookupConformance(
+        auto conformance = ModuleDecl::lookupConformance(
             nominal->getDeclaredInterfaceType(), objcBridgeable);
         if (conformance) {
           result =
@@ -5823,7 +5823,7 @@ Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
     if (!proto)
       return ProtocolConformanceRef::forInvalid();
 
-    return dc->getParentModule()->lookupConformance(type, proto);
+    return ModuleDecl::lookupConformance(type, proto);
   };
 
   // Do we conform to _ObjectiveCBridgeable?

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -199,7 +199,7 @@ Type ASTBuilder::createTypeAliasType(GenericTypeDecl *decl, Type parent) {
     return declaredType;
 
   auto *dc = aliasDecl->getDeclContext();
-  auto subs = parent->getContextSubstitutionMap(dc->getParentModule(), dc);
+  auto subs = parent->getContextSubstitutionMap(dc);
 
   return declaredType.subst(subs);
 }
@@ -239,7 +239,7 @@ Type ASTBuilder::createBoundGenericType(GenericTypeDecl *decl,
   // Build a SubstitutionMap.
   auto genericSig = nominalDecl->getGenericSignature();
   auto subs = createSubstitutionMapFromGenericArgs(
-      genericSig, args, LookUpConformanceInModule(decl->getParentModule()));
+      genericSig, args, LookUpConformanceInModule());
   if (!subs)
     return Type();
   auto origType = nominalDecl->getDeclaredInterfaceType();
@@ -278,7 +278,7 @@ Type ASTBuilder::resolveOpaqueType(NodePointer opaqueDescriptor,
 
     SubstitutionMap subs = createSubstitutionMapFromGenericArgs(
         opaqueDecl->getGenericSignature(), allArgs,
-        LookUpConformanceInModule(parentModule));
+        LookUpConformanceInModule());
     Type interfaceType = opaqueDecl->getOpaqueGenericParams()[ordinal];
     return OpaqueTypeArchetypeType::get(opaqueDecl, interfaceType, subs);
   }
@@ -318,11 +318,9 @@ Type ASTBuilder::createBoundGenericType(GenericTypeDecl *decl,
       substTy;
   }
 
-  // FIXME: This is the wrong module
-  auto *moduleDecl = decl->getParentModule();
   auto subMap = SubstitutionMap::get(genericSig,
                                      QueryTypeSubstitutionMap{subs},
-                                     LookUpConformanceInModule(moduleDecl));
+                                     LookUpConformanceInModule());
   if (!subMap)
     return Type();
 

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -953,7 +953,7 @@ Type ASTBuilder::createSILBoxTypeWithLayout(
   if (signature)
     substs = createSubstitutionMapFromGenericArgs(
         signature, replacements,
-        LookUpConformanceInSignature(signature.getPointer()));
+        LookUpConformanceInModule());
   return SILBoxType::get(Ctx, layout, substs);
 }
 
@@ -1052,7 +1052,7 @@ SubstitutionMap
 ASTBuilder::createSubstitutionMap(BuiltGenericSignature sig,
                                   ArrayRef<BuiltType> replacements) {
   return SubstitutionMap::get(sig, replacements,
-                              LookUpConformanceInSignature(sig.getPointer()));
+                              LookUpConformanceInModule());
 }
 
 Type ASTBuilder::subst(Type subject, const BuiltSubstitutionMap &Subs) const {

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1969,9 +1969,8 @@ void ASTMangler::appendRetroactiveConformances(SubstitutionMap subMap,
 void ASTMangler::appendRetroactiveConformances(Type type, GenericSignature sig) {
   // Dig out the substitution map to use.
   SubstitutionMap subMap;
-  ModuleDecl *module;
+
   if (auto typeAlias = dyn_cast<TypeAliasType>(type.getPointer())) {
-    module = Mod ? Mod : typeAlias->getDecl()->getModuleContext();
     subMap = typeAlias->getSubstitutionMap();
   } else {
     if (type->hasUnboundGenericType())
@@ -1980,8 +1979,7 @@ void ASTMangler::appendRetroactiveConformances(Type type, GenericSignature sig) 
     auto nominal = type->getAnyNominal();
     if (!nominal) return;
 
-    module = Mod ? Mod : nominal->getModuleContext();
-    subMap = type->getContextSubstitutionMap(module, nominal);
+    subMap = type->getContextSubstitutionMap(nominal);
   }
 
   appendRetroactiveConformances(subMap, sig);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -861,13 +861,12 @@ class PrintAST : public ASTVisitor<PrintAST> {
 
   Type getTransformedType(Type T) {
     if (CurrentType && Current && CurrentType->mayHaveMembers()) {
-      auto *M = Current->getDeclContext()->getParentModule();
       SubstitutionMap subMap;
 
       if (auto *NTD = dyn_cast<NominalTypeDecl>(Current))
-        subMap = CurrentType->getContextSubstitutionMap(M, NTD);
+        subMap = CurrentType->getContextSubstitutionMap(NTD);
       else if (auto *ED = dyn_cast<ExtensionDecl>(Current))
-        subMap = CurrentType->getContextSubstitutionMap(M, ED);
+        subMap = CurrentType->getContextSubstitutionMap(ED);
       else {
         Decl *subTarget = Current;
         if (isa<ParamDecl>(Current)) {
@@ -876,7 +875,7 @@ class PrintAST : public ASTVisitor<PrintAST> {
             subTarget = FD;
         }
         subMap = CurrentType->getMemberSubstitutionMap(
-          M, cast<ValueDecl>(subTarget));
+          cast<ValueDecl>(subTarget));
       }
 
       T = T.subst(subMap, SubstFlags::DesugarMemberTypes);
@@ -1135,7 +1134,7 @@ public:
       if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
         assert(Options.CurrentModule);
         auto Subs = CurrentType->getContextSubstitutionMap(
-          Options.CurrentModule, NTD->getDeclContext());
+          NTD->getDeclContext());
         setCurrentType(NTD->getDeclaredInterfaceType().subst(Subs));
       }
     }
@@ -1836,8 +1835,7 @@ void PrintAST::printSingleDepthOfGenericSignature(
   if (CurrentType && Current) {
     if (!CurrentType->isExistentialType()) {
       auto *DC = Current->getInnermostDeclContext()->getInnermostTypeContext();
-      M = DC->getParentModule();
-      subMap = CurrentType->getContextSubstitutionMap(M, DC);
+      subMap = CurrentType->getContextSubstitutionMap(DC);
       typeContextDepth = subMap.getGenericSignature().getNextDepth();
     }
   }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -7128,7 +7128,7 @@ public:
       }
       llvm_unreachable("ran out of type parameters");
       return Type();
-    }, LookUpConformanceInSignature(sig.getPointer()));
+    }, LookUpConformanceInModule());
   }
 
   void visitElementArchetypeType(ElementArchetypeType *T) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1831,7 +1831,7 @@ void PrintAST::printSingleDepthOfGenericSignature(
 
   unsigned typeContextDepth = 0;
   SubstitutionMap subMap;
-  ModuleDecl *M = nullptr;
+
   if (CurrentType && Current) {
     if (!CurrentType->isExistentialType()) {
       auto *DC = Current->getInnermostDeclContext()->getInnermostTypeContext();
@@ -1851,7 +1851,7 @@ void PrintAST::printSingleDepthOfGenericSignature(
         return type;
       },
       [&](CanType depType, Type substType, ProtocolDecl *proto) {
-        return M->lookupConformance(substType, proto);
+        return ModuleDecl::lookupConformance(substType, proto);
       });
   };
 

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -595,9 +595,8 @@ TangentPropertyInfo TangentStoredPropertyRequest::evaluate(
          "Expected a stored property or a property-wrapped property");
   auto *parentDC = originalField->getDeclContext();
   assert(parentDC->isTypeContext());
-  auto *moduleDecl = originalField->getModuleContext();
   auto parentTan =
-      baseType->getAutoDiffTangentSpace(LookUpConformanceInModule(moduleDecl));
+      baseType->getAutoDiffTangentSpace(LookUpConformanceInModule());
   // Error if parent nominal type does not conform to `Differentiable`.
   if (!parentTan) {
     return TangentPropertyInfo(
@@ -609,17 +608,16 @@ TangentPropertyInfo TangentStoredPropertyRequest::evaluate(
         TangentPropertyInfo::Error::Kind::NoDerivativeOriginalProperty);
   }
   // Error if original property's type does not conform to `Differentiable`.
-  auto originalFieldType = baseType->getTypeOfMember(
-      originalField->getModuleContext(), originalField);
+  auto originalFieldType = baseType->getTypeOfMember(originalField);
   auto originalFieldTan = originalFieldType->getAutoDiffTangentSpace(
-      LookUpConformanceInModule(moduleDecl));
+      LookUpConformanceInModule());
   if (!originalFieldTan) {
     return TangentPropertyInfo(
         TangentPropertyInfo::Error::Kind::OriginalPropertyNotDifferentiable);
   }
   // Get the parent `TangentVector` type.
   auto parentTanType =
-      baseType->getAutoDiffTangentSpace(LookUpConformanceInModule(moduleDecl))
+      baseType->getAutoDiffTangentSpace(LookUpConformanceInModule())
           ->getType();
   auto *parentTanStruct = parentTanType->getStructOrBoundGenericStruct();
   // Error if parent `TangentVector` is not a struct.
@@ -651,7 +649,7 @@ TangentPropertyInfo TangentStoredPropertyRequest::evaluate(
   // `TangentVector` type.
   auto originalFieldTanType = originalFieldTan->getType();
   auto tanFieldType =
-      parentTanType->getTypeOfMember(tanField->getModuleContext(), tanField);
+      parentTanType->getTypeOfMember(tanField);
   if (!originalFieldTanType->isEqual(tanFieldType)) {
     return TangentPropertyInfo(
         TangentPropertyInfo::Error::Kind::TangentPropertyWrongType,

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1383,10 +1383,10 @@ static ValueDecl *getAutoDiffApplyDerivativeFunction(
       Context, SmallBitVector(diffFnType->getNumParams(), true));
   // Generator for the resultant function type, i.e. the AD derivative function.
   BuiltinFunctionBuilder::LambdaGenerator resultGen{
-      [=, &Context](BuiltinFunctionBuilder &builder) -> Type {
+      [=](BuiltinFunctionBuilder &builder) -> Type {
         auto derivativeFnTy = diffFnType->getAutoDiffDerivativeFunctionType(
             paramIndices, kind,
-            LookUpConformanceInModule(Context.TheBuiltinModule));
+            LookUpConformanceInModule());
         return derivativeFnTy->getResult();
       }};
   builder.addParameter(firstArgGen);

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -62,12 +62,12 @@ ModuleDecl::collectExistentialConformances(CanType fromType,
     conformances.push_back(conformance);
   }
 
-  return getASTContext().AllocateCopy(conformances);
+  return fromType->getASTContext().AllocateCopy(conformances);
 }
 
 ProtocolConformanceRef
 ModuleDecl::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
-  ASTContext &ctx = getASTContext();
+  ASTContext &ctx = protocol->getASTContext();
 
   assert(type->isExistentialType());
 
@@ -177,22 +177,24 @@ ProtocolConformanceRef ProtocolConformanceRef::forMissingOrInvalid(
 ProtocolConformanceRef ModuleDecl::lookupConformance(Type type,
                                                      ProtocolDecl *protocol,
                                                      bool allowMissing) {
+  auto &eval = protocol->getASTContext().evaluator;
+
   // If we are recursively checking for implicit conformance of a nominal
   // type to a KnownProtocol, fail without evaluating this request. This
   // squashes cycles.
-  LookupConformanceInModuleRequest request{{this, type, protocol}};
+  LookupConformanceInModuleRequest request{{type, protocol}};
   if (auto kp = protocol->getKnownProtocolKind()) {
     if (auto nominal = type->getAnyNominal()) {
       ImplicitKnownProtocolConformanceRequest icvRequest{nominal, *kp};
-      if (getASTContext().evaluator.hasActiveRequest(icvRequest) ||
-          getASTContext().evaluator.hasActiveRequest(request)) {
+      if (eval.hasActiveRequest(icvRequest) ||
+          eval.hasActiveRequest(request)) {
         return ProtocolConformanceRef::forInvalid();
       }
     }
   }
 
   auto result = evaluateOrDefault(
-      getASTContext().evaluator, request, ProtocolConformanceRef::forInvalid());
+      eval, request, ProtocolConformanceRef::forInvalid());
 
   // If we aren't supposed to allow missing conformances but we have one,
   // replace the result with an "invalid" result.
@@ -207,8 +209,7 @@ ProtocolConformanceRef ModuleDecl::lookupConformance(Type type,
 /// Synthesize a builtin tuple type conformance to the given protocol, if
 /// appropriate.
 static ProtocolConformanceRef getBuiltinTupleTypeConformance(
-    Type type, const TupleType *tupleType, ProtocolDecl *protocol,
-    ModuleDecl *module) {
+    Type type, const TupleType *tupleType, ProtocolDecl *protocol) {
   ASTContext &ctx = protocol->getASTContext();
 
   auto *tupleDecl = ctx.getBuiltinTupleDecl();
@@ -238,7 +239,7 @@ static ProtocolConformanceRef getBuiltinTupleTypeConformance(
     }
 
     auto *conformance = cast<NormalProtocolConformance>(conformances.front());
-    auto subMap = type->getContextSubstitutionMap(module,
+    auto subMap = type->getContextSubstitutionMap(protocol->getParentModule(),
                                                   conformance->getDeclContext());
 
     // TODO: labels
@@ -432,7 +433,7 @@ getBuiltinBuiltinTypeConformance(Type type, const BuiltinType *builtinType,
 }
 
 static ProtocolConformanceRef getPackTypeConformance(
-    PackType *type, ProtocolDecl *protocol, ModuleDecl *mod) {
+    PackType *type, ProtocolDecl *protocol) {
   SmallVector<ProtocolConformanceRef, 2> patternConformances;
 
   for (auto packElement : type->getElementTypes()) {
@@ -442,8 +443,8 @@ static ProtocolConformanceRef getPackTypeConformance(
       auto patternConformance =
           (patternType->isTypeParameter()
            ? ProtocolConformanceRef(protocol)
-           : mod->lookupConformance(patternType, protocol,
-                                    /*allowMissing=*/true));
+           : ModuleDecl::lookupConformance(patternType, protocol,
+                                           /*allowMissing=*/true));
       patternConformances.push_back(patternConformance);
       continue;
     }
@@ -451,8 +452,8 @@ static ProtocolConformanceRef getPackTypeConformance(
     auto patternConformance =
         (packElement->isTypeParameter()
          ? ProtocolConformanceRef(protocol)
-         : mod->lookupConformance(packElement, protocol,
-                                  /*allowMissing=*/true));
+         : ModuleDecl::lookupConformance(packElement, protocol,
+                                         /*allowMissing=*/true));
     patternConformances.push_back(patternConformance);
   }
 
@@ -463,10 +464,9 @@ static ProtocolConformanceRef getPackTypeConformance(
 ProtocolConformanceRef
 LookupConformanceInModuleRequest::evaluate(
     Evaluator &evaluator, LookupConformanceDescriptor desc) const {
-  auto *mod = desc.Mod;
   auto type = desc.Ty;
   auto *protocol = desc.PD;
-  ASTContext &ctx = mod->getASTContext();
+  ASTContext &ctx = protocol->getASTContext();
 
   // Remove SIL reference ownership wrapper, if present.
   type = type->getReferenceStorageReferent();
@@ -491,7 +491,7 @@ LookupConformanceInModuleRequest::evaluate(
     // able to be resolved by a substitution that makes the archetype
     // concrete.
     if (auto super = archetype->getSuperclass()) {
-      auto inheritedConformance = mod->lookupConformance(
+      auto inheritedConformance = ModuleDecl::lookupConformance(
           super, protocol, /*allowMissing=*/false);
       if (protocol->isSpecificProtocol(KnownProtocolKind::Sendable) &&
           inheritedConformance.hasUnavailableConformance())
@@ -514,7 +514,7 @@ LookupConformanceInModuleRequest::evaluate(
   // existential's list of conformances and the existential conforms to
   // itself.
   if (type->isExistentialType()) {
-    auto result = mod->lookupExistentialConformance(type, protocol);
+    auto result = ModuleDecl::lookupExistentialConformance(type, protocol);
     if (result.isInvalid())
       return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);
     return result;
@@ -532,12 +532,12 @@ LookupConformanceInModuleRequest::evaluate(
 
   // Pack types can conform to protocols.
   if (auto packType = type->getAs<PackType>()) {
-    return getPackTypeConformance(packType, protocol, mod);
+    return getPackTypeConformance(packType, protocol);
   }
 
   // Tuple types can conform to protocols.
   if (auto tupleType = type->getAs<TupleType>()) {
-    return getBuiltinTupleTypeConformance(type, tupleType, protocol, mod);
+    return getBuiltinTupleTypeConformance(type, tupleType, protocol);
   }
 
   // Function types can conform to protocols.
@@ -688,7 +688,7 @@ LookupConformanceInModuleRequest::evaluate(
     auto superclassTy = type->getSuperclassForDecl(conformingClass);
 
     // Compute the conformance for the inherited type.
-    auto inheritedConformance = mod->lookupConformance(
+    auto inheritedConformance = ModuleDecl::lookupConformance(
         superclassTy, protocol, /*allowMissing=*/true);
     assert(inheritedConformance &&
            "We already found the inherited conformance");
@@ -728,7 +728,8 @@ LookupConformanceInModuleRequest::evaluate(
         conformanceDC = conformanceDC->getSelfNominalTypeDecl();
       }
 
-      auto subMap = type->getContextSubstitutionMap(mod, conformanceDC);
+      auto subMap = type->getContextSubstitutionMap(protocol->getParentModule(),
+                                                    conformanceDC);
       return ProtocolConformanceRef(
           ctx.getSpecializedConformance(type, normalConf, subMap));
     }

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -796,7 +796,7 @@ bool TypeBase::isSendableType() {
   if (auto *fas = getAs<AnyFunctionType>())
     return fas->isSendable();
 
-  auto conformance = proto->getParentModule()->checkConformance(
+  auto conformance = ModuleDecl::checkConformance(
       this, proto, false /*allow missing*/);
   return conformance && !conformance.hasUnavailableConformance();
 }
@@ -849,7 +849,7 @@ static bool conformsToInvertible(CanType type, InvertibleProtocolKind ip) {
                     SILTokenType>()));
 
   const bool conforms =
-      (bool) proto->getParentModule()->checkConformance(
+      (bool) ModuleDecl::checkConformance(
           type, proto,
           /*allowMissing=*/false);
 

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -719,6 +719,10 @@ LookupConformanceInModuleRequest::evaluate(
       auto *normalConf = cast<NormalProtocolConformance>(conformance);
       auto *conformanceDC = normalConf->getDeclContext();
 
+      // In -swift-version 5 mode, a conditional conformance to a protocol can imply
+      // a Sendable conformance. The implied conformance is unconditional so it uses
+      // the generic signature of the nominal type and not the generic signature of
+      // the extension that declared the (implying) conditional conformance.
       if (normalConf->getSourceKind() == ConformanceEntryKind::Implied &&
           normalConf->getProtocol()->isSpecificProtocol(KnownProtocolKind::Sendable)) {
         conformanceDC = conformanceDC->getSelfNominalTypeDecl();

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -239,8 +239,7 @@ static ProtocolConformanceRef getBuiltinTupleTypeConformance(
     }
 
     auto *conformance = cast<NormalProtocolConformance>(conformances.front());
-    auto subMap = type->getContextSubstitutionMap(protocol->getParentModule(),
-                                                  conformance->getDeclContext());
+    auto subMap = type->getContextSubstitutionMap(conformance->getDeclContext());
 
     // TODO: labels
     auto *specialized = ctx.getSpecializedConformance(type, conformance, subMap);
@@ -728,8 +727,7 @@ LookupConformanceInModuleRequest::evaluate(
         conformanceDC = conformanceDC->getSelfNominalTypeDecl();
       }
 
-      auto subMap = type->getContextSubstitutionMap(protocol->getParentModule(),
-                                                    conformanceDC);
+      auto subMap = type->getContextSubstitutionMap(conformanceDC);
       return ProtocolConformanceRef(
           ctx.getSpecializedConformance(type, normalConf, subMap));
     }

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -873,12 +873,11 @@ DeclContext *ConformanceLookupTable::getConformingContext(
       // FIXME: This is a hack because the inherited conformances aren't
       // getting updated properly.
       Type classTy = nominal->getDeclaredInterfaceType();
-      ModuleDecl *module = nominal->getParentModule();
       do {
         Type superclassTy = classTy->getSuperclassForDecl(superclassDecl);
         if (superclassTy->is<ErrorType>())
           return nullptr;
-        auto inheritedConformance = module->lookupConformance(
+        auto inheritedConformance = ModuleDecl::lookupConformance(
             superclassTy, protocol, /*allowMissing=*/false);
         if (inheritedConformance.hasUnavailableConformance())
           inheritedConformance = ProtocolConformanceRef::forInvalid();
@@ -956,8 +955,7 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
       return nullptr;
 
     // Look up the inherited conformance.
-    ModuleDecl *module = entry->getDeclContext()->getParentModule();
-    auto inheritedConformance = module->lookupConformance(
+    auto inheritedConformance = ModuleDecl::lookupConformance(
         superclassTy, protocol, /*allowMissing=*/true);
 
     // Form the inherited conformance.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11635,9 +11635,7 @@ ActorIsolation::forActorInstanceParameter(Expr *actor,
     auto baseType =
         memberRef->getBase()->getType()->getMetatypeInstanceType();
     if (auto globalActor = ctx.getProtocol(KnownProtocolKind::GlobalActor)) {
-      auto *dc = declRef.getDecl()->getDeclContext();
-      auto *module = dc->getParentModule();
-      auto conformance = module->checkConformance(baseType, globalActor);
+      auto conformance = ModuleDecl::checkConformance(baseType, globalActor);
       if (conformance &&
           conformance.getWitnessByName(baseType, ctx.Id_shared) == declRef) {
         return ActorIsolation::forGlobalActor(baseType);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5128,7 +5128,7 @@ NominalTypeDecl::canConformTo(InvertibleProtocolKind ip) const {
   Type selfTy = getDeclaredInterfaceType();
   assert(selfTy);
 
-  auto conformance = getModuleContext()->lookupConformance(selfTy, proto,
+  auto conformance = ModuleDecl::lookupConformance(selfTy, proto,
       /*allowMissing=*/false);
 
   if (conformance.isInvalid())

--- a/lib/AST/ExistentialGeneralization.cpp
+++ b/lib/AST/ExistentialGeneralization.cpp
@@ -186,8 +186,7 @@ private:
   /// Generalize the generic arguments of the given generic type.s
   Type generalizeGenericArguments(NominalTypeDecl *decl, CanType type) {
     assert(decl->isGenericContext());
-    auto origSubs = type->getContextSubstitutionMap(decl->getModuleContext(),
-                                                    decl);
+    auto origSubs = type->getContextSubstitutionMap(decl);
 
     // Generalize all of the arguments.
     auto origArgs = origSubs.getReplacementTypes();

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -452,8 +452,6 @@ auto GenericEnvironment::getOrCreateNestedTypeStorage() -> NestedTypeStorage & {
 Type
 GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
   auto genericSig = getGenericSignature();
-  LookUpConformanceInSignature conformanceLookupFn(genericSig.getPointer());
-
   auto requirements = genericSig->getLocalRequirements(depType);
 
   /// Substitute a type for the purpose of requirements.
@@ -462,7 +460,7 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
     case Kind::Primary:
     case Kind::OpenedExistential:
       if (type->hasTypeParameter()) {
-        return mapTypeIntoContext(type, conformanceLookupFn);
+        return mapTypeIntoContext(type, LookUpConformanceInModule());
       } else {
         return type;
       }
@@ -643,8 +641,7 @@ Type GenericEnvironment::mapTypeIntoContext(
 }
 
 Type GenericEnvironment::mapTypeIntoContext(Type type) const {
-  auto sig = getGenericSignature();
-  return mapTypeIntoContext(type, LookUpConformanceInSignature(sig.getPointer()));
+  return mapTypeIntoContext(type, LookUpConformanceInModule());
 }
 
 Type GenericEnvironment::mapTypeIntoContext(GenericTypeParamType *type) const {
@@ -769,7 +766,7 @@ GenericEnvironment::mapElementTypeIntoPackContext(Type type) const {
         }
         return mapIntoContext(genericParam);
       },
-      LookUpConformanceInSignature(sig.getPointer()),
+      LookUpConformanceInModule(),
       SubstFlags::PreservePackExpansionLevel);
 }
 
@@ -825,7 +822,7 @@ GenericEnvironment::mapConformanceRefIntoContext(
                                      ProtocolConformanceRef conformance) const {
   auto contextConformance = conformance.subst(conformingInterfaceType,
     QueryInterfaceTypeSubstitutions(this),
-    LookUpConformanceInSignature(getGenericSignature().getPointer()));
+    LookUpConformanceInModule());
   
   auto contextType = mapTypeIntoContext(conformingInterfaceType);
   return {contextType, contextConformance};

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -340,18 +340,6 @@ ASTContext &GenericSignatureImpl::getASTContext() const {
   return GenericSignature::getASTContext(getGenericParams(), getRequirements());
 }
 
-ProtocolConformanceRef
-GenericSignatureImpl::lookupConformance(CanType type,
-                                        ProtocolDecl *proto) const {
-  // FIXME: Actually implement this properly.
-  auto *M = proto->getParentModule();
-
-  if (type->isTypeParameter())
-    return ProtocolConformanceRef(proto);
-
-  return M->lookupConformance(type, proto, /*allowMissing=*/true);
-}
-
 bool GenericSignatureImpl::requiresClass(Type type) const {
   assert(type->isTypeParameter() &&
          "Only type parameters can have superclass requirements");
@@ -430,7 +418,7 @@ bool GenericSignatureImpl::isRequirementSatisfied(
 
           return type;
         },
-        LookUpConformanceInSignature(this));
+        LookUpConformanceInModule());
   }
 
   SmallVector<Requirement, 2> subReqs;

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -399,8 +399,6 @@ void swift::simple_display(llvm::raw_ostream &out,
   simple_display(out, desc.PD);
   out << " for ";
   out << desc.Ty.getString();
-  out << " in ";
-  simple_display(out, desc.Mod);
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -692,8 +692,7 @@ RootProtocolConformance::getWitnessDeclRef(ValueDecl *requirement) const {
     // witness's parent. Don't use witness.getSubstitutions(), which
     // are written in terms of the witness thunk signature.
     auto subs =
-      getType()->getContextSubstitutionMap(getDeclContext()->getParentModule(),
-                                           witnessDecl->getDeclContext());
+      getType()->getContextSubstitutionMap(witnessDecl->getDeclContext());
     return ConcreteDeclRef(witness.getDecl(), subs);
   }
 
@@ -756,20 +755,17 @@ void SpecializedProtocolConformance::computeConditionalRequirements() const {
     // Substitute the conditional requirements so that they're phrased in
     // terms of the specialized types, not the conformance-declaring decl's
     // types.
-    ModuleDecl *module;
     SubstitutionMap subMap;
     if (auto nominal = GenericConformance->getType()->getAnyNominal()) {
-      module = nominal->getModuleContext();
-      subMap = getType()->getContextSubstitutionMap(module, nominal);
+      subMap = getType()->getContextSubstitutionMap(nominal);
     } else {
-      module = getProtocol()->getModuleContext();
       subMap = getSubstitutionMap();
     }
 
     SmallVector<Requirement, 4> newReqs;
     for (auto oldReq : *parentCondReqs) {
       auto newReq = oldReq.subst(QuerySubstitutionMap{subMap},
-                                 LookUpConformanceInModule(module));
+                                 LookUpConformanceInModule());
       newReqs.push_back(newReq);
     }
     auto &ctxt = getProtocol()->getASTContext();

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1282,8 +1282,7 @@ findSynthesizedConformance(
   if (!cvProto)
     return nullptr;
 
-  auto module = dc->getParentModule();
-  auto conformance = module->lookupConformance(
+  auto conformance = ModuleDecl::lookupConformance(
       nominal->getDeclaredInterfaceType(), cvProto);
   if (!conformance || !conformance.isConcrete())
     return nullptr;

--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -327,12 +327,12 @@ swift::checkRequirementsWithoutContext(ArrayRef<Requirement> requirements) {
 }
 
 CheckRequirementsResult swift::checkRequirements(
-    ModuleDecl *module, ArrayRef<Requirement> requirements,
+    ArrayRef<Requirement> requirements,
     TypeSubstitutionFn substitutions, SubstOptions options) {
   SmallVector<Requirement, 4> substReqs;
   for (auto req : requirements) {
     substReqs.push_back(req.subst(substitutions,
-                              LookUpConformanceInModule(), options));
+                                  LookUpConformanceInModule(), options));
   }
 
   return checkRequirements(substReqs);

--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -112,8 +112,7 @@ CheckRequirementResult Requirement::checkRequirement(
     }
 
     auto *proto = getProtocolDecl();
-    auto *module = proto->getParentModule();
-    auto conformance = module->lookupConformance(
+    auto conformance = ModuleDecl::lookupConformance(
         firstType, proto, allowMissing);
     if (!conformance)
       return CheckRequirementResult::RequirementFailure;

--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -332,7 +332,7 @@ CheckRequirementsResult swift::checkRequirements(
   SmallVector<Requirement, 4> substReqs;
   for (auto req : requirements) {
     substReqs.push_back(req.subst(substitutions,
-                              LookUpConformanceInModule(module), options));
+                              LookUpConformanceInModule(), options));
   }
 
   return checkRequirements(substReqs);

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -125,8 +125,7 @@ RequirementEnvironment::RequirementEnvironment(
         ProtocolConformance *specialized = conformance;
         if (conformance && conformance->getGenericSignature()) {
           auto concreteSubs =
-            substConcreteType->getContextSubstitutionMap(
-              conformanceDC->getParentModule(), conformanceDC);
+            substConcreteType->getContextSubstitutionMap(conformanceDC);
           specialized =
             ctx.getSpecializedConformance(substConcreteType,
                                           cast<NormalProtocolConformance>(conformance),

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -396,7 +396,6 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
         firstType, Position::ConformanceRequirement);
 
     auto *proto = req.getProtocolDecl();
-    auto *module = proto->getParentModule();
 
     // For conformance to 'Sendable', allow synthesis of a missing conformance
     // if the generic parameter is concrete, that is, if we're looking at a
@@ -412,8 +411,8 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
       allowMissing = true;
 
     if (!substFirstType->isTypeParameter()) {
-      auto conformance = module->lookupConformance(substFirstType, proto,
-                                                   allowMissing);
+      auto conformance = ModuleDecl::lookupConformance(substFirstType, proto,
+                                                       allowMissing);
 
       if (!allowMissing &&
           proto->isSpecificProtocol(KnownProtocolKind::Sendable) &&
@@ -624,8 +623,7 @@ bool ConcreteContraction::performConcreteContraction(
     auto superclassTy = *found->second.begin();
 
     for (auto *proto : pair.second) {
-      auto *module = proto->getParentModule();
-      if (module->lookupConformance(superclassTy, proto)) {
+      if (ModuleDecl::lookupConformance(superclassTy, proto)) {
         auto genericSig = proto->getGenericSignature();
         // FIXME: If we end up here while building the requirement
         // signature of `proto`, we will hit a request cycle.

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -280,13 +280,12 @@ ConcreteContraction::substTypeParameterRec(Type type, Position position) const {
     // type's conformance to the associated type's protocol.
     if (auto *assocType = memberType->getAssocType()) {
       auto *proto = assocType->getProtocol();
-      auto *module = proto->getParentModule();
 
       // The 'Sendable' protocol does not declare any associated types, so the
       // 'allowMissing' value here is actually irrelevant.
       auto conformance = ((*substBaseType)->isTypeParameter()
                           ? ProtocolConformanceRef(proto)
-                          : module->lookupConformance(
+                          : ModuleDecl::lookupConformance(
                               *substBaseType, proto,
                               /*allowMissing=*/false));
 
@@ -307,7 +306,7 @@ ConcreteContraction::substTypeParameterRec(Type type, Position position) const {
 
       return assocType->getDeclaredInterfaceType()
                       ->castTo<DependentMemberType>()
-                      ->substBaseType(module, *substBaseType);
+                      ->substBaseType(*substBaseType);
     }
 
     // An unresolved DependentMemberType stores an identifier. Handle this
@@ -328,8 +327,7 @@ ConcreteContraction::substTypeParameterRec(Type type, Position position) const {
 
     // Substitute the base type into the member type.
     auto *dc = typeDecl->getDeclContext();
-    auto subMap = (*substBaseType)->getContextSubstitutionMap(
-        dc->getParentModule(), dc);
+    auto subMap = (*substBaseType)->getContextSubstitutionMap(dc);
     return typeDecl->getDeclaredInterfaceType().subst(subMap);
   }
 

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -140,10 +140,6 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
     if (!checkRulePairOnce(concreteRuleID, conformanceRuleID))
       continue;
 
-    // FIXME: Either remove the ModuleDecl entirely from conformance lookup,
-    // or pass the correct one down in here.
-    auto *module = proto->getParentModule();
-
     // For conformance to 'Sendable', allow synthesis of a missing conformance
     // if the requirement is a concrete type requirement, that is, if we're
     // looking at a signature of the form 'T == Foo, T : Sendable'.
@@ -154,9 +150,9 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
     // subclasses of 'C' which are 'Sendable'.
     bool allowMissing = (requirementKind == RequirementKind::SameType);
 
-    auto conformance = module->lookupConformance(concreteType,
-                                                 const_cast<ProtocolDecl *>(proto),
-                                                 allowMissing);
+    auto conformance = ModuleDecl::lookupConformance(concreteType,
+                                                     const_cast<ProtocolDecl *>(proto),
+                                                     allowMissing);
     if (!allowMissing &&
         proto->isSpecificProtocol(KnownProtocolKind::Sendable) &&
         conformance.hasUnavailableConformance()) {

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -349,7 +349,7 @@ static Type substPrefixType(Type type, unsigned suffixLength, Type prefixType,
   auto substBaseType = substPrefixType(memberType->getBase(), suffixLength - 1,
                                        prefixType, sig);
   return memberType->substBaseType(
-      substBaseType, LookUpConformanceInSignature(sig.getPointer()),
+      substBaseType, LookUpConformanceInModule(),
       std::nullopt);
 }
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -606,7 +606,7 @@ struct InferRequirementsWalker : public TypeWalker {
                                          AssociatedTypeDecl *assocType) {
           auto secondType = assocType->getDeclaredInterfaceType()
               ->castTo<DependentMemberType>()
-              ->substBaseType(module, firstType);
+              ->substBaseType(firstType);
           reqs.push_back({Requirement(RequirementKind::SameType,
                                       firstType, secondType),
                           SourceLoc()});
@@ -649,7 +649,7 @@ struct InferRequirementsWalker : public TypeWalker {
       return Action::Continue;
 
     /// Retrieve the substitution.
-    auto subMap = ty->getContextSubstitutionMap(module, decl);
+    auto subMap = ty->getContextSubstitutionMap(decl);
 
     // Handle the requirements.
     // FIXME: Inaccurate TypeReprs.

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -400,7 +400,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
   if (proto->getInvertibleProtocolKind()) {
     auto substType = type.subst(*this);
     if (!substType->isTypeParameter())
-      return proto->getModuleContext()->lookupConformance(substType, proto);
+      return ModuleDecl::lookupConformance(substType, proto);
     return ProtocolConformanceRef(proto);
   }
 
@@ -434,8 +434,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
            substType->castTo<ArchetypeType>()->getSuperclass()) &&
           !substType->isTypeParameter() &&
           !substType->isExistentialType()) {
-        auto *M = proto->getParentModule();
-        return M->lookupConformance(substType, proto);
+        return ModuleDecl::lookupConformance(substType, proto);
       }
 
       return ProtocolConformanceRef(proto);
@@ -645,7 +644,7 @@ LookUpConformanceInOverrideSubs::operator()(CanType type,
   if (substType->isTypeParameter())
     return ProtocolConformanceRef(proto);
 
-  return proto->getParentModule()->lookupConformance(substType, proto);
+  return ModuleDecl::lookupConformance(substType, proto);
 }
 
 SubstitutionMap
@@ -743,7 +742,7 @@ SubstitutionMap::combineSubstitutionMaps(SubstitutionMap firstSubMap,
       if (substType->isTypeParameter())
         return ProtocolConformanceRef(proto);
 
-      return proto->getParentModule()->lookupConformance(substType, proto);
+      return ModuleDecl::lookupConformance(substType, proto);
     });
 }
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -604,8 +604,7 @@ OverrideSubsInfo::OverrideSubsInfo(const NominalTypeDecl *baseNominal,
     }
 
     BaseSubMap = derivedNominalTy->getContextSubstitutionMap(
-        baseNominal->getParentModule(), baseNominal,
-        genericEnv);
+        baseNominal, genericEnv);
 
     BaseSubMap = BaseSubMap.mapReplacementTypesOutOfContext();
   }

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -261,17 +261,6 @@ operator()(CanType dependentType, Type conformingReplacementType,
   return ProtocolConformanceRef(conformedProtocol);
 }
 
-ProtocolConformanceRef LookUpConformanceInSignature::
-operator()(CanType dependentType, Type conformingReplacementType,
-           ProtocolDecl *conformedProtocol) const {
-  if (conformingReplacementType->isTypeParameter())
-    return ProtocolConformanceRef(conformedProtocol);
-
-  return ModuleDecl::lookupConformance(
-      conformingReplacementType->getCanonicalType(),
-      conformedProtocol, /*allowMissing=*/true);
-}
-
 Type DependentMemberType::substBaseType(Type substBase) {
   return substBaseType(substBase, LookUpConformanceInModule(),
                        std::nullopt);

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -191,10 +191,9 @@ operator()(CanType dependentType, Type conformingReplacementType,
   if (conformingReplacementType->isTypeParameter())
     return ProtocolConformanceRef(conformedProtocol);
 
-  assert(M && "null module in conformance lookup");
-  return M->lookupConformance(conformingReplacementType,
-                              conformedProtocol,
-                              /*allowMissing=*/true);
+  return ModuleDecl::lookupConformance(conformingReplacementType,
+                                       conformedProtocol,
+                                       /*allowMissing=*/true);
 }
 
 ProtocolConformanceRef LookUpConformanceInSubstitutionMap::
@@ -203,7 +202,7 @@ operator()(CanType dependentType, Type conformingReplacementType,
   // Lookup conformances for archetypes that conform concretely
   // via a superclass.
   if (auto archetypeType = conformingReplacementType->getAs<ArchetypeType>()) {
-    return conformedProtocol->getModuleContext()->lookupConformance(
+    return ModuleDecl::lookupConformance(
         conformingReplacementType, conformedProtocol,
         /*allowMissing=*/true);
   }
@@ -217,7 +216,7 @@ operator()(CanType dependentType, Type conformingReplacementType,
   if (auto genericSig = Subs.getGenericSignature()) {
     if (genericSig->isValidTypeParameter(dependentType) &&
         genericSig->isConcreteType(dependentType)) {
-      return conformedProtocol->getModuleContext()->lookupConformance(
+      return ModuleDecl::lookupConformance(
           conformingReplacementType, conformedProtocol,
           /*allowMissing=*/true);
     }
@@ -256,8 +255,7 @@ operator()(CanType dependentType, Type conformingReplacementType,
   // concretely.
   if (auto *archetypeType = conformingReplacementType->getAs<ArchetypeType>()) {
     if (auto superclassType = archetypeType->getSuperclass()) {
-      return conformedProtocol->getModuleContext()->lookupConformance(
-          archetypeType, conformedProtocol);
+      return ModuleDecl::lookupConformance(archetypeType, conformedProtocol);
     }
   }
   return ProtocolConformanceRef(conformedProtocol);
@@ -266,20 +264,16 @@ operator()(CanType dependentType, Type conformingReplacementType,
 ProtocolConformanceRef LookUpConformanceInSignature::
 operator()(CanType dependentType, Type conformingReplacementType,
            ProtocolDecl *conformedProtocol) const {
-  // Lookup conformances for opened existential.
-  if (conformingReplacementType->isOpenedExistential()) {
-    return conformedProtocol->getModuleContext()->lookupConformance(
-        conformingReplacementType, conformedProtocol);
-  }
+  if (conformingReplacementType->isTypeParameter())
+    return ProtocolConformanceRef(conformedProtocol);
 
-  // FIXME: Should pass dependentType instead, once
-  // GenericSignature::lookupConformance() does the right thing
-  return Sig->lookupConformance(conformingReplacementType->getCanonicalType(),
-                                conformedProtocol);
+  return ModuleDecl::lookupConformance(
+      conformingReplacementType->getCanonicalType(),
+      conformedProtocol, /*allowMissing=*/true);
 }
 
-Type DependentMemberType::substBaseType(ModuleDecl *module, Type substBase) {
-  return substBaseType(substBase, LookUpConformanceInModule(module),
+Type DependentMemberType::substBaseType(Type substBase) {
+  return substBaseType(substBase, LookUpConformanceInModule(),
                        std::nullopt);
 }
 
@@ -823,7 +817,7 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
 }
 
 SubstitutionMap TypeBase::getContextSubstitutionMap(
-    ModuleDecl *module, const DeclContext *dc,
+    const DeclContext *dc,
     GenericEnvironment *genericEnv) {
   auto genericSig = dc->getGenericSignatureOfContext();
   if (genericSig.isNull())
@@ -831,7 +825,7 @@ SubstitutionMap TypeBase::getContextSubstitutionMap(
   return SubstitutionMap::get(
     genericSig,
     QueryTypeSubstitutionMap{getContextSubstitutions(dc, genericEnv)},
-    LookUpConformanceInModule(module));
+    LookUpConformanceInModule());
 }
 
 TypeSubstitutionMap TypeBase::getMemberSubstitutions(
@@ -876,8 +870,7 @@ TypeSubstitutionMap TypeBase::getMemberSubstitutions(
 }
 
 SubstitutionMap TypeBase::getMemberSubstitutionMap(
-    ModuleDecl *module, const ValueDecl *member,
-    GenericEnvironment *genericEnv) {
+    const ValueDecl *member, GenericEnvironment *genericEnv) {
   auto genericSig = member->getInnermostDeclContext()
       ->getGenericSignatureOfContext();
   if (genericSig.isNull())
@@ -886,14 +879,14 @@ SubstitutionMap TypeBase::getMemberSubstitutionMap(
   return SubstitutionMap::get(
       genericSig,
       QueryTypeSubstitutionMap{subs},
-      LookUpConformanceInModule(module));
+      LookUpConformanceInModule());
 }
 
-Type TypeBase::getTypeOfMember(ModuleDecl *module, const VarDecl *member) {
-  return getTypeOfMember(module, member, member->getInterfaceType());
+Type TypeBase::getTypeOfMember(const VarDecl *member) {
+  return getTypeOfMember(member, member->getInterfaceType());
 }
 
-Type TypeBase::getTypeOfMember(ModuleDecl *module, const ValueDecl *member,
+Type TypeBase::getTypeOfMember(const ValueDecl *member,
                                Type memberType) {
   assert(memberType);
   assert(!memberType->is<GenericFunctionType>() &&
@@ -904,11 +897,11 @@ Type TypeBase::getTypeOfMember(ModuleDecl *module, const ValueDecl *member,
 
   if (auto *lvalue = getAs<LValueType>()) {
     auto objectTy = lvalue->getObjectType();
-    return objectTy->getTypeOfMember(module, member, memberType);
+    return objectTy->getTypeOfMember(member, memberType);
   }
 
   // Perform the substitution.
-  auto substitutions = getMemberSubstitutionMap(module, member);
+  auto substitutions = getMemberSubstitutionMap(member);
   return memberType.subst(substitutions);
 }
 
@@ -1223,10 +1216,7 @@ operator()(CanType maybeOpaqueType, Type replacementType,
     // SIL type lowering may have already substituted away the opaque type, in
     // which case we'll end up "substituting" the same type.
     if (maybeOpaqueType->isEqual(replacementType)) {
-      const auto *inContext = getContext();
-      assert(inContext && "Need context for already-substituted opaque types");
-      return inContext->getParentModule()
-                      ->lookupConformance(replacementType, protocol);
+      return ModuleDecl::lookupConformance(replacementType, protocol);
     }
     
     llvm_unreachable("origType should have been an opaque type or type parameter");

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -73,8 +73,7 @@ static Decl *lookupDirectSingleWithoutExtensions(NominalTypeDecl *decl,
 
 /// Similar to ModuleDecl::conformsToProtocol, but doesn't introduce a
 /// dependency on Sema.
-static bool isConcreteAndValid(ProtocolConformanceRef conformanceRef,
-                               ModuleDecl *module) {
+static bool isConcreteAndValid(ProtocolConformanceRef conformanceRef) {
   if (conformanceRef.isInvalid())
     return false;
   if (!conformanceRef.isConcrete())
@@ -83,7 +82,7 @@ static bool isConcreteAndValid(ProtocolConformanceRef conformanceRef,
   auto subMap = conformance->getSubstitutionMap();
   return llvm::all_of(subMap.getConformances(),
                       [&](ProtocolConformanceRef each) -> bool {
-                        return isConcreteAndValid(each, module);
+                        return isConcreteAndValid(each);
                       });
 }
 
@@ -205,7 +204,6 @@ static ValueDecl *getEqualEqualOperator(NominalTypeDecl *decl) {
 static FuncDecl *getMinusOperator(NominalTypeDecl *decl) {
   auto binaryIntegerProto =
       decl->getASTContext().getProtocol(KnownProtocolKind::BinaryInteger);
-  auto module = decl->getModuleContext();
 
   auto isValid = [&](ValueDecl *minusOp) -> bool {
     auto minus = dyn_cast<FuncDecl>(minusOp);
@@ -228,8 +226,8 @@ static FuncDecl *getMinusOperator(NominalTypeDecl *decl) {
       return false;
     auto returnTy = minus->getResultInterfaceType();
     auto conformanceRef =
-        module->lookupConformance(returnTy, binaryIntegerProto);
-    if (!isConcreteAndValid(conformanceRef, module))
+        ModuleDecl::lookupConformance(returnTy, binaryIntegerProto);
+    if (!isConcreteAndValid(conformanceRef))
       return false;
     return true;
   };
@@ -722,10 +720,9 @@ void swift::conformToCxxSequenceIfNeeded(
     return;
 
   // Check if RawIterator conforms to UnsafeCxxInputIterator.
-  ModuleDecl *module = decl->getModuleContext();
   auto rawIteratorConformanceRef =
-      module->lookupConformance(rawIteratorTy, cxxIteratorProto);
-  if (!isConcreteAndValid(rawIteratorConformanceRef, module))
+      ModuleDecl::lookupConformance(rawIteratorTy, cxxIteratorProto);
+  if (!isConcreteAndValid(rawIteratorConformanceRef))
     return;
   auto rawIteratorConformance = rawIteratorConformanceRef.getConcrete();
   auto pointeeDecl =
@@ -771,9 +768,8 @@ void swift::conformToCxxSequenceIfNeeded(
 
     // Check if RawIterator conforms to UnsafeCxxRandomAccessIterator.
     auto rawIteratorRAConformanceRef =
-        decl->getModuleContext()->lookupConformance(rawIteratorTy,
-                                                    cxxRAIteratorProto);
-    if (!isConcreteAndValid(rawIteratorRAConformanceRef, module))
+        ModuleDecl::lookupConformance(rawIteratorTy, cxxRAIteratorProto);
+    if (!isConcreteAndValid(rawIteratorRAConformanceRef))
       return false;
 
     // CxxRandomAccessCollection always uses Int as an Index.
@@ -893,10 +889,9 @@ void swift::conformToCxxSetIfNeeded(ClangImporter::Implementation &impl,
 
   auto rawMutableIteratorTy = rawMutableIteratorType->getUnderlyingType();
   // Check if RawMutableIterator conforms to UnsafeCxxInputIterator.
-  ModuleDecl *module = decl->getModuleContext();
   auto rawIteratorConformanceRef =
-      module->lookupConformance(rawMutableIteratorTy, cxxIteratorProto);
-  if (!isConcreteAndValid(rawIteratorConformanceRef, module))
+      ModuleDecl::lookupConformance(rawMutableIteratorTy, cxxIteratorProto);
+  if (!isConcreteAndValid(rawIteratorConformanceRef))
     return;
 
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawMutableIterator"),
@@ -977,16 +972,15 @@ void swift::conformToCxxDictionaryIfNeeded(
   auto rawMutableIteratorTy = mutableIterType->getUnderlyingType();
 
   // Check if RawIterator conforms to UnsafeCxxInputIterator.
-  ModuleDecl *module = decl->getModuleContext();
   auto rawIteratorConformanceRef =
-      module->lookupConformance(rawIteratorTy, cxxInputIteratorProto);
-  if (!isConcreteAndValid(rawIteratorConformanceRef, module))
+      ModuleDecl::lookupConformance(rawIteratorTy, cxxInputIteratorProto);
+  if (!isConcreteAndValid(rawIteratorConformanceRef))
     return;
 
   // Check if RawMutableIterator conforms to UnsafeCxxMutableInputIterator.
-  auto rawMutableIteratorConformanceRef = module->lookupConformance(
+  auto rawMutableIteratorConformanceRef = ModuleDecl::lookupConformance(
       rawMutableIteratorTy, cxxMutableInputIteratorProto);
-  if (!isConcreteAndValid(rawMutableIteratorConformanceRef, module))
+  if (!isConcreteAndValid(rawMutableIteratorConformanceRef))
     return;
 
   // Make the original subscript that returns a non-optional value unavailable.
@@ -1044,10 +1038,9 @@ void swift::conformToCxxVectorIfNeeded(ClangImporter::Implementation &impl,
   auto rawIteratorTy = iterType->getUnderlyingType();
 
   // Check if RawIterator conforms to UnsafeCxxRandomAccessIterator.
-  ModuleDecl *module = decl->getModuleContext();
   auto rawIteratorConformanceRef =
-      module->lookupConformance(rawIteratorTy, cxxRandomAccessIteratorProto);
-  if (!isConcreteAndValid(rawIteratorConformanceRef, module))
+      ModuleDecl::lookupConformance(rawIteratorTy, cxxRandomAccessIteratorProto);
+  if (!isConcreteAndValid(rawIteratorConformanceRef))
     return;
 
   impl.addSynthesizedTypealias(decl, ctx.Id_Element,

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -748,7 +748,7 @@ void swift::conformToCxxSequenceIfNeeded(
           return declSelfTy;
         return Type(dependentType);
       },
-      LookUpConformanceInModule(module));
+      LookUpConformanceInModule());
 
   impl.addSynthesizedTypealias(decl, ctx.Id_Element, pointeeTy);
   impl.addSynthesizedTypealias(decl, ctx.Id_Iterator, iteratorTy);
@@ -786,7 +786,7 @@ void swift::conformToCxxSequenceIfNeeded(
             return declSelfTy;
           return Type(dependentType);
         },
-        LookUpConformanceInModule(module));
+        LookUpConformanceInModule());
 
     auto indicesTy = ctx.getRangeType();
     indicesTy = indicesTy.subst(
@@ -795,7 +795,7 @@ void swift::conformToCxxSequenceIfNeeded(
             return indexTy;
           return Type(dependentType);
         },
-        LookUpConformanceInModule(module));
+        LookUpConformanceInModule());
 
     impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Element"), pointeeTy);
     impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Index"), indexTy);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8696,7 +8696,6 @@ static void finishTypeWitnesses(
     NormalProtocolConformance *conformance) {
   auto *dc = conformance->getDeclContext();
   auto nominal = dc->getSelfNominalTypeDecl();
-  auto *module = dc->getParentModule();
 
   auto *proto = conformance->getProtocol();
   auto selfType = conformance->getType();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8721,7 +8721,7 @@ static void finishTypeWitnesses(
 
       auto memberType = typeDecl->getDeclaredInterfaceType();
       auto subMap = selfType->getContextSubstitutionMap(
-          module, typeDecl->getDeclContext());
+          typeDecl->getDeclContext());
       memberType = memberType.subst(subMap);
       conformance->setTypeWitness(assocType, memberType, typeDecl);
       satisfied = true;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8069,10 +8069,10 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
         auto *nominal = dyn_cast<NominalTypeDecl>(MappedDecl);
         if (!nominal)
           continue;
-        auto *module = nominal->getModuleContext();
+
         // Don't synthesize a conformance if one already exists.
         auto ty = nominal->getDeclaredInterfaceType();
-        if (module->lookupConformance(ty, protocol))
+        if (ModuleDecl::lookupConformance(ty, protocol))
           continue;
         auto conformance = SwiftContext.getNormalConformance(
             ty, protocol, nominal->getLoc(), nominal->getDeclContextForModule(),

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -3003,8 +3003,7 @@ static Type mapGenericArgs(const DeclContext *fromDC,
   if (fromDC == toDC)
     return type;
 
-  auto subs = toDC->getDeclaredInterfaceType()->getContextSubstitutionMap(
-                                            toDC->getParentModule(), fromDC);
+  auto subs = toDC->getDeclaredInterfaceType()->getContextSubstitutionMap(fromDC);
   return type.subst(subs);
 }
 

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -749,8 +749,7 @@ Type CompletionLookup::getAssociatedTypeType(const AssociatedTypeDecl *ATD) {
   if (BaseTy) {
     BaseTy = BaseTy->getInOutObjectType()->getMetatypeInstanceType();
     if (auto NTD = BaseTy->getAnyNominal()) {
-      auto *Module = NTD->getParentModule();
-      auto Conformance = Module->lookupConformance(BaseTy, ATD->getProtocol());
+      auto Conformance = ModuleDecl::lookupConformance(BaseTy, ATD->getProtocol());
       if (Conformance.isConcrete()) {
         return Conformance.getConcrete()->getTypeWitness(
             const_cast<AssociatedTypeDecl *>(ATD));
@@ -2603,7 +2602,7 @@ void CompletionLookup::addTypeRelationFromProtocol(
 
     // Check for conformance to the literal protocol.
     if (T->getAnyNominal()) {
-      if (CurrModule->lookupConformance(T, PD)) {
+      if (ModuleDecl::lookupConformance(T, PD)) {
         literalType = T;
         break;
       }

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -259,7 +259,7 @@ void CompletionLookup::foundFunction(const AnyFunctionType *AFT) {
 bool CompletionLookup::canBeUsedAsRequirementFirstType(Type selfTy,
                                                        TypeAliasDecl *TAD) {
   auto T = TAD->getDeclaredInterfaceType();
-  auto subMap = selfTy->getMemberSubstitutionMap(TAD->getParentModule(), TAD);
+  auto subMap = selfTy->getMemberSubstitutionMap(TAD);
   T = T.subst(subMap)->getCanonicalType();
 
   ArchetypeType *archeTy = T->getAs<ArchetypeType>();
@@ -653,7 +653,7 @@ Type CompletionLookup::getTypeOfMember(const ValueDecl *VD,
     if (keyPathResultTy->hasTypeParameter()) {
       auto keyPathRootTy = getRootTypeOfKeypathDynamicMember(SD).subst(
           QueryTypeSubstitutionMap{subs},
-          LookUpConformanceInModule(CurrModule));
+          LookUpConformanceInModule());
 
       // The result type of the VD.
       // i.e. 'Circle.center' => 'Point'.
@@ -677,7 +677,7 @@ Type CompletionLookup::getTypeOfMember(const ValueDecl *VD,
     // Substitute the element type of the subscript using modified map.
     // i.e. 'Wrapped<U>' => 'Wrapped<Point>'.
     return elementTy.subst(QueryTypeSubstitutionMap{subs},
-                           LookUpConformanceInModule(CurrModule));
+                           LookUpConformanceInModule());
   }
   }
   llvm_unreachable("Unhandled DynamicLookupInfo Kind in switch");
@@ -721,7 +721,7 @@ Type CompletionLookup::getTypeOfMember(const ValueDecl *VD, Type ExprType) {
         return T;
 
       // For everything else, substitute in the base type.
-      auto Subs = MaybeNominalType->getMemberSubstitutionMap(CurrModule, VD);
+      auto Subs = MaybeNominalType->getMemberSubstitutionMap(VD);
 
       // For a GenericFunctionType, we only want to substitute the
       // param/result types, as otherwise we might end up with a bad generic

--- a/lib/IDE/CompletionOverrideLookup.cpp
+++ b/lib/IDE/CompletionOverrideLookup.cpp
@@ -76,8 +76,7 @@ Type CompletionOverrideLookup::getOpaqueResultType(
 
   // Try substitution to see if the associated type is resolved to concrete
   // type.
-  auto substMap =
-      currTy->getMemberSubstitutionMap(CurrDeclContext->getParentModule(), VD);
+  auto substMap = currTy->getMemberSubstitutionMap(VD);
   if (!ResultT.subst(substMap)->is<DependentMemberType>())
     // If resolved print it.
     return nullptr;

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -193,7 +193,7 @@ void ConformingMethodListCallbacks::getMatchingMethods(
 
       // The return type conforms to any of the requested protocols.
       for (auto Proto : ExpectedTypes) {
-        if (CurModule->checkConformance(resultTy, Proto))
+        if (ModuleDecl::checkConformance(resultTy, Proto))
           return true;
       }
 

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -155,8 +155,6 @@ void ConformingMethodListCallbacks::getMatchingMethods(
   assert(T->mayHaveMembers() && !T->is<ModuleType>());
 
   class LocalConsumer : public VisibleDeclConsumer {
-    ModuleDecl *CurModule;
-
     /// The type of the parsed expression.
     Type T;
 
@@ -204,8 +202,7 @@ void ConformingMethodListCallbacks::getMatchingMethods(
     LocalConsumer(DeclContext *DC, Type T,
                   llvm::SmallPtrSetImpl<ProtocolDecl*> &expectedTypes,
                   SmallVectorImpl<ValueDecl *> &result)
-        : CurModule(DC->getParentModule()), T(T), ExpectedTypes(expectedTypes),
-          Result(result) {}
+        : T(T), ExpectedTypes(expectedTypes), Result(result) {}
 
     void foundDecl(ValueDecl *VD, DeclVisibilityKind reason,
                    DynamicLookupInfo) override {

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -186,7 +186,7 @@ void ConformingMethodListCallbacks::getMatchingMethods(
       // we might run into trouble with really complicated cases but the fake
       // archetype setup will mostly work.
       auto substitutions = T->getMemberSubstitutionMap(
-          CurModule, FD, FD->getGenericEnvironment());
+          FD, FD->getGenericEnvironment());
       auto resultTy =  FD->getResultInterfaceType().subst(substitutions);
       if (resultTy->is<ErrorType>())
         return false;

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -358,7 +358,6 @@ struct SynthesizedExtensionAnalyzer::Implementation {
         assert(!Req.getFirstType()->hasArchetype());
         assert(!Req.getSecondType()->hasArchetype());
 
-        auto *M = DC->getParentModule();
         auto SubstReq = Req.subst(
           [&](Type type) -> Type {
             if (type->isTypeParameter())
@@ -366,7 +365,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
 
             return type;
           },
-          LookUpConformanceInModule(M));
+          LookUpConformanceInModule());
 
         SmallVector<Requirement, 2> subReqs;
         switch (SubstReq.checkRequirement(subReqs)) {
@@ -396,7 +395,6 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       return false;
     };
 
-    auto *M = DC->getParentModule();
     if (Ext->isConstrainedExtension()) {
       // Get the substitutions from the generic signature of
       // the extension to the interface types of the base type's
@@ -404,7 +402,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       SubstitutionMap subMap;
       if (!BaseType->isExistentialType()) {
         if (auto *NTD = Ext->getExtendedNominal())
-          subMap = BaseType->getContextSubstitutionMap(M, NTD);
+          subMap = BaseType->getContextSubstitutionMap(NTD);
       }
 
       assert(Ext->getGenericSignature() && "No generic signature.");
@@ -417,7 +415,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       SubstitutionMap subMap;
       if (!BaseType->isExistentialType()) {
         if (auto *NTD = EnablingExt->getExtendedNominal())
-          subMap = BaseType->getContextSubstitutionMap(M, NTD);
+          subMap = BaseType->getContextSubstitutionMap(NTD);
       }
       if (handleRequirements(subMap,
                              EnablingExt,

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -66,7 +66,7 @@ void swift::getTopLevelDeclsForDisplay(
 
       auto proto = M->getASTContext().getProtocol(KnownProtocolKind::Sendable);
       if (proto)
-        (void)M->lookupConformance(NTD->getDeclaredInterfaceType(), proto);
+        (void)ModuleDecl::lookupConformance(NTD->getDeclaredInterfaceType(), proto);
     }
   }
 

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -158,7 +158,6 @@ void ContextInfoCallbacks::getImplicitMembers(
 
   class LocalConsumer : public VisibleDeclConsumer {
     DeclContext *DC;
-    ModuleDecl *CurModule;
     Type T;
     SmallVectorImpl<ValueDecl *> &Result;
 
@@ -174,7 +173,7 @@ void ContextInfoCallbacks::getImplicitMembers(
       // Static properties which is convertible to 'Self'.
       if (auto *Var = dyn_cast<VarDecl>(VD)) {
         if (Var->isStatic()) {
-          auto declTy = T->getTypeOfMember(CurModule, Var);
+          auto declTy = T->getTypeOfMember(Var);
           if (declTy->isEqual(T) ||
               swift::isConvertibleTo(declTy, T, /*openArchetypes=*/true, *DC))
             return true;
@@ -186,7 +185,7 @@ void ContextInfoCallbacks::getImplicitMembers(
 
   public:
     LocalConsumer(DeclContext *DC, Type T, SmallVectorImpl<ValueDecl *> &Result)
-        : DC(DC), CurModule(DC->getParentModule()), T(T), Result(Result) {}
+        : DC(DC), T(T), Result(Result) {}
 
     void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
                    DynamicLookupInfo) override {

--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -361,7 +361,7 @@ bool FulfillmentMap::searchNominalTypeMetadata(IRGenModule &IGM,
 
   bool hadFulfillment = false;
 
-  auto subs = type->getContextSubstitutionMap(IGM.getSwiftModule(), nominal);
+  auto subs = type->getContextSubstitutionMap(nominal);
 
   GenericTypeRequirements requirements(IGM, nominal);
 

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -415,7 +415,7 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
       IGM.getSwiftModule()->getASTContext().getProtocol(
           KnownProtocolKind::BitwiseCopyable);
   // The protocol won't be present in swiftinterfaces from older SDKs.
-  if (bitwiseCopyableProtocol && IGM.getSwiftModule()->checkConformance(
+  if (bitwiseCopyableProtocol && ModuleDecl::checkConformance(
                                      archetype, bitwiseCopyableProtocol)) {
     return BitwiseCopyableTypeInfo::create(storageType, abiAccessible);
   }

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -80,7 +80,7 @@ public:
     auto kind = *component.getAsDerivativeFunctionKind();
     auto assocTy = origFnTy->getAutoDiffDerivativeFunctionType(
         parameterIndices, resultIndices, kind, IGM.getSILTypes(),
-        LookUpConformanceInModule(IGM.getSwiftModule()));
+        LookUpConformanceInModule());
     return SILType::getPrimitiveObjectType(assocTy);
   }
 };
@@ -207,7 +207,7 @@ public:
     auto kind = *component.getAsDerivativeFunctionKind();
     auto assocTy = originalType->getAutoDiffDerivativeFunctionType(
         parameterIndices, resultIndices, kind, IGM.getSILTypes(),
-        LookUpConformanceInModule(IGM.getSwiftModule()));
+        LookUpConformanceInModule());
     return SILType::getPrimitiveObjectType(assocTy);
   }
 
@@ -255,7 +255,7 @@ public:
     case LinearDifferentiableFunctionTypeComponent::Transpose:
       auto transposeTy = origFnTy->getAutoDiffTransposeFunctionType(
           parameterIndices, IGM.getSILTypes(),
-          LookUpConformanceInModule(IGM.getSwiftModule()));
+          LookUpConformanceInModule());
       return SILType::getPrimitiveObjectType(transposeTy);
     }
     llvm_unreachable("invalid component type");
@@ -377,7 +377,7 @@ public:
     case LinearDifferentiableFunctionTypeComponent::Transpose:
       auto transposeTy = originalType->getAutoDiffTransposeFunctionType(
           parameterIndices, IGM.getSILTypes(),
-          LookUpConformanceInModule(IGM.getSwiftModule()));
+          LookUpConformanceInModule());
       return SILType::getPrimitiveObjectType(transposeTy);
     }
     llvm_unreachable("invalid component type");

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -7324,8 +7324,8 @@ ResilientEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
       IGM.getSwiftModule()->getASTContext().getProtocol(
           KnownProtocolKind::BitwiseCopyable);
   if (bitwiseCopyableProtocol &&
-      IGM.getSwiftModule()->checkConformance(Type.getASTType(),
-                                             bitwiseCopyableProtocol)) {
+      ModuleDecl::checkConformance(Type.getASTType(),
+                                   bitwiseCopyableProtocol)) {
     return BitwiseCopyableTypeInfo::create(enumTy, abiAccessible);
   }
   return registerEnumTypeInfo(

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2689,7 +2689,6 @@ namespace {
             substitutions.lookupConformance(underlyingDependentType, P);
 
         if (underlyingType->hasTypeParameter()) {
-          auto sig = genericEnv->getGenericSignature();
           underlyingConformance = underlyingConformance.subst(
               underlyingType, QueryInterfaceTypeSubstitutions(genericEnv),
               LookUpConformanceInModule());
@@ -5424,7 +5423,6 @@ IRGenFunction::emitValueWitnessTableRefForMetadata(llvm::Value *metadata) {
       *this, metadata, &addrOfWitnessTablePtr, -1, IGM.WitnessTablePtrTy,
       ".valueWitnesses");
 
-  const auto &ptrAuthOpts = IGM.getOptions().PointerAuth;
   if (auto schema = IGM.getOptions().PointerAuth.ValueWitnessTable) {
     llvm::Value *signedWitnessTablePtr = loadOfWitnessTablePtr;
     llvm::Value *witnessTablePtr = emitPointerAuthAuth(

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2692,7 +2692,7 @@ namespace {
           auto sig = genericEnv->getGenericSignature();
           underlyingConformance = underlyingConformance.subst(
               underlyingType, QueryInterfaceTypeSubstitutions(genericEnv),
-              LookUpConformanceInSignature(sig.getPointer()));
+              LookUpConformanceInModule());
 
           underlyingType = genericEnv->mapTypeIntoContext(underlyingType)
                                ->getCanonicalType();

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4930,8 +4930,7 @@ namespace {
     }
 
     SubstitutionMap genericSubstitutions() {
-      return type->getContextSubstitutionMap(IGM.getSwiftModule(),
-                                             type->getAnyNominal());
+      return type->getContextSubstitutionMap(type->getAnyNominal());
     }
 
     MetadataTrailingFlags getTrailingFlags() {

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -352,12 +352,10 @@ static void bindElementSignatureRequirementsAtIndex(
                       patternPackArchetype)
                   ->getCanonicalType();
           llvm::Value *_metadata = nullptr;
-          auto packConformance =
-              context.signature->lookupConformance(ty, proto);
+          auto packConformance = ProtocolConformanceRef(proto);
           auto *wtablePack = emitWitnessTableRef(IGF, patternPackArchetype,
                                                  &_metadata, packConformance);
-          auto elementConformance =
-              context.signature->lookupConformance(ty, proto);
+          auto elementConformance = ProtocolConformanceRef(proto);
           auto *wtable = bindWitnessTableAtIndex(
               IGF, elementArchetype, elementConformance, wtablePack, index);
           assert(wtable);
@@ -574,7 +572,7 @@ static llvm::Value *emitPackExpansionElementWitnessTable(
   auto instantiatedPatternTy =
       context.environment->mapContextualPackTypeIntoElementContext(patternTy);
   auto instantiatedConformance =
-      context.environment->getGenericSignature()->lookupConformance(
+      ModuleDecl::lookupConformance(
           instantiatedPatternTy, conformance.getRequirement());
 
   // Emit the element witness table.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2989,8 +2989,7 @@ MetadataResponse MetadataPath::followComponent(IRGenFunction &IGF,
     GenericTypeRequirements requirements(IGF.IGM, nominal);
     auto &requirement = requirements.getRequirements()[reqtIndex];
 
-    auto module = IGF.getSwiftModule();
-    auto subs = sourceKey.Type->getContextSubstitutionMap(module, nominal);
+    auto subs = sourceKey.Type->getContextSubstitutionMap(nominal);
     auto sub = requirement.getTypeParameter().subst(subs)->getCanonicalType();
 
     // In either case, we need to change the type.

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -209,8 +209,7 @@ public:
       if (auto likeType = rawLayout->getResolvedScalarLikeType(structDecl)) {
         if (rawLayout->shouldMoveAsLikeType()) {
           auto astT = T.getASTType();
-          auto subs = astT->getContextSubstitutionMap(IGF.IGM.getSwiftModule(),
-                                                      structDecl);
+          auto subs = astT->getContextSubstitutionMap(structDecl);
           auto loweredLikeType = IGF.IGM.getLoweredType(likeType->subst(subs));
           auto &likeTypeInfo = IGF.IGM.getTypeInfo(loweredLikeType);
 
@@ -287,8 +286,7 @@ public:
       if (auto likeType = rawLayout->getResolvedScalarLikeType(structDecl)) {
         if (rawLayout->shouldMoveAsLikeType()) {
           auto astT = T.getASTType();
-          auto subs = astT->getContextSubstitutionMap(IGF.IGM.getSwiftModule(),
-                                                      structDecl);
+          auto subs = astT->getContextSubstitutionMap(structDecl);
           auto loweredLikeType = IGF.IGM.getLoweredType(likeType->subst(subs));
           auto &likeTypeInfo = IGF.IGM.getTypeInfo(loweredLikeType);
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -598,7 +598,7 @@ namespace {
 
       // Map the generic parameter to T
       auto subst = SubstitutionMap::get(sig, {T.getASTType()},
-                              LookUpConformanceInModule{IGF.getSwiftModule()});
+                              LookUpConformanceInModule());
       auto ptrType = ptrTypeDecl->getDeclaredInterfaceType().subst(subst);
       SILParameterInfo ptrParam(ptrType->getCanonicalType(),
                                 ParameterConvention::Direct_Unowned);
@@ -998,8 +998,7 @@ namespace {
         // The given struct type T that we're building is fully concrete, but
         // our like type is still in terms of the potential archetype of the
         // type.
-        auto subs = T.getASTType()->getContextSubstitutionMap(
-          IGM.getSwiftModule(), decl);
+        auto subs = T.getASTType()->getContextSubstitutionMap(decl);
 
         loweredLikeType = loweredLikeType.subst(IGM.getSILModule(), subs);
 
@@ -1119,8 +1118,7 @@ namespace {
         // environment that is different than that which was built our
         // resolved rawLayout like type. Map our like type into the given
         // environment.
-        auto subs = T.getASTType()->getContextSubstitutionMap(
-          IGM.getSwiftModule(), decl);
+        auto subs = T.getASTType()->getContextSubstitutionMap(decl);
 
         loweredLikeType = loweredLikeType.subst(IGM.getSILModule(), subs);
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1698,7 +1698,7 @@ const TypeInfo *TypeConverter::convertStructType(TypeBase *key, CanType type,
         IGM.getSwiftModule()->getASTContext().getProtocol(
             KnownProtocolKind::BitwiseCopyable);
     if (bitwiseCopyableProtocol &&
-        IGM.getSwiftModule()->checkConformance(type, bitwiseCopyableProtocol)) {
+        ModuleDecl::checkConformance(type, bitwiseCopyableProtocol)) {
       return BitwiseCopyableTypeInfo::create(IGM.OpaqueTy, structAccessible);
     }
     return &getResilientStructTypeInfo(copyable, structAccessible);

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -524,7 +524,7 @@ const TypeInfo *TypeConverter::convertTupleType(TupleType *tuple) {
     auto *bitwiseCopyableProtocol =
         IGM.getSwiftModule()->getASTContext().getProtocol(
             KnownProtocolKind::BitwiseCopyable);
-    if (bitwiseCopyableProtocol && IGM.getSwiftModule()->checkConformance(
+    if (bitwiseCopyableProtocol && ModuleDecl::checkConformance(
                                        tuple, bitwiseCopyableProtocol)) {
       return BitwiseCopyableTypeInfo::create(IGM.OpaqueTy, IsABIAccessible);
     }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -2942,8 +2942,7 @@ static bool tryEmitDeinitCall(IRGenFunction &IGF,
          && !deinitTy->hasError()
          && "deinit should have only one parameter");
 
-  auto substitutions = ty->getContextSubstitutionMap(IGF.getSwiftModule(),
-                                                     nominal);
+  auto substitutions = ty->getContextSubstitutionMap(nominal);
                                                      
   CalleeInfo info(deinitTy,
                   deinitTy->substGenericArgs(IGF.getSILModule(),

--- a/lib/IRGen/GenericArguments.h
+++ b/lib/IRGen/GenericArguments.h
@@ -65,7 +65,7 @@ struct GenericArguments {
 
   void collect(IRGenFunction &IGF, CanType type) {
     auto decl = type.getNominalOrBoundGenericNominal();
-    auto subs = type->getContextSubstitutionMap(IGF.IGM.getSwiftModule(), decl);
+    auto subs = type->getContextSubstitutionMap(decl);
     collect(IGF, subs);
   }
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1102,7 +1102,7 @@ private:
     SmallVector<llvm::Metadata *, 16> Elements;
     unsigned OffsetInBits = 0;
     for (VarDecl *VD : Decl->getStoredProperties()) {
-      auto memberTy = BaseTy->getTypeOfMember(IGM.getSwiftModule(), VD);
+      auto memberTy = BaseTy->getTypeOfMember(VD);
 
       if (auto DbgTy = CompletedDebugTypeInfo::getFromTypeInfo(
               VD->getInterfaceType(),
@@ -1150,7 +1150,7 @@ private:
     SmallVector<llvm::Metadata *, 16> Elements;
     for (VarDecl *VD : Decl->getStoredProperties()) {
       auto memberTy =
-          UnsubstitutedType->getTypeOfMember(IGM.getSwiftModule(), VD);
+          UnsubstitutedType->getTypeOfMember(VD);
       auto DbgTy = DebugTypeInfo::getFromTypeInfo(
           memberTy,
           IGM.getTypeInfoForUnlowered(

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2865,7 +2865,7 @@ void IRGenSILFunction::visitDifferentiableFunctionInst(
     auto derivativeFnType = origFnType->getAutoDiffDerivativeFunctionType(
         i->getParameterIndices(), i->getResultIndices(), kind,
         i->getModule().Types,
-        LookUpConformanceInModule(i->getModule().getSwiftModule()));
+        LookUpConformanceInModule());
     auto *undef = SILUndef::get(
         i->getFunction(), SILType::getPrimitiveObjectType(derivativeFnType));
     return getLoweredExplosion(undef);

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -870,8 +870,7 @@ bool irgen::isSpecializedNominalTypeMetadataStaticallyAddressable(
 
   // Analyze the substitution map to determine if everything can be referenced
   // statically.
-  auto substitutions =
-      type->getContextSubstitutionMap(IGM.getSwiftModule(), nominal);
+  auto substitutions = type->getContextSubstitutionMap(nominal);
 
   // If we cannot statically reference type metadata for our replacement types,
   // we cannot specialize.
@@ -2720,8 +2719,7 @@ irgen::emitCanonicalSpecializedGenericTypeMetadataAccessFunction(
   assert(!theType->hasUnboundGenericType());
 
   auto requirements = GenericTypeRequirements(IGF.IGM, nominal);
-  auto substitutions =
-      theType->getContextSubstitutionMap(IGF.IGM.getSwiftModule(), nominal);
+  auto substitutions = theType->getContextSubstitutionMap(nominal);
   for (auto requirement : requirements.getRequirements()) {
     if (requirement.isAnyWitnessTable()) {
       continue;

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1422,7 +1422,7 @@ getFunctionTypeFlags(CanFunctionType type) {
       auto proto =
         type->getASTContext().getProtocol(KnownProtocolKind::Copyable);
       if (proto &&
-          proto->getParentModule()->lookupConformance(type, proto).isInvalid())
+          ModuleDecl::lookupConformance(type, proto).isInvalid())
         InvertedProtocols.insert(invertibleKind);
       break;
     }

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -115,7 +115,7 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
       // If our likeType is dependent, then all calls to try and lay it out will
       // be non-fixed, but in a concrete case we want a fixed layout, so try to
       // substitute it out.
-      auto subs = (*type)->getContextSubstitutionMap(IGM.getSwiftModule(), decl);
+      auto subs = (*type)->getContextSubstitutionMap(decl);
       auto loweredLikeType = IGM.getLoweredType(likeType->subst(subs));
       const TypeInfo &likeTypeInfo = IGM.getTypeInfo(loweredLikeType);
                                       
@@ -151,7 +151,7 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
       auto elementType = likeArray->first;
       unsigned count = likeArray->second;
       
-      auto subs = (*type)->getContextSubstitutionMap(IGM.getSwiftModule(), decl);
+      auto subs = (*type)->getContextSubstitutionMap(decl);
       auto loweredElementType = IGM.getLoweredType(elementType.subst(subs));
       const TypeInfo &likeTypeInfo = IGM.getTypeInfo(loweredElementType);
       

--- a/lib/Refactoring/Async/AsyncHandlerDesc.cpp
+++ b/lib/Refactoring/Async/AsyncHandlerDesc.cpp
@@ -17,10 +17,10 @@ using namespace swift;
 using namespace swift::refactoring::asyncrefactorings;
 
 /// Whether the given type is (or conforms to) the stdlib Error type
-static bool isErrorType(Type Ty, ModuleDecl *MD) {
+static bool isErrorType(Type Ty) {
   if (!Ty)
     return false;
-  return !MD->checkConformance(Ty, Ty->getASTContext().getErrorDecl())
+  return !ModuleDecl::checkConformance(Ty, Ty->getASTContext().getErrorDecl())
               .isInvalid();
 }
 
@@ -70,8 +70,7 @@ AsyncHandlerDesc AsyncHandlerDesc::get(const ValueDecl *Handler,
     HandlerDesc.Type = HandlerType::PARAMS;
     if (!HandlerParams.empty()) {
       auto LastParamTy = HandlerParams.back().getParameterType();
-      HandlerDesc.HasError = isErrorType(LastParamTy->getOptionalObjectType(),
-                                         Handler->getModuleContext());
+      HandlerDesc.HasError = isErrorType(LastParamTy->getOptionalObjectType());
     }
   }
 

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -2066,7 +2066,7 @@ const {
   case Kind::ClangType:
   case Kind::Type:
   case Kind::Discard:
-    auto memberTy = getType()->getTypeOfMember(member->getModuleContext(),
+    auto memberTy = getType()->getTypeOfMember(
                                       member, origMemberInterfaceType)
                              ->getReducedType(getGenericSignature());
       
@@ -2524,9 +2524,8 @@ public:
     
     auto decl = orig->getAnyNominal();
 
-    auto moduleDecl = decl->getParentModule();
-    auto origSubMap = orig->getContextSubstitutionMap(moduleDecl, decl);
-    auto substSubMap = subst->getContextSubstitutionMap(moduleDecl, decl);
+    auto origSubMap = orig->getContextSubstitutionMap(decl);
+    auto substSubMap = subst->getContextSubstitutionMap(decl);
     
     auto nomGenericSig = decl->getGenericSignature();
     
@@ -2543,7 +2542,7 @@ public:
     }
 
     auto newSubMap = SubstitutionMap::get(nomGenericSig, replacementTypes,
-      LookUpConformanceInModule(moduleDecl));
+      LookUpConformanceInModule());
     
     for (auto reqt : nomGenericSig.getRequirements()) {
       // Skip conformance requirements to Copyable and Escapable.

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -291,9 +291,9 @@ bool AbstractionPattern::conformsToKnownProtocol(
     = substTy->getASTContext().getProtocol(protocolKind);
     
   auto definitelyConforms = [&](CanType t) -> bool {
-    auto result = suppressible->getParentModule()
-      ->checkConformanceWithoutContext(t, suppressible,
-                                       /*allowMissing=*/false);
+    auto result =
+      ModuleDecl::checkConformanceWithoutContext(t, suppressible,
+                                                 /*allowMissing=*/false);
     return result.has_value() && !result.value().isInvalid();
   };
     

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -503,7 +503,7 @@ Type SILFunction::mapTypeIntoContext(Type type) const {
     // Otherwise, assume we have an interface type for the "combined" captured
     // environment.
     return type.subst(MapIntoLocalArchetypeContext(GenericEnv, CapturedEnvs),
-                      LookUpConformanceInModule(Module.getSwiftModule()),
+                      LookUpConformanceInModule(),
                       SubstFlags::AllowLoweredTypes |
                       SubstFlags::PreservePackExpansionLevel);
   }
@@ -519,7 +519,7 @@ SILType SILFunction::mapTypeIntoContext(SILType type) const {
     auto genericSig = GenericEnv->getGenericSignature().getCanonicalSignature();
     return type.subst(Module,
                       MapIntoLocalArchetypeContext(GenericEnv, CapturedEnvs),
-                      LookUpConformanceInModule(Module.getSwiftModule()),
+                      LookUpConformanceInModule(),
                       genericSig,
                       SubstFlags::PreservePackExpansionLevel);
   }
@@ -535,7 +535,7 @@ SILType GenericEnvironment::mapTypeIntoContext(SILModule &M,
   auto genericSig = getGenericSignature().getCanonicalSignature();
   return type.subst(M,
                     QueryInterfaceTypeSubstitutions(this),
-                    LookUpConformanceInModule(M.getSwiftModule()),
+                    LookUpConformanceInModule(),
                     genericSig,
                     SubstFlags::PreservePackExpansionLevel);
 }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -279,7 +279,7 @@ CanSILFunctionType SILFunctionType::getDifferentiableComponentType(
     return originalFnTy->getAutoDiffDerivativeFunctionType(
         getDifferentiabilityParameterIndices(),
         getDifferentiabilityResultIndices(), *derivativeKind, module.Types,
-        LookUpConformanceInModule(module.getSwiftModule()));
+        LookUpConformanceInModule());
   }
   return originalFnTy;
 }
@@ -295,7 +295,7 @@ CanSILFunctionType SILFunctionType::getLinearComponentType(
   case LinearDifferentiableFunctionTypeComponent::Transpose:
     return originalFnTy->getAutoDiffTransposeFunctionType(
         getDifferentiabilityParameterIndices(), module.Types,
-        LookUpConformanceInModule(module.getSwiftModule()));
+        LookUpConformanceInModule());
   }
 }
 
@@ -4218,7 +4218,7 @@ TypeConverter::getConstantInfo(TypeExpansionContext expansion,
 
     silFnType = origFnConstantInfo.SILFnType->getAutoDiffDerivativeFunctionType(
         loweredParamIndices, loweredResultIndices, derivativeId->getKind(),
-        *this, LookUpConformanceInModule(&M));
+        *this, LookUpConformanceInModule());
   }
 
   LLVM_DEBUG(llvm::dbgs() << "lowering type for constant ";

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -924,7 +924,7 @@ SILType DifferentiableFunctionExtractInst::getExtracteeType(
   auto resultFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
       fnTy->getDifferentiabilityParameterIndices(),
       fnTy->getDifferentiabilityResultIndices(), *kindOpt, module.Types,
-      LookUpConformanceInModule(module.getSwiftModule()));
+      LookUpConformanceInModule());
   return SILType::getPrimitiveObjectType(resultFnTy);
 }
 
@@ -954,7 +954,7 @@ getExtracteeType(
   case LinearDifferentiableFunctionTypeComponent::Transpose:
     auto transposeFnTy = originalFnTy->getAutoDiffTransposeFunctionType(
         fnTy->getDifferentiabilityParameterIndices(), module.Types,
-        LookUpConformanceInModule(module.getSwiftModule()));
+        LookUpConformanceInModule());
     return SILType::getPrimitiveObjectType(transposeFnTy);
   }
   llvm_unreachable("invalid extractee");
@@ -981,14 +981,14 @@ SILType DifferentiabilityWitnessFunctionInst::getDifferentiabilityWitnessType(
         witness->getOriginalFunction()->isThunk() == IsReabstractionThunk;
     auto diffFnTy = fnTy->getAutoDiffDerivativeFunctionType(
         parameterIndices, resultIndices, *derivativeKind, module.Types,
-        LookUpConformanceInModule(module.getSwiftModule()), witnessCanGenSig,
+        LookUpConformanceInModule(), witnessCanGenSig,
         isReabstractionThunk);
     return SILType::getPrimitiveObjectType(diffFnTy);
   }
   assert(witnessKind == DifferentiabilityWitnessFunctionKind::Transpose);
   auto transposeFnTy = fnTy->getAutoDiffTransposeFunctionType(
       parameterIndices, module.Types,
-      LookUpConformanceInModule(module.getSwiftModule()), witnessCanGenSig);
+      LookUpConformanceInModule(), witnessCanGenSig);
   return SILType::getPrimitiveObjectType(transposeFnTy);
 }
 

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -324,7 +324,7 @@ static void addFieldSubstitutionsIfNeeded(TypeConverter &TC, SILType ty,
                                           AbstractionPattern &origType) {
   if (needsFieldSubstitutions(origType)) {
     auto subMap = ty.getASTType()->getContextSubstitutionMap(
-                    &TC.M, field->getDeclContext());
+                    field->getDeclContext());
     origType = origType.withSubstitutions(subMap);
   }
 }
@@ -348,7 +348,7 @@ SILType SILType::getFieldType(VarDecl *field, TypeConverter &TC,
     // to ensure that we can correctly get our substituted field type. If we
     // need to rewrap the type layer, we do it below.
     substFieldTy =
-        getASTType()->getTypeOfMember(&TC.M, field)->getCanonicalType();
+        getASTType()->getTypeOfMember(field)->getCanonicalType();
   }
 
   auto loweredTy =
@@ -413,7 +413,7 @@ SILType SILType::getEnumElementType(EnumElementDecl *elt, TypeConverter &TC,
   addFieldSubstitutionsIfNeeded(TC, *this, elt, origEltType);
 
   auto substEltTy = getASTType()->getTypeOfMember(
-      &TC.M, elt, elt->getArgumentInterfaceType());
+      elt, elt->getArgumentInterfaceType());
   auto loweredTy = TC.getLoweredRValueType(
       context, TC.getAbstractionPattern(elt), substEltTy);
 
@@ -899,7 +899,7 @@ bool SILType::isLoweringOf(TypeExpansionContext context, SILModule &Mod,
 
 bool SILType::isDifferentiable(SILModule &M) const {
   return getASTType()
-      ->getAutoDiffTangentSpace(LookUpConformanceInModule(M.getSwiftModule()))
+      ->getAutoDiffTangentSpace(LookUpConformanceInModule())
       .has_value();
 }
 

--- a/lib/SIL/Utils/GenericSpecializationMangler.cpp
+++ b/lib/SIL/Utils/GenericSpecializationMangler.cpp
@@ -147,7 +147,6 @@ static SubstitutionMap
 getSubstitutionMapForPrespecialization(GenericSignature genericSig,
                                        GenericSignature specSig) {
   auto CalleeGenericSig = genericSig;
-  auto SpecializedGenericSig = specSig;
   auto SpecializedGenericEnv = specSig.getGenericEnvironment();
 
   auto CalleeInterfaceToSpecializedInterfaceMap = SubstitutionMap::get(

--- a/lib/SIL/Utils/GenericSpecializationMangler.cpp
+++ b/lib/SIL/Utils/GenericSpecializationMangler.cpp
@@ -155,7 +155,7 @@ getSubstitutionMapForPrespecialization(GenericSignature genericSig,
       [&](SubstitutableType *type) -> Type {
         return type;
       },
-      LookUpConformanceInSignature(CalleeGenericSig.getPointer()));
+      LookUpConformanceInModule());
 
   auto subs = SubstitutionMap::get(
       CalleeGenericSig,
@@ -165,7 +165,7 @@ getSubstitutionMapForPrespecialization(GenericSignature genericSig,
         return SpecializedGenericEnv->mapTypeIntoContext(
             SpecializedInterfaceTy);
       },
-      LookUpConformanceInSignature(SpecializedGenericSig.getPointer()));
+      LookUpConformanceInModule());
   return subs;
 }
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -322,7 +322,7 @@ void verifyKeyPathComponent(SILModule &M,
               "property");
     }
 
-    auto fieldTy = baseTy->getTypeOfMember(M.getSwiftModule(), property)
+    auto fieldTy = baseTy->getTypeOfMember(property)
                          ->getReferenceStorageReferent()
                          ->getCanonicalType();
     require(getTypeInExpansionContext(fieldTy) ==
@@ -5907,7 +5907,7 @@ public:
       auto expectedJVPType = origTy->getAutoDiffDerivativeFunctionType(
           dfi->getParameterIndices(), dfi->getResultIndices(),
           AutoDiffDerivativeFunctionKind::JVP, TC,
-          LookUpConformanceInModule(M));
+          LookUpConformanceInModule());
       requireSameType(SILType::getPrimitiveObjectType(jvpType),
                       SILType::getPrimitiveObjectType(expectedJVPType),
                       "JVP type does not match expected JVP type");
@@ -5919,7 +5919,7 @@ public:
       auto expectedVJPType = origTy->getAutoDiffDerivativeFunctionType(
           dfi->getParameterIndices(), dfi->getResultIndices(),
           AutoDiffDerivativeFunctionKind::VJP, TC,
-          LookUpConformanceInModule(M));
+          LookUpConformanceInModule());
       requireSameType(SILType::getPrimitiveObjectType(vjpType),
                       SILType::getPrimitiveObjectType(expectedVJPType),
                       "VJP type does not match expected VJP type");
@@ -5946,7 +5946,7 @@ public:
       require(!transposeType->isDifferentiable(),
               "The transpose function must not be differentiable");
       auto expectedTransposeType = origTy->getAutoDiffTransposeFunctionType(
-          lfi->getParameterIndices(), TC, LookUpConformanceInModule(M));
+          lfi->getParameterIndices(), TC, LookUpConformanceInModule());
       // TODO: Consider tightening verification. This requires changes to
       // `SILFunctionType::getAutoDiffTransposeFunctionType`.
       requireSameType(

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6283,8 +6283,7 @@ public:
                                    Type conformingType,
                                    ProtocolDecl *protocol) -> ProtocolConformanceRef {
         // FIXME: This violates the spirit of this verifier check.
-        return protocol->getParentModule()
-            ->lookupConformance(conformingType, protocol);
+        return ModuleDecl::lookupConformance(conformingType, protocol);
       };
 
       // If the pack components and expected element types are SIL types,

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -973,7 +973,7 @@ public:
             SGF.F.mapTypeIntoContext(resumeType)->getCanonicalType()};
         auto subs = SubstitutionMap::get(errorIntrinsic->getGenericSignature(),
                                          replacementTypes,
-                         LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
+                                         LookUpConformanceInModule());
 
         SGF.emitApplyOfLibraryIntrinsic(
             loc, errorIntrinsic, subs,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -318,7 +318,7 @@ SILGenModule::getConformanceToObjectiveCBridgeable(SILLocation loc, Type type) {
   if (!proto) return nullptr;
 
   // Find the conformance to _ObjectiveCBridgeable.
-  auto result = SwiftModule->lookupConformance(type, proto);
+  auto result = ModuleDecl::lookupConformance(type, proto);
   if (result.isInvalid())
     return nullptr;
 
@@ -363,7 +363,7 @@ SILGenModule::getConformanceToBridgedStoredNSError(SILLocation loc, Type type) {
     return ProtocolConformanceRef::forInvalid();
 
   // Find the conformance to _BridgedStoredNSError.
-  return SwiftModule->lookupConformance(type, proto);
+  return ModuleDecl::lookupConformance(type, proto);
 }
 
 static FuncDecl *lookupConcurrencyIntrinsic(ASTContext &C, StringRef name) {
@@ -516,7 +516,7 @@ ProtocolConformance *SILGenModule::getNSErrorConformanceToError() {
   }
 
   auto conformance =
-    SwiftModule->lookupConformance(nsErrorTy, cast<ProtocolDecl>(error));
+    ModuleDecl::lookupConformance(nsErrorTy, cast<ProtocolDecl>(error));
 
   if (conformance.isConcrete())
     NSErrorConformanceToError = conformance.getConcrete();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5936,7 +5936,7 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc, SILValue fn,
         assert(outerErrorType == SILType::getExceptionType(getASTContext()));
 
         ProtocolConformanceRef conformances[1] = {
-          getModule().getSwiftModule()->checkConformance(
+          ModuleDecl::checkConformance(
             innerError->getType().getASTType(),
             getASTContext().getErrorDecl())
         };

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6622,8 +6622,7 @@ SILGenFunction::emitUninitializedArrayAllocation(Type ArrayTy,
   auto allocate = Ctx.getAllocateUninitializedArray();
 
   // Invoke the intrinsic, which returns a tuple.
-  auto subMap = ArrayTy->getContextSubstitutionMap(SGM.M.getSwiftModule(),
-                                                   Ctx.getArrayDecl());
+  auto subMap = ArrayTy->getContextSubstitutionMap(Ctx.getArrayDecl());
   auto result = emitApplyOfLibraryIntrinsic(
       Loc, allocate, subMap,
       ManagedValue::forObjectRValueWithoutOwnership(Length), SGFContext());
@@ -6648,8 +6647,7 @@ void SILGenFunction::emitUninitializedArrayDeallocation(SILLocation loc,
   CanType arrayTy = array->getType().getASTType();
 
   // Invoke the intrinsic.
-  auto subMap = arrayTy->getContextSubstitutionMap(SGM.M.getSwiftModule(),
-                                                   Ctx.getArrayDecl());
+  auto subMap = arrayTy->getContextSubstitutionMap(Ctx.getArrayDecl());
   emitApplyOfLibraryIntrinsic(loc, deallocate, subMap,
                               ManagedValue::forUnmanagedOwnedValue(array),
                               SGFContext());
@@ -6672,8 +6670,7 @@ ManagedValue SILGenFunction::emitUninitializedArrayFinalization(SILLocation loc,
   CanType arrayTy = arrayVal->getType().getASTType();
 
   // Invoke the intrinsic.
-  auto subMap = arrayTy->getContextSubstitutionMap(SGM.M.getSwiftModule(),
-                                                   Ctx.getArrayDecl());
+  auto subMap = arrayTy->getContextSubstitutionMap(Ctx.getArrayDecl());
   RValue result = emitApplyOfLibraryIntrinsic(
       loc, finalize, subMap, ManagedValue::forUnmanagedOwnedValue(arrayVal),
       SGFContext());

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -84,7 +84,7 @@ static bool shouldBridgeThroughError(SILGenModule &SGM, CanType type,
     }
   }
 
-  return (bool)SGM.SwiftModule->lookupConformance(type, errorProtocol);
+  return (bool)ModuleDecl::lookupConformance(type, errorProtocol);
 }
 
 /// Bridge the given Swift value to its corresponding Objective-C

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -126,8 +126,7 @@ emitBridgeNativeToObjectiveC(SILGenFunction &SGF, SILLocation loc,
          "Generic witnesses not supported");
 
   auto *dc = cast<FuncDecl>(witness)->getDeclContext();
-  auto typeSubMap = swiftValueType->getContextSubstitutionMap(
-      SGF.SGM.SwiftModule, dc);
+  auto typeSubMap = swiftValueType->getContextSubstitutionMap(dc);
 
   // Substitute into the witness function type.
   witnessFnTy = witnessFnTy.substGenericArgs(SGF.SGM.M, typeSubMap,
@@ -769,7 +768,7 @@ static ManagedValue emitNativeToCBridgedNonoptionalValue(SILGenFunction &SGF,
       [&](SubstitutableType *t) -> Type {
         return nativeType;
       },
-      LookUpConformanceInModule(SGF.SGM.SwiftModule));
+      LookUpConformanceInModule());
 
     // The intrinsic takes a T; reabstract to the generic abstraction
     // pattern.

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -315,7 +315,7 @@ emitDistributedActorIsolation(SILGenFunction &SGF, SILLocation loc,
   // simple case that it's okay.
   auto sig = distributedActorProto->getGenericSignature();
   auto distributedActorConf =
-    SGF.SGM.SwiftModule->lookupConformance(actorType, distributedActorProto);
+    ModuleDecl::lookupConformance(actorType, distributedActorProto);
   auto distributedActorSubs = SubstitutionMap::get(sig, {actorType},
                                                    {distributedActorConf});
 

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -257,9 +257,9 @@ SILGenFunction::emitLoadOfGlobalActorShared(SILLocation loc, CanType actorType) 
   VarDecl *sharedInstanceDecl = nominal->getGlobalActorInstance();
   assert(sharedInstanceDecl && "no shared actor field in global actor");
   SubstitutionMap subs =
-    actorType->getContextSubstitutionMap(SGM.SwiftModule, nominal);
+    actorType->getContextSubstitutionMap(nominal);
   Type instanceType =
-    actorType->getTypeOfMember(SGM.SwiftModule, sharedInstanceDecl);
+    actorType->getTypeOfMember(sharedInstanceDecl);
 
   auto metaRepr =
     nominal->isResilient(SGM.SwiftModule, F.getResilienceExpansion())

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -322,7 +322,7 @@ static SubstitutionMap getSubstitutionsForPropertyInitializer(
     return SubstitutionMap::get(
       nominal->getGenericSignatureOfContext(),
       QuerySubstitutionMap{genericEnv->getForwardingSubstitutionMap()},
-      LookUpConformanceInModule(dc->getParentModule()));
+      LookUpConformanceInModule());
   }
 
   return SubstitutionMap();
@@ -755,8 +755,6 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
     // lifetime checker doesn't seem to process trivial locations. But empty
     // move only structs are non-trivial, so we need to handle this here.
     if (nominal->getAttrs().hasAttribute<RawLayoutAttr>()) {
-      auto *module = ctor->getParentModule();
-
       // Raw memory is not directly decomposable, but we still want to mark
       // it as initialized. Use a zero initializer.
       auto &C = ctor->getASTContext();
@@ -766,7 +764,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
                       SubstitutionMap::get(zeroInit->getInnermostDeclContext()
                                                ->getGenericSignatureOfContext(),
                                            {selfDecl->getTypeInContext()},
-                                           LookUpConformanceInModule(module)),
+                                           LookUpConformanceInModule()),
                       selfLV.getLValueAddress());
     } else if (isa<StructDecl>(nominal)
                && lowering.getLoweredType().isMoveOnly()

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -530,10 +530,9 @@ SILGenFunction::emitPointerToPointer(SILLocation loc,
     origValue = emitManagedBufferWithCleanup(origBuf);
   }
   // Invoke the conversion intrinsic to convert to the destination type.
-  auto *M = SGM.M.getSwiftModule();
   auto *proto = getPointerProtocol();
-  auto firstSubMap = inputType->getContextSubstitutionMap(M, proto);
-  auto secondSubMap = outputType->getContextSubstitutionMap(M, proto);
+  auto firstSubMap = inputType->getContextSubstitutionMap(proto);
+  auto secondSubMap = outputType->getContextSubstitutionMap(proto);
 
   auto genericSig = converter->getGenericSignature();
   auto subMap =

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1276,7 +1276,7 @@ void EnumElementPatternInitialization::emitEnumMatch(
         CanType substEltTy =
             value.getType()
                 .getASTType()
-                ->getTypeOfMember(SGF.SGM.M.getSwiftModule(), eltDecl,
+                ->getTypeOfMember(eltDecl,
                                   eltDecl->getArgumentInterfaceType())
                 ->getCanonicalType();
 

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -121,8 +121,7 @@ void SILGenFunction::emitDestroyingDestructor(DestructorDecl *dd) {
     SILType dtorTy;
 
     auto subMap
-      = superclassTy->getContextSubstitutionMap(SGM.M.getSwiftModule(),
-                                                superclass);
+      = superclassTy->getContextSubstitutionMap(superclass);
 
     // We completely drop the generic signature if all generic parameters were
     // concrete.
@@ -635,8 +634,7 @@ void SILGenFunction::emitObjCDestructor(SILDeclRef dtor) {
   assert(superSelf->getOwnershipKind() == OwnershipKind::Owned);
 
   auto subMap
-    = superclassTy->getContextSubstitutionMap(SGM.M.getSwiftModule(),
-                                              superclass);
+    = superclassTy->getContextSubstitutionMap(superclass);
 
   B.createApply(cleanupLoc, superclassDtorValue, subMap, superSelf);
 

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -121,7 +121,6 @@ void SILGenFunction::emitDistributedIfRemoteBranch(SILLocation Loc,
 // MARK: local instance initialization
 
 static SILArgument *findFirstDistributedActorSystemArg(SILFunction &F) {
-  auto *module = F.getModule().getSwiftModule();
   auto &C = F.getASTContext();
 
   auto *DAS = C.getDistributedActorSystemDecl();
@@ -133,7 +132,7 @@ static SILArgument *findFirstDistributedActorSystemArg(SILFunction &F) {
     auto argDecl = arg->getDecl();
 
     auto conformsToSystem =
-        module->lookupConformance(argDecl->getInterfaceType(), DAS);
+        ModuleDecl::lookupConformance(argDecl->getInterfaceType(), DAS);
 
     // Is it a protocol that conforms to DistributedActorSystem?
     if (argTy->isEqual(systemTy) || conformsToSystem) {
@@ -141,7 +140,7 @@ static SILArgument *findFirstDistributedActorSystemArg(SILFunction &F) {
     }
 
     // Is it some specific DistributedActorSystem?
-    auto result = module->lookupConformance(argTy, DAS);
+    auto result = ModuleDecl::lookupConformance(argTy, DAS);
     if (!result.isInvalid()) {
       return arg;
     }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3979,7 +3979,7 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
         formalTy = genericEnv->mapTypeIntoContext(formalTy)->getCanonicalType();
         hashable = hashable.subst(index.FormalType,
           [&](Type t) -> Type { return genericEnv->mapTypeIntoContext(t); },
-          LookUpConformanceInSignature(genericSig.getPointer()));
+          LookUpConformanceInModule());
       }
 
       // Set up a substitution of Self => IndexType.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1219,7 +1219,7 @@ void SILGenFunction::ForceTryEmission::finish() {
         subMap = SubstitutionMap::get(
             genericSig, [&](SubstitutableType *dependentType) {
               return error.getType().getObjectType().getASTType();
-            }, LookUpConformanceInModule(SGF.getModule().getSwiftModule()));
+            }, LookUpConformanceInModule());
 
         // Generic errors are passed indirectly.
         if (!error.getType().isAddress()) {
@@ -1509,10 +1509,8 @@ RValue SILGenFunction::emitCollectionConversion(SILLocation loc,
   auto *fromDecl = fromCollection->getAnyNominal();
   auto *toDecl = toCollection->getAnyNominal();
 
-  auto fromSubMap = fromCollection->getContextSubstitutionMap(
-    SGM.SwiftModule, fromDecl);
-  auto toSubMap = toCollection->getContextSubstitutionMap(
-    SGM.SwiftModule, toDecl);
+  auto fromSubMap = fromCollection->getContextSubstitutionMap(fromDecl);
+  auto toSubMap = toCollection->getContextSubstitutionMap(toDecl);
 
   // Form type parameter substitutions.
   auto genericSig = fn->getGenericSignature();
@@ -4254,7 +4252,7 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
     } else {
       componentTy =
         GenericEnvironment::mapTypeIntoContext(genericEnv, baseTy)
-          ->getTypeOfMember(SwiftModule, var)
+          ->getTypeOfMember(var)
           ->getReferenceStorageReferent()
           ->mapTypeOutOfContext()
           ->getCanonicalType();
@@ -6295,8 +6293,7 @@ ManagedValue SILGenFunction::emitLValueToPointer(SILLocation loc, LValue &&lv,
     getASTContext().getConvertInOutToPointerArgument();
 
   auto pointerType = pointerInfo.PointerType;
-  auto subMap = pointerType->getContextSubstitutionMap(SGM.M.getSwiftModule(),
-                                                       getPointerProtocol());
+  auto subMap = pointerType->getContextSubstitutionMap(getPointerProtocol());
   return emitApplyOfLibraryIntrinsic(
              loc, converter, subMap,
              ManagedValue::forObjectRValueWithoutOwnership(pointer),
@@ -6357,11 +6354,10 @@ SILGenFunction::emitArrayToPointer(SILLocation loc, ManagedValue array,
   }
 
   // Invoke the conversion intrinsic, which will produce an owner-pointer pair.
-  auto *M = SGM.M.getSwiftModule();
   auto firstSubMap =
-      accessInfo.ArrayType->getContextSubstitutionMap(M, ctx.getArrayDecl());
+      accessInfo.ArrayType->getContextSubstitutionMap(ctx.getArrayDecl());
   auto secondSubMap = accessInfo.PointerType->getContextSubstitutionMap(
-      M, getPointerProtocol());
+      getPointerProtocol());
 
   auto genericSig = converter->getGenericSignature();
   auto subMap = SubstitutionMap::combineSubstitutionMaps(
@@ -6405,8 +6401,7 @@ SILGenFunction::emitStringToPointer(SILLocation loc, ManagedValue stringValue,
   FuncDecl *converter = Ctx.getConvertConstStringToUTF8PointerArgument();
   
   // Invoke the conversion intrinsic, which will produce an owner-pointer pair.
-  auto subMap = pointerType->getContextSubstitutionMap(SGM.M.getSwiftModule(),
-                                                       getPointerProtocol());
+  auto subMap = pointerType->getContextSubstitutionMap(getPointerProtocol());
   SmallVector<ManagedValue, 2> results;
   emitApplyOfLibraryIntrinsic(loc, converter, subMap, stringValue, SGFContext())
     .getAll(results);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -6142,15 +6142,15 @@ static void diagnoseImplicitRawConversion(Type sourceTy, Type pointerTy,
   if (SGF.getLoweredType(eltTy).isTrivial(SGF.F))
     return;
 
-  auto *SM = SGF.getModule().getSwiftModule();
-  if (auto *bitwiseCopyableDecl = SM->getASTContext().getProtocol(
+  auto &ctx = SGF.getASTContext();
+  if (auto *bitwiseCopyableDecl = ctx.getProtocol(
         KnownProtocolKind::BitwiseCopyable)) {
-    if (SM->checkConformance(eltTy, bitwiseCopyableDecl))
+    if (ModuleDecl::checkConformance(eltTy, bitwiseCopyableDecl))
       return;
   }
-  if (auto *fixedWidthIntegerDecl = SM->getASTContext().getProtocol(
+  if (auto *fixedWidthIntegerDecl = ctx.getProtocol(
           KnownProtocolKind::FixedWidthInteger)) {
-    if (SM->checkConformance(eltTy, fixedWidthIntegerDecl))
+    if (ModuleDecl::checkConformance(eltTy, fixedWidthIntegerDecl))
       return;
   }
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2381,7 +2381,7 @@ namespace {
       }
 
       auto subs = SubstitutionMap::get(sig, replacementTypes,
-                  LookUpConformanceInModule{SGF.getModule().getSwiftModule()});
+                  LookUpConformanceInModule());
 
       base = makeBaseConsumableMaterializedRValue(SGF, loc, base);
 
@@ -2407,7 +2407,6 @@ namespace {
 
       auto keyPathTy = keyPathValue.getType().castTo<BoundGenericType>();
       auto subs = keyPathTy->getContextSubstitutionMap(
-          keyPathTy->getDecl()->getParentModule(),
           keyPathTy->getDecl());
 
       auto origType = AbstractionPattern::getOpaque();
@@ -2483,7 +2482,6 @@ namespace {
 
       auto keyPathTy = keyPathValue.getType().castTo<BoundGenericType>();
       auto subs = keyPathTy->getContextSubstitutionMap(
-          keyPathTy->getDecl()->getParentModule(),
           keyPathTy->getDecl());
 
       auto substFnType = projectFnType->substGenericArgs(
@@ -4588,8 +4586,7 @@ LValue SILGenFunction::emitPropertyLValue(SILLocation loc, ManagedValue base,
   LValue lv;
 
   auto baseType = base.getType().getASTType();
-  auto subMap = baseType->getContextSubstitutionMap(
-      SGM.M.getSwiftModule(), ivar->getDeclContext());
+  auto subMap = baseType->getContextSubstitutionMap(ivar->getDeclContext());
 
   AccessStrategy strategy =
     ivar->getAccessStrategy(semantics,

--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -141,13 +141,13 @@ void SILGenModule::useConformancesFromObjectiveCType(CanType type) {
 
     if (objectiveCBridgeable) {
       if (auto subConformance =
-              SwiftModule->lookupConformance(t, objectiveCBridgeable))
+              ModuleDecl::lookupConformance(t, objectiveCBridgeable))
         useConformance(subConformance);
     }
 
     if (bridgedStoredNSError) {
       if (auto subConformance =
-              SwiftModule->lookupConformance(t, bridgedStoredNSError))
+              ModuleDecl::lookupConformance(t, bridgedStoredNSError))
         useConformance(subConformance);
     }
   });

--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -113,7 +113,7 @@ void SILGenModule::useConformancesFromType(CanType type) {
     if (!genericSig)
       return;
 
-    auto subMap = t->getContextSubstitutionMap(SwiftModule, decl);
+    auto subMap = t->getContextSubstitutionMap(decl);
     useConformancesFromSubstitutions(subMap);
     return;
   });

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -3099,7 +3099,7 @@ static void emitDiagnoseOfUnexpectedEnumCaseValue(SILGenFunction &SGF,
           llvm_unreachable("wrong generic signature for expected case value");
         }
       },
-      LookUpConformanceInSignature(genericSig.getPointer()));
+      LookUpConformanceInModule());
 
   SGF.emitApplyOfLibraryIntrinsic(
       loc, diagnoseFailure, subs,
@@ -3127,7 +3127,7 @@ static void emitDiagnoseOfUnexpectedEnumCase(SILGenFunction &SGF,
   auto genericArgsMap = SubstitutionMap::get(
       diagnoseSignature,
       [&](SubstitutableType *type) -> Type { return ueci.subjectTy; },
-      LookUpConformanceInSignature(diagnoseSignature.getPointer()));
+      LookUpConformanceInModule());
 
   SGF.emitApplyOfLibraryIntrinsic(loc, diagnoseFailure, genericArgsMap,
                                   ueci.metatype, SGFContext());

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2208,8 +2208,7 @@ void PatternMatchEmission::emitEnumElementObjectDispatch(
       // Reabstract to the substituted type, if needed.
       CanType substEltTy =
           sourceType
-              ->getTypeOfMember(SGF.SGM.M.getSwiftModule(), elt,
-                                elt->getArgumentInterfaceType())
+              ->getTypeOfMember(elt, elt->getArgumentInterfaceType())
               ->getCanonicalType();
 
       AbstractionPattern origEltTy =
@@ -2470,7 +2469,7 @@ void PatternMatchEmission::emitEnumElementDispatch(
 
       // Reabstract to the substituted type, if needed.
       CanType substEltTy =
-        sourceType->getTypeOfMember(SGF.SGM.M.getSwiftModule(), eltDecl,
+        sourceType->getTypeOfMember(eltDecl,
                                     eltDecl->getArgumentInterfaceType())
                   ->getCanonicalType();
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -667,7 +667,7 @@ ManagedValue Transform::transform(ManagedValue v,
   if (outputSubstType->isAnyHashable()) {
     auto *protocol = SGF.getASTContext().getProtocol(
         KnownProtocolKind::Hashable);
-    auto conformance = SGF.SGM.M.getSwiftModule()->lookupConformance(
+    auto conformance = ModuleDecl::lookupConformance(
         inputSubstType, protocol);
     auto addr = v.getType().isAddress() ? v : v.materialize(SGF, Loc);
     auto result = SGF.emitAnyHashableErasure(Loc, addr, inputSubstType,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -5676,7 +5676,7 @@ static ManagedValue createDifferentiableFunctionThunk(
           AutoDiffDerivativeFunctionKind kind) -> CanAnyFunctionType {
     auto assocTy = fnTy->getAutoDiffDerivativeFunctionType(
         parameterIndices, kind,
-        LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
+        LookUpConformanceInModule());
     return cast<AnyFunctionType>(assocTy->getCanonicalType());
   };
   auto getDerivativeFnPattern =
@@ -5684,7 +5684,7 @@ static ManagedValue createDifferentiableFunctionThunk(
           AutoDiffDerivativeFunctionKind kind) -> AbstractionPattern {
     return pattern.getAutoDiffDerivativeFunctionType(
         parameterIndices, kind,
-        LookUpConformanceInModule(SGF.SGM.M.getSwiftModule()));
+        LookUpConformanceInModule());
   };
   auto createDerivativeFnThunk =
       [&](AutoDiffDerivativeFunctionKind kind) -> ManagedValue {
@@ -6270,7 +6270,7 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
   auto derivativeCanGenSig = config.derivativeGenericSignature.getCanonicalSignature();
   auto thunkFnTy = origFnTy->getAutoDiffDerivativeFunctionType(
       config.parameterIndices, config.resultIndices, kind, Types,
-      LookUpConformanceInModule(M.getSwiftModule()), derivativeCanGenSig);
+      LookUpConformanceInModule(), derivativeCanGenSig);
   assert(!thunkFnTy->getExtInfo().hasContext());
 
   Mangle::ASTMangler mangler;

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1591,7 +1591,7 @@ void SILGenFunction::emitThrow(SILLocation loc, ManagedValue exnMV,
         SubstitutionMap subMap = SubstitutionMap::get(
             genericSig, [&](SubstitutableType *dependentType) {
               return exnMV.getType().getASTType();
-            }, LookUpConformanceInModule(getModule().getSwiftModule()));
+            }, LookUpConformanceInModule());
 
         // Generic errors are passed indirectly.
         if (!exnMV.getType().isAddress() && useLoweredAddresses()) {

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1633,7 +1633,7 @@ void SILGenFunction::emitThrow(SILLocation loc, ManagedValue exnMV,
     assert(destErrorType == SILType::getExceptionType(getASTContext()));
 
     ProtocolConformanceRef conformances[1] = {
-      getModule().getSwiftModule()->checkConformance(
+      ModuleDecl::checkConformance(
         exn->getType().getASTType(), getASTContext().getErrorDecl())
     };
 

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -482,7 +482,7 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
           = {F->mapTypeIntoContext(resumeType)->getCanonicalType()};
         auto subs = SubstitutionMap::get(errorIntrinsic->getGenericSignature(),
                                          replacementTypes,
-                                         LookUpConformanceInModule(SwiftModule));
+                                         LookUpConformanceInModule());
         SGF.emitApplyOfLibraryIntrinsic(loc, errorIntrinsic, subs,
                                         {continuation, nativeError},
                                         SGFContext());
@@ -580,7 +580,7 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
           = {F->mapTypeIntoContext(resumeType)->getCanonicalType()};
         auto subs = SubstitutionMap::get(resumeIntrinsic->getGenericSignature(),
                                          replacementTypes,
-                                         LookUpConformanceInModule(SwiftModule));
+                                         LookUpConformanceInModule());
         SGF.emitApplyOfLibraryIntrinsic(loc, resumeIntrinsic, subs,
                                         {continuation, resumeArg},
                                         SGFContext());

--- a/lib/SILGen/SILGenTopLevel.cpp
+++ b/lib/SILGen/SILGenTopLevel.cpp
@@ -303,7 +303,7 @@ void SILGenFunction::emitCallToMain(FuncDecl *mainFunc) {
       SubstitutionMap subMap = SubstitutionMap::get(
           genericSig, [&](SubstitutableType *dependentType) {
             return errorType.getASTType();
-          }, LookUpConformanceInModule(getModule().getSwiftModule()));
+          }, LookUpConformanceInModule());
 
       // Generic errors are passed indirectly.
       if (!error->getType().isAddress()) {

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -691,9 +691,10 @@ public:
   void addConditionalRequirements() {
     SILWitnessTable::enumerateWitnessTableConditionalConformances(
         Conformance, [&](unsigned, CanType type, ProtocolDecl *protocol) {
-          auto conformance =
-              Conformance->getGenericSignature()->lookupConformance(type,
-                                                                    protocol);
+          auto conformance = (type->isTypeParameter()
+                              ? ProtocolConformanceRef(protocol)
+                              : ModuleDecl::lookupConformance(type, protocol,
+                                                              /*allowMissing=*/true));
           assert(conformance &&
                  "unable to find conformance that should be known");
 

--- a/lib/SILOptimizer/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Differentiation/Common.cpp
@@ -417,7 +417,7 @@ SILValue emitMemoryLayoutSize(
       loc, id, SILType::getBuiltinWordType(ctx),
       SubstitutionMap::get(
           builtin->getGenericSignature(), ArrayRef<Type>{type},
-          LookUpConformanceInSignature(builtin->getGenericSignature().getPointer())),
+          LookUpConformanceInModule()),
       {metatypeVal});
 }
 

--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -350,7 +350,7 @@ private:
     type = witness->getDerivativeGenericSignature().getReducedType(
         type);
     return type->getAutoDiffTangentSpace(
-        LookUpConformanceInModule(getModule().getSwiftModule()));
+        LookUpConformanceInModule());
   }
 
   /// Assuming the given type conforms to `Differentiable` after remapping,
@@ -1619,7 +1619,7 @@ void JVPCloner::Implementation::prepareForDifferentialGeneration() {
   // binding all generic parameters to concrete types, JVP function type uses
   // all the concrete types and JVP generic signature is null.
   auto witnessCanGenSig = witness->getDerivativeGenericSignature().getCanonicalSignature();
-  auto lookupConformance = LookUpConformanceInModule(module.getSwiftModule());
+  auto lookupConformance = LookUpConformanceInModule();
 
   // Parameters of the differential are:
   // - the tangent values of the wrt parameters.

--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -271,8 +271,7 @@ Type LinearMapInfo::getLinearMapType(ADContext &context, FullApplySite fai) {
       remappedOrigFnSubstTy
           ->getAutoDiffDerivativeFunctionType(
               parameters, results, derivativeFnKind, context.getTypeConverter(),
-              LookUpConformanceInModule(
-                  derivative->getModule().getSwiftModule()))
+              LookUpConformanceInModule())
           ->getUnsubstitutedType(original->getModule());
 
   auto linearMapSILType = derivativeFnType->getAllResultsInterfaceType();

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -239,7 +239,7 @@ private:
         getWitness()->getDerivativeGenericSignature().getReducedType(
             type);
     return type->getAutoDiffTangentSpace(
-        LookUpConformanceInModule(getModule().getSwiftModule()));
+        LookUpConformanceInModule());
   }
 
   /// Returns the tangent value category of the given value.
@@ -1428,7 +1428,7 @@ public:
           recordTemporary(adjElt);
         } else {
           auto substMap = tangentVectorTy->getMemberSubstitutionMap(
-              field->getModuleContext(), field);
+              field);
           auto fieldTy = field->getInterfaceType().subst(substMap);
           auto fieldSILTy = getTypeLowering(fieldTy).getLoweredType();
           assert(fieldSILTy.isObject());
@@ -3122,8 +3122,7 @@ bool PullbackCloner::Implementation::runForSemanticMemberGetter() {
         if (field == tanField) {
           eltVals.push_back(adjResult);
         } else {
-          auto substMap = tangentVectorTy->getMemberSubstitutionMap(
-              field->getModuleContext(), field);
+          auto substMap = tangentVectorTy->getMemberSubstitutionMap(field);
           auto fieldTy = field->getInterfaceType().subst(substMap);
           auto fieldSILTy = getTypeLowering(fieldTy).getLoweredType();
           assert(fieldSILTy.isObject());

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2697,9 +2697,8 @@ AllocStackInst *PullbackCloner::Implementation::createOptionalAdjoint(
   auto *initFnRef = builder.createFunctionRef(pbLoc, initFn);
   auto *diffProto =
       builder.getASTContext().getProtocol(KnownProtocolKind::Differentiable);
-  auto *swiftModule = getModule().getSwiftModule();
   auto diffConf =
-      swiftModule->lookupConformance(wrappedType.getASTType(), diffProto);
+      ModuleDecl::lookupConformance(wrappedType.getASTType(), diffProto);
   assert(!diffConf.isInvalid() && "Missing conformance to `Differentiable`");
   auto subMap = SubstitutionMap::get(
       initFn->getLoweredFunctionType()->getSubstGenericSignature(),
@@ -3605,12 +3604,11 @@ AllocStackInst *PullbackCloner::Implementation::getArrayAdjointElementBuffer(
       ctx.getIntType()->getCanonicalType());
   // %index_int = struct $Int (%index_literal)
   auto *eltIndexInt = builder.createStruct(loc, intType, {eltIndexLiteral});
-  auto *swiftModule = getModule().getSwiftModule();
   auto *diffProto = ctx.getProtocol(KnownProtocolKind::Differentiable);
-  auto diffConf = swiftModule->lookupConformance(eltTanType, diffProto);
+  auto diffConf = ModuleDecl::lookupConformance(eltTanType, diffProto);
   assert(!diffConf.isInvalid() && "Missing conformance to `Differentiable`");
   auto *addArithProto = ctx.getProtocol(KnownProtocolKind::AdditiveArithmetic);
-  auto addArithConf = swiftModule->lookupConformance(eltTanType, addArithProto);
+  auto addArithConf = ModuleDecl::lookupConformance(eltTanType, addArithProto);
   assert(!addArithConf.isInvalid() &&
          "Missing conformance to `AdditiveArithmetic`");
   auto subMap = SubstitutionMap::get(subscriptFnGenSig, {eltTanType},

--- a/lib/SILOptimizer/Differentiation/TangentBuilder.cpp
+++ b/lib/SILOptimizer/Differentiation/TangentBuilder.cpp
@@ -35,11 +35,10 @@ void TangentBuilder::emitZeroIntoBuffer(SILLocation loc, SILValue buffer,
     }
     return;
   }
-  auto *swiftMod = getModule().getSwiftModule();
   // Look up conformance to `AdditiveArithmetic`.
   auto *additiveArithmeticProto = adContext.getAdditiveArithmeticProtocol();
   auto astType = buffer->getType().getASTType();
-  auto confRef = swiftMod->lookupConformance(astType, additiveArithmeticProto);
+  auto confRef = ModuleDecl::lookupConformance(astType, additiveArithmeticProto);
   assert(!confRef.isInvalid() && "Missing conformance to `AdditiveArithmetic`");
   SILDeclRef accessorDeclRef(adContext.getAdditiveArithmeticZeroGetter(),
                              SILDeclRef::Kind::Func);
@@ -96,9 +95,8 @@ void TangentBuilder::emitInPlaceAdd(
     return;
   }
   // Call the combiner function and return.
-  auto *swiftMod = getModule().getSwiftModule();
   auto astType = type.getASTType();
-  auto confRef = swiftMod->lookupConformance(
+  auto confRef = ModuleDecl::lookupConformance(
       astType, adContext.getAdditiveArithmeticProtocol());
   assert(!confRef.isInvalid() &&
          "Missing conformance to `AdditiveArithmetic`");
@@ -145,8 +143,7 @@ void TangentBuilder::emitAddIntoBuffer(SILLocation loc,
   auto *proto = adContext.getAdditiveArithmeticProtocol();
   auto *combinerFuncDecl = adContext.getPlusDecl();
   // Call the combiner function and return.
-  auto *swiftMod = getModule().getSwiftModule();
-  auto confRef = swiftMod->lookupConformance(astType, proto);
+  auto confRef = ModuleDecl::lookupConformance(astType, proto);
   assert(!confRef.isInvalid() &&
          "Missing conformance to `AdditiveArithmetic`");
   SILDeclRef declRef(combinerFuncDecl, SILDeclRef::Kind::Func);

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -455,9 +455,8 @@ getOrCreateSubsetParametersThunkForLinearMap(
     auto zeroSILType = zeroSILParameter.getSILStorageInterfaceType();
     auto zeroSILObjType = zeroSILType.getObjectType();
     auto zeroType = zeroSILType.getASTType();
-    auto *swiftMod = parentThunk->getModule().getSwiftModule();
     auto tangentSpace =
-        zeroType->getAutoDiffTangentSpace(LookUpConformanceInModule(swiftMod));
+        zeroType->getAutoDiffTangentSpace(LookUpConformanceInModule());
     assert(tangentSpace && "No tangent space for this type");
     switch (tangentSpace->getKind()) {
     case TangentSpace::Kind::TangentVector: {
@@ -716,7 +715,7 @@ getOrCreateSubsetParametersThunkForDerivativeFunction(
 
   auto origFnType = origFnOperand->getType().castTo<SILFunctionType>();
   auto &module = fb.getModule();
-  auto lookupConformance = LookUpConformanceInModule(module.getSwiftModule());
+  auto lookupConformance = LookUpConformanceInModule();
 
   // Compute target type for thunking.
   auto derivativeFnType = derivativeFn->getType().castTo<SILFunctionType>();

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -1095,7 +1095,6 @@ const DifferentiableActivityInfo &VJPCloner::getActivityInfo() const {
 }
 
 SILFunction *VJPCloner::Implementation::createEmptyPullback() {
-  auto &module = context.getModule();
   auto origTy = original->getLoweredFunctionType();
   // Get witness generic signature for remapping types.
   // Witness generic signature may have more requirements than VJP generic
@@ -1103,7 +1102,7 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
   // binding all generic parameters to concrete types, VJP function type uses
   // all the concrete types and VJP generic signature is null.
   auto witnessCanGenSig = witness->getDerivativeGenericSignature().getCanonicalSignature();
-  auto lookupConformance = LookUpConformanceInModule(module.getSwiftModule());
+  auto lookupConformance = LookUpConformanceInModule();
 
   // Given a type, returns its formal SIL parameter info.
   auto getTangentParameterInfoForOriginalResult =
@@ -1306,6 +1305,7 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
       IsNotTransparent, vjp->getSerializedKind(),
       original->isDynamicallyReplaceable(), original->isDistributed(),
       original->isRuntimeAccessible());
+  auto &module = context.getModule();
   pullback->setDebugScope(new (module)
                               SILDebugScope(original->getLocation(), pullback));
 

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -637,7 +637,7 @@ void ExistentialTransform::createExistentialSpecializedFunction() {
       [&](SubstitutableType *type) -> Type {
         return NewFGenericEnv->mapTypeIntoContext(type);
       },
-      LookUpConformanceInModule(F->getModule().getSwiftModule()));
+      LookUpConformanceInModule());
     ExistentialSpecializerCloner cloner(F, NewF, Subs, ArgumentDescList,
                                         ArgToGenericTypeMap,
                                         ExistentialArgDescriptor);

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -228,7 +228,7 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
       auto builtinDecl = cast<FuncDecl>(getBuiltinValueDecl(ctx, builtinName));
       auto subs = SubstitutionMap::get(builtinDecl->getGenericSignature(),
                                        {actorType},
-                                       LookUpConformanceInModule(module));
+                                       LookUpConformanceInModule());
       return B.createBuiltin(loc, builtinName, executorType, subs, {actor});
     }
 

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -249,7 +249,7 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
       actor = B.createOpenExistentialRef(loc, actor, loweredActorType);
     }
 
-    auto actorConf = module->lookupConformance(actorType, actorProtocol);
+    auto actorConf = ModuleDecl::lookupConformance(actorType, actorProtocol);
     assert(actorConf &&
            "hop_to_executor with actor that doesn't conform to Actor or DistributedActor");
 

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -519,7 +519,7 @@ static SILValue emitCodeForConstantArray(ArrayRef<SILValue> elements,
   // created array and the second element is a pointer to the internal storage
   // of the array.
   SubstitutionMap subMap = arrayType->getContextSubstitutionMap(
-      module.getSwiftModule(), astContext.getArrayDecl());
+      astContext.getArrayDecl());
   FunctionRefInst *arrayAllocateRef =
       builder.createFunctionRef(loc, arrayAllocateFun);
   ApplyInst *applyInst = builder.createApply(
@@ -683,8 +683,7 @@ static SILValue emitCodeForSymbolicValue(SymbolicValue symVal,
            "aggregate symbolic value's type and expected type do not match");
 
     VarDecl *propertyDecl = structDecl->getStoredProperties().front();
-    Type propertyType = expectedType->getTypeOfMember(
-        propertyDecl->getModuleContext(), propertyDecl);
+    Type propertyType = expectedType->getTypeOfMember(propertyDecl);
     SymbolicValue propertyVal = symVal.lookThroughSingleElementAggregates();
     SILValue newPropertySIL = emitCodeForSymbolicValue(
         propertyVal, propertyType, builder, loc, stringInfo);

--- a/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
@@ -327,7 +327,7 @@ bool ArrayAllocation::replaceAppendContentOf() {
     SILType ArrayType = ArrayValue->getType();
     auto *NTD = ArrayType.getASTType()->getAnyNominal();
     SubstitutionMap ArraySubMap = ArrayType.getASTType()
-      ->getContextSubstitutionMap(M.getSwiftModule(), NTD);
+      ->getContextSubstitutionMap(NTD);
 
     AppendContentsOf.replaceByAppendingValues(AppendFn, ReserveFn,
                                               ElementValueVector,

--- a/lib/SILOptimizer/Transforms/VTableSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/VTableSpecializer.cpp
@@ -173,8 +173,7 @@ SILVTable *swift::specializeVTableForType(SILType classTy, SILModule &module,
     return nullptr;
   }
 
-  SubstitutionMap subs = astType->getContextSubstitutionMap(
-      classDecl->getParentModule(), classDecl);
+  SubstitutionMap subs = astType->getContextSubstitutionMap(classDecl);
 
   llvm::SmallVector<SILVTableEntry, 8> newEntries;
 
@@ -249,8 +248,7 @@ bool swift::specializeClassMethodInst(ClassMethodInst *cm) {
   if (!genClassTy) return false;
 
   ClassDecl *classDecl = genClassTy->getDecl();
-  SubstitutionMap subs = astType->getContextSubstitutionMap(
-      classDecl->getParentModule(), classDecl);
+  SubstitutionMap subs = astType->getContextSubstitutionMap(classDecl);
 
   SILType funcTy = cm->getType();
   SILType substitutedType =

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -519,7 +519,7 @@ findBridgeToObjCFunc(SILOptFunctionBuilder &functionBuilder,
 
   // Get substitutions, if source is a bound generic type.
   auto subMap = sourceFormalType->getContextSubstitutionMap(
-      mod.getSwiftModule(), resultDecl->getDeclContext());
+      resultDecl->getDeclContext());
 
   // Implementation of _bridgeToObjectiveC could not be found.
   if (!bridgedFunc)

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -72,11 +72,10 @@ getObjCToSwiftBridgingFunction(SILOptFunctionBuilder &funcBuilder,
                                          ForDefinition_t::NotForDefinition);
 }
 
-static SubstitutionMap lookupBridgeToObjCProtocolSubs(SILModule &mod,
-                                                      CanType target) {
+static SubstitutionMap lookupBridgeToObjCProtocolSubs(CanType target) {
   auto bridgedProto =
-      mod.getASTContext().getProtocol(KnownProtocolKind::ObjectiveCBridgeable);
-  auto conf = mod.getSwiftModule()->lookupConformance(target, bridgedProto);
+      target->getASTContext().getProtocol(KnownProtocolKind::ObjectiveCBridgeable);
+  auto conf = ModuleDecl::lookupConformance(target, bridgedProto);
   return SubstitutionMap::getProtocolSubstitutions(conf.getRequirement(),
                                                    target, conf);
 }
@@ -315,7 +314,7 @@ CastOptimizer::optimizeBridgedObjCToSwiftCast(SILDynamicCastInst dynamicCast) {
   // This is done by means of calling _forceBridgeFromObjectiveC or
   // _conditionallyBridgeFromObjectiveC_bridgeable from the Target type.
   auto *funcRef = Builder.createFunctionRefFor(Loc, bridgingFunc);
-  SubstitutionMap subMap = lookupBridgeToObjCProtocolSubs(mod, target);
+  SubstitutionMap subMap = lookupBridgeToObjCProtocolSubs(target);
 
   auto MetaTy = MetatypeType::get(target, MetatypeRepresentation::Thick);
   auto SILMetaTy = F->getTypeLowering(MetaTy).getLoweredType();
@@ -444,7 +443,6 @@ CastOptimizer::optimizeBridgedObjCToSwiftCast(SILDynamicCastInst dynamicCast) {
 //===----------------------------------------------------------------------===//
 
 static bool canOptimizeCast(const swift::Type &BridgedTargetTy,
-                            swift::SILModule &M,
                             swift::SILFunctionConventions &substConv,
                             TypeExpansionContext context) {
   // DestTy is the type which we want to convert to
@@ -465,13 +463,11 @@ static bool canOptimizeCast(const swift::Type &BridgedTargetTy,
   }
   // check if it is a bridgeable CF type
   if (ConvTy.getASTType() ==
-      getNSBridgedClassOfCFClass(M.getSwiftModule(),
-                                 DestTy.getASTType())) {
+      getNSBridgedClassOfCFClass(DestTy.getASTType())) {
     return true;
   }
   if (DestTy.getASTType() ==
-      getNSBridgedClassOfCFClass(M.getSwiftModule(),
-                                 ConvTy.getASTType())) {
+      getNSBridgedClassOfCFClass(ConvTy.getASTType())) {
     return true;
   }
   // All else failed - can't optimize this case
@@ -482,31 +478,34 @@ static std::optional<std::pair<SILFunction *, SubstitutionMap>>
 findBridgeToObjCFunc(SILOptFunctionBuilder &functionBuilder,
                      SILDynamicCastInst dynamicCast) {
   CanType sourceFormalType = dynamicCast.getSourceFormalType();
-  auto loc = dynamicCast.getLocation();
-  auto &mod = dynamicCast.getModule();
-  auto bridgedProto =
-      mod.getASTContext().getProtocol(KnownProtocolKind::ObjectiveCBridgeable);
 
-  auto conf = mod.getSwiftModule()->lookupConformance(
+  auto *mod = dynamicCast.getModule().getSwiftModule();
+  auto &ctx = mod->getASTContext();
+  auto loc = dynamicCast.getLocation();
+  auto bridgedProto =
+      ctx.getProtocol(
+        KnownProtocolKind::ObjectiveCBridgeable);
+
+  auto conf = ModuleDecl::lookupConformance(
     sourceFormalType, bridgedProto);
   assert(conf && "_ObjectiveCBridgeable conformance should exist");
   (void)conf;
 
   // Generate code to invoke _bridgeToObjectiveC
   ModuleDecl *modDecl =
-      mod.getASTContext().getLoadedModule(mod.getASTContext().Id_Foundation);
+      ctx.getLoadedModule(ctx.Id_Foundation);
   if (!modDecl)
     return std::nullopt;
   SmallVector<ValueDecl *, 2> results;
   modDecl->lookupMember(results,
                         sourceFormalType.getNominalOrBoundGenericNominal(),
-                        mod.getASTContext().Id_bridgeToObjectiveC,
+                        ctx.Id_bridgeToObjectiveC,
                         Identifier());
   ArrayRef<ValueDecl *> resultsRef(results);
   if (resultsRef.empty()) {
-    mod.getSwiftModule()->lookupMember(
+    mod->lookupMember(
         results, sourceFormalType.getNominalOrBoundGenericNominal(),
-        mod.getASTContext().Id_bridgeToObjectiveC, Identifier());
+        ctx.Id_bridgeToObjectiveC, Identifier());
     resultsRef = results;
   }
   if (resultsRef.size() != 1)
@@ -554,7 +553,6 @@ static SILValue computeFinalCastedValue(SILBuilderWithScope &builder,
   assert(destLoweredTy == dynamicCast.getLoweredBridgedTargetObjectType() &&
          "Expected Dest Type to be the same as BridgedTargetTy");
 
-  auto &m = dynamicCast.getModule();
   if (convTy == destLoweredTy) {
     return newAI;
   }
@@ -599,9 +597,9 @@ static SILValue computeFinalCastedValue(SILBuilderWithScope &builder,
   }
 
   if (convTy.getASTType() ==
-          getNSBridgedClassOfCFClass(m.getSwiftModule(), destLoweredTy.getASTType()) ||
+          getNSBridgedClassOfCFClass(destLoweredTy.getASTType()) ||
       destLoweredTy.getASTType() ==
-          getNSBridgedClassOfCFClass(m.getSwiftModule(), convTy.getASTType())) {
+          getNSBridgedClassOfCFClass(convTy.getASTType())) {
     // Handle NS <-> CF toll-free bridging here.
     return SILValue(builder.createUncheckedRefCast(loc, newAI, destLoweredTy));
   }
@@ -650,7 +648,7 @@ CastOptimizer::optimizeBridgedSwiftToObjCCast(SILDynamicCastInst dynamicCast) {
 
   // Check that this is a case that the authors of this code thought it could
   // handle.
-  if (!canOptimizeCast(BridgedTargetTy, M, substConv,
+  if (!canOptimizeCast(BridgedTargetTy, substConv,
                        F->getTypeExpansionContext())) {
     return nullptr;
   }

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1455,7 +1455,6 @@ static bool optimizeStaticallyKnownProtocolConformance(
   if (TargetType->isAnyExistentialType() &&
       !SourceType->isAnyExistentialType()) {
     auto &Ctx = Mod.getASTContext();
-    auto *SM = Mod.getSwiftModule();
 
     auto *Proto = dyn_cast_or_null<ProtocolDecl>(TargetType->getAnyNominal());
     if (!Proto)
@@ -1471,7 +1470,7 @@ static bool optimizeStaticallyKnownProtocolConformance(
     // `foo(0)` but not for `foo("string")`. There are many cases where
     // everything is completely static (`X<Int>() as? P`), in which case a
     // valid conformance will be returned.
-    auto Conformance = SM->checkConformance(SourceType, Proto);
+    auto Conformance = ModuleDecl::checkConformance(SourceType, Proto);
     if (Conformance.isInvalid())
       return false;
 

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -420,7 +420,7 @@ getSubstitutionsForCallee(SILModule &module, CanSILFunctionType baseCalleeType,
     if (auto metatypeType = derivedClass->getAs<MetatypeType>())
       derivedClass = metatypeType->getInstanceType();
     baseSubMap = derivedClass->getContextSubstitutionMap(
-        module.getSwiftModule(), baseClassDecl);
+        baseClassDecl);
   }
 
   SubstitutionMap origSubMap = applySite.getSubstitutionMap();

--- a/lib/SILOptimizer/Utils/DistributedActor.cpp
+++ b/lib/SILOptimizer/Utils/DistributedActor.cpp
@@ -34,7 +34,6 @@ void emitDistributedActorSystemWitnessCall(
   ProtocolDecl *DAS = C.getDistributedActorSystemDecl();
   assert(DAS);
   auto systemASTType = base->getType().getASTType();
-  auto *module = M.getSwiftModule();
   ProtocolConformanceRef systemConfRef;
 
   // If the base is an existential open it.

--- a/lib/SILOptimizer/Utils/DistributedActor.cpp
+++ b/lib/SILOptimizer/Utils/DistributedActor.cpp
@@ -51,7 +51,7 @@ void emitDistributedActorSystemWitnessCall(
   if (systemASTType->isTypeParameter() || systemASTType->is<ArchetypeType>()) {
     systemConfRef = ProtocolConformanceRef(DAS);
   } else {
-    systemConfRef = module->lookupConformance(systemASTType, DAS);
+    systemConfRef = ModuleDecl::lookupConformance(systemASTType, DAS);
   }
 
   assert(!systemConfRef.isInvalid() &&
@@ -81,7 +81,7 @@ void emitDistributedActorSystemWitnessCall(
       assert(actorProto);
 
       ProtocolConformanceRef conformance;
-      auto distributedActorConfRef = module->lookupConformance(
+      auto distributedActorConfRef = ModuleDecl::lookupConformance(
           actorType.getASTType(), actorProto);
       assert(!distributedActorConfRef.isInvalid() &&
              "Missing conformance to `DistributedActor`");

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -390,7 +390,7 @@ ConcreteExistentialInfo::ConcreteExistentialInfo(SILValue existential,
 
   // We have the open_existential; we still need the conformance.
   auto ConformanceRef =
-      M->getSwiftModule()->checkConformance(ConcreteTypeCandidate, Protocol);
+      ModuleDecl::checkConformance(ConcreteTypeCandidate, Protocol);
   if (ConformanceRef.isInvalid())
     return;
 

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1401,7 +1401,7 @@ public:
         [&](SubstitutableType *type) -> Type {
           return CalleeGenericEnv->mapTypeIntoContext(type);
         },
-        LookUpConformanceInSignature(SpecializedGenericSig.getPointer()));
+        LookUpConformanceInModule());
   }
 
   GenericSignature getSpecializedGenericSignature() {
@@ -1472,7 +1472,7 @@ void FunctionSignaturePartialSpecializer::
       [&](SubstitutableType *type) -> Type {
         return CallerInterfaceToSpecializedInterfaceMapping.lookup(type);
       },
-      LookUpConformanceInSignature(CallerGenericSig.getPointer()));
+      LookUpConformanceInModule());
 
   LLVM_DEBUG(llvm::dbgs() << "\n\nCallerInterfaceToSpecializedInterfaceMap "
                              "map:\n";
@@ -1497,7 +1497,7 @@ void FunctionSignaturePartialSpecializer::
                    else llvm::dbgs() << "Not found!\n";);
         return SpecializedInterfaceToCallerArchetypeMapping.lookup(type);
       },
-      LookUpConformanceInSignature(SpecializedGenericSig.getPointer()));
+      LookUpConformanceInModule());
   LLVM_DEBUG(llvm::dbgs() << "\n\nSpecializedInterfaceToCallerArchetypeMap "
                              "map:\n";
              SpecializedInterfaceToCallerArchetypeMap.dump(llvm::dbgs()));
@@ -1511,7 +1511,7 @@ void FunctionSignaturePartialSpecializer::
       [&](SubstitutableType *type) -> Type {
         return CalleeInterfaceToSpecializedInterfaceMapping.lookup(type);
       },
-      LookUpConformanceInSignature(CalleeGenericSig.getPointer()));
+      LookUpConformanceInModule());
 
   LLVM_DEBUG(llvm::dbgs() << "\n\nCalleeInterfaceToSpecializedInterfaceMap:\n";
              CalleeInterfaceToSpecializedInterfaceMap.dump(llvm::dbgs()));
@@ -1724,7 +1724,7 @@ SubstitutionMap FunctionSignaturePartialSpecializer::computeClonerParamSubs() {
       return SpecializedGenericEnv->mapTypeIntoContext(
           SpecializedInterfaceTy);
     },
-    LookUpConformanceInSignature(SpecializedGenericSig.getPointer()));
+    LookUpConformanceInModule());
 }
 
 SubstitutionMap FunctionSignaturePartialSpecializer::getCallerParamSubs() {
@@ -1744,7 +1744,7 @@ void FunctionSignaturePartialSpecializer::computeCallerInterfaceSubs(
       assert(!SpecializedInterfaceTy->hasError());
       return SpecializedInterfaceTy;
     },
-    LookUpConformanceInSignature(CalleeGenericSig.getPointer()));
+    LookUpConformanceInModule());
 
   LLVM_DEBUG(llvm::dbgs() << "\n\nCallerInterfaceSubs map:\n";
              CallerInterfaceSubs.dump(llvm::dbgs()));

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -1931,11 +1931,9 @@ static Type getWitnessTypeForMatching(NormalProtocolConformance *conformance,
                              genericFn->getExtInfo());
   }
 
-  ModuleDecl *module = conformance->getDeclContext()->getParentModule();
-
   if (!witness->getDeclContext()->getExtendedProtocolDecl()) {
     return type.subst(QueryTypeSubstitutionMap{substitutions},
-                      LookUpConformanceInModule(module));
+                      LookUpConformanceInModule());
   }
 
   auto proto = conformance->getProtocol();
@@ -1977,7 +1975,7 @@ static Type getWitnessTypeForMatching(NormalProtocolConformance *conformance,
 
     // Replace Self with the concrete conforming type.
     substType = substType.subst(QueryTypeSubstitutionMap{substitutions},
-                                LookUpConformanceInModule(module));
+                                LookUpConformanceInModule());
 
     // If we don't have enough type witnesses, leave it abstract.
     if (substType->hasError())
@@ -2667,8 +2665,6 @@ bool AssociatedTypeInference::simplifyCurrentTypeWitnesses() {
         proto->getSelfInterfaceType()->getCanonicalType());
     substitutions[selfTy] = dc->mapTypeIntoContext(conformance->getType());
 
-    auto *module = dc->getParentModule();
-
     for (auto assocType : proto->getAssociatedTypeMembers()) {
       if (conformance->hasTypeWitness(assocType))
         continue;
@@ -2700,7 +2696,7 @@ bool AssociatedTypeInference::simplifyCurrentTypeWitnesses() {
 
           // Replace Self with the concrete conforming type.
           auto substType = Type(type).subst(QueryTypeSubstitutionMap{substitutions},
-                                            LookUpConformanceInModule(module),
+                                            LookUpConformanceInModule(),
                                             options);
 
           // If we don't have enough type witnesses to substitute fully,

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -190,11 +190,9 @@ checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
       return CheckTypeWitnessResult::forSuperclass(superclass);
   }
 
-  auto *module = dc->getParentModule();
-
   // Check protocol conformances. We don't check conditional requirements here.
   for (const auto reqProto : sig->getRequiredProtocols(depTy)) {
-    if (module->lookupConformance(
+    if (ModuleDecl::lookupConformance(
             type, reqProto,
             /*allowMissing=*/reqProto->isSpecificProtocol(
                 KnownProtocolKind::Sendable))
@@ -363,9 +361,9 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
 
     // Find the conformance for this overridden protocol.
     auto overriddenConformance =
-      dc->getParentModule()->lookupConformance(dc->getSelfInterfaceType(),
-                                               overridden->getProtocol(),
-                                               /*allowMissing=*/true);
+      ModuleDecl::lookupConformance(dc->getSelfInterfaceType(),
+                                    overridden->getProtocol(),
+                                    /*allowMissing=*/true);
     if (overriddenConformance.isInvalid() ||
         !overriddenConformance.isConcrete())
       continue;
@@ -4471,8 +4469,6 @@ AssociatedConformanceRequest::evaluate(Evaluator &eval,
                                        NormalProtocolConformance *conformance,
                                        CanType origTy, ProtocolDecl *reqProto,
                                        unsigned index) const {
-  auto *module = conformance->getDeclContext()->getParentModule();
-
   auto subMap = SubstitutionMap::getProtocolSubstitutions(
       conformance->getProtocol(),
       conformance->getType(),
@@ -4498,7 +4494,7 @@ AssociatedConformanceRequest::evaluate(Evaluator &eval,
   if (substTy->hasTypeParameter())
     substTy = conformance->getDeclContext()->mapTypeIntoContext(substTy);
 
-  return module->lookupConformance(substTy, reqProto, /*allowMissing=*/true)
+  return ModuleDecl::lookupConformance(substTy, reqProto, /*allowMissing=*/true)
       .mapConformanceOutOfContext();
 }
 

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -1385,10 +1385,9 @@ static bool isExtensionUsableForInference(const ExtensionDecl *extension,
   // in the first place. Only check conformances on the `Self` type,
   // because those have to be explicitly declared on the type somewhere
   // so won't be affected by whatever answer inference comes up with.
-  auto *module = conformanceDC->getParentModule();
   auto checkConformance = [&](ProtocolDecl *proto) {
     auto typeInContext = conformanceDC->mapTypeIntoContext(conformance->getType());
-    auto otherConf = module->checkConformance(typeInContext, proto);
+    auto otherConf = ModuleDecl::checkConformance(typeInContext, proto);
     return !otherConf.isInvalid();
   };
 

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -517,7 +517,7 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
     }
 
     auto memberType = TypeChecker::substMemberTypeWithBase(
-        dc->getParentModule(), typeDecl, dc->getSelfInterfaceType());
+        typeDecl, dc->getSelfInterfaceType());
 
     // Type witnesses that resolve to constraint types are always
     // existential types. This can only happen when the type witness

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2844,7 +2844,7 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
                                sanitizedRequirements);
 
   switch (checkRequirements(
-      dc->getParentModule(), sanitizedRequirements,
+      sanitizedRequirements,
       QuerySubstitutionMap{substitutions}, options)) {
   case CheckRequirementsResult::RequirementFailure:
     ++NumSolutionStatesFailedCheck;
@@ -2892,7 +2892,7 @@ bool AssociatedTypeInference::checkConstrainedExtension(ExtensionDecl *ext) {
 
   SubstOptions options = getSubstOptionsWithCurrentTypeWitnesses();
   switch (checkRequirements(
-      dc->getParentModule(), ext->getGenericSignature().getRequirements(),
+      ext->getGenericSignature().getRequirements(),
       QueryTypeSubstitutionMap{subs}, options)) {
   case CheckRequirementsResult::Success:
   case CheckRequirementsResult::SubstitutionFailure:

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -149,7 +149,6 @@ checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
     return CheckTypeWitnessResult::forSuccess();
 
   const auto proto = Conf->getProtocol();
-  const auto dc = Conf->getDeclContext();
   const auto sig = proto->getGenericSignature();
 
   // FIXME: The RequirementMachine will assert on re-entrant construction.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -580,7 +580,7 @@ namespace {
 
       return SubstitutionMap::get(sig,
                                   QueryTypeSubstitutionMap{subs},
-                                  LookUpConformanceInModule(dc->getParentModule()));
+                                  LookUpConformanceInModule());
     }
 
     /// Determine whether the given reference is to a method on
@@ -7324,7 +7324,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
           }
           return type;
         },
-        LookUpConformanceInModule(cs.DC->getParentModule()),
+        LookUpConformanceInModule(),
         SubstFlags::SubstituteOpaqueArchetypes);
 
       // Coerce the result expression to the underlying type.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -620,7 +620,7 @@ namespace {
           // the protocol requirement with Self == the concrete type, and SILGen
           // (or later) can devirtualize as appropriate.
           auto conformance =
-            dc->getParentModule()->checkConformance(baseTy, proto);
+            ModuleDecl::checkConformance(baseTy, proto);
           if (conformance.isConcrete()) {
             if (auto witness = conformance.getConcrete()->getWitnessDecl(decl)) {
               bool isMemberOperator = witness->getDeclContext()->isTypeContext();
@@ -2555,7 +2555,7 @@ namespace {
 
       // Try to find the conformance of the value type to _BridgedToObjectiveC.
       auto bridgedToObjectiveCConformance
-        = dc->getParentModule()->checkConformance(valueType, bridgedProto);
+        = ModuleDecl::checkConformance(valueType, bridgedProto);
 
       FuncDecl *fn = nullptr;
 
@@ -2816,7 +2816,7 @@ namespace {
       ProtocolDecl *protocol = TypeChecker::getProtocol(
           ctx, expr->getLoc(), KnownProtocolKind::ExpressibleByStringLiteral);
 
-      if (!dc->getParentModule()->checkConformance(type, protocol)) {
+      if (!ModuleDecl::checkConformance(type, protocol)) {
         // If the type does not conform to ExpressibleByStringLiteral, it should
         // be ExpressibleByExtendedGraphemeClusterLiteral.
         protocol = TypeChecker::getProtocol(
@@ -2825,7 +2825,7 @@ namespace {
         isStringLiteral = false;
         isGraphemeClusterLiteral = true;
       }
-      if (!dc->getParentModule()->checkConformance(type, protocol)) {
+      if (!ModuleDecl::checkConformance(type, protocol)) {
         // ... or it should be ExpressibleByUnicodeScalarLiteral.
         protocol = TypeChecker::getProtocol(
             cs.getASTContext(), expr->getLoc(),
@@ -2940,7 +2940,7 @@ namespace {
         assert(proto && "Missing string interpolation protocol?");
 
         auto conformance =
-          dc->getParentModule()->checkConformance(type, proto);
+          ModuleDecl::checkConformance(type, proto);
         assert(conformance && "string interpolation type conforms to protocol");
 
         DeclName constrName(ctx, DeclBaseName::createConstructor(), argLabels);
@@ -3081,7 +3081,7 @@ namespace {
       auto proto = TypeChecker::getLiteralProtocol(ctx, expr);
       assert(proto && "Missing object literal protocol?");
       auto conformance =
-        dc->getParentModule()->checkConformance(conformingType, proto);
+        ModuleDecl::checkConformance(conformingType, proto);
       assert(conformance && "object literal type conforms to protocol");
 
       auto constrName = TypeChecker::getObjectLiteralConstructorName(ctx, expr);
@@ -3790,7 +3790,7 @@ namespace {
       assert(arrayProto && "type-checked array literal w/o protocol?!");
 
       auto conformance =
-        dc->getParentModule()->checkConformance(arrayTy, arrayProto);
+        ModuleDecl::checkConformance(arrayTy, arrayProto);
       assert(conformance && "Type does not conform to protocol?");
 
       DeclName name(ctx, DeclBaseName::createConstructor(),
@@ -3836,7 +3836,7 @@ namespace {
           KnownProtocolKind::ExpressibleByDictionaryLiteral);
 
       auto conformance =
-        dc->getParentModule()->checkConformance(dictionaryTy, dictionaryProto);
+        ModuleDecl::checkConformance(dictionaryTy, dictionaryProto);
       if (conformance.isInvalid())
         return nullptr;
 
@@ -5450,7 +5450,7 @@ namespace {
         // verified by the solver, we just need to get it again
         // with all of the generic parameters resolved.
         auto hashableConformance =
-          dc->getParentModule()->checkConformance(indexType, hashable);
+          ModuleDecl::checkConformance(indexType, hashable);
         assert(hashableConformance);
 
         conformances.push_back(hashableConformance);
@@ -7080,7 +7080,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       // Find the conformance of the source type to Hashable.
       auto hashable = ctx.getProtocol(KnownProtocolKind::Hashable);
       auto conformance =
-        dc->getParentModule()->checkConformance(
+        ModuleDecl::checkConformance(
                         cs.getType(expr), hashable);
       assert(conformance && "must conform to Hashable");
 
@@ -7938,7 +7938,7 @@ Expr *ExprRewriter::convertLiteralInPlace(
   // Check whether this literal type conforms to the builtin protocol. If so,
   // initialize via the builtin protocol.
   if (builtinProtocol) {
-    auto builtinConformance = dc->getParentModule()->checkConformance(
+    auto builtinConformance = ModuleDecl::checkConformance(
         type, builtinProtocol);
     if (builtinConformance) {
       // Find the witness that we'll use to initialize the type via a builtin
@@ -7962,7 +7962,7 @@ Expr *ExprRewriter::convertLiteralInPlace(
 
   // This literal type must conform to the (non-builtin) protocol.
   assert(protocol && "requirements should have stopped recursion");
-  auto conformance = dc->getParentModule()->checkConformance(type, protocol);
+  auto conformance = ModuleDecl::checkConformance(type, protocol);
   assert(conformance && "must conform to literal protocol");
 
   // Dig out the literal type and perform a builtin literal conversion to it.
@@ -8086,7 +8086,7 @@ std::pair<Expr *, ArgumentList *> ExprRewriter::buildDynamicCallable(
     auto dictLitProto =
         ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral);
     auto conformance =
-        dc->getParentModule()->checkConformance(argumentType, dictLitProto);
+        ModuleDecl::checkConformance(argumentType, dictLitProto);
     auto keyType = conformance.getTypeWitnessByName(argumentType, ctx.Id_Key);
     auto valueType =
         conformance.getTypeWitnessByName(argumentType, ctx.Id_Value);
@@ -9467,7 +9467,7 @@ static std::optional<SequenceIterationInfo> applySolutionToForEachStmt(
         parsedSequence, LocatorPathElt::ContextualType(CTP_ForEachSequence));
     type = Type(solution.OpenedExistentialTypes[contextualLoc]);
   }
-  auto sequenceConformance = dc->getParentModule()->checkConformance(
+  auto sequenceConformance = ModuleDecl::checkConformance(
       type, sequenceProto);
   assert(!sequenceConformance.isInvalid() &&
          "Couldn't find sequence conformance");

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -122,7 +122,7 @@ Solution::computeSubstitutions(NullablePtr<ValueDecl> decl,
 
     // FIXME: Retrieve the conformance from the solution itself.
     auto conformance =
-        getConstraintSystem().DC->getParentModule()->lookupConformance(
+        ModuleDecl::lookupConformance(
             replacement, protoType, /*allowMissing=*/true);
 
     if (conformance.isInvalid()) {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -217,7 +217,7 @@ TreatArrayLiteralAsDictionary::attempt(ConstraintSystem &cs, Type dictionaryTy,
   auto &ctx = cs.getASTContext();
 
   if (auto *proto = ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral))
-      if (!cs.DC->getParentModule()->lookupConformance(unwrappedDict, proto))
+      if (!ModuleDecl::lookupConformance(unwrappedDict, proto))
         return nullptr;
 
   auto arrayLoc = cs.getConstraintLocator(arrayExpr);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4413,8 +4413,6 @@ static Expr *generateConstraintsFor(ConstraintSystem &cs, Expr *expr,
 
 bool ConstraintSystem::generateWrappedPropertyTypeConstraints(
     VarDecl *wrappedVar, Type initializerType, Type propertyType) {
-  auto dc = wrappedVar->getInnermostDeclContext();
-
   Type wrappedValueType;
   Type wrapperType;
   auto wrapperAttributes = wrappedVar->getAttachedPropertyWrappers();

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2175,15 +2175,13 @@ namespace {
         if (!contextualType)
           return false;
 
-        auto *M = CS.DC->getParentModule();
-
         auto type = contextualType->lookThroughAllOptionalTypes();
 
-        if (M->lookupConformance(type, arrayProto))
+        if (ModuleDecl::lookupConformance(type, arrayProto))
           return false;
 
         if (auto *proto = ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral))
-          if (M->lookupConformance(type, proto))
+          if (ModuleDecl::lookupConformance(type, proto))
             return true;
 
         return false;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4448,7 +4448,7 @@ bool ConstraintSystem::generateWrappedPropertyTypeConstraints(
     setType(typeExpr, wrapperType);
 
     wrappedValueType = wrapperType->getTypeOfMember(
-        dc->getParentModule(), wrapperInfo.valueVar);
+        wrapperInfo.valueVar);
   }
 
   // The property type must be equal to the wrapped value type

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -297,7 +297,7 @@ computeSelfTypeRelationship(DeclContext *dc, ValueDecl *decl1,
 
   // If the model type does not conform to the protocol, the bases are
   // unrelated.
-  auto conformance = dc->getParentModule()->lookupConformance(modelTy, proto);
+  auto conformance = ModuleDecl::lookupConformance(modelTy, proto);
   if (conformance.isInvalid())
     return {SelfTypeRelationship::Unrelated, conformance};
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11526,7 +11526,7 @@ ConstraintSystem::simplifyPropertyWrapperConstraint(
     return SolutionKind::Error;
   }
 
-  auto resolvedType = wrapperType->getTypeOfMember(DC->getParentModule(), typeInfo.valueVar);
+  auto resolvedType = wrapperType->getTypeOfMember(typeInfo.valueVar);
   if (typeInfo.valueVar->isSettable(nullptr) && typeInfo.valueVar->isSetterAccessibleFrom(DC) &&
       !typeInfo.valueVar->isSetterMutating()) {
     resolvedType = LValueType::get(resolvedType);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8604,8 +8604,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   switch (kind) {
   case ConstraintKind::SelfObjectOfProtocol: {
     auto conformance = TypeChecker::containsProtocol(
-        type, protocol, DC->getParentModule(),
-        /*allowMissing=*/true);
+        type, protocol, /*allowMissing=*/true);
     if (conformance) {
       return recordConformance(conformance);
     }
@@ -10282,7 +10281,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
 
     if (shouldCheckSendabilityOfBase()) {
       auto sendableProtocol = Context.getProtocol(KnownProtocolKind::Sendable);
-      auto baseConformance = DC->getParentModule()->lookupConformance(
+      auto baseConformance = ModuleDecl::lookupConformance(
           instanceTy, sendableProtocol);
 
       if (llvm::any_of(

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13424,8 +13424,7 @@ lookupDynamicCallableMethods(NominalTypeDecl *decl, ConstraintSystem &CS,
   auto candidates = matches.ViableCandidates;
   auto filter = [&](OverloadChoice choice) {
     auto cand = cast<FuncDecl>(choice.getDecl());
-    return !isValidDynamicCallableMethod(cand, CS.DC->getParentModule(),
-                                         hasKeywordArgs);
+    return !isValidDynamicCallableMethod(cand, hasKeywordArgs);
   };
   candidates.erase(
       std::remove_if(candidates.begin(), candidates.end(), filter),

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -681,7 +681,6 @@ bool IsDeclRefinementOfRequest::evaluate(Evaluator &evaluator,
     return false;
 
   auto result = checkRequirements(
-      declA->getDeclContext()->getParentModule(),
       genericSignatureB.getRequirements(),
       QueryTypeSubstitutionMap{ substMap });
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -778,7 +778,6 @@ createDesignatedInitOverride(ClassDecl *classDecl,
     // satisfied by the derived class. In this case, we don't want to inherit
     // this initializer; there's no way to call it on the derived class.
     auto checkResult = checkRequirements(
-        classDecl->getParentModule(),
         superclassCtorSig.getRequirements(),
         [&](Type type) -> Type {
           auto substType = type.subst(subMap);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1383,7 +1383,7 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
       return false;
 
     auto targetType = target->getDeclaredInterfaceType();
-    auto ref = target->getParentModule()->lookupConformance(
+    auto ref = ModuleDecl::lookupConformance(
         targetType, protocol);
     if (ref.isInvalid()) {
       return false;

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -767,7 +767,6 @@ addDistributedActorCodableConformance(
   assert(proto->isSpecificProtocol(swift::KnownProtocolKind::Decodable) ||
          proto->isSpecificProtocol(swift::KnownProtocolKind::Encodable));
   auto &C = actor->getASTContext();
-  auto module = actor->getParentModule();
 
   // === Only Distributed actors can gain this implicit conformance
   if (!actor->isDistributedActor()) {
@@ -776,7 +775,7 @@ addDistributedActorCodableConformance(
 
   // === Does the actor explicitly conform to the protocol already?
   auto explicitConformance =
-      module->lookupConformance(actor->getInterfaceType(), proto);
+      ModuleDecl::lookupConformance(actor->getInterfaceType(), proto);
   if (!explicitConformance.isInvalid()) {
     // ok, it was conformed explicitly -- let's not synthesize;
     return nullptr;
@@ -1071,12 +1070,10 @@ NormalProtocolConformance *
 GetDistributedActorAsActorConformanceRequest::evaluate(
     Evaluator &evaluator, ProtocolDecl *distributedActorProto) const {
   auto &ctx = distributedActorProto->getASTContext();
-  auto swiftModule = ctx.getStdlibModule();
-
   auto actorProto = ctx.getProtocol(KnownProtocolKind::Actor);
 
   auto ext = findDistributedActorAsActorExtension(
-      distributedActorProto, swiftModule);
+      distributedActorProto);
   if (!ext)
     return nullptr;
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -972,7 +972,6 @@ VarDecl *GetDistributedActorIDPropertyRequest::evaluate(
 VarDecl *GetDistributedActorSystemPropertyRequest::evaluate(
     Evaluator &evaluator, NominalTypeDecl *nominal) const {
   auto &C = nominal->getASTContext();
-  auto module = nominal->getParentModule();
 
   auto DAS = C.getDistributedActorSystemDecl();
 
@@ -988,7 +987,7 @@ VarDecl *GetDistributedActorSystemPropertyRequest::evaluate(
     auto DistributedActorProto = C.getDistributedActorDecl();
     for (auto system : DistributedActorProto->lookupDirect(C.Id_actorSystem)) {
       if (auto var = dyn_cast<VarDecl>(system)) {
-        auto conformance = module->checkConformance(
+        auto conformance = ModuleDecl::checkConformance(
             proto->mapTypeIntoContext(var->getInterfaceType()),
             DAS);
 
@@ -1063,9 +1062,9 @@ bool CanSynthesizeDistributedActorCodableConformanceRequest::evaluate(
     return false;
 
   return TypeChecker::conformsToKnownProtocol(
-             idTy, KnownProtocolKind::Decodable, actor->getParentModule()) &&
+             idTy, KnownProtocolKind::Decodable) &&
          TypeChecker::conformsToKnownProtocol(
-             idTy, KnownProtocolKind::Encodable, actor->getParentModule());
+             idTy, KnownProtocolKind::Encodable);
 }
 
 NormalProtocolConformance *

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2723,8 +2723,7 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
   if (auto *typeDecl = dyn_cast<TypeDecl>(value)) {
     assert(!isa<ModuleDecl>(typeDecl) && "Nested module?");
 
-    auto memberTy = TypeChecker::substMemberTypeWithBase(DC->getParentModule(),
-                                                         typeDecl, baseObjTy);
+    auto memberTy = TypeChecker::substMemberTypeWithBase(typeDecl, baseObjTy);
 
     // If the member type is a constraint, e.g. because the
     // reference is to a typealias with an underlying protocol

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7772,8 +7772,7 @@ ConstraintSystem::lookupConformance(Type type, ProtocolDecl *protocol) {
     return cachedConformance->second;
 
   auto conformance =
-      DC->getParentModule()->lookupConformance(type, protocol,
-                                               /*allowMissing=*/true);
+      ModuleDecl::lookupConformance(type, protocol, /*allowMissing=*/true);
   Conformances[cacheKey] = conformance;
   return conformance;
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1030,12 +1030,11 @@ static void checkNestedTypeConstraints(ConstraintSystem &cs, Type type,
   auto extension = dyn_cast<ExtensionDecl>(decl->getDeclContext());
   if (extension && extension->isConstrainedExtension()) {
     auto contextSubMap = parentTy->getContextSubstitutionMap(
-        extension->getParentModule(), extension->getSelfNominalTypeDecl());
+        extension->getSelfNominalTypeDecl());
     if (!subMap) {
       // The substitution map wasn't set above, meaning we should grab the map
       // for the extension itself.
-      subMap = parentTy->getContextSubstitutionMap(extension->getParentModule(),
-                                                   extension);
+      subMap = parentTy->getContextSubstitutionMap(extension);
     }
 
     if (auto signature = decl->getGenericSignature()) {
@@ -1372,8 +1371,7 @@ getPropertyWrapperInformationFromOverload(
       VarDecl *memberDecl;
       std::tie(memberDecl, type) = *declInformation;
       if (Type baseType = resolvedOverload.choice.getBaseType()) {
-        type =
-            baseType->getTypeOfMember(DC->getParentModule(), memberDecl, type);
+        type = baseType->getTypeOfMember(memberDecl, type);
       }
       return std::make_pair(decl, type);
     }

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -78,7 +78,7 @@ bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal,
     if (v->getInterfaceType()->hasError())
       return false;
     auto varType = DC->mapTypeIntoContext(v->getValueInterfaceType());
-    return (bool) DC->getParentModule()->checkConformance(varType, proto);
+    return (bool) ModuleDecl::checkConformance(varType, proto);
   });
 }
 

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -110,10 +110,9 @@ deriveBodyMathOperator(AbstractFunctionDecl *funcDecl, MathOperator op) {
 
   // Create expression combining lhs and rhs members using member operator.
   auto createMemberOpExpr = [&](VarDecl *member) -> Expr * {
-    auto module = nominal->getModuleContext();
     auto memberType =
         parentDC->mapTypeIntoContext(member->getValueInterfaceType());
-    auto confRef = module->lookupConformance(memberType, proto);
+    auto confRef = ModuleDecl::lookupConformance(memberType, proto);
     assert(confRef && "Member does not conform to math protocol");
 
     // Get member type's math operator, e.g. `Member.+`.
@@ -249,8 +248,7 @@ deriveBodyPropertyGetter(AbstractFunctionDecl *funcDecl, ProtocolDecl *proto,
           new (C) MemberRefExpr(selfDRE, SourceLoc(), member, DeclNameLoc(),
                                 /*Implicit*/ true);
     }
-    auto *module = nominal->getModuleContext();
-    auto confRef = module->lookupConformance(memberType, proto);
+    auto confRef = ModuleDecl::lookupConformance(memberType, proto);
     assert(confRef && "Member does not conform to `AdditiveArithmetic`");
     // If conformance reference is not concrete, then concrete witness
     // declaration for property cannot be resolved. Return reference to

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -338,7 +338,7 @@ static bool validateCodingKeysEnum(const DerivedConformance &derived,
     // We have a property to map to. Ensure it's {En,De}codable.
     auto target = derived.getConformanceContext()->mapTypeIntoContext(
          it->second->getValueInterfaceType());
-    if (derived.getParentModule()->checkConformance(target, derived.Protocol)
+    if (ModuleDecl::checkConformance(target, derived.Protocol)
             .isInvalid()) {
       TypeLoc typeLoc = {
           it->second->getTypeReprOrParentPatternTypeRepr(),
@@ -1945,7 +1945,7 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement,
     if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
       DeclName memberName;
       auto superType = superclassDecl->getDeclaredInterfaceType();
-      if (derived.getParentModule()->checkConformance(superType, proto)) {
+      if (ModuleDecl::checkConformance(superType, proto)) {
         // super.init(from:) must be accessible.
         memberName = cast<ConstructorDecl>(requirement)->getName();
       } else {

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -42,10 +42,8 @@ static bool superclassConformsTo(ClassDecl *target, KnownProtocolKind kpk) {
   if (!superclass)
     return false;
 
-  return !superclass
-              ->getModuleContext()
-              ->lookupConformance(target->getSuperclass(),
-                                  target->getASTContext().getProtocol(kpk))
+  return !ModuleDecl::lookupConformance(target->getSuperclass(),
+                                        target->getASTContext().getProtocol(kpk))
               .isInvalid();
 }
 
@@ -271,7 +269,7 @@ static EnumDecl *validateCodingKeysType(const DerivedConformance &derived,
 
   // Ensure that the type we found conforms to the CodingKey protocol.
   auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
-  if (!derived.getParentModule()->lookupConformance(codingKeysType, codingKeyProto)) {
+  if (!ModuleDecl::lookupConformance(codingKeysType, codingKeyProto)) {
     // If CodingKeys is a typealias which doesn't point to a valid nominal type,
     // codingKeysTypeDecl will be nullptr here. In that case, we need to warn on
     // the location of the usage, since there isn't an underlying type to
@@ -1407,7 +1405,7 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
             });
         auto *encodableProto = C.getProtocol(KnownProtocolKind::Encodable);
         bool conformsToEncodable =
-            conformanceDC->getParentModule()->lookupConformance(
+            ModuleDecl::lookupConformance(
                 targetDecl->getDeclaredInterfaceType(), encodableProto) != nullptr;
 
         // Strategy to use for CodingKeys enum diagnostic part - this is to

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -240,10 +240,9 @@ deriveBodyDifferentiable_move(AbstractFunctionDecl *funcDecl, void *) {
   // Create call expression applying a member `move(by:)` method to a
   // parameter member: `self.<member>.move(by: offset.<member>)`.
   auto createMemberMethodCallExpr = [&](VarDecl *member) -> Expr * {
-    auto *module = nominal->getModuleContext();
     auto memberType =
         parentDC->mapTypeIntoContext(member->getValueInterfaceType());
-    auto confRef = module->lookupConformance(memberType, diffProto);
+    auto confRef = ModuleDecl::lookupConformance(memberType, diffProto);
     assert(confRef && "Member does not conform to `Differentiable`");
 
     // Get member type's requirement witness: `<Member>.move(by:)`.

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -84,7 +84,7 @@ getStoredPropertiesForDifferentiation(
     if (vd->getInterfaceType()->hasError())
       continue;
     auto varType = DC->mapTypeIntoContext(vd->getValueInterfaceType());
-    auto conformance = DC->getParentModule()->checkConformance(
+    auto conformance = ModuleDecl::checkConformance(
         varType, diffableProto);
     if (!conformance)
       continue;
@@ -118,7 +118,7 @@ static Type getTangentVectorInterfaceType(Type contextualType,
   auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
   assert(diffableProto && "`Differentiable` protocol not found");
   auto conf =
-      DC->getParentModule()->checkConformance(contextualType, diffableProto);
+      ModuleDecl::checkConformance(contextualType, diffableProto);
   assert(conf && "Contextual type must conform to `Differentiable`");
   if (!conf)
     return nullptr;
@@ -140,7 +140,7 @@ static bool canDeriveTangentVectorAsSelf(NominalTypeDecl *nominal,
   auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
   auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
   // `Self` must conform to `AdditiveArithmetic`.
-  if (!DC->getParentModule()->checkConformance(nominalTypeInContext, addArithProto))
+  if (!ModuleDecl::checkConformance(nominalTypeInContext, addArithProto))
     return false;
   for (auto *field : nominal->getStoredProperties()) {
     // `Self` must not have any `@noDerivative` stored properties.
@@ -148,7 +148,7 @@ static bool canDeriveTangentVectorAsSelf(NominalTypeDecl *nominal,
       return false;
     // `Self` must have all stored properties satisfy `Self == TangentVector`.
     auto fieldType = DC->mapTypeIntoContext(field->getValueInterfaceType());
-    auto conf = DC->getParentModule()->checkConformance(fieldType, diffableProto);
+    auto conf = ModuleDecl::checkConformance(fieldType, diffableProto);
     if (!conf)
       return false;
     auto tangentType = conf.getTypeWitnessByName(fieldType, C.Id_TangentVector);
@@ -211,7 +211,7 @@ bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal,
     if (v->getInterfaceType()->hasError())
       return false;
     auto varType = DC->mapTypeIntoContext(v->getValueInterfaceType());
-    return (bool) DC->getParentModule()->checkConformance(varType, diffableProto);
+    return (bool) ModuleDecl::checkConformance(varType, diffableProto);
   });
 }
 
@@ -553,7 +553,7 @@ static void checkAndDiagnoseImplicitNoDerivative(ASTContext &Context,
     // Check whether to diagnose stored property.
     auto varType = DC->mapTypeIntoContext(vd->getValueInterfaceType());
     auto diffableConformance =
-        DC->getParentModule()->checkConformance(varType, diffableProto);
+        ModuleDecl::checkConformance(varType, diffableProto);
     // If stored property should not be diagnosed, continue.
     if (diffableConformance && 
         canInvokeMoveByOnProperty(vd, diffableConformance))

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -720,7 +720,7 @@ deriveBodyDistributedActor_unownedExecutor(AbstractFunctionDecl *getter, void *)
 
           return Type();
         },
-        LookUpConformanceInModule(getter->getParentModule())
+        LookUpConformanceInModule()
     );
     DeclRefExpr *buildRemoteExecutorExpr =
         new (ctx) DeclRefExpr(

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -878,15 +878,13 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   // We can't form a Hashable conformance if Int isn't Hashable or
   // ExpressibleByIntegerLiteral.
   if (!TypeChecker::conformsToKnownProtocol(
-          intType, KnownProtocolKind::Hashable,
-          derived.getParentModule())) {
+          intType, KnownProtocolKind::Hashable)) {
     derived.ConformanceDecl->diagnose(diag::broken_int_hashable_conformance);
     return nullptr;
   }
 
   if (!TypeChecker::conformsToKnownProtocol(
-          intType, KnownProtocolKind::ExpressibleByIntegerLiteral,
-          derived.getParentModule())) {
+          intType, KnownProtocolKind::ExpressibleByIntegerLiteral)) {
     derived.ConformanceDecl->diagnose(
       diag::broken_int_integer_literal_convertible_conformance);
     return nullptr;

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -843,7 +843,7 @@ deriveBodyHashable_hashValue(AbstractFunctionDecl *hashValueDecl, void *) {
 
         return Type(dependentType);
       },
-      LookUpConformanceInModule(hashValueDecl->getModuleContext()));
+      LookUpConformanceInModule());
   ConcreteDeclRef hashFuncRef(hashFunc, substitutions);
 
   Type hashFuncType = hashFunc->getInterfaceType().subst(substitutions);

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -419,8 +419,7 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
 
   assert([&]() -> bool {
     return TypeChecker::conformsToKnownProtocol(
-        rawType, KnownProtocolKind::Equatable,
-        derived.getParentModule());
+        rawType, KnownProtocolKind::Equatable);
   }());
 
   auto *rawDecl = new (C)
@@ -477,8 +476,7 @@ bool DerivedConformance::canDeriveRawRepresentable(DeclContext *DC,
 
   // The raw type must be Equatable, so that we have a suitable ~= for
   // synthesized switch statements.
-  if (!TypeChecker::conformsToKnownProtocol(rawType, KnownProtocolKind::Equatable,
-                                            DC->getParentModule()))
+  if (!TypeChecker::conformsToKnownProtocol(rawType, KnownProtocolKind::Equatable))
     return false;
 
   auto &C = type->getASTContext();

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -294,7 +294,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     auto proto = ctx.getProtocol(kind);
     if (!proto) return nullptr;
 
-    auto conformance = nominal->getParentModule()->lookupConformance(
+    auto conformance = ModuleDecl::lookupConformance(
         nominal->getDeclaredInterfaceType(), proto);
     if (conformance) {
       auto DC = conformance.getConcrete()->getDeclContext();

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -474,10 +474,9 @@ DerivedConformance::createBuiltinCall(ASTContext &ctx,
   ConcreteDeclRef declRef = decl;
   auto fnType = decl->getInterfaceType();
   if (auto genericFnType = fnType->getAs<GenericFunctionType>()) {
-    auto builtinModule = decl->getModuleContext();
     auto generics = genericFnType->getGenericSignature();
     auto subs = SubstitutionMap::get(generics, typeArgs,
-                                     LookUpConformanceInModule{builtinModule});
+                                     LookUpConformanceInModule{});
     declRef = ConcreteDeclRef(decl, subs);
     fnType = genericFnType->substGenericArgs(subs);
   } else {

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -188,8 +188,8 @@ DerivedConformance::storedPropertiesNotConformingToProtocol(
     if (!type)
       nonconformingProperties.push_back(propertyDecl);
 
-    if (!DC->getParentModule()->checkConformance(DC->mapTypeIntoContext(type),
-                                                 protocol)) {
+    if (!ModuleDecl::checkConformance(DC->mapTypeIntoContext(type),
+                                      protocol)) {
       nonconformingProperties.push_back(propertyDecl);
     }
   }
@@ -842,8 +842,8 @@ DerivedConformance::associatedValuesNotConformingToProtocol(
 
     for (auto param : *PL) {
       auto type = param->getInterfaceType();
-      if (DC->getParentModule()->checkConformance(DC->mapTypeIntoContext(type),
-                                                  protocol).isInvalid()) {
+      if (ModuleDecl::checkConformance(DC->mapTypeIntoContext(type),
+                                       protocol).isInvalid()) {
         nonconformingAssociatedValues.push_back(param);
       }
     }

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -138,8 +138,7 @@ static bool isExtensionWithSelfBound(const ExtensionDecl *ED,
   if (selfType->is<ExistentialType>())
     return false;
 
-  auto *M = ED->getParentModule();
-  return ED->getExtendedNominal() == PD || M->checkConformance(selfType, PD);
+  return ED->getExtendedNominal() == PD || ModuleDecl::checkConformance(selfType, PD);
 }
 
 static bool isExtensionAppliedInternal(const DeclContext *DC, Type BaseTy,

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -171,7 +171,7 @@ static bool isExtensionAppliedInternal(const DeclContext *DC, Type BaseTy,
   auto *module = DC->getParentModule();
   GenericSignature genericSig = ED->getGenericSignature();
   SubstitutionMap substMap = BaseTy->getContextSubstitutionMap(
-      module, ED->getExtendedNominal());
+      ED->getExtendedNominal());
   return checkRequirements(module,
                            genericSig.getRequirements(),
                            QuerySubstitutionMap{substMap}) ==
@@ -213,7 +213,7 @@ static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
   // outer generic parameters.
   auto *module = DC->getParentModule();
   auto substMap = BaseTy->getContextSubstitutionMap(
-      module, VD->getDeclContext(), genericDecl->getGenericEnvironment());
+      VD->getDeclContext(), genericDecl->getGenericEnvironment());
 
   // The innermost generic parameters are mapped to error types.
   unsigned innerDepth = genericSig->getMaxDepth();

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -167,12 +167,10 @@ static bool isExtensionAppliedInternal(const DeclContext *DC, Type BaseTy,
   if (isExtensionWithSelfBound(ED, BaseTypeProtocolDecl)) {
     return true;
   }
-  auto *module = DC->getParentModule();
   GenericSignature genericSig = ED->getGenericSignature();
   SubstitutionMap substMap = BaseTy->getContextSubstitutionMap(
       ED->getExtendedNominal());
-  return checkRequirements(module,
-                           genericSig.getRequirements(),
+  return checkRequirements(genericSig.getRequirements(),
                            QuerySubstitutionMap{substMap}) ==
          CheckRequirementsResult::Success;
 }
@@ -210,7 +208,6 @@ static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
 
   // The context substitution map for the base type fixes the declaration's
   // outer generic parameters.
-  auto *module = DC->getParentModule();
   auto substMap = BaseTy->getContextSubstitutionMap(
       VD->getDeclContext(), genericDecl->getGenericEnvironment());
 
@@ -221,8 +218,7 @@ static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
 
   // We treat substitution failure as success, to ignore requirements
   // that involve innermost generic parameters.
-  return checkRequirements(module,
-                           genericSig.getRequirements(),
+  return checkRequirements(genericSig.getRequirements(),
                            [&](SubstitutableType *type) -> Type {
                              auto *paramTy = cast<GenericTypeParamType>(type);
                              if (paramTy->getDepth() == innerDepth)

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -828,11 +828,11 @@ template <> struct DenseMapInfo<FoundDeclTy> {
 // If a class 'Base' conforms to 'Proto', and my base type is a subclass
 // 'Derived' of 'Base', use 'Base' not 'Derived' as the 'Self' type in the
 // substitution map.
-static Type getBaseTypeForMember(ModuleDecl *M, const ValueDecl *OtherVD,
+static Type getBaseTypeForMember(const ValueDecl *OtherVD,
                                  Type BaseTy) {
   if (auto *Proto = OtherVD->getDeclContext()->getSelfProtocolDecl()) {
     if (BaseTy->getClassOrBoundGenericClass()) {
-      if (auto Conformance = M->lookupConformance(BaseTy, Proto)) {
+      if (auto Conformance = ModuleDecl::lookupConformance(BaseTy, Proto)) {
         auto *Superclass = Conformance.getConcrete()
                                ->getRootConformance()
                                ->getType()
@@ -953,7 +953,7 @@ public:
           } else {
             GenEnv = DC->getGenericEnvironmentOfContext();
           }
-          auto subs = BaseTy->getMemberSubstitutionMap(M, VD, GenEnv);
+          auto subs = BaseTy->getMemberSubstitutionMap(VD, GenEnv);
           auto CT = GenFuncSignature->substGenericArgs(subs);
           if (!CT->hasError()) {
             return CT->getCanonicalType();
@@ -977,7 +977,7 @@ public:
           continue;
 
         auto OtherSignature = OtherVD->getOverloadSignature();
-        auto ActualBaseTy = getBaseTypeForMember(M, OtherVD, BaseTy);
+        auto ActualBaseTy = getBaseTypeForMember(OtherVD, BaseTy);
         auto OtherSignatureType = substGenericArgs(
             OtherVD->getOverloadSignatureType(), OtherVD, ActualBaseTy);
 
@@ -1140,7 +1140,7 @@ static void lookupVisibleDynamicMemberLookupDecls(
       continue;
 
     auto subs =
-        baseType->getMemberSubstitutionMap(dc->getParentModule(), subscript);
+        baseType->getMemberSubstitutionMap(subscript);
     auto memberType = rootType.subst(subs);
     if (!memberType->mayHaveMembers())
       continue;

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -446,7 +446,6 @@ static void lookupDeclsFromProtocolsBeingConformedTo(
   NominalTypeDecl *CurrNominal = BaseTy->getAnyNominal();
   if (!CurrNominal)
     return;
-  ModuleDecl *Module = FromContext->getParentModule();
 
   for (auto Conformance : CurrNominal->getAllConformances()) {
     auto Proto = Conformance->getProtocol();
@@ -462,7 +461,7 @@ static void lookupDeclsFromProtocolsBeingConformedTo(
     // couldn't be computed, so assume they conform in such cases.
     if (!BaseTy->hasUnboundGenericType()) {
       if (auto res = Conformance->getConditionalRequirementsIfAvailable()) {
-        if (!res->empty() && !Module->checkConformance(BaseTy, Proto))
+        if (!res->empty() && !ModuleDecl::checkConformance(BaseTy, Proto))
           continue;
       }
     }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3410,10 +3410,9 @@ public:
           bool conforms = llvm::all_of(
               OpaqueDecl->getOpaqueInterfaceGenericSignature()
                   .getRequirements(),
-              [&exprType, this](auto requirement) {
+              [&exprType](auto requirement) {
                 if (requirement.getKind() == RequirementKind::Conformance) {
-                  auto conformance = Implementation->getModuleContext()
-                      ->checkConformance(
+                  auto conformance = ModuleDecl::checkConformance(
                       exprType->getRValueType(),
                       requirement.getProtocolDecl(),
                       /*allowMissing=*/false);
@@ -5975,11 +5974,10 @@ static void diagnoseExplicitUseOfLazyVariableStorage(const Expr *E,
 static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
   class ComparisonWithNaNFinder : public ASTWalker {
     const ASTContext &C;
-    const DeclContext *DC;
 
   public:
     ComparisonWithNaNFinder(const DeclContext *dc)
-        : C(dc->getASTContext()), DC(dc) {}
+        : C(dc->getASTContext()) {}
 
     void tryDiagnoseComparisonWithNaN(BinaryExpr *BE) {
       ValueDecl *comparisonDecl = nullptr;
@@ -6019,11 +6017,9 @@ static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
 
       // Both arguments must conform to FloatingPoint protocol.
       if (!TypeChecker::conformsToKnownProtocol(firstArg->getType(),
-                                                KnownProtocolKind::FloatingPoint,
-                                                DC->getParentModule()) ||
+                                                KnownProtocolKind::FloatingPoint) ||
           !TypeChecker::conformsToKnownProtocol(secondArg->getType(),
-                                                KnownProtocolKind::FloatingPoint,
-                                                DC->getParentModule())) {
+                                                KnownProtocolKind::FloatingPoint)) {
         return;
       }
 

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -2436,7 +2436,7 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
       return nullptr;
   }
 
-  return DC->getParentModule()->lookupConformance(castTy, protocol)
+  return ModuleDecl::lookupConformance(castTy, protocol)
              ? CoerceExpr::forLiteralInit(getASTContext(), literal,
                                           call->getSourceRange(),
                                           typeExpr->getTypeRepr())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1810,9 +1810,9 @@ void TypeChecker::checkDeclAttributes(Decl *D) {
 /// @dynamicCallable attribute requirement. The method is given to be defined
 /// as one of the following: `dynamicallyCall(withArguments:)` or
 /// `dynamicallyCall(withKeywordArguments:)`.
-bool swift::isValidDynamicCallableMethod(FuncDecl *decl, ModuleDecl *module,
+bool swift::isValidDynamicCallableMethod(FuncDecl *decl,
                                          bool hasKeywordArguments) {
-  auto &ctx = module->getASTContext();
+  auto &ctx = decl->getASTContext();
   // There are two cases to check.
   // 1. `dynamicallyCall(withArguments:)`.
   //    In this case, the method is valid if the argument has type `A` where
@@ -1833,7 +1833,7 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, ModuleDecl *module,
   if (!hasKeywordArguments) {
     auto arrayLitProto =
       ctx.getProtocol(KnownProtocolKind::ExpressibleByArrayLiteral);
-    return (bool) module->checkConformance(argType, arrayLitProto);
+    return (bool) ModuleDecl::checkConformance(argType, arrayLitProto);
   }
   // If keyword arguments, check that argument type conforms to
   // `ExpressibleByDictionaryLiteral` and that the `Key` associated type
@@ -1842,11 +1842,11 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, ModuleDecl *module,
     ctx.getProtocol(KnownProtocolKind::ExpressibleByStringLiteral);
   auto dictLitProto =
     ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral);
-  auto dictConf = module->checkConformance(argType, dictLitProto);
+  auto dictConf = ModuleDecl::checkConformance(argType, dictLitProto);
   if (dictConf.isInvalid())
     return false;
   auto keyType = dictConf.getTypeWitnessByName(argType, ctx.Id_Key);
-  return (bool) module->checkConformance(keyType, stringLitProtocol);
+  return (bool) ModuleDecl::checkConformance(keyType, stringLitProtocol);
 }
 
 /// Returns true if the given nominal type has a valid implementation of a
@@ -1861,10 +1861,9 @@ static bool hasValidDynamicCallableMethod(NominalTypeDecl *decl,
   if (candidates.empty()) return false;
 
   // Filter valid candidates.
-  auto *module = decl->getParentModule();
   candidates.filter([&](LookupResultEntry entry, bool isOuter) {
     auto candidate = cast<FuncDecl>(entry.getValueDecl());
-    return isValidDynamicCallableMethod(candidate, module, hasKeywordArgs);
+    return isValidDynamicCallableMethod(candidate, hasKeywordArgs);
   });
 
   // If there are no valid candidates, return false.
@@ -1913,17 +1912,15 @@ static bool hasSingleNonVariadicParam(SubscriptDecl *decl,
 /// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
 /// The method is given to be defined as `subscript(dynamicMember:)`.
 bool swift::isValidDynamicMemberLookupSubscript(SubscriptDecl *decl,
-                                                ModuleDecl *module,
                                                 bool ignoreLabel) {
   // It could be
   // - `subscript(dynamicMember: {Writable}KeyPath<...>)`; or
   // - `subscript(dynamicMember: String*)`
   return isValidKeyPathDynamicMemberLookup(decl, ignoreLabel) ||
-         isValidStringDynamicMemberLookup(decl, module, ignoreLabel);
+         isValidStringDynamicMemberLookup(decl, ignoreLabel);
 }
 
 bool swift::isValidStringDynamicMemberLookup(SubscriptDecl *decl,
-                                             ModuleDecl *module,
                                              bool ignoreLabel) {
   auto &ctx = decl->getASTContext();
   // There are two requirements:
@@ -1938,7 +1935,7 @@ bool swift::isValidStringDynamicMemberLookup(SubscriptDecl *decl,
 
   // If this is `subscript(dynamicMember: String*)`
   return TypeChecker::conformsToKnownProtocol(
-      paramType, KnownProtocolKind::ExpressibleByStringLiteral, module);
+      paramType, KnownProtocolKind::ExpressibleByStringLiteral);
 }
 
 bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
@@ -1994,8 +1991,6 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   auto type = decl->getDeclaredType();
   auto &ctx = decl->getASTContext();
 
-  auto *module = decl->getParentModule();
-
   auto emitInvalidTypeDiagnostic = [&](const SourceLoc loc) {
     diagnose(loc, diag::invalid_dynamic_member_lookup_type, type);
     attr->setInvalid();
@@ -2011,7 +2006,7 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
     auto oneCandidate = candidates.front().getValueDecl();
     candidates.filter([&](LookupResultEntry entry, bool isOuter) -> bool {
       auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-      return isValidDynamicMemberLookupSubscript(cand, module);
+      return isValidDynamicMemberLookupSubscript(cand);
     });
 
     if (candidates.empty()) {
@@ -2033,8 +2028,7 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   // Validate the candidates while ignoring the label.
   newCandidates.filter([&](const LookupResultEntry entry, bool isOuter) {
     auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-    return isValidDynamicMemberLookupSubscript(cand, module,
-                                               /*ignoreLabel*/ true);
+    return isValidDynamicMemberLookupSubscript(cand, /*ignoreLabel*/ true);
   });
 
   // If there were no potentially valid candidates, then throw an error.
@@ -2687,8 +2681,8 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
   }
 
   if (!ApplicationDelegateProto ||
-      !CD->getParentModule()->checkConformance(CD->getDeclaredInterfaceType(),
-                                               ApplicationDelegateProto)) {
+      !ModuleDecl::checkConformance(CD->getDeclaredInterfaceType(),
+                                    ApplicationDelegateProto)) {
     diagnose(attr->getLocation(),
              diag::attr_ApplicationMain_not_ApplicationDelegate,
              applicationMainKind);
@@ -3802,7 +3796,7 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
   }
 
   // The type eraser must conform to the annotated protocol
-  if (!module->checkConformance(typeEraser, protocol)) {
+  if (!ModuleDecl::checkConformance(typeEraser, protocol)) {
     diags.diagnose(attr->getLoc(), diag::type_eraser_does_not_conform,
                    typeEraser, protocolType);
     diags.diagnose(nominalTypeDecl->getLoc(), diag::type_eraser_declared_here);
@@ -5046,12 +5040,12 @@ SpecializeAttrTargetDeclRequest::evaluate(Evaluator &evaluator,
 /// Returns true if the given type conforms to `Differentiable` in the given
 /// context. If `tangentVectorEqualsSelf` is true, also check whether the given
 /// type satisfies `TangentVector == Self`.
-static bool conformsToDifferentiable(Type type, ModuleDecl *module,
+static bool conformsToDifferentiable(Type type,
                                      bool tangentVectorEqualsSelf = false) {
-  auto &ctx = module->getASTContext();
+  auto &ctx = type->getASTContext();
   auto *differentiableProto =
       ctx.getProtocol(KnownProtocolKind::Differentiable);
-  auto conf = module->checkConformance(type, differentiableProto);
+  auto conf = ModuleDecl::checkConformance(type, differentiableProto);
   if (conf.isInvalid())
     return false;
   if (!tangentVectorEqualsSelf)
@@ -5086,7 +5080,7 @@ IndexSubset *TypeChecker::inferDifferentiabilityParameters(
     if (paramType->isExistentialType())
       return false;
     // Return true if the type conforms to `Differentiable`.
-    return conformsToDifferentiable(paramType, module);
+    return conformsToDifferentiable(paramType);
   };
 
   // Get all parameter types.
@@ -5146,7 +5140,7 @@ static IndexSubset *computeDifferentiabilityParameters(
         selfType = derivativeGenEnv->mapTypeIntoContext(selfType);
       else
         selfType = function->mapTypeIntoContext(selfType);
-      if (!conformsToDifferentiable(selfType, module)) {
+      if (!conformsToDifferentiable(selfType)) {
         diags
             .diagnose(attrLoc, diag::diff_function_no_parameters, function)
             .highlight(function->getSignatureSourceRange());
@@ -6676,7 +6670,7 @@ static bool checkLinearityParameters(
         parsedLinearParams.empty() ? attrLoc : parsedLinearParams[i].getLoc();
     // Parameter must conform to `Differentiable` and satisfy
     // `Self == Self.TangentVector`.
-    if (!conformsToDifferentiable(linearParamType, module,
+    if (!conformsToDifferentiable(linearParamType,
                                   /*tangentVectorEqualsSelf*/ true)) {
       diags.diagnose(loc,
                      diag::transpose_attr_invalid_linearity_parameter_or_result,
@@ -6723,7 +6717,6 @@ doTransposeStaticAndInstanceSelfTypesMatch(AnyFunctionType *transposeType,
 
 void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
   auto *transpose = cast<FuncDecl>(D);
-  auto *module = transpose->getParentModule();
   auto originalName = attr->getOriginalFunctionName();
   auto *transposeInterfaceType =
       transpose->getInterfaceType()->castTo<AnyFunctionType>();
@@ -6789,7 +6782,7 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
   if (expectedOriginalResultType->hasTypeParameter())
     expectedOriginalResultType = transpose->mapTypeIntoContext(
         expectedOriginalResultType);
-  if (!conformsToDifferentiable(expectedOriginalResultType, module,
+  if (!conformsToDifferentiable(expectedOriginalResultType,
                                 /*tangentVectorEqualsSelf*/ true)) {
     diagnoseAndRemoveAttr(
         attr, diag::transpose_attr_invalid_linearity_parameter_or_result,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2753,7 +2753,7 @@ synthesizeMainBody(AbstractFunctionDecl *fn, void *arg) {
     substitutionMap = SubstitutionMap::get(
       environment->getGenericSignature(),
       [&](SubstitutableType *type) { return nominal->getDeclaredType(); },
-      LookUpConformanceInModule(nominal->getModuleContext()));
+      LookUpConformanceInModule());
   } else {
     substitutionMap = SubstitutionMap();
   }
@@ -3848,8 +3848,7 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
     // the requirements in the generic signature are satisfied.
     auto *module = nominalTypeDecl->getParentModule();
     auto baseMap =
-        typeEraser->getContextSubstitutionMap(module,
-                                              nominalTypeDecl);
+        typeEraser->getContextSubstitutionMap(nominalTypeDecl);
     QuerySubstitutionMap getSubstitution{baseMap};
 
     auto result = checkRequirements(
@@ -5799,7 +5798,7 @@ bool resolveDifferentiableAttrDifferentiabilityParameters(
   auto expectedLinearMapTypeOrError =
       originalFnRemappedTy->getAutoDiffDerivativeFunctionLinearMapType(
           diffParamIndices, AutoDiffLinearMapKind::Differential,
-          LookUpConformanceInModule(original->getModuleContext()),
+          LookUpConformanceInModule(),
           /*makeSelfParamFirst*/ true);
 
   // Helper for diagnosing derivative function type errors.
@@ -6421,7 +6420,7 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
   auto expectedLinearMapTypeOrError =
       originalFnType->getAutoDiffDerivativeFunctionLinearMapType(
           resolvedDiffParamIndices, kind.getLinearMapKind(),
-          LookUpConformanceInModule(derivative->getModuleContext()),
+          LookUpConformanceInModule(),
           /*makeSelfParamFirst*/ true);
 
   // Helper for diagnosing derivative function type errors.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3840,13 +3840,12 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
     // type conforming to the annotated protocol. We will check this by
     // substituting the protocol's Self type for the generic arg and check that
     // the requirements in the generic signature are satisfied.
-    auto *module = nominalTypeDecl->getParentModule();
     auto baseMap =
         typeEraser->getContextSubstitutionMap(nominalTypeDecl);
     QuerySubstitutionMap getSubstitution{baseMap};
 
     auto result = checkRequirements(
-          module, genericSignature.getRequirements(),
+          genericSignature.getRequirements(),
           [&](SubstitutableType *type) -> Type {
             if (type->isEqual(genericParamType))
               return protocol->getSelfTypeInContext();

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -4236,8 +4236,7 @@ public:
     if (isa<ProtocolType>(ty))
       return Action::Continue;
 
-    ModuleDecl *useModule = Where.getDeclContext()->getParentModule();
-    auto subs = ty->getContextSubstitutionMap(useModule, ty->getDecl());
+    auto subs = ty->getContextSubstitutionMap(ty->getDecl());
     (void) diagnoseSubstitutionMapAvailability(Loc, subs, Where);
     return Action::Continue;
   }
@@ -4245,8 +4244,7 @@ public:
   Action visitBoundGenericType(BoundGenericType *ty) override {
     visitTypeDecl(ty->getDecl());
 
-    ModuleDecl *useModule = Where.getDeclContext()->getParentModule();
-    auto subs = ty->getContextSubstitutionMap(useModule, ty->getDecl());
+    auto subs = ty->getContextSubstitutionMap(ty->getDecl());
     (void)diagnoseSubstitutionMapAvailability(
         Loc, subs, Where,
         /*depTy=*/Type(),

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3916,11 +3916,11 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
 
 /// Return true if the specified type looks like an integer of floating point
 /// type.
-static bool isIntegerOrFloatingPointType(Type ty, ModuleDecl *M) {
+static bool isIntegerOrFloatingPointType(Type ty) {
   return (TypeChecker::conformsToKnownProtocol(
-            ty, KnownProtocolKind::ExpressibleByIntegerLiteral, M) ||
+            ty, KnownProtocolKind::ExpressibleByIntegerLiteral) ||
           TypeChecker::conformsToKnownProtocol(
-            ty, KnownProtocolKind::ExpressibleByFloatLiteral, M));
+            ty, KnownProtocolKind::ExpressibleByFloatLiteral));
 }
 
 
@@ -3948,9 +3948,8 @@ ExprAvailabilityWalker::diagnoseIncDecRemoval(const ValueDecl *D, SourceRange R,
 
   // If the expression type is integer or floating point, then we can rewrite it
   // to "lvalue += 1".
-  auto *DC = Where.getDeclContext();
   std::string replacement;
-  if (isIntegerOrFloatingPointType(call->getType(), DC->getParentModule()))
+  if (isIntegerOrFloatingPointType(call->getType()))
     replacement = isInc ? " += 1" : " -= 1";
   else {
     // Otherwise, it must be an index type.  Rewrite to:

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -142,7 +142,7 @@ bool BitwiseCopyableStorageVisitor::visitMemberDecl(ValueDecl *decl, Type ty) {
 }
 
 bool BitwiseCopyableStorageVisitor::visitMemberType(Type ty, SourceLoc loc) {
-  auto conformance = module->checkConformance(ty, protocol);
+  auto conformance = ModuleDecl::checkConformance(ty, protocol);
   if (conformance.isInvalid() || conformance.hasUnavailableConformance()) {
     return visitNonconformingMemberType(ty, loc);
   }

--- a/lib/Sema/TypeCheckCircularity.cpp
+++ b/lib/Sema/TypeCheckCircularity.cpp
@@ -249,8 +249,7 @@ bool CircularityChecker::expandStruct(CanType type, StructDecl *S,
                                       unsigned depth) {
   startExpandingType(type);
 
-  auto subMap = type->getContextSubstitutionMap(
-      S->getModuleContext(), S);
+  auto subMap = type->getContextSubstitutionMap(S);
 
   for (auto field: S->getStoredProperties()) {
     auto fieldType =field->getValueInterfaceType().subst(subMap);
@@ -273,8 +272,7 @@ bool CircularityChecker::expandEnum(CanType type, EnumDecl *E,
 
   startExpandingType(type);
 
-  auto subMap = type->getContextSubstitutionMap(
-      E->getModuleContext(), E);
+  auto subMap = type->getContextSubstitutionMap(E);
 
   for (auto elt: E->getAllElements()) {
     // Indirect elements are representational leaves.
@@ -472,8 +470,7 @@ void CircularityChecker::addPathElement(Path &path, ValueDecl *member,
     elt.TupleIndex = 0;
 
     Type memberIfaceType = getMemberStorageInterfaceType(member);
-    elt.Ty = parentType->getTypeOfMember(member->getModuleContext(), member,
-                                         memberIfaceType);
+    elt.Ty = parentType->getTypeOfMember(member, memberIfaceType);
 
   } else {
     auto tupleType = parentType->castTo<TupleType>();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6054,6 +6054,10 @@ bool swift::checkSendableConformance(
     }
   }
 
+  // In -swift-version 5 mode, a conditional conformance to a protocol can imply
+  // a Sendable conformance. The implied conformance is unconditional, so check
+  // the storage for sendability as if the conformance was declared on the nominal,
+  // and not some (possibly constrained) extension.
   if (conformance->getSourceKind() == ConformanceEntryKind::Implied)
     conformanceDC = nominal;
   return checkSendableInstanceStorage(nominal, conformanceDC, check);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1288,8 +1288,7 @@ inferSendableFromInstanceStorage(NominalTypeDecl *nominal,
       if (!sendableProto)
         return true;
 
-      auto module = nominal->getParentModule();
-      auto conformance = module->checkConformance(type, sendableProto);
+      auto conformance = ModuleDecl::checkConformance(type, sendableProto);
       if (conformance.isInvalid())
         return true;
 
@@ -6213,8 +6212,7 @@ ProtocolConformance *swift::deriveImplicitSendableConformance(
   // form an inherited conformance.
   if (classDecl) {
     if (Type superclass = classDecl->getSuperclass()) {
-      auto classModule = classDecl->getParentModule();
-      auto inheritedConformance = classModule->checkConformance(
+      auto inheritedConformance = ModuleDecl::checkConformance(
           classDecl->mapTypeIntoContext(superclass),
           proto, /*allowMissing=*/false);
       if (inheritedConformance.hasUnavailableConformance())

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4963,10 +4963,9 @@ static bool checkClassGlobalActorIsolation(
   case ActorIsolation::GlobalActor: {
     // If the global actors match, we're fine.
     Type superclassGlobalActor = superIsolation.getGlobalActor();
-    auto module = classDecl->getParentModule();
     SubstitutionMap subsMap = classDecl->getDeclaredInterfaceType()
       ->getSuperclassForDecl(superclassDecl)
-      ->getContextSubstitutionMap(module, superclassDecl);
+      ->getContextSubstitutionMap(superclassDecl);
     Type superclassGlobalActorInSub = superclassGlobalActor.subst(subsMap);
     if (isolation.getGlobalActor()->isEqual(superclassGlobalActorInSub))
       return false;
@@ -5006,8 +5005,7 @@ static ActorIsolation getOverriddenIsolationFor(ValueDecl *value) {
 
   SubstitutionMap subs;
   if (Type selfType = value->getDeclContext()->getSelfInterfaceType()) {
-    subs = selfType->getMemberSubstitutionMap(
-        value->getModuleContext(), overridden);
+    subs = selfType->getMemberSubstitutionMap(overridden);
   }
   return isolation.subst(subs);
 }
@@ -5416,7 +5414,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
               return ActorIsolation::forUnspecified();
 
             SubstitutionMap subs = superclassType->getMemberSubstitutionMap(
-                classDecl->getModuleContext(), classDecl);
+                classDecl);
             superclassIsolation = superclassIsolation.subst(subs);
           }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1177,12 +1177,10 @@ swift::computeAutomaticEnumValueKind(EnumDecl *ED) {
   if (ED->getGenericEnvironmentOfContext() != nullptr)
     rawTy = ED->mapTypeIntoContext(rawTy);
 
-  auto *module = ED->getParentModule();
-
   // Swift enums require that the raw type is convertible from one of the
   // primitive literal protocols.
   auto conformsToProtocol = [&](KnownProtocolKind protoKind) {
-    return TypeChecker::conformsToKnownProtocol(rawTy, protoKind, module);
+    return TypeChecker::conformsToKnownProtocol(rawTy, protoKind);
   };
 
   static auto otherLiteralProtocolKinds = {
@@ -2538,8 +2536,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       ProtocolDecl *errorProto = Context.getErrorDecl();
       if (thrownTy && errorProto) {
         Type thrownTyInContext = AFD->mapTypeIntoContext(thrownTy);
-        if (!AFD->getParentModule()->checkConformance(
-                thrownTyInContext, errorProto)) {
+        if (!ModuleDecl::checkConformance(thrownTyInContext, errorProto)) {
           SourceLoc loc;
           if (auto thrownTypeRepr = AFD->getThrownTypeRepr())
             loc = thrownTypeRepr->getLoc();

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -488,8 +488,7 @@ static void checkForEmptyOptionSet(const VarDecl *VD) {
   // Make sure this type conforms to OptionSet
   bool conformsToOptionSet =
     (bool)TypeChecker::conformsToKnownProtocol(DC->getSelfTypeInContext(),
-                                               KnownProtocolKind::OptionSet,
-                                               DC->getParentModule());
+                                               KnownProtocolKind::OptionSet);
   
   if (!conformsToOptionSet)
     return;
@@ -1421,11 +1420,9 @@ buildDefaultInitializerString(DeclContext *dc, Pattern *pattern) {
     // Special-case the various types we might see here.
     auto type = pattern->getType();
 
-    auto *module = dc->getParentModule();
-
     // For literal-convertible types, form the corresponding literal.
 #define CHECK_LITERAL_PROTOCOL(Kind, String)                                       \
-  if (TypeChecker::conformsToKnownProtocol(type, KnownProtocolKind::Kind, module)) \
+  if (TypeChecker::conformsToKnownProtocol(type, KnownProtocolKind::Kind)) \
     return std::string(String);
 
     CHECK_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "[]")

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1543,8 +1543,7 @@ static void diagnoseClassWithoutInitializers(ClassDecl *classDecl) {
   if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
     auto *decodableProto = C.getProtocol(KnownProtocolKind::Decodable);
     auto superclassType = superclassDecl->getDeclaredInterfaceType();
-    auto ref = classDecl->getParentModule()->lookupConformance(
-        superclassType, decodableProto);
+    auto ref = ModuleDecl::lookupConformance(superclassType, decodableProto);
     if (ref) {
       // super conforms to Decodable, so we've failed to inherit init(from:).
       // Let's suggest overriding it here.
@@ -1572,8 +1571,7 @@ static void diagnoseClassWithoutInitializers(ClassDecl *classDecl) {
       // likely that the user forgot to override its encode(to:). In this case,
       // we can produce a slightly different diagnostic to suggest doing so.
       auto *encodableProto = C.getProtocol(KnownProtocolKind::Encodable);
-      auto ref = classDecl->getParentModule()->lookupConformance(
-          superclassType, encodableProto);
+      auto ref = ModuleDecl::lookupConformance(superclassType, encodableProto);
       if (ref) {
         // We only want to produce this version of the diagnostic if the
         // subclass doesn't directly implement encode(to:).
@@ -1798,8 +1796,7 @@ static void diagnoseRetroactiveConformances(
     proto->walkInheritedProtocols([&](ProtocolDecl *decl) {
 
       // Get the original conformance of the extended type to this protocol.
-      auto conformanceRef = ext->getParentModule()->lookupConformance(
-          extendedType, decl);
+      auto conformanceRef = ModuleDecl::lookupConformance(extendedType, decl);
       if (!conformanceRef.isConcrete()) {
         return TypeWalker::Action::Continue;
       }

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -404,7 +404,7 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
 }
 
 static bool checkDistributedTargetResultType(
-    ModuleDecl *module, ValueDecl *valueDecl,
+    ValueDecl *valueDecl,
     Type serializationRequirement,
     bool diagnose) {
   auto &C = valueDecl->getASTContext();
@@ -442,7 +442,7 @@ static bool checkDistributedTargetResultType(
 
   for (auto serializationReq: serializationRequirements) {
     auto conformance =
-        module->checkConformance(resultType, serializationReq);
+        ModuleDecl::checkConformance(resultType, serializationReq);
     if (conformance.isInvalid()) {
       if (diagnose) {
         llvm::StringRef conformanceToSuggest = isCodableRequirement ?
@@ -535,7 +535,6 @@ bool CheckDistributedFunctionRequest::evaluate(
   }
 
   auto &C = func->getASTContext();
-  auto module = func->getParentModule();
 
   /// If no distributed module is available, then no reason to even try checks.
   if (!C.getLoadedModule(C.Id_Distributed)) {
@@ -560,7 +559,7 @@ bool CheckDistributedFunctionRequest::evaluate(
 
       auto srl = serializationReqType->getExistentialLayout();
       for (auto req: srl.getProtocols()) {
-        if (module->checkConformance(paramTy, req).isInvalid()) {
+        if (ModuleDecl::checkConformance(paramTy, req).isInvalid()) {
           auto diag = func->diagnose(
               diag::distributed_actor_func_param_not_codable,
               param->getArgumentName().str(), param->getInterfaceType(),
@@ -611,7 +610,7 @@ bool CheckDistributedFunctionRequest::evaluate(
   }
 
   // --- Result type must be either void or a serialization requirement conforming type
-  if (checkDistributedTargetResultType(module, func, serializationReqType,
+  if (checkDistributedTargetResultType(func, serializationReqType,
                                        /*diagnose=*/true)) {
     return true;
   }
@@ -657,8 +656,7 @@ bool swift::checkDistributedActorProperty(VarDecl *var, bool diagnose) {
   auto serializationRequirement =
       getDistributedActorSerializationType(var->getDeclContext());
 
-  auto module = var->getModuleContext();
-  if (checkDistributedTargetResultType(module, var, serializationRequirement, diagnose)) {
+  if (checkDistributedTargetResultType(var, serializationRequirement, diagnose)) {
     return true;
   }
 

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -374,7 +374,7 @@ std::optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
       Type newType;
       if (lookupType && !lookupType->isAnyObject()) {
-        newType = lookupType->getTypeOfMember(dc->getParentModule(), type,
+        newType = lookupType->getTypeOfMember(type,
                                               type->getDeclaredInterfaceType());
       } else {
         newType = type->getDeclaredInterfaceType();

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1003,7 +1003,7 @@ CheckGenericArgumentsResult TypeChecker::checkGenericArgumentsForDiagnostics(
   SmallVector<WorklistItem, 4> worklist;
 
   for (auto req : llvm::reverse(requirements)) {
-    auto substReq = req.subst(substitutions, LookUpConformanceInModule(module));
+    auto substReq = req.subst(substitutions, LookUpConformanceInModule());
     worklist.emplace_back(req, substReq, ParentConditionalConformances{});
   }
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -475,8 +475,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
     }
 
     // Substitute the base into the member's type.
-    auto memberType = substMemberTypeWithBase(dc->getParentModule(),
-                                              typeDecl, type);
+    auto memberType = substMemberTypeWithBase(typeDecl, type);
 
     // If we haven't seen this type result yet, add it to the result set.
     if (types.insert(memberType->getCanonicalType()).second)
@@ -516,7 +515,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
         continue;
 
       auto memberType =
-          substMemberTypeWithBase(dc->getParentModule(), typeDecl, type);
+          substMemberTypeWithBase(typeDecl, type);
       if (types.insert(memberType->getCanonicalType()).second)
         result.addResult({typeDecl, memberType, assocType});
     }

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -154,7 +154,7 @@ namespace {
 
       // Dig out the protocol conformance.
       auto *foundProto = cast<ProtocolDecl>(foundDC);
-      auto conformance = DC->getParentModule()->lookupConformance(
+      auto conformance = ModuleDecl::lookupConformance(
           conformingType, foundProto);
       if (conformance.isInvalid()) {
         if (foundInType->isExistentialType()) {
@@ -490,7 +490,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       // member entirely.
       auto *protocol = cast<ProtocolDecl>(assocType->getDeclContext());
 
-      auto conformance = dc->getParentModule()->lookupConformance(type, protocol);
+      auto conformance = ModuleDecl::lookupConformance(type, protocol);
       if (!conformance) {
         // FIXME: This is an error path. Should we try to recover?
         continue;

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1620,8 +1620,7 @@ Pattern *TypeChecker::coercePatternToType(
       
       Type elementType;
       if (argType)
-        elementType = enumTy->getTypeOfMember(elt->getModuleContext(),
-                                              elt, argType);
+        elementType = enumTy->getTypeOfMember(elt, argType);
       else
         elementType = TupleType::getEmpty(Context);
       auto newSubOptions = subOptions;
@@ -1642,8 +1641,7 @@ Pattern *TypeChecker::coercePatternToType(
       // Else if the element pattern has no sub-pattern but the element type has
       // associated values, expand it to be semantically equivalent to an
       // element pattern of wildcards.
-      Type elementType = enumTy->getTypeOfMember(elt->getModuleContext(),
-                                                 elt, argType);
+      Type elementType = enumTy->getTypeOfMember(elt, argType);
       SmallVector<TuplePatternElt, 8> elements;
       if (auto *TTy = dyn_cast<TupleType>(elementType.getPointer())) {
         for (auto &elt : TTy->getElements()) {

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -664,7 +664,6 @@ Type swift::computeWrappedValueType(const VarDecl *var, Type backingStorageType,
                                     
   // Follow the chain of wrapped value properties.
   Type wrappedValueType = backingStorageType;
-  DeclContext *dc = var->getDeclContext();
   while (realLimit--) {
     auto *nominal = wrappedValueType->getDesugaredType()->getAnyNominal();
     if (!nominal)
@@ -691,7 +690,6 @@ Type swift::computeProjectedValueType(const VarDecl *var, Type backingStorageTyp
   if (var->hasImplicitPropertyWrapper())
     return backingStorageType;
 
-  DeclContext *dc = var->getDeclContext();
   auto wrapperInfo = var->getAttachedPropertyWrapperTypeInfo(0);
   return backingStorageType->getTypeOfMember(wrapperInfo.projectedValueVar);
 }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -675,7 +675,6 @@ Type swift::computeWrappedValueType(const VarDecl *var, Type backingStorageType,
       return wrappedValueType;
 
     wrappedValueType = wrappedValueType->getTypeOfMember(
-        dc->getParentModule(),
         wrappedInfo.valueVar,
         wrappedInfo.valueVar->getValueInterfaceType());
     if (wrappedValueType->hasError())
@@ -694,8 +693,7 @@ Type swift::computeProjectedValueType(const VarDecl *var, Type backingStorageTyp
 
   DeclContext *dc = var->getDeclContext();
   auto wrapperInfo = var->getAttachedPropertyWrapperTypeInfo(0);
-  return backingStorageType->getTypeOfMember(dc->getParentModule(),
-                                             wrapperInfo.projectedValueVar);
+  return backingStorageType->getTypeOfMember(wrapperInfo.projectedValueVar);
 }
 
 Expr *swift::buildPropertyWrapperInitCall(

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2417,7 +2417,9 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
 
   bool allowImpliedConditionalConformance = false;
   if (Proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
-    if (Context.LangOpts.StrictConcurrencyLevel != StrictConcurrency::Complete)
+    // In -swift-version 5 mode, a conditional conformance to a protocol can imply
+    // a Sendable conformance.
+    if (!Context.LangOpts.isSwiftVersionAtLeast(6))
       allowImpliedConditionalConformance = true;
   } else if (Proto->isMarkerProtocol()) {
     allowImpliedConditionalConformance = true;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -499,15 +499,14 @@ unsigned LocalDiscriminatorsRequest::evaluate(
 /// \endcode
 static void tryDiagnoseUnnecessaryCastOverOptionSet(ASTContext &Ctx,
                                                     Expr *E,
-                                                    Type ResultType,
-                                                    ModuleDecl *module) {
+                                                    Type ResultType) {
   auto *NTD = ResultType->getAnyNominal();
   if (!NTD)
     return;
   auto optionSetType = dyn_cast_or_null<ProtocolDecl>(Ctx.getOptionSetDecl());
   if (!optionSetType)
     return;
-  if (!module->lookupConformance(ResultType, optionSetType))
+  if (!ModuleDecl::lookupConformance(ResultType, optionSetType))
     return;
 
   auto *CE = dyn_cast<CallExpr>(E);
@@ -1089,7 +1088,7 @@ public:
       RS->setResult(resultTarget->getAsExpr());
     } else {
       tryDiagnoseUnnecessaryCastOverOptionSet(getASTContext(), RS->getResult(),
-                                              ResultTy, DC->getParentModule());
+                                              ResultTy);
     }
     return RS;
   }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1002,7 +1002,6 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
       auto subs = result->getType()
           ->getWithoutSpecifierType()
           ->getContextSubstitutionMap(
-            accessor->getParentModule(),
             underlyingVar->getDeclContext());
 
       ConcreteDeclRef memberRef(underlyingVar, subs);
@@ -1068,10 +1067,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
       // fails (because, for instance, a generic parameter of a generic nominal
       // type cannot be resolved).
       if (!selfTypeForAccess->is<ErrorType>()) {
-        subs =
-          selfTypeForAccess->getContextSubstitutionMap(
-            accessor->getParentModule(),
-            baseClass);
+        subs = selfTypeForAccess->getContextSubstitutionMap(baseClass);
       }
 
       storage = override;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1313,7 +1313,7 @@ static ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var,
   auto proto = ctx.getNSCopyingDecl();
 
   if (proto) {
-    if (auto result = dc->getParentModule()->checkConformance(type, proto))
+    if (auto result = ModuleDecl::checkConformance(type, proto))
       return result;
   }
 

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -848,7 +848,7 @@ namespace {
                 SmallVector<Space, 4> constElemSpaces;
                 if (auto payloadTy = eed->getArgumentInterfaceType()) {
                   auto eedTy = tp->getCanonicalType()->getTypeOfMember(
-                      E->getModuleContext(), eed, payloadTy);
+                      eed, payloadTy);
                   if (auto *TTy = eedTy->getAs<TupleType>()) {
                     Space::getTupleTypeSpaces(eedTy, TTy, constElemSpaces);
                   } else if (auto *TTy =

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1228,8 +1228,7 @@ static void maybeDiagnoseBadConformanceRef(DeclContext *dc,
   // If we weren't given a conformance, go look it up.
   ProtocolConformance *conformance = nullptr;
   if (protocol) {
-    auto conformanceRef = dc->getParentModule()->lookupConformance(
-        parentTy, protocol);
+    auto conformanceRef = ModuleDecl::lookupConformance(parentTy, protocol);
     if (conformanceRef.isConcrete())
       conformance = conformanceRef.getConcrete();
   }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1166,14 +1166,14 @@ Type TypeResolution::applyUnboundGenericArguments(
 
   // Apply the substitution map to the interface type of the declaration.
   resultType = resultType.subst(QueryTypeSubstitutionMap{subs},
-                                LookUpConformanceInModule(module));
+                                LookUpConformanceInModule());
 
   // Form a sugared typealias reference.
   if (typealias && (!parentTy || !parentTy->isAnyExistentialType())) {
     auto genericSig = typealias->getGenericSignature();
     auto subMap = SubstitutionMap::get(genericSig,
                                        QueryTypeSubstitutionMap{subs},
-                                       LookUpConformanceInModule(module));
+                                       LookUpConformanceInModule());
     resultType = TypeAliasType::get(typealias, parentTy, subMap, resultType);
   }
 
@@ -4099,7 +4099,7 @@ NeverNullType TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
 
     subMap = SubstitutionMap::get(
         genericSig, QueryTypeSubstitutionMap{genericArgMap},
-        LookUpConformanceInModule(getDeclContext()->getParentModule()));
+        LookUpConformanceInModule());
   }
 
   bool capturesGenerics = claim<CapturesGenericsTypeAttr>(attrs);
@@ -4307,7 +4307,7 @@ NeverNullType TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
     }
     return SubstitutionMap::get(
                sig, QueryTypeSubstitutionMap{subsMap},
-               LookUpConformanceInModule(getDeclContext()->getParentModule()))
+               LookUpConformanceInModule())
         .getCanonical();
   };
 
@@ -5866,7 +5866,7 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
     if (baseTy->is<ErrorType>())
       return ErrorType::get(memberType);
 
-    subs = baseTy->getMemberSubstitutionMap(module, member);
+    subs = baseTy->getMemberSubstitutionMap(member);
     resultType = memberType.subst(subs);
   } else {
     resultType = memberType;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3996,7 +3996,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
       thrownTy = Type();
     } else if (!options.contains(TypeResolutionFlags::SilenceErrors) &&
                !thrownTy->hasTypeParameter() &&
-               !resolution.getDeclContext()->getParentModule()->checkConformance(
+               !ModuleDecl::checkConformance(
                   thrownTy, ctx.getErrorDecl())) {
       diagnoseInvalid(
           thrownTypeRepr, thrownTypeRepr->getLoc(), diag::thrown_type_not_error,
@@ -4377,8 +4377,8 @@ NeverNullType TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
       selfType = next;
     }
 
-    witnessMethodConformance = getDeclContext()->getParentModule()
-      ->checkConformance(selfType, protocolType->getDecl());
+    witnessMethodConformance = ModuleDecl::checkConformance(
+        selfType, protocolType->getDecl());
     assert(witnessMethodConformance &&
            "found witness_method without matching conformance");
   }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -310,8 +310,7 @@ Type TypeResolution::resolveDependentMemberType(
     }
   }
 
-  return TypeChecker::substMemberTypeWithBase(DC->getParentModule(), concrete,
-                                              baseTy);
+  return TypeChecker::substMemberTypeWithBase(concrete, baseTy);
 }
 
 bool TypeResolution::areSameType(Type type1, Type type2) const {
@@ -580,7 +579,7 @@ Type TypeResolution::resolveTypeInContext(TypeDecl *typeDecl,
 
   // Finally, substitute the base type into the member type.
   return TypeChecker::substMemberTypeWithBase(
-      fromDC->getParentModule(), typeDecl, selfType, /*useArchetypes=*/false);
+      typeDecl, selfType, /*useArchetypes=*/false);
 }
 
 /// This function checks if a bound generic type is UnsafePointer<Void> or
@@ -1872,8 +1871,7 @@ static Type resolveQualifiedIdentTypeRepr(const TypeResolution &resolution,
   // Phase 2: If a declaration has already been bound, use it.
   if (auto *typeDecl = repr->getBoundDecl()) {
     auto memberType =
-      TypeChecker::substMemberTypeWithBase(DC->getParentModule(), typeDecl,
-                                           parentTy);
+      TypeChecker::substMemberTypeWithBase(typeDecl, parentTy);
     return maybeDiagnoseBadMemberType(typeDecl, memberType, nullptr);
   }
 
@@ -5796,8 +5794,7 @@ NeverNullType TypeResolver::buildProtocolType(
   return MetatypeType::get(instanceType, storedRepr);
 }
 
-Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
-                                          TypeDecl *member,
+Type TypeChecker::substMemberTypeWithBase(TypeDecl *member,
                                           Type baseTy,
                                           bool useArchetypes) {
   Type sugaredBaseTy = baseTy;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -612,7 +612,7 @@ bool TypeChecker::isDifferentiable(Type type, bool tangentVectorEqualsSelf,
   if (stage)
     type = dc->mapTypeIntoContext(type);
   auto tanSpace = type->getAutoDiffTangentSpace(
-      LookUpConformanceInModule(dc->getParentModule()));
+      LookUpConformanceInModule());
   if (!tanSpace)
     return false;
   // If no `Self == Self.TangentVector` requirement, return true.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -810,15 +810,14 @@ ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
 
 /// Check whether the type conforms to a given known protocol.
 bool conformsToKnownProtocol(Type type, KnownProtocolKind protocol,
-                             ModuleDecl *module, bool allowMissing = true);
+                             bool allowMissing = true);
 
 /// This is similar to \c conformsToProtocol, but returns \c true for cases where
 /// the type \p T could be dynamically cast to \p Proto protocol, such as a non-final
 /// class where a subclass conforms to \p Proto.
 ///
 /// \returns True if \p T conforms to the protocol \p Proto, false otherwise.
-bool couldDynamicallyConformToProtocol(Type T, ProtocolDecl *Proto,
-                                       ModuleDecl *M);
+bool couldDynamicallyConformToProtocol(Type T, ProtocolDecl *Proto);
 
 /// Check all of the conformances in the given context.
 void checkConformancesInContext(IterableDeclContext *idc);
@@ -1308,13 +1307,13 @@ diag::RequirementKind getProtocolRequirementKind(ValueDecl *Requirement);
 /// @dynamicCallable attribute requirement. The method is given to be defined
 /// as one of the following: `dynamicallyCall(withArguments:)` or
 /// `dynamicallyCall(withKeywordArguments:)`.
-bool isValidDynamicCallableMethod(FuncDecl *decl, ModuleDecl *module,
+bool isValidDynamicCallableMethod(FuncDecl *decl,
                                   bool hasKeywordArguments);
 
 /// Returns true if the given subscript method is an valid implementation of
 /// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
 /// The method is given to be defined as `subscript(dynamicMember:)`.
-bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl, ModuleDecl *module,
+bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl,
                                          bool ignoreLabel = false);
 
 /// Returns true if the given subscript method is an valid implementation of
@@ -1322,7 +1321,7 @@ bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl, ModuleDecl *module
 /// The method is given to be defined as `subscript(dynamicMember:)` which
 /// takes a single non-variadic parameter that conforms to
 /// `ExpressibleByStringLiteral` protocol.
-bool isValidStringDynamicMemberLookup(SubscriptDecl *decl, ModuleDecl *module,
+bool isValidStringDynamicMemberLookup(SubscriptDecl *decl,
                                       bool ignoreLabel = false);
 
 /// Returns true if the given subscript method is an valid implementation of

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -804,7 +804,6 @@ Expr *addImplicitLoadExpr(
 /// \returns the conformance, if \c T conforms to the protocol \c Proto, or
 /// an empty optional.
 ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
-                                        ModuleDecl *M,
                                         bool allowMissing=false);
 
 /// Check whether the type conforms to a given known protocol.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -322,13 +322,12 @@ void checkExistentialTypes(ASTContext &ctx,
 /// Substitute the given base type into the type of the given nested type,
 /// producing the effective type that the nested type will have.
 ///
-/// \param module The module in which the substitution will be performed.
 /// \param member The member whose type projection is being computed.
 /// \param baseTy The base type that will be substituted for the 'Self' of the
 /// member.
 /// \param useArchetypes Whether to use context archetypes for outer generic
 /// parameters if the class is nested inside a generic function.
-Type substMemberTypeWithBase(ModuleDecl *module, TypeDecl *member, Type baseTy,
+Type substMemberTypeWithBase(TypeDecl *member, Type baseTy,
                              bool useArchetypes = true);
 
 /// Determine whether this is a "pass-through" typealias, which has the

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -485,9 +485,8 @@ static SubstitutionMap getSubMapForDecl(const ValueDecl *D, Type BaseType) {
   else
     DC = D->getInnermostDeclContext()->getInnermostTypeContext();
 
-  swift::ModuleDecl *M = DC->getParentModule();
   if (isa<swift::NominalTypeDecl>(D) || isa<swift::ExtensionDecl>(D)) {
-    return BaseType->getContextSubstitutionMap(M, DC);
+    return BaseType->getContextSubstitutionMap(DC);
   }
 
   const swift::ValueDecl *SubTarget = D;
@@ -496,7 +495,7 @@ static SubstitutionMap getSubMapForDecl(const ValueDecl *D, Type BaseType) {
     if (auto *FD = dyn_cast<swift::AbstractFunctionDecl>(DC))
       SubTarget = FD;
   }
-  return BaseType->getMemberSubstitutionMap(M, SubTarget);
+  return BaseType->getMemberSubstitutionMap(SubTarget);
 }
 
 void Symbol::serializeSwiftGenericMixin(llvm::json::OStream &OS) const {

--- a/test/Concurrency/implied_sendable_conformance_swift5.swift
+++ b/test/Concurrency/implied_sendable_conformance_swift5.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
-// RUN: %target-swift-emit-silgen %s -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -strict-concurrency=complete
+// RUN: %target-swift-emit-silgen %s -swift-version 5 -strict-concurrency=complete
 
 protocol P: Sendable {}
 protocol Q: Sendable {}

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -79,7 +79,7 @@ deliverResults(SourceKit::ConformingMethodListConsumer &SKConsumer,
 
       auto funcTy = cast<FuncDecl>(member)->getMethodInterfaceType();
       funcTy = Result->Result->ExprType->getTypeOfMember(
-          Result->Result->DC->getParentModule(), member, funcTy);
+          member, funcTy);
       auto resultTy = funcTy->castTo<FunctionType>()->getResult();
 
       // Name.

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -274,7 +274,6 @@ static void initDocGenericParams(const Decl *D, DocEntityInfo &Info,
   // substitution).
   unsigned TypeContextDepth = 0;
   SubstitutionMap SubMap;
-  ModuleDecl *M = nullptr;
   Type BaseType;
   if (SynthesizedTarget) {
     BaseType = SynthesizedTarget.getBaseNominal()->getDeclaredInterfaceType();
@@ -284,8 +283,7 @@ static void initDocGenericParams(const Decl *D, DocEntityInfo &Info,
         DC = cast<ExtensionDecl>(D)->getExtendedNominal();
       else
         DC = D->getInnermostDeclContext()->getInnermostTypeContext();
-      M = DC->getParentModule();
-      SubMap = BaseType->getContextSubstitutionMap(M, DC);
+      SubMap = BaseType->getContextSubstitutionMap(DC);
       TypeContextDepth = SubMap.getGenericSignature().getNextDepth();
     }
   }
@@ -301,7 +299,7 @@ static void initDocGenericParams(const Decl *D, DocEntityInfo &Info,
         return type;
       },
       [&](CanType depType, Type substType, ProtocolDecl *proto) {
-        return M->lookupConformance(substType, proto);
+        return ModuleDecl::lookupConformance(substType, proto);
       },
       SubstFlags::DesugarMemberTypes);
   };

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -922,8 +922,7 @@ void SwiftLangSupport::printMemberDeclDescription(const swift::ValueDecl *VD,
   OS << VD->getBaseName().userFacingName();
 
   // Parameters.
-  auto *M = VD->getModuleContext();
-  auto substMap = baseTy->getMemberSubstitutionMap(M, VD);
+  auto substMap = baseTy->getMemberSubstitutionMap(VD);
   auto printSingleParam = [&](ParamDecl *param) {
     auto paramTy = param->getInterfaceType();
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1232,8 +1232,7 @@ static int printConformingMethodList(
         llvm::outs() << "\n";
         for (auto VD : Result->Members) {
           auto funcTy = cast<FuncDecl>(VD)->getMethodInterfaceType();
-          funcTy = Result->ExprType->getTypeOfMember(
-              Result->DC->getParentModule(), VD, funcTy);
+          funcTy = Result->ExprType->getTypeOfMember(VD, funcTy);
           auto resultTy = funcTy->castTo<FunctionType>()->getResult();
 
           llvm::outs() << "   - Name: ";


### PR DESCRIPTION
It has never taken the module into account, and callers are just passing in the nearest random module they can reach from whatever other AST object they have on hand.