### PR TITLE
[IRGen] Move some typed error code in CallEmission into separate func…

### DIFF
--- a/lib/IRGen/CallEmission.h
+++ b/lib/IRGen/CallEmission.h
@@ -110,6 +110,11 @@ protected:
                                    TemporarySet &temporaries,
                                    bool isOutlined);
 
+  bool mayReturnTypedErrorDirectly() const;
+  void emitToUnmappedExplosionWithDirectTypedError(SILType resultType,
+                                                   llvm::Value *result,
+                                                   Explosion &out);
+
   CallEmission(IRGenFunction &IGF, llvm::Value *selfValue, Callee &&callee)
       : IGF(IGF), selfValue(selfValue), CurCallee(std::move(callee)) {}
 


### PR DESCRIPTION
…tion

This is in preparation of adding support for async calls, so the code can be shared between sync and async calls.