### PR TITLE
[cxx-interop] Adjust two IRGen tests for rebranch

### DIFF
--- a/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-itanium.swift
+++ b/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-itanium.swift
@@ -14,4 +14,4 @@ public func use() -> CInt {
 // CHECK: %[[result:.*]] = alloca %TSo19NonTrivialInWrapperV
 // CHECK: call void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr noalias sret(%TSo19NonTrivialInWrapperV) %[[result]], ptr %[[instance]], i32 42)
 
-// CHECK: define {{.*}} void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, ptr {{.*}} %{{.*}}, i32 noundef %{{.*}})
+// CHECK: define {{.*}} void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr {{.*}} sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, ptr {{.*}} %{{.*}}, i32{{( noundef)?}} %{{.*}})

--- a/test/Interop/Cxx/class/returns-large-class-irgen.swift
+++ b/test/Interop/Cxx/class/returns-large-class-irgen.swift
@@ -17,4 +17,4 @@ foo()
 // CHECK: call swiftcc void @"$s4main3fooSo10LargeClassVyF"(ptr noalias nocapture sret(%TSo10LargeClassV) %{{.*}})
 
 // The C++ function:
-// CHECK: define{{( dso_local)?}} void @{{_Z21funcReturnsLargeClassv|"\?funcReturnsLargeClass@@YA\?AULargeClass@@XZ"}}({{%struct.LargeClass\*|ptr}} noalias sret(%struct.LargeClass){{( align .*)?}} %{{.*}})
+// CHECK: define{{( dso_local)?}} void @{{_Z21funcReturnsLargeClassv|"\?funcReturnsLargeClass@@YA\?AULargeClass@@XZ"}}({{%struct.LargeClass\*|ptr}}{{.*}} sret(%struct.LargeClass){{( align .*)?}} %{{.*}})


### PR DESCRIPTION
This fixes `Interop/Cxx/class/returns-large-class-irgen.swift` by adjusting the expected function signature.

On rebranch, the actual signature is:
```
define void @_Z21funcReturnsLargeClassv(ptr dead_on_unwind noalias writable sret(%struct.LargeClass) align 8 %agg.result)
```

rdar://127263407