### PR TITLE
Typos: `test/*` (misc folders in test)

### DIFF
--- a/test/APIJSON/availability.swift
+++ b/test/APIJSON/availability.swift
@@ -18,7 +18,7 @@ public func callUnavailable() {}
 public func availableOnlyOnActiveOS() {}
 
 @available(tvOS, unavailable)
-public func unavailableOnSeperateOS() {}
+public func unavailableOnSeparateOS() {}
 
 extension A {
     @available(macOS 12, *)
@@ -114,7 +114,7 @@ extension A {
 // CHECK-NEXT:             "introduced": "10.10"
 // CHECK-NEXT:         },
 // CHECK-NEXT:         {
-// CHECK-NEXT:             "name": "_$s8MyModule23unavailableOnSeperateOSyyF",
+// CHECK-NEXT:             "name": "_$s8MyModule23unavailableOnSeparateOSyyF",
 // CHECK-NEXT:             "access": "public",
 // CHECK-NEXT:             "file": "SOURCE_DIR/test/APIJSON/availability.swift",
 // CHECK-NEXT:             "linkage": "exported"

--- a/test/ASTGen/stmts.swift
+++ b/test/ASTGen/stmts.swift
@@ -129,7 +129,7 @@ struct GenericTypeWithYields<T> {
     }
   }
 
-/* FXIME: yield(...) is parsed as an expression. ASTGen needs to onvert it to a statments.
+/* FXIME: yield(...) is parsed as an expression. ASTGen needs to convert it to a statement.
   subscript<U>(u: U) -> (T,U) {
     _read {
       yield ((storedProperty!, u))

--- a/test/AssociatedTypeInference/associated_type_inference.swift
+++ b/test/AssociatedTypeInference/associated_type_inference.swift
@@ -449,7 +449,7 @@ struct X15d : P15d { }
 // FIXME: Better diagnostic here?
 struct X15g : P15g { } // expected-error{{type 'X15g' does not conform to protocol 'P15g'}} expected-note {{add stubs for conformance}}
 
-// Associated type defaults in overidden associated types that require
+// Associated type defaults in overridden associated types that require
 // substitution.
 struct X16<T> { }
 

--- a/test/AssociatedTypeInference/associated_type_inference_tautology_4.swift
+++ b/test/AssociatedTypeInference/associated_type_inference_tautology_4.swift
@@ -9,7 +9,7 @@ protocol P2 {
 }
 
 struct S2<A>: P2 {
-  // These are not candiate witnesses for the requirement.
+  // These are not candidate witnesses for the requirement.
   func f(_: Float, _: Array<A>) {}
   func f(_: String, _: Array<A>) {}
 

--- a/test/AutoDiff/compiler_crashers_fixed/issue-65073-substmap.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-65073-substmap.swift
@@ -4,7 +4,7 @@
 // We need to ensure we are not dropping the substitution map during the
 // derivative type calculation in sil combiner that causes errors in the
 // subsequent optimizations as we're ending with invalid "recursive" 
-// subsitutions
+// substitutions
 
 import _Differentiation;
 

--- a/test/CAS/bridging-header.swift
+++ b/test/CAS/bridging-header.swift
@@ -65,7 +65,7 @@
 // RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %t/test.swift \
 // RUN:   -emit-module -o %t/Test.swiftmodule
 
-/// Importing binary module with bridging header built from CAS from a regluar build.
+/// Importing binary module with bridging header built from CAS from a regular build.
 /// This should succeed even it is also importing a bridging header that shares same header dependencies (with proper header guard).
 // RUN: %target-swift-frontend -typecheck -module-name User -swift-version 5 \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \

--- a/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/complete-types.m
+++ b/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/complete-types.m
@@ -14,6 +14,6 @@ void takeACompleteInterface(ForwardDeclaredInterface *param) {
   [param doSomethingForwardDeclaredInterfacesCan];
 }
 void takeACompleteProtocol(NSObject<ForwardDeclaredProtocol> *param) {
-  NSLog(@"takeACompleteProcotol");
+  NSLog(@"takeACompleteProtocol");
   [param doSomethingForwardDeclaredProtocolsCan];
 }

--- a/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.h
+++ b/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.h
@@ -17,7 +17,7 @@ void takeASubscript(subscript *param);
 subscript* returnASubscript();
 
 // There is a Swift protocol, @objc protocol ShadowedProtocol, but
-// since here we are refering to a class and not a protocol, this
+// since here we are referring to a class and not a protocol, this
 // shouldn't be an issue.
 ShadowedProtocol* returnANativeObjCClassShadowedProtocol();
 

--- a/test/ConstExtraction/ExtractCoerce.swift
+++ b/test/ConstExtraction/ExtractCoerce.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractLiterals.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
 // RUN: cat %t/ExtractLiterals.swiftconstvalues 2>&1 | %FileCheck %s
 
-struct CoercableThing : ExpressibleByStringLiteral {
+struct CoercibleThing : ExpressibleByStringLiteral {
     let thing: String
     public init(unicodeScalarLiteral value: String) {
         self.init(stringLiteral: value)
@@ -17,8 +17,8 @@ struct CoercableThing : ExpressibleByStringLiteral {
 
 protocol MyProto {}
 public struct TestStruct : MyProto {
-    let foo: CoercableThing = "foo"
-    let bar: CoercableThing = CoercableThing("bar")
+    let foo: CoercibleThing = "foo"
+    let bar: CoercibleThing = CoercibleThing("bar")
 }
 
 // CHECK:             "label": "foo",

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -34,7 +34,7 @@ _ = f0(X2(), {$0.g()})
 
 func inoutToSharedConversions() {
   func fooOW<T, U>(_ f : (__owned T) -> U) {}
-  fooOW({ (x : Int) in return Int(5) }) // defaut-to-'__owned' allowed
+  fooOW({ (x : Int) in return Int(5) }) // default-to-'__owned' allowed
   fooOW({ (x : __owned Int) in return Int(5) }) // '__owned'-to-'__owned' allowed
   fooOW({ (x : __shared Int) in return Int(5) }) // '__shared'-to-'__owned' allowed
   fooOW({ (x : inout Int) in return Int(5) }) // expected-error {{cannot convert value of type '(inout Int) -> Int' to expected argument type '(__owned Int) -> Int'}}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -173,7 +173,7 @@ func rdar21080030() {
   if s.count() == 0 {} // expected-error {{cannot call value of non-function type 'Int'}}
 }
 
-// <rdar://problem/21248136> QoI: problem with return type inference mis-diagnosed as invalid arguments
+// <rdar://problem/21248136> QoI: problem with return type inference misdiagnosed as invalid arguments
 func r21248136<T>() -> T { preconditionFailure() } // expected-note 2 {{in call to function 'r21248136()'}}
 
 r21248136()            // expected-error {{generic parameter 'T' could not be inferred}}

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -478,7 +478,7 @@ class AmbiguityA : NSObject {
 }
 
 
-class AmbuguityB : NSObject {
+class AmbiguityB : NSObject {
   @objc class var testProp: B { get { B() } }
 }
 

--- a/test/DebugInfo/sroa_debug_value.sil
+++ b/test/DebugInfo/sroa_debug_value.sil
@@ -28,7 +28,7 @@ sil hidden @foo : $@convention(thin) (Int64, Int64) -> Int64 {
 bb0(%0 : $Int64, %1 : $Int64):
   %4 = alloc_stack $MyStruct, var, name "my_struct", loc "sroa.swift":8:9, scope 2
   debug_value %4 : $*MyStruct, let, name "my_copy", expr op_deref, loc "sroa.swift":7:10, scope 2
-  // Make sure SROA propagate the debug info to the splitted alloc_stack/debug_value instructions
+  // Make sure SROA propagate the debug info to the split alloc_stack/debug_value instructions
   // CHECK-SROA: %[[ALLOC_X:[0-9]+]] = alloc_stack $Int64, var
   // CHECK-SROA-SAME:        (name "my_struct", loc "sroa.swift":8:9
   // CHECK-SROA-SAME:        type $MyStruct, expr op_fragment:#MyStruct.x

--- a/test/DebugInfo/sroa_mem2reg.sil
+++ b/test/DebugInfo/sroa_mem2reg.sil
@@ -32,7 +32,7 @@ bb0(%0 : $Int64, %1 : $Int64):
   debug_value %0 : $Int64, let, name "in_x", argno 1, loc "sroa.swift":7:10, scope 2
   debug_value %1 : $Int64, let, name "in_y", argno 2, loc "sroa.swift":7:21, scope 2
   %4 = alloc_stack $MyStruct, var, name "my_struct", loc "sroa.swift":8:9, scope 2
-  // Make sure SROA propagate the debug info to the splitted alloc_stack instructions
+  // Make sure SROA propagate the debug info to the split alloc_stack instructions
   // CHECK-SROA: alloc_stack $Int64, var
   // CHECK-SROA-SAME:        (name "my_struct", loc "sroa.swift":8:9
   // CHECK-SROA-SAME:        type $MyStruct, expr op_fragment:#MyStruct.x

--- a/test/DebugInfo/sroa_mem2reg_tuple.sil
+++ b/test/DebugInfo/sroa_mem2reg_tuple.sil
@@ -20,7 +20,7 @@ bb0(%0 : $Int64, %1 : $Int64):
   debug_value %1 : $Int64, let, name "in_y", argno 2, loc "sroa.swift":1:21, scope 2
 
   %4 = alloc_stack $(x: Int64, y: Int64), var, name "my_tup", loc "sroa.swift":2:7, scope 3
-  // Make sure SROA propagate the debug info to the splitted alloc_stack instructions
+  // Make sure SROA propagate the debug info to the split alloc_stack instructions
   // CHECK-SROA: alloc_stack $Builtin.Int64, var
   // CHECK-SROA-SAME:        (name "my_tup", loc "sroa.swift":2:7
   // CHECK-SROA-SAME:        type $(x: Int64, y: Int64), expr op_tuple_fragment:$(x: Int64, y: Int64):0:op_fragment:#Int64._value

--- a/test/Driver/loaded_module_trace_directness_2.swift
+++ b/test/Driver/loaded_module_trace_directness_2.swift
@@ -6,7 +6,7 @@
 // Dependency graph:
 //
 // * CoreFilesystem - Swift module with generated ObjC header
-// * FilesystemKit - ObjC module without overlay, has #import <CoreFileystem-Generated.h>
+// * FilesystemKit - ObjC module without overlay, has #import <CoreFilesystem-Generated.h>
 // * TestFilesystem - Swift module, has import CoreFilesystem or FilesystemKit.
 //
 // * CoreDaemon - ObjC module with overlay, the overlay has import DaemonKit

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -387,7 +387,7 @@ extension TwoDisjointConformances: P2 where T == String {}
 
 
 // FIXME: these cases should be equivalent (and both with the same output as the
-// first), but the second one choses T as the representative of the
+// first), but the second one chooses T as the representative of the
 // equivalence class containing both T and U in the extension's generic
 // signature, meaning the stored conditional requirement is T: P1, which isn't
 // true in the original type's generic signature.

--- a/test/Index/Store/unit-custom-output-path-driver.swift
+++ b/test/Index/Store/unit-custom-output-path-driver.swift
@@ -139,7 +139,7 @@
 //    Check the unit output is based on "index-unit-output-path":
 //    RUN: c-index-test core -print-unit %/t/idx_batch_with | %FileCheck -check-prefixes=INDEX_WITH %s
 //
-//    Check the unit output is not baed on the "output" values:
+//    Check the unit output is not based on the "output" values:
 //    RUN: c-index-test core -print-unit %/t/idx_batch_with | %FileCheck -check-prefixes=INDEX_WITH_NEGATIVE %s
 //
 // C) Do the above again but with a fresh index store and using file lists.

--- a/test/Index/Store/unit-custom-output-path.swift
+++ b/test/Index/Store/unit-custom-output-path.swift
@@ -117,7 +117,7 @@
 //    Check the unit output is based on -index-unit-output-path:
 //    RUN: c-index-test core -print-unit %t/idx_batch_with | %FileCheck -check-prefixes=INDEX_BATCH_WITH %s
 //
-//    Check the unit output is not baed on the -o values:
+//    Check the unit output is not based on the -o values:
 //    RUN: c-index-test core -print-unit %t/idx_batch_with | %FileCheck -check-prefixes=INDEX_BATCH_WITH_NEGATIVE %s
 //
 //    INDEX_BATCH_WITH:      custom_main.o-{{.*}}

--- a/test/Inputs/lazy_typecheck_client.swift
+++ b/test/Inputs/lazy_typecheck_client.swift
@@ -27,7 +27,7 @@ func testGlobalFunctions() {
   }
 }
 
-func testGobalVars() {
+func testGlobalVars() {
   let _: Int = publicGlobalVar
   let _: Int = publicGlobalVarTypealias
   let _: String = publicGlobalVarInferredType

--- a/test/Interpreter/SDK/Inputs/OldABI/OldABI.mm
+++ b/test/Interpreter/SDK/Inputs/OldABI/OldABI.mm
@@ -11,7 +11,7 @@
 
 // Implementation of ObjC classes
 // with bits set to mimic the pre-stable Swift ABI
-// and additional memory protection to detect mis-use
+// and additional memory protection to detect misuse
 
 #if __has_include(<objc/objc-internal.h>)
 #include <objc/objc-internal.h>

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -140,7 +140,7 @@ struct TestNoInitAndInit {
 
   var pointX: Int {
     @storageRestrictions(accesses: x)
-    init(initalValue) {
+    init(initialValue) {
     }
 
     get { x }
@@ -559,7 +559,7 @@ func test_effects_are_still_supported() {
 }
 
 test_effects_are_still_supported()
-// CHEKC: effects-support-test: Test(_a: 42, b: 0)
+// CHECK: effects-support-test: Test(_a: 42, b: 0)
 
 func test_memberwise_without_stored_properties() {
   struct Test {
@@ -819,9 +819,9 @@ do {
   print(TestDefaultInitializable())
   print(TestDefaultInitializable(a: 42))
 
-  struct TestMixedDefaultInitalizable : CustomStringConvertible {
+  struct TestMixedDefaultInitializable : CustomStringConvertible {
     var description: String {
-      "TestMixedDefaultInitalizable(a: \(a), b: \(b))"
+      "TestMixedDefaultInitializable(a: \(a), b: \(b))"
     }
 
     var a: Int? {
@@ -838,15 +838,15 @@ do {
     }
   }
 
-  print(TestMixedDefaultInitalizable())
-  print(TestMixedDefaultInitalizable(b: "Hello"))
-  print(TestMixedDefaultInitalizable(a: 42))
+  print(TestMixedDefaultInitializable())
+  print(TestMixedDefaultInitializable(b: "Hello"))
+  print(TestMixedDefaultInitializable(a: 42))
 }
 // CHECK: TestDefaultInitializable(a: nil)
 // CHECK-NEXT: TestDefaultInitializable(a: Optional(42))
-// CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional(""))
-// CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional("Hello"))
-// CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional(""))
+// CHECK-NEXT: TestMixedDefaultInitializable(a: nil, b: Optional(""))
+// CHECK-NEXT: TestMixedDefaultInitializable(a: nil, b: Optional("Hello"))
+// CHECK-NEXT: TestMixedDefaultInitializable(a: nil, b: Optional(""))
 
 do {
   struct TestNonMutatingSetDefault {

--- a/test/Macros/lit.local.cfg
+++ b/test/Macros/lit.local.cfg
@@ -2,7 +2,7 @@
 if 'asserts' not in config.available_features:
     config.unsupported = True
 
-config.subsitutions = list(config.substitutions)
+config.substitutions = list(config.substitutions)
 
 def get_target_os():
     import re

--- a/test/Macros/macro_expand_closure.swift
+++ b/test/Macros/macro_expand_closure.swift
@@ -17,7 +17,7 @@ func multiStatementInference() -> Int {
   #multiStatement()
 }
 
-// The closure intruduced by the macro expansion should not contain any inline
+// The closure introduced by the macro expansion should not contain any inline
 // locations, but instead point directly into the macro buffer.
 // CHECK-SIL: sil_scope [[S0:[0-9]+]] { loc "@__swiftmacro_9MacroUser0031macro_expand_closureswift_yFFIifMX16_2_14multiStatementfMf_.swift":1:1 parent @$s9MacroUser23multiStatementInferenceSiyFSiyXEfU_
 // CHECK-SIL: sil_scope [[S2:[0-9]+]] { loc "@__swiftmacro_9MacroUser0031macro_expand_closureswift_yFFIifMX16_2_14multiStatementfMf_.swift":2:14 parent [[S0]] }

--- a/test/Macros/macro_plugin_disable_sandbox.swift
+++ b/test/Macros/macro_plugin_disable_sandbox.swift
@@ -1,6 +1,6 @@
 // REQUIRES: swift_swift_parser
 
-// sandbox-exec is only avaiable in Darwin
+// sandbox-exec is only available in Darwin
 // REQUIRES: OS=macosx
 
 // RUN: %empty-directory(%t)

--- a/test/Macros/macro_swiftdeps.swift
+++ b/test/Macros/macro_swiftdeps.swift
@@ -103,7 +103,7 @@
 // WITHOUT_PLUGIN-NOT:  AssertPlugin
 // WITHOUT_PLUGIN-NOT:  mock-plugin
 
-// TRACE_WITH_PLGUIN: "swiftmacros":[
+// TRACE_WITH_PLUGIN: "swiftmacros":[
 // TRACE_WITH_PLUGIN-DAG: {"name":"AssertPlugin","path":"{{.*}}AssertPlugin.{{(dylib|so|dll)}}"}
 // TRACE_WITH_PLUGIN-DAG: {"name":"StringifyPlugin","path":"{{.*}}StringifyPlugin.{{(dylib|so|dll)}}"}
 // TRACE_WITH_PLUGIN-DAG: {"name":"TestPlugin","path":"{{.*}}mock-plugin"}

--- a/test/ModuleInterface/async_sequence_conformance.swift
+++ b/test/ModuleInterface/async_sequence_conformance.swift
@@ -4,7 +4,7 @@
 
 // REQUIRES: concurrency, OS=macosx
 
-// CHECK: public struct SequenceAdapte
+// CHECK: public struct SequenceAdapter
 @available(SwiftStdlib 5.1, *)
 public struct SequenceAdapter<Base: AsyncSequence>: AsyncSequence {
   // CHECK-LABEL: public struct AsyncIterator
@@ -28,7 +28,7 @@ public struct SequenceAdapter<Base: AsyncSequence>: AsyncSequence {
   // CHECK-SAME: public typealias __AsyncSequence_Failure = Base.Failure
 }
 
-// CHECK: public struct OtherSequenceAdapte
+// CHECK: public struct OtherSequenceAdapter
 @available(SwiftStdlib 5.1, *)
 public struct OtherSequenceAdapter<Base: AsyncSequence>: AsyncSequence {
   // CHECK: public typealias Element = Base.Element

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -19,7 +19,7 @@
 // the uses of those features are guarded by appropriate #if's that allow older
 // compilers to skip over the uses of newer features.
 
-// Some feature gaurds are retired when the first compiler that supports the
+// Some feature guards are retired when the first compiler that supports the
 // feature is old enough. The --implicit-check-not arguments to FileCheck above
 // verify that those guards no longer pollute the emitted interface.
 

--- a/test/Parse/availability_query_unavailability.swift
+++ b/test/Parse/availability_query_unavailability.swift
@@ -65,7 +65,7 @@ if #unavailable(iOS 8.0) {
 if #unavailable(iOSApplicationExtension, unavailable) { // expected-error 2{{expected version number}}
 }
 
-// Should this be a valid spelling since `#unvailable(*)` cannot be written?
+// Should this be a valid spelling since `#unavailable(*)` cannot be written?
 if #unavailable() { // expected-error {{expected platform name}}
 }
 

--- a/test/Profiler/coverage_result_builder.swift
+++ b/test/Profiler/coverage_result_builder.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_functon_builder %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_function_builder %s | %FileCheck %s
 // RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir %s
 
 @resultBuilder
@@ -11,7 +11,7 @@ struct Summer {
   }
 }
 
-// CHECK-LABEL: sil_coverage_map {{.*}} "$s24coverage_functon_builder5test0SiyF"
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s25coverage_function_builder5test0SiyF"
 @Summer
 func test0() -> Int {
   // CHECK: [[@LINE-1]]:21 -> [[@LINE+3]]:2 : 0
@@ -19,7 +19,7 @@ func test0() -> Int {
   12
 }
 
-// CHECK-LABEL: sil_coverage_map {{.*}} "$s24coverage_functon_builder5test1SiyF"
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s25coverage_function_builder5test1SiyF"
 @Summer
 func test1() -> Int {
   // CHECK: [[@LINE-1]]:21 -> [[@LINE+7]]:2 : 0

--- a/test/Profiler/unmapped.swift
+++ b/test/Profiler/unmapped.swift
@@ -93,10 +93,10 @@ struct UnavailableType {
   var storedClosure: Int = { .random() ? 0 : 1 }()
 
   @Wrapper
-  var wrappered = .random() ? 0 : 1
+  var wrapped = .random() ? 0 : 1
 
   @Wrapper(wrappedValue: .random() ? 0 : 1)
-  var alsoWrappered: Int
+  var alsoWrapped: Int
 }
 
 @available(*, unavailable)

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -459,7 +459,7 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
       return
     }
 
-    // Comare `lhs` and `rhs` so we can use `_unsignedSubtract` to subtract
+    // Compare `lhs` and `rhs` so we can use `_unsignedSubtract` to subtract
     // the smaller magnitude from the larger magnitude.
     switch lhs._compareMagnitude(to: rhs) {
     case .equal:
@@ -1032,7 +1032,7 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
     case lessThan, equal, greaterThan
   }
 
-  /// Returns whether this instance is less than, greather than, or equal to
+  /// Returns whether this instance is less than, greater than, or equal to
   /// the given value.
   func _compare(to rhs: _BigInt) -> _ComparisonResult {
     // Negative values are less than positive values
@@ -1050,7 +1050,7 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
     }
   }
 
-  /// Returns whether the magnitude of this instance is less than, greather
+  /// Returns whether the magnitude of this instance is less than, greater
   /// than, or equal to the magnitude of the given value.
   func _compareMagnitude(to rhs: _BigInt) -> _ComparisonResult {
     guard _data.count == rhs._data.count else {

--- a/test/SIL/OwnershipVerifier/borrow_extract_validate.sil
+++ b/test/SIL/OwnershipVerifier/borrow_extract_validate.sil
@@ -55,8 +55,8 @@ bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
   return %ret : $()
 }
 
-// CHECK-NOT: Function: 'borrowed_extract_dominate_discrepency_simple_correct'
-sil [ossa] @borrowed_extract_dominate_discrepency_simple_correct : $@convention(thin) (@guaranteed WrapperStruct) -> () {
+// CHECK-NOT: Function: 'borrowed_extract_dominate_discrepancy_simple_correct'
+sil [ossa] @borrowed_extract_dominate_discrepancy_simple_correct : $@convention(thin) (@guaranteed WrapperStruct) -> () {
 bb0(%0 : @guaranteed $WrapperStruct):
   %elem = struct_extract %0 : $WrapperStruct, #WrapperStruct.cls
   br bb1(%elem : $Klass)
@@ -77,14 +77,14 @@ bb1(%newelem : @guaranteed $Klass):
   return %res : $()
 }
 
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_extract_dominate_discrepency_incorrect1'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_extract_dominate_discrepancy_incorrect1'
 // CHECK: Found outside of lifetime use?!
 // CHECK: Value: %7 = argument of bb1 : $WrapperStruct
 // CHECK: Consuming User:   end_borrow %7 : $WrapperStruct
 // CHECK: Non Consuming User:   %10 = apply %9(%6) : $@convention(thin) (@guaranteed Klass) -> ()
 // CHECK: Block: bb1
-// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_extract_dominate_discrepency_incorrect1'
-sil [ossa] @borrowed_extract_dominate_discrepency_incorrect1 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_extract_dominate_discrepancy_incorrect1'
+sil [ossa] @borrowed_extract_dominate_discrepancy_incorrect1 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
 bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
   %copy0 = copy_value %0 : $WrapperStruct
   %borrow0 = begin_borrow %copy0 : $WrapperStruct
@@ -100,15 +100,15 @@ bb1(%elem : @guaranteed $Klass, %newborrow : @guaranteed $WrapperStruct):
   return %ret : $()
 }
 
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_extract_dominate_discrepency_incorrect2'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_extract_dominate_discrepancy_incorrect2'
 // CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %2 = copy_value %0 : $WrapperStruct           
 // CHECK: Consuming User:   destroy_value %2 : $WrapperStruct               
 // CHECK: Non Consuming User:   end_borrow %7 : $WrapperStruct                  
 // CHECK: Block: bb1
-// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_extract_dominate_discrepency_incorrect2'
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'borrowed_extract_dominate_discrepency_incorrect2'
-sil [ossa] @borrowed_extract_dominate_discrepency_incorrect2 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_extract_dominate_discrepancy_incorrect2'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'borrowed_extract_dominate_discrepancy_incorrect2'
+sil [ossa] @borrowed_extract_dominate_discrepancy_incorrect2 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
 bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
   %copy0 = copy_value %0 : $WrapperStruct
   %borrow0 = begin_borrow %copy0 : $WrapperStruct

--- a/test/SIL/OwnershipVerifier/borrow_validate.sil
+++ b/test/SIL/OwnershipVerifier/borrow_validate.sil
@@ -239,8 +239,8 @@ bb3(%newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
   return %ret : $()
 }
 
-// CHECK-NOT: Function: 'borrow_lifetime_discrepency'
-sil [ossa] @borrow_lifetime_discrepency : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+// CHECK-NOT: Function: 'borrow_lifetime_discrepancy'
+sil [ossa] @borrow_lifetime_discrepancy : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
 bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
   %copy0 = copy_value %0 : $WrapperStruct
   cond_br undef, bb1, bb2
@@ -263,8 +263,8 @@ bb3(%newborrowi : @guaranteed $WrapperStruct, %newborrowo : @guaranteed $Wrapper
   return %ret : $()
 }
 
-// CHECK-NOT: Function: 'borrow_lifetime_discrepency_2'
-sil [ossa] @borrow_lifetime_discrepency_2 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+// CHECK-NOT: Function: 'borrow_lifetime_discrepancy_2'
+sil [ossa] @borrow_lifetime_discrepancy_2 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
 bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
   cond_br undef, bb1, bb2
 
@@ -288,15 +288,15 @@ bb3(%newborrowi : @guaranteed $WrapperStruct, %newborrowo : @guaranteed $Wrapper
   return %ret : $()
 }
 
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrow_lifetime_discrepency_incorrect_1'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrow_lifetime_discrepancy_incorrect_1'
 // CHECK: Found outside of lifetime use?!
 // CHECK: Value: %13 = argument of bb3 : $WrapperStruct            // user: %15
 // CHECK: Consuming User:   destroy_value %13 : $WrapperStruct              // id: %15
 // CHECK: Non Consuming User:   end_borrow %12 : $WrapperStruct                 // id: %16
 // CHECK: Block: bb3
-// CHECK-LABEL: Error#: 0. End Error in Function: 'borrow_lifetime_discrepency_incorrect_1'
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrow_lifetime_discrepancy_incorrect_1'
 // CHECK-NOT: Error#: 1.
-sil [ossa] @borrow_lifetime_discrepency_incorrect_1 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+sil [ossa] @borrow_lifetime_discrepancy_incorrect_1 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
 bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
   cond_br undef, bb1, bb2
 
@@ -320,15 +320,15 @@ bb3(%newborrowi : @guaranteed $WrapperStruct, %newborrowo : @guaranteed $Wrapper
   return %ret : $()
 }
 
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrow_lifetime_discrepency_incorrect_2'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrow_lifetime_discrepancy_incorrect_2'
 // CHECK: Found outside of lifetime use?!
 // CHECK: Value: %12 = argument of bb3 : $WrapperStruct            // user: %14
 // CHECK: Consuming User:   end_borrow %12 : $WrapperStruct                 // id: %14
 // CHECK: Non Consuming User:   end_borrow %11 : $WrapperStruct                 // id: %15
 // CHECK: Block: bb3
-// CHECK-LABEL: Error#: 0. End Error in Function: 'borrow_lifetime_discrepency_incorrect_2'
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrow_lifetime_discrepancy_incorrect_2'
 // CHECK-NOT: Error#: 1.
-sil [ossa] @borrow_lifetime_discrepency_incorrect_2 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+sil [ossa] @borrow_lifetime_discrepancy_incorrect_2 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
 bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
   cond_br undef, bb1, bb2
 

--- a/test/SIL/Serialization/public_external.sil
+++ b/test/SIL/Serialization/public_external.sil
@@ -40,7 +40,7 @@ sil hidden @he : $@convention(thin) () -> () {
   return %0 : $()
 }
 
-sil hidden [transparent] @tranparent_he : $@convention(thin) () -> () {
+sil hidden [transparent] @transparent_he : $@convention(thin) () -> () {
   %0 = tuple()
   return %0 : $()
 }

--- a/test/SPI/accidental-reexport.swift
+++ b/test/SPI/accidental-reexport.swift
@@ -4,13 +4,13 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -emit-module %t/Overlayed.swift -I %t -o %t
+// RUN: %target-swift-frontend -emit-module %t/Overlaid.swift -I %t -o %t
 // RUN: %target-swift-frontend -typecheck -verify %t/Client.swift -I %t
 // RUN: %target-swift-frontend -typecheck -verify %t/LowerClient.swift -I %t
 
 //--- module.modulemap
-module Overlayed {
-    header "Overlayed.h"
+module Overlaid {
+    header "Overlaid.h"
 }
 
 module Middle {
@@ -23,9 +23,9 @@ module LowerMiddle {
     export *
 }
 
-//--- Overlayed.h
-//--- Overlayed.swift
-@_exported import Overlayed
+//--- Overlaid.h
+//--- Overlaid.swift
+@_exported import Overlaid
 
 public func funcPublic() {}
 
@@ -33,7 +33,7 @@ public func funcPublic() {}
 public func funcSPI() {}
 
 //--- Middle.h
-#include <Overlayed.h>
+#include <Overlaid.h>
 
 //--- LowerMiddle.h
 #include <Middle.h>

--- a/test/ScanDependencies/optional_deps_of_binary_testable_imports.swift
+++ b/test/ScanDependencies/optional_deps_of_binary_testable_imports.swift
@@ -16,6 +16,6 @@
 
 // The dependency of `Foo` on `A` will not be visible if the scanner simply scans the textual interface
 // of `Foo`. So we verify that for a `@testable` import, the scanner also opens up the adjacent binary module and
-// attemtps to resolve optional dependencies contained within.
+// attempts to resolve optional dependencies contained within.
 //
 // CHECK: "swift": "A"

--- a/test/ScanDependencies/optional_deps_of_testable_imports.swift
+++ b/test/ScanDependencies/optional_deps_of_testable_imports.swift
@@ -16,6 +16,6 @@
 
 // The dependency of `Foo` on `A` will not be visible if the scanner simply scans the textual interface
 // of `Foo`. So we verify that for a `@testable` import, the scanner also opens up the adjacent binary module and
-// attemtps to resolve optional dependencies contained within.
+// attempts to resolve optional dependencies contained within.
 //
 // CHECK: "swift": "A"

--- a/test/ScanDependencies/optional_transitive_dep_load_fail.swift
+++ b/test/ScanDependencies/optional_transitive_dep_load_fail.swift
@@ -37,7 +37,7 @@
 // Step 1: build Foo Swift module
 // RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name -enable-library-evolution -I %S/Inputs/CHeaders -I %S/Inputs/Swift -enable-testing -swift-version 5 -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
 
-// Step 2: scan dependencies and ensure the transitive dependency on "A" is misssing
+// Step 2: scan dependencies and ensure the transitive dependency on "A" is missing
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -sdk %t -prebuilt-module-cache-path %t/clang-module-cache
 // RUN: %validate-json %t/deps.json | %FileCheck -check-prefix CHECK_SCAN %s
 // CHECK_SCAN-NOT: "swift": "A"

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -955,7 +955,7 @@ package enum PackageGenericEnumT<T: InternalProto> { // expected-error {{generic
   case A
 }
 
-/// Test setters with less accss level
+/// Test setters with less access level
 public protocol PublicMutationOperations {
   var size: Int { get set }
   subscript (_: Int) -> Int { get set }
@@ -1482,19 +1482,19 @@ public class DerivedFromInternalConcreteGenericCompositionPkg : InternalConcrete
 }
 
 package typealias PackageConcreteGenericComposition = PublicGenericClass<Int> & PublicProto // expected-note {{declared here}}
-public class DerivedFromPacakgeConcreteGenericComposition : PackageConcreteGenericComposition { // expected-error {{class cannot be declared public because its superclass is package}}
+public class DerivedFromPackageConcreteGenericComposition : PackageConcreteGenericComposition { // expected-error {{class cannot be declared public because its superclass is package}}
   public func publicReq() {}
 }
 
 package typealias PackageConcreteGenericCompositionStr = PackageGenericClass<String> & PackageProto // expected-note {{declared here}}
-public class DerivedFromPacakgeConcreteGenericComposition2 : PackageConcreteGenericCompositionStr { // expected-error {{class cannot be declared public because its superclass is package}}
+public class DerivedFromPackageConcreteGenericComposition2 : PackageConcreteGenericCompositionStr { // expected-error {{class cannot be declared public because its superclass is package}}
   public func packageReq() {}
 }
 
-package class DerivedFromPacakgeConcreteGenericComposition3 : PackageConcreteGenericCompositionStr { // no-warning
+package class DerivedFromPackageConcreteGenericComposition3 : PackageConcreteGenericCompositionStr { // no-warning
   public func packageReq() {}
 }
-internal class DerivedFromPacakgeConcreteGenericComposition4 : PackageConcreteGenericCompositionStr { // no-warning
+internal class DerivedFromPackageConcreteGenericComposition4 : PackageConcreteGenericCompositionStr { // no-warning
   public func packageReq() {}
 }
 

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -841,7 +841,7 @@ class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
 }
 
 @available(OSX, introduced: 10.51)
-class SubWithLimitedAvailablility : SuperWithAlwaysAvailableMembers {
+class SubWithLimitedAvailability : SuperWithAlwaysAvailableMembers {
   override func shouldAlwaysBeAvailableMethod() {}
   
   override var shouldAlwaysBeAvailableProperty: Int {

--- a/test/Sema/availability_versions_objc_api.swift
+++ b/test/Sema/availability_versions_objc_api.swift
@@ -40,7 +40,7 @@ func functionWithObjCParam(o: NSAvailableOn10_51) { // expected-error {{'NSAvail
     // expected-note@-1 {{add @available attribute to enclosing global function}}
 }
 
-class ClassExtendingUnvailableClass : NSAvailableOn10_51 { // expected-error {{'NSAvailableOn10_51' is only available in macOS 10.51 or newer}}
+class ClassExtendingUnavailableClass : NSAvailableOn10_51 { // expected-error {{'NSAvailableOn10_51' is only available in macOS 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing class}}
 }
 

--- a/test/Sema/diag_constantness_check.swift
+++ b/test/Sema/diag_constantness_check.swift
@@ -198,7 +198,7 @@ func testConstantArgumentWithConstEval(constParam: Int) {
   constantArgumentFunction(constantEval(constParam, true))
 }
 
-// Test parital-apply of constantArgumentFunction.
+// Test partial-apply of constantArgumentFunction.
 @_semantics("oslog.requires_constant_arguments")
 func constArg2(_ x: Int) -> Int { x }
 

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -271,7 +271,7 @@ module ClangSubmodule {
 module ClangSubmoduleUnused {
     header "ClangSubmoduleUnused.h"
 
-    module ClangSubmoduleUnsuedSubmodule {
+    module ClangSubmoduleUnusedSubmodule {
       header "ClangSubmoduleUnusedSubmodule.h"
     }
 }
@@ -302,7 +302,7 @@ struct ClangTopModuleType {};
 public import ClangSimple
 public import ClangSimpleUnused // expected-warning {{public import of 'ClangSimpleUnused' was not used in public declarations or inlinable code}}
 public import ClangSubmodule.ClangSubmoduleSubmodule
-public import ClangSubmoduleUnused.ClangSubmoduleUnsuedSubmodule // expected-warning {{public import of 'ClangSubmoduleUnused' was not used in public declarations or inlinable code}}
+public import ClangSubmoduleUnused.ClangSubmoduleUnusedSubmodule // expected-warning {{public import of 'ClangSubmoduleUnused' was not used in public declarations or inlinable code}}
 
 // Only the top-level module is used, but we can't detect whether the submodule was used or not.
 public import ClangTopModule.ClangTopModuleSubmodule

--- a/test/attr/attr_availability_narrow.swift
+++ b/test/attr/attr_availability_narrow.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 // REQUIRES: OS=macosx
-// <rdar://problem/17669805> Suggest narrowing the range of bad availabile checks
+// <rdar://problem/17669805> Suggest narrowing the range of bad available checks
 
 import Foundation
 

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -446,7 +446,7 @@ func test_memberwise_ordering() {
 
     var pair: (Int, Int) {
       @storageRestrictions(accesses: _a, _b)
-      init(initalValue) {
+      init(initialValue) {
       }
 
       get { (_a, _b) }
@@ -464,7 +464,7 @@ func test_memberwise_ordering() {
 
     var c: Int {
       @storageRestrictions(initializes: _c, accesses: _a, _b)
-      init(initalValue) {
+      init(initialValue) {
       }
 
       get { _c }
@@ -494,7 +494,7 @@ func test_default_arguments_are_analyzed() {
 
     var otherPair = (0, 1) {
       // expected-error@-1 {{computed property must have an explicit type}}
-      init(initalValue) {}
+      init(initialValue) {}
 
       get { 42 }
       // expected-error@-1 {{cannot convert return expression of type 'Int' to return type '(Int, Int)'}}

--- a/test/embedded/FixedArray.swift
+++ b/test/embedded/FixedArray.swift
@@ -28,7 +28,7 @@ func testDestroyOfElements() {
   a.append(CheckLifetime(29))
   a.append(CheckLifetime(30))
 
-  // The `*` is a prefix operator and serves as syntatic sugar for FixedArray.view.
+  // The `*` is a prefix operator and serves as syntactic sugar for FixedArray.view.
   printit(*a)
 }
 
@@ -58,7 +58,7 @@ struct S {
   static var a = FixedArray<Int>(capacity: 10)
 
   // Elements are initialized in the data section.
-  // The `^` is a prefix operator and serves as syntatic sugar to create a FixedArray literal.
+  // The `^` is a prefix operator and serves as syntactic sugar to create a FixedArray literal.
   static let b = ^[1, 2, 3]
 
   static let c: FixedArray<Int64?> = ^[10, 20, 30]

--- a/test/embedded/Inputs/ExperimentalFixedArray.swift
+++ b/test/embedded/Inputs/ExperimentalFixedArray.swift
@@ -93,7 +93,7 @@ public struct FixedArray<T> : ~Copyable {
   }
 }
 
-// Syntatic sugar for creating a FixedArray literal
+// Syntactic sugar for creating a FixedArray literal
 prefix operator ^
 
 @_transparent
@@ -102,7 +102,7 @@ public prefix func ^<T>(_ literal: FixedArray<T>._Literal) -> FixedArray<T> {
   return FixedArray<T>(elements: literal.array)
 }
 
-// Syntatic sugar for getting a BufferView to a FixedArray
+// Syntactic sugar for getting a BufferView to a FixedArray
 prefix operator *
 
 @_transparent

--- a/test/embedded/ouroboros-bug.swift
+++ b/test/embedded/ouroboros-bug.swift
@@ -1,5 +1,5 @@
 // Regression test for a "Ouroboros Bug": The ARC optimizer doesn't like the
-// presense of a direct call to swift_retain and swift_release in any Swift
+// presence of a direct call to swift_retain and swift_release in any Swift
 // code, but in the embedded Swift's runtime that's somewhat reasonable thing
 // to do (but is to be avoided because of this).
 

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -383,7 +383,7 @@ func throwsError() throws {
 }
 
 // FIXME: If we ever support this, we need to fix the premature inference of '[Any]'/'[AnyHashable: Any]'.
-// The issue is that we're attempting to bind defaults to type variables before solving the conjuction.
+// The issue is that we're attempting to bind defaults to type variables before solving the conjunction.
 let g = [if .random() { "a" } else { "b" }]
 // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 // expected-error@-2 {{heterogeneous collection literal could only be inferred to '[Any]'; add explicit type annotation if this is intentional}}
@@ -850,7 +850,7 @@ func testPoundIfBranch4() -> Int {
 }
 
 func testPoundIfBranch5() -> Int {
-  // Not allowed (matches the behavior of implict expression returns)
+  // Not allowed (matches the behavior of implicit expression returns)
   if .random() {
     #if false
     0
@@ -862,7 +862,7 @@ func testPoundIfBranch5() -> Int {
 }
 
 func testPoundIfBranch6() -> Int {
-  // Not allowed (matches the behavior of implict expression returns)
+  // Not allowed (matches the behavior of implicit expression returns)
   let x = if .random() {
     #if false
     0

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -458,7 +458,7 @@ func throwsError() throws {
 }
 
 // FIXME: If we ever support this, we need to fix the premature inference of '[Any]'/'[AnyHashable: Any]'.
-// The issue is that we're attempting to bind defaults to type variables before solving the conjuction.
+// The issue is that we're attempting to bind defaults to type variables before solving the conjunction.
 let g = [switch Bool.random() { case true: "a" case false: "b" }]
 // expected-error@-1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 // expected-error@-2 {{heterogeneous collection literal could only be inferred to '[Any]'; add explicit type annotation if this is intentional}}
@@ -1078,7 +1078,7 @@ func testPoundIfBranch4() -> Int {
 }
 
 func testPoundIfBranch5() -> Int {
-  // Not allowed (matches the behavior of implict expression returns)
+  // Not allowed (matches the behavior of implicit expression returns)
   switch Bool.random() {
   case true:
     #if false
@@ -1091,7 +1091,7 @@ func testPoundIfBranch5() -> Int {
 }
 
 func testPoundIfBranch6() -> Int {
-  // Not allowed (matches the behavior of implict expression returns)
+  // Not allowed (matches the behavior of implicit expression returns)
   let x = switch Bool.random() {
   case true:
     #if false

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -399,7 +399,7 @@ if kIsWindows:
     config.swift_system_overlay_opt = "-vfsoverlay {} -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
         os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
     )
-    # this variant is for extract-symbolgraph which doesn't accept all the same arugments as swiftc
+    # this variant is for extract-symbolgraph which doesn't accept all the same arguments as swiftc
     # so the extra ceremony lets us pass in the relevant pieces needed for Windows SDK access.
     config.windows_vfs_overlay_opt = "-Xcc -vfsoverlay -Xcc {} -Xcc -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
         os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
@@ -597,7 +597,7 @@ lit_config.note("Using code completion cache: " + completion_cache_path)
 
 if kIsWindows:
     config.swift_plugin_dir = config.swift_bin_dir
-    # FIXME: this is a workaround for the collsion between the build toolchain
+    # FIXME: this is a workaround for the collision between the build toolchain
     # and the current build, this should be `make_path(config.swift_lib_dir, 'swift')`
     config.swift_build_lib_dir = make_path(config.swift_lib_dir, 'swift', 'host')
 else:
@@ -2876,7 +2876,7 @@ config.substitutions.append(('%raw-FileCheck', shell_quote(config.filecheck)))
 config.substitutions.append(('%import-libdispatch', getattr(config, 'import_libdispatch', '')))
 # WARNING: the order of components in a substitution name has to be different from the previous one, as lit does
 # a pure string substitution without understanding that these components are grouped together. That is, the following
-# subsitution name can't be `%import-libdispatch-static`, otherwise the first two components will be substituted with
+# substitution name can't be `%import-libdispatch-static`, otherwise the first two components will be substituted with
 # the value of `%import-libdispatch` substitution with `-static` string appended to it.
 config.substitutions.append(('%import-static-libdispatch', getattr(config, 'import_libdispatch_static', '')))
 

--- a/test/refactoring/RefactoringKind/simplify_long_number.swift
+++ b/test/refactoring/RefactoringKind/simplify_long_number.swift
@@ -11,16 +11,16 @@ func foo() {
   _ = 123.123
 }
 
-// RUN: %refactor -source-filename %s -pos=4:10 | %FileCheck %s -check-prefix=CHECK-LONG-NUMER
-// RUN: %refactor -source-filename %s -pos=5:10 | %FileCheck %s -check-prefix=CHECK-LONG-NUMER
-// RUN: %refactor -source-filename %s -pos=6:15 | %FileCheck %s -check-prefix=CHECK-LONG-NUMER
-// RUN: %refactor -source-filename %s -pos=7:10 | %FileCheck %s -check-prefix=CHECK-LONG-NUMER
-// RUN: %refactor -source-filename %s -pos=8:10 | %FileCheck %s -check-prefix=CHECK-LONG-NUMER
+// RUN: %refactor -source-filename %s -pos=4:10 | %FileCheck %s -check-prefix=CHECK-LONG-NUMBER
+// RUN: %refactor -source-filename %s -pos=5:10 | %FileCheck %s -check-prefix=CHECK-LONG-NUMBER
+// RUN: %refactor -source-filename %s -pos=6:15 | %FileCheck %s -check-prefix=CHECK-LONG-NUMBER
+// RUN: %refactor -source-filename %s -pos=7:10 | %FileCheck %s -check-prefix=CHECK-LONG-NUMBER
+// RUN: %refactor -source-filename %s -pos=8:10 | %FileCheck %s -check-prefix=CHECK-LONG-NUMBER
 
 // RUN: %refactor -source-filename %s -pos=10:8 | %FileCheck %s -check-prefix=CHECK-NONE
 // RUN: %refactor -source-filename %s -pos=11:8 | %FileCheck %s -check-prefix=CHECK-NONE
 
-// CHECK-LONG-NUMER: Simplify Long Number Literal
+// CHECK-LONG-NUMBER: Simplify Long Number Literal
 
 // CHECK-NONE: Action begins
 // CHECK-NONE-NEXT: Action ends

--- a/test/refactoring/SyntacticRename/Outputs/textual/foo.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/textual/foo.swift.expected
@@ -36,4 +36,4 @@ _ = /*MyClass:unknown*/Mismatch()
 _ = /*MyClass:unknown*/MyClass()
 #endif
 
-// All occcurrences of MyClass are outside of comments and string literals, so there's nothing to rename. swift-refactor indicates this by outputing empty results.
+// All occcurrences of MyClass are outside of comments and string literals, so there's nothing to rename. swift-refactor indicates this by outputting empty results.

--- a/test/refactoring/SyntacticRename/textual.swift
+++ b/test/refactoring/SyntacticRename/textual.swift
@@ -41,5 +41,5 @@ _ = /*MyClass:unknown*/MyClass()
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="foo" -is-function-like -old-name "foo()" >> %t.ranges/textual_foo.swift
 // RUN: diff -u %S/Outputs/textual/foo.swift.expected %t.ranges/textual_foo.swift
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="MyClass" -is-non-protocol-type -old-name "MyClass" -new-name "YourClass" >> %t.ranges/textual_MyClass.swift
-// All occcurrences of MyClass are outside of comments and string literals, so there's nothing to rename. swift-refactor indicates this by outputing empty results.
+// All occcurrences of MyClass are outside of comments and string literals, so there's nothing to rename. swift-refactor indicates this by outputting empty results.
 // RUN: diff -u %t.ranges/textual_MyClass.swift -

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -245,7 +245,7 @@ if #available(OSX 10.12, iOS 10.0, *) {
   TestNonEquatableEquals(F1(i: 1), E(i: 1))
   TestEquatableEquals(H(i:1), E(i:1))
 
-  // Equatable but not Hashable: alway have the same Obj-C hashValue
+  // Equatable but not Hashable: always have the same Obj-C hashValue
   TestEquatableHash(E(i: 1))
   TestEquatableHash(E1(i: 3))
   TestEquatableHash(E2(i: 8))

--- a/test/stdlib/SwiftValueNSObject.swift
+++ b/test/stdlib/SwiftValueNSObject.swift
@@ -140,7 +140,7 @@ if #available(OSX 10.12, iOS 10.0, *) {
   TestNonEquatableEquals(F(i: 1), F(i: 1))
   TestSwiftValueNSObjectNotEquals(H(i:1) as AnyObject, E(i:1) as AnyObject)
 
-  // Equatable but not Hashable: alway have the same Obj-C hashValue
+  // Equatable but not Hashable: always have the same Obj-C hashValue
   TestEquatableHash(E(i: 1))
   TestEquatableHash(E1(i: 17))
 


### PR DESCRIPTION
Fix typos in `test/*` ((misc folders in test)

This is one batch of many PRs fixing typos, [see the tracking issue.](https://github.com/swiftlang/swift/issues/75022)