### PR TITLE
[build] Disable cleaning sourcekit-lsp by default, rather than having the flag do nothing

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -83,7 +83,7 @@ class IndexStoreDB(product.Product):
 
 
 def run_build_script_helper(action, host_target, product, args,
-                            sanitize_all=False, clean=True):
+                            sanitize_all=False, clean=False):
     script_path = os.path.join(
         product.source_dir, 'Utilities', 'build-script-helper.py')
 
@@ -113,8 +113,8 @@ def run_build_script_helper(action, host_target, product, args,
     elif args.enable_tsan:
         helper_cmd.extend(['--sanitize', 'thread'])
 
-    if not clean:
-        helper_cmd.append('--no-clean')
+    if clean:
+        helper_cmd.append('--clean')
 
     # Pass Cross compile host info unless we're testing.
     # It doesn't make sense to run tests of the cross compile host.

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -53,14 +53,14 @@ class SourceKitLSP(product.Product):
     def test(self, host_target):
         indexstoredb.run_build_script_helper(
             'test', host_target, self, self.args,
-            self.args.test_sourcekitlsp_sanitize_all, clean=False)
+            self.args.test_sourcekitlsp_sanitize_all)
 
     def should_install(self, host_target):
         return self.args.install_sourcekitlsp
 
     def install(self, host_target):
         indexstoredb.run_build_script_helper(
-            'install', host_target, self, self.args, clean=False)
+            'install', host_target, self, self.args)
 
     @classmethod
     def get_dependencies(cls):


### PR DESCRIPTION
Rather than make this change, swiftlang/sourcekit-lsp@37d003eb7 had the `--no-clean` flag do nothing, which means the flag can't be used at all.

@ahoppen, I'm building sourcekit-lsp locally on my Android phone right now and I'd like to be able to ~dis~enable the ~`--no-clean`~`--clean` flag and have the build cleaned sometimes, so I ~will next~have submitted a pull to revert the above sourcekit-lsp commit.

This pull changes no behavior, since the flag currently does nothing, but let me know if you'd also like me to change [the `build` action here to clean on repeated sourcekit-lsp builds, as it once did](https://github.com/swiftlang/swift/blob/059128feca3251c6954b153d6d3fd0bd7332ea4c/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py#L49).