### PR TITLE
[SILGen] Create SIL variable declaration scopes for trivial values.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1459,7 +1459,7 @@ public:
       HasPointerEscape_t hasPointerEscape = DoesNotHavePointerEscape,
       IsFromVarDecl_t fromVarDecl = IsNotFromVarDecl) {
     assert(getFunction().hasOwnership());
-    assert(!operand->getType().isTrivial(getFunction()) &&
+    assert(fromVarDecl || !operand->getType().isTrivial(getFunction()) &&
            "Should not be passing trivial values to this api. Use instead "
            "emitMoveValueOperation");
     return insert(new (getModule())

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1978,6 +1978,7 @@ enum HasPointerEscape_t : bool {
   HasPointerEscape = true,
 };
 
+// See SILValue::isFromVarDecl()
 enum IsFromVarDecl_t : bool {
   IsNotFromVarDecl = false,
   IsFromVarDecl = true,

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -609,6 +609,12 @@ public:
   /// (it has a debug_value [trace] user).
   bool hasDebugTrace() const;
 
+  /// Does this SILValue begin a VarDecl scope? Only true in OSSA.
+  ///
+  /// If this is true, the value must be a SingleValueInstruction whose first
+  /// operand is the variable's initial value.
+  bool isFromVarDecl();
+
   static bool classof(SILNodePointer node) {
     return node->getKind() >= SILNodeKind::First_ValueBase &&
            node->getKind() <= SILNodeKind::Last_ValueBase;

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -610,9 +610,6 @@ public:
   bool hasDebugTrace() const;
 
   /// Does this SILValue begin a VarDecl scope? Only true in OSSA.
-  ///
-  /// If this is true, the value must be a SingleValueInstruction whose first
-  /// operand is the variable's initial value.
   bool isFromVarDecl();
 
   static bool classof(SILNodePointer node) {

--- a/include/swift/SILOptimizer/Utils/StackNesting.h
+++ b/include/swift/SILOptimizer/Utils/StackNesting.h
@@ -160,7 +160,11 @@ private:
   /// Returns the stack allocation instruction for a stack deallocation
   /// instruction.
   SILInstruction *getAllocForDealloc(SILInstruction *Dealloc) const {
-    return Dealloc->getOperand(0)->getDefiningInstruction();
+    SILValue op = Dealloc->getOperand(0);
+    while (auto *mvi = dyn_cast<MoveValueInst>(op)) {
+      op = mvi->getOperand();
+    }
+    return op->getDefiningInstruction();
   }
 
   /// Insert deallocations at block boundaries.

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -209,6 +209,16 @@ bool ValueBase::hasDebugTrace() const {
   return false;
 }
 
+bool ValueBase::isFromVarDecl() {
+  if (auto *mvi = dyn_cast<MoveValueInst>(this)) {
+    return mvi->isFromVarDecl();
+  }
+  if (auto *bbi = dyn_cast<BeginBorrowInst>(this)) {
+    return bbi->isFromVarDecl();
+  }
+  return false;
+}
+
 SILBasicBlock *SILNode::getParentBlock() const {
   if (auto *Inst = dyn_cast<SILInstruction>(this))
     return Inst->getParent();

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1061,6 +1061,15 @@ namespace {
 
     void emitDestroyValue(SILBuilder &B, SILLocation loc,
                           SILValue value) const override {
+      if (B.getFunction().hasOwnership()
+          && B.getModule().getStage() == SILStage::Raw
+          && value->isFromVarDecl()) {
+        // Do not use destroy_value for trivial values. The lifetime introducer
+        // may be implicitly copied and used outside of its original scope,
+        // which violates the invariants of destroy_value.
+        B.createExtendLifetime(loc, value);
+        return;
+      }
       // Trivial
     }
   };

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -85,7 +85,6 @@ CONSTANT_OWNERSHIP_INST(Owned, CopyBlock)
 CONSTANT_OWNERSHIP_INST(Owned, CopyBlockWithoutEscaping)
 CONSTANT_OWNERSHIP_INST(Owned, CopyValue)
 CONSTANT_OWNERSHIP_INST(Owned, ExplicitCopyValue)
-CONSTANT_OWNERSHIP_INST(Owned, MoveValue)
 CONSTANT_OWNERSHIP_INST(Owned, EndCOWMutation)
 CONSTANT_OWNERSHIP_INST(Owned, EndInitLetRef)
 CONSTANT_OWNERSHIP_INST(Owned, BeginDeallocRef)
@@ -212,7 +211,9 @@ CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, OpenExistentialBoxValue)
 // value).
 CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, MarkUninitialized)
 
-// unchecked_bitwise_cast is a bitwise copy. It produces a trivial or unowned
+// In raw SIL, a MoveValue delimits the scope of trivial variables.
+CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, MoveValue)
+
 // result.
 //
 // If the operand is nontrivial and the result is trivial, then it is the

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -607,8 +607,8 @@ bool SILValueOwnershipChecker::checkYieldWithoutLifetimeEndingUses(
 
 bool SILValueOwnershipChecker::checkValueWithoutLifetimeEndingUses(
     ArrayRef<Operand *> regularUses, ArrayRef<Operand *> extendLifetimeUses) {
-  if (extendLifetimeUses.size()) {
-  }
+  if (value->getOwnershipKind() == OwnershipKind::None)
+    return true;
 
   LLVM_DEBUG(llvm::dbgs() << "No lifetime ending users?! Bailing early.\n");
   if (auto *arg = dyn_cast<SILFunctionArgument>(value)) {

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -428,7 +428,9 @@ bool ConsumeOperatorCopyableValuesChecker::check() {
   for (auto &block : *fn) {
     for (auto &ii : block) {
       if (auto *mvi = dyn_cast<MoveValueInst>(&ii)) {
-        if (mvi->isFromVarDecl() && !mvi->getType().isMoveOnly()) {
+        if (mvi->isFromVarDecl()
+            && mvi->getOwnershipKind() != OwnershipKind::None
+            && !mvi->getType().isMoveOnly()) {
           LLVM_DEBUG(llvm::dbgs()
                      << "Found lexical lifetime to check: " << *mvi);
           valuesToCheck.insert(mvi);

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -1768,6 +1768,7 @@ ConstExprFunctionState::evaluateFlowSensitive(SILInstruction *inst) {
       isa<ReleaseValueInst>(inst) || isa<StrongRetainInst>(inst) ||
       isa<StrongReleaseInst>(inst) || isa<DestroyValueInst>(inst) ||
       isa<EndBorrowInst>(inst) || isa<DebugStepInst>(inst) ||
+      isa<ExtendLifetimeInst>(inst) ||
       // Skip instrumentation
       isInstrumentation(inst))
     return std::nullopt;

--- a/test/AutoDiff/SILGen/autodiff_builtins.swift
+++ b/test/AutoDiff/SILGen/autodiff_builtins.swift
@@ -99,7 +99,7 @@ func test_context_builtins_with_type<T>(t: T) {
 // CHECK:   [[CTX:%.*]] = builtin "autoDiffCreateLinearMapContextWithType"<T>({{%.*}} : $@thick T.Type) : $Builtin.NativeObject
 // CHECK:   [[CTX_LIFETIME:%.*]] = move_value [lexical] [var_decl] [[CTX]]
 // CHECK:   [[BORROWED_CTX:%.*]] = begin_borrow [[CTX_LIFETIME]]
-// CHECK:   [[BUF:%.*]] = builtin "autoDiffProjectTopLevelSubcontext"([[BORROWED_CTX]] : $Builtin.NativeObject) : $Builtin.RawPointer // users: {{.*}}
+// CHECK:   [[BUF:%.*]] = builtin "autoDiffProjectTopLevelSubcontext"([[BORROWED_CTX]] : $Builtin.NativeObject) : $Builtin.RawPointer
 // CHECK:   [[BORROWED_CTX:%.*]] = begin_borrow [[CTX_LIFETIME]]
-// CHECK:   [[BUF:%.*]] = builtin "autoDiffAllocateSubcontextWithType"<T>([[BORROWED_CTX]] : $Builtin.NativeObject, {{.*}} : $@thick T.Type) : $Builtin.RawPointer // users: {{.*}}
+// CHECK:   [[BUF:%.*]] = builtin "autoDiffAllocateSubcontextWithType"<T>([[BORROWED_CTX]] : $Builtin.NativeObject, {{.*}} : $@thick T.Type) : $Builtin.RawPointer
 // CHECK:   destroy_value [[CTX_LIFETIME]]

--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -220,11 +220,11 @@ func checked_cast_addr_active_result<T: Differentiable>(x: T) -> T {
 // CHECK: bb3:
 // CHECK: [ACTIVE] %14 = argument of bb3 : $Optional<Float>
 // CHECK: bb4:
-// CHECK: [ACTIVE] %16 = argument of bb4 : $Float
-// CHECK: [ACTIVE]   %19 = alloc_stack $Float
+// CHECK: [ACTIVE] [[ARG4:%.*]] = argument of bb4 : $Float
+// CHECK: [ACTIVE]   [[ALLOC4:%.*]] = alloc_stack $Float
 // CHECK: bb5:
 // CHECK: bb6:
-// CHECK: [NONE]   %27 = tuple ()
+// CHECK: [NONE]   %{{[0-9]+}} = tuple ()
 
 // CHECK-LABEL: sil hidden [ossa] @${{.*}}checked_cast_addr_active_result{{.*}} : $@convention(thin) <T where T : Differentiable> (@in_guaranteed T) -> @out T {
 // CHECK:   checked_cast_addr_br take_always T in %3 : $*T to Float in %5 : $*Float, bb1, bb2
@@ -832,15 +832,15 @@ func testActiveEnumValue(_ e: DirectEnum, _ x: Float) -> Float {
 // CHECK: bb2:
 // CHECK: [ACTIVE] %6 = argument of bb2 : $Float
 // CHECK: bb3:
-// CHECK: [ACTIVE] %9 = argument of bb3 : $(Float, Float)
-// CHECK: [ACTIVE] (**%10**, %11) = destructure_tuple %9 : $(Float, Float)
-// CHECK: [ACTIVE] (%10, **%11**) = destructure_tuple %9 : $(Float, Float)
-// CHECK: [USEFUL]   %14 = metatype $@thin Float.Type
+// CHECK: [ACTIVE] [[ARG3:%.*]] = argument of bb3 : $(Float, Float)
+// CHECK: [ACTIVE] (**[[D1:%.*]]**, [[D2:%.*]]) = destructure_tuple [[ARG3]] : $(Float, Float)
+// CHECK: [ACTIVE] ([[D1]], **[[D2]]**) = destructure_tuple [[ARG3]] : $(Float, Float)
+// CHECK: [USEFUL]   %{{.*}} = metatype $@thin Float.Type
 // CHECK: [NONE]   // function_ref static Float.+ infix(_:_:)
-// CHECK:   %15 = function_ref @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
-// CHECK: [ACTIVE]   %16 = apply %15(%10, %11, %14) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK:   %{{.*}} = function_ref @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK: [ACTIVE]   %{{.*}} = apply %{{[0-9]+}}(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
 // CHECK: bb4:
-// CHECK: [ACTIVE] %18 = argument of bb4 : $Float
+// CHECK: [ACTIVE] %{{[0-9]+}} = argument of bb4 : $Float
 
 enum IndirectEnum<T: Differentiable>: Differentiable & AdditiveArithmetic {
   case case1(T)

--- a/test/AutoDiff/SILOptimizer/derivative_sil.swift
+++ b/test/AutoDiff/SILOptimizer/derivative_sil.swift
@@ -41,10 +41,11 @@ func foo(_ x: Float) -> Float {
 // CHECK-SIL:   [[ADD_JVP_FN:%.*]] = differentiable_function_extract [jvp] [[ADD_DIFF_FN]]
 // CHECK-SIL:   [[ADD_RESULT:%.*]] = apply [[ADD_JVP_FN]]([[X]], [[X]], {{.*}})
 // CHECK-SIL:   ([[ORIG_RES:%.*]], [[ADD_DF:%.*]]) = destructure_tuple [[ADD_RESULT]]
+// CHECK-SIL:   [[MV_RES:%.*]] = move_value [var_decl] [[ORIG_RES]] : $Float
 // CHECK-SIL:   [[DF_STRUCT:%.*]] = tuple ([[ADD_DF]] : $@callee_guaranteed (Float, Float) -> Float)
 // CHECK-SIL:   [[DF_REF:%.*]] = function_ref @fooTJdSpSr : $@convention(thin) (Float, @owned (_: @callee_guaranteed (Float, Float) -> Float)) -> Float
 // CHECK-SIL:   [[DF_FN:%.*]] = partial_apply [callee_guaranteed] [[DF_REF]]([[DF_STRUCT]])
-// CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[DF_FN]] : $@callee_guaranteed (Float) -> Float)
+// CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[MV_RES]] : $Float, [[DF_FN]] : $@callee_guaranteed (Float) -> Float)
 // CHECK-SIL:   return [[VJP_RESULT]] : $(Float, @callee_guaranteed (Float) -> Float)
 // CHECK-SIL: }
 
@@ -67,7 +68,7 @@ func foo(_ x: Float) -> Float {
 // CHECK-SIL:   ([[ORIG_RES:%.*]], [[ADD_PB:%.*]]) = destructure_tuple [[ADD_RESULT]]
 // CHECK-SIL:   [[PB_REF:%.*]] = function_ref @fooTJpSpSr : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float
 // CHECK-SIL:   [[PB_FN:%.*]] = partial_apply [callee_guaranteed] [[PB_REF]]([[ADD_PB]])
-// CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[PB_FN]] : $@callee_guaranteed (Float) -> Float)
+// CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[MV_RES]] : $Float, [[PB_FN]] : $@callee_guaranteed (Float) -> Float)
 // CHECK-SIL:   return [[VJP_RESULT]] : $(Float, @callee_guaranteed (Float) -> Float)
 // CHECK-SIL: }
 

--- a/test/Interop/Cxx/class/function-call-macosx.swift
+++ b/test/Interop/Cxx/class/function-call-macosx.swift
@@ -20,11 +20,13 @@ public func testARCWeak() {
 // CHECK: sil [ossa] @$s4main26testARCWeakFunctionPointeryyF : $@convention(thin) () -> () {
 // CHECK: %[[V0:.*]] = function_ref @_Z9getFnPtr2v : $@convention(c) () -> @convention(c) (@in ARCWeak) -> ()
 // CHECK: %[[V1:.*]] = apply %[[V0]]() : $@convention(c) () -> @convention(c) (@in ARCWeak) -> ()
+// CHECK: %[[MV1:.*]] = move_value [var_decl] %[[V1]] : $@convention(c) (@in ARCWeak) -> ()
 // CHECK: %[[V3:.*]] = alloc_stack $ARCWeak
 // CHECK: %[[V6:.*]] = function_ref @_ZN7ARCWeakC1Ev : $@convention(c) () -> @out ARCWeak
 // CHECK: apply %[[V6]](%[[V3]]) : $@convention(c) () -> @out ARCWeak
-// CHECK: apply %[[V1]](%[[V3]]) : $@convention(c) (@in ARCWeak) -> ()
+// CHECK: apply %[[MV1]](%[[V3]]) : $@convention(c) (@in ARCWeak) -> ()
 // CHECK-NEXT: dealloc_stack %[[V3]] : $*ARCWeak
+// CHECK-NEXT: extend_lifetime %[[MV1]] : $@convention(c) (@in ARCWeak) -> ()
 // CHECK-NEXT: %[[V9:.*]] = tuple ()
 // CHECK-NEXT: return %[[V9]] : $()
 

--- a/test/Interop/Cxx/foreign-reference/reference-counted-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-silgen.swift
@@ -9,7 +9,6 @@ import ReferenceCounted
 // CHECK-NOT: retain
 // CHECK-NOT: release
 // CHECK-NOT: copy_value
-// CHECK-NOT: destroy_value
 // CHECK-NOT: begin_borrow
 // CHECK-NOT: end_borrow
 // CHECK: return

--- a/test/SILGen/access_marker_gen.swift
+++ b/test/SILGen/access_marker_gen.swift
@@ -111,8 +111,9 @@ func testClassInstanceProperties(c: C) {
 // CHECK-NEXT:  debug_value
 // CHECK-NEXT:  [[CX:%.*]] = ref_element_addr [[C]] : $C, #C.x
 // CHECK-NEXT:  [[ACCESS:%.*]] = begin_access [read] [dynamic] [[CX]] : $*Int
-// CHECK-NEXT:  [[Y:%.*]] = load [trivial] [[ACCESS]]
+// CHECK-NEXT:  [[L:%.*]] = load [trivial] [[ACCESS]]
 // CHECK-NEXT:  end_access [[ACCESS]]
+// CHECK-NEXT:  [[Y:%.*]] = move_value [var_decl] [[L]]
 // CHECK-NEXT:  debug_value
 // CHECK-NEXT:  [[CX:%.*]] = ref_element_addr [[C]] : $C, #C.x
 // CHECK-NEXT:  [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[CX]] : $*Int

--- a/test/SILGen/async_conversion.swift
+++ b/test/SILGen/async_conversion.swift
@@ -47,7 +47,7 @@ actor A: P2 {
   // CHECK: hop_to_executor {{.*}} : $MainActor
   // CHECK: [[F:%.*]] = function_ref @$s4test11mainActorFnyyF : $@convention(thin) () -> ()
   // CHECK: [[THICK_F:%.*]] = thin_to_thick_function [[F]] : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
-  // CHECK: [[THICK_F_VAR:%.*]] = move_value [var_decl] [[THICK_F]]
+  // CHECK: [[THICK_F_VAR:%.*]] = move_value [lexical] [var_decl] [[THICK_F]]
   // CHECK: [[THICK_F_BORROW:%.*]] = begin_borrow [[THICK_F_VAR]]
   // CHECK: [[THICK_F_COPY:%.*]] = copy_value [[THICK_F_BORROW]]
   // CHECK: [[THUNK:%.*]] = function_ref @$sIeg_IegH_TR : $@convention(thin) @async (@guaranteed @callee_guaranteed () -> ()) -> ()

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -782,8 +782,10 @@ func bindMemory<T>(ptr: Builtin.RawPointer, idx: Builtin.Word, _: T.Type) {
 // CHECK-LABEL: sil hidden [ossa] @$s8builtins12rebindMemory{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0([[P:%.*]] : $Builtin.RawPointer, [[I:%.*]] : $Builtin.Word, [[T:%.*]] : $@thick T.Type):
 // CHECK: [[BIND:%.*]] = bind_memory [[P]] : $Builtin.RawPointer, [[I]] : $Builtin.Word to $*T
-// CHECK: [[REBIND:%.*]] = rebind_memory [[P]] : $Builtin.RawPointer to [[BIND]] : $Builtin.Word
-// CHECK: %{{.*}} = rebind_memory [[P]] : $Builtin.RawPointer to [[REBIND]] : $Builtin.Word
+// CHECK: [[MV1:%.*]] = move_value [var_decl] [[BIND]] : $Builtin.Word
+// CHECK: [[REBIND:%.*]] = rebind_memory [[P]] : $Builtin.RawPointer to [[MV1]] : $Builtin.Word
+// CHECK: [[MV2:%.*]] = move_value [var_decl] [[REBIND]] : $Builtin.Word
+// CHECK: %{{.*}} = rebind_memory [[P]] : $Builtin.RawPointer to [[MV2]] : $Builtin.Word
 // CHECK:   return {{%.*}} : $()
 // CHECK: }
 func rebindMemory<T>(ptr: Builtin.RawPointer, idx: Builtin.Word, _: T.Type) {

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -19,9 +19,10 @@ public func foo(_ x: Double) {
   // CHECK: [[GLOBALVAR:%.*]] = global_addr @IAMStruct1GlobalVar
   // CHECK: [[READ:%.*]] = begin_access [read] [dynamic] [[GLOBALVAR]] : $*Double
   // CHECK: [[ZZ:%.*]] = load [trivial] [[READ]]
+  // CHECK: [[MV:%.*]] = move_value [var_decl] [[ZZ]] : $Double
   let zz = Struct1.globalVar
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[GLOBALVAR]] : $*Double
-  // CHECK: assign [[ZZ]] to [[WRITE]]
+  // CHECK: assign [[MV]] to [[WRITE]]
   Struct1.globalVar = zz
 
   // CHECK: [[Z:%.*]] = project_box
@@ -39,7 +40,7 @@ public func foo(_ x: Double) {
 
   // CHECK: [[FN:%.*]] = function_ref @$s10cf_members3fooyySdFSo10IAMStruct1VSdcfu_ : $@convention(thin) (Double) -> Struct1
   // CHECK: [[A:%.*]] = thin_to_thick_function [[FN]]
-  // CHECK: [[MOVED_A:%.*]] = move_value [var_decl] [[A]]
+  // CHECK: [[MOVED_A:%.*]] = move_value [lexical] [var_decl] [[A]]
   // CHECK: [[BORROWED_A:%.*]] = begin_borrow [[MOVED_A]]
   // CHECK: [[COPIED_A:%.*]] = copy_value [[BORROWED_A]]
   // CHECK: [[BORROWED_A:%.*]] = begin_borrow [[COPIED_A]]
@@ -81,7 +82,7 @@ public func foo(_ x: Double) {
   z = c(x)
   // CHECK: [[THUNK:%.*]] = function_ref @$s10cf_members3fooyySdFSo10IAMStruct1VSdcADcfu2_ : $@convention(thin) (Struct1) -> @owned @callee_guaranteed (Double) -> Struct1
   // CHECK: [[THICK:%.*]] = thin_to_thick_function [[THUNK]]
-  // CHECK: [[MOVED_THICK:%.*]] = move_value [var_decl] [[THICK]]
+  // CHECK: [[MOVED_THICK:%.*]] = move_value [lexical] [var_decl] [[THICK]]
   // CHECK: [[BORROWED_THICK:%.*]] = begin_borrow [[MOVED_THICK]]
   // CHECK: [[COPIED_THICK:%.*]] = copy_value [[BORROWED_THICK]]
   let d: (Struct1) -> (Double) -> Struct1 = Struct1.translate(radians:)
@@ -162,7 +163,7 @@ public func foo(_ x: Double) {
   var y = Struct1.staticMethod()
   // CHECK: [[THUNK:%.*]] = function_ref @$s10cf_members3fooyySdFs5Int32Vycfu8_ : $@convention(thin) () -> Int32 
   // CHECK: [[I2:%.*]] = thin_to_thick_function [[THUNK]]
-  // CHECK: [[MOVED_I2:%.*]] = move_value [var_decl] [[I2]]
+  // CHECK: [[MOVED_I2:%.*]] = move_value [lexical] [var_decl] [[I2]]
   // CHECK: [[BORROWED_I2:%.*]] = begin_borrow [[MOVED_I2]]
   // CHECK: [[COPIED_I2:%.*]] = copy_value [[BORROWED_I2]]
   let i = Struct1.staticMethod

--- a/test/SILGen/closure_literal_reabstraction.swift
+++ b/test/SILGen/closure_literal_reabstraction.swift
@@ -132,8 +132,9 @@ func reabstractDynamicGenericStaticMemberRef<T: Buttable>(t: T.Type) {
 }
 
 // CHECK-LABEL: sil {{.*}} @{{.*}}reabstractExistentialInitializerRef
+// CHECK:         [[MV:%.*]] = move_value [var_decl] %0 : $@thick any Buttable.Type
 // CHECK:         [[CLOSURE_FN:%.*]] = function_ref {{.*}}u_
-// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]](%0)
+// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]([[MV]])
 // CHECK:         [[CLOSURE_NE:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE]]
 // CHECK:         apply {{.*}}<Int, any Buttable>([[CLOSURE_NE]])
 func reabstractExistentialInitializerRef(butt: any Buttable.Type) {
@@ -141,26 +142,31 @@ func reabstractExistentialInitializerRef(butt: any Buttable.Type) {
 }
 
 // CHECK-LABEL: sil {{.*}} @{{.*}}reabstractExistentialStaticMemberRef
+// CHECK:         [[MV:%.*]] = move_value [var_decl] %0 : $@thick any Buttable.Type
 // CHECK:         [[CLOSURE_FN:%.*]] = function_ref {{.*}}u_
-// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]](%0)
+// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]([[MV]])
 // CHECK:         [[CLOSURE_NE:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE]]
 // CHECK:         apply {{.*}}<Int, any Buttable>([[CLOSURE_NE]])
 func reabstractExistentialStaticMemberRef(butt: any Buttable.Type) {
     gen(f: butt.create)
 }
 
+// TODO: The move_value [var_decl]'s here are an unexpected consequence of how SILGen generates reabstractions.
+//
 // CHECK-LABEL: sil {{.*}} @{{.*}}reabstractClassCompInitializerRefs
 func reabstractClassCompInitializerRefs<T>(
     butt: any (AbstractGenericButt<T> & Buttable).Type
 ) {
+// CHECK:         [[MV1:%.*]] = move_value [var_decl] %0
 // CHECK:         [[CLOSURE_FN:%.*]] = function_ref {{.*}}u_
-// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>(%0)
+// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>([[MV1]])
 // CHECK:         [[CLOSURE_C:%.*]] = convert_function [[CLOSURE]]
 // CHECK:         [[CLOSURE_NE:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE_C]]
 // CHECK:         apply {{.*}}<Int, any (AbstractGenericButt<T> & Buttable)>([[CLOSURE_NE]])
     gen(f: butt.init(c:))
+// CHECK:         [[MV2:%.*]] = move_value [var_decl] %0
 // CHECK:         [[CLOSURE_FN:%.*]] = function_ref {{.*}}u0_
-// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>(%0)
+// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>([[MV2]])
 // CHECK:         [[CLOSURE_C:%.*]] = convert_function [[CLOSURE]]
 // CHECK:         [[CLOSURE_NE:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE_C]]
 // CHECK:         apply {{.*}}<Int, any (AbstractGenericButt<T> & Buttable)>([[CLOSURE_NE]])
@@ -171,14 +177,16 @@ func reabstractClassCompInitializerRefs<T>(
 func reabstractClassCompStaticMemberRefs<T>(
     butt: any (AbstractGenericButt<T> & Buttable).Type
 ) {
+// CHECK:         [[MV1:%.*]] = move_value [var_decl] %0
 // CHECK:         [[CLOSURE_FN:%.*]] = function_ref {{.*}}u_
-// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>(%0)
+// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>([[MV1]])
 // CHECK:         [[CLOSURE_C:%.*]] = convert_function [[CLOSURE]]
 // CHECK:         [[CLOSURE_NE:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE_C]]
 // CHECK:         apply {{.*}}<Int, any (AbstractGenericButt<T> & Buttable)>([[CLOSURE_NE]])
     gen(f: butt.create(c:))
+// CHECK:         [[MV2:%.*]] = move_value [var_decl] %0
 // CHECK:         [[CLOSURE_FN:%.*]] = function_ref {{.*}}u0_
-// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>(%0)
+// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FN]]<T>([[MV2]])
 // CHECK:         [[CLOSURE_C:%.*]] = convert_function [[CLOSURE]]
 // CHECK:         [[CLOSURE_NE:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE_C]]
 // CHECK:         apply {{.*}}<Int, any (AbstractGenericButt<T> & Buttable)>([[CLOSURE_NE]])

--- a/test/SILGen/do_expr.swift
+++ b/test/SILGen/do_expr.swift
@@ -51,17 +51,20 @@ func test6() -> Int {
 // CHECK:       [[RESULT:%[0-9]+]] = alloc_stack $Int
 // CHECK:       [[Y_LIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 0
 // CHECK:       [[Y:%[0-9]+]] = apply {{%[0-9]+}}([[Y_LIT]], {{%[0-9]+}})
+// CHECK:       [[MVY:%.*]] = move_value [var_decl] [[Y]] : $Int
 // CHECK:       [[THROWS_ERR_FN:%[0-9]+]] = function_ref @$s7do_expr11throwsErroryS2iKF : $@convention(thin) (Int) -> (Int, @error any Error)
 // CHECK:       try_apply [[THROWS_ERR_FN]]({{%[0-9]+}}) : $@convention(thin) (Int) -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
 //
 // CHECK:       [[BB_NORMAL]]
-// CHECK-NEXT:  store [[Y]] to [trivial] [[RESULT]] : $*Int
+// CHECK-NEXT:  store [[MVY]] to [trivial] [[RESULT]] : $*Int
+// CHECK-NEXT:  extend_lifetime [[MVY]] : $Int
 // CHECK-NEXT:  br [[BB_EXIT:bb[0-9]+]]
 //
 // CHECK:       [[BB_EXIT]]
 // CHECK:       [[RET:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[MVR:%[0-9]+]] = move_value [var_decl] [[RET]] : $Int
 // CHECK:       dealloc_stack [[RESULT]] : $*Int
-// CHECK:       return [[RET]] : $Int
+// CHECK:       return [[MVR]] : $Int
 //
 // CHECK:       [[BB_ERR]]
 // CHECK:       [[SEVEN_LIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 7
@@ -84,17 +87,20 @@ func test7() throws -> Int {
 // CHECK:       [[RESULT:%[0-9]+]] = alloc_stack $Int
 // CHECK:       [[Y_LIT:%[0-9]]] = integer_literal $Builtin.IntLiteral, 0
 // CHECK:       [[Y:%[0-9]+]] = apply {{%[0-9]+}}([[Y_LIT]], {{%[0-9]+}})
+// CHECK:       [[MVY:%.*]] = move_value [var_decl] [[Y]] : $Int
 // CHECK:       [[THROWS_ERR_FN:%[0-9]]] = function_ref @$s7do_expr11throwsErroryS2iKF : $@convention(thin) (Int) -> (Int, @error any Error)
-// CHECK:       try_apply [[THROWS_ERR_FN]]([[Y]]) : $@convention(thin) (Int) -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+// CHECK:       try_apply [[THROWS_ERR_FN]]([[MVY]]) : $@convention(thin) (Int) -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
 //
 // CHECK:       [[BB_NORMAL]]([[I:%[0-9]+]] : $Int)
 // CHECK-NEXT:  store [[I]] to [trivial] [[RESULT]] : $*Int
+// CHECK-NEXT:  extend_lifetime [[MVY]] : $Int
 // CHECK-NEXT:  br [[BB_EXIT:bb[0-9]+]]
 //
 // CHECK:       [[BB_EXIT]]
 // CHECK:       [[RET:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[MVR:%.*]] = move_value [var_decl] [[RET]] : $Int
 // CHECK:       dealloc_stack [[RESULT]] : $*Int
-// CHECK:       return [[RET]] : $Int
+// CHECK:       return [[MVR]] : $Int
 //
 // CHECK:       [[BB_ERR]]
 // CHECK:       function_ref @$sSb6randomSbyFZ : $@convention(method) (@thin Bool.Type) -> Bool

--- a/test/SILGen/enum_raw_representable_available.swift
+++ b/test/SILGen/enum_raw_representable_available.swift
@@ -54,6 +54,7 @@ public enum E: Int {
 // CHECK: {{enum \$E|inject_enum_addr %[0-9]+ : \$\*E}}, #E.notObsoleteYet!enumelt
 
 // CHECK: [[potentiallyUnavailable]]:
+// CHECK-NEXT: extend_lifetime
 // CHECK-NEXT: integer_literal $Builtin.Word, 10
 // CHECK-NEXT: integer_literal $Builtin.Word, 55
 // CHECK-NEXT: integer_literal $Builtin.Word, 0

--- a/test/SILGen/existential_member_accesses_self_assoctype.swift
+++ b/test/SILGen/existential_member_accesses_self_assoctype.swift
@@ -85,7 +85,8 @@ func testCovariantSelfMethod2(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantSelfMethod3 : <Self where Self : P> (Self) -> () -> Self.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.Type
 // CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self).Type, $@thick any P.Type
-// CHECK: debug_value [[EXIST_META]] : $@thick any P.Type, let, name "x"
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[EXIST_META]] : $@thick any P.Type
+// CHECK: debug_value [[MV]] : $@thick any P.Type, let, name "x"
 func testCovariantSelfMethod3(p: any P) {
   let x = p.covariantSelfMethod3()
 }
@@ -170,7 +171,8 @@ func testCovariantSelfProperty2(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantSelfProperty3!getter : <Self where Self : P> (Self) -> () -> Self.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.Type
 // CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self).Type, $@thick any P.Type
-// CHECK: debug_value [[EXIST_META]] : $@thick any P.Type, let, name "x"
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[EXIST_META]] : $@thick any P.Type
+// CHECK: debug_value [[MV]] : $@thick any P.Type, let, name "x"
 func testCovariantSelfProperty3(p: any P) {
   let x = p.covariantSelfProperty3
 }
@@ -256,7 +258,8 @@ func testCovariantSelfSubscript2(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Self.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.Type
 // CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self).Type, $@thick any P.Type
-// CHECK: debug_value [[EXIST_META]] : $@thick any P.Type, let, name "x"
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[EXIST_META]] : $@thick any P.Type
+// CHECK: debug_value [[MV]] : $@thick any P.Type, let, name "x"
 func testCovariantSelfSubscript3(p: any P) {
   let x = p[covariantSelfSubscript3: ()]
 }
@@ -336,7 +339,8 @@ func testCovariantAssocMethod2(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocMethod3 : <Self where Self : P> (Self) -> () -> Self.A.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.A.Type
 // CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self.A).Type, $@thick any Any.Type
-// CHECK: debug_value [[EXIST_META]] : $@thick any Any.Type, let, name "x"
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[EXIST_META]] : $@thick any Any.Type
+// CHECK: debug_value [[MV]] : $@thick any Any.Type, let, name "x"
 func testCovariantAssocMethod3(p: any P) {
   let x = p.covariantAssocMethod3()
 }
@@ -422,7 +426,8 @@ func testCovariantAssocProperty2(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty3!getter : <Self where Self : P> (Self) -> () -> Self.A.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.A.Type
 // CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self.A).Type, $@thick any Any.Type
-// CHECK: debug_value [[EXIST_META]] : $@thick any Any.Type, let, name "x"
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[EXIST_META]] : $@thick any Any.Type
+// CHECK: debug_value [[MV]] : $@thick any Any.Type, let, name "x"
 func testCovariantAssocProperty3(p: any P) {
   let x = p.covariantAssocProperty3
 }
@@ -507,7 +512,8 @@ func testCovariantAssocSubscript2(p: any P) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Self.A.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.A.Type
 // CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self.A).Type, $@thick any Any.Type
-// CHECK: debug_value [[EXIST_META]] : $@thick any Any.Type, let, name "x"
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[EXIST_META]] : $@thick any Any.Type
+// CHECK: debug_value [[MV]] : $@thick any Any.Type, let, name "x"
 func testCovariantAssocSubscript3(p: any P) {
   let x = p[covariantAssocSubscript3: ()]
 }
@@ -594,7 +600,8 @@ func testCovariantAssocMethod2Constrained(p2: any P2) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P2) Self, #P.covariantAssocMethod3 : <Self where Self : P> (Self) -> () -> Self.A.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P2) Self>([[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.A.Type
 // CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P2) Self.A).Type, $@thick any (Class & P).Type
-// CHECK: debug_value [[EXIST_META]] : $@thick any (Class & P).Type, let, name "x"
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[EXIST_META]]
+// CHECK: debug_value [[MV]] : $@thick any (Class & P).Type, let, name "x"
 func testCovariantAssocMethod3Constrained(p2: any P2) {
   let x = p2.covariantAssocMethod3()
 }
@@ -657,7 +664,8 @@ protocol P3: P where A == Bool {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P3) Self, #P.covariantAssocMethod1 : <Self where Self : P> (Self) -> () -> Self.A
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P3) Self>([[BOOL_ADDR]], [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
 // CHECK: [[BOOL:%[0-9]+]] = load [trivial] [[BOOL_ADDR]] : $*Bool
-// CHECK: debug_value [[BOOL]] : $Bool, let, name "x"
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[BOOL]] : $Bool
+// CHECK: debug_value [[MV]] : $Bool, let, name "x"
 func testCovariantAssocMethod1Concrete(p3: any P3) {
   let x = p3.covariantAssocMethod1()
 }
@@ -672,7 +680,8 @@ func testContravariantAssocMethod1Concrete(p3: any P3) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P3 to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P3) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P3) Self, #P3.invariantAssocMethod1 : <Self where Self : P3> (Self) -> () -> GenericStruct<Self.A>
 // CHECK: [[RESULT:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P3) Self>([[OPENED]]) : $@convention(witness_method: P3) <τ_0_0 where τ_0_0 : P3> (@in_guaranteed τ_0_0) -> GenericStruct<Bool>
-// CHECK: debug_value [[RESULT]] : $GenericStruct<Bool>, let, name "x"
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[RESULT]] : $GenericStruct<Bool>
+// CHECK: debug_value [[MV]] : $GenericStruct<Bool>, let, name "x"
 // CHECK: } // end sil function '$s42existential_member_accesses_self_assoctype33testInvariantAssocMethod1Concrete2p3yAA2P3_p_tF'
 func testInvariantAssocMethod1Concrete(p3: any P3) {
   let x = p3.invariantAssocMethod1()

--- a/test/SILGen/existential_metatypes.swift
+++ b/test/SILGen/existential_metatypes.swift
@@ -23,9 +23,11 @@ struct S: P {
 // CHECK: bb0([[X:%.*]] : $*any P):
 func existentialMetatype(_ x: P) {
   // CHECK: [[TYPE1:%.*]] = existential_metatype $@thick any P.Type, [[X]]
+  // CHECK: [[MV1:%.*]] = move_value [var_decl] [[TYPE1]] : $@thick any P.Type
+
   let type1 = type(of: x)
   // CHECK: [[INSTANCE1:%.*]] = alloc_stack [lexical] [var_decl] $any P
-  // CHECK: [[OPEN_TYPE1:%.*]] = open_existential_metatype [[TYPE1]]
+  // CHECK: [[OPEN_TYPE1:%.*]] = open_existential_metatype [[MV1]]
   // CHECK: [[INIT:%.*]] = witness_method {{.*}} #P.init!allocator
   // CHECK: [[INSTANCE1_VALUE:%.*]] = init_existential_addr [[INSTANCE1]] : $*any P
   // CHECK: apply [[INIT]]<{{.*}}>([[INSTANCE1_VALUE]], [[OPEN_TYPE1]])
@@ -33,9 +35,10 @@ func existentialMetatype(_ x: P) {
 
   // CHECK: [[S:%.*]] = metatype $@thick S.Type
   // CHECK: [[TYPE2:%.*]] = init_existential_metatype [[S]] : $@thick S.Type, $@thick any P.Type
+  // CHECK: [[MV2:%.*]] = move_value [var_decl] [[TYPE2]] : $@thick any P.Type
   let type2: P.Type = S.self
   // CHECK: [[INSTANCE2:%.*]] = alloc_stack [lexical] [var_decl] $any P
-  // CHECK: [[OPEN_TYPE2:%.*]] = open_existential_metatype [[TYPE2]]
+  // CHECK: [[OPEN_TYPE2:%.*]] = open_existential_metatype [[MV2]]
   // CHECK: [[STATIC_METHOD:%.*]] = witness_method {{.*}} #P.staticMethod
   // CHECK: [[INSTANCE2_VALUE:%.*]] = init_existential_addr [[INSTANCE2]] : $*any P
   // CHECK: apply [[STATIC_METHOD]]<{{.*}}>([[INSTANCE2_VALUE]], [[OPEN_TYPE2]])

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -667,8 +667,10 @@ func implodeRecursiveTuple(_ expr: ((Int, Int), Int)?) {
   // CHECK-NEXT: ([[X:%[0-9]+]], [[Y:%[0-9]+]]) = destructure_tuple [[WHOLE]]
   // CHECK-NEXT: ([[X0:%[0-9]+]], [[X1:%[0-9]+]]) = destructure_tuple [[X]]
   // CHECK-NEXT: [[X:%[0-9]+]] = tuple ([[X0]] : $Int, [[X1]] : $Int)
-  // CHECK-NEXT: debug_value [[X]] : $(Int, Int), let, name "x"
-  // CHECK-NEXT: debug_value [[Y]] : $Int, let, name "y"
+  // CHECK-NEXT: [[MVX:%.*]] = move_value [var_decl] [[X]] : $(Int, Int)
+  // CHECK-NEXT: debug_value [[MVX]] : $(Int, Int), let, name "x"
+  // CHECK-NEXT: [[MVY:%.*]] = move_value [var_decl] [[Y]] : $Int
+  // CHECK-NEXT: debug_value [[MVY]] : $Int, let, name "y"
 
   let (x, y) = expr!
 }

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -624,7 +624,8 @@ func genericFuncWithConversion<T: C>(list : [T]) {
 // CHECK: switch_enum [[NEXT_RESULT]] : $Optional<Int>, case #Optional.some!enumelt: [[BB_SOME:bb.*]], case
 // CHECK: [[BB_SOME]]([[X_PRE_BINDING:%.*]] : $Int):
 // CHECK: [[X_BINDING:%.*]] = enum $Optional<Int>, #Optional.some!enumelt, [[X_PRE_BINDING]] : $Int
-// CHECK: debug_value [[X_BINDING]] : $Optional<Int>, let, name "x"
+// CHECK: [[MVX_BINDING:%.*]] = move_value [var_decl] [[X_BINDING]] : $Optional<Int>
+// CHECK: debug_value [[MVX_BINDING]] : $Optional<Int>, let, name "x"
 func injectForEachElementIntoOptional(_ xs: [Int]) {
   for x : Int? in xs {}
 }

--- a/test/SILGen/guaranteed_closure_context.swift
+++ b/test/SILGen/guaranteed_closure_context.swift
@@ -21,6 +21,8 @@ func guaranteed_captures() {
   var mutableAddressOnly: P = C()
 
   // CHECK: [[IMMUTABLE_TRIVIAL:%.*]] = apply {{.*}} -> S
+  // CHECK: [[MV_IMMUTABLE_TRIVIAL:%.*]] = move_value [var_decl] [[IMMUTABLE_TRIVIAL]] : $S
+
   let immutableTrivial = S()
   // CHECK: [[IMMUTABLE_RETAINABLE:%.*]] = apply {{.*}} -> @owned C
   // CHECK: [[B_IMMUTABLE_RETAINABLE:%.*]] = move_value [lexical] [var_decl] [[IMMUTABLE_RETAINABLE]] : $C
@@ -40,7 +42,7 @@ func guaranteed_captures() {
 
   // CHECK: [[B_IMMUTABLE_RETAINABLE_BORROW:%.*]] = begin_borrow [[B_IMMUTABLE_RETAINABLE]] : $C
   // CHECK: [[FN:%.*]] = function_ref [[FN_NAME:@\$s26guaranteed_closure_context0A9_capturesyyF17captureEverythingL_yyF]]
-  // CHECK: apply [[FN]]([[MUTABLE_TRIVIAL_BOX_BORROW]], [[MUTABLE_RETAINABLE_BOX_LIFETIME]], [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]], [[IMMUTABLE_TRIVIAL]], [[B_IMMUTABLE_RETAINABLE_BORROW]], [[IMMUTABLE_ADDRESS_ONLY]])
+  // CHECK: apply [[FN]]([[MUTABLE_TRIVIAL_BOX_BORROW]], [[MUTABLE_RETAINABLE_BOX_LIFETIME]], [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]], [[MV_IMMUTABLE_TRIVIAL]], [[B_IMMUTABLE_RETAINABLE_BORROW]], [[IMMUTABLE_ADDRESS_ONLY]])
   captureEverything()
 
   // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX]]
@@ -55,7 +57,7 @@ func guaranteed_captures() {
   // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX_COPY:%.*]] = copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK: [[IMMUTABLE_RETAINABLE_COPY:%.*]] = copy_value [[B_IMMUTABLE_RETAINABLE]]
   // CHECK: [[IMMUTABLE_ADDRESS:%.*]] = alloc_stack $any P
-  // CHECK: [[CLOSURE:%.*]] = partial_apply {{.*}}([[MUTABLE_TRIVIAL_BOX_COPY]], [[MUTABLE_RETAINABLE_BOX_COPY]], [[MUTABLE_ADDRESS_ONLY_BOX_COPY]], [[IMMUTABLE_TRIVIAL]], [[IMMUTABLE_RETAINABLE_COPY]], [[IMMUTABLE_ADDRESS]])
+  // CHECK: [[CLOSURE:%.*]] = partial_apply {{.*}}([[MUTABLE_TRIVIAL_BOX_COPY]], [[MUTABLE_RETAINABLE_BOX_COPY]], [[MUTABLE_ADDRESS_ONLY_BOX_COPY]], [[MV_IMMUTABLE_TRIVIAL]], [[IMMUTABLE_RETAINABLE_COPY]], [[IMMUTABLE_ADDRESS]])
   // CHECK: [[CONVERT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE]]
   // CHECK: apply {{.*}}[[CONVERT]]
 

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -73,7 +73,7 @@ func f_46343() {
   // Verify that there are no additional reabstractions introduced.
   // CHECK: [[CLOSURE:%.+]] = function_ref @$s29implicitly_unwrapped_optional7f_46343yyFyypSgcfU_ : $@convention(thin) (@in_guaranteed Optional<Any>) -> ()
   // CHECK: [[F:%.+]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) (@in_guaranteed Optional<Any>) -> () to $@callee_guaranteed (@in_guaranteed Optional<Any>) -> ()
-  // CHECK: [[MOVED_F:%.*]] = move_value [var_decl] [[F]]
+  // CHECK: [[MOVED_F:%.*]] = move_value [lexical] [var_decl] [[F]]
   // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[MOVED_F]]
   // CHECK: [[COPIED_F:%.*]] = copy_value [[BORROWED_F]]
   // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[COPIED_F]]

--- a/test/SILGen/lazy_property_with_observers.swift
+++ b/test/SILGen/lazy_property_with_observers.swift
@@ -43,6 +43,7 @@ foo1.bar = 2
 // CHECK-NEXT: // function_ref Foo1.bar.getter
 // CHECK-NEXT:  [[GETTER:%.*]] = function_ref @$s28lazy_property_with_observers4Foo1V3barSivg : $@convention(method) (@inout Foo1) -> Int
 // CHECK-NEXT:  [[OLDVALUE:%.*]] = apply [[GETTER]]([[BEGIN_ACCESS]]) : $@convention(method) (@inout Foo1) -> Int
+// CHECK-NEXT:  [[MV:%.*]] = move_value [var_decl] [[OLDVALUE]] : $Int
 // CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Foo1
 // CHECK-NEXT:  [[ENUM:%.*]] = enum $Optional<Int>, #Optional.some!enumelt, [[VALUE]] : $Int
 // CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [unknown] [[FOO1]] : $*Foo1
@@ -52,8 +53,9 @@ foo1.bar = 2
 // CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [unknown] [[FOO1]] : $*Foo1
 // CHECK-NEXT:  // function_ref Foo1.bar.didset
 // CHECK-NEXT:  [[DIDSET:%.*]] = function_ref @$s28lazy_property_with_observers4Foo1V3barSivW : $@convention(method) (Int, @inout Foo1) -> ()
-// CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[OLDVALUE]], [[BEGIN_ACCESS]]) : $@convention(method) (Int, @inout Foo1) -> ()
+// CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[MV]], [[BEGIN_ACCESS]]) : $@convention(method) (Int, @inout Foo1) -> ()
 // CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Foo1
+// CHECK-NEXT:  extend_lifetime [[MV]] : $Int
 // CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
 // CHECK-NEXT:  return [[TUPLE]] : $()
 // CHECK-END: }
@@ -67,6 +69,7 @@ foo1.bar = 2
 // CHECK-NEXT:  debug_value [[FOO]] : $Foo, let, name "self", argno 2 
 // CHECK-NEXT:  [[GETTER:%.*]] = class_method [[FOO]] : $Foo, #Foo.bar!getter : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
 // CHECK-NEXT:  [[OLDVALUE:%.*]] = apply [[GETTER]]([[FOO]]) : $@convention(method) (@guaranteed Foo) -> Int
+// CHECK-NEXT:  [[MV:%.*]] = move_value [var_decl] [[OLDVALUE]] : $Int
 // CHECK-NEXT:  // function_ref Foo.bar.willset
 // CHECK-NEXT:  [[WILLSET:%.*]] = function_ref @$s28lazy_property_with_observers3FooC3barSivw : $@convention(method) (Int, @guaranteed Foo) -> ()
 // CHECK-NEXT:  [[WILLSET_RESULT:%.*]] = apply [[WILLSET]]([[VALUE]], [[FOO]]) : $@convention(method) (Int, @guaranteed Foo) -> ()
@@ -77,7 +80,8 @@ foo1.bar = 2
 // CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Optional<Int>
 // CHECK-NEXT:  // function_ref Foo.bar.didset
 // CHECK-NEXT:  [[DIDSET:%.*]] = function_ref @$s28lazy_property_with_observers3FooC3barSivW : $@convention(method) (Int, @guaranteed Foo) -> ()
-// CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[OLDVALUE]], [[FOO]]) : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[MV]], [[FOO]]) : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  extend_lifetime [[MV]] : $Int
 // CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
 // CHECK-NEXT:  return [[TUPLE]] : $()
 // CHECK-END: }
@@ -111,6 +115,7 @@ foo1.bar = 2
 // CHECK-NEXT:  debug_value [[FOO]] : $Foo, let, name "self", argno 2 
 // CHECK-NEXT:  [[GETTER:%.*]] = class_method [[FOO]] : $Foo, #Foo.observable1!getter : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
 // CHECK-NEXT:  [[OLDVALUE:%.*]] = apply [[GETTER]]([[FOO]]) : $@convention(method) (@guaranteed Foo) -> Int
+// CHECK-NEXT:  [[MV:%.*]] = move_value [var_decl] [[OLDVALUE]] : $Int
 // CHECK-NEXT:  [[ENUM:%.*]] = enum $Optional<Int>, #Optional.some!enumelt, [[VALUE]] : $Int
 // CHECK-NEXT:  [[REF_ELEM:%.*]] = ref_element_addr [[FOO]] : $Foo, #Foo.$__lazy_storage_$_observable1
 // CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF_ELEM]] : $*Optional<Int>
@@ -118,7 +123,8 @@ foo1.bar = 2
 // CHECK-NEXT:  end_access [[BEGIN_ACCESS]] : $*Optional<Int>
 // CHECK-NEXT:  // function_ref Foo.observable1.didset
 // CHECK-NEXT:  [[DIDSET:%.*]] = function_ref @$s28lazy_property_with_observers3FooC11observable1SivW : $@convention(method) (Int, @guaranteed Foo) -> ()
-// CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[OLDVALUE]], [[FOO]]) : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  [[DIDSET_RESULT:%.*]] = apply [[DIDSET]]([[MV]], [[FOO]]) : $@convention(method) (Int, @guaranteed Foo) -> ()
+// CHECK-NEXT:  extend_lifetime [[MV]] : $Int
 // CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
 // CHECK-NEXT:  return [[TUPLE]] : $()
 // CHECK-END: }

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -326,7 +326,8 @@ func testLetArchetypeBases<T : SimpleProtocol>(_ p : T) {
 // CHECK-NEXT: debug_value %1 : $*any SimpleProtocol, let, name "b", {{.*}} expr op_deref
 func testDebugValue(_ a : Int, b : SimpleProtocol) -> Int {
 
-  // CHECK-NEXT: debug_value %0 : $Int, let, name "x"
+  // CHECK-NEXT: [[MV:%.*]] = move_value [var_decl] %0 : $Int
+  // CHECK-NEXT: debug_value [[MV]] : $Int, let, name "x"
   let x = a
 
   // CHECK: apply
@@ -334,7 +335,7 @@ func testDebugValue(_ a : Int, b : SimpleProtocol) -> Int {
   
   // CHECK-NOT: destroy_addr
 
-  // CHECK: return %0
+  // CHECK: return [[MV]]
   return x
 }
 

--- a/test/SILGen/literals.swift
+++ b/test/SILGen/literals.swift
@@ -288,7 +288,8 @@ class TakesDictionaryLiteral<Key, Value> : ExpressibleByDictionaryLiteral {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8literals23returnsCustomDictionaryAA05TakesD7LiteralCyS2iGyF : $@convention(thin) () -> @owned TakesDictionaryLiteral<Int, Int> {
-// CHECK: [[TMP:%.*]] = apply %2(%0, %1) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [[TMP_VAL:%.*]] = apply %2(%0, %1) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [[TMP:%.*]] = move_value [var_decl] [[TMP_VAL]] : $Int
 // CHECK: [[ARRAY_LENGTH:%.*]] = integer_literal $Builtin.Word, 2
 // CHECK: // function_ref _allocateUninitializedArray<A>(_:)
 // CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)

--- a/test/SILGen/metatypes.swift
+++ b/test/SILGen/metatypes.swift
@@ -92,10 +92,12 @@ func existential_metatype_from_thin() -> Any.Type {
 // CHECK:      [[T1:%.*]] = metatype $@thin SomeStruct.Type
 // CHECK:      [[T0:%.*]] = function_ref @$s9metatypes10SomeStructV{{[_0-9a-zA-Z]*}}fC
 // CHECK-NEXT: [[T2:%.*]] = apply [[T0]]([[T1]])
-// CHECK-NEXT: debug_value [[T2]] : $SomeStruct, let, name "s"
+// CHECK-NEXT: [[MV:%.*]] = move_value [var_decl] [[T2]] : $SomeStruct
+// CHECK-NEXT: debug_value [[MV]] : $SomeStruct, let, name "s"
 // CHECK-NEXT: [[T0:%.*]] = metatype $@thin SomeStruct.Type
 // CHECK-NEXT: [[T1:%.*]] = metatype $@thick SomeStruct.Type
 // CHECK-NEXT: [[T2:%.*]] = init_existential_metatype [[T1]] : $@thick SomeStruct.Type, $@thick any Any.Type
+// CHECK-NEXT: extend_lifetime [[MV]] : $SomeStruct
 // CHECK-NEXT: return [[T2]] : $@thick any Any.Type
 func existential_metatype_from_thin_value() -> Any.Type {
   let s = SomeStruct()

--- a/test/SILGen/noimplicitcopy.swift
+++ b/test/SILGen/noimplicitcopy.swift
@@ -44,9 +44,9 @@ func print2(_ x: Int) {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s14noimplicitcopy8printIntyyF : $@convention(thin) () -> () {
-// CHECK:   [[X_MOVEONLY:%.*]] = copyable_to_moveonlywrapper [owned] {{%.*}} : $Int
-// CHECK:   [[X:%.*]] = move_value [lexical] [[X_MOVEONLY]]
-// CHECK:   [[X_MOVEONLYWRAPPED_MARKED:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[X]]
+// CHECK:   [[X:%.*]] = move_value [var_decl] {{%.*}}
+// CHECK:   [[X_MOVEONLY:%.*]] = copyable_to_moveonlywrapper [owned] [[X]] : $Int
+// CHECK:   [[X_MOVEONLYWRAPPED_MARKED:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[X_MOVEONLY]]
 // CHECK:   [[BORROWED_X_MOVEONLYWRAPPED_MARKED_1:%.*]] = begin_borrow [[X_MOVEONLYWRAPPED_MARKED]]
 // CHECK:   [[BORROWED_X_MOVEONLYWRAPPED_MARKED_2:%.*]] = begin_borrow [[X_MOVEONLYWRAPPED_MARKED]]
 // CHECK:   [[FUNC:%.*]] = function_ref @$sSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int
@@ -96,8 +96,9 @@ func printIntArg(@_noImplicitCopy _ x: Int) {
 //
 // CHECK: [[INT_LITERAL_FUNC:%.*]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [[VALUE:%.*]] = apply [[INT_LITERAL_FUNC]](
+// CHECK: [[MV_VAL:%.*]] = move_value [var_decl] [[VALUE]] : $Int
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy11printIntArgyySiF : $@convention(thin) (Int) -> ()
-// CHECK: apply [[FUNC]]([[VALUE]])
+// CHECK: apply [[FUNC]]([[MV_VAL]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
 // CHECK: [[Y_BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[Y_BOX]]
@@ -146,8 +147,9 @@ func printIntOwnedArg(@_noImplicitCopy _ x: __owned Int) {
 //
 // CHECK: [[INT_LITERAL_FUNC:%.*]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [[VALUE:%.*]] = apply [[INT_LITERAL_FUNC]](
+// CHECK: [[MV_VAL:%.*]] = move_value [var_decl] [[VALUE]] : $Int
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy16printIntOwnedArgyySinF : $@convention(thin) (Int) -> ()
-// CHECK: apply [[FUNC]]([[VALUE]])
+// CHECK: apply [[FUNC]]([[MV_VAL]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
 // CHECK: [[Y_BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[Y_BOX]]
@@ -196,8 +198,9 @@ func printIntArgThrows(@_noImplicitCopy _ x: Int) throws {
 //
 // CHECK: [[INT_LITERAL_FUNC:%.*]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [[VALUE:%.*]] = apply [[INT_LITERAL_FUNC]](
+// CHECK: [[MV_VAL:%.*]] = move_value [var_decl] [[VALUE]] : $Int
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy17printIntArgThrowsyySiKF : $@convention(thin) (Int) -> @error any Error
-// CHECK: try_apply [[FUNC]]([[VALUE]])
+// CHECK: try_apply [[FUNC]]([[MV_VAL]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
 // CHECK: [[Y_BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[Y_BOX]]
@@ -237,8 +240,9 @@ func printIntOwnedArgThrows(@_noImplicitCopy _ x: __owned Int) throws {
 //
 // CHECK: [[INT_LITERAL_FUNC:%.*]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [[VALUE:%.*]] = apply [[INT_LITERAL_FUNC]](
+// CHECK: [[MV_VAL:%.*]] = move_value [var_decl] [[VALUE]] : $Int
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy22printIntOwnedArgThrowsyySinKF : $@convention(thin) (Int) -> @error any Error
-// CHECK: try_apply [[FUNC]]([[VALUE]])
+// CHECK: try_apply [[FUNC]]([[MV_VAL]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
 // CHECK: [[Y_BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[Y_BOX]]
@@ -480,9 +484,9 @@ func callPrintKlassOwnedOwnedArgThrows() throws {
 
 // CHECK-LABEL: sil hidden [ossa] @$s14noimplicitcopy19test_nontrivial_gepyyAA7TrivialVF : $@convention(thin) (Trivial) -> () {
 // CHECK: bb0([[ARG:%.*]] : $Trivial):
-// CHECK:   [[WRAPPED:%.*]] = copyable_to_moveonlywrapper [owned] [[ARG]]
-// CHECK:   [[MV_WRAPPED:%.*]] = move_value [lexical] [[WRAPPED]]
-// CHECK:   [[MARKED:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[MV_WRAPPED]]
+// CHECK:   [[MV:%.*]] = move_value [var_decl] [[ARG]] : $Trivial
+// CHECK:   [[WRAPPED:%.*]] = copyable_to_moveonlywrapper [owned] [[MV]]
+// CHECK:   [[MARKED:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[WRAPPED]]
 // CHECK:   [[BORROW:%.*]] = begin_borrow [[MARKED]]
 // CHECK:   [[EXT:%.*]] = struct_extract [[BORROW]]
 // CHECK:   [[UNWRAPPED:%.*]] = moveonlywrapper_to_copyable [guaranteed] [[EXT]]

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -398,6 +398,7 @@ func propertyWithDidSetTakingOldValue() {
 // CHECK-NEXT:  [[READ:%.*]] = begin_access [read] [unknown] [[ARG2_PB]]
 // CHECK-NEXT:  [[ARG2_PB_VAL:%.*]] = load [trivial] [[READ]] : $*Int
 // CHECK-NEXT:  end_access [[READ]]
+// CHECK-NEXT:  [[MV_ARG2_PB_VAL:%.*]] = move_value [var_decl] [[ARG2_PB_VAL]] : $Int
 // CHECK-NEXT:  [[WRITE:%.*]] = begin_access [modify] [unknown] [[ARG2_PB]]
 // CHECK-NEXT:  assign [[ARG1]] to [[WRITE]] : $*Int
 // CHECK-NEXT:  end_access [[WRITE]]
@@ -405,7 +406,8 @@ func propertyWithDidSetTakingOldValue() {
 // CHECK-NEXT:  mark_function_escape [[ARG2_PB]]
 // CHECK-NEXT:  // function_ref
 // CHECK-NEXT:  [[FUNC:%.*]] = function_ref @$s9observers32propertyWithDidSetTakingOldValueyyF1pL_SivW : $@convention(thin) (Int, @guaranteed { var Int }) -> ()
-// CHECK-NEXT:  %{{.*}} = apply [[FUNC]]([[ARG2_PB_VAL]], [[ARG2]]) : $@convention(thin) (Int, @guaranteed { var Int }) -> ()
+// CHECK-NEXT:  %{{.*}} = apply [[FUNC]]([[MV_ARG2_PB_VAL]], [[ARG2]]) : $@convention(thin) (Int, @guaranteed { var Int }) -> ()
+// CHECK-NEXT:  extend_lifetime [[MV_ARG2_PB_VAL]] : $Int
 // CHECK-NEXT:  %{{.*}} = tuple ()
 // CHECK-NEXT:  return %{{.*}} : $()
 // CHECK-NEXT:} // end sil function '$s9observers32propertyWithDidSetTakingOldValue{{[_0-9a-zA-Z]*}}'

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -538,11 +538,12 @@ func testExistentialsGetters(_ p1: P1) {
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*any P1 to $*@opened([[UUID:".*"]], any P1) Self
   // CHECK: [[FN:%[0-9]+]] = function_ref @$s19protocol_extensions2P1PAAE5prop2Sbvg
   // CHECK: [[B:%[0-9]+]] = apply [[FN]]<@opened([[UUID]], any P1) Self>([[POPENED]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> Bool
+  // CHECK: [[MV_B:%.*]] = move_value [var_decl] [[B]] : $Bool
   let b: Bool = p1.prop2
 
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*any P1 to $*@opened([[UUID:".*"]], any P1) Self
   // CHECK: [[GETTER:%[0-9]+]] = function_ref @$s19protocol_extensions2P1PAAEyS2bcig
-  // CHECK: apply [[GETTER]]<@opened([[UUID]], any P1) Self>([[B]], [[POPENED]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (Bool, @in_guaranteed τ_0_0) -> Bool
+  // CHECK: apply [[GETTER]]<@opened([[UUID]], any P1) Self>([[MV_B]], [[POPENED]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (Bool, @in_guaranteed τ_0_0) -> Bool
   let b2: Bool = p1[b]
 }
 

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -359,6 +359,7 @@ func testExistentialPropertyRead<T: ExistentialProperty>(_ t: inout T) {
 // CHECK-NEXT: [[OPEN:%.*]] = open_existential_addr immutable_access [[P_TEMP]] : $*any PropertyWithGetterSetter to $*[[P_OPENED:@opened\(.*, any PropertyWithGetterSetter\) Self]]
 // CHECK-NEXT: [[B_GETTER:%.*]] = witness_method $[[P_OPENED]], #PropertyWithGetterSetter.b!getter
 // CHECK-NEXT: apply [[B_GETTER]]<[[P_OPENED]]>([[OPEN]])
+// CHECK-NEXT: move_value [var_decl]
 // CHECK-NEXT: debug_value
 // CHECK-NOT:  witness_method
 // CHECK:      return

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -585,8 +585,10 @@ func testRequireExprPattern(_ a : Int) {
 func testRequireOptional1(_ a : Int?) -> Int {
 
   // CHECK: [[SOME]]([[PAYLOAD:%.*]] : $Int):
-  // CHECK-NEXT:   debug_value [[PAYLOAD]] : $Int, let, name "t"
-  // CHECK-NEXT:   return [[PAYLOAD]] : $Int
+  // CHECK-NEXT:   [[MV_PAYLOAD:%.*]] = move_value [var_decl] [[PAYLOAD]] : $Int
+  // CHECK-NEXT:   debug_value [[MV_PAYLOAD]] : $Int, let, name "t"
+  // CHECK-NEXT:   extend_lifetime [[MV_PAYLOAD]] : $Int
+  // CHECK-NEXT:   return [[MV_PAYLOAD]] : $Int
   guard let t = a else { abort() }
 
   // CHECK: [[NONE]]:
@@ -770,8 +772,12 @@ func let_else_tuple_binding(_ a : (Int, Int)?) -> Int {
 
   // CHECK: [[SOME_BB]]([[PAYLOAD:%.*]] : $(Int, Int)):
   // CHECK-NEXT:   ([[PAYLOAD_1:%.*]], [[PAYLOAD_2:%.*]]) = destructure_tuple [[PAYLOAD]]
-  // CHECK-NEXT:   debug_value [[PAYLOAD_1]] : $Int, let, name "x"
-  // CHECK-NEXT:   debug_value [[PAYLOAD_2]] : $Int, let, name "y"
-  // CHECK-NEXT:   return [[PAYLOAD_1]] : $Int
+  // CHECK-NEXT:   [[MV_1:%.*]] = move_value [var_decl] [[PAYLOAD_1]] : $Int
+  // CHECK-NEXT:   debug_value [[MV_1]] : $Int, let, name "x"
+  // CHECK-NEXT:   [[MV_2:%.*]] = move_value [var_decl] [[PAYLOAD_2]] : $Int
+  // CHECK-NEXT:   debug_value [[MV_2]] : $Int, let, name "y"
+  // CHECK-NEXT:   extend_lifetime [[MV_2]] : $Int
+  // CHECK-NEXT:   extend_lifetime [[MV_1]] : $Int
+  // CHECK-NEXT:   return [[MV_1]] : $Int
 }
 

--- a/test/SILGen/variadic-generic-results.swift
+++ b/test/SILGen/variadic-generic-results.swift
@@ -123,7 +123,8 @@ func copyOrThrowIntoTuple<each T>(_ args: repeat each T) throws -> (repeat each 
 // CHECK-NEXT:    dealloc_pack [[ARG_PACK]] : $*Pack{Int, String, String}
 //   Load from the pack and bind the locals.
 // CHECK-NEXT:    [[A:%.*]] = load [trivial] [[R0]] : $*Int
-// CHECK-NEXT:    debug_value [[A]] : $Int
+// CHECK-NEXT:    [[MV:%.*]] = move_value [var_decl] %39 : $Int
+// CHECK-NEXT:    debug_value [[MV]] : $Int
 // CHECK-NEXT:    [[B:%.*]] = load [take] [[R1]] : $*String
 // CHECK-NEXT:    [[C:%.*]] = load [take] [[R2]] : $*String
 // CHECK-NEXT:    [[C_LIFETIME:%.*]] = move_value [var_decl] [[C]]
@@ -140,6 +141,7 @@ func copyOrThrowIntoTuple<each T>(_ args: repeat each T) throws -> (repeat each 
 // CHECK-NEXT:    apply [[SEQUENCE_FN]]()
 //   Leave the function.
 // CHECK-NEXT:    destroy_value [[C_LIFETIME]] : $String
+// CHECK-NEXT:    extend_lifetime [[MV]] : $Int
 // CHECK-NEXT:    [[RET:%.*]] = tuple ()
 // CHECK-NEXT:    return [[RET]] : $()
 func callCopyAndDestructure(a: Int, b: String, c: String) {

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_fail.swift
@@ -12,7 +12,6 @@ struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
-  @_unsafeNonescapableResult
   init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
     self.p = p
     self.i = i
@@ -36,7 +35,6 @@ struct NE : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
-  @_unsafeNonescapableResult
   init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
     self.p = p
     self.i = i

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit.swift
@@ -8,6 +8,15 @@
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
+// TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
+// hidden within the function body.
+@_unsafeNonescapableResult
+func unsafeLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
+  dependent: consuming T, dependsOn source: borrowing U)
+  -> dependsOn(source) T {
+  dependent
+}
+
 struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
@@ -17,8 +26,7 @@ struct BV : ~Escapable {
     self.i = i
   }
 
-  @_unsafeNonescapableResult
-  init(independent p: UnsafeRawPointer, _ i: Int) {
+  init(independent p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
     self.p = p
     self.i = i
   }
@@ -26,7 +34,8 @@ struct BV : ~Escapable {
   consuming func derive() -> dependsOn(self) BV {
     // Technically, this "new" view does not depend on the 'view' argument.
     // This unsafely creates a new view with no dependence.
-    return BV(independent: self.p, self.i)
+    let bv = BV(independent: self.p, self.i)
+    return unsafeLifetime(dependent: bv, dependsOn: self)
   }
 }
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit_fail.swift
@@ -8,6 +8,15 @@
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
+// TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
+// hidden within the function body.
+@_unsafeNonescapableResult
+func unsafeLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
+  dependent: consuming T, dependsOn source: borrowing U)
+  -> dependsOn(source) T {
+  dependent
+}
+
 struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
@@ -17,8 +26,7 @@ struct BV : ~Escapable {
     self.i = i
   }
 
-  @_unsafeNonescapableResult
-  init(independent p: UnsafeRawPointer, _ i: Int) {
+  init(independent p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
     self.p = p
     self.i = i
   }
@@ -26,7 +34,8 @@ struct BV : ~Escapable {
   consuming func derive() -> dependsOn(self) BV {
     // Technically, this "new" view does not depend on the 'view' argument.
     // This unsafely creates a new view with no dependence.
-    return BV(independent: self.p, self.i)
+    let bv = BV(independent: self.p, self.i)
+    return unsafeLifetime(dependent: bv, dependsOn: self)
   }
 }
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
@@ -10,9 +10,7 @@
 // Simply test that it is possible for a module to define a pseudo-Optional type without triggering any compiler errors.
 
 public protocol ExpressibleByNilLiteral: ~Copyable & ~Escapable {
-  // TODO: dependsOn(immortal)
-  @_unsafeNonescapableResult
-  init(nilLiteral: ())
+  init(nilLiteral: ()) -> dependsOn(immortal) Self
 }
 
 @frozen
@@ -30,10 +28,8 @@ extension Nillable: Sendable where Wrapped: ~Copyable & ~Escapable & Sendable { 
 extension Nillable: BitwiseCopyable where Wrapped: BitwiseCopyable { }
 
 extension Nillable: ExpressibleByNilLiteral where Wrapped: ~Copyable & ~Escapable {
-  // TODO: dependsOn(immortal)
   @_transparent
-  @_unsafeNonescapableResult
-  public init(nilLiteral: ()) {
+  public init(nilLiteral: ()) -> dependsOn(immortal) Self {
     self = .none
   }
 }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
@@ -17,8 +17,7 @@ struct NCContainer : ~Copyable {
 struct View : ~Escapable {
   let ptr: UnsafeRawBufferPointer
   let c: Int
-  @_unsafeNonescapableResult
-  init(_ ptr: UnsafeRawBufferPointer, _ c: Int) {
+  init(_ ptr: UnsafeRawBufferPointer, _ c: Int) -> dependsOn(p) Self {
     self.ptr = ptr
     self.c = c
   }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_todo.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_todo.swift
@@ -14,7 +14,6 @@ struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
-  @_unsafeNonescapableResult
   init(_ p: UnsafeRawPointer, _ i: Int) -> dependsOn(p) Self {
     self.p = p
     self.i = i

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -1,0 +1,155 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -o /dev/null \
+// RUN:   -verify \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NonescapableTypes
+
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
+
+// Lifetime dependence semantics by example.
+
+struct Span<T>: ~Escapable {
+  private var base: UnsafePointer<T>
+  private var count: Int
+
+  init(base: UnsafePointer<T>, count: Int) -> dependsOn(base) Self {
+    self.base = base
+    self.count = count
+  }
+
+  init<S>(base: UnsafePointer<T>, count: Int, generic: borrowing S) -> dependsOn(generic) Self {
+    self.base = base
+    self.count = count
+  }
+}
+
+extension Span {
+  consuming func dropFirst() -> Span<T> {
+    let local = Span(base: self.base + 1, count: self.count - 1)
+    return unsafeLifetime(dependent: local, dependsOn: self)
+  }
+}
+
+// TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
+// hidden within the function body.
+@_unsafeNonescapableResult
+func unsafeLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
+  dependent: consuming T, dependsOn source: borrowing U)
+  -> dependsOn(source) T {
+  dependent
+}
+
+// TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
+// hidden within the function body.
+@_unsafeNonescapableResult
+func unsafeLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
+  dependent: consuming T, scope source: borrowing U)
+  -> dependsOn(scoped source) T {
+  dependent
+}
+
+extension Span {
+  mutating func droppingPrefix(length: Int) -> /* dependsOn(self) */ Span<T> {
+    let oldBase = base
+    let result = Span(base: oldBase, count: length)
+    self.base += length
+    self.count -= length
+    return unsafeLifetime(dependent: result, dependsOn: self)
+  }
+}
+
+extension Array {
+  // TODO: comment out dependsOn(scoped)
+  borrowing func span() -> /* dependsOn(scoped self) */ Span<Element> {
+    /* not the real implementation */
+    let p = self.withUnsafeBufferPointer { $0.baseAddress! }
+    return Span(base: p, count: 1)
+  }
+}
+
+func parse(_ span: Span<Int>) {}
+
+// =============================================================================
+// Scoped dependence on values
+// =============================================================================
+
+// The duration of a scoped dependence is the lexical scope of the variable.
+func testScopedLet(_ arg: [Int] ) {
+  let a: Array<Int> = arg
+  let span: Span<Int> // expected-error {{lifetime-dependent variable 'span' escapes its scope}}
+  do {
+    let a2 = a        // expected-note {{it depends on the lifetime of variable 'a2'}}
+    span = a2.span()
+  }
+  parse(span) // expected-note {{this use of the lifetime-dependent value is out of scope}}
+}
+
+func testScopedCopy(_ arg: [Int] ) {
+  let a: Array<Int> = arg
+  let span: Span<Int> // expected-error {{lifetime-dependent variable 'span' escapes its scope}}
+  do {
+    let a2 = a        // expected-note {{it depends on the lifetime of variable 'a2'}}
+    span = a2.span()
+  }
+  parse(span) // expected-note {{this use of the lifetime-dependent value is out of scope}}
+}
+
+// =============================================================================
+// Inherited dependence on values
+// =============================================================================
+
+func copySpan<T>(_ arg: Span<T>) -> /* dependsOn(arg) */ Span<T> { arg }
+
+func testInheritedCopy(_ arg: [Int] ) {
+  let a: Array<Int> = arg
+  let result: Span<Int>
+  do {
+    let span = a.span()
+    let temp = span
+    result = copySpan(temp)
+  }
+  parse(result) // ✅ Safe: within lifetime of 'a'
+}
+
+func testInheritedCopyVar(_ arg: [Int] ) {
+  let a1: Array<Int> = arg
+  let a2: Array<Int> = arg
+  var span = a1.span()
+  var result: Span<Int>
+  do {
+    var temp = span
+    result = copySpan(temp)
+    span = a2.span()
+    temp = a2.span()
+    // 'result' still depends on 'a1', not 'a2'
+  }
+  parse(result) // ✅ Safe: within lifetime of 'a'
+}
+
+// =============================================================================
+// Scoped dependence on inherited dependence
+// =============================================================================
+
+func reborrowSpan<T>(_ arg: Span<T>) -> dependsOn(scoped arg) Span<T> { arg }
+
+func testScopedOfInheritedWithCall(_ arg: [Int] ) {
+  let a: Array<Int> = arg
+  let span = a.span()
+  // TODO: should be // ✅ Safe: 'copySpan' result should be borrowed over `parse`
+  // rdar://128821299 ([nonescaping] extend borrowed arguments that are the source of a scoped dependence)
+  parse(reborrowSpan(copySpan(span))) // expected-error {{lifetime-dependent value escapes its scope}}
+  // expected-note @-1{{this use of the lifetime-dependent value is out of scope}}
+  // expected-note @-2{{it depends on the lifetime of this parent value}}
+}
+
+func testScopedOfInheritedWithLet(_ arg: [Int] ) {
+  let a: Array<Int> = arg
+  let span = a.span()
+  // TODO: should be // ✅ Safe: 'copySpan' result should be borrowed over `result`
+  // rdar://128821299 ([nonescaping] extend borrowed arguments that are the source of a scoped dependence)
+  let result = reborrowSpan(copySpan(span)) // expected-error {{lifetime-dependent variable 'result' escapes its scope}}
+  // expected-note @-1{{it depends on the lifetime of this parent value}}  
+  _ = result
+} // expected-note {{this use of the lifetime-dependent value is out of scope}}


### PR DESCRIPTION
[SILGen] emit local variable scopes for trivial values.

Required for SIL analysis of local variable scopes. For example, to track lifetime dependence on a variable.

Example:

.swift:

    func foo(i: Int) {
      let v = i

.sil:

```
    %1 = move_value [var_decl] %0 : $Int // starts the variable scope
    extend_lifetime %1 : $Int            // ends the variable scope
```