### PR TITLE
[6.0][Concurrency] Fix build in actors as locks configuration

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1274,6 +1274,13 @@ static NonDefaultDistributedActorImpl *asImpl(NonDefaultDistributedActor *actor)
 /******************** NEW DEFAULT ACTOR IMPLEMENTATION ***********************/
 /*****************************************************************************/
 
+TaskExecutorRef TaskExecutorRef::fromTaskExecutorPreference(Job *job) {
+  if (auto task = dyn_cast<AsyncTask>(job)) {
+    return task->getPreferredTaskExecutor();
+  }
+  return TaskExecutorRef::undefined();
+}
+
 #if !SWIFT_CONCURRENCY_ACTORS_AS_LOCKS
 
 static void traceJobQueue(DefaultActorImpl *actor, Job *first) {
@@ -1318,13 +1325,6 @@ void DefaultActorImpl::scheduleActorProcessJob(
   }
 
   swift_task_enqueueGlobal(job);
-}
-
-TaskExecutorRef TaskExecutorRef::fromTaskExecutorPreference(Job *job) {
-  if (auto task = dyn_cast<AsyncTask>(job)) {
-    return task->getPreferredTaskExecutor();
-  }
-  return TaskExecutorRef::undefined();
 }
 
 void DefaultActorImpl::enqueue(Job *job, JobPriority priority) {


### PR DESCRIPTION
**Description:** Fixes build due to placement of function inside #if !SWIFT_CONCURRENCY_ACTORS_AS_LOCKS.

We have to start testing these configurations, it's gotten to a point where it's not possible to just keep it all in your head every time.

**Risk/reward:** low risk, moves a function out of wrong #if. Makes the build compile again

**Reviewed by:** @bnbarham 
**Original PR:** https://github.com/swiftlang/swift/pull/75004
**Radar:** resolves rdar://131195175