### PR TITLE
Add embedded REQUIRES for noncopyable-captures.swift.

### DIFF
--- a/test/embedded/noncopyable-captures.swift
+++ b/test/embedded/noncopyable-captures.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-emit-ir %s -DIGNORE_FAILS -enable-experimental-feature Embedded -wmo -o /dev/null
 // RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -wmo -verify
 
+// REQUIRES: OS=macosx || OS=linux-gnu
+
 struct MyStruct<Item> : ~Copyable {
     var member = "42"
 


### PR DESCRIPTION
Skips test for iphonesimulator-x86_64 which errors with error: module 'Swift' cannot be imported in embedded Swift mode