### PR TITLE
[region-isolation] When determining isolation from a class_method, check for global actor isolation first.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -180,6 +180,12 @@ public:
     return parameterIndex;
   }
 
+  /// Returns true if this actor-instance isolation appllies to the self
+  /// parameter of a method.
+  bool isActorInstanceForSelfParameter() const {
+    return getActorInstanceParameter() == 0;
+  }
+
   bool isSILParsed() const { return silParsed; }
 
   bool isActorIsolated() const {

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -604,40 +604,55 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
         bool isNonIsolatedUnsafe = exprAnalysis.hasNonisolatedUnsafe();
         {
           auto isolation = swift::getActorIsolation(dre->getDecl());
-          if (isolation.isActorIsolated() &&
-              (isolation.getKind() != ActorIsolation::ActorInstance ||
-               isolation.getActorInstanceParameter() == 0)) {
-            if (cmi->getOperand()->getType().isAnyActor()) {
-              return SILIsolationInfo::getActorInstanceIsolated(
-                  cmi, cmi->getOperand(),
-                  cmi->getOperand()
-                      ->getType()
-                      .getNominalOrBoundGenericNominal());
-            }
-            return SILIsolationInfo::getGlobalActorIsolated(
-                cmi, isolation.getGlobalActor());
-          }
 
-          isNonIsolatedUnsafe |= isolation.isNonisolatedUnsafe();
+          if (isolation.isActorIsolated()) {
+            // Check if we have a global actor and handle it appropriately.
+            if (isolation.getKind() == ActorIsolation::GlobalActor) {
+              bool localNonIsolatedUnsafe =
+                  isNonIsolatedUnsafe | isolation.isNonisolatedUnsafe();
+              return SILIsolationInfo::getGlobalActorIsolated(
+                         cmi, isolation.getGlobalActor())
+                  .withUnsafeNonIsolated(localNonIsolatedUnsafe);
+            }
+
+            // In this case, we have an actor instance that is self.
+            if (isolation.getKind() != ActorIsolation::ActorInstance &&
+                isolation.isActorInstanceForSelfParameter()) {
+              bool localNonIsolatedUnsafe =
+                  isNonIsolatedUnsafe | isolation.isNonisolatedUnsafe();
+              return SILIsolationInfo::getActorInstanceIsolated(
+                         cmi, cmi->getOperand(),
+                         cmi->getOperand()
+                             ->getType()
+                             .getNominalOrBoundGenericNominal())
+                  .withUnsafeNonIsolated(localNonIsolatedUnsafe);
+            }
+          }
         }
 
         if (auto type = dre->getType()->getNominalOrBoundGenericNominal()) {
           if (auto isolation = swift::getActorIsolation(type)) {
-            if (isolation.isActorIsolated() &&
-                (isolation.getKind() != ActorIsolation::ActorInstance ||
-                 isolation.getActorInstanceParameter() == 0)) {
-              if (cmi->getOperand()->getType().isAnyActor()) {
+            if (isolation.isActorIsolated()) {
+              // Check if we have a global actor and handle it appropriately.
+              if (isolation.getKind() == ActorIsolation::GlobalActor) {
+                bool localNonIsolatedUnsafe =
+                    isNonIsolatedUnsafe | isolation.isNonisolatedUnsafe();
+                return SILIsolationInfo::getGlobalActorIsolated(
+                           cmi, isolation.getGlobalActor())
+                    .withUnsafeNonIsolated(localNonIsolatedUnsafe);
+              }
+
+              // In this case, we have an actor instance that is self.
+              if (isolation.getKind() != ActorIsolation::ActorInstance &&
+                  isolation.isActorInstanceForSelfParameter()) {
+                bool localNonIsolatedUnsafe =
+                    isNonIsolatedUnsafe | isolation.isNonisolatedUnsafe();
                 return SILIsolationInfo::getActorInstanceIsolated(
                            cmi, cmi->getOperand(),
                            cmi->getOperand()
                                ->getType()
                                .getNominalOrBoundGenericNominal())
-                    .withUnsafeNonIsolated(isNonIsolatedUnsafe);
-              }
-
-              if (auto globalIso = SILIsolationInfo::getGlobalActorIsolated(
-                      cmi, isolation.getGlobalActor())) {
-                return globalIso.withUnsafeNonIsolated(isNonIsolatedUnsafe);
+                    .withUnsafeNonIsolated(localNonIsolatedUnsafe);
               }
             }
           }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -40,6 +40,7 @@ actor MyActor {
   func useSendableFunction(_: @Sendable () -> Void) {}
   func useNonSendableFunction(_: () -> Void) {}
   func doSomething() {}
+  @MainActor func useKlassMainActor(_ x: NonSendableKlass) {}
 }
 
 final actor FinalActor {
@@ -1808,4 +1809,17 @@ actor FunctionWithSendableResultAndIsolationActor {
     func string(someCondition: Bool = false) -> String {
         return ""
     }
+}
+
+@MainActor
+func testThatGlobalActorTakesPrecedenceOverActorIsolationOnMethods() async {
+  let a = MyActor()
+  let ns = NonSendableKlass()
+
+  // 'ns' should be main actor isolated since useKlassMainActor is @MainActor
+  // isolated. Previously we would let MyActor take precedence here...
+  a.useKlassMainActor(ns)
+
+  // Meaning we would get an error here.
+  Task { @MainActor in print(ns) }
 }


### PR DESCRIPTION
Before this change in the following code, we would say that message is isolated to the actor instead of the global actor isolation of the actor's method:

```swift
class Message { ... }

actor MessageHolder {
  @MainActor func hold(_ message: Message) { ... }
}

@MainActor
func sendMessage() async {
    let messageHolder = MessageHolder()
    let message = Message()
    // We identified messageHolder.hold as being MessageHolder isolated
    // instead of main actor isolated.
    messageHolder.hold(message)
    Task { @MainActor in print(message) }
}
```

I also used this as an opportunity to simplify the logic in this part of the code. Specifically, I had made it so that multiple interesting cases were handled in the same conditional statement in a manner that it made it hard to know which cases were actually being handled and why it was correct. Now I split that into two separate if statements with comments that make it clear what we are actually trying to pattern match against.

rdar://130980933
