### PR TITLE
[cxx-interop] Adjust a concepts test for rebranch

### DIFF
--- a/test/Interop/Cxx/concepts/Inputs/method-requires.h
+++ b/test/Interop/Cxx/concepts/Inputs/method-requires.h
@@ -1,4 +1,6 @@
-inline void calledFromConceptBody(int x) {}
+inline void shouldNotBeCalledOrEmitted(int) {}
+
+inline void calledFromConceptBody(int x) { shouldNotBeCalledOrEmitted(x); }
 inline void calledFromMethodBody(int x) {}
 
 struct MyStruct {

--- a/test/Interop/Cxx/concepts/method-requires.swift
+++ b/test/Interop/Cxx/concepts/method-requires.swift
@@ -4,5 +4,5 @@ import MethodRequires
 
 var s = MyStruct()
 s.foo(123)
-// CHECK-NOT: calledFromConceptBody
+// CHECK-NOT: shouldNotBeCalledOrEmitted
 // CHECK: calledFromMethodBody


### PR DESCRIPTION
Clang now includes concepts in the mangled names of C++ functions: https://github.com/apple/llvm-project/commit/4b163e343cfa54c8d55c9da73c70d58f55ea9df2

This adjusts the test to verify that we don't transitively emit the symbols referenced from the requires expression. Those symbols shouldn't be emitted because they are not executed.

rdar://127263407