### PR TITLE
Typos: `SwiftCompilerSources`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AsyncDemotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AsyncDemotion.swift
@@ -590,7 +590,7 @@ private func analyzeForDemotion(_ function: Function) -> Node? {
   // because it may be a caller of a function that can be demoted.
 
   var executors = Set<Executor>()
-  var knownAsyncApplys: [ApplySite] = []
+  var knownAsyncApplySites: [ApplySite] = []
   var hops: [Instruction] = []
   var unknownAsyncOp: Instruction? = nil
 
@@ -614,7 +614,7 @@ private func analyzeForDemotion(_ function: Function) -> Node? {
       if apply.referencedFunction == nil {
         unknownAsyncOp.setIfUnset(inst)
       } else {
-        knownAsyncApplys.append(apply)
+        knownAsyncApplySites.append(apply)
         stats.tick(.asyncKnownCallsCount)
       }
 
@@ -630,7 +630,7 @@ private func analyzeForDemotion(_ function: Function) -> Node? {
 
   let data: AnalysisResult.Data =
     (function: function,
-     knownAsyncCalls: knownAsyncApplys,
+     knownAsyncCalls: knownAsyncApplySites,
      executors: executors,
      hops: hops)
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -145,7 +145,7 @@ private struct CollectedEffects {
       // In addition to the effects of the apply, also consider the
       // effects of the capture, which reads the captured value in
       // order to move it into the context. This only applies to
-      // addressible values, because capturing does not dereference
+      // addressable values, because capturing does not dereference
       // any class objects.
       //
       // Ignore captures for on-stack partial applies. They only
@@ -332,7 +332,7 @@ private struct CollectedEffects {
   /// Adds effects to a specific value.
   ///
   /// If the value comes from an argument (or multiple arguments), then the effects are added
-  /// to the corrseponding `argumentEffects`. Otherwise they are added to the `global` effects.
+  /// to the corresponding `argumentEffects`. Otherwise they are added to the `global` effects.
   private mutating func addEffects(_ effects: SideEffects.GlobalEffects, to value: Value) {
     addEffects(effects, to: value, fromInitialPath: defaultPath(for: value))
   }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -112,7 +112,7 @@ private func extendAccessScopes(dependence: LifetimeDependence,
 /// caller scope, which is handled separately). A nested 'read' access can never interfere with another access in the
 /// same outer 'read', because it is impossible to nest a 'modify' access within a 'read'. For 'modify' accesses,
 /// however, the inner scope must be extended for correctness. A 'modify' access can interfere with other 'modify'
-/// accesss in the same scope. We rely on exclusivity diagnostics to report these interferences. For example:
+/// access in the same scope. We rely on exclusivity diagnostics to report these interferences. For example:
 ///
 ///     sil @foo : $(@inout C) -> () {
 ///       bb0(%0 : $*C):
@@ -133,12 +133,12 @@ private func extendAccessScopes(dependence: LifetimeDependence,
 /// violation, and that subsequent optimizations do not shrink the inner access `%a1`.
 private func extendAccessScope(beginAccess: BeginAccessInst, range: inout InstructionRange,
                                _ context: FunctionPassContext) -> FunctionArgument? {
-  var endAcceses = [Instruction]()
+  var endAccesses = [Instruction]()
   // Collect the original end_access instructions and extend the range to to cover them. The resulting access scope must
   // cover the original scope because it may protect other memory operations.
   var requiresExtension = false
   for end in beginAccess.endInstructions {
-    endAcceses.append(end)
+    endAccesses.append(end)
     if range.contains(end) {
       // If any end_access is inside the new range, then all end_accesses must be rewritten.
       requiresExtension = true
@@ -171,7 +171,7 @@ private func extendAccessScope(beginAccess: BeginAccessInst, range: inout Instru
     range.insert(endAccess)
   }
   // Delete original end_access instructions
-  for endAccess in endAcceses {
+  for endAccess in endAccesses {
     context.erase(instruction: endAccess)
   }
   // TODO: Add SIL support for lifetime dependence and write unit test for nested access scopes

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
@@ -273,7 +273,7 @@ private struct ComputeOuterBlockrange : EscapeVisitorWithResult {
     // instructions (for which the `visitUse` closure is not called).
     result.insert(operandsDefinitionBlock)
 
-    // We need to explicitly add predecessor blocks of phis becaues they
+    // We need to explicitly add predecessor blocks of phis because they
     // are not necesesarily visited during the down-walk in `isEscaping()`.
     // This is important for the special case where there is a back-edge from the
     // inner range to the inner rage's begin-block:

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginBorrow.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginBorrow.swift
@@ -132,7 +132,7 @@ private extension Instruction {
     // In instruction simplification we don't have a domtree. Therefore do a simple dominance
     // check based on same-block relations.
     if parentBlock == value.parentBlock {
-      // The value and instruction are in the same block. All uses are dominanted by both.
+      // The value and instruction are in the same block. All uses are dominated by both.
       return true
     }
     let destroys = value.uses.filterUsers(ofType: DestroyValueInst.self)

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
@@ -20,7 +20,7 @@ extension LoadInst : OnoneSimplifyable, SILCombineSimplifyable {
     if optimizeLoadFromStringLiteral(context) {
       return
     }
-    if optmizeLoadFromEmptyCollection(context) {
+    if optimizeLoadFromEmptyCollection(context) {
       return
     }
     if replaceLoadOfGlobalLet(context) {
@@ -85,7 +85,7 @@ extension LoadInst : OnoneSimplifyable, SILCombineSimplifyable {
 
   /// Loading `count` or `capacity` from the empty `Array`, `Set` or `Dictionary` singleton
   /// is replaced by a 0 literal.
-  private func optmizeLoadFromEmptyCollection(_ context: SimplifyContext) -> Bool {
+  private func optimizeLoadFromEmptyCollection(_ context: SimplifyContext) -> Bool {
     if self.isZeroLoadFromEmptyCollection() {
       let builder = Builder(before: self, context)
       let zeroLiteral = builder.createIntegerLiteral(0, type: type)

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -184,7 +184,7 @@ extension MutatingContext {
   }
 
   func inlineFunction(apply: FullApplySite, mandatoryInline: Bool) {
-    // This is only a best-effort attempt to notity the new cloned instructions as changed.
+    // This is only a best-effort attempt to notify the new cloned instructions as changed.
     // TODO: get a list of cloned instructions from the `inlineFunction`
     let instAfterInling: Instruction?
     switch apply {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -194,7 +194,7 @@ extension AddressUseVisitor {
       if operand.instruction.isIncidentalUse {
         return leafAddressUse(of: operand)
       }
-      // Unkown instruction.
+      // Unknown instruction.
       return unknownAddressUse(of: operand)
     }
   }
@@ -289,7 +289,7 @@ extension AddressInitializationWalker {
   }
 }
 
-// Implement AddresUseVisitor
+// Implement AddressUseVisitor
 extension AddressInitializationWalker {
   /// An address projection produces a single address result and does not
   /// escape its address operand in any other way.
@@ -359,7 +359,7 @@ extension AddressInitializationWalker {
   }
 }
 
-/// A live range representing the ownership of addressible memory.
+/// A live range representing the ownership of addressable memory.
 ///
 /// This live range represents the minimal guaranteed lifetime of the object being addressed. Uses of derived addresses
 /// may be extended up to the ends of this scope without violating ownership.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
@@ -126,7 +126,7 @@
 //
 //
 // TODO: These utilities should be integrated with OSSA SIL verification and
-// guaranteed to be compelete (produce known results for all legal SIL
+// guaranteed to be complete (produce known results for all legal SIL
 // patterns).
 // ===----------------------------------------------------------------------===//
 
@@ -211,7 +211,7 @@ enum BorrowingInstruction : CustomStringConvertible, Hashable {
   /// the last in the function (e.g. a store rather than a destroy or return).
   /// The client needs to use LifetimeDependenceDefUseWalker to do better.
   ///
-  /// TODO: to hande reborrow-extended uses, migrate ExtendedLiveness
+  /// TODO: to handle reborrow-extended uses, migrate ExtendedLiveness
   /// to SwiftCompilerSources.
   ///
   /// TODO: Handle .partialApply and .markDependence forwarded uses
@@ -278,7 +278,7 @@ enum BorrowingInstruction : CustomStringConvertible, Hashable {
 ///
 /// If the value is a begin_apply result, then it may be the token or
 /// one of the yielded values. In any case, the scope ending operands
-/// are on the end_apply or abort_apply intructions that use the
+/// are on the end_apply or abort_apply instructions that use the
 /// token.
 ///
 /// Note: equivalent to C++ BorrowedValue, but also handles begin_apply.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -156,7 +156,7 @@ protocol EscapeVisitor {
   /// If true, the traversals follow values with trivial types.
   var followTrivialTypes: Bool { get }
 
-  /// If true, the traveral follows loaded values.
+  /// If true, the traversal follows loaded values.
   var followLoads: Bool { get }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -113,7 +113,7 @@ struct LifetimeDependence : CustomStringConvertible {
     case yield(Value)
     /// An owned value whose OSSA lifetime encloses nonescapable values
     case owned(Value)
-    /// Singly-initialized addressible storage (likely for an
+    /// Singly-initialized addressable storage (likely for an
     /// immutable address-only value). The lifetime extends until the
     /// memory is destroyed. e.g. A value produced by an @in
     /// FunctionArgument or @out apply. @inout has caller scope
@@ -559,7 +559,7 @@ extension LifetimeDependence {
 /// This uses LifetimeDependenceUseDefWalker to find the introducers
 /// of a dependence chain, which represent the value's "inherited"
 /// dependencies. This stops at an address, unless the address refers
-/// to a singly-initialized temprorary, in which case it continues to
+/// to a singly-initialized temporary, in which case it continues to
 /// walk up the stored value.
 ///
 /// This overrides LifetimeDependenceUseDefWalker to stop at a value
@@ -773,7 +773,7 @@ extension LifetimeDependenceUseDefWalker {
 /// follows interior pointers using AddressUseVisitor. Handles stores to and loads from local variables using
 /// LocalVariableReachabilityCache.
 ///
-/// Ignores trivial values (~Escapable types are never trivial. Escapable types may only be lifetime-depenent values if
+/// Ignores trivial values (~Escapable types are never trivial. Escapable types may only be lifetime-dependent values if
 /// they are non-trivial).
 ///
 /// Skips uses within nested borrow scopes.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 ///
-/// SIL operates on three kinds of addressible memory:
+/// SIL operates on three kinds of addressable memory:
 ///
 /// 1. Temporary RValues. These are recognied by AddressInitializationWalker. These largely disappear with opaque SIL
 /// values.
@@ -35,13 +35,13 @@ private func log(_ message: @autoclosure () -> String) {
 
 // Local variables are accessed in one of these ways.
 //
-// Note: @in is only immutable up to when it is destroyed, so still requies a local live range.
+// Note: @in is only immutable up to when it is destroyed, so still requires a local live range.
 struct LocalVariableAccess: CustomStringConvertible {
   enum Kind {
     case incomingArgument // @in, @inout, @inout_aliasable
     case outgoingArgument // @inout, @inout_aliasable
     case inoutYield       // indirect yield from this accessor
-    case beginAccess // Reading or reassinging a 'var'
+    case beginAccess // Reading or reassigning a 'var'
     case load        // Reading a 'let'. Returning 'var' from an initializer.
     case store       // 'var' initialization and destruction
     case apply       // indirect arguments
@@ -214,7 +214,7 @@ class LocalVariableAccessInfo: CustomStringConvertible {
   }
 }
 
-/// Model the formal accesses of an addressible variable introduced by an alloc_box, alloc_stack, or indirect
+/// Model the formal accesses of an addressable variable introduced by an alloc_box, alloc_stack, or indirect
 /// FunctionArgument.
 ///
 /// This instantiates a unique LocalVariableAccessInfo instances for each access instruction, caching it an an access

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -554,7 +554,7 @@ extension BasicBlock {
 
 extension SimplifyContext {
 
-  /// Replaces a pair of redudant instructions, like
+  /// Replaces a pair of redundant instructions, like
   /// ```
   ///   %first = enum $E, #E.CaseA!enumelt, %replacement
   ///   %second = unchecked_enum_data %first : $E, #E.CaseA!enumelt

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -275,10 +275,10 @@ protocol OwnershipUseVisitor {
   mutating func pointerEscapingUse(of operand: Operand) -> WalkResult
 
   /// A use that creates an implicit borrow scope over the lifetime of
-  /// an owned dependent value. The operand owership is .borrow, but
+  /// an owned dependent value. The operand ownership is .borrow, but
   /// there are no explicit scope-ending operations. Instead
   /// BorrowingInstruction.scopeEndingOperands will return the final
-  /// consumes in the dependent value's forwaring chain.
+  /// consumes in the dependent value's forwarding chain.
   mutating func dependentUse(of operand: Operand, into value: Value)
     -> WalkResult
 
@@ -490,7 +490,7 @@ extension OwnershipUseVisitor {
 ///
 /// - Does not assume the current lifetime is linear. Transitively
 /// follows guaranteed forwarding and address uses within the current
-/// scope. Phis that are not dominanted by definingValue or an outer
+/// scope. Phis that are not dominated by definingValue or an outer
 /// adjacent phi are marked "unenclosed" to signal an incomplete
 /// lifetime.
 ///

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Verifier.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Verifier.swift
@@ -13,7 +13,7 @@
 import SIL
 import OptimizerBridging
 
-private protocol VerifyableInstruction : Instruction {
+private protocol VerifiableInstruction : Instruction {
   func verify(_ context: FunctionPassContext)
 }
 
@@ -36,8 +36,8 @@ extension Function {
 
         inst.checkForwardingConformance()
 
-        if let verifyableInst = inst as? VerifyableInstruction {
-          verifyableInst.verify(context)
+        if let verifiableInst = inst as? VerifiableInstruction {
+          verifiableInst.verify(context)
         }
       }
     }
@@ -54,7 +54,7 @@ private extension Instruction {
   }
 }
 
-extension BorrowedFromInst : VerifyableInstruction {
+extension BorrowedFromInst : VerifiableInstruction {
   func verify(_ context: FunctionPassContext) {
     var computedEVs = Stack<Value>(context)
     defer { computedEVs.deinitialize() }

--- a/SwiftCompilerSources/Sources/SIL/Effects.swift
+++ b/SwiftCompilerSources/Sources/SIL/Effects.swift
@@ -162,7 +162,7 @@ extension Function {
     }
     if isProgramTerminationPoint {
       // We can ignore any memory writes in a program termination point, because it's not relevant
-      // for the caller. But we need to consider memory reads, otherwise preceeding memory writes
+      // for the caller. But we need to consider memory reads, otherwise preceding memory writes
       // would be eliminated by dead-store-elimination in the caller. E.g. String initialization
       // for error strings which are printed by the program termination point.
       // Regarding ownership: a program termination point must not touch any reference counted objects.
@@ -394,7 +394,7 @@ public struct SideEffects : CustomStringConvertible, NoReflectionChildren {
 
   /// Returns the effects of an argument.
   ///
-  /// In constrast to using `arguments` directly, it's valid to have an `argumentIndex`
+  /// In contrast to using `arguments` directly, it's valid to have an `argumentIndex`
   /// which is larger than the number of elements in `arguments`.
   public func getArgumentEffects(for argumentIndex: Int) -> ArgumentEffects {
     if argumentIndex < arguments.count {
@@ -430,7 +430,7 @@ public struct SideEffects : CustomStringConvertible, NoReflectionChildren {
   
   /// Side-effects of a specific function argument.
   ///
-  /// The paths describe what (projeted) values of an argument are affected.
+  /// The paths describe what (projected) values of an argument are affected.
   /// If a path is nil, than there is no such effect on the argument.
   ///
   /// A path can contain any projection or wildcards, as long as there is no load involved.

--- a/SwiftCompilerSources/Sources/SIL/Operand.swift
+++ b/SwiftCompilerSources/Sources/SIL/Operand.swift
@@ -87,7 +87,7 @@ public struct OperandArray : RandomAccessCollection, CustomReflectable {
   
   /// Returns a sub-array defined by `bounds`.
   ///
-  /// Note: this does not return a Slice. The first index of the returnd array is always 0.
+  /// Note: this does not return a Slice. The first index of the returned array is always 0.
   public subscript(bounds: Range<Int>) -> OperandArray {
     assert(bounds.lowerBound >= startIndex && bounds.upperBound <= endIndex)
     return OperandArray(

--- a/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
@@ -335,7 +335,7 @@ public struct AccessPath : CustomStringConvertible {
   /// Returns true if this access addresses the same memory location as `other` or if `other`
   /// is a sub-field of this access.
 
-  /// Note that this access _contains_ `other` if `other` has a _larger_ projection path than this acccess.
+  /// Note that this access _contains_ `other` if `other` has a _larger_ projection path than this access.
   /// For example:
   ///   `%value.s0` contains `%value.s0.s1`
   public func isEqualOrContains(_ other: AccessPath) -> Bool {

--- a/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
@@ -570,7 +570,7 @@ extension AddressDefUseWalker {
 ///     to reflect that a further projection is needed to reach the value of interest from the new initial value.
 ///   2. If the instruction of the definition is a value construction such as `struct` and
 ///     the head of the path matches the instruction type then the walk continues
-///     with a call to `walkUp` with initial value the operand defintion denoted by the path
+///     with a call to `walkUp` with initial value the operand definition denoted by the path
 ///     and the suffix path as path since the target value can now be reached with fewer projections.
 ///     If the defining instruction of the value does not match the head of the path as in
 ///     `%t = tuple ...` and `"s0.t1"` then `unmatchedPath(%t, ...)` is called.

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -198,7 +198,7 @@ extension Value {
     ProjectedValue(value: self, path: path)
   }
 
-  /// Returns a projected value, defined by this value and path containig a single field of `kind` and `index`.
+  /// Returns a projected value, defined by this value and path containing a single field of `kind` and `index`.
   public func at(_ kind: SmallProjectionPath.FieldKind, index: Int = 0) -> ProjectedValue {
     ProjectedValue(value: self, path: SmallProjectionPath(kind, index: index))
   }

--- a/SwiftCompilerSources/force_lib.c
+++ b/SwiftCompilerSources/force_lib.c
@@ -11,5 +11,5 @@
 //===----------------------------------------------------------------------===//
 
 /// Dummy source file to force CMake generated SwiftInTheCompiler.xcodeproj
-/// to successfully build static libraries conatining only object files used
+/// to successfully build static libraries containing only object files used
 /// during "bootstrap" process to link Swift sources into the compiler.


### PR DESCRIPTION
Fix typos in `SwiftCompilerSources`

This is one batch of many PRs fixing typos, [see the tracking issue.](https://github.com/swiftlang/swift/issues/75022)