### PR TITLE
Typos: `stdlib`

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -596,7 +596,7 @@ function(_compile_swift_files
     list(APPEND swift_flags "-swift-version" "5")
   endif()
 
-  # Avoiding emiting ABI descriptor files while building stdlib.
+  # Avoiding emitting ABI descriptor files while building stdlib.
   if (SWIFTFILE_IS_STDLIB)
     list(APPEND swift_flags "-Xfrontend" "-empty-abi-descriptor")
   endif()

--- a/stdlib/include/llvm/ADT/STLExtras.h
+++ b/stdlib/include/llvm/ADT/STLExtras.h
@@ -529,8 +529,8 @@ make_filter_range(RangeT &&Range, PredicateT Pred) {
 /// somewhere between them. The constraints of these iterators are:
 ///
 /// - On construction or after being incremented, it is comparable and
-///   dereferencable. It is *not* incrementable.
-/// - After being dereferenced, it is neither comparable nor dereferencable, it
+///   dereferenceable. It is *not* incrementable.
+/// - After being dereferenced, it is neither comparable nor dereferenceable, it
 ///   is only incrementable.
 ///
 /// This means you can only dereference the iterator once, and you can only

--- a/stdlib/include/llvm/Support/MathExtras.h
+++ b/stdlib/include/llvm/Support/MathExtras.h
@@ -906,7 +906,7 @@ std::enable_if_t<std::is_signed<T>::value, T> AddOverflow(T X, T Y, T &Result) {
 }
 
 /// Subtract two signed integers, computing the two's complement truncated
-/// result, returning true if an overflow ocurred.
+/// result, returning true if an overflow occurred.
 template <typename T>
 std::enable_if_t<std::is_signed<T>::value, T> SubOverflow(T X, T Y, T &Result) {
 #if __has_builtin(__builtin_sub_overflow)
@@ -932,7 +932,7 @@ std::enable_if_t<std::is_signed<T>::value, T> SubOverflow(T X, T Y, T &Result) {
 }
 
 /// Multiply two signed integers, computing the two's complement truncated
-/// result, returning true if an overflow ocurred.
+/// result, returning true if an overflow occurred.
 template <typename T>
 std::enable_if_t<std::is_signed<T>::value, T> MulOverflow(T X, T Y, T &Result) {
   // Perform the unsigned multiplication on absolute values.

--- a/stdlib/private/StdlibUnicodeUnittest/WordBreaking.swift
+++ b/stdlib/private/StdlibUnicodeUnittest/WordBreaking.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Normalization tests are currently only avaible on Darwin, awaiting a sensible
+// Normalization tests are currently only available on Darwin, awaiting a sensible
 // file API...
 #if _runtime(_ObjC)
 import Foundation

--- a/stdlib/private/SwiftPrivate/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivate/CMakeLists.txt
@@ -3,9 +3,9 @@ set(swift_swiftprivate_compile_flags
     "-Xfrontend" "-disable-access-control")
 
 if(SWIFT_BUILD_SDK_OVERLAY)
-set(swift_swiftprivate_darwin_depencencies Darwin)
+set(swift_swiftprivate_darwin_dependencies Darwin)
 else()
-set(swift_swiftprivate_darwin_depencencies)
+set(swift_swiftprivate_darwin_dependencies)
 endif()
 
 add_swift_target_library(swiftSwiftPrivate ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
@@ -21,11 +21,11 @@ add_swift_target_library(swiftSwiftPrivate ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   GYB_SOURCES
     AtomicInt.swift.gyb
 
-  SWIFT_MODULE_DEPENDS_OSX ${swift_swiftprivate_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_IOS ${swift_swiftprivate_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_TVOS ${swift_swiftprivate_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_swiftprivate_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_swiftprivate_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_OSX ${swift_swiftprivate_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_IOS ${swift_swiftprivate_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_swiftprivate_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_swiftprivate_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_swiftprivate_darwin_dependencies}
   SWIFT_MODULE_DEPENDS_FREESTANDING "${SWIFT_FREESTANDING_TEST_DEPENDENCIES}"
   SWIFT_MODULE_DEPENDS_ANDROID Android
   SWIFT_MODULE_DEPENDS_LINUX Glibc

--- a/stdlib/private/SwiftPrivateLibcExtras/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivateLibcExtras/CMakeLists.txt
@@ -15,9 +15,9 @@ else()
 endif()
 
 if(SWIFT_BUILD_SDK_OVERLAY)
-set(swift_private_libc_extras_darwin_depencencies Darwin)
+set(swift_private_libc_extras_darwin_dependencies Darwin)
 else()
-set(swift_private_libc_extras_darwin_depencencies)
+set(swift_private_libc_extras_darwin_dependencies)
 endif()
 
 add_swift_target_library(swiftSwiftPrivateLibcExtras ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
@@ -31,12 +31,12 @@ add_swift_target_library(swiftSwiftPrivateLibcExtras ${SWIFT_STDLIB_LIBRARY_BUIL
 
   SWIFT_MODULE_DEPENDS SwiftPrivate
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS} ${swift_private_libc_extras_flags}
-  SWIFT_MODULE_DEPENDS_OSX ${swift_private_libc_extras_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_IOS ${swift_private_libc_extras_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_TVOS ${swift_private_libc_extras_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_private_libc_extras_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_XROS ${swift_private_libc_extras_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_private_libc_extras_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_OSX ${swift_private_libc_extras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_IOS ${swift_private_libc_extras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_private_libc_extras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_private_libc_extras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_XROS ${swift_private_libc_extras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_private_libc_extras_darwin_dependencies}
   SWIFT_MODULE_DEPENDS_FREESTANDING "${SWIFT_FREESTANDING_TEST_DEPENDENCIES}"
   SWIFT_MODULE_DEPENDS_ANDROID Android
   SWIFT_MODULE_DEPENDS_LINUX Glibc

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.c
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.c
@@ -54,5 +54,5 @@ int _stdlib_posix_spawn(pid_t *__restrict pid, const char * __restrict path,
   return posix_spawn(pid, path, file_actions, attrp, argv, envp);
 }
 
-#endif // !defined(__ANDROID__) && !defined(__HAIKU__) && (!defined(_WIN32) || defined(__CGYWIN__)) && !defined(__wasi__)
+#endif // !defined(__ANDROID__) && !defined(__HAIKU__) && (!defined(_WIN32) || defined(__CYGWIN__)) && !defined(__wasi__)
 

--- a/stdlib/private/SwiftPrivateThreadExtras/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivateThreadExtras/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(SWIFT_BUILD_SDK_OVERLAY)
-set(swift_private_thread_extras_darwin_depencencies Darwin)
+set(swift_private_thread_extras_darwin_dependencies Darwin)
 else()
-set(swift_private_thread_extras_darwin_depencencies)
+set(swift_private_thread_extras_darwin_dependencies)
 endif()
 
 add_swift_target_library(swiftSwiftPrivateThreadExtras ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
@@ -12,12 +12,12 @@ add_swift_target_library(swiftSwiftPrivateThreadExtras ${SWIFT_STDLIB_LIBRARY_BU
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
-  SWIFT_MODULE_DEPENDS_IOS ${swift_private_thread_extras_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_OSX ${swift_private_thread_extras_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_TVOS ${swift_private_thread_extras_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_private_thread_extras_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_XROS ${swift_private_thread_extras_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_private_thread_extras_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_IOS ${swift_private_thread_extras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_OSX ${swift_private_thread_extras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_private_thread_extras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_private_thread_extras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_XROS ${swift_private_thread_extras_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_private_thread_extras_darwin_dependencies}
   SWIFT_MODULE_DEPENDS_FREESTANDING "${SWIFT_FREESTANDING_TEST_DEPENDENCIES}"
   SWIFT_MODULE_DEPENDS_ANDROID Android
   SWIFT_MODULE_DEPENDS_LINUX Glibc

--- a/stdlib/private/SwiftReflectionTest/CMakeLists.txt
+++ b/stdlib/private/SwiftReflectionTest/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(SWIFT_BUILD_SDK_OVERLAY)
-set(swift_reflection_test_darwin_depencencies Darwin)
+set(swift_reflection_test_darwin_dependencies Darwin)
 else()
-set(swift_reflection_test_darwin_depencencies)
+set(swift_reflection_test_darwin_dependencies)
 endif()
 
 if (SWIFT_INCLUDE_TESTS AND SWIFT_BUILD_DYNAMIC_STDLIB)
@@ -9,11 +9,11 @@ if (SWIFT_INCLUDE_TESTS AND SWIFT_BUILD_DYNAMIC_STDLIB)
     SwiftReflectionTest.swift
     SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     SWIFT_COMPILE_FLAGS_LINUX -Xcc -D_GNU_SOURCE
-    SWIFT_MODULE_DEPENDS_OSX ${swift_reflection_test_darwin_depencencies}
-    SWIFT_MODULE_DEPENDS_IOS ${swift_reflection_test_darwin_depencencies}
-    SWIFT_MODULE_DEPENDS_TVOS ${swift_reflection_test_darwin_depencencies}
-    SWIFT_MODULE_DEPENDS_WATCHOS ${swift_reflection_test_darwin_depencencies}
-    SWIFT_MODULE_DEPENDS_XROS ${swift_reflection_test_darwin_depencencies}
+    SWIFT_MODULE_DEPENDS_OSX ${swift_reflection_test_darwin_dependencies}
+    SWIFT_MODULE_DEPENDS_IOS ${swift_reflection_test_darwin_dependencies}
+    SWIFT_MODULE_DEPENDS_TVOS ${swift_reflection_test_darwin_dependencies}
+    SWIFT_MODULE_DEPENDS_WATCHOS ${swift_reflection_test_darwin_dependencies}
+    SWIFT_MODULE_DEPENDS_XROS ${swift_reflection_test_darwin_dependencies}
     SWIFT_MODULE_DEPENDS_ANDROID Android
     SWIFT_MODULE_DEPENDS_LINUX Glibc
     SWIFT_MODULE_DEPENDS_LINUX_STATIC Musl

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1195,7 +1195,7 @@ private:
   /// It can be done when actor transitions from Idle to Scheduled or
   /// when actor gets a priority override and we schedule a stealer.
   ///
-  /// When the task executor is `undefined` ths task will be scheduled on the
+  /// When the task executor is `undefined` the task will be scheduled on the
   /// default global executor.
   void scheduleActorProcessJob(JobPriority priority, TaskExecutorRef taskExecutor);
 

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -267,7 +267,7 @@ extension CheckedContinuation {
 /// indefinitely which will result in the task "hanging" as well as being leaked with
 /// no possibility to destroy it.
 ///
-/// The checked continuation offers detection of mis-use, and dropping the last reference
+/// The checked continuation offers detection of misuse, and dropping the last reference
 /// to it, without having resumed it will trigger a warning. Resuming a continuation twice
 /// is also diagnosed and will cause a crash.
 ///
@@ -328,7 +328,7 @@ internal func __abi_withCheckedContinuation<T>(
 /// indefinitely which will result in the task "hanging" as well as being leaked with
 /// no possibility to destroy it.
 ///
-/// The checked continuation offers detection of mis-use, and dropping the last reference
+/// The checked continuation offers detection of misuse, and dropping the last reference
 /// to it, without having resumed it will trigger a warning. Resuming a continuation twice
 /// is also diagnosed and will cause a crash.
 ///

--- a/stdlib/public/Concurrency/Deque/_UnsafeWrappedBuffer.swift
+++ b/stdlib/public/Concurrency/Deque/_UnsafeWrappedBuffer.swift
@@ -153,7 +153,7 @@ extension _UnsafeMutableWrappedBuffer {
     // Note: Array._copyContents traps when not given enough space, so we
     // need to check if we have enough contiguous space available above.
     //
-    // FIXME: Add suppport for segmented (a.k.a. piecewise contiguous)
+    // FIXME: Add support for segmented (a.k.a. piecewise contiguous)
     // collections to the stdlib.
     var (it, copied) = elements._copyContents(initializing: first)
     if copied == first.count, let second = second {

--- a/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
@@ -70,7 +70,7 @@ extension TaskGroup {
   ///
   /// - Parameters:
   ///   - taskExecutor: The task executor that the child task should be started on and keep using.
-  ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
+  ///                   If `nil` is passed explicitly, that parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `addTaskUnlessCancelled()` without passing a value to the `taskExecutor` parameter,
   ///                   and it will be inherited automatically.
@@ -135,7 +135,7 @@ extension ThrowingTaskGroup {
   ///
   /// - Parameters:
   ///   - taskExecutor: The task executor that the child task should be started on and keep using.
-  ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
+  ///                   If `nil` is passed explicitly, that parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `addTask()` without passing a value to the `taskExecutor` parameter,
   ///                   and it will be inherited automatically.
@@ -245,7 +245,7 @@ extension DiscardingTaskGroup {
   ///
   /// - Parameters:
   ///   - taskExecutor: The task executor that the child task should be started on and keep using.
-  ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
+  ///                   If `nil` is passed explicitly, that parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `addTask()` without passing a value to the `taskExecutor` parameter,
   ///                   and it will be inherited automatically.
@@ -295,7 +295,7 @@ extension DiscardingTaskGroup {
   ///
   /// - Parameters:
   ///   - taskExecutor: The task executor that the child task should be started on and keep using.
-  ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
+  ///                   If `nil` is passed explicitly, that parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `addTask()` without passing a value to the `taskExecutor` parameter,
   ///                   and it will be inherited automatically.
@@ -360,7 +360,7 @@ extension ThrowingDiscardingTaskGroup {
   ///
   /// - Parameters:
   ///   - taskExecutor: The task executor that the child task should be started on and keep using.
-  ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
+  ///                   If `nil` is passed explicitly, that parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `addTask()` without passing a value to the `taskExecutor` parameter,
   ///                   and it will be inherited automatically.
@@ -410,7 +410,7 @@ extension ThrowingDiscardingTaskGroup {
   ///
   /// - Parameters:
   ///   - taskExecutor: The task executor that the child task should be started on and keep using.
-  ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
+  ///                   If `nil` is passed explicitly, that parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `addTask()` without passing a value to the `taskExecutor` parameter,
   ///                   and it will be inherited automatically.

--- a/stdlib/public/Distributed/CMakeLists.txt
+++ b/stdlib/public/Distributed/CMakeLists.txt
@@ -11,9 +11,9 @@
 #===----------------------------------------------------------------------===#
 
 if(SWIFT_BUILD_SDK_OVERLAY)
-set(swift_distributed_darwin_depencencies Darwin)
+set(swift_distributed_darwin_dependencies Darwin)
 else()
-set(swift_distributed_darwin_depencencies)
+set(swift_distributed_darwin_dependencies)
 endif()
 
 set(swift_distributed_link_libraries
@@ -30,10 +30,10 @@ add_swift_target_library(swiftDistributed ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS
   DistributedMetadata.swift
   LocalTestingDistributedActorSystem.swift
 
-  SWIFT_MODULE_DEPENDS_IOS ${swift_distributed_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_OSX ${swift_distributed_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_TVOS ${swift_distributed_darwin_depencencies}
-  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_distributed_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_IOS ${swift_distributed_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_OSX ${swift_distributed_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_distributed_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_distributed_darwin_dependencies}
   SWIFT_MODULE_DEPENDS_ANDROID Android
   SWIFT_MODULE_DEPENDS_LINUX Glibc
   SWIFT_MODULE_DEPENDS_FREEBSD Glibc

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -325,7 +325,7 @@ extension DistributedActor /*: implicitly Decodable */ where Self.ID: Decodable 
   /// on, in order to obtain the instance this initializer should return.
   ///
   /// - Parameter decoder: used to decode the ``ID`` of this distributed actor.
-  /// - Throws: If the actor system value in `decoder.userInfo` is missing or mis-typed;
+  /// - Throws: If the actor system value in `decoder.userInfo` is missing or mistyped;
   ///           the `ID` fails to decode from the passed `decoder`;
   //            or if the ``DistributedActor/resolve(id:using:)`` method invoked by this initializer throws.
   nonisolated public init(from decoder: Decoder) throws {

--- a/stdlib/public/Platform/android.modulemap
+++ b/stdlib/public/Platform/android.modulemap
@@ -12,7 +12,7 @@
 // The module map for the Android NDK.
 // A portion of the modules in this file are prefixed
 // with an underscore, to discourage users from importing them from
-// Swift directly, as these modules might be overriden by the C++ stdlib.
+// Swift directly, as these modules might be overridden by the C++ stdlib.
 // Instead, users should import 'Android' or another
 // umbrella module that includes these headers.
 

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -895,7 +895,7 @@ public:
       node->addChild(MemberId, Dem);
     } else {
       // Otherwise, build up a DependentAssociatedTR node with
-      // the member Identifer and protocol
+      // the member Identifier and protocol
       auto AssocTy = Dem.createNode(Node::Kind::DependentAssociatedTypeRef);
       AssocTy->addChild(MemberId, Dem);
       auto Proto = Dem.demangleType(MangledProtocol);

--- a/stdlib/public/Synchronization/Atomics/AtomicMemoryOrderings.swift
+++ b/stdlib/public/Synchronization/Atomics/AtomicMemoryOrderings.swift
@@ -245,7 +245,7 @@ extension AtomicUpdateOrdering {
   /// An acquiring update synchronizes with a releasing operation
   /// whose value its reads. It ensures that the releasing and
   /// acquiring threads agree that all subsequent variable accesses on
-  /// the acquring thread happen after the atomic operation itself.
+  /// the acquiring thread happen after the atomic operation itself.
   ///
   /// This value corresponds to `std::memory_order_acquire` in C++.
   @available(SwiftStdlib 6.0, *)

--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -19,13 +19,13 @@ import Glibc
 
 extension Atomic where Value == UInt32 {
   // This returns 'false' on success and 'true' on error. Check 'errno' for the
-  // specifc error value.
+  // specific error value.
   internal borrowing func _futexLock() -> UInt32 {
     _swift_stdlib_futex_lock(.init(_rawAddress))
   }
 
   // This returns 'false' on success and 'true' on error. Check 'errno' for the
-  // specifc error value.
+  // specific error value.
   internal borrowing func _futexTryLock() -> UInt32 {
     _swift_stdlib_futex_trylock(.init(_rawAddress))
   }
@@ -189,7 +189,7 @@ extension _MutexHandle {
       // ESRCH  - "The thread ID in the futex word at uaddr does not exist."
       default:
         // TODO: Replace with a colder function / one that takes a StaticString
-        fatalError("Unknown error occured while attempting to acquire a Mutex")
+        fatalError("Unknown error occurred while attempting to acquire a Mutex")
       }
     }
   }
@@ -359,7 +359,7 @@ extension _MutexHandle {
       //           space.)"
       default:
         // TODO: Replace with a colder function / one that takes a StaticString
-        fatalError("Unknown error occured while attempting to release a Mutex")
+        fatalError("Unknown error occurred while attempting to release a Mutex")
       }
     }
   }

--- a/stdlib/public/Synchronization/Mutex/Mutex.swift
+++ b/stdlib/public/Synchronization/Mutex/Mutex.swift
@@ -24,7 +24,7 @@
 ///     class Manager {
 ///       let cache = Mutex<[Key: Resource]>([:])
 ///
-///       func saveResouce(_ resource: Resouce, as key: Key) {
+///       func saveResource(_ resource: Resource, as key: Key) {
 ///         cache.withLock {
 ///           $0[key] = resource
 ///         }
@@ -57,7 +57,7 @@ extension Mutex: @unchecked Sendable where Value: ~Copyable {}
 
 @available(SwiftStdlib 6.0, *)
 extension Mutex where Value: ~Copyable {
-  /// Calls the given closure after acquring the lock and then releases
+  /// Calls the given closure after acquiring the lock and then releases
   /// ownership.
   ///
   /// This method is equivalent to the following sequence of code:

--- a/stdlib/public/Synchronization/Mutex/MutexUnavailable.swift
+++ b/stdlib/public/Synchronization/Mutex/MutexUnavailable.swift
@@ -24,7 +24,7 @@
 ///     class Manager {
 ///       let cache = Mutex<[Key: Resource]>([:])
 ///
-///       func saveResouce(_ resource: Resouce, as key: Key) {
+///       func saveResource(_ resource: Resource, as key: Key) {
 ///         cache.withLock {
 ///           $0[key] = resource
 ///         }

--- a/stdlib/public/core/DiscontiguousSlice.swift
+++ b/stdlib/public/core/DiscontiguousSlice.swift
@@ -45,7 +45,7 @@ extension DiscontiguousSlice: Equatable where Base.Element: Equatable {
 @available(SwiftStdlib 6.0, *)
 extension DiscontiguousSlice: Hashable where Base.Element: Hashable {
   public func hash(into hasher: inout Hasher) {
-    hasher.combine(count) // delimeter; do not remove
+    hasher.combine(count) // delimiter; do not remove
     for element in self {
       hasher.combine(element)
     }

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1787,7 +1787,7 @@ extension BinaryInteger {
 //===--- Ambiguity breakers -----------------------------------------------===//
 //
 // These two versions of the operators are not ordered with respect to one
-// another, but the compiler choses the second one, and that results in infinite
+// another, but the compiler chooses the second one, and that results in infinite
 // recursion.
 //
 //     <T: Comparable>(T, T) -> Bool

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -200,7 +200,7 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 /// all of the following pairs of declarations are equivalent:
 ///
 ///     struct MyStructure { }
-///     struct MyStructere: Copyable { }
+///     struct MyStructure: Copyable { }
 ///
 ///     protocol MyProtocol { }
 ///     protocol MyProtocol: Copyable { }

--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -714,7 +714,7 @@ extension _GraphemeBreakingState {
 
     let x = Unicode._GraphemeBreakProperty(from: scalar1)
     
-    // GB4 handled here because we don't need to know `y` for this csae
+    // GB4 handled here because we don't need to know `y` for this case
     if x == .control {
       return true
     }

--- a/stdlib/public/libexec/swift-backtrace/Utils.swift
+++ b/stdlib/public/libexec/swift-backtrace/Utils.swift
@@ -58,7 +58,7 @@ internal func parseUInt64<S: StringProtocol>(_ s: S) -> UInt64? {
 struct PosixError: Error {
   var errno: Int32
 
-  var desription: String {
+  var description: String {
     return String(cString: strerror(self.errno))
   }
 }

--- a/stdlib/public/runtime/Bincompat.cpp
+++ b/stdlib/public/runtime/Bincompat.cpp
@@ -261,7 +261,7 @@ bool useLegacySwiftObjCHashing() {
 // * The `swift_task_isCurrentExecutorImpl` cannot crash
 // * This means cases where no "current" executor is present cannot be diagnosed correctly
 //    * The runtime can NOT use 'SerialExecutor/checkIsolated'
-//    * The runtime can NOT use 'dispatch_precondition' which is able ot handle some dispatch and main actor edge cases
+//    * The runtime can NOT use 'dispatch_precondition' which is able to handle some dispatch and main actor edge cases
 //
 // New behavior in "swift6" "crash" mode:
 // * The 'swift_task_isCurrentExecutorImpl' will CRASH rather than return 'false'

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -6201,7 +6201,7 @@ public:
        if (req.Flags.getKind() ==
            ProtocolRequirementFlags::Kind::BaseProtocol) {
          ++result;
-         // We currently assume that base protocol requirements preceed other
+         // We currently assume that base protocol requirements precede other
          // requirements i.e we store the base protocol pointers sequentially in
          // instantiateRelativeWitnessTable starting at index 1.
          assert(currIdx == result &&
@@ -6270,7 +6270,7 @@ using RelativeBaseWitness = RelativeDirectPointer<void, true /*nullable*/>;
 //
 // The layout of a dynamically allocated relative witness table is:
 //             [ conditional conformance n] ... private area
-//             [ conditional conformance 0]     (negatively adressed)
+//             [ conditional conformance 0]     (negatively addressed)
 // pointer ->  [ pointer to relative witness table (pattern) ]
 //             [ base protocol witness table pointer 0 ] ... base protocol
 //             [ base protocol witness table pointer n ]     pointers

--- a/stdlib/public/stubs/Unicode/UnicodeData.cpp
+++ b/stdlib/public/stubs/Unicode/UnicodeData.cpp
@@ -73,7 +73,7 @@ __swift_intptr_t _swift_stdlib_getMphIdx(__swift_uint32_t scalar,
       // within each bit array every 512 bits. Say our level (bit array)
       // contains 16 uint64 integers to represent all of the required bits.
       // There would be a total of 1024 bits, so our rankings for this level
-      // would contain two values for precomputed counted bits for both halfs
+      // would contain two values for precomputed counted bits for both halves
       // of this bit array (1024 / 512 = 2).
       auto rank = ranks[i][idx / 512];
 
@@ -189,7 +189,7 @@ __swift_intptr_t _swift_stdlib_getScalarBitArrayIdx(__swift_uint32_t scalar,
   auto chunkRank = ranks[idx];
 
   // If our specific bit within the chunk isn't the first bit, then count the
-  // number of bits turned on preceeding our chunk bit.
+  // number of bits turned on preceding our chunk bit.
   if (chunkBit != 0) {
     chunkRank += __builtin_popcountll(quickLook << (64 - chunkBit));
   }

--- a/stdlib/toolchain/Compatibility56/CompatibilityOverride.h
+++ b/stdlib/toolchain/Compatibility56/CompatibilityOverride.h
@@ -1,4 +1,4 @@
-//===--- CompatibiltyOverride.h - Back-deploying compatibility fixes --*- C++ -*-===//
+//===--- CompatibilityOverride.h - Back-deploying compatibility fixes --*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -77,7 +77,7 @@ namespace swift {
 
 #ifdef SWIFT_RUNTIME_NO_COMPATIBILITY_OVERRIDES
 
-# error Back-deployment library must always be built with compatibilty overrides
+# error Back-deployment library must always be built with compatibility overrides
 
 #else // #ifdef SWIFT_RUNTIME_NO_COMPATIBILITY_OVERRIDES
 

--- a/stdlib/toolchain/Compatibility56/CompatibilityOverrideConcurrency.def
+++ b/stdlib/toolchain/Compatibility56/CompatibilityOverrideConcurrency.def
@@ -343,7 +343,7 @@ OVERRIDE_TASK_STATUS(task_escalate, JobPriority,
                      swift::, (AsyncTask *task, JobPriority newPriority),
                      (task, newPriority))
 
-/// We need to keep this entry due to ABI requirements but this overrideable
+/// We need to keep this entry due to ABI requirements but this overridable
 /// function is not used at all so we will change the function definition to
 /// return void instead.
 OVERRIDE_TASK_STATUS(task_getNearestDeadline, void,

--- a/stdlib/toolchain/Compatibility56/Concurrency/Task.cpp
+++ b/stdlib/toolchain/Compatibility56/Concurrency/Task.cpp
@@ -23,7 +23,7 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
   auto fragment = futureFragment();
 
   auto queueHead = fragment->waitQueue.load(std::memory_order_acquire);
-  bool contextIntialized = false;
+  bool contextInitialized = false;
   auto escalatedPriority = JobPriority::Unspecified;
   while (true) {
     switch (queueHead.getStatus()) {
@@ -32,7 +32,7 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
       SWIFT_TASK_DEBUG_LOG("task %p waiting on task %p, completed immediately",
                            waitingTask, this);
       _swift_tsan_acquire(static_cast<Job *>(this));
-      if (contextIntialized) waitingTask->flagAsRunning();
+      if (contextInitialized) waitingTask->flagAsRunning();
       // The task is done; we don't need to wait.
       return queueHead.getStatus();
 
@@ -44,8 +44,8 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
       break;
     }
 
-    if (!contextIntialized) {
-      contextIntialized = true;
+    if (!contextInitialized) {
+      contextInitialized = true;
       auto context =
           reinterpret_cast<TaskFutureWaitAsyncContext *>(waitingTaskContext);
       context->errorResult = nullptr;

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/Task.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/Task.h
@@ -313,7 +313,7 @@ public:
   void flagAsRunning_slow();
 
   /// Flag that this task is now suspended.  This can update the
-  /// priority stored in the job flags if the priority hsa been
+  /// priority stored in the job flags if the priority has been
   /// escalated.  Generally this should be done immediately after
   /// clearing ActiveTask and immediately before enqueuing the task
   /// somewhere.  TODO: record where the task is enqueued if


### PR DESCRIPTION
Fix typos in `stdlib` folder

This is one batch of many PRs fixing typos, [see the tracking issue.](https://github.com/swiftlang/swift/issues/75022)