### PR TITLE
[cxx-interop] Clone all of the attributes from base method correctly

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5699,9 +5699,10 @@ makeBaseClassMemberAccessors(DeclContext *declContext,
 }
 
 // Clone attributes that have been imported from Clang.
-DeclAttributes cloneImportedAttributes(ValueDecl *decl, ASTContext &context) {
-  auto attrs = DeclAttributes();
-  for (auto attr : decl->getAttrs()) {
+void cloneImportedAttributes(ValueDecl *fromDecl, ValueDecl* toDecl) {
+  ASTContext& context = fromDecl->getASTContext();
+  DeclAttributes& attrs = toDecl->getAttrs();
+  for (auto attr : fromDecl->getAttrs()) {
     switch (attr->getKind()) {
     case DeclAttrKind::Available: {
       attrs.add(cast<AvailableAttr>(attr)->clone(context, true));
@@ -5739,8 +5740,6 @@ DeclAttributes cloneImportedAttributes(ValueDecl *decl, ASTContext &context) {
       break;
     }
   }
-
-  return attrs;
 }
 
 static ValueDecl *
@@ -5770,8 +5769,7 @@ cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext) {
         fn->getThrownInterfaceType(),
         fn->getGenericParams(), fn->getParameters(),
         fn->getResultInterfaceType(), newContext);
-    auto inheritedAttributes = cloneImportedAttributes(decl, context);
-    out->getAttrs().add(inheritedAttributes);
+    cloneImportedAttributes(decl, out);
     out->copyFormalAccessFrom(fn);
     out->setBodySynthesizer(synthesizeBaseClassMethodBody, fn);
     out->setSelfAccessKind(fn->getSelfAccessKind());

--- a/test/Interop/Cxx/class/inheritance/Inputs/functions.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions.h
@@ -54,7 +54,7 @@ struct Base {
     return i * 2;
   }
 
-  void pure() const __attribute__((pure)) {}
+  int pure() const __attribute__((pure)) { return 123; }
 
   inline int sameMethodNameSameSignature() const {
     return 42;

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -30,7 +30,8 @@
 // CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
 // CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
-// CHECK-NEXT:   @_effects(readonly) func pure()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   @_effects(readonly) func pure() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func sameMethodNameSameSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
@@ -65,7 +66,8 @@
 // CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
 // CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
-// CHECK-NEXT:   @_effects(readonly) func pure()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   @_effects(readonly) func pure() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
@@ -96,7 +98,8 @@
 // CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
 // CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
-// CHECK-NEXT:   @_effects(readonly) func pure()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   @_effects(readonly) func pure() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT:   @discardableResult


### PR DESCRIPTION
If a C++ `struct Base` declares a method with a Clang attribute that Swift is able to import, and `struct Derived` inherits from `Base`, the method should get cloned from `Base` to `Derived` with its attributes.

Previously we were only cloning one attribute at most due to a bug in `cloneImportedAttributes`. DeclAttributes is an intrusively linked list, and it was being made invalid while iterating over it: `otherDecl->getAttrs().add(attrs)` iterates over the list and calls `otherDecl->add(eachElement)`, which invalidates the iterator after the first iteration.