### PR TITLE
Typos: `test/Interop`

### DIFF
--- a/test/Interop/Cxx/class/constructors-silgen.swift
+++ b/test/Interop/Cxx/class/constructors-silgen.swift
@@ -23,7 +23,7 @@ public func testConstructorWithParam() {
 // CHECK: apply [[FN]]([[AS]]) : $@convention(c) () -> @out EmptyStruct
 // CHECK-LABEL: end sil function '$s4main18emptyTypeNoArgInityyF'
 
-// CHECL-LABEL: sil [clang EmptyStruct.init] @{{_ZN11EmptyStructC1Ev|\?\?0EmptyStruct@@QEAA@XZ}} : $@convention(c) () -> @out EmptyStruct
+// CHECK-LABEL: sil [clang EmptyStruct.init] @{{_ZN11EmptyStructC1Ev|\?\?0EmptyStruct@@QEAA@XZ}} : $@convention(c) () -> @out EmptyStruct
 public func emptyTypeNoArgInit() {
   let e = EmptyStruct()
 }

--- a/test/Interop/Cxx/class/invalid-unsafe-projection-errors.swift
+++ b/test/Interop/Cxx/class/invalid-unsafe-projection-errors.swift
@@ -10,7 +10,7 @@ module Test {
 
 //--- Inputs/test.h
 struct Ptr { int *p; };
-struct __attribute__((swift_attr("import_owned"))) StirngLiteral { const char *name; };
+struct __attribute__((swift_attr("import_owned"))) StringLiteral { const char *name; };
 
 struct M {
   M(const M&);
@@ -20,7 +20,7 @@ struct M {
 
   int *begin() const;
 
-  StirngLiteral stringLiteral() const { return StirngLiteral{"M"}; }
+  StringLiteral stringLiteral() const { return StringLiteral{"M"}; }
 };
 
 //--- test.swift

--- a/test/Interop/Cxx/extern-c/Inputs/inline-func.h
+++ b/test/Interop/Cxx/extern-c/Inputs/inline-func.h
@@ -2,13 +2,13 @@ extern "C" {
 
 inline void inlineFn();
 
-void cacheMis() { }
+void cacheMiss() { }
 void incorrectCacheHit() {
   inlineFn();
 }
 
 static void caller() {
-  cacheMis();
+  cacheMiss();
   incorrectCacheHit();
 }
 

--- a/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
@@ -11,9 +11,9 @@ module Test {
 //--- Inputs/test.h
 struct
     __attribute__((swift_attr("import_reference")))
-    __attribute__((swift_attr("retain:nonexistant")))
-    __attribute__((swift_attr("release:nonexistant")))
-NonExistant {};
+    __attribute__((swift_attr("retain:nonexistent")))
+    __attribute__((swift_attr("release:nonexistent")))
+NonExistent {};
 
 struct
         __attribute__((swift_attr("import_reference")))
@@ -32,9 +32,9 @@ void badRelease(BadRetainRelease *v, int i);
 
 import Test
 
-// CHECK: error: cannot find retain function 'nonexistant' for reference type 'NonExistant'
-// CHECK: error: cannot find release function 'nonexistant' for reference type 'NonExistant'
-public func test(x: NonExistant) { }
+// CHECK: error: cannot find retain function 'nonexistent' for reference type 'NonExistent'
+// CHECK: error: cannot find release function 'nonexistent' for reference type 'NonExistent'
+public func test(x: NonExistent) { }
 
 // CHECK: error: reference type 'NoRetainRelease' must have 'retain:' swift attribute
 // CHECK: error: reference type 'NoRetainRelease' must have 'release:' swift attribute

--- a/test/Interop/Cxx/reference/reference-silgen-cxx-objc-ctors+init.swift
+++ b/test/Interop/Cxx/reference/reference-silgen-cxx-objc-ctors+init.swift
@@ -7,7 +7,7 @@ var a: Int32 = 32
 var b = IntWrapper(a)
 var c = ObjCSwiftBridge(embedded: b)
 
-// FIXME: the const-ref C++ Consructor here is not getting an @in_guaranteed or even an @in convention here.
+// FIXME: the const-ref C++ Constructor here is not getting an @in_guaranteed or even an @in convention here.
 // CHECK: {{%[0-9]+}} = function_ref @_ZN10IntWrapperC1ERKi : $@convention(c) (@in_guaranteed Int32) -> @out IntWrapper
 // CHECK: {{%[0-9]+}} = apply {{%[0-9]+}}({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(c) (@in_guaranteed Int32) -> @out IntWrapper
 // CHECK: alloc_global @$s4main1cSo15ObjCSwiftBridgeCSgvp

--- a/test/Interop/Cxx/templates/Inputs/class-template-with-typedef.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-with-typedef.h
@@ -11,7 +11,7 @@ struct Lander<void> {};
 template <class T> struct Lander {
   typedef unsigned long size_type;
   // Make sure we don't crash here. Before being specialized, "size_type" is
-  // technically a depedent type because it expands to "Lander<T>::size_type".
+  // technically a dependent type because it expands to "Lander<T>::size_type".
   void test(size_type) { }
 };
 

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -106,7 +106,7 @@ template <class T> void takesDependent(Dependent<T> d) {}
 
 void takesAtomic(_Atomic(int) a) {}
 
-struct HasImposibleMember {
+struct HasImpossibleMember {
   void memberTakesAtomic(_Atomic(int) a) {}
 };
 

--- a/test/Interop/SwiftToC/functions/swift-primitive-functions-c-bridging.swift
+++ b/test/Interop/SwiftToC/functions/swift-primitive-functions-c-bridging.swift
@@ -4,13 +4,13 @@
 
 // RUN: %check-interop-c-header-in-clang(%t/functions.h)
 
-// CHECK: SWIFT_EXTERN float $s9Functions16passThrougCFloatyS2fF(float x) SWIFT_NOEXCEPT SWIFT_CALL;
-// CHECK-NEXT: SWIFT_EXTERN bool $s9Functions15passThroughBoolyS2bF(bool x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK: SWIFT_EXTERN bool $s9Functions15passThroughBoolyS2bF(bool x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN bool $s9Functions16passThroughCBoolyS2bF(bool x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN char $s9Functions16passThroughCCharys4Int8VADF(char x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN char16_t $s9Functions18passThroughCChar16ys6UInt16VADF(char16_t x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN char32_t $s9Functions18passThroughCChar32ys7UnicodeO6ScalarVAFF(char32_t x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN double $s9Functions18passThroughCDoubleyS2dF(double x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: SWIFT_EXTERN float $s9Functions17passThroughCFloatyS2fF(float x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN int $s9Functions15passThroughCIntys5Int32VADF(int x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN long long $s9Functions20passThroughCLongLongys5Int64VADF(long long x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN short $s9Functions17passThroughCShortys5Int16VADF(short x) SWIFT_NOEXCEPT SWIFT_CALL;
@@ -63,7 +63,7 @@ public func passThroughCUnsignedShort(_ x: CUnsignedShort) -> CUnsignedShort { r
 public func passThroughCUnsignedInt(_ x: CUnsignedInt) -> CUnsignedInt { return x }
 public func passThroughCUnsignedLongLong(_ x: CUnsignedLongLong) -> CUnsignedLongLong { return x }
 
-public func passThrougCFloat(_ x: CFloat) -> CFloat { return x }
+public func passThroughCFloat(_ x: CFloat) -> CFloat { return x }
 public func passThroughCDouble(_ x: CDouble) -> CDouble { return x }
 
 public func passThroughInt8(_ x: Int8) -> Int8 { return x }

--- a/test/Interop/SwiftToC/functions/swift-primitive-functions-execution.c
+++ b/test/Interop/SwiftToC/functions/swift-primitive-functions-execution.c
@@ -51,7 +51,7 @@ int main() {
   VERIFY_PASSTHROUGH_VALUE($s9Functions024passThroughCUnsignedLongE0ys6UInt64VADF, 0xFFFFFFFF);
 
   // passThrougCFloat
-  VERIFY_PASSTHROUGH_VALUE($s9Functions16passThrougCFloatyS2fF, 1.0f);
+  VERIFY_PASSTHROUGH_VALUE($s9Functions17passThroughCFloatyS2fF, 1.0f);
   // passThroughCDouble
   VERIFY_PASSTHROUGH_VALUE($s9Functions18passThroughCDoubleyS2dF, 42.125f);
 

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
@@ -4,10 +4,6 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
-// CHECK:      SWIFT_INLINE_THUNK float passThrougCFloat(float x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT: return _impl::$s9Functions16passThrougCFloatyS2fF(x);
-// CHECK-NEXT: }
-
 // CHECK:      SWIFT_INLINE_THUNK bool passThroughBool(bool x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions15passThroughBoolyS2bF(x);
 // CHECK-NEXT: }
@@ -30,6 +26,10 @@
 
 // CHECK:      SWIFT_INLINE_THUNK double passThroughCDouble(double x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions18passThroughCDoubleyS2dF(x);
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_INLINE_THUNK float passThroughCFloat(float x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: return _impl::$s9Functions17passThroughCFloatyS2fF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK int passThroughCInt(int x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
@@ -179,7 +179,7 @@ public func passThroughCUnsignedShort(_ x: CUnsignedShort) -> CUnsignedShort { r
 public func passThroughCUnsignedInt(_ x: CUnsignedInt) -> CUnsignedInt { return x }
 public func passThroughCUnsignedLongLong(_ x: CUnsignedLongLong) -> CUnsignedLongLong { return x }
 
-public func passThrougCFloat(_ x: CFloat) -> CFloat { return x }
+public func passThroughCFloat(_ x: CFloat) -> CFloat { return x }
 public func passThroughCDouble(_ x: CDouble) -> CDouble { return x }
 
 public func passThroughInt8(_ x: Int8) -> Int8 { return x }

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-functions-execution.cpp
@@ -35,7 +35,7 @@ int main() {
   VERIFY_PASSTHROUGH_VALUE(passThroughCUnsignedInt, 0xFFFFFFFF);
   VERIFY_PASSTHROUGH_VALUE(passThroughCUnsignedLongLong, 0xFFFFFFFF);
 
-  VERIFY_PASSTHROUGH_VALUE(passThrougCFloat, 1.0f);
+  VERIFY_PASSTHROUGH_VALUE(passThroughCFloat, 1.0f);
   VERIFY_PASSTHROUGH_VALUE(passThroughCDouble, 42.125f);
 
   VERIFY_PASSTHROUGH_VALUE(passThroughInt8, -1);

--- a/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -typecheck %t/print-string.swift -typecheck -module-name Stringer -enable-experimental-cxx-interop -emit-clang-header-path %t/Stringer.h
 
-// Ensure: we don't hit any spurios warnings instantiating
+// Ensure: we don't hit any spurious warnings instantiating
 // C++ standard library templates because of the generated header.
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -fsyntax-only -c %t/test-stdlib.cpp -I %t -Wall -Werror -Werror=ignored-attributes -Wno-error=unused-command-line-argument


### PR DESCRIPTION
Fix typos in `test/Interop`

This is one batch of many PRs fixing typos, [see the tracking issue.](https://github.com/swiftlang/swift/issues/75022)