### PR TITLE
Typos: `test/concurrency`

### DIFF
--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -131,7 +131,7 @@ actor MyActor {
   func hello() {} // expected-typechecker-note {{calls to instance method 'hello()' from outside of its actor context are implicitly asynchronous}}
 }
 
-// Compiler >= 5.3 is eneded to suppress the parser error
+// Compiler >= 5.3 is ended to suppress the parser error
 #if compiler(>=5.3) && ALLOW_TYPECHECKER_ERRORS
 typealias MyFn = (isolated: Int) -> Void // expected-typechecker-error {{function types cannot have argument labels; use '_' before 'isolated'}}
 #endif

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift5_strict.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift5_strict.swift
@@ -103,13 +103,13 @@ func test_sendable_attr_in_type_context(test: Test) {
 
   _ = TestWithSendableID<SendableValue>() // Ok
 
-  // TOOD(diagnostics): Duplicate diagnostics
+  // TODO(diagnostics): Duplicate diagnostics
   TestWithSendableID().add(MyValue())
   // expected-warning@-1 3 {{type 'MyValue' does not conform to the 'Sendable' protocol}}
 
   TestWithSendableSuperclass().add(SendableMyValue()) // Ok
 
-  // TOOD(diagnostics): Duplicate diagnostics
+  // TODO(diagnostics): Duplicate diagnostics
   TestWithSendableSuperclass().add(MyValue())
   // expected-warning@-1 3 {{type 'MyValue' does not conform to the 'Sendable' protocol}}
 }

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
@@ -102,13 +102,13 @@ func test_sendable_attr_in_type_context(test: Test) {
 
   _ = TestWithSendableID<SendableValue>() // Ok
 
-  // TOOD(diagnostics): Duplicate diagnostics
+  // TODO(diagnostics): Duplicate diagnostics
   TestWithSendableID().add(MyValue())
   // expected-error@-1 3 {{type 'MyValue' does not conform to the 'Sendable' protocol}}
 
   TestWithSendableSuperclass().add(SendableMyValue()) // Ok
 
-  // TOOD(diagnostics): Duplicate diagnostics
+  // TODO(diagnostics): Duplicate diagnostics
   TestWithSendableSuperclass().add(MyValue())
   // expected-error@-1 3 {{type 'MyValue' does not conform to the 'Sendable' protocol}}
 }

--- a/test/Concurrency/sending_mangling.swift
+++ b/test/Concurrency/sending_mangling.swift
@@ -32,8 +32,8 @@ func testNoRemoveFunctionResultSubTypeResult() -> sending S<() -> sending NonSen
 // CHECK: sil hidden [ossa] @sending_mangling.testNoRemoveFunctionResultImmediateTypedFunctionWithArg() -> (sending __owned sending_mangling.NonSendableKlass) -> () : $@convention(thin) () -> @owned @callee_guaranteed (@sil_sending @owned NonSendableKlass) -> () {
 func testNoRemoveFunctionResultImmediateTypedFunctionWithArg() -> ((sending NonSendableKlass) -> ()) { fatalError() }
 
-// CHECK: sil hidden [ossa] @sending_mangling.testNoRemoveFunctionResultImmedateTypedFunctionWithResult() -> () -> sending sending_mangling.NonSendableKlass : $@convention(thin) () -> @owned @callee_guaranteed () -> @sil_sending @owned NonSendableKlass {
-func testNoRemoveFunctionResultImmedateTypedFunctionWithResult() -> (() -> sending NonSendableKlass) { fatalError() }
+// CHECK: sil hidden [ossa] @sending_mangling.testNoRemoveFunctionResultImmediateTypedFunctionWithResult() -> () -> sending sending_mangling.NonSendableKlass : $@convention(thin) () -> @owned @callee_guaranteed () -> @sil_sending @owned NonSendableKlass {
+func testNoRemoveFunctionResultImmediateTypedFunctionWithResult() -> (() -> sending NonSendableKlass) { fatalError() }
 
 struct MethodTest {
   // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.init(__owned sending_mangling.NonSendableKlass) -> sending_mangling.MethodTest : $@convention(method) (@sil_sending @owned NonSendableKlass, @thin MethodTest.Type) -> MethodTest {
@@ -61,8 +61,8 @@ struct MethodTest {
   // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.testNoRemoveFunctionResultImmediateTypedFunctionWithArg() -> (sending __owned sending_mangling.NonSendableKlass) -> () : $@convention(method) (MethodTest) -> @owned @callee_guaranteed (@sil_sending @owned NonSendableKlass) -> () {
   func testNoRemoveFunctionResultImmediateTypedFunctionWithArg() -> ((sending NonSendableKlass) -> ()) { fatalError() }
 
-  // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.testNoRemoveFunctionResultImmedateTypedFunctionWithResult() -> () -> sending sending_mangling.NonSendableKlass : $@convention(method) (MethodTest) -> @owned @callee_guaranteed () -> @sil_sending @owned NonSendableKlass {
-  func testNoRemoveFunctionResultImmedateTypedFunctionWithResult() -> (() -> sending NonSendableKlass) { fatalError() }
+  // CHECK: sil hidden [ossa] @sending_mangling.MethodTest.testNoRemoveFunctionResultImmediateTypedFunctionWithResult() -> () -> sending sending_mangling.NonSendableKlass : $@convention(method) (MethodTest) -> @owned @callee_guaranteed () -> @sil_sending @owned NonSendableKlass {
+  func testNoRemoveFunctionResultImmediateTypedFunctionWithResult() -> (() -> sending NonSendableKlass) { fatalError() }
 }
 
 protocol SendingProtocol {
@@ -107,6 +107,6 @@ struct ConstructorSharedTest {
 
   // This is a func which takes its parameter at +0 so we should suppress both.
   //
-  // CHECK: sil hidden [ossa] @sending_mangling.ConstructorSharedTest.functionSupressed(sending_mangling.NonSendableKlass) -> () : $@convention(method) (@sil_sending @guaranteed NonSendableKlass, ConstructorSharedTest) -> () {
-  func functionSupressed(_ x: __shared sending NonSendableKlass) {}
+  // CHECK: sil hidden [ossa] @sending_mangling.ConstructorSharedTest.functionSuppressed(sending_mangling.NonSendableKlass) -> () : $@convention(method) (@sil_sending @guaranteed NonSendableKlass, ConstructorSharedTest) -> () {
+  func functionSuppressed(_ x: __shared sending NonSendableKlass) {}
 }

--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -121,7 +121,7 @@ func useValue<T>(_ x: T) { }
 
 @CustomActor
 func test_CallerSyncNormal_CalleeSyncNonIsolated() async {
-    // Just to help start our pattern matchin since the closure #$NUM line
+    // Just to help start our pattern matching since the closure #$NUM line
     // appears in other parts of the file.
     // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference028test_CallerSyncNormal_CalleeF11NonIsolatedyyYaF'
 
@@ -270,7 +270,7 @@ func test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated() async {
 
 @CustomActor
 func test_CallerAsyncNormal_CalleeSyncNonIsolated() async {
-    // Just to help start our pattern matchin since the closure #$NUM line
+    // Just to help start our pattern matching since the closure #$NUM line
     // appears in other parts of the file.
     // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference44test_CallerAsyncNormal_CalleeSyncNonIsolatedyyYaF'
 
@@ -582,7 +582,7 @@ extension MyActor {
 extension MyActor {
 
     func test_CallerAsyncNormal_CalleeSyncNonIsolated() async {
-        // Just to help start our pattern matchin since the closure #$NUM line
+        // Just to help start our pattern matching since the closure #$NUM line
         // appears in other parts of the file.
         // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC44test_CallerAsyncNormal_CalleeSyncNonIsolatedyyYaF'
 

--- a/test/Concurrency/transfernonsendable_sending_results.swift
+++ b/test/Concurrency/transfernonsendable_sending_results.swift
@@ -79,7 +79,7 @@ func simpleTest() async {
   useValue(y)
 }
 
-// Since y is transfered, we should emit the error on useValue(x). We generally
+// Since y is transferred, we should emit the error on useValue(x). We generally
 // emit the first seen error on a path, so if we were to emit an error on
 // useValue(y), we would have emitted that error.
 func simpleTest2() async {


### PR DESCRIPTION
Fix typos in `test/concurrency`

This is one batch of many PRs fixing typos, [see the tracking issue.](https://github.com/swiftlang/swift/issues/75022)