### PR TITLE
Typos: `test/SILGen`

### DIFF
--- a/test/SILGen/dynamically_replaceable.swift
+++ b/test/SILGen/dynamically_replaceable.swift
@@ -401,8 +401,8 @@ public func testWithLocalFun() {
     localLocalFun()
   }
   localFun()
-  let unamedClosure = { print("foo") }
-  unamedClosure()
+  let unnamedClosure = { print("foo") }
+  unnamedClosure()
 }
 
 @propertyWrapper

--- a/test/SILGen/extern_c.swift
+++ b/test/SILGen/extern_c.swift
@@ -14,7 +14,7 @@ public func publicVisibility(_ x: Int) -> Int
 
 // CHECK-DAG: sil @private_visible : $@convention(c) (Int) -> Int
 @_extern(c, "private_visible")
-private func privateVisiblity(_ x: Int) -> Int
+private func privateVisibility(_ x: Int) -> Int
 
 // CHECK-DAG: sil hidden_external @withoutCName : $@convention(c) () -> Int
 @_extern(c)
@@ -35,7 +35,7 @@ func main() {
   _ = publicVisibility(42)
   // CHECK-DAG: [[F4:%.+]] = function_ref @private_visible : $@convention(c) (Int) -> Int
   // CHECK-DAG: apply [[F4]]({{.*}}) : $@convention(c) (Int) -> Int
-  _ = privateVisiblity(24)
+  _ = privateVisibility(24)
   // CHECK-DAG: [[F5:%.+]] = function_ref @withoutCName : $@convention(c) () -> Int
   // CHECK-DAG: apply [[F5]]() : $@convention(c) () -> Int
   _ = withoutCName()

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -800,7 +800,7 @@ class ThrowDerivedClass : ThrowBaseClass {
   // CHECK:   try_apply [[UNWRAP_FN]]({{%.*}}) : $@convention(thin) (Int) -> (Int, @error any Error), normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
   //
   // Now we emit the call to the initializer. Notice how we return self back to
-  // its memory locatio nbefore any other work is done.
+  // its memory location before any other work is done.
   // CHECK: [[NORMAL_BB]](
   // CHECK:   [[INIT_FN:%.*]] = function_ref @$s21failable_initializers14ThrowBaseClassC6noFailACSi_tcfc : $@convention(method)
   // CHECK:   [[BASE_SELF_INIT:%.*]] = apply [[INIT_FN]]({{%.*}}, [[BASE_SELF]])

--- a/test/SILGen/noimplicitcopy_borrowing_parameters.swift
+++ b/test/SILGen/noimplicitcopy_borrowing_parameters.swift
@@ -212,7 +212,7 @@ func testLoadableBorrowingEnum(_ x: borrowing LoadableEnum) {
 // CHECK:   copy_addr [[UNWRAP]] to [init] [[STACK]]
 // CHECK:   destroy_addr [[STACK]]
 // CHECK:   [[UNWRAP:%.*]] = moveonlywrapper_to_copyable_addr [[CHECK]]
-// TODO: We probably want the unwrap to be on the struct_element_addr, not the other wya around.
+// TODO: We probably want the unwrap to be on the struct_element_addr, not the other way around.
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[UNWRAP]]
 // CHECK:   [[STACK:%.*]] = alloc_stack
 // CHECK:   copy_addr [[GEP]] to [init] [[STACK]]


### PR DESCRIPTION
Fix typos in `test/SILGen`

This is one batch of many PRs fixing typos, [see the tracking issue.](https://github.com/swiftlang/swift/issues/75022)