### PR TITLE
[6.0][region-isolation] Reuse ActorInstance::lookThroughInsts when computing the actor instance for SILIsolationInfo purposes.

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -114,6 +114,10 @@ public:
   }
 };
 
+/// The isolation info inferred for a specific SILValue. Use
+/// SILIsolationInfo::get() to compute these. It is intended to be a
+/// conservatively correct model that we expand over time with more pattern
+/// matching.
 class SILIsolationInfo {
 public:
   /// The lattice is:
@@ -127,6 +131,20 @@ public:
     Task,
     Actor,
   };
+
+  enum class Flag : uint8_t {
+    None,
+
+    /// If set, this means that the element that we derived this from was marked
+    /// with nonisolated(unsafe).
+    UnsafeNonIsolated = 0x1,
+
+    /// If set, this means that this actor isolation is from an isolated
+    /// parameter and should be allowed to merge into a self parameter.
+    UnappliedIsolatedAnyParameter = 0x2,
+  };
+
+  using Options = OptionSet<Flag>;
 
 private:
   /// The actor isolation if this value has one. The default unspecified case
@@ -142,13 +160,13 @@ private:
   ActorInstance actorInstance;
 
   unsigned kind : 8;
-  unsigned unsafeNonIsolated : 1;
+  unsigned options : 8;
 
   SILIsolationInfo(SILValue isolatedValue, SILValue actorInstance,
-                   ActorIsolation actorIsolation, bool isUnsafeNonIsolated)
+                   ActorIsolation actorIsolation, Options options = Options())
       : actorIsolation(actorIsolation), isolatedValue(isolatedValue),
         actorInstance(ActorInstance::getForValue(actorInstance)), kind(Actor),
-        unsafeNonIsolated(isUnsafeNonIsolated) {
+        options(options.toRaw()) {
     assert((!actorInstance ||
             (actorIsolation.getKind() == ActorIsolation::ActorInstance &&
              actorInstance->getType()
@@ -159,24 +177,22 @@ private:
   }
 
   SILIsolationInfo(SILValue isolatedValue, ActorInstance actorInstance,
-                   ActorIsolation actorIsolation, bool isUnsafeNonIsolated)
+                   ActorIsolation actorIsolation, Options options = Options())
       : actorIsolation(actorIsolation), isolatedValue(isolatedValue),
-        actorInstance(actorInstance), kind(Actor),
-        unsafeNonIsolated(isUnsafeNonIsolated) {
+        actorInstance(actorInstance), kind(Actor), options(options.toRaw()) {
     assert(actorInstance);
     assert(actorIsolation.getKind() == ActorIsolation::ActorInstance);
   }
 
   SILIsolationInfo(Kind kind, SILValue isolatedValue)
-      : actorIsolation(), isolatedValue(isolatedValue), kind(kind),
-        unsafeNonIsolated(false) {}
+      : actorIsolation(), isolatedValue(isolatedValue), kind(kind), options(0) {
+  }
 
-  SILIsolationInfo(Kind kind, bool isUnsafeNonIsolated)
-      : actorIsolation(), kind(kind), unsafeNonIsolated(isUnsafeNonIsolated) {}
+  SILIsolationInfo(Kind kind, Options options = Options())
+      : actorIsolation(), kind(kind), options(options.toRaw()) {}
 
 public:
-  SILIsolationInfo()
-      : actorIsolation(), kind(Kind::Unknown), unsafeNonIsolated(false) {}
+  SILIsolationInfo() : actorIsolation(), kind(Kind::Unknown), options(0) {}
 
   operator bool() const { return kind != Kind::Unknown; }
 
@@ -188,12 +204,43 @@ public:
   bool isActorIsolated() const { return kind == Kind::Actor; }
   bool isTaskIsolated() const { return kind == Kind::Task; }
 
-  bool isUnsafeNonIsolated() const { return unsafeNonIsolated; }
+  Options getOptions() const { return Options(options); }
+
+  void setOptions(Options newOptions) { options = newOptions.toRaw(); }
+
+  bool isUnsafeNonIsolated() const {
+    return getOptions().contains(Flag::UnsafeNonIsolated);
+  }
 
   SILIsolationInfo withUnsafeNonIsolated(bool newValue = true) const {
     assert(*this && "Cannot be unknown");
     auto self = *this;
-    self.unsafeNonIsolated = newValue;
+    if (newValue) {
+      self.options = (self.getOptions() | Flag::UnsafeNonIsolated).toRaw();
+    } else {
+      self.options =
+          self.getOptions().toRaw() & ~Options(Flag::UnsafeNonIsolated).toRaw();
+    }
+    return self;
+  }
+
+  /// Returns true if this actor isolation is derived from an unapplied
+  /// isolation parameter. When merging, we allow for this to be merged with a
+  /// more specific isolation kind.
+  bool isUnappliedIsolatedAnyParameter() const {
+    return getOptions().contains(Flag::UnappliedIsolatedAnyParameter);
+  }
+
+  SILIsolationInfo withUnappliedIsolatedParameter(bool newValue = true) const {
+    assert(*this && "Cannot be unknown");
+    auto self = *this;
+    if (newValue) {
+      self.options =
+          (self.getOptions() | Flag::UnappliedIsolatedAnyParameter).toRaw();
+    } else {
+      self.options = self.getOptions().toRaw() &
+                     ~Options(Flag::UnappliedIsolatedAnyParameter).toRaw();
+    }
     return self;
   }
 
@@ -243,7 +290,8 @@ public:
   }
 
   static SILIsolationInfo getDisconnected(bool isUnsafeNonIsolated) {
-    return {Kind::Disconnected, isUnsafeNonIsolated};
+    return {Kind::Disconnected,
+            isUnsafeNonIsolated ? Flag::UnsafeNonIsolated : Flag::None};
   }
 
   /// Create an actor isolation for a value that we know is actor isolated to a
@@ -261,7 +309,7 @@ public:
   getFlowSensitiveActorIsolated(SILValue isolatedValue,
                                 ActorIsolation actorIsolation) {
     return {isolatedValue, SILValue(), actorIsolation,
-            false /*nonisolated(unsafe)*/};
+            Flag::UnappliedIsolatedAnyParameter};
   }
 
   /// Only use this as a fallback if we cannot find better information.
@@ -270,8 +318,7 @@ public:
     if (crossing.getCalleeIsolation().isActorIsolated()) {
       // SIL level, just let it through
       return SILIsolationInfo(SILValue(), SILValue(),
-                              crossing.getCalleeIsolation(),
-                              false /*nonisolated(unsafe)*/);
+                              crossing.getCalleeIsolation());
     }
 
     return {};
@@ -287,8 +334,7 @@ public:
       return {};
     }
     return {isolatedValue, actorInstance,
-            ActorIsolation::forActorInstanceSelf(typeDecl),
-            false /*nonisolated(unsafe)*/};
+            ActorIsolation::forActorInstanceSelf(typeDecl)};
   }
 
   static SILIsolationInfo getActorInstanceIsolated(SILValue isolatedValue,
@@ -301,8 +347,7 @@ public:
       return {};
     }
     return {isolatedValue, actorInstance,
-            ActorIsolation::forActorInstanceSelf(typeDecl),
-            false /*nonisolated(unsafe)*/};
+            ActorIsolation::forActorInstanceSelf(typeDecl)};
   }
 
   /// A special actor instance isolated for partial apply cases where we do not
@@ -318,14 +363,13 @@ public:
     }
     return {isolatedValue, SILValue(),
             ActorIsolation::forActorInstanceSelf(typeDecl),
-            false /*nonisolated(unsafe)*/};
+            Flag::UnappliedIsolatedAnyParameter};
   }
 
   static SILIsolationInfo getGlobalActorIsolated(SILValue value,
                                                  Type globalActorType) {
     return {value, SILValue() /*no actor instance*/,
-            ActorIsolation::forGlobalActor(globalActorType),
-            false /*nonisolated(unsafe)*/};
+            ActorIsolation::forGlobalActor(globalActorType)};
   }
 
   static SILIsolationInfo getGlobalActorIsolated(SILValue value,
@@ -395,7 +439,7 @@ class SILDynamicMergedIsolationInfo {
 
 public:
   SILDynamicMergedIsolationInfo() : innerInfo() {}
-  explicit SILDynamicMergedIsolationInfo(SILIsolationInfo innerInfo)
+  SILDynamicMergedIsolationInfo(SILIsolationInfo innerInfo)
       : innerInfo(innerInfo) {}
 
   /// Returns nullptr only if both this isolation info and \p other are actor

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -485,6 +485,10 @@ public:
   SWIFT_DEBUG_DUMPER(dumpForDiagnostics()) {
     innerInfo.dumpForDiagnostics();
   }
+
+  void printForOneLineLogging(llvm::raw_ostream &os) const {
+    innerInfo.printForOneLineLogging(os);
+  }
 };
 
 } // namespace swift

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -142,6 +142,9 @@ public:
     /// If set, this means that this actor isolation is from an isolated
     /// parameter and should be allowed to merge into a self parameter.
     UnappliedIsolatedAnyParameter = 0x2,
+
+    /// The maximum number of bits used by a Flag.
+    MaxNumBits = 2,
   };
 
   using Options = OptionSet<Flag>;
@@ -426,6 +429,9 @@ public:
   bool isEqual(const SILIsolationInfo &other) const;
 
   void Profile(llvm::FoldingSetNodeID &id) const;
+
+private:
+  void printOptions(llvm::raw_ostream &os) const;
 };
 
 /// A SILIsolationInfo that has gone through merging and represents the dynamic

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1633,8 +1633,9 @@ public:
               if (originalMergedInfo)
                   originalMergedInfo->printForDiagnostics(llvm::dbgs());
               else llvm::dbgs() << "nil";
-              llvm::dbgs() << "\nValue: "
+              llvm::dbgs() << "\nValue Rep: "
                            << value->getRepresentative().getValue();
+              llvm::dbgs() << "Original Src: " << src;
               llvm::dbgs() << "Value Info: ";
               value->getIsolationRegionInfo().printForDiagnostics(llvm::dbgs());
               llvm::dbgs() << "\n");

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -874,15 +874,38 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
 }
 
 void SILIsolationInfo::print(llvm::raw_ostream &os) const {
+  auto printOptions = [&] {
+    auto opts = getOptions();
+    if (!opts)
+      return;
+
+    os << ": ";
+
+    std::array<std::pair<Flag, StringLiteral>, 2> data = {
+        std::make_pair(Flag::UnsafeNonIsolated,
+                       StringLiteral("nonisolated(unsafe)")),
+        std::make_pair(Flag::UnappliedIsolatedAnyParameter,
+                       StringLiteral("unapplied_isolated_parameter")),
+    };
+
+    llvm::interleave(
+        data, os,
+        [&](const std::pair<Flag, StringLiteral> &value) {
+          opts -= value.first;
+          os << value.second;
+        },
+        ", ");
+
+    assert(!opts && "Unhandled flag?!");
+  };
+
   switch (Kind(*this)) {
   case Unknown:
     os << "unknown";
     return;
   case Disconnected:
     os << "disconnected";
-    if (unsafeNonIsolated) {
-      os << ": nonisolated(unsafe)";
-    }
+    printOptions();
     return;
   case Actor:
     if (ActorInstance instance = getActorInstance()) {
@@ -891,9 +914,7 @@ void SILIsolationInfo::print(llvm::raw_ostream &os) const {
         SILValue value = instance.getValue();
         if (auto name = VariableNameInferrer::inferName(value)) {
           os << "'" << *name << "'-isolated";
-          if (unsafeNonIsolated) {
-            os << ": nonisolated(unsafe)";
-          }
+          printOptions();
           os << "\n";
           os << "instance: " << *value;
 
@@ -903,9 +924,7 @@ void SILIsolationInfo::print(llvm::raw_ostream &os) const {
       }
       case ActorInstance::Kind::ActorAccessorInit:
         os << "'self'-isolated";
-        if (unsafeNonIsolated) {
-          os << ": nonisolated(unsafe)";
-        }
+        printOptions();
         os << '\n';
         os << "instance: actor accessor init\n";
         return;
@@ -915,23 +934,17 @@ void SILIsolationInfo::print(llvm::raw_ostream &os) const {
     if (getActorIsolation().getKind() == ActorIsolation::ActorInstance) {
       if (auto *vd = getActorIsolation().getActorInstance()) {
         os << "'" << vd->getBaseIdentifier() << "'-isolated";
-        if (unsafeNonIsolated) {
-          os << ": nonisolated(unsafe)";
-        }
+        printOptions();
         return;
       }
     }
 
     getActorIsolation().printForDiagnostics(os);
-    if (unsafeNonIsolated) {
-      os << ": nonisolated(unsafe)";
-    }
+    printOptions();
     return;
   case Task:
     os << "task-isolated";
-    if (unsafeNonIsolated) {
-      os << ": nonisolated(unsafe)";
-    }
+    printOptions();
     os << '\n';
     os << "instance: " << *getIsolatedValue();
     return;
@@ -958,8 +971,13 @@ bool SILIsolationInfo::hasSameIsolation(const SILIsolationInfo &other) const {
     ActorInstance actor1 = getActorInstance();
     ActorInstance actor2 = other.getActorInstance();
 
-    // If either are non-null, and the actor instance doesn't match, return
-    // false.
+    // If either have an actor instance, and the actor instance doesn't match,
+    // return false.
+    //
+    // This ensures that cases like comparing two global actor isolated things
+    // do not hit this path.
+    //
+    // It also catches cases where we have a missing actor instance.
     if ((actor1 || actor2) && actor1 != actor2)
       return false;
 
@@ -1053,7 +1071,7 @@ void SILIsolationInfo::printForOneLineLogging(llvm::raw_ostream &os) const {
     return;
   case Disconnected:
     os << "disconnected";
-    if (unsafeNonIsolated) {
+    if (getOptions().contains(Flag::UnsafeNonIsolated)) {
       os << ": nonisolated(unsafe)";
     }
     return;
@@ -1142,14 +1160,31 @@ std::optional<SILDynamicMergedIsolationInfo>
 SILDynamicMergedIsolationInfo::merge(SILIsolationInfo other) const {
   // If we are greater than the other kind, then we are further along the
   // lattice. We ignore the change.
-  if (unsigned(other.getKind()) < unsigned(innerInfo.getKind()))
+  if (unsigned(innerInfo.getKind() > unsigned(other.getKind())))
     return {*this};
 
-  // If we are both actor isolated and our isolations are not
-  // compatible... return None.
-  if (other.isActorIsolated() && innerInfo.isActorIsolated() &&
-      !innerInfo.hasSameIsolation(other))
+  // If we are both actor isolated...
+  if (innerInfo.isActorIsolated() && other.isActorIsolated()) {
+    // If both innerInfo and other have the same isolation, we are obviously
+    // done. Just return innerInfo since we could return either.
+    if (innerInfo.hasSameIsolation(other))
+      return {innerInfo};
+
+    // Ok, there is some difference in between innerInfo and other. Lets see if
+    // they are both actor instance isolated and if either are unapplied
+    // isolated any parameter. In such a case, take the one that is further
+    // along.
+    if (innerInfo.getActorIsolation().isActorInstanceIsolated() &&
+        other.getActorIsolation().isActorInstanceIsolated()) {
+      if (innerInfo.isUnappliedIsolatedAnyParameter())
+        return other;
+      if (other.isUnappliedIsolatedAnyParameter())
+        return innerInfo;
+    }
+
+    // Otherwise, they do not match... so return None to signal merge failure.
     return {};
+  }
 
   // If we are both disconnected and other has the unsafeNonIsolated bit set,
   // drop that bit and return that.
@@ -1158,11 +1193,11 @@ SILDynamicMergedIsolationInfo::merge(SILIsolationInfo other) const {
   // merging. These bits should not propagate through merging and should instead
   // always be associated with non-merged infos.
   if (other.isDisconnected() && other.isUnsafeNonIsolated()) {
-    return SILDynamicMergedIsolationInfo(other.withUnsafeNonIsolated(false));
+    return {other.withUnsafeNonIsolated(false)};
   }
 
   // Otherwise, just return other.
-  return SILDynamicMergedIsolationInfo(other);
+  return {other};
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -363,49 +363,47 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     }
 
     if (auto *isolatedOp = fas.getIsolatedArgumentOperandOrNullPtr()) {
-      // First see if we have an enum inst.
-      if (auto *ei = dyn_cast<EnumInst>(isolatedOp->get())) {
-        if (ei->getElement()->getParentEnum()->isOptionalDecl()) {
-          // Pattern match from global actors being passed as isolated
-          // parameters. This gives us better type information. If we can
-          // pattern match... we should!
-          if (ei->hasOperand()) {
-            if (auto *ieri =
-                    dyn_cast<InitExistentialRefInst>(ei->getOperand())) {
-              CanType selfASTType = ieri->getFormalConcreteType();
+      // First look through ActorInstance agnostic values so we can find the
+      // type of the actual underlying actor (e.x.: copy_value,
+      // init_existential_ref, begin_borrow, etc).
+      auto actualIsolatedValue =
+          ActorInstance::lookThroughInsts(isolatedOp->get());
 
-              if (auto *nomDecl = selfASTType->getAnyActor()) {
-                // The SILValue() parameter doesn't matter until we have
-                // isolation history.
-                if (nomDecl->isGlobalActor())
-                  return SILIsolationInfo::getGlobalActorIsolated(SILValue(),
-                                                                  nomDecl);
-              }
-            }
-          } else {
-            // In this case, we have a .none so we are attempting to use the
-            // global queue. In such a case, we need to not use the enum as our
-            // value and instead need to grab the isolation of our apply.
-            if (auto isolationInfo = get(fas.getCallee())) {
-              return isolationInfo;
-            }
-          }
+      // First see if we have a .none enum inst. In such a case, we are actually
+      // on the nonisolated global queue.
+      if (auto *ei = dyn_cast<EnumInst>(actualIsolatedValue)) {
+        if (ei->getElement()->getParentEnum()->isOptionalDecl() &&
+            !ei->hasOperand()) {
+          // In this case, we have a .none so we are attempting to use the
+          // global queue. This means that the isolation effect of the
+          // function is disconnected since we are treating the function as
+          // nonisolated.
+          return SILIsolationInfo::getDisconnected(false);
         }
       }
 
-      // If we did not find an AST type, just see if we can find a value by
-      // looking through all optional types. This is conservatively correct.
-      CanType selfASTType = isolatedOp->get()->getType().getASTType();
+      // Then using that value, grab the AST type from the actual isolated
+      // value.
+      CanType selfASTType = actualIsolatedValue->getType().getASTType();
+
+      // Then look through optional types since in cases like where we have a
+      // function argument that is an Optional actor... like an optional actor
+      // returned from a function, we still need to be able to lookup the actor
+      // as being the underlying type.
       selfASTType =
           selfASTType->lookThroughAllOptionalTypes()->getCanonicalType();
-
       if (auto *nomDecl = selfASTType->getAnyActor()) {
+        // Then see if we have a global actor. This pattern matches the output
+        // for doing things like GlobalActor.shared.
+        if (nomDecl->isGlobalActor()) {
+          return SILIsolationInfo::getGlobalActorIsolated(SILValue(), nomDecl);
+        }
+
         // TODO: We really should be doing this based off of an Operand. Then
         // we would get the SILValue() for the first element. Today this can
         // only mess up isolation history.
-
         return SILIsolationInfo::getActorInstanceIsolated(
-            SILValue(), isolatedOp->get(), nomDecl);
+            SILValue(), actualIsolatedValue, nomDecl);
       }
     }
 
@@ -1146,9 +1144,31 @@ SILValue ActorInstance::lookThroughInsts(SILValue value) {
         isa<MoveValueInst>(svi) || isa<ExplicitCopyValueInst>(svi) ||
         isa<BeginBorrowInst>(svi) ||
         isa<CopyableToMoveOnlyWrapperValueInst>(svi) ||
-        isa<MoveOnlyWrapperToCopyableValueInst>(svi)) {
+        isa<MoveOnlyWrapperToCopyableValueInst>(svi) ||
+        isa<InitExistentialRefInst>(svi) || isa<UncheckedRefCastInst>(svi) ||
+        isa<UnconditionalCheckedCastInst>(svi)) {
       value = lookThroughInsts(svi->getOperand(0));
       continue;
+    }
+
+    // Look Through extracting from optionals.
+    if (auto *uedi = dyn_cast<UncheckedEnumDataInst>(svi)) {
+      if (uedi->getEnumDecl() ==
+          uedi->getFunction()->getASTContext().getOptionalDecl()) {
+        value = lookThroughInsts(uedi->getOperand());
+        continue;
+      }
+    }
+
+    // Look Through wrapping in an enum.
+    if (auto *ei = dyn_cast<EnumInst>(svi)) {
+      if (ei->hasOperand()) {
+        if (ei->getElement()->getParentEnum() ==
+            ei->getFunction()->getASTContext().getOptionalDecl()) {
+          value = lookThroughInsts(ei->getOperand());
+          continue;
+        }
+      }
     }
 
     break;
@@ -1212,7 +1232,7 @@ SILDynamicMergedIsolationInfo::merge(SILIsolationInfo other) const {
 namespace swift::test {
 
 // Arguments:
-// - SILValue: value to emit a name for.
+// - SILValue: value to look up isolation for.
 // Dumps:
 // - The inferred isolation.
 static FunctionTest
@@ -1227,5 +1247,34 @@ static FunctionTest
                               info.printForOneLineLogging(llvm::outs());
                               llvm::outs() << "\n";
                             });
+
+// Arguments:
+// - SILValue: first value to merge
+// - SILValue: second value to merge
+// Dumps:
+// - The merged isolation.
+static FunctionTest IsolationMergeTest(
+    "sil-isolation-info-merged-inference",
+    [](auto &function, auto &arguments, auto &test) {
+      auto firstValue = arguments.takeValue();
+      auto secondValue = arguments.takeValue();
+      SILIsolationInfo firstValueInfo = SILIsolationInfo::get(firstValue);
+      SILIsolationInfo secondValueInfo = SILIsolationInfo::get(secondValue);
+      std::optional<SILDynamicMergedIsolationInfo> mergedInfo(firstValueInfo);
+      mergedInfo = mergedInfo->merge(secondValueInfo);
+      llvm::outs() << "First Value: " << *firstValue;
+      llvm::outs() << "First Isolation: ";
+      firstValueInfo.printForOneLineLogging(llvm::outs());
+      llvm::outs() << "\nSecond Value: " << *secondValue;
+      llvm::outs() << "Second Isolation: ";
+      secondValueInfo.printForOneLineLogging(llvm::outs());
+      llvm::outs() << "\nMerged Isolation: ";
+      if (mergedInfo) {
+        mergedInfo->printForOneLineLogging(llvm::outs());
+      } else {
+        llvm::outs() << "Merge failure!";
+      }
+      llvm::outs() << "\n";
+    });
 
 } // namespace swift::test

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -439,8 +439,9 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   let myActor = A()
 
   await optionalIsolated(ns, to: myActor)
-  // expected-complete-warning@-1 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{pattern that the region based isolation checker does not understand how to check. Please file a bug}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
+  // expected-tns-note @-3 {{sending task-isolated 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated and task-isolated uses}}
 
 #if ALLOW_TYPECHECKER_ERRORS
   optionalIsolatedSync(ns, to: myActor)
@@ -456,13 +457,14 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated global function 'optionalIsolated(_:to:)' risks causing data races between nonisolated and main actor-isolated uses}}
 
-  optionalIsolatedSync(ns, to: nil) // expected-tns-warning {{pattern that the region based isolation checker does not understand how to check. Please file a bug}}
+  optionalIsolatedSync(ns, to: nil)
 
   let myActor = A()
 
   await optionalIsolated(ns, to: myActor)
   // expected-complete-warning@-1 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{pattern that the region based isolation checker does not understand how to check. Please file a bug}}
+  // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
+  // expected-tns-note @-3 {{sending main actor-isolated 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated and main actor-isolated uses}}
 
 #if ALLOW_TYPECHECKER_ERRORS
   optionalIsolatedSync(ns, to: myActor)
@@ -566,4 +568,15 @@ public func useDefaultIsolationWithoutIsolatedParam(
 @MainActor func callUseDefaultIsolation() async {
   useDefaultIsolation()
   useDefaultIsolationWithoutIsolatedParam()
+}
+
+public actor MyActorIsolatedParameterMerge {
+  private var inProgressIndexTasks: [Int: Int] = [:]
+
+  public func test() async {
+    await withTaskGroup(of: Void.self) { taskGroup in
+      for (_, _) in inProgressIndexTasks {}
+      await taskGroup.waitForAll()
+    }
+  }
 }

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -23,6 +23,8 @@ class NonSendableKlass {
 
 actor MyActor {
   var ns: NonSendableKlass
+
+  func doSomething() async -> NonSendableKlass
 }
 
 sil @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
@@ -33,6 +35,7 @@ sil @constructNonSendableKlassIndirectAsync : $@convention(thin) @async () -> @o
 sil @useUnmanagedNonSendableKlass : $@convention(thin) (@guaranteed @sil_unmanaged NonSendableKlass) -> ()
 
 sil @useActor : $@convention(thin) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+sil @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
 
 ///////////////////////
 // MARK: Basic Tests //
@@ -720,4 +723,99 @@ bb0(%0 : @owned $MyActor):
   destroy_value %1 : $MyActor
   destroy_value %1b : $MyActor
   return %3 : $NonSendableKlass
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on isolated_variable_test_1: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: Input Value:   %2 = apply %1(%0) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+// CHECK-NEXT: Isolation: disconnected
+// CHECK-NEXT: end running test 1 of 1 on isolated_variable_test_1: sil-isolation-info-inference with: @trace[0]
+sil [ossa] @isolated_variable_test_1 : $@convention(thin) @async () -> () {
+bb0:
+  specify_test "sil-isolation-info-inference @trace[0]"
+  %0 = enum $Optional<MyActor>, #Optional.none
+  %1 = function_ref @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %2 = apply %1(%0) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  //debug_value [trace] %1 : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  debug_value [trace] %2 : $NonSendableKlass
+  destroy_value %2 : $NonSendableKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil @$s5infer7MyActorC11doSomethingAA16NonSendableKlassCyYaF : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+
+// CHECK-LABEL: begin running test 1 of 1 on isolated_variable_test_2:
+// CHECK-NEXT: First Value:   %3 = apply %2(%0) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+// CHECK-NEXT: First Isolation: 'self'-isolated
+// CHECK-NEXT: Second Value:   %6 = apply %4(%5) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+// CHECK-NEXT: Second Isolation: 'self'-isolated
+// CHECK-NEXT: Merged Isolation: 'self'-isolated
+// CHECK-NEXT: end running test 1 of 1 on isolated_variable_test_2: sil-isolation-info-merged-inference with: @trace[0], @trace[1]
+sil [ossa] @isolated_variable_test_2 : $@convention(thin) @async (@guaranteed Optional<MyActor>) -> () {
+bb0(%0 : @guaranteed $Optional<MyActor>):
+  debug_value %0 : $Optional<MyActor>, let, name "self"
+  specify_test "sil-isolation-info-merged-inference @trace[0] @trace[1]"
+  %1 = function_ref @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %2 = apply %1(%0) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %3 = function_ref @$s5infer7MyActorC11doSomethingAA16NonSendableKlassCyYaF : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  %0a = unchecked_enum_data %0 : $Optional<MyActor>, #Optional.some!enumelt
+  %4 = apply %3(%0a) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  debug_value [trace] %2 : $NonSendableKlass
+  debug_value [trace] %4 : $NonSendableKlass
+  destroy_value %2 : $NonSendableKlass
+  destroy_value %4 : $NonSendableKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on isolated_variable_test_3:
+// CHECK-NEXT: First Value:   %4 = apply %2(%3) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+// CHECK-NEXT: First Isolation: 'self'-isolated
+// CHECK-NEXT: Second Value:   %6 = apply %5(%0) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+// CHECK-NEXT: Second Isolation: 'self'-isolated
+// CHECK-NEXT: Merged Isolation: 'self'-isolated
+// CHECK-NEXT: end running test 1 of 1 on isolated_variable_test_3: sil-isolation-info-merged-inference with: @trace[0], @trace[1]
+sil [ossa] @isolated_variable_test_3 : $@convention(thin) @async (@guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  debug_value %0 : $MyActor, let, name "self"
+  specify_test "sil-isolation-info-merged-inference @trace[0] @trace[1]"
+  %1 = function_ref @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %0a = enum $Optional<MyActor>, #Optional.some!enumelt, %0 : $MyActor
+  %2 = apply %1(%0a) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %3 = function_ref @$s5infer7MyActorC11doSomethingAA16NonSendableKlassCyYaF : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  %4 = apply %3(%0) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  debug_value [trace] %2 : $NonSendableKlass
+  debug_value [trace] %4 : $NonSendableKlass
+  destroy_value %2 : $NonSendableKlass
+  destroy_value %4 : $NonSendableKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on isolated_variable_test_4:
+// CHECK-NEXT: First Value:   %8 = apply %2(%7) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+// CHECK-NEXT: First Isolation: 'self'-isolated
+// CHECK-NEXT: Second Value:   %10 = apply %9(%0) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+// CHECK-NEXT: Second Isolation: 'self'-isolated
+// CHECK-NEXT: Merged Isolation: 'self'-isolated
+// CHECK-NEXT: end running test 1 of 1 on isolated_variable_test_4: sil-isolation-info-merged-inference with: @trace[0], @trace[1]
+sil [ossa] @isolated_variable_test_4 : $@convention(thin) @async (@guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  debug_value %0 : $MyActor, let, name "self"
+  specify_test "sil-isolation-info-merged-inference @trace[0] @trace[1]"
+  %1 = function_ref @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %0a = init_existential_ref %0 : $MyActor : $MyActor, $AnyObject
+  %0b = unconditional_checked_cast %0a : $AnyObject to MyActor
+  %0c = unchecked_ref_cast %0b : $MyActor to $AnyObject
+  %0d = unchecked_ref_cast %0c : $AnyObject to $MyActor
+  %0e = enum $Optional<MyActor>, #Optional.some!enumelt, %0d : $MyActor
+  %2 = apply %1(%0e) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
+  %3 = function_ref @$s5infer7MyActorC11doSomethingAA16NonSendableKlassCyYaF : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  %4 = apply %3(%0) : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  debug_value [trace] %2 : $NonSendableKlass
+  debug_value [trace] %4 : $NonSendableKlass
+  destroy_value %2 : $NonSendableKlass
+  destroy_value %4 : $NonSendableKlass
+  %9999 = tuple ()
+  return %9999 : $()
 }


### PR DESCRIPTION
Explanation: This PR improves our ability to properly unify actor instances by standardizing region isolation to use the same ActorInstance::lookThroughInsts in both RegionAnalysis and SILIsolationInfo inference. The result is that cases like the following compile since we are able to ensure that all of the #isolation parameters are viewed as having the same isolation as the ambient isolation in callers:

```swift
    public actor MyActor {
      private var intDict: [Int: Int] = [:]
    
      public func test() async {
        await withTaskGroup(of: Void.self) { taskGroup in
          for (_, _) in intDict {}
          await taskGroup.waitForAll() // Isolation merge failure happens here resulting in "pattern compiler doesn't understand"
        }
      }
    }
```

Before we would view them as different and upon isolation merges would hit merge failures (since a region cannot have two values within the region that are actor isolated to different actors). This merge failure would then cause us to emit a "pattern compiler doesn't understand" error at taskGroup.waitForAll().

Radars:

- rdar://130113744

Original PRs:

- https://github.com/swiftlang/swift/pull/75017

Risk: Low. This allows the compiler to view more actor instances as the same in a very conservative way since we just look through instructions that propagate the same actor identity (e.x.: copy_value, move_value, init_existential_ref, optional formation). If looking through these instructions caused any issue, it would show a differing significant issue in the compiler that would be a separate error.
Testing: Added/Ran tests
Reviewer: N/A