### PR TITLE
[6.0🍒][Concurrency] Allow 'nonisolated' to be applied to mutable storage of 'Sendable' type on a 'Sendable' value type.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6941,15 +6941,13 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
     if (var->hasStorage()) {
       {
         // 'nonisolated' can not be applied to mutable stored properties unless
-        // qualified as 'unsafe', or is of a Sendable type on a
-        // globally-isolated value type.
+        // qualified as 'unsafe', or is of a Sendable type on a Sendable
+        // value type.
         bool canBeNonisolated = false;
-        if (dc->isTypeContext()) {
-          if (auto nominal = dc->getSelfStructDecl()) {
-            if (!var->isStatic() && type->isSendableType() &&
-                getActorIsolation(nominal).isGlobalActor()) {
-              canBeNonisolated = true;
-            }
+        if (auto nominal = dc->getSelfStructDecl()) {
+          if (nominal->getDeclaredTypeInContext()->isSendableType() &&
+              !var->isStatic() && type->isSendableType()) {
+            canBeNonisolated = true;
           }
         }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6937,18 +6937,32 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
 
   if (auto var = dyn_cast<VarDecl>(D)) {
     // stored properties have limitations as to when they can be nonisolated.
+    auto type = var->getTypeInContext();
     if (var->hasStorage()) {
-      // 'nonisolated' can not be applied to mutable stored properties unless
-      // qualified as 'unsafe'.
-      if (var->supportsMutation() && !attr->isUnsafe()) {
-        diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
-            .fixItInsertAfter(attr->getRange().End, "(unsafe)");
-        var->diagnose(diag::nonisolated_mutable_storage_note, var);
-        return;
+      {
+        // 'nonisolated' can not be applied to mutable stored properties unless
+        // qualified as 'unsafe', or is of a Sendable type on a
+        // globally-isolated value type.
+        bool canBeNonisolated = false;
+        if (dc->isTypeContext()) {
+          if (auto nominal = dc->getSelfStructDecl()) {
+            if (!var->isStatic() && type->isSendableType() &&
+                getActorIsolation(nominal).isGlobalActor()) {
+              canBeNonisolated = true;
+            }
+          }
+        }
+
+        if (var->supportsMutation() && !attr->isUnsafe() && !canBeNonisolated) {
+          diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
+              .fixItInsertAfter(attr->getRange().End, "(unsafe)");
+          var->diagnose(diag::nonisolated_mutable_storage_note, var);
+          return;
+        }
       }
 
-      // 'nonisolated' without '(unsafe)' is not allowed on non-Sendable variables.
-      auto type = var->getTypeInContext();
+      // 'nonisolated' without '(unsafe)' is not allowed on non-Sendable
+      // variables.
       if (!attr->isUnsafe() && !type->hasError()) {
         bool diagnosed = diagnoseIfAnyNonSendableTypes(
             type,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -515,11 +515,10 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
     // A mutable storage of a value type accessed from within the module is
     // okay.
     if (dyn_cast_or_null<StructDecl>(var->getDeclContext()->getAsDecl()) &&
-        !var->isStatic() &&
-        var->hasStorage() &&
-        var->getTypeInContext()->isSendableType() &&
-        accessWithinModule) {
-      return true;
+        !var->isStatic() && var->hasStorage() &&
+        var->getTypeInContext()->isSendableType()) {
+      if (accessWithinModule || varIsolation.isNonisolated())
+        return true;
     }
     // Otherwise, must be immutable.
     return false;

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -138,8 +138,7 @@ struct InferredFromContext {
     get { [] }
   }
 
-  nonisolated var status: Bool = true // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}{{3-15=}}{{3-15=}}{{14-14=(unsafe)}}
-  // expected-note@-1{{convert 'status' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
+  nonisolated var status: Bool = true // okay
 
   nonisolated let flag: Bool = false
 
@@ -1215,6 +1214,12 @@ func test_conforming_actor_to_global_actor_protocol() {
   @available(SwiftStdlib 5.1, *)
   actor MyValue : GloballyIsolatedProto {}
   // expected-error@-1 {{actor 'MyValue' cannot conform to global actor isolated protocol 'GloballyIsolatedProto'}}
+}
+
+func test_nonisolated_variable() {
+  struct S: GloballyIsolatedProto {
+    nonisolated var x: Int = 0 // okay
+  }
 }
 
 func test_invalid_reference_to_actor_member_without_a_call_note() {

--- a/test/Concurrency/derived_conformances_nonisolated.swift
+++ b/test/Concurrency/derived_conformances_nonisolated.swift
@@ -14,7 +14,7 @@ struct X1: Equatable, Hashable, Codable {
 @MainActor
 struct X2: Equatable, Hashable, Codable {
   let x: Int
-  var y: String
+  nonisolated var y: String // okay
 }
 
 class NonSendable {

--- a/test/Concurrency/mutable_storage_nonisolated.swift
+++ b/test/Concurrency/mutable_storage_nonisolated.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+class NonSendable {}
+
+struct ImplicitlySendable {
+  var x: Int
+  nonisolated var y: Int // okay
+}
+
+struct ImplicitlyNonSendable {
+  let x: NonSendable
+  // expected-note@+1 {{convert 'y' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
+  nonisolated var y: Int // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+}
+
+public struct PublicSendable: Sendable {
+  nonisolated var x: Int // okay
+}
+
+public struct PublicNonSendable {
+  // expected-note@+1 {{convert 'x' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
+  nonisolated var x: Int // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+}

--- a/test/Concurrency/nonisolated_access.swift
+++ b/test/Concurrency/nonisolated_access.swift
@@ -19,6 +19,13 @@
 @MainActor
 public protocol P {}
 
+@frozen
+public struct ImplicitlySendable {
+  nonisolated public var prop: Bool = true
+
+  nonisolated public init() {}
+}
+
 public struct S: P {
   nonisolated public var x: Int = 0
 
@@ -32,5 +39,7 @@ actor A {
   func test() {
     var s = S()
     s.x += 0 // okay
+    var sendable = ImplicitlySendable()
+    sendable.prop = false // okay
   }
 }

--- a/test/Concurrency/nonisolated_access.swift
+++ b/test/Concurrency/nonisolated_access.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+/// Build the library A
+// RUN: %target-swift-frontend -emit-module %t/src/A.swift \
+// RUN: -disable-availability-checking \
+// RUN: -module-name A -swift-version 6 \
+// RUN: -emit-module-path %t/A.swiftmodule
+
+// Build the client
+// RUN: %target-swift-frontend -emit-module %t/src/Client.swift \
+// RUN: -disable-availability-checking \
+// RUN: -module-name Client -I %t -swift-version 6 \
+// RUN: -emit-module-path %t/Client.swiftmodule
+
+// REQUIRES: concurrency
+
+//--- A.swift
+@MainActor
+public protocol P {}
+
+public struct S: P {
+  nonisolated public var x: Int = 0
+
+  nonisolated public init() {}
+}
+
+//--- Client.swift
+import A
+
+actor A {
+  func test() {
+    var s = S()
+    s.x += 0 // okay
+  }
+}


### PR DESCRIPTION
- **Explanation:** Allow 'nonisolated' to be applied to mutable storage of 'Sendable' type on a 'Sendable' value type.
- **Scope**:  Concurrency model improvement.
- **Issue**:  rdar://130992526, rdar://131339439
- **Original PR**: #74958, #75084
- **Risk**: Low (additive change)
- **Testing**: Added tests to the testing suite.
- **Reviewer**: @hborla  