### PR TITLE
Typos: `test/IRGen`

### DIFF
--- a/test/IRGen/Inputs/weak_import_availability_helper.swift
+++ b/test/IRGen/Inputs/weak_import_availability_helper.swift
@@ -26,7 +26,7 @@ extension ConditionallyAvailableStruct {
 }
 
 @available(macOS, unavailable)
-public struct UnvailableStruct {
+public struct UnavailableStruct {
   public func unavailableMethod() {}
 }
 

--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -126,12 +126,12 @@ bb0(%0 : $Builtin.Int64, %1 : $() -> @owned BigStruct):
   return undef : $BigStruct
 }
 
-// CHECK-LABEL: define swiftcc void @poninter_to_mod_ret(ptr %0, ptr %1)
+// CHECK-LABEL: define swiftcc void @pointer_to_mod_ret(ptr %0, ptr %1)
 // CHECK: [[CALL:%.*]] = call swiftcc { ptr, ptr } %0(ptr swiftself %1)
 // CHECK: extractvalue { ptr, ptr } [[CALL]], 0
 // CHECK: extractvalue { ptr, ptr } [[CALL]], 1
 // CHECK: ret void
-sil @poninter_to_mod_ret : $@convention(thin) (@owned @callee_owned () -> @owned @callee_owned (@owned Builtin.Int64) -> @owned BigStruct) -> () {
+sil @pointer_to_mod_ret : $@convention(thin) (@owned @callee_owned () -> @owned @callee_owned (@owned Builtin.Int64) -> @owned BigStruct) -> () {
 bb0(%funcpointer : $@callee_owned () -> @owned @callee_owned (@owned Builtin.Int64) -> @owned BigStruct):
   %papply = apply %funcpointer() : $@callee_owned () -> @owned @callee_owned (@owned Builtin.Int64) -> @owned BigStruct
   %ret = tuple ()

--- a/test/IRGen/comdat.swift
+++ b/test/IRGen/comdat.swift
@@ -9,6 +9,6 @@
 // CHECK-1: "$s6comdat1C33_{{.*}}LLCMa" = comdat any
 // CHECK-1: "$s6comdat1C33_{{.*}}LLCMn" = comdat any
 
-// Ensure that no foward declaration is emitted
+// Ensure that no forward declaration is emitted
 // CHECK-2-NOT: "$s6comdat1C33_{{.*}}LLCMa" = comdat any
 // CHECK-2-NOT: "$s6comdat1C33_{{.*}}LLCMn" = comdat any

--- a/test/IRGen/debug_fragment_merge.sil
+++ b/test/IRGen/debug_fragment_merge.sil
@@ -2,7 +2,7 @@
 
 // Checking the below on 32 bit architectures would be cumbersome: each
 // fragment is 32 bits long, which changes the number of checks as well as the
-// arithmethic on the bounds of each fragment.
+// arithmetic on the bounds of each fragment.
 // REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=arm64e
 
 // CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR:[0-9]+]], metadata !DIExpression(DW_OP_LLVM_fragment, 192, 64){{.*}} !dbg ![[LOC1:[0-9]+]]

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -124,7 +124,7 @@ entry(%arg : $*any Constrained<Int>):
 }
 
 // Make sure we don't instantiate metadata for constrained existentials. Metadata
-// instatiation is not supported on older runtimes.
+// instantiation is not supported on older runtimes.
 
 // OPT: define{{.*}} void @constrained_protocol(
 // OPT: call {{.*}} @"$s12existentials11Constrained_pSi1TAaBPRts_XPWOc"

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -584,14 +584,14 @@ public class GC2<T> {
   public var y: String
 }
 
-sil @class_constrainted : $@convention(thin) <V where V : C> () -> () {
+sil @class_constrained : $@convention(thin) <V where V : C> () -> () {
 bb0:
   %k = keypath $KeyPath<V, String>, <τ_0_0 where τ_0_0 : C> (root $τ_0_0; stored_property #C.y : $String) <V>
   %t = tuple ()
   return %t : $()
 }
 
-sil @generic_class_constrainted : $@convention(thin) <U, V where V : GC2<U>> () -> () {
+sil @generic_class_constrained : $@convention(thin) <U, V where V : GC2<U>> () -> () {
 bb0:
   %k = keypath $KeyPath<V, String>, <τ_0_0, τ_0_1 where τ_0_1 : GC2<τ_0_0>> (root $τ_0_1; stored_property #GC2.y : $String) <U, V>
   %t = tuple ()

--- a/test/IRGen/opaque_result_type_substitution_2.swift
+++ b/test/IRGen/opaque_result_type_substitution_2.swift
@@ -71,7 +71,7 @@ extension Thing {
   }
 }
 
-struct OutterThing<Content : Thing> : Thing {
+struct OuterThing<Content : Thing> : Thing {
   let content: Content
 
   init(_ c: Content) {

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -122,7 +122,7 @@ struct MyError: Error {
 
 // CHECK: define hidden swiftcc { float, i64, float } @"$s12typed_throws8mayThrow1x1ySf_s5Int32VSftSb_yXltAA7MyErrorVYKF"
 // CHECK:   [[CONVERTED:%.*]] = ptrtoint ptr {{%.*}} to i64
-// CEHCK:   insertvalue { float, i64, float } undef, i64 [[CONVERTED]], 1
+// CHECK:   insertvalue { float, i64, float } undef, i64 [[CONVERTED]], 1
 // CHECK: }
 @inline(never)
 func mayThrow(x: Bool, y: AnyObject) throws(MyError) -> (Float, Int32, Float) {

--- a/test/IRGen/typelayout_based_value_operation.sil
+++ b/test/IRGen/typelayout_based_value_operation.sil
@@ -16,12 +16,12 @@ public struct A<T> {
 
 public class C {}
 
-// CHECK-LABEL: define{{.*}} void @testDestroyValueTrival(
+// CHECK-LABEL: define{{.*}} void @testDestroyValueTrivial(
 // CHECK-NEXT: entry:
 // CHECK-NEXT:  ret void
 // CHECK-NEXT: }
 
-sil @testDestroyValueTrival : $@convention(thin) (@in A<Builtin.Int32>) -> ()  {
+sil @testDestroyValueTrivial : $@convention(thin) (@in A<Builtin.Int32>) -> ()  {
 entry(%arg : $*A<Builtin.Int32>):
   destroy_addr %arg : $*A<Builtin.Int32>
   %ret = tuple ()

--- a/test/IRGen/weak_import_availability.swift
+++ b/test/IRGen/weak_import_availability.swift
@@ -115,14 +115,14 @@ public func useConditionallyAvailableMethod(s: ConditionallyAvailableStruct) {
 
 @available(macOS, unavailable)
 public func useUnavailableStruct() {
-  blackHole(UnvailableStruct.self)
+  blackHole(UnavailableStruct.self)
 }
 
-// CHECK-LABEL: declare extern_weak swiftcc %swift.metadata_response @"$s31weak_import_availability_helper16UnvailableStructVMa"(i64)
+// CHECK-LABEL: declare extern_weak swiftcc %swift.metadata_response @"$s31weak_import_availability_helper17UnavailableStructVMa"(i64)
 
 @available(macOS, unavailable)
-public func useUnavailableMethod(s: UnvailableStruct) {
+public func useUnavailableMethod(s: UnavailableStruct) {
   s.unavailableMethod()
 }
 
-// CHECK-LABEL: declare extern_weak swiftcc void @"$s31weak_import_availability_helper16UnvailableStructV17unavailableMethodyyF"(ptr noalias swiftself)
+// CHECK-LABEL: declare extern_weak swiftcc void @"$s31weak_import_availability_helper17UnavailableStructV17unavailableMethodyyF"(ptr noalias swiftself)


### PR DESCRIPTION
Fix typos in `test/IRGen`

This is one batch of many PRs fixing typos, [see the tracking issue.](https://github.com/swiftlang/swift/issues/75022)