### PR TITLE
stdlib: Remove `#if $TypedThrows` guards

### DIFF
--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -360,16 +360,12 @@ extension Actor {
       fatalError("Incorrect actor executor assumption; Expected same executor as \(self).", file: file, line: line)
     }
 
-    #if $TypedThrows
     // To do the unsafe cast, we have to pretend it's @escaping.
     return try withoutActuallyEscaping(operation) {
       (_ fn: @escaping YesActor) throws -> T in
       let rawFn = unsafeBitCast(fn, to: NoActor.self)
       return try rawFn(self)
     }
-    #else
-    fatalError("unsupported compiler")
-    #endif
   }
 
   @available(SwiftStdlib 5.9, *)

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -138,16 +138,12 @@ extension MainActor {
       fatalError("Incorrect actor executor assumption; Expected same executor as \(self).", file: file, line: line)
     }
 
-    #if $TypedThrows
     // To do the unsafe cast, we have to pretend it's @escaping.
     return try withoutActuallyEscaping(operation) {
       (_ fn: @escaping YesActor) throws -> T in
       let rawFn = unsafeBitCast(fn, to: NoActor.self)
       return try rawFn()
     }
-    #else
-    fatalError("unsupported compiler")
-    #endif
   }
 
   @available(SwiftStdlib 5.9, *)

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -171,16 +171,12 @@ extension DistributedActor {
       fatalError("Incorrect actor executor assumption; Expected same executor as \(self).", file: file, line: line)
     }
 
-    #if $TypedThrows
     // To do the unsafe cast, we have to pretend it's @escaping.
     return try withoutActuallyEscaping(operation) {
       (_ fn: @escaping YesActor) throws -> T in
       let rawFn = unsafeBitCast(fn, to: NoActor.self)
       return try rawFn(self)
     }
-    #else
-    fatalError("unsupported compiler")
-    #endif
   }
 
   @available(SwiftStdlib 5.9, *)

--- a/stdlib/public/core/ArrayCast.swift
+++ b/stdlib/public/core/ArrayCast.swift
@@ -49,11 +49,7 @@ public func _arrayForceCast<SourceElement, TargetElement>(
     return Array(_immutableCocoaArray: source._buffer._asCocoaArray())
   }
 #endif
-#if $TypedThrows
   return source.map { $0 as! TargetElement }
-#else
-  return try! source.__rethrows_map { $0 as! TargetElement }
-#endif
 }
 
 /// Called by the casting machinery.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1216,6 +1216,7 @@ extension Collection {
   // ABI-only entrypoint for the rethrows version of map, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
   @_silgen_name("$sSlsE3mapySayqd__Gqd__7ElementQzKXEKlF")
   func __rethrows_map<T>(

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -550,11 +550,7 @@ internal final class _SequenceBox<S: Sequence>: _AnySequenceBox<S.Element> {
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
-#if $TypedThrows
     try _base.map(transform)
-#else
-    try _base.__rethrows_map(transform)
-#endif
   }
   @inlinable
   internal override func _filter(
@@ -650,11 +646,7 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
-#if $TypedThrows
     try _base.map(transform)
-#else
-    try _base.__rethrows_map(transform)
-#endif
   }
   @inlinable
   internal override func _filter(
@@ -852,11 +844,7 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
-#if $TypedThrows
     try _base.map(transform)
-#else
-    try _base.__rethrows_map(transform)
-#endif
   }
   @inlinable
   internal override func _filter(
@@ -1072,11 +1060,7 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
-#if $TypedThrows
     try _base.map(transform)
-#else
-    try _base.__rethrows_map(transform)
-#endif
   }
   @inlinable
   internal override func _filter(
@@ -1380,6 +1364,7 @@ extension AnySequence {
   // ABI-only entrypoint for the rethrows version of map, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
   @_silgen_name("$ss11AnySequenceV3mapySayqd__Gqd__xKXEKlF")
   func __rethrows_map<T>(
@@ -1483,6 +1468,7 @@ extension AnyCollection {
   // ABI-only entrypoint for the rethrows version of map, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
   @_silgen_name("$ss13AnyCollectionV3mapySayqd__Gqd__xKXEKlF")
   func __rethrows_map<T>(
@@ -1592,6 +1578,7 @@ extension AnyBidirectionalCollection {
   // ABI-only entrypoint for the rethrows version of map, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
   @_silgen_name("$ss26AnyBidirectionalCollectionV3mapySayqd__Gqd__xKXEKlF")
   func __rethrows_map<T>(
@@ -1703,6 +1690,7 @@ extension AnyRandomAccessCollection {
   // ABI-only entrypoint for the rethrows version of map, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
   @_silgen_name("$ss25AnyRandomAccessCollectionV3mapySayqd__Gqd__xKXEKlF")
   func __rethrows_map<T>(

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -169,7 +169,6 @@ extension ${Self}: LosslessStringConvertible {
       self.init(Substring(text))
     } else {
       self = 0.0
-#if $TypedThrows
       let success = _withUnprotectedUnsafeMutablePointer(to: &self) { p -> Bool in
         text.withCString { chars -> Bool in
           switch chars[0] {
@@ -185,23 +184,6 @@ extension ${Self}: LosslessStringConvertible {
           return endPtr != nil && endPtr![0] == 0
         }
       }
-#else
-      let success = __abi_se0413_withUnsafeMutablePointer(to: &self) { p -> Bool in
-        text.withCString { chars -> Bool in
-          switch chars[0] {
-          case 9, 10, 11, 12, 13, 32:
-            return false // Reject leading whitespace
-          case 0:
-            return false // Reject empty string
-          default:
-            break
-          }
-          let endPtr = _swift_stdlib_strto${cFuncSuffix2[bits]}_clocale(chars, p)
-          // Succeed only if endPtr points to end of C string
-          return endPtr != nil && endPtr![0] == 0
-        }
-      }
-#endif
       if !success {
         return nil
       }
@@ -216,7 +198,6 @@ extension ${Self}: LosslessStringConvertible {
   @available(SwiftStdlib 5.3, *)
   public init?(_ text: Substring) {
     self = 0.0
-#if $TypedThrows
     let success = _withUnprotectedUnsafeMutablePointer(to: &self) { p -> Bool in
       text.withCString { chars -> Bool in
         switch chars[0] {
@@ -232,23 +213,6 @@ extension ${Self}: LosslessStringConvertible {
         return endPtr != nil && endPtr![0] == 0
       }
     }
-#else
-    let success = __abi_se0413_withUnsafeMutablePointer(to: &self) { p -> Bool in
-      text.withCString { chars -> Bool in
-        switch chars[0] {
-        case 9, 10, 11, 12, 13, 32:
-          return false // Reject leading whitespace
-        case 0:
-          return false // Reject empty string
-        default:
-          break
-        }
-        let endPtr = _swift_stdlib_strto${cFuncSuffix2[bits]}_clocale(chars, p)
-        // Succeed only if endPtr points to end of C string
-        return endPtr != nil && endPtr![0] == 0
-      }
-    }
-#endif
     if !success {
       return nil
     }

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -106,14 +106,13 @@ public func withUnsafeMutablePointer<
   try body(UnsafeMutablePointer<T>(Builtin.addressof(&value)))
 }
 
-// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
-//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss24withUnsafeMutablePointer2to_q_xz_q_SpyxGKXEtKr0_lF")
 @usableFromInline
 internal func __abi_se0413_withUnsafeMutablePointer<T, Result>(
   to value: inout T,
   _ body: (UnsafeMutablePointer<T>) throws -> Result
-) rethrows -> Result {
+) throws -> Result {
   return try body(UnsafeMutablePointer<T>(Builtin.addressof(&value)))
 }
 
@@ -167,14 +166,13 @@ public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafePointer(to:_:) rethrows, expressed as "throws",
 /// which is ABI-compatible with "rethrows".
-// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
-//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss17withUnsafePointer2to_q_x_q_SPyxGKXEtKr0_lF")
 @usableFromInline
 internal func __abi_withUnsafePointer<T, Result>(
   to value: T,
   _ body: (UnsafePointer<T>) throws -> Result
-) rethrows -> Result
+) throws -> Result
 {
   return try body(UnsafePointer<T>(Builtin.addressOfBorrow(value)))
 }
@@ -213,14 +211,13 @@ public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafePointer(to:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
-//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss17withUnsafePointer2to_q_xz_q_SPyxGKXEtKr0_lF")
 @usableFromInline
 internal func __abi_se0413_withUnsafePointer<T, Result>(
   to value: inout T,
   _ body: (UnsafePointer<T>) throws -> Result
-) rethrows -> Result {
+) throws -> Result {
   return try body(UnsafePointer<T>(Builtin.addressof(&value)))
 }
 

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -158,15 +158,9 @@ public struct SystemRandomNumberGenerator: RandomNumberGenerator, Sendable {
   @inlinable
   public mutating func next() -> UInt64 {
     var random: UInt64 = 0
-#if $TypedThrows
     _withUnprotectedUnsafeMutablePointer(to: &random) {
       swift_stdlib_random($0, MemoryLayout<UInt64>.size)
     }
-#else
-    __abi_se0413_withUnsafeMutablePointer(to: &random) {
-      swift_stdlib_random($0, MemoryLayout<UInt64>.size)
-    }
-#endif
     return random
   }
 }

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -139,19 +139,11 @@ func _stdlib_atomicInitializeARCRef(
   let desiredPtr = unmanaged.toOpaque()
   let rawTarget = UnsafeMutableRawPointer(target).assumingMemoryBound(
     to: Optional<UnsafeRawPointer>.self)
-#if $TypedThrows
   let wonRace = withUnsafeMutablePointer(to: &expected) {
     _stdlib_atomicCompareExchangeStrongPtr(
       object: rawTarget, expected: $0, desired: desiredPtr
     )
   }
-#else
-  let wonRace = __abi_se0413_withUnsafeMutablePointer(to: &expected) {
-    _stdlib_atomicCompareExchangeStrongPtr(
-      object: rawTarget, expected: $0, desired: desiredPtr
-    )
-  }
-#endif
   if !wonRace {
     // Some other thread initialized the value.  Balance the retain that we
     // performed on 'desired'.

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -706,6 +706,7 @@ extension Sequence {
   // ABI-only entrypoint for the rethrows version of map, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
   @_silgen_name("$sSTsE3mapySayqd__Gqd__7ElementQzKXEKlF")
   func __rethrows_map<T>(

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -223,7 +223,6 @@ extension _SmallString {
   ) rethrows -> Result {
     let count = self.count
     var raw = self.zeroTerminatedRawCodeUnits
-#if $TypedThrows
     return try Swift._withUnprotectedUnsafeBytes(of: &raw) {
       let rawPtr = $0.baseAddress._unsafelyUnwrappedUnchecked
       // Rebind the underlying (UInt64, UInt64) tuple to UInt8 for the
@@ -235,19 +234,6 @@ extension _SmallString {
       }
       return try f(UnsafeBufferPointer(_uncheckedStart: ptr, count: count))
     }
-#else
-    return try Swift.__abi_se0413_withUnsafeBytes(of: &raw) {
-      let rawPtr = $0.baseAddress._unsafelyUnwrappedUnchecked
-      // Rebind the underlying (UInt64, UInt64) tuple to UInt8 for the
-      // duration of the closure. Accessing self after this rebind is undefined.
-      let ptr = rawPtr.bindMemory(to: UInt8.self, capacity: count)
-      defer {
-        // Restore the memory type of self._storage
-        _ = rawPtr.bindMemory(to: RawBitPattern.self, capacity: 1)
-      }
-      return try f(UnsafeBufferPointer(_uncheckedStart: ptr, count: count))
-    }
-#endif
   }
 
   // Overwrite stored code units, including uninitialized. `f` should return the

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -528,18 +528,10 @@ extension Unicode.Scalar {
 
     // The first code unit is in the least significant byte of codeUnits.
     codeUnits = codeUnits.littleEndian
-#if $TypedThrows
     return try Swift._withUnprotectedUnsafePointer(to: &codeUnits) {
       return try $0.withMemoryRebound(to: UInt8.self, capacity: 4) {
         return try body(UnsafeBufferPointer(start: $0, count: utf8Count))
       }
     }
-#else
-    return try Swift.__abi_se0413_withUnsafePointer(to: &codeUnits) {
-      return try $0.withMemoryRebound(to: UInt8.self, capacity: 4) {
-        return try body(UnsafeBufferPointer(start: $0, count: utf8Count))
-      }
-    }
-#endif
   }
 }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1135,7 +1135,6 @@ extension Unsafe${Mutable}RawBufferPointer {
   public func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    #if $TypedThrows
     try withMemoryRebound(to: Element.self) { b in
       var buffer = b
       defer {
@@ -1146,9 +1145,6 @@ extension Unsafe${Mutable}RawBufferPointer {
       }
       return try body(&buffer)
     }
-    #else
-    fatalError("unsupported compiler")
-    #endif
   }
 
 %  end
@@ -1156,13 +1152,9 @@ extension Unsafe${Mutable}RawBufferPointer {
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    #if $TypedThrows
     try withMemoryRebound(to: Element.self) {
       try body(${ 'UnsafeBufferPointer<Element>($0)' if Mutable else '$0' })
     }
-    #else
-    fatalError("unsupported compiler")
-    #endif
   }
 }
 
@@ -1228,14 +1220,13 @@ public func withUnsafeMutableBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafeMutableBytes(of:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
-//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss22withUnsafeMutableBytes2of_q_xz_q_SwKXEtKr0_lF")
 @usableFromInline
 func __abi_se0413_withUnsafeMutableBytes<T, Result>(
   of value: inout T,
   _ body: (UnsafeMutableRawBufferPointer) throws -> Result
-) rethrows -> Result {
+) throws -> Result {
   return try withUnsafeMutablePointer(to: &value) {
     return try body(UnsafeMutableRawBufferPointer(
         start: $0, count: MemoryLayout<T>.size))
@@ -1296,14 +1287,13 @@ public func withUnsafeBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafeBytes(of:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
-//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss15withUnsafeBytes2of_q_xz_q_SWKXEtKr0_lF")
 @usableFromInline
 func __abi_se0413_withUnsafeBytes<T, Result>(
   of value: inout T,
   _ body: (UnsafeRawBufferPointer) throws -> Result
-) rethrows -> Result {
+) throws -> Result {
   return try withUnsafePointer(to: &value) {
     try body(UnsafeRawBufferPointer(start: $0, count: MemoryLayout<T>.size))
   }
@@ -1361,14 +1351,13 @@ public func withUnsafeBytes<
 
 /// ABI: Historical withUnsafeBytes(of:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
-//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss15withUnsafeBytes2of_q_x_q_SWKXEtKr0_lF")
 @usableFromInline
 func __abi_se0413_withUnsafeBytes<T, Result>(
   of value: T,
   _ body: (UnsafeRawBufferPointer) throws -> Result
-) rethrows -> Result {
+) throws -> Result {
   let addr = UnsafeRawPointer(Builtin.addressOfBorrow(value))
   let buffer = UnsafeRawBufferPointer(start: addr, count: MemoryLayout<T>.size)
   return try body(buffer)

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1458,7 +1458,6 @@ extension UnsafeMutableRawPointer {
       "storeBytes only supports storing the bytes of BitwiseCopyable types."
     )
 
-#if $TypedThrows
     withUnsafePointer(to: value) { source in
       // FIXME: to be replaced by _memcpy when conversions are implemented.
       Builtin.int_memcpy_RawPointer_RawPointer_Int64(
@@ -1468,17 +1467,6 @@ extension UnsafeMutableRawPointer {
         /*volatile:*/ false._value
       )
     }
-#else
-    try! __abi_withUnsafePointer(to: value) { source in
-      // FIXME: to be replaced by _memcpy when conversions are implemented.
-      Builtin.int_memcpy_RawPointer_RawPointer_Int64(
-        (self + offset)._rawValue,
-        source._rawValue,
-        UInt64(MemoryLayout<T>.size)._value,
-        /*volatile:*/ false._value
-      )
-    }
-#endif
   }
 
   // This obsolete implementation uses the expected mangled name
@@ -1504,7 +1492,6 @@ extension UnsafeMutableRawPointer {
       "storeBytes to misaligned raw pointer")
 
     var temp = value
-#if $TypedThrows
     withUnsafeMutablePointer(to: &temp) { source in
       let rawSrc = UnsafeMutableRawPointer(source)._rawValue
       // FIXME: to be replaced by _memcpy when conversions are implemented.
@@ -1512,15 +1499,6 @@ extension UnsafeMutableRawPointer {
         (self + offset)._rawValue, rawSrc, UInt64(MemoryLayout<T>.size)._value,
         /*volatile:*/ false._value)
     }
-#else
-    __abi_se0413_withUnsafeMutablePointer(to: &temp) { source in
-      let rawSrc = UnsafeMutableRawPointer(source)._rawValue
-      // FIXME: to be replaced by _memcpy when conversions are implemented.
-      Builtin.int_memcpy_RawPointer_RawPointer_Int64(
-        (self + offset)._rawValue, rawSrc, UInt64(MemoryLayout<T>.size)._value,
-        /*volatile:*/ false._value)
-    }
-#endif
   }
 
   /// Copies the specified number of bytes from the given raw pointer's memory

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -215,19 +215,11 @@ public func _encodeBitsAsWords<T>(_ x: T) -> [Int] {
   _internalInvariant(!result.isEmpty)
   var tmp = x
   // FIXME: use UnsafeMutablePointer.assign(from:) instead of memcpy.
-#if $TypedThrows
   _withUnprotectedUnsafeMutablePointer(to: &tmp) {
     _memcpy(dest: UnsafeMutablePointer(result._baseAddressIfContiguous!),
             src: $0,
             size: UInt(MemoryLayout<T>.size))
   }
-#else
-  __abi_se0413_withUnsafeMutablePointer(to: &tmp) {
-    _memcpy(dest: UnsafeMutablePointer(result._baseAddressIfContiguous!),
-            src: $0,
-            size: UInt(MemoryLayout<T>.size))
-  }
-#endif
   return result
 }
 

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -83,24 +83,12 @@ Enum Never has added a conformance to an existing protocol Encodable
 Enum Never has added a conformance to an existing protocol Identifiable
 
 // These functions haven't actually changed ABI, but are using @_silgen_name tricks to maintain the old ABI while moving to typed throws.
-Func AnyBidirectionalCollection.map(_:) has been renamed to Func __rethrows_map(_:)
-Func AnyBidirectionalCollection.map(_:) has mangled name changing from 'Swift.AnyBidirectionalCollection.map<A>((A) throws -> A1) throws -> Swift.Array<A1>' to 'Swift.AnyBidirectionalCollection.__rethrows_map<A>((A) throws -> A1) throws -> Swift.Array<A1>'
-Func AnyBidirectionalCollection.map(_:) is now without @rethrows
-Func AnyCollection.map(_:) has been renamed to Func __rethrows_map(_:)
-Func AnyCollection.map(_:) has mangled name changing from 'Swift.AnyCollection.map<A>((A) throws -> A1) throws -> Swift.Array<A1>' to 'Swift.AnyCollection.__rethrows_map<A>((A) throws -> A1) throws -> Swift.Array<A1>'
-Func AnyCollection.map(_:) is now without @rethrows
-Func AnyRandomAccessCollection.map(_:) has been renamed to Func __rethrows_map(_:)
-Func AnyRandomAccessCollection.map(_:) has mangled name changing from 'Swift.AnyRandomAccessCollection.map<A>((A) throws -> A1) throws -> Swift.Array<A1>' to 'Swift.AnyRandomAccessCollection.__rethrows_map<A>((A) throws -> A1) throws -> Swift.Array<A1>'
-Func AnyRandomAccessCollection.map(_:) is now without @rethrows
-Func AnySequence.map(_:) has been renamed to Func __rethrows_map(_:)
-Func AnySequence.map(_:) has mangled name changing from 'Swift.AnySequence.map<A>((A) throws -> A1) throws -> Swift.Array<A1>' to 'Swift.AnySequence.__rethrows_map<A>((A) throws -> A1) throws -> Swift.Array<A1>'
-Func AnySequence.map(_:) is now without @rethrows
-Func Sequence.map(_:) has been renamed to Func __rethrows_map(_:)
-Func Sequence.map(_:) has mangled name changing from '(extension in Swift):Swift.Sequence.map<A>((A.Element) throws -> A1) throws -> Swift.Array<A1>' to '(extension in Swift):Swift.Sequence.__rethrows_map<A>((A.Element) throws -> A1) throws -> Swift.Array<A1>'
-Func Sequence.map(_:) is now without @rethrows
-Func Collection.map(_:) has been renamed to Func __rethrows_map(_:)
-Func Collection.map(_:) has mangled name changing from '(extension in Swift):Swift.Collection.map<A>((A.Element) throws -> A1) throws -> Swift.Array<A1>' to '(extension in Swift):Swift.Collection.__rethrows_map<A>((A.Element) throws -> A1) throws -> Swift.Array<A1>'
-Func Collection.map(_:) is now without @rethrows
+Func AnyBidirectionalCollection.map(_:) has been removed
+Func AnyCollection.map(_:) has been removed
+Func AnyRandomAccessCollection.map(_:) has been removed
+Func AnySequence.map(_:) has been removed
+Func Collection.map(_:) has been removed
+Func Sequence.map(_:) has been removed
 Constructor Result.init(catching:) has been removed
 Func withoutActuallyEscaping(_:do:) has been renamed to Func __abi_withoutActuallyEscaping(_:do:)
 Func withoutActuallyEscaping(_:do:) has mangled name changing from 'Swift.withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B' to 'Swift.__abi_withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B'
@@ -699,17 +687,10 @@ Func _fixLifetime(_:) is now with @_preInverseGenerics
 Func swap(_:_:) has generic signature change from <T> to <T where T : ~Copyable>
 Func swap(_:_:) has mangled name changing from 'Swift.swap<A>(inout A, inout A) -> ()' to 'Swift.swap<A where A: ~Swift.Copyable>(inout A, inout A) -> ()'
 Func swap(_:_:) is now with @_preInverseGenerics
-Func withUnsafeBytes(of:_:) has been renamed to Func __abi_se0413_withUnsafeBytes(of:_:)
-Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeBytes<A, B>(of: A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeBytes<A, B>(of: A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
-Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
-Func withUnsafeMutableBytes(of:_:) has been renamed to Func __abi_se0413_withUnsafeMutableBytes(of:_:)
-Func withUnsafeMutableBytes(of:_:) has mangled name changing from 'Swift.withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeMutableRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeMutableRawBufferPointer) throws -> B) throws -> B'
-Func withUnsafeMutablePointer(to:_:) has been renamed to Func __abi_se0413_withUnsafeMutablePointer(to:_:)
-Func withUnsafeMutablePointer(to:_:) has mangled name changing from 'Swift.withUnsafeMutablePointer<A, B>(to: inout A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutablePointer<A, B>(to: inout A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B'
-Func withUnsafePointer(to:_:) has been renamed to Func __abi_se0413_withUnsafePointer(to:_:)
-Func withUnsafePointer(to:_:) has been renamed to Func __abi_withUnsafePointer(to:_:)
-Func withUnsafePointer(to:_:) has mangled name changing from 'Swift.withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B'
-Func withUnsafePointer(to:_:) has mangled name changing from 'Swift.withUnsafePointer<A, B>(to: inout A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafePointer<A, B>(to: inout A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B'
+Func withUnsafeBytes(of:_:) has been removed
+Func withUnsafeMutableBytes(of:_:) has been removed
+Func withUnsafeMutablePointer(to:_:) has been removed
+Func withUnsafePointer(to:_:) has been removed
 Protocol _Pointer has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable> to <Self : Swift.BitwiseCopyable, Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable, Self.Pointee : ~Copyable>
 Struct ManagedBufferPointer has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
 Struct UnsafeBufferPointer has generic signature change from <Element> to <Element where Element : ~Copyable>


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/72612 can be reverted because it is no longer necessary for the interface of the stdlib to be compatible with compilers without `$TypedThrows` support.
