### PR TITLE
[concurrency/stdlib] declare `POSIXErrorCode` as `Sendable`

### DIFF
--- a/stdlib/public/Platform/POSIXError.swift
+++ b/stdlib/public/Platform/POSIXError.swift
@@ -14,7 +14,7 @@
 
 /// Enumeration describing POSIX error codes.
 @objc
-public enum POSIXErrorCode : Int32 {
+public enum POSIXErrorCode: Int32, Sendable {
   /// Operation not permitted.
   case EPERM           = 1
   /// No such file or directory.
@@ -266,7 +266,7 @@ public enum POSIXErrorCode : Int32 {
 #elseif os(Linux) || os(Android)
 
 /// Enumeration describing POSIX error codes.
-public enum POSIXErrorCode : Int32 {
+public enum POSIXErrorCode: Int32, Sendable {
   /// Operation not permitted.
   case EPERM           = 1
   /// No such file or directory.
@@ -561,7 +561,7 @@ public enum POSIXErrorCode : Int32 {
 // Matches WASI-libc declarations at https://github.com/WebAssembly/wasi-libc/blob/ad513341/libc-bottom-half/headers/public/wasi/api.h#L106
 
 /// Enumeration describing POSIX error codes.
-public enum POSIXErrorCode : Int32 {
+public enum POSIXErrorCode: Int32, Sendable {
   /// Argument list too long.
   case E2BIG           = 1
   /// Permission denied.
@@ -727,7 +727,7 @@ public enum POSIXErrorCode : Int32 {
 #elseif os(Windows)
 
 /// Enumeration describing POSIX error codes.
-public enum POSIXErrorCode : Int32 {
+public enum POSIXErrorCode: Int32, Sendable {
     
     /// Operation not permitted
     case EPERM          = 1
@@ -853,7 +853,7 @@ public enum POSIXErrorCode : Int32 {
 #elseif os(OpenBSD) || os(FreeBSD)
 
 /// Enumeration describing POSIX error codes.
-public enum POSIXErrorCode : Int32 {
+public enum POSIXErrorCode: Int32, Sendable {
     /// Operation not permitted
     case EPERM			= 1
     /// No such file or directory


### PR DESCRIPTION
This change makes `POSIXErrorCode` a `Sendable` type. `POSIXErrorCode` is an enum that simply maps an `Int32` value. It isn't frozen, though, so it is not inferred as Sendable.

Resolves rdar://99047401