### PR TITLE
Typos: `benchmark` folder

### DIFF
--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -564,7 +564,7 @@ class TestComparator(object):
     It determines which tests were `added`, `removed` and which can be
     compared. It then splits the `ResultComparison`s into 3 groups according to
     the `delta_threshold` by the change in performance: `increased`,
-    `descreased` and `unchanged`. Whole computation is performed during
+    `decreased` and `unchanged`. Whole computation is performed during
     initialization and results are provided as properties on this object.
 
     The lists of `added`, `removed` and `unchanged` tests are sorted

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -629,7 +629,7 @@ class TestReportFormatter(OldAndNewLog):
         )
 
     def test_justified_columns(self):
-        """Table columns are all formated with same width, defined by the
+        """Table columns are all formatted with same width, defined by the
         longest value.
         """
         self.assert_markdown_contains(

--- a/benchmark/scripts/test_utils.py
+++ b/benchmark/scripts/test_utils.py
@@ -58,7 +58,7 @@ class Mock(object):
     """
 
     def __init__(self, responses=None):
-        """Optionaly initialized with a list of expected calls. See expect."""
+        """Optionally initialized with a list of expected calls. See expect."""
         self.calls = []
         self.expected = []
         self.respond = dict()

--- a/benchmark/single-source/SortIntPyramids.swift
+++ b/benchmark/single-source/SortIntPyramids.swift
@@ -37,7 +37,7 @@ let pyramidTemplate: [Int] = (1...pH) + (1...pH).reversed()
 // A^R - reversed array A, + - array concatenation operator,
 // A indices are in range 1...A.length.
 // define adjacent pyramid as A + A^R + A + A^R,
-// defne adjacent pyramid height as A[A.length].
+// define adjacent pyramid height as A[A.length].
 
 
 // On 25% of following dataset stdlib sorting function will use heapSort.

--- a/benchmark/single-source/SortIntPyramids.swift
+++ b/benchmark/single-source/SortIntPyramids.swift
@@ -37,7 +37,7 @@ let pyramidTemplate: [Int] = (1...pH) + (1...pH).reversed()
 // A^R - reversed array A, + - array concatenation operator,
 // A indices are in range 1...A.length.
 // define adjacent pyramid as A + A^R + A + A^R,
-// defne adjacent pyramid hight as A[A.length].
+// defne adjacent pyramid height as A[A.length].
 
 
 // On 25% of following dataset stdlib sorting function will use heapSort.


### PR DESCRIPTION
Fix typos in `Benchmark` folder.

This is one batch of many PRs fixing typos, [see the tracking issue.](https://github.com/swiftlang/swift/issues/75022)