### PR TITLE
[region-isolation] Improve pattern matching for isolated parameters in SILIsolationInfo by reusing infrastructure from other parts of RegionAnalysis

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -114,6 +114,10 @@ public:
   }
 };
 
+/// The isolation info inferred for a specific SILValue. Use
+/// SILIsolationInfo::get() to compute these. It is intended to be a
+/// conservatively correct model that we expand over time with more pattern
+/// matching.
 class SILIsolationInfo {
 public:
   /// The lattice is:
@@ -127,6 +131,20 @@ public:
     Task,
     Actor,
   };
+
+  enum class Flag : uint8_t {
+    None,
+
+    /// If set, this means that the element that we derived this from was marked
+    /// with nonisolated(unsafe).
+    UnsafeNonIsolated = 0x1,
+
+    /// If set, this means that this actor isolation is from an isolated
+    /// parameter and should be allowed to merge into a self parameter.
+    UnappliedIsolatedAnyParameter = 0x2,
+  };
+
+  using Options = OptionSet<Flag>;
 
 private:
   /// The actor isolation if this value has one. The default unspecified case
@@ -142,13 +160,13 @@ private:
   ActorInstance actorInstance;
 
   unsigned kind : 8;
-  unsigned unsafeNonIsolated : 1;
+  unsigned options : 8;
 
   SILIsolationInfo(SILValue isolatedValue, SILValue actorInstance,
-                   ActorIsolation actorIsolation, bool isUnsafeNonIsolated)
+                   ActorIsolation actorIsolation, Options options = Options())
       : actorIsolation(actorIsolation), isolatedValue(isolatedValue),
         actorInstance(ActorInstance::getForValue(actorInstance)), kind(Actor),
-        unsafeNonIsolated(isUnsafeNonIsolated) {
+        options(options.toRaw()) {
     assert((!actorInstance ||
             (actorIsolation.getKind() == ActorIsolation::ActorInstance &&
              actorInstance->getType()
@@ -159,24 +177,22 @@ private:
   }
 
   SILIsolationInfo(SILValue isolatedValue, ActorInstance actorInstance,
-                   ActorIsolation actorIsolation, bool isUnsafeNonIsolated)
+                   ActorIsolation actorIsolation, Options options = Options())
       : actorIsolation(actorIsolation), isolatedValue(isolatedValue),
-        actorInstance(actorInstance), kind(Actor),
-        unsafeNonIsolated(isUnsafeNonIsolated) {
+        actorInstance(actorInstance), kind(Actor), options(options.toRaw()) {
     assert(actorInstance);
     assert(actorIsolation.getKind() == ActorIsolation::ActorInstance);
   }
 
   SILIsolationInfo(Kind kind, SILValue isolatedValue)
-      : actorIsolation(), isolatedValue(isolatedValue), kind(kind),
-        unsafeNonIsolated(false) {}
+      : actorIsolation(), isolatedValue(isolatedValue), kind(kind), options(0) {
+  }
 
-  SILIsolationInfo(Kind kind, bool isUnsafeNonIsolated)
-      : actorIsolation(), kind(kind), unsafeNonIsolated(isUnsafeNonIsolated) {}
+  SILIsolationInfo(Kind kind, Options options = Options())
+      : actorIsolation(), kind(kind), options(options.toRaw()) {}
 
 public:
-  SILIsolationInfo()
-      : actorIsolation(), kind(Kind::Unknown), unsafeNonIsolated(false) {}
+  SILIsolationInfo() : actorIsolation(), kind(Kind::Unknown), options(0) {}
 
   operator bool() const { return kind != Kind::Unknown; }
 
@@ -188,12 +204,43 @@ public:
   bool isActorIsolated() const { return kind == Kind::Actor; }
   bool isTaskIsolated() const { return kind == Kind::Task; }
 
-  bool isUnsafeNonIsolated() const { return unsafeNonIsolated; }
+  Options getOptions() const { return Options(options); }
+
+  void setOptions(Options newOptions) { options = newOptions.toRaw(); }
+
+  bool isUnsafeNonIsolated() const {
+    return getOptions().contains(Flag::UnsafeNonIsolated);
+  }
 
   SILIsolationInfo withUnsafeNonIsolated(bool newValue = true) const {
     assert(*this && "Cannot be unknown");
     auto self = *this;
-    self.unsafeNonIsolated = newValue;
+    if (newValue) {
+      self.options = (self.getOptions() | Flag::UnsafeNonIsolated).toRaw();
+    } else {
+      self.options =
+          self.getOptions().toRaw() & ~Options(Flag::UnsafeNonIsolated).toRaw();
+    }
+    return self;
+  }
+
+  /// Returns true if this actor isolation is derived from an unapplied
+  /// isolation parameter. When merging, we allow for this to be merged with a
+  /// more specific isolation kind.
+  bool isUnappliedIsolatedAnyParameter() const {
+    return getOptions().contains(Flag::UnappliedIsolatedAnyParameter);
+  }
+
+  SILIsolationInfo withUnappliedIsolatedParameter(bool newValue = true) const {
+    assert(*this && "Cannot be unknown");
+    auto self = *this;
+    if (newValue) {
+      self.options =
+          (self.getOptions() | Flag::UnappliedIsolatedAnyParameter).toRaw();
+    } else {
+      self.options = self.getOptions().toRaw() &
+                     ~Options(Flag::UnappliedIsolatedAnyParameter).toRaw();
+    }
     return self;
   }
 
@@ -243,7 +290,8 @@ public:
   }
 
   static SILIsolationInfo getDisconnected(bool isUnsafeNonIsolated) {
-    return {Kind::Disconnected, isUnsafeNonIsolated};
+    return {Kind::Disconnected,
+            isUnsafeNonIsolated ? Flag::UnsafeNonIsolated : Flag::None};
   }
 
   /// Create an actor isolation for a value that we know is actor isolated to a
@@ -261,7 +309,7 @@ public:
   getFlowSensitiveActorIsolated(SILValue isolatedValue,
                                 ActorIsolation actorIsolation) {
     return {isolatedValue, SILValue(), actorIsolation,
-            false /*nonisolated(unsafe)*/};
+            Flag::UnappliedIsolatedAnyParameter};
   }
 
   /// Only use this as a fallback if we cannot find better information.
@@ -270,8 +318,7 @@ public:
     if (crossing.getCalleeIsolation().isActorIsolated()) {
       // SIL level, just let it through
       return SILIsolationInfo(SILValue(), SILValue(),
-                              crossing.getCalleeIsolation(),
-                              false /*nonisolated(unsafe)*/);
+                              crossing.getCalleeIsolation());
     }
 
     return {};
@@ -287,8 +334,7 @@ public:
       return {};
     }
     return {isolatedValue, actorInstance,
-            ActorIsolation::forActorInstanceSelf(typeDecl),
-            false /*nonisolated(unsafe)*/};
+            ActorIsolation::forActorInstanceSelf(typeDecl)};
   }
 
   static SILIsolationInfo getActorInstanceIsolated(SILValue isolatedValue,
@@ -301,8 +347,7 @@ public:
       return {};
     }
     return {isolatedValue, actorInstance,
-            ActorIsolation::forActorInstanceSelf(typeDecl),
-            false /*nonisolated(unsafe)*/};
+            ActorIsolation::forActorInstanceSelf(typeDecl)};
   }
 
   /// A special actor instance isolated for partial apply cases where we do not
@@ -318,14 +363,13 @@ public:
     }
     return {isolatedValue, SILValue(),
             ActorIsolation::forActorInstanceSelf(typeDecl),
-            false /*nonisolated(unsafe)*/};
+            Flag::UnappliedIsolatedAnyParameter};
   }
 
   static SILIsolationInfo getGlobalActorIsolated(SILValue value,
                                                  Type globalActorType) {
     return {value, SILValue() /*no actor instance*/,
-            ActorIsolation::forGlobalActor(globalActorType),
-            false /*nonisolated(unsafe)*/};
+            ActorIsolation::forGlobalActor(globalActorType)};
   }
 
   static SILIsolationInfo getGlobalActorIsolated(SILValue value,
@@ -395,7 +439,7 @@ class SILDynamicMergedIsolationInfo {
 
 public:
   SILDynamicMergedIsolationInfo() : innerInfo() {}
-  explicit SILDynamicMergedIsolationInfo(SILIsolationInfo innerInfo)
+  SILDynamicMergedIsolationInfo(SILIsolationInfo innerInfo)
       : innerInfo(innerInfo) {}
 
   /// Returns nullptr only if both this isolation info and \p other are actor

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -485,6 +485,10 @@ public:
   SWIFT_DEBUG_DUMPER(dumpForDiagnostics()) {
     innerInfo.dumpForDiagnostics();
   }
+
+  void printForOneLineLogging(llvm::raw_ostream &os) const {
+    innerInfo.printForOneLineLogging(os);
+  }
 };
 
 } // namespace swift

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -142,6 +142,9 @@ public:
     /// If set, this means that this actor isolation is from an isolated
     /// parameter and should be allowed to merge into a self parameter.
     UnappliedIsolatedAnyParameter = 0x2,
+
+    /// The maximum number of bits used by a Flag.
+    MaxNumBits = 2,
   };
 
   using Options = OptionSet<Flag>;
@@ -426,6 +429,9 @@ public:
   bool isEqual(const SILIsolationInfo &other) const;
 
   void Profile(llvm::FoldingSetNodeID &id) const;
+
+private:
+  void printOptions(llvm::raw_ostream &os) const;
 };
 
 /// A SILIsolationInfo that has gone through merging and represents the dynamic

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1635,8 +1635,9 @@ public:
               if (originalMergedInfo)
                   originalMergedInfo->printForDiagnostics(llvm::dbgs());
               else llvm::dbgs() << "nil";
-              llvm::dbgs() << "\nValue: "
+              llvm::dbgs() << "\nValue Rep: "
                            << value->getRepresentative().getValue();
+              llvm::dbgs() << "Original Src: " << src;
               llvm::dbgs() << "Value Info: ";
               value->getIsolationRegionInfo().printForDiagnostics(llvm::dbgs());
               llvm::dbgs() << "\n");

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -874,39 +874,41 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   return SILIsolationInfo::getTaskIsolated(fArg);
 }
 
+void SILIsolationInfo::printOptions(llvm::raw_ostream &os) const {
+  auto opts = getOptions();
+  if (!opts)
+    return;
+
+  os << ": ";
+
+  llvm::SmallVector<StringLiteral, unsigned(Flag::MaxNumBits)> data;
+
+  if (opts.contains(Flag::UnsafeNonIsolated)) {
+    data.push_back(StringLiteral("nonisolated(unsafe)"));
+    opts -= Flag::UnsafeNonIsolated;
+  }
+
+  if (opts.contains(Flag::UnappliedIsolatedAnyParameter)) {
+    data.push_back(StringLiteral("unapplied_isolated_any_parameter"));
+    opts -= Flag::UnappliedIsolatedAnyParameter;
+  }
+
+  assert(!opts && "Unhandled flag?!");
+  assert(data.size() < unsigned(Flag::MaxNumBits) &&
+         "Please update MaxNumBits so that we can avoid heap allocations in "
+         "this SmallVector");
+
+  llvm::interleave(data, os, ", ");
+}
+
 void SILIsolationInfo::print(llvm::raw_ostream &os) const {
-  auto printOptions = [&] {
-    auto opts = getOptions();
-    if (!opts)
-      return;
-
-    os << ": ";
-
-    std::array<std::pair<Flag, StringLiteral>, 2> data = {
-        std::make_pair(Flag::UnsafeNonIsolated,
-                       StringLiteral("nonisolated(unsafe)")),
-        std::make_pair(Flag::UnappliedIsolatedAnyParameter,
-                       StringLiteral("unapplied_isolated_parameter")),
-    };
-
-    llvm::interleave(
-        data, os,
-        [&](const std::pair<Flag, StringLiteral> &value) {
-          opts -= value.first;
-          os << value.second;
-        },
-        ", ");
-
-    assert(!opts && "Unhandled flag?!");
-  };
-
   switch (Kind(*this)) {
   case Unknown:
     os << "unknown";
     return;
   case Disconnected:
     os << "disconnected";
-    printOptions();
+    printOptions(os);
     return;
   case Actor:
     if (ActorInstance instance = getActorInstance()) {
@@ -915,7 +917,7 @@ void SILIsolationInfo::print(llvm::raw_ostream &os) const {
         SILValue value = instance.getValue();
         if (auto name = VariableNameInferrer::inferName(value)) {
           os << "'" << *name << "'-isolated";
-          printOptions();
+          printOptions(os);
           os << "\n";
           os << "instance: " << *value;
 
@@ -925,7 +927,7 @@ void SILIsolationInfo::print(llvm::raw_ostream &os) const {
       }
       case ActorInstance::Kind::ActorAccessorInit:
         os << "'self'-isolated";
-        printOptions();
+        printOptions(os);
         os << '\n';
         os << "instance: actor accessor init\n";
         return;
@@ -935,17 +937,17 @@ void SILIsolationInfo::print(llvm::raw_ostream &os) const {
     if (getActorIsolation().getKind() == ActorIsolation::ActorInstance) {
       if (auto *vd = getActorIsolation().getActorInstance()) {
         os << "'" << vd->getBaseIdentifier() << "'-isolated";
-        printOptions();
+        printOptions(os);
         return;
       }
     }
 
     getActorIsolation().printForDiagnostics(os);
-    printOptions();
+    printOptions(os);
     return;
   case Task:
     os << "task-isolated";
-    printOptions();
+    printOptions(os);
     os << '\n';
     os << "instance: " << *getIsolatedValue();
     return;
@@ -1072,9 +1074,7 @@ void SILIsolationInfo::printForOneLineLogging(llvm::raw_ostream &os) const {
     return;
   case Disconnected:
     os << "disconnected";
-    if (getOptions().contains(Flag::UnsafeNonIsolated)) {
-      os << ": nonisolated(unsafe)";
-    }
+    printOptions(os);
     return;
   case Actor:
     if (auto instance = getActorInstance()) {
@@ -1083,12 +1083,14 @@ void SILIsolationInfo::printForOneLineLogging(llvm::raw_ostream &os) const {
         SILValue value = instance.getValue();
         if (auto name = VariableNameInferrer::inferName(value)) {
           os << "'" << *name << "'-isolated";
+          printOptions(os);
           return;
         }
         break;
       }
       case ActorInstance::Kind::ActorAccessorInit:
         os << "'self'-isolated";
+        printOptions(os);
         return;
       }
     }
@@ -1096,14 +1098,17 @@ void SILIsolationInfo::printForOneLineLogging(llvm::raw_ostream &os) const {
     if (getActorIsolation().getKind() == ActorIsolation::ActorInstance) {
       if (auto *vd = getActorIsolation().getActorInstance()) {
         os << "'" << vd->getBaseIdentifier() << "'-isolated";
+        printOptions(os);
         return;
       }
     }
 
     getActorIsolation().printForDiagnostics(os);
+    printOptions(os);
     return;
   case Task:
     os << "task-isolated";
+    printOptions(os);
     return;
   }
 }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -439,8 +439,9 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   let myActor = A()
 
   await optionalIsolated(ns, to: myActor)
-  // expected-complete-warning@-1 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{pattern that the region based isolation checker does not understand how to check. Please file a bug}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
+  // expected-tns-note @-3 {{sending task-isolated 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated and task-isolated uses}}
 
 #if ALLOW_TYPECHECKER_ERRORS
   optionalIsolatedSync(ns, to: myActor)
@@ -456,13 +457,14 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated global function 'optionalIsolated(_:to:)' risks causing data races between nonisolated and main actor-isolated uses}}
 
-  optionalIsolatedSync(ns, to: nil) // expected-tns-warning {{pattern that the region based isolation checker does not understand how to check. Please file a bug}}
+  optionalIsolatedSync(ns, to: nil)
 
   let myActor = A()
 
   await optionalIsolated(ns, to: myActor)
   // expected-complete-warning@-1 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{pattern that the region based isolation checker does not understand how to check. Please file a bug}}
+  // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
+  // expected-tns-note @-3 {{sending main actor-isolated 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated and main actor-isolated uses}}
 
 #if ALLOW_TYPECHECKER_ERRORS
   optionalIsolatedSync(ns, to: myActor)
@@ -566,4 +568,15 @@ public func useDefaultIsolationWithoutIsolatedParam(
 @MainActor func callUseDefaultIsolation() async {
   useDefaultIsolation()
   useDefaultIsolationWithoutIsolatedParam()
+}
+
+public actor MyActorIsolatedParameterMerge {
+  private var inProgressIndexTasks: [Int: Int] = [:]
+
+  public func test() async {
+    await withTaskGroup(of: Void.self) { taskGroup in
+      for (_, _) in inProgressIndexTasks {}
+      await taskGroup.waitForAll()
+    }
+  }
 }

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -23,6 +23,8 @@ class NonSendableKlass {
 
 actor MyActor {
   var ns: NonSendableKlass
+
+  func doSomething() async -> NonSendableKlass
 }
 
 sil @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
@@ -33,6 +35,7 @@ sil @constructNonSendableKlassIndirectAsync : $@convention(thin) @async () -> @o
 sil @useUnmanagedNonSendableKlass : $@convention(thin) (@guaranteed @sil_unmanaged NonSendableKlass) -> ()
 
 sil @useActor : $@convention(thin) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+sil @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
 
 ///////////////////////
 // MARK: Basic Tests //
@@ -720,4 +723,99 @@ bb0(%0 : @owned $MyActor):
   destroy_value %1 : $MyActor
   destroy_value %1b : $MyActor
   return %3 : $NonSendableKlass
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on isolated_variable_test_1: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: Input Value:   %2 = apply %1(%0) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+// CHECK-NEXT: Isolation: disconnected
+// CHECK-NEXT: end running test 1 of 1 on isolated_variable_test_1: sil-isolation-info-inference with: @trace[0]
+sil [ossa] @isolated_variable_test_1 : $@convention(thin) @async () -> () {
+bb0:
+  specify_test "sil-isolation-info-inference @trace[0]"
+  %0 = enum $Optional<MyActor>, #Optional.none
+  %1 = function_ref @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %2 = apply %1(%0) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  //debug_value [trace] %1 : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  debug_value [trace] %2 : $NonSendableKlass
+  destroy_value %2 : $NonSendableKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil @$s5infer7MyActorC11doSomethingAA16NonSendableKlassCyYaF : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+
+// CHECK-LABEL: begin running test 1 of 1 on isolated_variable_test_2:
+// CHECK-NEXT: First Value:   %3 = apply %2(%0) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+// CHECK-NEXT: First Isolation: 'self'-isolated
+// CHECK-NEXT: Second Value:   %6 = apply %4(%5) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+// CHECK-NEXT: Second Isolation: 'self'-isolated
+// CHECK-NEXT: Merged Isolation: 'self'-isolated
+// CHECK-NEXT: end running test 1 of 1 on isolated_variable_test_2: sil-isolation-info-merged-inference with: @trace[0], @trace[1]
+sil [ossa] @isolated_variable_test_2 : $@convention(thin) @async (@guaranteed Optional<MyActor>) -> () {
+bb0(%0 : @guaranteed $Optional<MyActor>):
+  debug_value %0 : $Optional<MyActor>, let, name "self"
+  specify_test "sil-isolation-info-merged-inference @trace[0] @trace[1]"
+  %1 = function_ref @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %2 = apply %1(%0) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %3 = function_ref @$s5infer7MyActorC11doSomethingAA16NonSendableKlassCyYaF : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  %0a = unchecked_enum_data %0 : $Optional<MyActor>, #Optional.some!enumelt
+  %4 = apply %3(%0a) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  debug_value [trace] %2 : $NonSendableKlass
+  debug_value [trace] %4 : $NonSendableKlass
+  destroy_value %2 : $NonSendableKlass
+  destroy_value %4 : $NonSendableKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on isolated_variable_test_3:
+// CHECK-NEXT: First Value:   %4 = apply %2(%3) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+// CHECK-NEXT: First Isolation: 'self'-isolated
+// CHECK-NEXT: Second Value:   %6 = apply %5(%0) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+// CHECK-NEXT: Second Isolation: 'self'-isolated
+// CHECK-NEXT: Merged Isolation: 'self'-isolated
+// CHECK-NEXT: end running test 1 of 1 on isolated_variable_test_3: sil-isolation-info-merged-inference with: @trace[0], @trace[1]
+sil [ossa] @isolated_variable_test_3 : $@convention(thin) @async (@guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  debug_value %0 : $MyActor, let, name "self"
+  specify_test "sil-isolation-info-merged-inference @trace[0] @trace[1]"
+  %1 = function_ref @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %0a = enum $Optional<MyActor>, #Optional.some!enumelt, %0 : $MyActor
+  %2 = apply %1(%0a) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %3 = function_ref @$s5infer7MyActorC11doSomethingAA16NonSendableKlassCyYaF : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  %4 = apply %3(%0) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  debug_value [trace] %2 : $NonSendableKlass
+  debug_value [trace] %4 : $NonSendableKlass
+  destroy_value %2 : $NonSendableKlass
+  destroy_value %4 : $NonSendableKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on isolated_variable_test_4:
+// CHECK-NEXT: First Value:   %8 = apply %2(%7) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+// CHECK-NEXT: First Isolation: 'self'-isolated
+// CHECK-NEXT: Second Value:   %10 = apply %9(%0) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+// CHECK-NEXT: Second Isolation: 'self'-isolated
+// CHECK-NEXT: Merged Isolation: 'self'-isolated
+// CHECK-NEXT: end running test 1 of 1 on isolated_variable_test_4: sil-isolation-info-merged-inference with: @trace[0], @trace[1]
+sil [ossa] @isolated_variable_test_4 : $@convention(thin) @async (@guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  debug_value %0 : $MyActor, let, name "self"
+  specify_test "sil-isolation-info-merged-inference @trace[0] @trace[1]"
+  %1 = function_ref @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %0a = init_existential_ref %0 : $MyActor : $MyActor, $AnyObject
+  %0b = unconditional_checked_cast %0a : $AnyObject to MyActor
+  %0c = unchecked_ref_cast %0b : $MyActor to $AnyObject
+  %0d = unchecked_ref_cast %0c : $AnyObject to $MyActor
+  %0e = enum $Optional<MyActor>, #Optional.some!enumelt, %0d : $MyActor
+  %2 = apply %1(%0e) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %3 = function_ref @$s5infer7MyActorC11doSomethingAA16NonSendableKlassCyYaF : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  %4 = apply %3(%0) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  debug_value [trace] %2 : $NonSendableKlass
+  debug_value [trace] %4 : $NonSendableKlass
+  destroy_value %2 : $NonSendableKlass
+  destroy_value %4 : $NonSendableKlass
+  %9999 = tuple ()
+  return %9999 : $()
 }


### PR DESCRIPTION
By improving the pattern matching, we prevent a mismerge of isolations in this case in between the isolation of the context and the isolation of the actor being passed as a #isolation parameter. 

rdar://130113744