### PR TITLE
[6.0 🍒] [SE-0364] Relax @retroactive check to allow same-package declarations (#73512)

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -184,7 +184,14 @@ usesDefaultDefinition(AssociatedTypeDecl *requirement) const {
 bool ProtocolConformance::isRetroactive() const {
   auto extensionModule = getDeclContext()->getParentModule();
   auto protocolModule = getProtocol()->getParentModule();
-  if (extensionModule->isSameModuleLookingThroughOverlays(protocolModule)) {
+  
+  auto isSameRetroactiveContext = 
+    [](ModuleDecl *moduleA, ModuleDecl *moduleB) -> bool {
+      return moduleA->isSameModuleLookingThroughOverlays(moduleB) ||
+        moduleA->inSamePackage(moduleB);
+    };
+  
+  if (isSameRetroactiveContext(extensionModule, protocolModule)) {
     return false;
   }
 
@@ -192,8 +199,7 @@ bool ProtocolConformance::isRetroactive() const {
       ConformingType->getNominalOrBoundGenericNominal();
   if (conformingTypeDecl) {
     auto conformingTypeModule = conformingTypeDecl->getParentModule();
-    if (extensionModule->
-        isSameModuleLookingThroughOverlays(conformingTypeModule)) {
+    if (isSameRetroactiveContext(extensionModule, conformingTypeModule)) {
       return false;
     }
   }

--- a/test/Sema/extension_retroactive_conformances_package.swift
+++ b/test/Sema/extension_retroactive_conformances_package.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -swift-version 5 %t/Library.swift -emit-module -module-name Library -o %t -package-name Library 
+// RUN: %target-swift-frontend -swift-version 5 %t/OtherLibrary.swift -emit-module -module-name OtherLibrary -o %t -package-name Library
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -module-name Client -verify -swift-version 5 -I %t -package-name Library 
+
+//--- Library.swift
+
+public class LibraryClass {}
+public protocol LibraryProtocol {}
+package class PackageLibraryClass {}
+package protocol PackageLibraryProtocol {}
+
+//--- OtherLibrary.swift
+
+public class OtherLibraryClass {}
+public protocol OtherLibraryProtocol {}
+package class PackageOtherLibraryClass {}
+package protocol PackageOtherLibraryProtocol {}
+
+//--- Client.swift
+
+public import Library
+public import OtherLibrary
+
+// These are all fine because all 3 of these modules are in the same package.
+
+extension LibraryClass: LibraryProtocol {}
+extension OtherLibraryClass: LibraryProtocol {}
+extension LibraryClass: OtherLibraryProtocol {}
+
+extension PackageLibraryClass: LibraryProtocol {}
+extension PackageOtherLibraryClass: LibraryProtocol {}
+extension PackageLibraryClass: OtherLibraryProtocol {}
+
+extension LibraryClass: PackageLibraryProtocol {}
+extension OtherLibraryClass: PackageLibraryProtocol {}
+extension LibraryClass: PackageOtherLibraryProtocol {}
+
+extension PackageLibraryClass: PackageLibraryProtocol {}
+extension PackageOtherLibraryClass: PackageLibraryProtocol {}
+extension PackageLibraryClass: PackageOtherLibraryProtocol {}


### PR DESCRIPTION
- **Explanation:** Silences the warning for retroactive conformances for declarations in the same package. This implements an [approved](https://forums.swift.org/t/accepted-amendment-se-0364-allow-same-package-conformances/72880) amendment to SE-0364.
- **Scope:** Influences whether diagnostics about the `@retroactive` attribute are emitted on a conformance declaration. With this change, fewer conformances will be diagnosed as needing `@retroactive` since conformances involving types from modules in the same package will no longer be considered retroactive.
- **Original PR:**  https://github.com/swiftlang/swift/pull/73512
- **Risk:** Low. This should generally cause a diagnostic that is new in 6.0 to be emitted less often.
- **Testing:** New tests in the test suite.
- **Reviewer:** @tshortli 