### PR TITLE
[ClangImporter] Adjust tests after Clang changes for `__attribute__((pure))`

### DIFF
--- a/test/Interop/Cxx/class/inheritance/Inputs/functions.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions.h
@@ -54,7 +54,7 @@ struct Base {
     return i * 2;
   }
 
-  void pure() const __attribute__((pure)) {}
+  int pure() __attribute__((pure)) { return 123; }
 
   inline int sameMethodNameSameSignature() const {
     return 42;

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -30,7 +30,7 @@
 // CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
 // CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
-// CHECK-NEXT:   @_effects(readonly) func pure()
+// CHECK-NEXT:   @_effects(readonly) mutating func pure() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func sameMethodNameSameSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
@@ -65,7 +65,7 @@
 // CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
 // CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
-// CHECK-NEXT:   @_effects(readonly) func pure()
+// CHECK-NEXT:   @_effects(readonly) mutating func pure() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
@@ -96,7 +96,7 @@
 // CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
 // CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
-// CHECK-NEXT:   @_effects(readonly) func pure()
+// CHECK-NEXT:   @_effects(readonly) mutating func pure() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT:   @discardableResult


### PR DESCRIPTION
There was a recent change in Clang's handling of `__attribute__((pure))`: https://github.com/llvm/llvm-project/pull/78200

`__attribute__((pure))` is now dropped for const functions, and for functions that return `void`.

This adjusts the test for the new behavior. There might be future changes required in the Swift's handling of `__attribute__((pure))`.

rdar://131300381