### PR TITLE
[Concurrency] Attempt to unbreak embedded build

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1161,7 +1161,9 @@ void swift::swift_task_run_inline(OpaqueValue *result, void *closureAFP,
   }
 
   ResultTypeInfo futureResultType;
+#if !SWIFT_CONCURRENCY_EMBEDDED
   futureResultType.metadata = futureResultTypeMetadata;
+#endif
 
   // Unpack the asynchronous function pointer.
   FutureAsyncSignature::FunctionType *closure;
@@ -1194,7 +1196,7 @@ void swift::swift_task_run_inline(OpaqueValue *result, void *closureAFP,
   size_t taskCreateFlags = 1 << TaskCreateFlags::Task_IsInlineTask;
 
   auto taskAndContext = swift_task_create_common(
-      taskCreateFlags, &option, futureResultType.metadata,
+      taskCreateFlags, &option, futureResultTypeMetadata,
       reinterpret_cast<TaskContinuationFunction *>(closure), closureContext,
       /*initialContextSize=*/closureContextSize);
 


### PR DESCRIPTION
**Description**: Unbreaks embedded build which cannot touch `metadata` field as it does not exist. No idea why this "worked" before, as this code was here for years and could not have worked on embedded.
**Scope/Impact**: Compilation fix for embedded.
**Risk:** Low
**Testing**: CI build
**Reviewed by**: @bnbarham 

**Original PR:** https://github.com/swiftlang/swift/pull/75006
**Radar:** rdar://131191938