### PR TITLE
Move main/6.0 windows Foundation builds to separate branch

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1669,7 +1669,7 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
 
     $env:CTEST_OUTPUT_ON_FAILURE = 1
     Build-CMakeProject `
-      -Src $SourceCache\swift-corelibs-foundation `
+      -Src $SourceCache\swift-corelibs-foundation-windows `
       -Bin $FoundationBinaryCache `
       -InstallTo $InstallPath `
       -Arch $Arch `

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -42,6 +42,8 @@
             "remote": { "id": "apple/swift-corelibs-xctest" } },
         "swift-corelibs-foundation": {
             "remote": { "id": "apple/swift-corelibs-foundation" } },  
+        "swift-corelibs-foundation-windows": {
+            "remote": { "id": "apple/swift-corelibs-foundation" } },  
         "swift-foundation-icu": {
             "remote": { "id": "apple/swift-foundation-icu" } },  
         "swift-foundation": {
@@ -138,6 +140,7 @@
                 "swift-stress-tester": "main",
                 "swift-corelibs-xctest": "main",
                 "swift-corelibs-foundation": "main",
+                "swift-corelibs-foundation-windows": "windows/main",
                 "swift-foundation-icu": "main",
                 "swift-foundation": "main",
                 "swift-corelibs-libdispatch": "main",
@@ -189,6 +192,7 @@
                 "swift-stress-tester": "release/6.0",
                 "swift-corelibs-xctest": "release/6.0",
                 "swift-corelibs-foundation": "release/6.0",
+                "swift-corelibs-foundation-windows": "windows/release/6.0",
                 "swift-corelibs-libdispatch": "release/6.0",
                 "swift-integration-tests": "release/6.0",
                 "swift-xcode-playground-support": "release/6.0",


### PR DESCRIPTION
This (temporarily) forks the swift-corelibs-foundation checkout into a Windows and non-Windows checkout. The Windows checkout will use `windows/*` branches while building for non-windows will use the standard branches. This is a temporary change to allow us to land the re-cored `Foundation` for Linux while we still work out the final Windows blockers. We expect that in the near future we'll revert this after resolving those blockers.