### PR TITLE
[cxx-interop] Suppress new diagnostic in Clang for testing C interop headers

### DIFF
--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -62,5 +62,5 @@ config.substitutions.insert(0, ('%check-interop-cxx-header-in-clang\(([^)]+)\)',
 
 # Test parsing of the generated C header in different C language modes.
 config.substitutions.insert(0, ('%check-interop-c-header-in-clang\(([^)]+)\)',
-                             SubstituteCaptures(r'%check-c-header-in-clang -std=c99 -Wno-padded -Wno-c11-extensions \1 && '
-                                                r'%check-c-header-in-clang -std=c11 -Wno-padded \1')))
+                             SubstituteCaptures(r'%check-c-header-in-clang -std=c99 -Wno-padded -Wno-c11-extensions -Wno-pre-c11-compat \1 && '
+                                                r'%check-c-header-in-clang -std=c11 -Wno-padded -Wno-pre-c11-compat \1')))


### PR DESCRIPTION
Clang now (correctly) diagnoses that `_Alignas` is not available before C11. Since this was available before C11 as an extension, I only suppressed the diagnostic instead of removing the testing in c=C99 mode.

rdar://128459884