### PR TITLE
[6.0][Concurrency] TaskExecutors may be non-swift objects; dont swift_rele…

### DIFF
--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -772,7 +772,11 @@ void AsyncTask::dropInitialTaskExecutorPreferenceRecord() {
   //
   // This should not be done for withTaskExecutorPreference executors,
   // however in that case, we would not enter this function here to clean up.
-  swift_release(executorIdentityToRelease);
+  //
+  // NOTE: This MUST NOT assume that the object is a swift object (and use
+  // swift_release), because a dispatch_queue_t conforms to TaskExecutor,
+  // and may be passed in here; in which case swift_releasing it would be incorrect.
+  swift_unknownObjectRelease(executorIdentityToRelease);
 }
 
 /**************************************************************************/

--- a/test/Concurrency/Runtime/async_task_executor_nsobject.swift
+++ b/test/Concurrency/Runtime/async_task_executor_nsobject.swift
@@ -1,0 +1,49 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library )
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// REQUIRES: OS=macosx
+// REQUIRES: objc_interop
+
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+import Dispatch
+import StdlibUnittest
+import _Concurrency
+
+import Foundation
+import Darwin
+
+// Sneaky trick to make this type objc reference counted.
+//
+// This test specifically checks that our reference counting accounts for existence of
+// objective-c types as TaskExecutors -- which was a bug where we'd swift_release
+// obj-c excecutors by accident (rdar://131151645).
+final class NSQueueTaskExecutor: NSData, TaskExecutor, @unchecked Sendable {
+  public func enqueue(_ _job: consuming ExecutorJob) {
+    let job = UnownedJob(_job)
+    DispatchQueue.main.async {
+      job.runSynchronously(on: self.asUnownedTaskExecutor())
+    }
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    var taskExecutor: (any TaskExecutor)? = NSQueueTaskExecutor()
+
+    let task = Task(executorPreference: taskExecutor) {
+      dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
+      try? await Task.sleep(for: .seconds(2))
+      return 12
+    }
+
+    taskExecutor = nil
+
+    let num = await task.value
+    assert(num == 12)
+  }
+}


### PR DESCRIPTION
**Description**: Since we introduced proper ownership of task executors, they are now released and retained. The problem appears with a dispatch_queue_t which conforms to TaskExecutor being passed to Task initializer and retains work okey because it is __owned. However, upon destroy we swift_released the executor reference, which is incorrect as we must be using object specific release methods -- in this case the safe way to support all kinds of objects is swift_unknownObjectRelease
**Scope/Impact**: Unbreaks users of task executors who use a raw dispatchqueue as the executor.
**Risk:** Low, changes swift_release to swift_unknownObjectRelease which is stricly more accepting.
**Testing**: Verified in a reproducer project
**Reviewed by**: @mikeash 

**Original PR:** https://github.com/swiftlang/swift/pull/75059
**Radar:** rdar://131151645