### PR TITLE
Adopt SwiftIfConfig library to help with `#if` clause handling

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -252,9 +252,10 @@ enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedCanImportVersion : size_t {
   CanImportUnderlyingVersion,
 };
 
-SWIFT_NAME("BridgedASTContext.canImport(self:importPath:versionKind:versionComponents:numVersionComponents:)")
+SWIFT_NAME("BridgedASTContext.canImport(self:importPath:location:versionKind:versionComponents:numVersionComponents:)")
 bool BridgedASTContext_canImport(BridgedASTContext cContext,
                                  BridgedStringRef importPath,
+                                 BridgedSourceLoc canImportLoc,
                                  BridgedCanImportVersion versionKind,
                                  const SwiftInt * _Nullable versionComponents,
                                  SwiftInt numVersionComponents);

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -26,6 +26,7 @@
 #include "swift/AST/Attr.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/IfConfigClauseRangeInfo.h"
 #include "swift/AST/Stmt.h"
 #endif
 
@@ -1911,6 +1912,49 @@ SWIFT_NAME("BridgedParameterList.createParsed(_:leftParenLoc:parameters:"
 BridgedParameterList BridgedParameterList_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc cLeftParenLoc,
     BridgedArrayRef cParameters, BridgedSourceLoc cRightParenLoc);
+
+//===----------------------------------------------------------------------===//
+// MARK: #if handling
+//===----------------------------------------------------------------------===//
+
+/// Bridged version of IfConfigClauseRangeInfo::ClauseKind.
+enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedIfConfigClauseKind : size_t {
+  IfConfigActive,
+  IfConfigInactive,
+  IfConfigEnd
+};
+
+/// Bridged version of IfConfigClauseRangeInfo.
+struct BridgedIfConfigClauseRangeInfo {
+  BridgedSourceLoc directiveLoc;
+  BridgedSourceLoc bodyLoc;
+  BridgedSourceLoc endLoc;
+  BridgedIfConfigClauseKind kind;
+
+#ifdef USED_IN_CPP_SOURCE
+  swift::IfConfigClauseRangeInfo unbridged() const {
+    swift::IfConfigClauseRangeInfo::ClauseKind clauseKind;
+    switch (kind) {
+    case IfConfigActive:
+      clauseKind = swift::IfConfigClauseRangeInfo::ActiveClause;
+      break;
+
+    case IfConfigInactive:
+      clauseKind = swift::IfConfigClauseRangeInfo::InactiveClause;
+      break;
+
+    case IfConfigEnd:
+      clauseKind = swift::IfConfigClauseRangeInfo::EndDirective;
+      break;
+    }
+
+    return swift::IfConfigClauseRangeInfo(directiveLoc.unbridged(),
+                                          bodyLoc.unbridged(),
+                                          endLoc.unbridged(),
+                                          clauseKind);
+  }
+#endif
+};
 
 //===----------------------------------------------------------------------===//
 // MARK: Plugins

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -190,6 +190,74 @@ bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,
 SWIFT_NAME("getter:BridgedASTContext.majorLanguageVersion(self:)")
 unsigned BridgedASTContext_majorLanguageVersion(BridgedASTContext cContext);
 
+SWIFT_NAME("BridgedASTContext.langOptsCustomConditionSet(self:_:)")
+bool BridgedASTContext_langOptsCustomConditionSet(BridgedASTContext cContext,
+                                                  BridgedStringRef cName);
+
+SWIFT_NAME("BridgedASTContext.langOptsHasFeatureNamed(self:_:)")
+bool BridgedASTContext_langOptsHasFeatureNamed(BridgedASTContext cContext,
+                                               BridgedStringRef cName);
+
+SWIFT_NAME("BridgedASTContext.langOptsHasAttributeNamed(self:_:)")
+bool BridgedASTContext_langOptsHasAttributeNamed(BridgedASTContext cContext,
+                                                 BridgedStringRef cName);
+
+SWIFT_NAME("BridgedASTContext.langOptsIsActiveTargetOS(self:_:)")
+bool BridgedASTContext_langOptsIsActiveTargetOS(BridgedASTContext cContext,
+                                                BridgedStringRef cName);
+
+SWIFT_NAME("BridgedASTContext.langOptsIsActiveTargetArchitecture(self:_:)")
+bool BridgedASTContext_langOptsIsActiveTargetArchitecture(BridgedASTContext cContext,
+                                                          BridgedStringRef cName);
+
+SWIFT_NAME("BridgedASTContext.langOptsIsActiveTargetEnvironment(self:_:)")
+bool BridgedASTContext_langOptsIsActiveTargetEnvironment(BridgedASTContext cContext,
+                                                         BridgedStringRef cName);
+
+SWIFT_NAME("BridgedASTContext.langOptsIsActiveTargetRuntime(self:_:)")
+bool BridgedASTContext_langOptsIsActiveTargetRuntime(BridgedASTContext cContext,
+                                                     BridgedStringRef cName);
+
+SWIFT_NAME("BridgedASTContext.langOptsIsActiveTargetPtrAuth(self:_:)")
+bool BridgedASTContext_langOptsIsActiveTargetPtrAuth(BridgedASTContext cContext,
+                                                     BridgedStringRef cName);
+
+SWIFT_NAME("getter:BridgedASTContext.langOptsTargetPointerBitWidth(self:)")
+unsigned BridgedASTContext_langOptsTargetPointerBitWidth(BridgedASTContext cContext);
+
+SWIFT_NAME("BridgedASTContext.langOptsGetTargetAtomicBitWidths(self:_:)")
+SwiftInt BridgedASTContext_langOptsGetTargetAtomicBitWidths(BridgedASTContext cContext,
+                                                      SwiftInt* _Nullable * _Nonnull cComponents);
+
+enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedEndianness : size_t {
+  EndianLittle,
+  EndianBig,
+};
+
+SWIFT_NAME("getter:BridgedASTContext.langOptsTargetEndianness(self:)")
+BridgedEndianness BridgedASTContext_langOptsTargetEndianness(BridgedASTContext cContext);
+
+SWIFT_NAME("BridgedASTContext.langOptsGetLanguageVersion(self:_:)")
+SwiftInt BridgedASTContext_langOptsGetLanguageVersion(BridgedASTContext cContext,
+                                                      SwiftInt* _Nullable * _Nonnull cComponents);
+
+SWIFT_NAME("BridgedASTContext.langOptsGetCompilerVersion(self:_:)")
+SwiftInt BridgedASTContext_langOptsGetCompilerVersion(BridgedASTContext cContext,
+                                                      SwiftInt* _Nullable * _Nonnull cComponents);
+
+enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedCanImportVersion : size_t {
+  CanImportUnversioned,
+  CanImportVersion,
+  CanImportUnderlyingVersion,
+};
+
+SWIFT_NAME("BridgedASTContext.canImport(self:importPath:versionKind:versionComponents:numVersionComponents:)")
+bool BridgedASTContext_canImport(BridgedASTContext cContext,
+                                 BridgedStringRef importPath,
+                                 BridgedCanImportVersion versionKind,
+                                 const SwiftInt * _Nullable versionComponents,
+                                 SwiftInt numVersionComponents);
+
 //===----------------------------------------------------------------------===//
 // MARK: AST nodes
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/IfConfigClauseRangeInfo.h
+++ b/include/swift/AST/IfConfigClauseRangeInfo.h
@@ -1,4 +1,4 @@
-//===--- ASTBridging.h - header for the swift SILBridging module ----------===//
+//===--- IfConfigClauseRangeInfo.h - header for #if clauses -=====---------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/IfConfigClauseRangeInfo.h
+++ b/include/swift/AST/IfConfigClauseRangeInfo.h
@@ -1,0 +1,62 @@
+//===--- ASTBridging.h - header for the swift SILBridging module ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_IFCONFIGCLAUSERANGEINFO_H
+#define SWIFT_AST_IFCONFIGCLAUSERANGEINFO_H
+
+#include "swift/Basic/SourceLoc.h"
+
+namespace swift {
+
+class SourceManager;
+
+/// Stores range information for a \c #if block in a SourceFile.
+class IfConfigClauseRangeInfo final {
+public:
+  enum ClauseKind {
+    // Active '#if', '#elseif', or '#else' clause.
+    ActiveClause,
+    // Inactive '#if', '#elseif', or '#else' clause.
+    InactiveClause,
+    // '#endif' directive.
+    EndDirective,
+  };
+
+private:
+  /// Source location of '#if', '#elseif', etc.
+  SourceLoc DirectiveLoc;
+  /// Character source location of body starts.
+  SourceLoc BodyLoc;
+  /// Location of the end of the body.
+  SourceLoc EndLoc;
+
+  ClauseKind Kind;
+
+public:
+  IfConfigClauseRangeInfo(SourceLoc DirectiveLoc, SourceLoc BodyLoc,
+                          SourceLoc EndLoc, ClauseKind Kind)
+      : DirectiveLoc(DirectiveLoc), BodyLoc(BodyLoc), EndLoc(EndLoc),
+        Kind(Kind) {
+    assert(DirectiveLoc.isValid() && BodyLoc.isValid() && EndLoc.isValid());
+  }
+
+  SourceLoc getStartLoc() const { return DirectiveLoc; }
+  CharSourceRange getDirectiveRange(const SourceManager &SM) const;
+  CharSourceRange getWholeRange(const SourceManager &SM) const;
+  CharSourceRange getBodyRange(const SourceManager &SM) const;
+
+  ClauseKind getKind() const { return Kind; }
+};
+
+}
+
+#endif /* SWIFT_AST_IFCONFIGCLAUSERANGEINFO_H */

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -15,6 +15,7 @@
 
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/FileUnit.h"
+#include "swift/AST/IfConfigClauseRangeInfo.h"
 #include "swift/AST/Import.h"
 #include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/Basic/Debug.h"
@@ -47,44 +48,6 @@ enum class RestrictedImportKind {
 
 /// Import that limits the access level of imported entities.
 using ImportAccessLevel = std::optional<AttributedImport<ImportedModule>>;
-
-/// Stores range information for a \c #if block in a SourceFile.
-class IfConfigClauseRangeInfo final {
-public:
-  enum ClauseKind {
-    // Active '#if', '#elseif', or '#else' clause.
-    ActiveClause,
-    // Inactive '#if', '#elseif', or '#else' clause.
-    InactiveClause,
-    // '#endif' directive.
-    EndDirective,
-  };
-
-private:
-  /// Source location of '#if', '#elseif', etc.
-  SourceLoc DirectiveLoc;
-  /// Character source location of body starts.
-  SourceLoc BodyLoc;
-  /// Location of the end of the body.
-  SourceLoc EndLoc;
-
-  ClauseKind Kind;
-
-public:
-  IfConfigClauseRangeInfo(SourceLoc DirectiveLoc, SourceLoc BodyLoc,
-                          SourceLoc EndLoc, ClauseKind Kind)
-      : DirectiveLoc(DirectiveLoc), BodyLoc(BodyLoc), EndLoc(EndLoc),
-        Kind(Kind) {
-    assert(DirectiveLoc.isValid() && BodyLoc.isValid() && EndLoc.isValid());
-  }
-
-  SourceLoc getStartLoc() const { return DirectiveLoc; }
-  CharSourceRange getDirectiveRange(const SourceManager &SM) const;
-  CharSourceRange getWholeRange(const SourceManager &SM) const;
-  CharSourceRange getBodyRange(const SourceManager &SM) const;
-
-  ClauseKind getKind() const { return Kind; }
-};
 
 /// A file containing Swift source code.
 ///

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -730,18 +730,23 @@ namespace swift {
       switch (maxWidth) {
       case 128:
         AtomicBitWidths.emplace_back("_128");
+        AtomicBitWidthValues.push_back(128);
         LLVM_FALLTHROUGH;
       case 64:
         AtomicBitWidths.emplace_back("_64");
+        AtomicBitWidthValues.push_back(64);
         LLVM_FALLTHROUGH;
       case 32:
         AtomicBitWidths.emplace_back("_32");
+        AtomicBitWidthValues.push_back(32);
         LLVM_FALLTHROUGH;
       case 16:
         AtomicBitWidths.emplace_back("_16");
+        AtomicBitWidthValues.push_back(16);
         LLVM_FALLTHROUGH;
       case 8:
         AtomicBitWidths.emplace_back("_8");
+        AtomicBitWidthValues.push_back(8);
         break;
       default:
         return;
@@ -751,6 +756,11 @@ namespace swift {
     /// Removes all atomic bit widths.
     void clearAtomicBitWidths() {
       AtomicBitWidths.clear();
+      AtomicBitWidthValues.clear();
+    }
+
+    llvm::ArrayRef<unsigned> getAtomicBitWidthValues() const {
+      return AtomicBitWidthValues;
     }
 
     /// Returns true if the given platform condition argument represents
@@ -791,6 +801,7 @@ namespace swift {
 
   private:
     llvm::SmallVector<std::string, 2> AtomicBitWidths;
+    llvm::SmallVector<unsigned, 2> AtomicBitWidthValues;
     llvm::SmallVector<std::pair<PlatformConditionKind, std::string>, 10>
         PlatformConditionValues;
     llvm::SmallVector<std::string, 2> CustomConditionalCompilationFlags;

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -155,6 +155,8 @@ intptr_t swift_ASTGen_configuredRegions(
     BridgedASTContext astContext,
     void *_Nonnull sourceFile,
     BridgedIfConfigClauseRangeInfo *_Nullable *_Nonnull);
+void swift_ASTGen_freeConfiguredRegions(
+    BridgedIfConfigClauseRangeInfo *_Nullable regions, intptr_t numRegions);
 
 #ifdef __cplusplus
 }

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -151,6 +151,11 @@ bool swift_ASTGen_parseRegexLiteral(BridgedStringRef inputPtr,
                                     BridgedSourceLoc diagLoc,
                                     BridgedDiagnosticEngine diagEngine);
 
+intptr_t swift_ASTGen_configuredRegions(
+    BridgedASTContext astContext,
+    void *_Nonnull sourceFile,
+    BridgedIfConfigClauseRangeInfo *_Nullable *_Nonnull);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -216,6 +216,7 @@ SwiftInt BridgedASTContext_langOptsGetTargetAtomicBitWidths(BridgedASTContext cC
 
 bool BridgedASTContext_canImport(BridgedASTContext cContext,
                                  BridgedStringRef importPath,
+                                 BridgedSourceLoc canImportLoc,
                                  BridgedCanImportVersion versionKind,
                                  const SwiftInt * _Nullable versionComponents,
                                  SwiftInt numVersionComponents) {
@@ -240,15 +241,11 @@ bool BridgedASTContext_canImport(BridgedASTContext cContext,
     break;
   }
 
-  // FIXME: The source location here is empty because build configurations
-  // are supposed to be completely separated from source code. We could re-plumb
-  // things to have any errors reported up through the "canImportModule"
-  // API.
   ImportPath::Module::Builder builder(
       cContext.unbridged(), importPath.unbridged(), /*separator=*/'.',
-      SourceLoc());
+      canImportLoc.unbridged());
   return cContext.unbridged().canImportModule(
-      builder.get(), SourceLoc(), version,
+      builder.get(), canImportLoc.unbridged(), version,
       versionKind == CanImportUnderlyingVersion);
 }
 

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -238,7 +238,7 @@ bool BridgedASTContext_canImport(BridgedASTContext cContext,
 
   // FIXME: The source location here is empty because build configurations
   // are supposed to be completely separated from source code. We could re-plumb
-  // things to have any errors reported up thruough the "canImportModule"
+  // things to have any errors reported up through the "canImportModule"
   // API.
   ImportPath::Module::Builder builder(
       cContext.unbridged(), importPath.unbridged(), /*separator=*/'.',

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -123,8 +123,12 @@ unsigned BridgedASTContext_majorLanguageVersion(BridgedASTContext cContext) {
 
 bool BridgedASTContext_langOptsCustomConditionSet(BridgedASTContext cContext,
                                                   BridgedStringRef cName) {
-  return cContext.unbridged().LangOpts
-    .isCustomConditionalCompilationFlagSet(cName.unbridged());
+  ASTContext &ctx = cContext.unbridged();
+  auto name = cName.unbridged();
+  if (name.starts_with("$") && ctx.LangOpts.hasFeature(name.drop_front()))
+    return true;
+
+  return ctx.LangOpts.isCustomConditionalCompilationFlagSet(name);
 }
 
 bool BridgedASTContext_langOptsHasFeatureNamed(BridgedASTContext cContext,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2598,7 +2598,10 @@ bool ASTContext::canImportModuleImpl(ImportPath::Module ModuleName,
     // The module version could not be parsed from the preferred source for
     // this query. Diagnose and treat the query as if it succeeded.
     auto mID = ModuleName[0];
-    Diags.diagnose(mID.Loc, diag::cannot_find_project_version,
+    auto diagLoc = mID.Loc;
+    if (mID.Loc.isInvalid())
+      diagLoc = loc;
+    Diags.diagnose(diagLoc, diag::cannot_find_project_version,
                    getModuleVersionKindString(bestVersionInfo), mID.Item.str());
     return true;
   }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2960,8 +2960,12 @@ IfConfigClauseRangeInfo::getWholeRange(const SourceManager &SM) const {
 
 void SourceFile::recordIfConfigClauseRangeInfo(
     const IfConfigClauseRangeInfo &range) {
+#if SWIFT_BUILD_SWIFT_SYNTAX
+  // Don't record ranges; they'll be extracted from swift-syntax when needed.
+#else
   IfConfigClauseRanges.Ranges.push_back(range);
   IfConfigClauseRanges.IsSorted = false;
+#endif
 }
 
 ArrayRef<IfConfigClauseRangeInfo> SourceFile::getIfConfigClauseRanges() const {

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 add_pure_swift_host_library(swiftASTGen STATIC
   Sources/ASTGen/ASTGen.swift
   Sources/ASTGen/Bridge.swift
+  Sources/ASTGen/CompilerBuildConfiguration.swift
   Sources/ASTGen/DeclAttrs.swift
   Sources/ASTGen/Decls.swift
   Sources/ASTGen/Diagnostics.swift
@@ -44,6 +45,7 @@ add_pure_swift_host_library(swiftASTGen STATIC
     swiftAST
   SWIFT_DEPENDENCIES
     _CompilerSwiftSyntax
+    _CompilerSwiftIfConfig
     _CompilerSwiftOperators
     _CompilerSwiftSyntaxBuilder
     _CompilerSwiftParser

--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -59,6 +59,7 @@ let package = Package(
       dependencies: [
         .product(name: "_SwiftCompilerPluginMessageHandling", package: "swift-syntax"),
         .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+        .product(name: "SwiftIfConfig", package: "swift-syntax"),
         .product(name: "SwiftOperators", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "SwiftParserDiagnostics", package: "swift-syntax"),

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -1,0 +1,146 @@
+//===--- CompilerBuildConfiguration.swift --------------\------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ASTBridging
+import SwiftIfConfig
+
+/// A build configuration that uses the compiler's ASTContext to answer
+/// queries.
+struct CompilerBuildConfiguration: BuildConfiguration {
+  let ctx: BridgedASTContext
+
+  func isCustomConditionSet(name: String) throws -> Bool {
+    var name = name
+    return name.withBridgedString { nameRef in
+      ctx.langOptsCustomConditionSet(nameRef)
+    }
+  }
+  
+  func hasFeature(name: String) throws -> Bool {
+    var name = name
+    return name.withBridgedString { nameRef in
+      ctx.langOptsHasFeatureNamed(nameRef)
+    }
+  }
+  
+  func hasAttribute(name: String) throws -> Bool {
+    var name = name
+    return name.withBridgedString { nameRef in
+      ctx.langOptsHasAttributeNamed(nameRef)
+    }
+  }
+  
+  func canImport(importPath: [String], version: CanImportVersion) throws -> Bool {
+    var importPathStr = importPath.joined(separator: ".")
+
+    var versionComponents: [Int]
+    let cVersionKind: BridgedCanImportVersion
+    switch version {
+    case .unversioned:
+      cVersionKind = .CanImportUnversioned
+      versionComponents = []
+
+    case .version(let versionTuple):
+      cVersionKind = .CanImportVersion
+      versionComponents = versionTuple.components
+
+    case .underlyingVersion(let versionTuple):
+      cVersionKind = .CanImportUnderlyingVersion
+      versionComponents = versionTuple.components
+    }
+
+    return importPathStr.withBridgedString { bridgedImportPathStr in
+      versionComponents.withUnsafeBufferPointer { versionComponentsBuf in
+        ctx.canImport(
+          importPath: bridgedImportPathStr,
+          versionKind: cVersionKind,
+          versionComponents: versionComponentsBuf.baseAddress,
+          numVersionComponents: versionComponentsBuf.count
+        )
+      }
+    }
+  }
+  
+  func isActiveTargetOS(name: String) throws -> Bool {
+    var name = name
+    return name.withBridgedString { nameRef in
+      ctx.langOptsIsActiveTargetOS(nameRef)
+    }
+  }
+  
+  func isActiveTargetArchitecture(name: String) throws -> Bool {
+    var name = name
+    return name.withBridgedString { nameRef in
+      ctx.langOptsIsActiveTargetArchitecture(nameRef)
+    }
+  }
+  
+  func isActiveTargetEnvironment(name: String) throws -> Bool {
+    var name = name
+    return name.withBridgedString { nameRef in
+      ctx.langOptsIsActiveTargetEnvironment(nameRef)
+    }
+  }
+  
+  func isActiveTargetRuntime(name: String) throws -> Bool {
+    var name = name
+    return name.withBridgedString { nameRef in
+      ctx.langOptsIsActiveTargetRuntime(nameRef)
+    }
+  }
+  
+  func isActiveTargetPointerAuthentication(name: String) throws -> Bool {
+    var name = name
+    return name.withBridgedString { nameRef in
+      ctx.langOptsIsActiveTargetPtrAuth(nameRef)
+    }
+  }
+  
+  var targetPointerBitWidth: Int {
+    Int(ctx.langOptsTargetPointerBitWidth)
+  }
+
+  var targetAtomicBitWidths: [Int] {
+    var bitWidthsBuf: UnsafeMutablePointer<SwiftInt>? = nil
+    let count = ctx.langOptsGetTargetAtomicBitWidths(&bitWidthsBuf)
+    let bitWidths = Array(UnsafeMutableBufferPointer(start: bitWidthsBuf, count: count))
+    bitWidthsBuf?.deallocate()
+    return bitWidths
+  }
+
+  var endianness: Endianness {
+    switch ctx.langOptsTargetEndianness {
+    case .EndianBig: return .big
+    case .EndianLittle: return .little
+    }
+  }
+
+  var languageVersion: VersionTuple { 
+    var componentsBuf: UnsafeMutablePointer<SwiftInt>? = nil
+    let count = ctx.langOptsGetLanguageVersion(&componentsBuf)
+    let version = VersionTuple(
+      components: Array(UnsafeMutableBufferPointer(start: componentsBuf, count: count))
+    )
+    componentsBuf?.deallocate()
+    return version
+  }
+
+  var compilerVersion: VersionTuple { 
+    var componentsBuf: UnsafeMutablePointer<SwiftInt>? = nil
+    let count = ctx.langOptsGetCompilerVersion(&componentsBuf)
+    let version = VersionTuple(
+      components: Array(UnsafeMutableBufferPointer(start: componentsBuf, count: count))
+    )
+    componentsBuf?.deallocate()
+    return version
+  }
+}

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -275,3 +275,11 @@ extension SyntaxProtocol {
     return false
   }
 }
+
+@_cdecl("swift_ASTGen_freeConfiguredRegions")
+public func freeConfiguredRegions(
+  regions: UnsafeMutablePointer<BridgedIfConfigClauseRangeInfo>?,
+  numRegions: Int
+) {
+  UnsafeMutableBufferPointer(start: regions, count: numRegions).deallocate()
+}

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -1,4 +1,4 @@
-//===--- CompilerBuildConfiguration.swift --------------\------------------===//
+//===--- CompilerBuildConfiguration.swift ---------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -44,6 +44,12 @@ public struct ExportedSourceFile {
     }
     return AbsolutePosition(utf8Offset: opaqueValue - sourceFileBaseAddress)
   }
+
+  /// Retrieve a bridged source location for the given absolute position in
+  /// this source file.
+  public func sourceLoc(at position: AbsolutePosition) -> BridgedSourceLoc {
+    BridgedSourceLoc(at: position, in: buffer)
+  }
 }
 
 extension Parser.ExperimentalFeatures {

--- a/lib/CompilerSwiftSyntax/CMakeLists.txt
+++ b/lib/CompilerSwiftSyntax/CMakeLists.txt
@@ -30,6 +30,7 @@ includeSwiftSyntax()
 
 set(compiler_swiftsyntax_libs
   _CompilerSwiftSyntax
+  _CompilerSwiftIfConfig
   _CompilerSwiftOperators
   _CompilerSwiftSyntaxBuilder
   _CompilerSwiftParser

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -48,6 +48,7 @@
 #include "swift/AST/TypeWalker.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
+#include "swift/Bridging/ASTGen.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Sema/IDETypeChecking.h"
@@ -3120,4 +3121,74 @@ std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
 LifetimeDependenceInfoRequest::evaluate(Evaluator &evaluator,
                                         AbstractFunctionDecl *decl) const {
   return LifetimeDependenceInfo::get(decl);
+}
+
+ArrayRef<IfConfigClauseRangeInfo> SourceFile::getIfConfigClauseRanges() const {
+#if SWIFT_BUILD_SWIFT_SYNTAX
+  if (!IfConfigClauseRanges.IsSorted) {
+    IfConfigClauseRanges.Ranges.clear();
+
+    BridgedIfConfigClauseRangeInfo *regions;
+    intptr_t numRegions = swift_ASTGen_configuredRegions(
+        getASTContext(), getExportedSourceFile(), &regions);
+    IfConfigClauseRanges.Ranges.reserve(numRegions);
+    for (intptr_t i = 0; i != numRegions; ++i)
+      IfConfigClauseRanges.Ranges.push_back(regions[i].unbridged());
+    free(regions);
+
+    IfConfigClauseRanges.IsSorted = true;
+  }
+#else
+  if (!IfConfigClauseRanges.IsSorted) {
+    auto &SM = getASTContext().SourceMgr;
+    // Sort the ranges if we need to.
+    llvm::sort(
+        IfConfigClauseRanges.Ranges, [&](const IfConfigClauseRangeInfo &lhs,
+                                         const IfConfigClauseRangeInfo &rhs) {
+          return SM.isBeforeInBuffer(lhs.getStartLoc(), rhs.getStartLoc());
+        });
+
+    // Be defensive and eliminate duplicates in case we've parsed twice.
+    auto newEnd = llvm::unique(
+        IfConfigClauseRanges.Ranges, [&](const IfConfigClauseRangeInfo &lhs,
+                                         const IfConfigClauseRangeInfo &rhs) {
+          if (lhs.getStartLoc() != rhs.getStartLoc())
+            return false;
+          assert(lhs.getBodyRange(SM) == rhs.getBodyRange(SM) &&
+                 "range changed on a re-parse?");
+          return true;
+        });
+    IfConfigClauseRanges.Ranges.erase(newEnd,
+                                      IfConfigClauseRanges.Ranges.end());
+    IfConfigClauseRanges.IsSorted = true;
+  }
+#endif
+
+  return IfConfigClauseRanges.Ranges;
+}
+
+ArrayRef<IfConfigClauseRangeInfo>
+SourceFile::getIfConfigClausesWithin(SourceRange outer) const {
+  auto &SM = getASTContext().SourceMgr;
+  assert(SM.getRangeForBuffer(BufferID).contains(outer.Start) &&
+         "Range not within this file?");
+
+  // First let's find the first #if that is after the outer start loc.
+  auto ranges = getIfConfigClauseRanges();
+  auto lower = llvm::lower_bound(
+      ranges, outer.Start,
+      [&](const IfConfigClauseRangeInfo &range, SourceLoc loc) {
+        return SM.isBeforeInBuffer(range.getStartLoc(), loc);
+      });
+  if (lower == ranges.end() ||
+      SM.isBeforeInBuffer(outer.End, lower->getStartLoc())) {
+    return {};
+  }
+  // Next let's find the first #if that's after the outer end loc.
+  auto upper = llvm::upper_bound(
+      ranges, outer.End,
+      [&](SourceLoc loc, const IfConfigClauseRangeInfo &range) {
+        return SM.isBeforeInBuffer(loc, range.getStartLoc());
+      });
+  return llvm::ArrayRef(lower, upper - lower);
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3134,7 +3134,7 @@ ArrayRef<IfConfigClauseRangeInfo> SourceFile::getIfConfigClauseRanges() const {
     IfConfigClauseRanges.Ranges.reserve(numRegions);
     for (intptr_t i = 0; i != numRegions; ++i)
       IfConfigClauseRanges.Ranges.push_back(regions[i].unbridged());
-    free(regions);
+    swift_ASTGen_freeConfiguredRegions(regions, numRegions);
 
     IfConfigClauseRanges.IsSorted = true;
   }


### PR DESCRIPTION
Start adopting the new `SwiftIfConfig` library to reason about `#if` clauses in a few places in the compiler. There are two aspects to this:
* Introduce `CompilerBuildConfiguration`, a wrapper around an `ASTContext` that conforms to the new `BuildConfiguration` protocol from the `SwiftIfConfig` library. This allows us to use the APIs in `SwiftIfConfig` backed by the logic for compiler conditionals (`hasFeature`, `os(XYZ)`, `canImport`, etc.) within the compiler itself.
* Replace the implementation of `SourceFile::getIfConfigClauseRanges()` with one based on `SwiftIfConfig`'s enumeration of configured regions. This has the advantage of being less "stateful", because it doesn't need to rely on the C++ parser populating an array as it parses.