### PR TITLE
🌸 Enable @objc @implementation in the form approved by SE-0436

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2422,6 +2422,9 @@ public:
 
 class ObjCImplementationAttr final : public DeclAttribute {
 public:
+  /// Name of the category being implemented. This should only be used with
+  /// the early adopter \@\_objcImplementation syntax, but we support it there
+  /// for backwards compatibility.
   Identifier CategoryName;
 
   ObjCImplementationAttr(Identifier CategoryName, SourceLoc AtLoc,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1025,6 +1025,10 @@ public:
   /// Returns the source range of the declaration including its attributes.
   SourceRange getSourceRangeIncludingAttrs() const;
 
+  /// Retrieve the location at which we should insert a new attribute or
+  /// modifier.
+  SourceLoc getAttributeInsertionLoc(bool forModifier) const;
+
   using ImportAccessLevel = std::optional<AttributedImport<ImportedModule>>;
 
   /// Returns the import that may restrict the access to this decl
@@ -1915,11 +1919,6 @@ public:
   /// Does this extension add conformance to an invertible protocol for the
   /// extended type?
   bool isAddingConformanceToInvertible() const;
-
-  /// Returns the name of the category specified by the \c \@_objcImplementation
-  /// attribute, or \c None if the name is invalid or
-  /// \c isObjCImplementation() is false.
-  std::optional<Identifier> getCategoryNameForObjCImplementation() const;
 
   /// If this extension represents an imported Objective-C category, returns the
   /// category's name. Otherwise returns the empty identifier.
@@ -3181,10 +3180,6 @@ public:
   /// can't be "static" or are in a context where "static" doesn't make sense.
   bool isStatic() const;
 
-  /// Retrieve the location at which we should insert a new attribute or
-  /// modifier.
-  SourceLoc getAttributeInsertionLoc(bool forModifier) const;
-
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_ValueDecl &&
            D->getKind() <= DeclKind::Last_ValueDecl;
@@ -4215,6 +4210,12 @@ public:
   /// Retrieve the set of extensions of this type.
   ExtensionRange getExtensions();
 
+  /// Retrieve the extension most recently added to this type. Helpful to
+  /// determine if an extension has been added.
+  ExtensionDecl *getLastExtension() const {
+    return LastExtension;
+  }
+
   /// Special-behaviour flags passed to lookupDirect()
   enum class LookupDirectFlags {
     /// Whether to include @_implements members.
@@ -5079,6 +5080,11 @@ public:
   /// category by that name.
   llvm::TinyPtrVector<Decl *>
   getImportedObjCCategory(Identifier name) const;
+
+  /// Return a map of category names to extensions with that category name,
+  /// whether imported or otherwise. 
+  llvm::DenseMap<Identifier, llvm::TinyPtrVector<ExtensionDecl *>>
+  getObjCCategoryNameMap();
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -136,12 +136,10 @@ WARNING(api_pattern_attr_ignored, none,
         (StringRef, StringRef))
 
 ERROR(objc_implementation_two_impls, none,
-      "duplicate implementation of Objective-C %select{|category %0 on }0"
-      "%kind1",
-      (Identifier, Decl *))
-
+      "duplicate implementation of imported %kind0",
+      (Decl *))
 NOTE(previous_objc_implementation, none,
-     "previously implemented by extension here", ())
+     "previously implemented here", ())
 
 NOTE(macro_not_imported_unsupported_operator, none, "operator not supported in macro arithmetic", ())
 NOTE(macro_not_imported_unsupported_named_operator, none, "operator '%0' not supported in macro arithmetic", (StringRef))

--- a/include/swift/AST/DiagnosticsIRGen.def
+++ b/include/swift/AST/DiagnosticsIRGen.def
@@ -69,5 +69,16 @@ NOTE(layout_strings_blocked,none,
      "Layout string value witnesses have been disabled for module '%0' "
      "through block list entry", (StringRef))
 
+ERROR(attr_objc_implementation_resilient_property_not_supported, none,
+      "'@implementation' does not support stored properties whose size can "
+      "change due to library evolution; store this value in an object or 'any' "
+      "type",
+      ())
+ERROR(attr_objc_implementation_resilient_property_deployment_target, none,
+      "'@implementation' on %0 %1 does not support stored properties whose "
+      "size can change due to library evolution; raise the minimum deployment "
+      "target to %0 %2 or store this value in an object or 'any' type",
+      (StringRef, const llvm::VersionTuple, const llvm::VersionTuple))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1796,6 +1796,10 @@ ERROR(attr_objc_implementation_no_conformance,none,
       "add this conformance %select{with an ordinary extension|"
       "in the Objective-C header}1",
       (Type, bool))
+ERROR(attr_objc_implementation_raise_minimum_deployment_target,none,
+      "'@implementation' of an Objective-C class requires a minimum deployment "
+      "target of at least %0 %1",
+      (StringRef, llvm::VersionTuple))
 
 ERROR(member_of_objc_implementation_not_objc_or_final,none,
       "%kind0 does not match any %kindonly0 declared in the headers for %1; "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -763,6 +763,9 @@ ERROR(expr_selector_not_objc,none,
 NOTE(make_decl_objc,none,
      "add '@objc' to expose this %0 to Objective-C",
      (DescriptiveDeclKind))
+NOTE(make_decl_objc_for_implementation,none,
+     "add '@objc' to implement an Objective-C %0",
+     (DescriptiveDeclKind))
 
 // Selectors-as-string-literals.
 WARNING(selector_literal_invalid,none,
@@ -1760,10 +1763,6 @@ WARNING(objc_implementation_early_spelling_deprecated,none,
 ERROR(attr_objc_implementation_must_be_unconditional,none,
       "only unconditional extensions can implement an Objective-C '@interface'",
       ())
-ERROR(attr_objc_implementation_must_extend_class,none,
-      "cannot mark extension of %kind0 with '@_objcImplementation'; it is not "
-      "an imported Objective-C class",
-      (ValueDecl *))
 ERROR(attr_objc_implementation_must_be_imported,none,
       "'@_objcImplementation' cannot be used to extend %kind0 because it was "
       "defined by a Swift 'class' declaration, not an imported Objective-C "
@@ -1800,6 +1799,14 @@ ERROR(attr_objc_implementation_raise_minimum_deployment_target,none,
       "'@implementation' of an Objective-C class requires a minimum deployment "
       "target of at least %0 %1",
       (StringRef, llvm::VersionTuple))
+ERROR(attr_implementation_requires_language,none,
+      "'@implementation' used without specifying the language being "
+      "implemented",
+      ())
+ERROR(attr_implementation_category_goes_on_objc_attr,none,
+      "Objective-C category should be specified on '@objc', not "
+      "'@implementation'",
+      ())
 
 ERROR(member_of_objc_implementation_not_objc_or_final,none,
       "%kind0 does not match any %kindonly0 declared in the headers for %1; "
@@ -6285,7 +6292,7 @@ ERROR(objc_extension_not_class,none,
       "'@objc' can only be applied to an extension of a class", ())
 
 // If you change this, also change enum ObjCReason
-#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @objcMembers|marked @IBOutlet|marked @IBAction|marked @IBSegueAction|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override|an implementation of an @objc requirement|marked @IBInspectable|marked @GKInspectable|in an @objc extension of a class (without @nonobjc)|in an @_objcImplementation extension of a class (without final or @nonobjc)|marked @objc by an access note}"
+#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @objcMembers|marked @IBOutlet|marked @IBAction|marked @IBSegueAction|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override|an implementation of an @objc requirement|marked @IBInspectable|marked @GKInspectable|in an @objc extension of a class (without @nonobjc)|in an @objc @implementation extension of a class (without final or @nonobjc)|marked @objc by an access note}"
 
 ERROR(objc_invalid_on_var,none,
       "property cannot be %" OBJC_ATTR_SELECT "0 "
@@ -6439,6 +6446,12 @@ ERROR(objc_redecl_same,none,
       OBJC_DIAG_SELECT " with Objective-C selector %4 conflicts with "
       "previous declaration with the same Objective-C selector",
       (unsigned, DeclName, unsigned, DeclName, ObjCSelector))
+
+ERROR(objc_redecl_category_name,none,
+      "%select{|imported }0extension with Objective-C category name %2 "
+      "conflicts with previous %select{|imported }1extension with the same "
+      "category name",
+      (bool, bool, Identifier))
 
 ERROR(objc_override_other,none,
       OBJC_DIAG_SELECT " with Objective-C selector %4 conflicts with "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1764,16 +1764,16 @@ ERROR(attr_objc_implementation_must_be_unconditional,none,
       "only unconditional extensions can implement an Objective-C '@interface'",
       ())
 ERROR(attr_objc_implementation_must_be_imported,none,
-      "'@_objcImplementation' cannot be used to extend %kind0 because it was "
+      "'@objc @implementation' cannot be used to extend %kind0 because it was "
       "defined by a Swift 'class' declaration, not an imported Objective-C "
       "'@interface' declaration",
       (ValueDecl *))
 ERROR(attr_objc_implementation_must_have_super,none,
-      "'@_objcImplementation' cannot be used to implement root %kind0; declare "
-      "its superclass in the header",
+      "'@objc @implementation' cannot be used to implement root %kind0; "
+      "declare its superclass in the header",
       (ValueDecl *))
 ERROR(objc_implementation_cannot_have_generics,none,
-      "'@_objcImplementation' cannot be used to implement %kind0",
+      "'@objc @implementation' cannot be used to implement %kind0",
       (ValueDecl *))
 ERROR(attr_objc_implementation_category_not_found,none,
       "could not find category %0 on Objective-C class %1; make sure your "
@@ -1791,7 +1791,7 @@ ERROR(attr_objc_implementation_no_category_for_func,none,
       "name from this attribute",
       (ValueDecl*))
 ERROR(attr_objc_implementation_no_conformance,none,
-      "'@_objcImplementation' extension cannot add conformance to %0; "
+      "'@objc @implementation' extension cannot add conformance to %0; "
       "add this conformance %select{with an ordinary extension|"
       "in the Objective-C header}1",
       (Type, bool))
@@ -1919,7 +1919,7 @@ NOTE(objc_implementation_requirement_here,none,
      (ValueDecl *))
 
 ERROR(objc_implementation_init_must_be_convenience, none,
-      "%kind0 is not valid in an '@_objcImplementation' extension because "
+      "%kind0 is not valid in an '@objc @implementation' extension because "
       "Objective-C subclasses must be able to override "
       "%select{designated|required}1 initializers",
       (const ValueDecl *, /*isRequired=*/bool))
@@ -1933,7 +1933,7 @@ NOTE(objc_implementation_init_turn_required_to_convenience, none,
 
 // Fallback diagnostic; super-general by nature.
 ERROR(objc_implementation_member_requires_vtable, none,
-      "%kind0 is not valid in an '@_objcImplementation' extension because it "
+      "%kind0 is not valid in an '@objc @implementation' extension because it "
       "is an overridable Swift-only %kindonly0",
       (const ValueDecl *))
 

--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -74,6 +74,7 @@ FEATURE(IsolatedAny,                                    (6, 0))
 FEATURE(TaskExecutor,                                   FUTURE)
 FEATURE(Differentiation,                                FUTURE)
 FEATURE(InitRawStructMetadata,                          FUTURE)
+FEATURE(UpdatePureObjCClassMetadata,                    FUTURE)
 
 #undef FEATURE
 #undef FUTURE

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -970,6 +970,39 @@ public:
   bool isCached() const { return true; }
 };
 
+using ObjCCategoryNameMap =
+  llvm::DenseMap<Identifier, llvm::TinyPtrVector<ExtensionDecl *>>;
+
+/// Generate a map of all known extensions of the given class that have an
+/// explicit category name. This request does not force clang categories that
+/// haven't been imported already, but it will generate a new map if new
+/// categories have been imported since the cached value was generated.
+///
+/// \seeAlso ClassDecl::getObjCCategoryNameMap()
+class ObjCCategoryNameMapRequest
+    : public SimpleRequest<ObjCCategoryNameMapRequest,
+                           ObjCCategoryNameMap(ClassDecl *, ExtensionDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+  // Convenience to automatically extract `lastExtension`.
+  ObjCCategoryNameMapRequest(ClassDecl *classDecl)
+    : ObjCCategoryNameMapRequest(classDecl, classDecl->getLastExtension())
+  {}
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ObjCCategoryNameMap evaluate(Evaluator &evaluator,
+                               ClassDecl *classDecl,
+                               ExtensionDecl *lastExtension) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 #define SWIFT_TYPEID_ZONE NameLookup
 #define SWIFT_TYPEID_HEADER "swift/AST/NameLookupTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -116,3 +116,5 @@ SWIFT_REQUEST(NameLookup, ImplementsAttrProtocolRequest,
               ProtocolDecl *(const ImplementsAttr *, DeclContext *), Cached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, LookupIntrinsicRequest,
               FuncDecl *(ModuleDecl *, Identifier), Cached, NoLocationInfo)
+SWIFT_REQUEST(NameLookup, ObjCCategoryNameMapRequest,
+              ObjCCategoryNameMap(ClassDecl *, ExtensionDecl *), Cached, NoLocationInfo)

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -359,6 +359,10 @@ public:
   /// List of Objective-C member conflicts we have found during type checking.
   llvm::SetVector<ObjCMethodConflict> ObjCMethodConflicts;
 
+  /// Categories (extensions with explicit @objc names) declared in this
+  /// source file. They need to be checked for conflicts after type checking.
+  llvm::TinyPtrVector<ExtensionDecl *> ObjCCategories;
+
   /// List of attributes added by access notes, used to emit remarks for valid
   /// ones.
   llvm::DenseMap<ValueDecl *, std::vector<DeclAttribute *>>

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -201,6 +201,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(SendingArgsAndResults, 430, "Sending arg and resul
 LANGUAGE_FEATURE(BorrowingSwitch, 432, "Noncopyable type pattern matching")
 CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE(IsolatedAny, 431, "@isolated(any) function types")
 LANGUAGE_FEATURE(IsolatedAny2, 431, "@isolated(any) function types")
+LANGUAGE_FEATURE(ObjCImplementation, 436, "@objc @implementation extensions")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
@@ -374,9 +375,6 @@ EXPERIMENTAL_FEATURE(ClosureIsolation, true)
 
 // Whether lookup of members respects the enclosing file's imports.
 EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(MemberImportVisibility, true)
-
-// Enable @implementation on extensions of ObjC classes.
-EXPERIMENTAL_FEATURE(ObjCImplementation, true)
 
 // Enable @implementation on extensions of ObjC classes with non-fixed layout
 // due to resilient stored properties. Requires OS support; this flag exists for

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -378,6 +378,11 @@ EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(MemberImportVisibility, true
 // Enable @implementation on extensions of ObjC classes.
 EXPERIMENTAL_FEATURE(ObjCImplementation, true)
 
+// Enable @implementation on extensions of ObjC classes with non-fixed layout
+// due to resilient stored properties. Requires OS support; this flag exists for
+// staging purposes.
+EXPERIMENTAL_FEATURE(ObjCImplementationWithResilientStorage, true)
+
 // Enable @implementation on @_cdecl functions.
 EXPERIMENTAL_FEATURE(CImplementation, true)
 

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -256,7 +256,7 @@ struct ObjCInterfaceAndImplementation final {
   ObjCInterfaceAndImplementation()
       : interfaceDecls(), implementationDecl(nullptr) {}
 
-  operator bool() const {
+  bool empty() const {
     return interfaceDecls.empty();
   }
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -782,6 +782,13 @@ swift_updateClassMetadata2(ClassMetadata *self,
                            size_t numFields,
                            const TypeLayout * const *fieldTypes,
                            size_t *fieldOffsets);
+
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+Class
+swift_updatePureObjCClassMetadata(Class self,
+                                  ClassLayoutFlags flags,
+                                  size_t numFields,
+                                  const TypeLayout * const *fieldTypes);
 #endif
 
 /// Given class metadata, a class descriptor and a method descriptor, look up

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1437,6 +1437,19 @@ FUNCTION(UpdateClassMetadata2,
          EFFECT(MetaData),
          UNKNOWN_MEMEFFECTS)
 
+// objc_class *swift_updatePureObjCClassMetadata(
+//             objc_class *self,
+//             ClassLayoutFlags flags,
+//             size_t numFields,
+//             TypeLayout * const *fieldTypes);
+FUNCTION(UpdatePureObjCClassMetadata,
+         swift_updatePureObjCClassMetadata, SwiftCC, AlwaysAvailable,
+         RETURNS(ObjCClassPtrTy),
+         ARGS(ObjCClassPtrTy, SizeTy, SizeTy, Int8PtrPtrTy->getPointerTo()),
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         UNKNOWN_MEMEFFECTS)
+
 // void *swift_lookUpClassMethod(Metadata *metadata,
 //                               ClassDescriptor *description,
 //                               MethodDescriptor *method);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1326,6 +1326,14 @@ void PrintAST::printAttributes(const Decl *D) {
     }
   }
 
+  // If we are suppressing @implementation, also suppress @objc on extensions.
+  if (auto ED = dyn_cast<ExtensionDecl>(D)) {
+    if (ED->isObjCImplementation() &&
+            Options.excludeAttrKind(DeclAttrKind::ObjCImplementation)) {
+      Options.ExcludeAttrList.push_back(DeclAttrKind::ObjC);
+    }
+  }
+
   // We will handle ownership specifiers separately.
   if (isa<FuncDecl>(D)) {
     Options.ExcludeAttrList.push_back(DeclAttrKind::Mutating);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1922,16 +1922,6 @@ bool Decl::isObjCImplementation() const {
   return getAttrs().hasAttribute<ObjCImplementationAttr>(/*AllowInvalid=*/true);
 }
 
-std::optional<Identifier>
-ExtensionDecl::getCategoryNameForObjCImplementation() const {
-  auto attr = getAttrs()
-                  .getAttribute<ObjCImplementationAttr>(/*AllowInvalid=*/true);
-  if (!attr || attr->isCategoryNameInvalid())
-    return std::nullopt;
-
-  return attr->CategoryName;
-}
-
 PatternBindingDecl::PatternBindingDecl(SourceLoc StaticLoc,
                                        StaticSpellingKind StaticSpelling,
                                        SourceLoc VarLoc,
@@ -3749,6 +3739,20 @@ void ValueDecl::setIsObjC(bool value) {
   LazySemanticInfo.isObjC = value;
 }
 
+Identifier ExtensionDecl::getObjCCategoryName() const {
+  // If there's an @objc attribute, it's authoritative. (ClangImporter
+  // attaches one automatically.)
+  if (auto objcAttr = getAttrs().getAttribute<ObjCAttr>(/*AllowInvalid*/true)) {
+    if (objcAttr->hasName() && objcAttr->getName()->getNumArgs() == 0)
+      return objcAttr->getName()->getSimpleName();
+
+    return Identifier();
+  }
+
+  // Not a category, evidently.
+  return Identifier();
+}
+
 bool ValueDecl::isSemanticallyFinal() const {
   // Actor types are semantically final.
   if (auto classDecl = dyn_cast<ClassDecl>(this)) {
@@ -4043,25 +4047,86 @@ bool ValueDecl::canInferObjCFromRequirement(ValueDecl *requirement) {
   return false;
 }
 
-SourceLoc ValueDecl::getAttributeInsertionLoc(bool forModifier) const {
+SourceLoc Decl::getAttributeInsertionLoc(bool forModifier) const {
+  // Some decls have a parent/child split where the introducer keyword is on the
+  // parent, but the attributes are on the children. If this is a child in such
+  // a pair, `introDecl` will be changed to point to the parent. (The parent
+  // decl should delegate to one of its children.)
+  const Decl *introDecl = this;
+
+  switch (getKind()) {
+  case DeclKind::Module:
+  case DeclKind::TopLevelCode:
+  case DeclKind::IfConfig:
+  case DeclKind::PoundDiagnostic:
+  case DeclKind::Missing:
+  case DeclKind::MissingMember:
+  case DeclKind::MacroExpansion:
+  case DeclKind::BuiltinTuple:
+    // These don't take attributes.
+    return SourceLoc();
+
+  case DeclKind::EnumCase:
+    // An ECD's attributes are attached to its elements.
+    if (auto elem = cast<EnumCaseDecl>(this)->getFirstElement())
+      return elem->getAttributeInsertionLoc(forModifier);
+    break;
+
+  case DeclKind::EnumElement:
+    // An EED's introducer keyword is on its parent case.
+    if (auto parent = cast<EnumElementDecl>(this)->getParentCase())
+      introDecl = parent;
+    break;
+
+  case DeclKind::PatternBinding: {
+    // A PBD's attributes are attached to the vars in its patterns.
+    auto pbd = cast<PatternBindingDecl>(this);
+
+    for (unsigned i = 0; i < pbd->getNumPatternEntries(); i++) {
+      if (auto var = pbd->getAnchoringVarDecl(i)) {
+        return var->getAttributeInsertionLoc(forModifier);
+      }
+    }
+
+    break;
+  }
+
+  case DeclKind::Var:
+  case DeclKind::Param:
+    // A VarDecl's introducer keyword, if it has one, is on its pattern binding.
+    if (auto pbd = cast<VarDecl>(this)->getParentPatternBinding())
+      introDecl = pbd;
+    break;
+
+  case DeclKind::Enum:
+  case DeclKind::Struct:
+  case DeclKind::Class:
+  case DeclKind::Protocol:
+  case DeclKind::OpaqueType:
+  case DeclKind::TypeAlias:
+  case DeclKind::GenericTypeParam:
+  case DeclKind::AssociatedType:
+  case DeclKind::Subscript:
+  case DeclKind::Constructor:
+  case DeclKind::Destructor:
+  case DeclKind::Func:
+  case DeclKind::Accessor:
+  case DeclKind::Macro:
+  case DeclKind::Extension:
+  case DeclKind::Import:
+  case DeclKind::PrecedenceGroup:
+  case DeclKind::InfixOperator:
+  case DeclKind::PrefixOperator:
+  case DeclKind::PostfixOperator:
+    // Both the introducer keyword and the attributes are on `this`.
+    break;
+  }
+
   if (isImplicit())
     return SourceLoc();
 
-  if (auto var = dyn_cast<VarDecl>(this)) {
-    // [attrs] var ...
-    // The attributes are part of the VarDecl, but the 'var' is part of the PBD.
-    SourceLoc resultLoc = var->getAttrs().getStartLoc(forModifier);
-    if (resultLoc.isValid()) {
-      return resultLoc;
-    } else if (auto pbd = var->getParentPatternBinding()) {
-      return pbd->getStartLoc();
-    } else {
-      return var->getStartLoc();
-    }
-  }
-
   SourceLoc resultLoc = getAttrs().getStartLoc(forModifier);
-  return resultLoc.isValid() ? resultLoc : getStartLoc();
+  return resultLoc.isValid() ? resultLoc : introDecl->getStartLoc();
 }
 
 /// Returns true if \p VD needs to be treated as publicly-accessible
@@ -11255,7 +11320,7 @@ void swift::simple_display(llvm::raw_ostream &out, const Decl *decl) {
   }
 
   if (auto value = dyn_cast<ValueDecl>(decl)) {
-    simple_display(out, value);
+    return simple_display(out, value);
   } else if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
     out << "extension of ";
     if (auto typeRepr = ext->getExtendedTypeRepr())
@@ -11265,12 +11330,12 @@ void swift::simple_display(llvm::raw_ostream &out, const Decl *decl) {
   } else if (auto med = dyn_cast<MacroExpansionDecl>(decl)) {
     out << '#' << med->getMacroName() << " in ";
     printContext(out, med->getDeclContext());
-    if (med->getLoc().isValid()) {
-      out << '@';
-      med->getLoc().print(out, med->getASTContext().SourceMgr);
-    }
   } else {
     out << "(unknown decl)";
+  }
+  if (decl->getLoc().isValid()) {
+    out << '@';
+    decl->getLoc().print(out, decl->getASTContext().SourceMgr);
   }
 }
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -762,6 +762,7 @@ UNINTERESTING_FEATURE(IsolatedAny2)
 
 UNINTERESTING_FEATURE(ObjCImplementation)
 UNINTERESTING_FEATURE(CImplementation)
+UNINTERESTING_FEATURE(ObjCImplementationWithResilientStorage)
 
 UNINTERESTING_FEATURE(DebugDescriptionMacro)
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2262,6 +2262,35 @@ void NominalTypeDecl::recordObjCMethod(AbstractFunctionDecl *method,
   vec.push_back(method);
 }
 
+ObjCCategoryNameMap
+ObjCCategoryNameMapRequest::evaluate(Evaluator &evaluator,
+                                     ClassDecl *classDecl,
+                                     ExtensionDecl *lastExtension) const {
+  // The purpose of the `lastExtension` parameter is to bake something into the
+  // request that will change when another extension is added. This ensures that
+  // if more extensions are added later, we don't return an outdated version of
+  // the extension map by accident.
+
+  ObjCCategoryNameMap results;
+
+  for (auto ext : classDecl->getExtensions()) {
+    auto catName = ext->getObjCCategoryName();
+    if (!catName.empty())
+      results[catName].push_back(ext);
+
+    if (ext == lastExtension)
+      break;
+  }
+
+  return results;
+}
+
+ObjCCategoryNameMap ClassDecl::getObjCCategoryNameMap() {
+  return evaluateOrDefault(getASTContext().evaluator,
+                           ObjCCategoryNameMapRequest{this},
+                           ObjCCategoryNameMap());
+}
+
 /// Determine whether the given declaration is an acceptable lookup
 /// result when searching from the given DeclContext.
 static bool isAcceptableLookupResult(const DeclContext *dc,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5961,26 +5961,6 @@ struct OrderDecls {
 };
 }
 
-Identifier ExtensionDecl::getObjCCategoryName() const {
-  // Could it be an imported category?
-  if (!hasClangNode())
-    // Nope, not imported.
-    return Identifier();
-
-  auto category = dyn_cast<clang::ObjCCategoryDecl>(getClangDecl());
-  if (!category)
-    // Nope, not a category.
-    return Identifier();
-
-  // We'll look for an implementation with this category name.
-  auto clangCategoryName = category->getName();
-  if (clangCategoryName.empty())
-    // Class extension (has an empty name).
-    return Identifier();
-  
-  return getASTContext().getIdentifier(clangCategoryName);
-}
-
 static ObjCInterfaceAndImplementation
 constructResult(const llvm::TinyPtrVector<Decl *> &interfaces,
                 llvm::TinyPtrVector<Decl *> &impls,
@@ -5994,16 +5974,35 @@ constructResult(const llvm::TinyPtrVector<Decl *> &interfaces,
     auto &diags = interfaces.front()->getASTContext().Diags;
     for (auto extraImpl : llvm::ArrayRef<Decl *>(impls).drop_front()) {
       auto attr = extraImpl->getAttrs().getAttribute<ObjCImplementationAttr>();
-      attr->setCategoryNameInvalid();
+      attr->setInvalid();
 
-      diags.diagnose(attr->getLocation(), diag::objc_implementation_two_impls,
-                     categoryName, diagnoseOn)
-        .fixItRemove(attr->getRangeWithAt());
-      diags.diagnose(impls.front(), diag::previous_objc_implementation);
+      // @objc @implementations for categories are diagnosed as category
+      // conflicts, so we're only concerned with main class bodies and
+      // non-category implementations here.
+      if (categoryName.empty() || !isa<ExtensionDecl>(impls.front())) {
+        diags.diagnose(attr->getLocation(), diag::objc_implementation_two_impls,
+                       diagnoseOn)
+          .fixItRemove(attr->getRangeWithAt());
+        diags.diagnose(impls.front(), diag::previous_objc_implementation);
+      }
     }
   }
 
   return ObjCInterfaceAndImplementation(interfaces, impls.front());
+}
+
+static bool isImplValid(ExtensionDecl *ext) {
+  auto attr = ext->getAttrs().getAttribute<ObjCImplementationAttr>();
+
+  if (!attr)
+    return false;
+
+  // Clients using the stable syntax shouldn't have a category name on the attr.
+  // This is diagnosed in AttributeChecker::visitObjCImplementationAttr().
+  if (!attr->isEarlyAdopter() && !attr->CategoryName.empty())
+    return false;
+  
+  return !attr->isCategoryNameInvalid();
 }
 
 static ObjCInterfaceAndImplementation
@@ -6020,16 +6019,11 @@ findContextInterfaceAndImplementation(DeclContext *dc) {
   Identifier categoryName;
 
   if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
-    if (ext->hasClangNode()) {
-      // This is either an interface, or it's not objcImpl at all.
-      categoryName = ext->getObjCCategoryName();
-    } else {
-      // This is either the implementation, or it's not objcImpl at all.
-      if (auto name = ext->getCategoryNameForObjCImplementation())
-        categoryName = *name;
-      else
-        return {};
-    }
+    assert(ext);
+    if (!ext->hasClangNode() && !isImplValid(ext))
+      return {};
+
+    categoryName = ext->getObjCCategoryName();
   } else {
     // Must be an imported class. Look for its main implementation.
     assert(isa_and_nonnull<ClassDecl>(dc));
@@ -6043,7 +6037,8 @@ findContextInterfaceAndImplementation(DeclContext *dc) {
   llvm::TinyPtrVector<Decl *> implDecls;
   for (ExtensionDecl *ext : classDecl->getExtensions()) {
     if (ext->isObjCImplementation()
-        && ext->getCategoryNameForObjCImplementation() == categoryName)
+          && ext->getObjCCategoryName() == categoryName
+          && isImplValid(ext))
       implDecls.push_back(ext);
   }
 
@@ -6149,15 +6144,15 @@ evaluate(Evaluator &evaluator, Decl *decl) const {
 
 void swift::simple_display(llvm::raw_ostream &out,
                            const ObjCInterfaceAndImplementation &pair) {
-  if (!pair) {
+  if (pair.empty()) {
     out << "no clang interface or @_objcImplementation";
     return;
   }
 
-  out << "clang interface ";
-  simple_display(out, pair.interfaceDecls);
-  out << " with @_objcImplementation ";
+  out << "@implementation ";
   simple_display(out, pair.implementationDecl);
+  out << " matches clang interfaces ";
+  simple_display(out, pair.interfaceDecls);
 }
 
 SourceLoc
@@ -6173,7 +6168,8 @@ llvm::TinyPtrVector<Decl *> Decl::getAllImplementedObjCDecls() const {
     return {};
 
   ObjCInterfaceAndImplementationRequest req{const_cast<Decl *>(this)};
-  return evaluateOrDefault(getASTContext().evaluator, req, {}).interfaceDecls;
+  auto result = evaluateOrDefault(getASTContext().evaluator, req, {});
+  return result.interfaceDecls;
 }
 
 DeclContext *DeclContext::getImplementedObjCContext() const {
@@ -6189,8 +6185,8 @@ Decl *Decl::getObjCImplementationDecl() const {
     return nullptr;
 
   ObjCInterfaceAndImplementationRequest req{const_cast<Decl *>(this)};
-  return evaluateOrDefault(getASTContext().evaluator, req, {})
-             .implementationDecl;
+  auto result = evaluateOrDefault(getASTContext().evaluator, req, {});
+  return result.implementationDecl;
 }
 
 llvm::TinyPtrVector<Decl *>

--- a/lib/ClangImporter/ClangImporterRequests.cpp
+++ b/lib/ClangImporter/ClangImporterRequests.cpp
@@ -25,12 +25,14 @@ using namespace swift;
 std::optional<ObjCInterfaceAndImplementation>
 ObjCInterfaceAndImplementationRequest::getCachedResult() const {
   auto passedDecl = std::get<0>(getStorage());
-  if (!passedDecl)
+  if (!passedDecl) {
     return {};
+  }
 
-  if (!passedDecl->getCachedLacksObjCInterfaceOrImplementation())
+  if (passedDecl->getCachedLacksObjCInterfaceOrImplementation()) {
     // We've computed this request and found that this is a normal declaration.
     return {};
+  }
 
   // Either we've computed this request and cached a result in the ImporterImpl,
   // or we haven't computed this request. Check the caches.
@@ -44,20 +46,21 @@ ObjCInterfaceAndImplementationRequest::getCachedResult() const {
   // `ImplementationsByInterface`.
 
   Decl *implDecl = nullptr;
-  if (!passedDecl->hasClangNode()) {
-    // `passedDecl` *could* be an implementation.
+  if (passedDecl->hasClangNode()) {
+    // `passedDecl` *could* be an interface.
     auto iter = impl.ImplementationsByInterface.find(passedDecl);
     if (iter != impl.ImplementationsByInterface.end())
       implDecl = iter->second;
   } else {
-    // `passedDecl` *could* be an interface.
+    // `passedDecl` *could* be an implementation.
     implDecl = passedDecl;
   }
 
   if (implDecl) {
     auto iter = impl.InterfacesByImplementation.find(implDecl);
-    if (iter != impl.InterfacesByImplementation.end())
+    if (iter != impl.InterfacesByImplementation.end()) {
       return ObjCInterfaceAndImplementation(iter->second, implDecl);
+    }
   }
 
   // Nothing in the caches, so we must need to compute this.
@@ -68,7 +71,7 @@ void ObjCInterfaceAndImplementationRequest::
 cacheResult(ObjCInterfaceAndImplementation value) const {
   Decl *passedDecl = std::get<0>(getStorage());
 
-  if (!value) {
+  if (value.empty()) {
     // `decl` is neither an interface nor an implementation; remember this.
     passedDecl->setCachedLacksObjCInterfaceOrImplementation(true);
     return;

--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -19,6 +19,7 @@
 #define SWIFT_IRGEN_CLASSMETADATAVISITOR_H
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILModule.h"
@@ -67,6 +68,9 @@ protected:
     : super(IGM), Target(target), VTable(vtable) {}
 
 public:
+  bool isPureObjC() const {
+    return Target->getObjCImplementationDecl();
+  }
 
   // Layout in embedded mode while considering the class type.
   // This is important for adding the right superclass pointer.
@@ -90,6 +94,16 @@ public:
       asImpl().addDestructorFunction();
       asImpl().addIVarDestroyer();
       addEmbeddedClassMembers(Target);
+      return;
+    }
+
+    if (isPureObjC()) {
+      assert(IGM.ObjCInterop);
+      asImpl().noteAddressPoint();
+      asImpl().addMetadataFlags();
+      asImpl().addSuperclass();
+      asImpl().addClassCacheData();
+      asImpl().addClassDataPointer();
       return;
     }
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1138,12 +1138,13 @@ namespace {
       return pair.second;
     }
 
-    std::optional<StringRef> getObjCImplCategoryName() const {
-      if (!TheExtension || !TheExtension->isObjCImplementation())
+    std::optional<StringRef> getCustomCategoryName() const {
+      if (!TheExtension)
         return std::nullopt;
-      if (auto ident = TheExtension->getCategoryNameForObjCImplementation()) {
-        assert(!ident->empty());
-        return ident->str();
+      assert(!TheExtension->hasClangNode());
+      auto ident = TheExtension->getObjCCategoryName();
+      if (!ident.empty()) {
+        return ident.str();
       }
       return std::nullopt;
     }
@@ -1425,8 +1426,8 @@ namespace {
     void buildCategoryName(SmallVectorImpl<char> &s) {
       llvm::raw_svector_ostream os(s);
 
-      if (auto implementationCategoryName = getObjCImplCategoryName()) {
-        os << *implementationCategoryName;
+      if (auto customCategoryName = getCustomCategoryName()) {
+        os << *customCategoryName;
         return;
       }
 
@@ -2448,8 +2449,8 @@ namespace {
         os << "@";
         TheExtension->getLoc().print(os, IGM.Context.SourceMgr);
       }
-      if (auto name = getObjCImplCategoryName()) {
-        os << " objc_impl_category_name=" << *name;
+      if (auto name = getCustomCategoryName()) {
+        os << " custom_category_name=" << *name;
       }
       
       if (HasNonTrivialConstructor)

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5838,7 +5838,7 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
 
 static bool shouldEmitCategory(IRGenModule &IGM, ExtensionDecl *ext) {
   if (ext->isObjCImplementation()) {
-    assert(ext->getCategoryNameForObjCImplementation() != Identifier());
+    assert(!ext->getObjCCategoryName().empty());
     return true;
   }
 
@@ -5882,8 +5882,7 @@ void IRGenModule::emitExtension(ExtensionDecl *ext) {
   if (!origClass)
     return;
 
-  if (ext->isObjCImplementation()
-        && ext->getCategoryNameForObjCImplementation() == Identifier()) {
+  if (ext->isObjCImplementation() && ext->getObjCCategoryName().empty()) {
     // This is the @_objcImplementation for the class--generate its class
     // metadata.
     emitClassDecl(origClass);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2955,37 +2955,40 @@ IRGenModule::getAddrOfOriginalModuleContextDescriptor(StringRef Name) {
                                           .first->getValue());
 }
 
-static void emitInitializeFieldOffsetVector(IRGenFunction &IGF,
-                                            SILType T,
-                                            llvm::Value *metadata,
-                                            bool isVWTMutable,
-                                       MetadataDependencyCollector *collector) {
-  auto &IGM = IGF.IGM;
-
+void IRGenFunction::
+emitInitializeFieldOffsetVector(SILType T, llvm::Value *metadata,
+                                bool isVWTMutable,
+                                MetadataDependencyCollector *collector) {
   auto *target = T.getNominalOrBoundGenericNominal();
-  llvm::Value *fieldVector
-    = emitAddressOfFieldOffsetVector(IGF, metadata, target)
+
+  llvm::Value *fieldVector = nullptr;
+  // @objc @implementation classes don't actually have a field vector; for them,
+  // we're just trying to update the direct field offsets.
+  if (!isa<ClassDecl>(target)
+        || !cast<ClassDecl>(target)->getObjCImplementationDecl()) {
+    fieldVector = emitAddressOfFieldOffsetVector(*this, metadata, target)
       .getAddress();
-  
+  }
+
   // Collect the stored properties of the type.
   unsigned numFields = getNumFields(target);
 
   // Fill out an array with the field type metadata records.
-  Address fields = IGF.createAlloca(
-                   llvm::ArrayType::get(IGM.Int8PtrPtrTy, numFields),
-                   IGM.getPointerAlignment(), "classFields");
-  IGF.Builder.CreateLifetimeStart(fields, IGM.getPointerSize() * numFields);
-  fields = IGF.Builder.CreateStructGEP(fields, 0, Size(0));
+  Address fields = createAlloca(
+                     llvm::ArrayType::get(IGM.Int8PtrPtrTy, numFields),
+                     IGM.getPointerAlignment(), "classFields");
+  Builder.CreateLifetimeStart(fields, IGM.getPointerSize() * numFields);
+  fields = Builder.CreateStructGEP(fields, 0, Size(0));
 
   unsigned index = 0;
   forEachField(IGM, target, [&](Field field) {
     assert(field.isConcrete() &&
            "initializing offset vector for type with missing member?");
     SILType propTy = field.getType(IGM, T);
-    llvm::Value *fieldLayout = emitTypeLayoutRef(IGF, propTy, collector);
+    llvm::Value *fieldLayout = emitTypeLayoutRef(*this, propTy, collector);
     Address fieldLayoutAddr =
-      IGF.Builder.CreateConstArrayGEP(fields, index, IGM.getPointerSize());
-    IGF.Builder.CreateStore(fieldLayout, fieldLayoutAddr);
+      Builder.CreateConstArrayGEP(fields, index, IGM.getPointerSize());
+    Builder.CreateStore(fieldLayout, fieldLayoutAddr);
     ++index;
   });
   assert(index == numFields);
@@ -3011,29 +3014,41 @@ static void emitInitializeFieldOffsetVector(IRGenFunction &IGF,
       llvm_unreachable("Emitting metadata init for fixed class metadata?");
     }
 
-    llvm::Value *dependency;
-    
+    llvm::Value *dependency = nullptr;
+
     switch (IGM.getClassMetadataStrategy(classDecl)) {
     case ClassMetadataStrategy::Resilient:
     case ClassMetadataStrategy::Singleton:
       // Call swift_initClassMetadata().
-      dependency = IGF.Builder.CreateCall(
-          IGM.getInitClassMetadata2FunctionPointer(),
-          {metadata, IGM.getSize(Size(uintptr_t(flags))), numFieldsV,
-           fields.getAddress(), fieldVector});
+      assert(fieldVector && "Singleton/Resilient strategies not supported for "
+                            "objcImplementation");
+      dependency = Builder.CreateCall(
+            IGM.getInitClassMetadata2FunctionPointer(),
+            {metadata, IGM.getSize(Size(uintptr_t(flags))), numFieldsV,
+             fields.getAddress(), fieldVector});
       break;
 
     case ClassMetadataStrategy::Update:
     case ClassMetadataStrategy::FixedOrUpdate:
       assert(IGM.Context.LangOpts.EnableObjCInterop);
 
-      // Call swift_updateClassMetadata(). Note that the static metadata
-      // already references the superclass in this case, but we still want
-      // to ensure the superclass metadata is initialized first.
-      dependency = IGF.Builder.CreateCall(
-          IGM.getUpdateClassMetadata2FunctionPointer(),
-          {metadata, IGM.getSize(Size(uintptr_t(flags))), numFieldsV,
-           fields.getAddress(), fieldVector});
+      if (fieldVector) {
+        // Call swift_updateClassMetadata(). Note that the static metadata
+        // already references the superclass in this case, but we still want
+        // to ensure the superclass metadata is initialized first.
+        dependency = Builder.CreateCall(
+              IGM.getUpdateClassMetadata2FunctionPointer(),
+              {metadata, IGM.getSize(Size(uintptr_t(flags))), numFieldsV,
+               fields.getAddress(), fieldVector});
+      } else {
+        // If we don't have a field vector, we must be updating an
+        // @objc @implementation class layout. Call
+        // swift_updatePureObjCClassMetadata() instead.
+        Builder.CreateCall(
+              IGM.getUpdatePureObjCClassMetadataFunctionPointer(),
+              {metadata, IGM.getSize(Size(uintptr_t(flags))), numFieldsV,
+               fields.getAddress()});
+      }
       break;
 
     case ClassMetadataStrategy::Fixed:
@@ -3042,8 +3057,8 @@ static void emitInitializeFieldOffsetVector(IRGenFunction &IGF,
 
     // Collect any possible dependency from initializing the class; generally
     // this involves the superclass.
-    assert(collector);
-    collector->collect(IGF, dependency);
+    if (collector && dependency)
+      collector->collect(*this, dependency);
 
   } else {
     assert(isa<StructDecl>(target));
@@ -3054,12 +3069,12 @@ static void emitInitializeFieldOffsetVector(IRGenFunction &IGF,
       flags |= StructLayoutFlags::IsVWTMutable;
 
     // Call swift_initStructMetadata().
-    IGF.Builder.CreateCall(IGM.getInitStructMetadataFunctionPointer(),
-                           {metadata, IGM.getSize(Size(uintptr_t(flags))),
-                            numFieldsV, fields.getAddress(), fieldVector});
+    Builder.CreateCall(IGM.getInitStructMetadataFunctionPointer(),
+                       {metadata, IGM.getSize(Size(uintptr_t(flags))),
+                        numFieldsV, fields.getAddress(), fieldVector});
   }
 
-  IGF.Builder.CreateLifetimeEnd(fields, IGM.getPointerSize() * numFields);
+  Builder.CreateLifetimeEnd(fields, IGM.getPointerSize() * numFields);
 }
 
 static void emitInitializeFieldOffsetVectorWithLayoutString(
@@ -3321,8 +3336,8 @@ static void emitInitializeValueMetadata(IRGenFunction &IGF,
       emitInitializeFieldOffsetVectorWithLayoutString(IGF, loweredTy, metadata,
                                                       isVWTMutable, collector);
     } else {
-      emitInitializeFieldOffsetVector(IGF, loweredTy, metadata, isVWTMutable,
-                                      collector);
+      IGF.emitInitializeFieldOffsetVector(loweredTy, metadata, isVWTMutable,
+                                          collector);
     }
   } else {
     assert(isa<EnumDecl>(nominalDecl));
@@ -3354,9 +3369,9 @@ static void emitInitializeClassMetadata(IRGenFunction &IGF,
 
   // Set the superclass, fill out the field offset vector, and copy vtable
   // entries, generic requirements and field offsets from superclasses.
-  emitInitializeFieldOffsetVector(IGF, loweredTy,
-                                  metadata, /*VWT is mutable*/ false,
-                                  collector);
+  IGF.emitInitializeFieldOffsetVector(loweredTy,
+                                      metadata, /*VWT is mutable*/ false,
+                                      collector);
 
   // Realizing the class with the ObjC runtime will copy back to the
   // field offset globals for us; but if ObjC interop is disabled, we
@@ -3718,6 +3733,25 @@ createSingletonInitializationMetadataAccessFunction(IRGenModule &IGM,
                                           [&](IRGenFunction &IGF,
                                               DynamicMetadataRequest request,
                                               llvm::Constant *cacheVariable) {
+    if (auto CD = dyn_cast<ClassDecl>(typeDecl)) {
+      if (CD->getObjCImplementationDecl()) {
+        // Use the Objective-C runtime symbol instead of the Swift one.
+        llvm::Value *descriptor =
+          IGF.IGM.getAddrOfObjCClass(CD, NotForDefinition);
+
+        // Make the ObjC runtime initialize the class.
+        llvm::Value *initializedDescriptor =
+          IGF.Builder.CreateCall(IGF.IGM.getFixedClassInitializationFn(),
+                                 {descriptor});
+
+        // Turn the ObjC class into a valid Swift metadata pointer.
+        auto response =
+          IGF.Builder.CreateCall(IGF.IGM.getGetObjCClassMetadataFunctionPointer(),
+                                 {initializedDescriptor});
+        return MetadataResponse::forComplete(response);
+      }
+    }
+
     llvm::Value *descriptor =
       IGF.IGM.getAddrOfTypeContextDescriptor(typeDecl, RequireMetadata);
     auto responsePair =
@@ -3951,6 +3985,7 @@ namespace {
 
   public:
     const ClassLayout &getFieldLayout() const { return FieldLayout; }
+    using super::isPureObjC;
 
     SILType getLoweredType() {
       return IGM.getLoweredType(Target->getDeclaredTypeInContext());
@@ -3964,9 +3999,7 @@ namespace {
     ClassFlags getClassFlags() { return ::getClassFlags(Target); }
 
     void addClassFlags() {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       B.addInt32((uint32_t)asImpl().getClassFlags());
     }
 
@@ -4002,9 +4035,7 @@ namespace {
     }
 
     void addValueWitnessTable() {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       B.add(asImpl().getValueWitnessTable(false).getValue());
     }
 
@@ -4122,9 +4153,7 @@ namespace {
     }
 
     void addLayoutStringPointer() {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       if (auto *layoutString = getLayoutString()) {
         B.addSignedPointer(layoutString,
                            IGM.getOptions().PointerAuth.TypeLayoutString,
@@ -4149,8 +4178,7 @@ namespace {
         return;
       }
 
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
+      assert(!isPureObjC());
 
       if (auto ptr = getAddrOfDestructorFunction(IGM, Target)) {
         B.addSignedPointer(*ptr,
@@ -4181,8 +4209,7 @@ namespace {
         return;
       }
 
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
+      assert(!isPureObjC());
 
       auto dtorFunc = IGM.getAddrOfIVarInitDestroy(Target,
                                                    /*isDestroyer=*/ true,
@@ -4206,9 +4233,7 @@ namespace {
     }
 
     void addNominalTypeDescriptor() {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       B.addSignedPointer(asImpl().getNominalTypeDescriptor(),
                          IGM.getOptions().PointerAuth.TypeDescriptors,
                          PointerAuthEntity::Special::TypeDescriptor);
@@ -4223,9 +4248,7 @@ namespace {
     }
 
     void addInstanceAddressPoint() {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       // Right now, we never allocate fields before the address point.
       B.addInt32(0);
     }
@@ -4235,9 +4258,7 @@ namespace {
     const ClassLayout &getFieldLayout() { return FieldLayout; }
 
     void addInstanceSize() {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       if (asImpl().hasFixedLayout()) {
         B.addInt32(asImpl().getFieldLayout().getSize().getValue());
       } else {
@@ -4247,9 +4268,7 @@ namespace {
     }
     
     void addInstanceAlignMask() {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       if (asImpl().hasFixedLayout()) {
         B.addInt16(asImpl().getFieldLayout().getAlignMask().getValue());
       } else {
@@ -4259,24 +4278,18 @@ namespace {
     }
 
     void addRuntimeReservedBits() {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       B.addInt16(0);
     }
 
     void addClassSize() {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       auto size = MetadataLayout.getSize();
       B.addInt32(size.FullSize.getValue());
     }
 
     void addClassAddressPoint() {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       // FIXME: Wrong
       auto size = MetadataLayout.getSize();
       B.addInt32(size.AddressPoint.getValue());
@@ -4293,6 +4306,9 @@ namespace {
     llvm::Constant *getROData() { return emitClassPrivateData(IGM, Target); }
 
     uint64_t getClassDataPointerHasSwiftMetadataBits() {
+      // objcImpl classes should not have the Swift bit set.
+      if (isPureObjC())
+        return 0;
       return IGM.UseDarwinPreStableABIBit ? 1 : 2;
     }
 
@@ -4308,15 +4324,13 @@ namespace {
       // Derive the RO-data.
       llvm::Constant *data = asImpl().getROData();
 
-      if (!asImpl().getFieldLayout().hasObjCImplementation()) {
-        // Set a low bit to indicate this class has Swift metadata.
-        auto bit = llvm::ConstantInt::get(
-            IGM.IntPtrTy, asImpl().getClassDataPointerHasSwiftMetadataBits());
+      // Set a low bit to indicate this class has Swift metadata.
+      auto bit = llvm::ConstantInt::get(
+          IGM.IntPtrTy, asImpl().getClassDataPointerHasSwiftMetadataBits());
 
-        // Emit data + bit.
-        data = llvm::ConstantExpr::getPtrToInt(data, IGM.IntPtrTy);
-        data = llvm::ConstantExpr::getAdd(data, bit);
-      }
+      // Emit data + bit.
+      data = llvm::ConstantExpr::getPtrToInt(data, IGM.IntPtrTy);
+      data = llvm::ConstantExpr::getAdd(data, bit);
 
       B.add(data);
     }
@@ -4387,6 +4401,9 @@ namespace {
       if (IGM.getClassMetadataStrategy(Target) == ClassMetadataStrategy::Fixed)
         return;
 
+      if (isPureObjC())
+        return;
+
       emitMetadataCompletionFunction(
           IGM, Target,
           [&](IRGenFunction &IGF, llvm::Value *metadata,
@@ -4427,15 +4444,14 @@ namespace {
       : super(IGM, theClass, builder, fieldLayout, vtable) {}
 
     void addFieldOffset(VarDecl *var) {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       addFixedFieldOffset(IGM, B, var, [](DeclContext *dc) {
         return dc->getDeclaredTypeInContext();
       });
     }
 
     void addFieldOffsetPlaceholders(MissingMemberDecl *placeholder) {
+      assert(!isPureObjC());
       llvm_unreachable("Fixed class metadata cannot have missing members");
     }
 
@@ -4461,18 +4477,14 @@ namespace {
       : super(IGM, theClass, builder, fieldLayout) {}
 
     void addFieldOffset(VarDecl *var) {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       // Field offsets are either copied from the superclass or calculated
       // at runtime.
       B.addInt(IGM.SizeTy, 0);
     }
 
     void addFieldOffsetPlaceholders(MissingMemberDecl *placeholder) {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       for (unsigned i = 0,
                     e = placeholder->getNumberOfFieldOffsetVectorEntries();
            i < e; ++i) {
@@ -4513,12 +4525,12 @@ namespace {
       : IGM(IGM), Target(theClass), B(builder), FieldLayout(fieldLayout) {}
 
     llvm::Constant *emitNominalTypeDescriptor() {
-      if (FieldLayout.hasObjCImplementation())
-        return nullptr;
       return ClassContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
     }
 
     void layout() {
+      assert(!FieldLayout.hasObjCImplementation()
+                && "Resilient class metadata not supported for @objcImpl");
       emitNominalTypeDescriptor();
 
       addRelocationFunction();
@@ -4541,17 +4553,11 @@ namespace {
     }
 
     void addDestructorFunction() {
-      if (FieldLayout.hasObjCImplementation())
-        return;
-
       auto function = getAddrOfDestructorFunction(IGM, Target);
       B.addCompactFunctionReferenceOrNull(function ? *function : nullptr);
     }
 
     void addIVarDestroyer() {
-      if (FieldLayout.hasObjCImplementation())
-        return;
-
       auto function = IGM.getAddrOfIVarInitDestroy(Target,
                                                    /*isDestroyer=*/ true,
                                                    /*isForeign=*/ false,
@@ -4560,9 +4566,6 @@ namespace {
     }
 
     void addClassFlags() {
-      if (FieldLayout.hasObjCImplementation())
-        return;
-
       B.addInt32((uint32_t) getClassFlags(Target));
     }
 
@@ -4625,7 +4628,7 @@ namespace {
       // @_objcImplementation on true (non-ObjC) generic classes doesn't make
       // much sense, and we haven't updated this builder to handle it.
       assert(!FieldLayout.hasObjCImplementation()
-             && "@_objcImplementation class with generic metadata?");
+             && "Generic metadata not supported for @objcImpl");
 
       super::layoutHeader();
 
@@ -4977,14 +4980,13 @@ namespace {
     }
 
     void addFieldOffsetPlaceholders(MissingMemberDecl *placeholder) {
+      assert(!isPureObjC());
       llvm_unreachable(
           "Prespecialized generic class metadata cannot have missing members");
     }
 
     void addFieldOffset(VarDecl *var) {
-      if (asImpl().getFieldLayout().hasObjCImplementation())
-        return;
-
+      assert(!isPureObjC());
       addFixedFieldOffset(IGM, B, var, [&](DeclContext *dc) {
         return dc->mapTypeIntoContext(type);
       });
@@ -5007,6 +5009,7 @@ namespace {
     }
 
     uint64_t getClassDataPointerHasSwiftMetadataBits() {
+      assert(!isPureObjC());
       return super::getClassDataPointerHasSwiftMetadataBits() | 2;
     }
 
@@ -5051,12 +5054,87 @@ static void emitObjCClassSymbol(IRGenModule &IGM, ClassDecl *classDecl,
       .to(alias, link.isForDefinition());
 }
 
+/// Check whether the metadata update strategy requires runtime support that is
+/// not guaranteed available by the minimum deployment target, and diagnose if
+/// so.
+static void
+diagnoseUnsupportedObjCImplLayout(IRGenModule &IGM, ClassDecl *classDecl,
+                                  const ClassLayout &fragileLayout) {
+  if (!fragileLayout.hasObjCImplementation())
+    return;
+
+  auto strategy = IGM.getClassMetadataStrategy(classDecl);
+
+  switch (strategy) {
+  case ClassMetadataStrategy::Fixed:
+    // Fixed is just fine; no special support needed.
+    break;
+
+  case ClassMetadataStrategy::FixedOrUpdate:
+  case ClassMetadataStrategy::Update: {
+    auto &ctx = IGM.Context;
+
+    // Update and FixedOrUpdate require support in both the Swift and ObjC
+    // runtimes.
+    auto requiredAvailability=ctx.getUpdatePureObjCClassMetadataAvailability();
+    // FIXME: Take the class's availability into account
+    auto currentAvailability = AvailabilityContext::forDeploymentTarget(ctx);
+    if (currentAvailability.isContainedIn(requiredAvailability))
+      break;
+
+    // We don't have the support we need. Find and diagnose the variable-size
+    // stored properties.
+    auto &diags = ctx.Diags;
+
+    bool diagnosed = false;
+    forEachField(IGM, classDecl, [&](Field field) {
+      auto elemLayout = fragileLayout.getFieldAccessAndElement(field).second;
+      if (field.getKind() != Field::Kind::Var ||
+            elemLayout.getType().isFixedSize())
+        return;
+
+      if (ctx.LangOpts.hasFeature(
+                    Feature::ObjCImplementationWithResilientStorage))
+        diags.diagnose(
+            field.getVarDecl(),
+            diag::attr_objc_implementation_resilient_property_deployment_target,
+            prettyPlatformString(targetPlatform(ctx.LangOpts)),
+            currentAvailability.getOSVersion().getLowerEndpoint(),
+            requiredAvailability.getOSVersion().getLowerEndpoint());
+      else
+        diags.diagnose(
+            field.getVarDecl(),
+            diag::attr_objc_implementation_resilient_property_not_supported);
+
+      diagnosed = true;
+    });
+
+    // We should have found at least one property to complain about.
+    if (diagnosed)
+      break;
+
+    LLVM_FALLTHROUGH;
+  }
+
+  case ClassMetadataStrategy::Singleton:
+  case ClassMetadataStrategy::Resilient:
+    // This isn't supposed to happen, but just in case, let's give some sort of
+    // vaguely legible output instead of using llvm_unreachable().
+    IGM.error(classDecl->getLoc(),
+              llvm::Twine("class '") + classDecl->getBaseIdentifier().str() +
+              "' needs a metadata strategy not supported by @implementation");
+    break;
+  }
+}
+
 /// Emit the type metadata or metadata template for a class.
 void irgen::emitClassMetadata(IRGenModule &IGM, ClassDecl *classDecl,
                               const ClassLayout &fragileLayout,
                               const ClassLayout &resilientLayout) {
   assert(!classDecl->isForeign());
   PrettyStackTraceDecl stackTraceRAII("emitting metadata for", classDecl);
+
+  diagnoseUnsupportedObjCImplLayout(IGM, classDecl, fragileLayout);
 
   emitFieldOffsetGlobals(IGM, classDecl, fragileLayout, resilientLayout);
 

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -59,6 +59,7 @@ namespace irgen {
   class IRGenModule;
   class LinkEntity;
   class LocalTypeDataCache;
+  class MetadataDependencyCollector;
   class MetadataResponse;
   class Scope;
   class TypeInfo;
@@ -392,6 +393,12 @@ public:
   FunctionPointer emitValueWitnessFunctionRef(SILType type,
                                               llvm::Value *&metadataSlot,
                                               ValueWitness index);
+
+  void emitInitializeFieldOffsetVector(SILType T,
+                                       llvm::Value *metadata,
+                                       bool isVWTMutable,
+                                       MetadataDependencyCollector *collector);
+
 
   llvm::Value *optionallyLoadFromConditionalProtocolWitnessTable(
     llvm::Value *wtable);

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -280,6 +280,10 @@ llvm::Value *irgen::emitArgumentPackShapeRef(IRGenFunction &IGF,
 Address irgen::emitAddressOfFieldOffsetVector(IRGenFunction &IGF,
                                               llvm::Value *metadata,
                                               NominalTypeDecl *decl) {
+  assert(!isa<ClassDecl>(decl)
+            || !cast<ClassDecl>(decl)->getObjCImplementationDecl()
+                && "objcImpl classes don't have a field offset vector");
+
   auto &layout = IGF.IGM.getMetadataLayout(decl);
   auto offset = [&]() {
     if (isa<ClassDecl>(decl)) {

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -824,6 +824,10 @@ private:
   void buildCategoryName(const ExtensionDecl *ext, const ClassDecl *cls,
                          SmallVectorImpl<char> &s) {
     llvm::raw_svector_ostream os(s);
+    if (!ext->getObjCCategoryName().empty()) {
+      os << ext->getObjCCategoryName();
+      return;
+    }
     ModuleDecl *module = ext->getParentModule();
     os << module->getName();
     unsigned categoryCount = CategoryCounts[{cls, module}]++;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7138,6 +7138,20 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     status |= whereStatus;
   }
 
+  // @implementation requires an explicit @objc attribute, but
+  // @_objcImplementation didn't. Insert one if necessary.
+  auto implAttr = Attributes.getAttribute<ObjCImplementationAttr>();
+  if (implAttr && implAttr->isEarlyAdopter()
+        && !Attributes.hasAttribute<ObjCAttr>()) {
+    ObjCAttr *objcAttr;
+    if (implAttr->CategoryName.empty())
+      objcAttr = ObjCAttr::createUnnamedImplicit(Context);
+    else
+      objcAttr = ObjCAttr::createNullary(Context, implAttr->CategoryName,
+                                         /*isNameImplicit=*/false);
+    Attributes.add(objcAttr);
+  }
+
   ExtensionDecl *ext = ExtensionDecl::create(Context, ExtensionLoc,
                                              extendedType.getPtrOrNull(),
                                              Context.AllocateCopy(Inherited),

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -403,7 +403,10 @@ private:
       os << "\n";
     os << "@interface " << getNameForObjC(baseClass);
     maybePrintObjCGenericParameters(baseClass);
-    os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
+    if (ED->getObjCCategoryName().empty())
+      os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
+    else
+      os << " (" << ED->getObjCCategoryName() << ")";
     printProtocols(ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
     printMembers(ED->getMembers());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1598,6 +1598,17 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
 
       return;
     }
+
+    // While it's possible that @objc @implementation would function with
+    // pre-stable runtimes, this isn't a configuration that's been tested or
+    // supported.
+    auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(Ctx);
+    if (!deploymentAvailability.isContainedIn(Ctx.getSwift50Availability())) {
+      diagnose(attr->getLocation(),
+               diag::attr_objc_implementation_raise_minimum_deployment_target,
+               prettyPlatformString(targetPlatform(Ctx.LangOpts)),
+               Ctx.getSwift50Availability().getOSVersion().getLowerEndpoint());
+    }
   }
   else if (auto AFD = dyn_cast<AbstractFunctionDecl>(D)) {
     if (!hasObjCImplementationFeature(D, attr, Feature::CImplementation))

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1429,6 +1429,12 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
                                     attr->getLParenLoc(), firstNameLoc,
                                     objcName->getSelectorPieces()[0],
                                     attr->getRParenLoc()));
+      } else if (auto Ext = dyn_cast<ExtensionDecl>(D)) {
+        assert(Ext->getSelfClassDecl());
+        // This is an extension with an explicit, and otherwise valid, category
+        // name. Schedule it to be checked for name conflicts later.
+        if (auto *SF = Ext->getParentSourceFile())
+          SF->ObjCCategories.push_back(Ext);
       }
     } else if (isa<SubscriptDecl>(D) || isa<DestructorDecl>(D)) {
       SourceLoc diagLoc = attr->getLParenLoc();
@@ -1521,7 +1527,9 @@ void AttributeChecker::visitNonObjCAttr(NonObjCAttr *attr) {
 
 static bool hasObjCImplementationFeature(Decl *D, ObjCImplementationAttr *attr,
                                          Feature requiredFeature) {
-  if (D->getASTContext().LangOpts.hasFeature(requiredFeature))
+  auto &ctx = D->getASTContext();
+
+  if (ctx.LangOpts.hasFeature(requiredFeature))
     return true;
 
   // Allow the use of @_objcImplementation *without* Feature::ObjCImplementation
@@ -1532,17 +1540,72 @@ static bool hasObjCImplementationFeature(Decl *D, ObjCImplementationAttr *attr,
 
   // Either you're using Feature::ObjCImplementation without the early adopter
   // syntax, or you're using Feature::CImplementation. Either way, no go.
-  swift::diagnoseAndRemoveAttr(D, attr, diag::requires_experimental_feature,
-                               attr->getAttrName(), attr->isDeclModifier(),
-                               getFeatureName(requiredFeature));
+  ctx.Diags.diagnose(attr->getLocation(), diag::requires_experimental_feature,
+                     attr->getAttrName(), attr->isDeclModifier(),
+                     getFeatureName(requiredFeature));
   return false;
+}
+
+static SourceRange getArgListRange(ASTContext &Ctx, DeclAttribute *attr) {
+  // attr->getRange() covers the attr name and argument list; adjust it to
+  // exclude the first token.
+  auto newStart = Lexer::getLocForEndOfToken(Ctx.SourceMgr,
+                                             attr->getRange().Start);
+  if (attr->getRange().contains(newStart)) {
+    return SourceRange(newStart, attr->getRange().End);
+  }
+  return SourceRange();
 }
 
 void AttributeChecker::
 visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
+  DeclAttribute * langAttr =
+    D->getAttrs().getAttribute<ObjCAttr>(/*AllowInvalid=*/true);
+  if (!langAttr)
+    langAttr = D->getAttrs().getAttribute<CDeclAttr>(/*AllowInvalid=*/true);
+
+  if (!langAttr) {
+    diagnose(attr->getLocation(), diag::attr_implementation_requires_language);
+
+    // If this is an extension, suggest '@objc'.
+    if (auto ED = dyn_cast<ExtensionDecl>(D)) {
+      auto diag = diagnose(attr->getLocation(),
+                           diag::make_decl_objc_for_implementation,
+                           D->getDescriptiveKind());
+
+      ObjCSelector correctSelector(Ctx, 0, {attr->CategoryName});
+      fixDeclarationObjCName(diag, ED, ObjCSelector(), correctSelector);
+    }
+
+    return;
+  }
+
   if (auto ED = dyn_cast<ExtensionDecl>(D)) {
     if (!hasObjCImplementationFeature(D, attr, Feature::ObjCImplementation))
       return;
+
+    auto objcLangAttr = dyn_cast<ObjCAttr>(langAttr);
+    assert(objcLangAttr && "extension with @_cdecl or another lang attr???");
+
+    // Only early adopters should specify the category name on the attribute;
+    // the stabilized syntax uses @objc(CustomName) for that.
+    if (!attr->isEarlyAdopter() && !attr->CategoryName.empty()) {
+      auto diag = diagnose(attr->getLocation(),
+                           diag::attr_implementation_category_goes_on_objc_attr);
+
+      ObjCSelector correctSelector(Ctx, 0, {attr->CategoryName});
+      auto argListRange = getArgListRange(Ctx, attr);
+      if (argListRange.isValid()) {
+        diag.fixItRemove(argListRange);
+        fixDeclarationObjCName(diag, ED, objcLangAttr->getName(),
+                               correctSelector);
+      }
+      objcLangAttr->setName(correctSelector, /*implicit=*/false);
+
+      attr->setCategoryNameInvalid();
+
+      return;
+    }
 
     if (ED->isConstrainedExtension())
       diagnoseAndRemoveAttr(attr,
@@ -1550,11 +1613,8 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
 
     auto CD = dyn_cast<ClassDecl>(ED->getExtendedNominal());
     if (!CD) {
-      diagnoseAndRemoveAttr(attr,
-                            diag::attr_objc_implementation_must_extend_class,
-                            ED->getExtendedNominal());
-      ED->getExtendedNominal()->diagnose(diag::decl_declared_here,
-                                         ED->getExtendedNominal());
+      // This will be diagnosed as diag::objc_extension_not_class.
+      attr->setInvalid();
       return;
     }
 
@@ -1566,35 +1626,36 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
     }
 
     if (!CD->hasSuperclass()) {
-      diagnoseAndRemoveAttr(attr, diag::attr_objc_implementation_must_have_super,
-                            CD);
+      diagnoseAndRemoveAttr(attr,
+                            diag::attr_objc_implementation_must_have_super, CD);
       CD->diagnose(diag::decl_declared_here, CD);
       return;
     }
 
     if (CD->isTypeErasedGenericClass()) {
-      diagnoseAndRemoveAttr(attr, diag::objc_implementation_cannot_have_generics,
-                            CD);
+      diagnoseAndRemoveAttr(attr,
+                            diag::objc_implementation_cannot_have_generics, CD);
       CD->diagnose(diag::decl_declared_here, CD);
+      return;
     }
 
     if (!attr->isCategoryNameInvalid() && !ED->getImplementedObjCDecl()) {
       diagnose(attr->getLocation(),
                diag::attr_objc_implementation_category_not_found,
-               attr->CategoryName, CD);
+               ED->getObjCCategoryName(), CD);
 
-      // attr->getRange() covers the attr name and argument list; adjust it to
-      // exclude the first token.
-      auto newStart = Lexer::getLocForEndOfToken(Ctx.SourceMgr,
-                                                 attr->getRange().Start);
-      if (attr->getRange().contains(newStart)) {
-        auto argListRange = SourceRange(newStart, attr->getRange().End);
+      SourceRange argListRange;
+      if (attr->CategoryName.empty())
+        argListRange = getArgListRange(Ctx, langAttr);
+      else
+        argListRange = getArgListRange(Ctx, attr);
+      if (argListRange.isValid()) {
         diagnose(attr->getLocation(),
                  diag::attr_objc_implementation_fixit_remove_category_name)
             .fixItRemove(argListRange);
       }
 
-      attr->setCategoryNameInvalid();
+      attr->setInvalid();
 
       return;
     }
@@ -1619,12 +1680,8 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
           diagnose(attr->getLocation(),
                    diag::attr_objc_implementation_no_category_for_func, AFD);
 
-      // attr->getRange() covers the attr name and argument list; adjust it to
-      // exclude the first token.
-      auto newStart = Lexer::getLocForEndOfToken(Ctx.SourceMgr,
-                                                 attr->getRange().Start);
-      if (attr->getRange().contains(newStart)) {
-        auto argListRange = SourceRange(newStart, attr->getRange().End);
+      auto argListRange = getArgListRange(Ctx, attr);
+      if (argListRange.isValid()) {
         diagnostic.fixItRemove(argListRange);
       }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1665,10 +1665,13 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
     // supported.
     auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(Ctx);
     if (!deploymentAvailability.isContainedIn(Ctx.getSwift50Availability())) {
-      diagnose(attr->getLocation(),
+      auto diag = diagnose(attr->getLocation(),
                diag::attr_objc_implementation_raise_minimum_deployment_target,
                prettyPlatformString(targetPlatform(Ctx.LangOpts)),
                Ctx.getSwift50Availability().getOSVersion().getLowerEndpoint());
+      if (attr->isEarlyAdopter()) {
+        diag.wrapIn(diag::wrap_objc_implementation_will_become_error);
+      }
     }
   }
   else if (auto AFD = dyn_cast<AbstractFunctionDecl>(D)) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1851,26 +1851,15 @@ static void fixAvailabilityForDecl(SourceRange ReferenceRange, const Decl *D,
   // parsing.
   const Decl *ConcDecl = concreteSyntaxDeclForAvailableAttribute(D);
 
-  DescriptiveDeclKind KindForDiagnostic = ConcDecl->getDescriptiveKind();
-  SourceLoc InsertLoc;
-
   // To avoid exposing the pattern binding declaration to the user, get the
-  // descriptive kind from one of the VarDecls. We get the Fix-It location
-  // from the PatternBindingDecl unless the VarDecl has attributes,
-  // in which case we get the start location of the VarDecl attributes.
-  DeclAttributes AttrsForLoc;
+  // descriptive kind from one of the VarDecls.
+  DescriptiveDeclKind KindForDiagnostic = ConcDecl->getDescriptiveKind();
   if (KindForDiagnostic == DescriptiveDeclKind::PatternBinding) {
     KindForDiagnostic = D->getDescriptiveKind();
-    AttrsForLoc = D->getAttrs();
-  } else {
-    InsertLoc = ConcDecl->getAttrs().getStartLoc(/*forModifiers=*/false);
   }
 
-  InsertLoc = D->getAttrs().getStartLoc(/*forModifiers=*/false);
-  if (InsertLoc.isInvalid()) {
-    InsertLoc = ConcDecl->getStartLoc();
-  }
-
+  SourceLoc InsertLoc =
+      ConcDecl->getAttributeInsertionLoc(/*forModifier=*/false);
   if (InsertLoc.isInvalid())
     return;
 
@@ -4518,10 +4507,7 @@ void swift::checkExplicitAvailability(Decl *decl) {
 
     auto suggestPlatform = ctx.LangOpts.RequireExplicitAvailabilityTarget;
     if (!suggestPlatform.empty()) {
-      auto InsertLoc = decl->getAttrs().getStartLoc(/*forModifiers=*/false);
-      if (InsertLoc.isInvalid())
-        InsertLoc = decl->getStartLoc();
-
+      auto InsertLoc = decl->getAttributeInsertionLoc(/*forModifiers=*/false);
       if (InsertLoc.isInvalid())
         return;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -962,11 +962,6 @@ IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
     return true;
   }
 
-  // @_objcImplementation extension member implementations are implicitly
-  // dynamic.
-  if (decl->isObjCMemberImplementation())
-    return true;
-
   if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
     // Runtime-replaceable accessors are dynamic when their storage declaration
     // is dynamic and they were explicitly defined or they are implicitly defined

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -38,6 +38,13 @@ using namespace swift;
 DiagnosticBehavior
 swift::behaviorLimitForObjCReason(ObjCReason reason, ASTContext &ctx) {
   switch(reason) {
+  case ObjCReason::MemberOfObjCImplementationExtension:
+    // If they're using the old syntax, soften to a warning.
+    if (cast<ObjCImplementationAttr>(reason.getAttr())->isEarlyAdopter())
+      return DiagnosticBehavior::Warning;
+
+    LLVM_FALLTHROUGH;
+
   case ObjCReason::ExplicitlyCDecl:
   case ObjCReason::ExplicitlyDynamic:
   case ObjCReason::ExplicitlyObjC:
@@ -51,7 +58,6 @@ swift::behaviorLimitForObjCReason(ObjCReason reason, ASTContext &ctx) {
   case ObjCReason::WitnessToObjC:
   case ObjCReason::ImplicitlyObjC:
   case ObjCReason::MemberOfObjCExtension:
-  case ObjCReason::MemberOfObjCImplementationExtension:
     return DiagnosticBehavior::Unspecified;
 
   case ObjCReason::ExplicitlyIBInspectable:

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -71,7 +71,7 @@ public:
     ExplicitlyGKInspectable,
     /// Is it a member of an @objc extension of a class.
     MemberOfObjCExtension,
-    /// Is it a member of an \@\_objcImplementation extension.
+    /// Is it a member of an \@objc \@implementation extension.
     MemberOfObjCImplementationExtension,
     /// Has an explicit '@objc' attribute added by an access note, rather than
     /// written in source code.
@@ -212,7 +212,7 @@ bool fixDeclarationName(InFlightDiagnostic &diag, const ValueDecl *decl,
 ///
 /// For properties, the selector should be a zero-parameter selector of the
 /// given property's name.
-bool fixDeclarationObjCName(InFlightDiagnostic &diag, const ValueDecl *decl,
+bool fixDeclarationObjCName(InFlightDiagnostic &diag, const Decl *decl,
                             std::optional<ObjCSelector> nameOpt,
                             std::optional<ObjCSelector> targetNameOpt,
                             bool ignoreImpliedName = false);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3510,8 +3510,7 @@ static void finishStorageImplInfo(AbstractStorageDecl *storage,
 
       // @_objcImplementation extensions on a non-category can declare stored
       // properties; StoredPropertiesRequest knows to look for them there.
-      if (ext->isObjCImplementation() &&
-          ext->getCategoryNameForObjCImplementation() == Identifier())
+      if (ext->isObjCImplementation() && ext->getObjCCategoryName().empty())
         return;
 
       storage->diagnose(diag::extension_stored_property);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -380,6 +380,7 @@ void swift::performWholeModuleTypeChecking(SourceFile &SF) {
   case SourceFileKind::Main:
   case SourceFileKind::MacroExpansion:
     diagnoseObjCMethodConflicts(SF);
+    diagnoseObjCCategoryConflicts(SF);
     diagnoseObjCUnsatisfiedOptReqConflicts(SF);
     diagnoseUnintendedObjCMethodOverrides(SF);
     diagnoseAttrsAddedByAccessNote(SF);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1410,6 +1410,14 @@ bool diagnoseUnintendedObjCMethodOverrides(SourceFile &sf);
 /// \returns true if there were any conflicts diagnosed.
 bool diagnoseObjCMethodConflicts(SourceFile &sf);
 
+/// Diagnose all conflicts between extensions of the same class that have the
+/// same Objective-C category name.
+///
+/// \param sf The source file for which we are diagnosing conflicts.
+///
+/// \returns true if there were any conflicts diagnosed.
+bool diagnoseObjCCategoryConflicts(SourceFile &sf);
+
 /// Diagnose any unsatisfied @objc optional requirements of
 /// protocols that conflict with methods.
 bool diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf);

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -25,6 +25,7 @@
 #include "MetadataCache.h"
 #include "BytecodeLayouts.h"
 #include "swift/ABI/TypeIdentity.h"
+#include "swift/Basic/Defer.h"
 #include "swift/Basic/MathUtils.h"
 #include "swift/Basic/Lazy.h"
 #include "swift/Basic/Range.h"
@@ -3207,6 +3208,13 @@ namespace {
     const uint8_t *WeakIvarLayout;
     const void *PropertyList;
   };
+
+  struct ObjCClass {
+    ObjCClass *Isa;
+    ObjCClass *Superclass;
+    void *CacheData[2];
+    uintptr_t RODataAndFlags;
+  };
 } // end anonymous namespace
 
 #if SWIFT_OBJC_INTEROP
@@ -3224,6 +3232,9 @@ static inline ClassROData *getROData(ClassMetadata *theClass) {
   return (ClassROData*)(theClass->Data & ~uintptr_t(SWIFT_CLASS_IS_SWIFT_MASK));
 }
 
+static inline ClassROData *getROData(ObjCClass *theClass) {
+  return (ClassROData*)(theClass->RODataAndFlags & ~uintptr_t(SWIFT_CLASS_IS_SWIFT_MASK));
+}
 // This gets called if we fail during copyGenericClassObjcName().  Its job is
 // to generate a unique name, even though the name won't be very helpful if
 // we end up looking at it in a debugger.
@@ -3976,6 +3987,98 @@ swift::swift_updateClassMetadata2(ClassMetadata *self,
                                         /*allowDependency*/ true);
 }
 
+Class
+swift::swift_updatePureObjCClassMetadata(Class cls,
+                                         ClassLayoutFlags flags,
+                                         size_t numFields,
+                                         const TypeLayout * const *fieldTypes) {
+  bool hasRealizeClassFromSwift =
+    SWIFT_RUNTIME_WEAK_CHECK(_objc_realizeClassFromSwift);
+  assert(hasRealizeClassFromSwift);
+  (void)hasRealizeClassFromSwift;
+
+  SWIFT_DEFER {
+    // Realize the class. This causes the runtime to slide the field offsets
+    // stored in the field offset globals.
+    SWIFT_RUNTIME_WEAK_USE(_objc_realizeClassFromSwift(cls, cls));
+  };
+
+  // Update the field offset globals using runtime type information; the layout
+  // of resilient types might be different than the statically-emitted layout.
+  ObjCClass *self = (ObjCClass *)cls;
+  ClassROData *rodata = getROData(self);
+  ClassIvarList *ivars = rodata->IvarList;
+
+  if (!ivars) {
+    assert(numFields == 0);
+    return cls;
+  }
+
+  assert(ivars->Count == numFields);
+  assert(ivars->EntrySize == sizeof(ClassIvarEntry));
+
+  bool copiedIvarList = false;
+
+  // Start layout from our static notion of where the superclass starts.
+  // Objective-C expects us to have generated a correct ivar layout, which it
+  // will simply slide if it needs to.
+  assert(self->Superclass && "Swift cannot implement a root class");
+  size_t size = rodata->InstanceStart;
+  size_t alignMask = 0xF; // malloc alignment guarantee
+
+  // Okay, now do layout.
+  for (unsigned i = 0; i != numFields; ++i) {
+    ClassIvarEntry *ivar = &ivars->getIvars()[i];
+
+    size_t offset = 0;
+    if (ivar->Offset) {
+      offset = *ivar->Offset;
+    }
+
+    auto *eltLayout = fieldTypes[i];
+
+    // Skip empty fields.
+    if (offset != 0 || eltLayout->size != 0) {
+      offset = roundUpToAlignMask(size, eltLayout->flags.getAlignmentMask());
+      size = offset + eltLayout->size;
+      alignMask = std::max(alignMask, eltLayout->flags.getAlignmentMask());
+
+      // Fill in the field offset global, if this ivar has one.
+      if (ivar->Offset) {
+        if (*ivar->Offset != offset)
+          *ivar->Offset = offset;
+      }
+    }
+
+    // If the ivar's size doesn't match the field layout we
+    // computed, overwrite it and give it better type information.
+    if (ivar->Size != eltLayout->size) {
+      // If we're going to modify the ivar list, we need to copy it first.
+      if (!copiedIvarList) {
+        auto ivarListSize = sizeof(ClassIvarList) +
+                            numFields * sizeof(ClassIvarEntry);
+        ivars = (ClassIvarList*) getResilientMetadataAllocator()
+          .Allocate(ivarListSize, alignof(ClassIvarList));
+        memcpy(ivars, rodata->IvarList, ivarListSize);
+        rodata->IvarList = ivars;
+        copiedIvarList = true;
+
+        // Update ivar to point to the newly copied list.
+        ivar = &ivars->getIvars()[i];
+      }
+      ivar->Size = eltLayout->size;
+      ivar->Type = nullptr;
+      ivar->Log2Alignment =
+        getLog2AlignmentFromMask(eltLayout->flags.getAlignmentMask());
+    }
+  }
+
+  // Save the size into the Objective-C metadata.
+  if (rodata->InstanceSize != size)
+    rodata->InstanceSize = size;
+
+  return cls;
+}
 #endif
 
 #ifndef NDEBUG

--- a/test/APIJSON/extension.swift
+++ b/test/APIJSON/extension.swift
@@ -45,6 +45,12 @@ extension B {
   public func fun() {}
 }
 
+// This creates a category with a custom name.
+@objc(CustomCategoryName)
+extension B {
+  public func doIt() {}
+}
+
 // CHECK:      "interfaces": [
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "name": "_TtC8MyModule1B",
@@ -65,6 +71,23 @@ extension B {
 // CHECK-NEXT:    }
 // CHECK-NEXT:  ],
 // CHECK-NEXT:  "categories": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "name": "CustomCategoryName",
+// CHECK-NEXT:      "access": "public",
+// CHECK-EXTRACT-NEXT:  "file": "/@input/MyModule.swiftinterface",
+// CHECK-EMIT-NEXT:     "file": "SOURCE_DIR/test/APIJSON/extension.swift",
+// CHECK-NEXT:      "linkage": "exported",
+// CHECK-NEXT:      "interface": "_TtC8MyModule1B",
+// CHECK-NEXT:      "instanceMethods": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "name": "doIt",
+// CHECK-NEXT:          "access": "public",
+// CHECK-EXTRACT-NEXT:  "file": "/@input/MyModule.swiftinterface"
+// CHECK-EMIT-NEXT:     "file": "SOURCE_DIR/test/APIJSON/extension.swift"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      ],
+// CHECK-NEXT:      "classMethods": []
+// CHECK-NEXT:    },
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "name": "MyModule",
 // CHECK-NEXT:      "access": "public",

--- a/test/ClangImporter/Inputs/frameworks/Module.framework/Headers/Module.h
+++ b/test/ClangImporter/Inputs/frameworks/Module.framework/Headers/Module.h
@@ -3,7 +3,9 @@
 #define MODULE_H
 const char *getModuleVersion(void);
 
-@interface Module
+@interface ModuleRoot @end
+
+@interface Module : ModuleRoot
 +(const char *)version; // retrieve module version
 +alloc;
 @end

--- a/test/ClangImporter/diags_from_module.swift
+++ b/test/ClangImporter/diags_from_module.swift
@@ -37,7 +37,7 @@ import Module
 // CHECK-PRIMARY: diags_from_module.swift:[[@LINE-4]]:8: error: could not build Objective-C module 'Module'
 
 // CHECK-WARN: Sub2.h:7:2: warning: here is some warning about something
-// CHECK-WARN: Module.h:22:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h'
+// CHECK-WARN: Module.h:24:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h'
 // FIXME: show [-Wincomplete-umbrella]
 
 // CHECK-NO-WARN-NOT: warning about something

--- a/test/ClangImporter/rdar123543707.swift
+++ b/test/ClangImporter/rdar123543707.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-typecheck-verify-swift -F %S/Inputs/frameworks -module-cache-path %t/mcp1
+// RUN: %target-typecheck-verify-swift -F %S/Inputs/frameworks -module-cache-path %t/mcp1  -target %target-stable-abi-triple
 
 // REQUIRES: objc_interop
 
@@ -7,9 +7,8 @@ import Module
 import Module_Private.Sub4
 
 @_objcImplementation extension Module {
-  // expected-error@-1 {{'@_objcImplementation' cannot be used to implement root class 'Module'}}
-  // expected-warning@-2 {{extension for main class interface should provide implementation for class method 'version()'}}
-  // expected-warning@-3 {{extension for main class interface should provide implementation for class method 'alloc()'}}
+  // expected-warning@-1 {{extension for main class interface should provide implementation for class method 'version()'}}
+  // expected-warning@-2 {{extension for main class interface should provide implementation for class method 'alloc()'}}
 }
 
 extension Module: @retroactive ModuleProto {} // no-error

--- a/test/ConstExtraction/ExtractFromObjcImplementationExtension.swift
+++ b/test/ConstExtraction/ExtractFromObjcImplementationExtension.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: echo "[MyProto]" > %t/protocols.json
 
-// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractFromObjcImplementationExtension.swiftconstvalues -const-gather-protocols-file %t/protocols.json %s -import-objc-header %S/Inputs/objc_implementation.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractFromObjcImplementationExtension.swiftconstvalues -const-gather-protocols-file %t/protocols.json %s -import-objc-header %S/Inputs/objc_implementation.h -disable-objc-attr-requires-foundation-module -target %target-stable-abi-triple
 // RUN: cat %t/ExtractFromObjcImplementationExtension.swiftconstvalues 2>&1 | %FileCheck %s
 
 protocol MyProto { }

--- a/test/IRGen/Inputs/objc_implementation.h
+++ b/test/IRGen/Inputs/objc_implementation.h
@@ -48,3 +48,10 @@ extern void implFuncCName(int param) __asm__("_implFuncAsmName");
 @property (strong, nonnull) NSString *s4;
 
 @end
+
+@interface ImplClassWithResilientStoredProperty : NSObject
+
+@property (assign) int beforeInt;
+@property (assign) int afterInt;
+
+@end

--- a/test/IRGen/objc_extensions.swift
+++ b/test/IRGen/objc_extensions.swift
@@ -78,6 +78,24 @@ extension Gizmo {
 }
 
 /*
+ * Make sure that extensions of an ObjC class with `@objc(CustomName)` get the
+ * indicated category name.
+ */
+// CHECK: @"_CATEGORY_Gizmo_$_WidgetMaker" = internal constant
+// CHECK:   ptr @.str.11.WidgetMaker,
+// CHECK:   ptr @"OBJC_CLASS_$_Gizmo",
+// CHECK:   {{.*}} @"_CATEGORY_INSTANCE_METHODS_Gizmo_$_WidgetMaker",
+// CHECK:   {{.*}} ptr null,
+// CHECK:   ptr null,
+// CHECK:   ptr null
+// CHECK: }, section "__DATA, {{.*}}", align 8
+
+@objc(WidgetMaker) extension Gizmo {
+  func makeWidget() {
+  }
+}
+
+/*
  * Check that extensions of Swift subclasses of ObjC objects get categories.
  */
 

--- a/test/IRGen/objc_implementation.swift
+++ b/test/IRGen/objc_implementation.swift
@@ -1,15 +1,15 @@
 // Test doesn't pass on all platforms (rdar://101420862)
 // REQUIRES: OS=macosx
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature CImplementation -I %S/Inputs/abi -F %clang-importer-sdk-path/frameworks %s -import-objc-header %S/Inputs/objc_implementation.h -emit-ir > %t.ir
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-feature CImplementation -I %S/Inputs/abi -F %clang-importer-sdk-path/frameworks %s -import-objc-header %S/Inputs/objc_implementation.h -emit-ir -target %target-future-triple > %t.ir
 // RUN: %FileCheck --input-file %t.ir %s
 // RUN: %FileCheck --input-file %t.ir --check-prefix NEGATIVE %s
 // REQUIRES: objc_interop
 
-// CHECK: [[selector_data_implProperty:@[^, ]+]] = private global [13 x i8] c"implProperty\00", section "__TEXT,__objc_methname,cstring_literals", align 1
-// CHECK: [[selector_data_setImplProperty_:@[^, ]+]] = private global [17 x i8] c"setImplProperty:\00", section "__TEXT,__objc_methname,cstring_literals", align 1
-
-// CHECK: [[selector_data_mainMethod_:@[^, ]+]] = private global [12 x i8] c"mainMethod:\00", section "__TEXT,__objc_methname,cstring_literals", align 1
+// CHECK-DAG: @"$sSo36ImplClassWithResilientStoredPropertyC19objc_implementationE9beforeInts5Int32VvpWvd" = hidden global i64 8, align 8
+// CHECK-DAG: @"$sSo36ImplClassWithResilientStoredPropertyC19objc_implementationE6mirrors6MirrorVSgvpWvd" = hidden global i64 0, align 8
+// CHECK-DAG: @"$sSo36ImplClassWithResilientStoredPropertyC19objc_implementationE13afterIntFinals5Int32VvpWvd" = hidden global i64 0, align 8
+// CHECK-DAG: @"$sSo36ImplClassWithResilientStoredPropertyC19objc_implementationE8afterInts5Int32VvpWvd" = hidden global i64 0, align 8
 
 //
 // @_objcImplementation class
@@ -17,18 +17,18 @@
 
 // Metaclass
 // CHECK: @"OBJC_METACLASS_$_ImplClass" = global %objc_class { ptr @"OBJC_METACLASS_$_NSObject", ptr @"OBJC_METACLASS_$_NSObject", ptr @_objc_empty_cache, ptr null, {{.*}}ptr [[_METACLASS_DATA_ImplClass:@[^, ]+]]{{.*}}, align 8
-// CHECK: @_PROTOCOLS_ImplClass = internal constant { i64, [2 x ptr] } { i64 2, [2 x ptr] [ptr @_PROTOCOL_NSCopying, ptr @_PROTOCOL_NSMutableCopying] }, section "__DATA, __objc_const", align 8
+// CHECK: @_PROTOCOLS_ImplClass = internal constant { i64, [2 x ptr] } { i64 2, [2 x ptr] [ptr @"_OBJC_PROTOCOL_$_NSCopying", ptr @"_OBJC_PROTOCOL_$_NSMutableCopying"] }, section "__DATA, __objc_const", align 8
 // CHECK: [[_METACLASS_DATA_ImplClass]] = internal constant { i32, i32, i32, i32, ptr, ptr, ptr, ptr, ptr, ptr, ptr } { i32 129, i32 40, i32 40, i32 0, ptr null, ptr @.str.9.ImplClass, ptr null, ptr @_PROTOCOLS_ImplClass, ptr null, ptr null, ptr null }, section "__DATA, __objc_const", align 8
 // TODO: Why the extra i32 field above?
 
 // Class
 // CHECK: [[selector_data__cxx_destruct:@[^, ]+]] = private global [14 x i8] c".cxx_destruct\00", section "__TEXT,__objc_methname,cstring_literals", align 1
-// CHECK: [[_INSTANCE_METHODS_ImplClass:@[^, ]+]] = internal constant { i32, i32, [9 x { ptr, ptr, ptr }] } { i32 24, i32 9, [9 x { ptr, ptr, ptr }] [{ ptr, ptr, ptr } { ptr @"\01L_selector_data(init)", ptr @".str.7.@16@0:8", ptr @"$sSo9ImplClassC19objc_implementationEABycfcTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_implProperty]], ptr @".str.7.i16@0:8", ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvgTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_setImplProperty_]], ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvsTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_mainMethod_]], ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE10mainMethodyys5Int32VFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(extensionMethod:)", ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE15extensionMethodyys5Int32VFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(copyWithZone:)", ptr @".str.11.@24@0:8^v16", ptr @"$sSo9ImplClassC19objc_implementationE4copy4withypSg10ObjectiveC6NSZoneVSg_tFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(mutableCopyWithZone:)", ptr @".str.11.@24@0:8^v16", ptr @"$sSo9ImplClassC19objc_implementationE11mutableCopy4withypSg10ObjectiveC6NSZoneVSg_tFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(dealloc)", ptr @".str.7.v16@0:8", ptr @"$sSo9ImplClassC19objc_implementationEfDTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data__cxx_destruct]], ptr @".str.7.v16@0:8", ptr @"$sSo9ImplClassCfETo{{(\.ptrauth)?}}" }] }, section "__DATA, __objc_data", align 8
+// CHECK: [[_INSTANCE_METHODS_ImplClass:@[^, ]+]] = internal constant { i32, i32, [9 x { ptr, ptr, ptr }] } { i32 24, i32 9, [9 x { ptr, ptr, ptr }] [{ ptr, ptr, ptr } { ptr @"\01L_selector_data(init)", ptr @".str.7.@16@0:8", ptr @"$sSo9ImplClassC19objc_implementationEABycfcTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(implProperty)", ptr @".str.7.i16@0:8", ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvgTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(setImplProperty:)", ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvsTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(mainMethod:)", ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE10mainMethodyys5Int32VFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(extensionMethod:)", ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE15extensionMethodyys5Int32VFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(copyWithZone:)", ptr @".str.11.@24@0:8^v16", ptr @"$sSo9ImplClassC19objc_implementationE4copy4withypSg10ObjectiveC6NSZoneVSg_tFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(mutableCopyWithZone:)", ptr @".str.11.@24@0:8^v16", ptr @"$sSo9ImplClassC19objc_implementationE11mutableCopy4withypSg10ObjectiveC6NSZoneVSg_tFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(dealloc)", ptr @".str.7.v16@0:8", ptr @"$sSo9ImplClassC19objc_implementationEfDTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data__cxx_destruct]], ptr @".str.7.v16@0:8", ptr @"$sSo9ImplClassCfETo{{(\.ptrauth)?}}" }] }, section "__DATA, __objc_data", align 8
 // CHECK: [[_IVARS_ImplClass:@[^, ]+]] = internal constant { i32, i32, [2 x { ptr, ptr, ptr, i32, i32 }] } { i32 32, i32 2, [2 x { ptr, ptr, ptr, i32, i32 }] [{ ptr, ptr, ptr, i32, i32 } { ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvpWvd", ptr @.str.12.implProperty, ptr @.str.0., i32 2, i32 4 }, { ptr, ptr, ptr, i32, i32 } { ptr @"$sSo9ImplClassC19objc_implementationE13implProperty2So8NSObjectCSgvpWvd", ptr @.str.13.implProperty2, ptr @.str.0., i32 3, i32 8 }] }, section "__DATA, __objc_const", align 8
 // CHECK: [[_PROPERTIES_ImplClass:@[^, ]+]] = internal constant { i32, i32, [1 x { ptr, ptr }] } { i32 16, i32 1, [1 x { ptr, ptr }] [{ ptr, ptr } { ptr @.str.12.implProperty, ptr @".str.18.Ti,N,VimplProperty" }] }, section "__DATA, __objc_const", align 8
 // FIXME: Should just be @_PROTOCOLS_ImplClass, but an IRGen bug causes the protocol list to be emitted twice.
 // CHECK: [[_DATA_ImplClass:@[^, ]+]] = internal constant { i32, i32, i32, i32, ptr, ptr, ptr, ptr, ptr, ptr, ptr } { i32 388, i32 8, i32 24, i32 0, ptr null, ptr @.str.9.ImplClass, ptr [[_INSTANCE_METHODS_ImplClass]], ptr @_PROTOCOLS_ImplClass.{{[0-9]+}}, ptr [[_IVARS_ImplClass]], ptr null, ptr [[_PROPERTIES_ImplClass]] }, section "__DATA, __objc_data", align 8
-// CHECK: @"OBJC_CLASS_$_ImplClass" = global <{ i64, ptr, ptr, ptr, ptr }> <{ i64 ptrtoint (ptr @"OBJC_METACLASS_$_ImplClass" to i64), ptr @"OBJC_CLASS_$_NSObject", ptr @_objc_empty_cache, ptr null, ptr [[_DATA_ImplClass]] }>, section "__DATA,__objc_data, regular", align 8
+// CHECK: @"OBJC_CLASS_$_ImplClass" = global <{ i64, ptr, ptr, ptr, i64 }> <{ i64 ptrtoint (ptr @"OBJC_METACLASS_$_ImplClass" to i64), ptr @"OBJC_CLASS_$_NSObject", ptr @_objc_empty_cache, ptr null, i64 ptrtoint (ptr [[_DATA_ImplClass]] to i64) }>, section "__DATA,__objc_data, regular", align 8
 
 // Swift metadata
 // NEGATIVE-NOT: OBJC_CLASS_$_ImplClass.{{[0-9]}}
@@ -92,7 +92,7 @@
 // CHECK: @_IVARS_NoInitImplClass = internal constant { i32, i32, [4 x { ptr, ptr, ptr, i32, i32 }] } { i32 32, i32 4, [4 x { ptr, ptr, ptr, i32, i32 }] [{ ptr, ptr, ptr, i32, i32 } { ptr @"$sSo15NoInitImplClassC19objc_implementationE2s1SSvpWvd", ptr @.str.2.s1, ptr @.str.0., i32 3, i32 16 }, { ptr, ptr, ptr, i32, i32 } { ptr @"$sSo15NoInitImplClassC19objc_implementationE2s2SSvpWvd", ptr @.str.2.s2, ptr @.str.0., i32 3, i32 16 }, { ptr, ptr, ptr, i32, i32 } { ptr @"$sSo15NoInitImplClassC19objc_implementationE2s3SSvpWvd", ptr @.str.2.s3, ptr @.str.0., i32 3, i32 16 }, { ptr, ptr, ptr, i32, i32 } { ptr @"$sSo15NoInitImplClassC19objc_implementationE2s4SSvpWvd", ptr @.str.2.s4, ptr @.str.0., i32 3, i32 16 }] }, section "__DATA, __objc_const", align 8
 // CHECK: @_PROPERTIES_NoInitImplClass = internal constant { i32, i32, [4 x { ptr, ptr }] } { i32 16, i32 4, [4 x { ptr, ptr }] [{ ptr, ptr } { ptr @.str.2.s1, ptr @".str.16.T@\22NSString\22,N,R" }, { ptr, ptr } { ptr @.str.2.s2, ptr @".str.16.T@\22NSString\22,N,C" }, { ptr, ptr } { ptr @.str.2.s3, ptr @".str.16.T@\22NSString\22,N,R" }, { ptr, ptr } { ptr @.str.2.s4, ptr @".str.16.T@\22NSString\22,N,C" }] }, section "__DATA, __objc_const", align 8
 // CHECK: @_DATA_NoInitImplClass = internal constant { i32, i32, i32, i32, ptr, ptr, ptr, ptr, ptr, ptr, ptr } { i32 388, i32 8, i32 72, i32 0, ptr null, ptr @.str.15.NoInitImplClass, ptr @_INSTANCE_METHODS_NoInitImplClass, ptr null, ptr @_IVARS_NoInitImplClass, ptr null, ptr @_PROPERTIES_NoInitImplClass }, section "__DATA, __objc_data", align 8
-// CHECK: @"OBJC_CLASS_$_NoInitImplClass" = global <{ i64, ptr, ptr, ptr, ptr }> <{ i64 ptrtoint (ptr @"OBJC_METACLASS_$_NoInitImplClass" to i64), ptr @"OBJC_CLASS_$_NSObject", ptr @_objc_empty_cache, ptr null, ptr @_DATA_NoInitImplClass }>, section "__DATA,__objc_data, regular", align 8
+// CHECK: @"OBJC_CLASS_$_NoInitImplClass" = global <{ i64, ptr, ptr, ptr, i64 }> <{ i64 ptrtoint (ptr @"OBJC_METACLASS_$_NoInitImplClass" to i64), ptr @"OBJC_CLASS_$_NSObject", ptr @_objc_empty_cache, ptr null, i64 ptrtoint (ptr @_DATA_NoInitImplClass to i64) }>, section "__DATA,__objc_data, regular", align 8
 @_objcImplementation extension NoInitImplClass {
   @objc let s1 = "s1v"
   @objc var s2 = "s2v"
@@ -114,20 +114,41 @@
 // CHECK: [[_METACLASS_DATA_SwiftSubclass]] = internal constant { i32, i32, i32, i32, ptr, ptr, ptr, ptr, ptr, ptr, ptr } { i32 129, i32 40, i32 40, i32 0, ptr null, ptr @.str.40._TtC19objc_implementation13SwiftSubclass, ptr null, ptr null, ptr null, ptr null, ptr null }, section "__DATA, __objc_const", align 8
 
 // Class
-// CHECK: [[_INSTANCE_METHODS_SwiftSubclass:@[^, ]+]] = internal constant { i32, i32, [2 x { ptr, ptr, ptr }] } { i32 24, i32 2, [2 x { ptr, ptr, ptr }] [{ ptr, ptr, ptr } { ptr [[selector_data_mainMethod_]], ptr @".str.10.v20@0:8i16", ptr @"$s19objc_implementation13SwiftSubclassC10mainMethodyys5Int32VFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(init)", ptr @".str.7.@16@0:8", ptr @"$s19objc_implementation13SwiftSubclassCACycfcTo{{(\.ptrauth)?}}" }] }, section "__DATA, __objc_data", align 8
+// CHECK: [[_INSTANCE_METHODS_SwiftSubclass:@[^, ]+]] = internal constant { i32, i32, [2 x { ptr, ptr, ptr }] } { i32 24, i32 2, [2 x { ptr, ptr, ptr }] [{ ptr, ptr, ptr } { ptr @"\01L_selector_data(mainMethod:)", ptr @".str.10.v20@0:8i16", ptr @"$s19objc_implementation13SwiftSubclassC10mainMethodyys5Int32VFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(init)", ptr @".str.7.@16@0:8", ptr @"$s19objc_implementation13SwiftSubclassCACycfcTo{{(\.ptrauth)?}}" }] }, section "__DATA, __objc_data", align 8
 // CHECK: [[_DATA_SwiftSubclass:@[^, ]+]] = internal constant { i32, i32, i32, i32, ptr, ptr, ptr, ptr, ptr, ptr, ptr } { i32 128, i32 24, i32 24, i32 0, ptr null, ptr @.str.40._TtC19objc_implementation13SwiftSubclass, ptr [[_INSTANCE_METHODS_SwiftSubclass]], ptr null, ptr null, ptr null, ptr null }, section "__DATA, __objc_data", align 8
 
 // Swift metadata
 // CHECK: @"$s19objc_implementationMXM" = linkonce_odr hidden constant <{ i32, i32, i32 }> <{ i32 0, i32 0, i32 trunc (i64 sub (i64 ptrtoint (ptr @.str.19.objc_implementation to i64), i64 ptrtoint (ptr getelementptr inbounds (<{ i32, i32, i32 }>, ptr @"$s19objc_implementationMXM", i32 0, i32 2) to i64)) to i32) }>, section "__TEXT,__constg_swiftt", align 4
 // CHECK: @"symbolic So9ImplClassC" = linkonce_odr hidden constant <{ [13 x i8], i8 }> <{ [13 x i8] c"So9ImplClassC", i8 0 }>, section "__TEXT,__swift5_typeref, regular"{{.*}}, align 2
 // CHECK: @"$s19objc_implementation13SwiftSubclassCMn" = constant <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }> <{ i32 80, i32 trunc (i64 sub (i64 ptrtoint (ptr @"$s19objc_implementationMXM" to i64), i64 ptrtoint (ptr getelementptr inbounds (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }>, ptr @"$s19objc_implementation13SwiftSubclassCMn", i32 0, i32 1) to i64)) to i32), i32 trunc (i64 sub (i64 ptrtoint (ptr @.str.13.SwiftSubclass to i64), i64 ptrtoint (ptr getelementptr inbounds (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }>, ptr @"$s19objc_implementation13SwiftSubclassCMn", i32 0, i32 2) to i64)) to i32), i32 trunc (i64 sub (i64 ptrtoint (ptr @"$s19objc_implementation13SwiftSubclassCMa" to i64), i64 ptrtoint (ptr getelementptr inbounds (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }>, ptr @"$s19objc_implementation13SwiftSubclassCMn", i32 0, i32 3) to i64)) to i32), i32 trunc (i64 sub (i64 ptrtoint (ptr @"$s19objc_implementation13SwiftSubclassCMF" to i64), i64 ptrtoint (ptr getelementptr inbounds (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }>, ptr @"$s19objc_implementation13SwiftSubclassCMn", i32 0, i32 4) to i64)) to i32), i32 trunc (i64 sub (i64 ptrtoint (ptr @"symbolic So9ImplClassC" to i64), i64 ptrtoint (ptr getelementptr inbounds (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }>, ptr @"$s19objc_implementation13SwiftSubclassCMn", i32 0, i32 5) to i64)) to i32), i32 3, i32 10, i32 0, i32 0, i32 10 }>, section "__TEXT,__constg_swiftt", align 4
-// CHECK: @"$s19objc_implementation13SwiftSubclassCMf" = internal global <{ ptr, ptr, ptr, i64, ptr, ptr, ptr, i64, i32, i32, i32, i16, i16, i32, i32, ptr, ptr }> <{ ptr null, ptr @"$s19objc_implementation13SwiftSubclassCfD", ptr @"$sBOWV", i64 ptrtoint (ptr @"OBJC_METACLASS_$__TtC19objc_implementation13SwiftSubclass" to i64), ptr @"OBJC_CLASS_$_ImplClass", ptr @_objc_empty_cache, ptr null, i64 add (i64 ptrtoint (ptr @_DATA__TtC19objc_implementation13SwiftSubclass to i64), i64 1), i32 0, i32 0, i32 24, i16 7, i16 0, i32 104, i32 24, ptr @"$s19objc_implementation13SwiftSubclassCMn", ptr null }>, section "__DATA,__objc_data, regular", align 8
+// CHECK: @"$s19objc_implementation13SwiftSubclassCMf" = internal global <{ ptr, ptr, ptr, i64, ptr, ptr, ptr, i64, i32, i32, i32, i16, i16, i32, i32, ptr, ptr }> <{ ptr null, ptr @"$s19objc_implementation13SwiftSubclassCfD", ptr @"$sBOWV", i64 ptrtoint (ptr @"OBJC_METACLASS_$__TtC19objc_implementation13SwiftSubclass" to i64), ptr @"OBJC_CLASS_$_ImplClass", ptr @_objc_empty_cache, ptr null, i64 add (i64 ptrtoint (ptr @_DATA__TtC19objc_implementation13SwiftSubclass to i64), i64 2), i32 0, i32 0, i32 24, i16 7, i16 0, i32 104, i32 24, ptr @"$s19objc_implementation13SwiftSubclassCMn", ptr null }>, section "__DATA,__objc_data, regular", align 8
 // CHECK: @"symbolic _____ 19objc_implementation13SwiftSubclassC" = linkonce_odr hidden constant <{ i8, i32, i8 }> <{ i8 1, i32 trunc (i64 sub (i64 ptrtoint (ptr @"$s19objc_implementation13SwiftSubclassCMn" to i64), i64 ptrtoint (ptr getelementptr inbounds (<{ i8, i32, i8 }>, ptr @"symbolic _____ 19objc_implementation13SwiftSubclassC", i32 0, i32 1) to i64)) to i32), i8 0 }>, section "__TEXT,__swift5_typeref, regular"{{.*}}, align 2
 // CHECK: @"$s19objc_implementation13SwiftSubclassCMF" = internal constant { i32, i32, i16, i16, i32 } { i32 trunc (i64 sub (i64 ptrtoint (ptr @"symbolic _____ 19objc_implementation13SwiftSubclassC" to i64), i64 ptrtoint (ptr @"$s19objc_implementation13SwiftSubclassCMF" to i64)) to i32), i32 trunc (i64 sub (i64 ptrtoint (ptr @"symbolic So9ImplClassC" to i64), i64 ptrtoint (ptr getelementptr inbounds ({ i32, i32, i16, i16, i32 }, ptr @"$s19objc_implementation13SwiftSubclassCMF", i32 0, i32 1) to i64)) to i32), i16 7, i16 12, i32 0 }, section "__TEXT,__swift5_fieldmd, regular"{{.*}}, align 4
 open class SwiftSubclass: ImplClass {
   override open func mainMethod(_: Int32) {
     print("subclass mainMethod")
   }
+}
+
+//
+// @_objcImplementation class with a resilient stored property
+//
+
+// Metaclass
+// CHECK: @"OBJC_METACLASS_$_ImplClassWithResilientStoredProperty" = global %objc_class { ptr @"OBJC_METACLASS_$_NSObject", ptr @"OBJC_METACLASS_$_NSObject", ptr @_objc_empty_cache, ptr null, {{.*}}ptr @_METACLASS_DATA_ImplClassWithResilientStoredProperty{{.*}}, align 8
+// CHECK: @_METACLASS_DATA_ImplClassWithResilientStoredProperty = internal constant { i32, i32, i32, i32, ptr, ptr, ptr, ptr, ptr, ptr, ptr } { i32 129, i32 40, i32 40, i32 0, ptr null, ptr @.str.36.ImplClassWithResilientStoredProperty, ptr null, ptr null, ptr null, ptr null, ptr null }, section "__DATA, __objc_const", align 8
+// TODO: Why the extra i32 field above?
+
+// Class
+// CHECK: @_IVARS_ImplClassWithResilientStoredProperty = internal constant { i32, i32, [4 x { ptr, ptr, ptr, i32, i32 }] } { i32 32, i32 4, [4 x { ptr, ptr, ptr, i32, i32 }] [{ ptr, ptr, ptr, i32, i32 } { ptr @"$sSo36ImplClassWithResilientStoredPropertyC19objc_implementationE9beforeInts5Int32VvpWvd", ptr @.str.9.beforeInt, ptr @.str.0., i32 2, i32 4 }, { ptr, ptr, ptr, i32, i32 } { ptr @"$sSo36ImplClassWithResilientStoredPropertyC19objc_implementationE6mirrors6MirrorVSgvpWvd", ptr @.str.6.mirror, ptr @.str.0., i32 0, i32 0 }, { ptr, ptr, ptr, i32, i32 } { ptr @"$sSo36ImplClassWithResilientStoredPropertyC19objc_implementationE13afterIntFinals5Int32VvpWvd", ptr @.str.13.afterIntFinal, ptr @.str.0., i32 2, i32 4 }, { ptr, ptr, ptr, i32, i32 } { ptr @"$sSo36ImplClassWithResilientStoredPropertyC19objc_implementationE8afterInts5Int32VvpWvd", ptr @.str.8.afterInt, ptr @.str.0., i32 2, i32 4 }] }, section "__DATA, __objc_const", align 8
+// CHECK: @_DATA_ImplClassWithResilientStoredProperty = internal constant { i32, i32, i32, i32, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr } { i32 452, i32 8, i32 20, i32 0, ptr null, ptr @.str.36.ImplClassWithResilientStoredProperty, ptr @_INSTANCE_METHODS_ImplClassWithResilientStoredProperty, ptr null, ptr @_IVARS_ImplClassWithResilientStoredProperty, ptr null, ptr @_PROPERTIES_ImplClassWithResilientStoredProperty, ptr @"$sSo36ImplClassWithResilientStoredPropertyCMU" }, section "__DATA, __objc_data", align 8
+// CHECK: @"OBJC_CLASS_$_ImplClassWithResilientStoredProperty" = global <{ i64, ptr, ptr, ptr, i64 }> <{ i64 ptrtoint (ptr @"OBJC_METACLASS_$_ImplClassWithResilientStoredProperty" to i64), ptr @"OBJC_CLASS_$_NSObject", ptr @_objc_empty_cache, ptr null, i64 ptrtoint (ptr @_DATA_ImplClassWithResilientStoredProperty to i64) }>, section "__DATA,__objc_data, regular", align 8
+
+@_objcImplementation extension ImplClassWithResilientStoredProperty {
+  @objc var beforeInt: Int32 = 0
+  final var mirror: Mirror?
+  final var afterIntFinal: Int32 = 0
+  @objc var afterInt: Int32 = 0
 }
 
 //
@@ -287,6 +308,48 @@ public func fn(impl: ImplClass, swiftSub: SwiftSubclass) {
 // CHECK:   call void @implFunc
 // CHECK:   ret void
 // CHECK: }
+
+// ImplClassWithResilientStoredProperty ObjC metadata update function
+// CHECK-LABEL: define internal ptr @"$sSo36ImplClassWithResilientStoredPropertyCMU"
+//
+// This function should not invoke the metadata accessor.
+// CHECK-NOT:     sSo36ImplClassWithResilientStoredPropertyCMa
+//
+// This function should directly gather the field sizes and invoke the metadata update.
+// CHECK:         %classFields = alloca [4 x ptr]
+// CHECK:         [[FIELDS_ARRAY:%[0-9]+]] = getelementptr inbounds [4 x ptr], ptr %classFields, i32 0, i32 0
+// CHECK:         store ptr getelementptr inbounds (ptr, ptr @"$sBi32_WV", i32 8), ptr {{%[0-9]+}}
+// CHECK:         {{%[0-9]+}} = call swiftcc %swift.metadata_response @"$ss6MirrorVSgMa"(i64 63)
+// CHECK:         store ptr {{%[0-9]+}}, ptr {{%[0-9]+}}
+// CHECK:         store ptr getelementptr inbounds (ptr, ptr @"$sBi32_WV", i32 8), ptr {{%[0-9]+}}
+// CHECK:         store ptr getelementptr inbounds (ptr, ptr @"$sBi32_WV", i32 8), ptr {{%[0-9]+}}
+// CHECK:         {{%[0-9]+}} = call swiftcc ptr @swift_updatePureObjCClassMetadata(ptr @"OBJC_CLASS_$_ImplClassWithResilientStoredProperty", i64 256, i64 4, ptr [[FIELDS_ARRAY]])
+//
+// This function should not invoke the metadata accessor.
+// CHECK-NOT:     sSo36ImplClassWithResilientStoredPropertyCMa
+//
+// CHECK:         ret ptr @"OBJC_CLASS_$_ImplClassWithResilientStoredProperty"
+// CHECK:       }
+
+// ImplClassWithResilientStoredProperty type metadata accessor
+// CHECK-LABEL: define swiftcc %swift.metadata_response @"$sSo36ImplClassWithResilientStoredPropertyCMa"
+//
+// This function should not use the runtime call for Swift class metadata
+// CHECK-NOT:     swift_getSingletonMetadata
+//
+// This function should realize the ObjC class and then convert it to metadata.
+// CHECK:         {{%[0-9]+}} = call ptr @objc_opt_self(ptr @"OBJC_CLASS_$_ImplClassWithResilientStoredProperty")
+// CHECK-NEXT:    {{%[0-9]+}} = call ptr @swift_getObjCClassMetadata(ptr {{%[0-9]+}})
+//
+// This function should not use the runtime call for Swift class metadata
+// CHECK-NOT:     swift_getSingletonMetadata
+//
+// CHECK:         ret
+// CHECK:       }
+
+// ImplClassWithResilientStoredProperty Swift metadata completion function
+// This function shouldn't exist or be referenced
+// NEGATIVE-NOT: sSo36ImplClassWithResilientStoredPropertyCMr
 
 //
 // Not implemented in Swift

--- a/test/IRGen/objc_implementation_deployment_target_resilience.swift
+++ b/test/IRGen/objc_implementation_deployment_target_resilience.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target %target-stable-abi-triple -I %S/Inputs/abi -F %clang-importer-sdk-path/frameworks %s -import-objc-header %S/Inputs/objc_implementation.h -emit-ir -o %t.ir -enable-library-evolution -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target %target-stable-abi-triple -I %S/Inputs/abi -F %clang-importer-sdk-path/frameworks %s -import-objc-header %S/Inputs/objc_implementation.h -emit-ir -o %t.ir -enable-library-evolution -enable-experimental-feature ObjCImplementationWithResilientStorage -target %target-future-triple
+// REQUIRES: objc_interop
+
+@_objcImplementation extension ImplClassWithResilientStoredProperty {
+  @objc var beforeInt: Int32 = 0    // no-error
+  final var a: Mirror?              // expected-error {{does not support stored properties whose size can change due to library evolution; store this value in an object or 'any' type}}
+  final var b: AnyKeyPath?          // no-error
+  final var c: Int = 0              // no-error
+  final var d: S1?                  // no-error
+  final var e: S2?                  // expected-error {{does not support stored properties whose size can change due to library evolution; store this value in an object or 'any' type}}
+  final var f: C1?                  // no-error
+  @objc var afterInt: Int32 = 0     // no-error
+}
+
+public struct S1 {
+  var int = 1
+}
+
+public struct S2 {
+  var mirror: Mirror?
+}
+
+public class C1 {
+  var mirror: Mirror?
+}

--- a/test/IRGen/objc_implementation_deployment_target_resilience.swift
+++ b/test/IRGen/objc_implementation_deployment_target_resilience.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target %target-stable-abi-triple -I %S/Inputs/abi -F %clang-importer-sdk-path/frameworks %s -import-objc-header %S/Inputs/objc_implementation.h -emit-ir -o %t.ir -enable-library-evolution -enable-experimental-feature ObjCImplementationWithResilientStorage -target %target-future-triple
 // REQUIRES: objc_interop
 
-@_objcImplementation extension ImplClassWithResilientStoredProperty {
+@objc @implementation extension ImplClassWithResilientStoredProperty {
   @objc var beforeInt: Int32 = 0    // no-error
   final var a: Mirror?              // expected-error {{does not support stored properties whose size can change due to library evolution; store this value in an object or 'any' type}}
   final var b: AnyKeyPath?          // no-error

--- a/test/Index/index_objc_impl.swift
+++ b/test/Index/index_objc_impl.swift
@@ -4,8 +4,8 @@
 // RUN: %empty-directory(%t/mods)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -emit-module -o %t/mods %t/ObjcImpl.swift -import-objc-header %t/objc_impl.h -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-ide-test -print-indexed-symbols -module-to-print ObjcImpl -source-filename none -I %t/mods | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o %t/mods %t/ObjcImpl.swift -import-objc-header %t/objc_impl.h -disable-objc-attr-requires-foundation-module -target %target-stable-abi-triple
+// RUN: %target-swift-ide-test -print-indexed-symbols -module-to-print ObjcImpl -source-filename none -I %t/mods -target %target-stable-abi-triple | %FileCheck %s
 
 //--- objc_impl.h
 @interface NSObject

--- a/test/Interpreter/Inputs/objc_implementation.h
+++ b/test/Interpreter/Inputs/objc_implementation.h
@@ -2,6 +2,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class ImplClassWithResilientStoredProperty;
+
 @interface ImplClass : NSObject
 
 - (instancetype)init;
@@ -10,7 +12,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign) NSInteger defaultIntProperty;
 
 + (void)runTests;
++ (ImplClassWithResilientStoredProperty *)makeResilientImpl;
+
+- (void)testSelf;
+- (void)printSelfWithLabel:(int)label;
 - (nonnull NSString *)someMethod;
+
+@end
+
+@interface ImplClassWithResilientStoredProperty : NSObject
+
+- (void)printSelfWithLabel:(int)label;
+- (void)mutate;
 
 @end
 

--- a/test/Interpreter/objc_implementation.swift
+++ b/test/Interpreter/objc_implementation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/objc_implementation.h -D TOP_LEVEL_CODE -swift-version 5 -enable-experimental-feature CImplementation) %s | %FileCheck %s
+// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/objc_implementation.h -D TOP_LEVEL_CODE -swift-version 5 -enable-experimental-feature CImplementation -target %target-stable-abi-triple) %s | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
@@ -20,6 +20,7 @@ class LastWords {
 
 @_objcImplementation extension ImplClass {
   @objc override init() {
+    print("ImplClass.init()")
     self.implProperty = 0
     self.object = LastWords(text: String(describing: type(of: self)))
     super.init()
@@ -31,34 +32,54 @@ class LastWords {
   @objc var defaultIntProperty: Int = 17
 
   @objc class func runTests() {
-    do {
-      let impl = ImplClass()
-      print("someMethod =", impl.someMethod())
-      print("implProperty =", impl.implProperty)
-      impl.implProperty = 42
-      print("implProperty =", impl.implProperty)
-      print("defaultIntProperty =", impl.defaultIntProperty)
-      print("description =", impl.description)
-    }
-
-    do {
-      let swiftSub = SwiftSubclass()
-      print("someMethod =", swiftSub.someMethod())
-      print("implProperty =", swiftSub.implProperty)
-      swiftSub.implProperty = 42
-      print("implProperty =", swiftSub.implProperty)
-      print("defaultIntProperty =", swiftSub.defaultIntProperty)
-
-      print("otherProperty =", swiftSub.otherProperty)
-      swiftSub.otherProperty = 13
-      print("otherProperty =", swiftSub.otherProperty)
-      print("implProperty =", swiftSub.implProperty)
-    }
-
     implFunc(2023 - 34)
+
+    do {
+      print("*** ImplClass init ***")
+      let impl = ImplClass()
+      impl.testSelf()
+      print("*** ImplClass end ***")
+    }
+
+    do {
+      print("*** SwiftSubclass init ***")
+      let swiftSub = SwiftSubclass()
+      swiftSub.testSelf()
+      print("*** SwiftSubclass end ***")
+    }
   }
 
-  @objc func someMethod() -> String { "ImplClass.someMethod()" }
+  @objc func testSelf() {
+#if RESILIENCE
+    let resilientImpl = Self.makeResilientImpl()
+    resilientImpl.printSelf(withLabel: 1)
+    resilientImpl.mutate()
+    resilientImpl.printSelf(withLabel: 2)
+#endif
+
+    self.printSelf(withLabel: 1)
+    self.implProperty = 42
+    self.printSelf(withLabel: 2)
+  }
+
+  @objc func printSelf(withLabel label: CInt) {
+    let type = type(of: self)
+    print("*** \(type) #\(label) ***")
+    print("\(type).someMethod() =", self.someMethod())
+    print("\(type).implProperty =", self.implProperty)
+    print("\(type).defaultIntProperty =", self.defaultIntProperty)
+    print("\(type).description =", self.description)
+  }
+
+  @objc func someMethod() -> String { "ImplClass" }
+
+  @objc class func makeResilientImpl() -> ImplClassWithResilientStoredProperty {
+#if RESILIENCE
+    ImplClassWithResilientStoredProperty()
+#else
+    fatalError()
+#endif
+  }
 
   open override var description: String {
     "ImplClass(implProperty: \(implProperty), object: \(object))"
@@ -69,11 +90,77 @@ class SwiftSubclass: ImplClass {
   @objc var otherProperty: Int = 1
 
   override init() {
+    print("SwiftSubclass.init()")
     super.init()
   }
 
-  override func someMethod() -> String { "SwiftSubclass.someMethod()" }
+  override func someMethod() -> String { "SwiftSubclass" }
+
+  override func testSelf() {
+    super.testSelf()
+    self.otherProperty = 13
+    self.printSelf(withLabel: 3)
+  }
+
+  override func printSelf(withLabel label: CInt) {
+    super.printSelf(withLabel: label)
+    let type = type(of: self)
+    print("\(type).otherProperty =", self.otherProperty)
+  }
+
+#if RESILIENCE
+  override class func makeResilientImpl() -> ImplClassWithResilientStoredProperty {
+    SwiftResilientStoredSubclass()
+  }
+#endif
 }
+
+#if RESILIENCE
+@_objcImplementation extension ImplClassWithResilientStoredProperty {
+  final var mirror: Mirror?
+  final var afterMirrorProperty: Int
+
+  public override init() {
+    self.mirror = nil
+    self.afterMirrorProperty = 0
+  }
+
+  @objc func printSelf(withLabel label: CInt) {
+    let type = type(of: self)
+    print("*** \(type) #\(label) ***")
+    print("\(type).mirror =", self.mirror as Any)
+    print("\(type).afterMirrorProperty =", self.afterMirrorProperty)
+  }
+
+  @objc func mutate() {
+    self.afterMirrorProperty = 42
+  }
+}
+
+extension SwiftSubclass {
+  class SwiftResilientStoredSubclass: ImplClassWithResilientStoredProperty {
+    final var mirror2: Mirror?
+    final var afterMirrorProperty2: Int
+
+    public override init() {
+      self.mirror2 = nil
+      self.afterMirrorProperty2 = 1
+    }
+
+    override func printSelf(withLabel label: CInt) {
+      super.printSelf(withLabel: label)
+      let type = type(of: self)
+      print("\(type).mirror2 =", self.mirror2 as Any)
+      print("\(type).afterMirrorProperty2 =", self.afterMirrorProperty2)
+    }
+
+    override func mutate() {
+      super.mutate()
+      self.afterMirrorProperty2 = 43
+    }
+  }
+}
+#endif
 
 @_objcImplementation @_cdecl("implFunc") public func implFunc(_ param: Int32) {
   print("implFunc(\(param))")
@@ -82,19 +169,58 @@ class SwiftSubclass: ImplClass {
 // `#if swift` to ignore the inactive branch's contents
 #if swift(>=5.0) && TOP_LEVEL_CODE
 ImplClass.runTests()
-// CHECK: someMethod = ImplClass.someMethod()
-// CHECK: implProperty = 0
-// CHECK: implProperty = 42
-// CHECK: defaultIntProperty = 17
-// CHECK: description = ImplClass(implProperty: 42, object: main.LastWords)
-// CHECK: ImplClass It's better to burn out than to fade away.
-// CHECK: someMethod = SwiftSubclass.someMethod()
-// CHECK: implProperty = 0
-// CHECK: implProperty = 42
-// CHECK: defaultIntProperty = 17
-// CHECK: otherProperty = 1
-// CHECK: otherProperty = 13
-// CHECK: implProperty = 42
-// CHECK: SwiftSubclass It's better to burn out than to fade away.
 // CHECK: implFunc(1989)
+// CHECK-LABEL: *** ImplClass init ***
+// CHECK: ImplClass.init()
+// CHECK-RESILIENCE-LABEL: *** ImplClassWithResilientStoredProperty #1 ***
+// CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.mirror = nil
+// CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.afterMirrorProperty = 0
+// CHECK-RESILIENCE-LABEL: *** ImplClassWithResilientStoredProperty #2 ***
+// CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.mirror = nil
+// CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.afterMirrorProperty = 42
+// CHECK-LABEL: *** ImplClass #1 ***
+// CHECK: ImplClass.someMethod() = ImplClass
+// CHECK: ImplClass.implProperty = 0
+// CHECK: ImplClass.defaultIntProperty = 17
+// CHECK: ImplClass.description = ImplClass(implProperty: 0, object: main.LastWords)
+// CHECK-LABEL: *** ImplClass #2 ***
+// CHECK: ImplClass.someMethod() = ImplClass
+// CHECK: ImplClass.implProperty = 42
+// CHECK: ImplClass.defaultIntProperty = 17
+// CHECK: ImplClass.description = ImplClass(implProperty: 42, object: main.LastWords)
+// CHECK-LABEL: *** ImplClass end ***
+// CHECK: ImplClass It's better to burn out than to fade away.
+// CHECK-LABEL: *** SwiftSubclass init ***
+// CHECK: SwiftSubclass.init()
+// CHECK: ImplClass.init()
+// CHECK-RESILIENCE-LABEL: *** SwiftResilientStoredSubclass #1 ***
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror = nil
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty = 0
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror2 = nil
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty2 = 1
+// CHECK-RESILIENCE-LABEL: *** SwiftResilientStoredSubclass #2 ***
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror = nil
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty = 42
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror2 = nil
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty2 = 43
+// CHECK-LABEL: *** SwiftSubclass #1 ***
+// CHECK: SwiftSubclass.someMethod() = SwiftSubclass
+// CHECK: SwiftSubclass.implProperty = 0
+// CHECK: SwiftSubclass.defaultIntProperty = 17
+// CHECK: SwiftSubclass.description = ImplClass(implProperty: 0, object: main.LastWords)
+// CHECK: SwiftSubclass.otherProperty = 1
+// CHECK-LABEL: *** SwiftSubclass #2 ***
+// CHECK: SwiftSubclass.someMethod() = SwiftSubclass
+// CHECK: SwiftSubclass.implProperty = 42
+// CHECK: SwiftSubclass.defaultIntProperty = 17
+// CHECK: SwiftSubclass.description = ImplClass(implProperty: 42, object: main.LastWords)
+// CHECK: SwiftSubclass.otherProperty = 1
+// CHECK-LABEL: *** SwiftSubclass #3 ***
+// CHECK: SwiftSubclass.someMethod() = SwiftSubclass
+// CHECK: SwiftSubclass.implProperty = 42
+// CHECK: SwiftSubclass.defaultIntProperty = 17
+// CHECK: SwiftSubclass.description = ImplClass(implProperty: 42, object: main.LastWords)
+// CHECK: SwiftSubclass.otherProperty = 13
+// CHECK-LABEL: *** SwiftSubclass end ***
+// CHECK: SwiftSubclass It's better to burn out than to fade away.
 #endif

--- a/test/Interpreter/objc_implementation_objc_client.m
+++ b/test/Interpreter/objc_implementation_objc_client.m
@@ -8,7 +8,7 @@
 // RUN: %empty-directory(%t-frameworks/objc_implementation.framework/Headers)
 // RUN: cp %S/Inputs/objc_implementation.modulemap %t-frameworks/objc_implementation.framework/Modules/module.modulemap
 // RUN: cp %S/Inputs/objc_implementation.h %t-frameworks/objc_implementation.framework/Headers
-// RUN: %target-build-swift-dylib(%t-frameworks/objc_implementation.framework/objc_implementation) -emit-module-path %t-frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule/%module-target-triple.swiftmodule -module-name objc_implementation -F %t-frameworks -import-underlying-module -Xlinker -install_name -Xlinker %t-frameworks/objc_implementation.framework/objc_implementation %S/objc_implementation.swift
+// RUN: %target-build-swift-dylib(%t-frameworks/objc_implementation.framework/objc_implementation) -emit-module-path %t-frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule/%module-target-triple.swiftmodule -module-name objc_implementation -F %t-frameworks -import-underlying-module -Xlinker -install_name -Xlinker %t-frameworks/objc_implementation.framework/objc_implementation %S/objc_implementation.swift -enable-experimental-feature CImplementation -target %target-stable-abi-triple
 
 //
 // Execute this file
@@ -38,6 +38,9 @@
 @end
 
 static void print(NSString *str) {
+  // Flush any buffered Swift output.
+  fflush(stdout);
+
   NSData *strData = [str dataUsingEncoding:NSUTF8StringEncoding];
   NSData *nlData = [@"\n" dataUsingEncoding:NSUTF8StringEncoding];
 
@@ -57,64 +60,200 @@ static void print(NSString *str) {
   }
 }
 
-static void printInt(NSString *str, NSUInteger num) {
+static void printInt(Class class, NSString *property, NSUInteger num) {
   NSString *fullStr =
-    [NSString stringWithFormat:@"%@ %lld", str, (long long)num];
+    [NSString stringWithFormat:@"%@.%@ = %lld", class, property, (long long)num];
+  print(fullStr);
+}
+
+static void printString(Class class, NSString *property, NSString *str) {
+  NSString *fullStr =
+    [NSString stringWithFormat:@"%@.%@ = %@", class, property, str];
   print(fullStr);
 }
 
 int main() {
   [ImplClass runTests];
-  // CHECK: someMethod = ImplClass.someMethod()
-  // CHECK: implProperty = 0
-  // CHECK: implProperty = 42
-  // CHECK: someMethod = SwiftSubclass.someMethod()
-  // CHECK: implProperty = 0
-  // CHECK: implProperty = 42
-  // CHECK: otherProperty = 1
-  // CHECK: otherProperty = 13
-  // CHECK: implProperty = 42
+  // CHECK: implFunc(1989)
+  // CHECK-LABEL: *** ImplClass init ***
+  // CHECK: ImplClass.init()
+  // CHECK-RESILIENCE-LABEL: *** ImplClassWithResilientStoredProperty #1 ***
+  // CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.mirror = nil
+  // CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.afterMirrorProperty = 0
+  // CHECK-RESILIENCE-LABEL: *** ImplClassWithResilientStoredProperty #2 ***
+  // CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.mirror = nil
+  // CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.afterMirrorProperty = 42
+  // CHECK-LABEL: *** ImplClass #1 ***
+  // CHECK: ImplClass.someMethod() = ImplClass
+  // CHECK: ImplClass.implProperty = 0
+  // CHECK: ImplClass.defaultIntProperty = 17
+  // CHECK: ImplClass.description = ImplClass(implProperty: 0, object: objc_implementation.LastWords)
+  // CHECK-LABEL: *** ImplClass #2 ***
+  // CHECK: ImplClass.someMethod() = ImplClass
+  // CHECK: ImplClass.implProperty = 42
+  // CHECK: ImplClass.defaultIntProperty = 17
+  // CHECK: ImplClass.description = ImplClass(implProperty: 42, object: objc_implementation.LastWords)
+  // CHECK-LABEL: *** ImplClass end ***
+  // CHECK: ImplClass It's better to burn out than to fade away.
+  // CHECK-LABEL: *** SwiftSubclass init ***
+  // CHECK: SwiftSubclass.init()
+  // CHECK: ImplClass.init()
+  // CHECK-RESILIENCE-LABEL: *** SwiftResilientStoredSubclass #1 ***
+  // CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror = nil
+  // CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty = 0
+  // CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror2 = nil
+  // CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty2 = 1
+  // CHECK-RESILIENCE-LABEL: *** SwiftResilientStoredSubclass #2 ***
+  // CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror = nil
+  // CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty = 42
+  // CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror2 = nil
+  // CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty2 = 43
+  // CHECK-LABEL: *** SwiftSubclass #1 ***
+  // CHECK: SwiftSubclass.someMethod() = SwiftSubclass
+  // CHECK: SwiftSubclass.implProperty = 0
+  // CHECK: SwiftSubclass.defaultIntProperty = 17
+  // CHECK: SwiftSubclass.description = ImplClass(implProperty: 0, object: objc_implementation.LastWords)
+  // CHECK: SwiftSubclass.otherProperty = 1
+  // CHECK-LABEL: *** SwiftSubclass #2 ***
+  // CHECK: SwiftSubclass.someMethod() = SwiftSubclass
+  // CHECK: SwiftSubclass.implProperty = 42
+  // CHECK: SwiftSubclass.defaultIntProperty = 17
+  // CHECK: SwiftSubclass.description = ImplClass(implProperty: 42, object: objc_implementation.LastWords)
+  // CHECK: SwiftSubclass.otherProperty = 1
+  // CHECK-LABEL: *** SwiftSubclass #3 ***
+  // CHECK: SwiftSubclass.someMethod() = SwiftSubclass
+  // CHECK: SwiftSubclass.implProperty = 42
+  // CHECK: SwiftSubclass.defaultIntProperty = 17
+  // CHECK: SwiftSubclass.description = ImplClass(implProperty: 42, object: objc_implementation.LastWords)
+  // CHECK: SwiftSubclass.otherProperty = 13
+  // CHECK-LABEL: *** SwiftSubclass end ***
+  // CHECK: SwiftSubclass It's better to burn out than to fade away.
+
+  {
+    print(@"*** ObjCClientSubclass init ***");
+    ObjCClientSubclass *objcSub = [[ObjCClientSubclass alloc] init];
+    [objcSub testSelf];
+    print(@"*** ObjCClientSubclass end ***");
+  }
+  // CHECK-LABEL: *** ObjCClientSubclass init ***
+  // CHECK: -[ObjCClientSubclass init]
+  // CHECK: ImplClass.init()
+  // CHECK-RESILIENCE-LABEL: *** ObjCClientResilientSubclass #1 ***
+  // CHECK-RESILIENCE: ObjCClientResilientSubclass.mirror = nil
+  // CHECK-RESILIENCE: ObjCClientResilientSubclass.afterMirrorProperty = 0
+  // CHECK-RESILIENCE: ObjCClientResilientSubclass.subclassProperty = 100
+  // CHECK-RESILIENCE-LABEL: *** ObjCClientResilientSubclass #2 ***
+  // CHECK-RESILIENCE: ObjCClientResilientSubclass.mirror = nil
+  // CHECK-RESILIENCE: ObjCClientResilientSubclass.afterMirrorProperty = 42
+  // CHECK-RESILIENCE: ObjCClientResilientSubclass.subclassProperty = 101
+  // CHECK-LABEL: *** ObjCClientSubclass #1 ***
+  // CHECK: ObjCClientSubclass.someMethod() = ObjCClientSubclass
+  // CHECK: ObjCClientSubclass.implProperty = 0
+  // CHECK: ObjCClientSubclass.defaultIntProperty = 17
+  // CHECK: ObjCClientSubclass.description = ImplClass(implProperty: 0, object: objc_implementation.LastWords)
+  // CHECK: ObjCClientSubclass.otherProperty = 4
+  // CHECK-LABEL: *** ObjCClientSubclass #2 ***
+  // CHECK: ObjCClientSubclass.someMethod() = ObjCClientSubclass
+  // CHECK: ObjCClientSubclass.implProperty = 42
+  // CHECK: ObjCClientSubclass.defaultIntProperty = 17
+  // CHECK: ObjCClientSubclass.description = ImplClass(implProperty: 42, object: objc_implementation.LastWords)
+  // CHECK: ObjCClientSubclass.otherProperty = 4
+  // CHECK-LABEL: *** ObjCClientSubclass #3 ***
+  // CHECK: ObjCClientSubclass.someMethod() = ObjCClientSubclass
+  // CHECK: ObjCClientSubclass.implProperty = 42
+  // CHECK: ObjCClientSubclass.defaultIntProperty = 17
+  // CHECK: ObjCClientSubclass.description = ImplClass(implProperty: 42, object: objc_implementation.LastWords)
+  // CHECK: ObjCClientSubclass.otherProperty = 6
+  // CHECK-LABEL: *** ObjCClientSubclass end ***
+  // CHECK: ObjCClientSubclass It's better to burn out than to fade away.
 
   fflush(stdout);
 
   ImplClass *impl = [[ImplClass alloc] init];
-  print([impl someMethod]);
-  // CHECK: ImplClass.someMethod()
-  printInt(@"implProperty", impl.implProperty);
-  // CHECK: implProperty 0
+  printInt([impl class], @"implProperty", impl.implProperty);
   impl.implProperty = -2;
-  printInt(@"implProperty", impl.implProperty);
-  // CHECK: implProperty -2
+  printInt([impl class], @"implProperty", impl.implProperty);
+  // CHECK: ImplClass.implProperty = 0
+  // CHECK: ImplClass.implProperty = -2
 
   ObjCClientSubclass *objcSub = [[ObjCClientSubclass alloc] init];
   print([objcSub someMethod]);
-  // CHECK: -[ObjCClientSubclass someMethod]
+  // CHECK: ObjCClientSubclass
 
-  printInt(@"implProperty", objcSub.implProperty);
-  // CHECK: implProperty 0
-  printInt(@"otherProperty", objcSub.otherProperty);
-  // CHECK: otherProperty 4
+  printInt([objcSub class], @"implProperty", objcSub.implProperty);
+  printInt([objcSub class], @"otherProperty", objcSub.otherProperty);
   objcSub.implProperty = 7;
   objcSub.otherProperty = 9;
-  printInt(@"implProperty", objcSub.implProperty);
-  // CHECK: implProperty 7
-  printInt(@"otherProperty", objcSub.otherProperty);
-  // CHECK: otherProperty 9
+  printInt([objcSub class], @"implProperty", objcSub.implProperty);
+  printInt([objcSub class], @"otherProperty", objcSub.otherProperty);
+  // CHECK: ObjCClientSubclass.implProperty = 0
+  // CHECK: ObjCClientSubclass.otherProperty = 4
+  // CHECK: ObjCClientSubclass.implProperty = 7
+  // CHECK: ObjCClientSubclass.otherProperty = 9
 
   return 0;
 }
 
+#if RESILIENCE
+@interface ObjCClientResilientSubclass : ImplClassWithResilientStoredProperty
+
+@property (assign) NSInteger subclassProperty;
+
+@end
+#endif
+
 @implementation ObjCClientSubclass
 
 - (id)init {
+  print(@"-[ObjCClientSubclass init]");
   if (self = [super init]) {
     _otherProperty = 4;
   }
   return self;
 }
 
+- (void)testSelf {
+  [super testSelf];
+  self.otherProperty = 6;
+  [self printSelfWithLabel:3];
+}
+
+- (void)printSelfWithLabel:(int)label {
+  [super printSelfWithLabel:label];
+  printInt([self class], @"otherProperty", self.otherProperty);
+}
+
 - (NSString *)someMethod {
-  return @"-[ObjCClientSubclass someMethod]";
+  return @"ObjCClientSubclass";
+}
+
+#if RESILIENCE
++ (ImplClassWithResilientStoredProperty *)makeResilientImpl {
+  return [ObjCClientResilientSubclass new];
+}
+#endif
+
+@end
+
+#if RESILIENCE
+@implementation ObjCClientResilientSubclass
+
+- (id)init {
+  if (self = [super init]) {
+    _subclassProperty = 100;
+  }
+  return self;
+}
+
+- (void)printSelfWithLabel:(int)label {
+  [super printSelfWithLabel:label];
+  printInt([self class], @"subclassProperty", self.subclassProperty);
+}
+
+- (void)mutate {
+  [super mutate];
+  self.subclassProperty = 101;
 }
 
 @end
+#endif

--- a/test/Interpreter/objc_implementation_resilience.swift
+++ b/test/Interpreter/objc_implementation_resilience.swift
@@ -1,0 +1,7 @@
+// Variant of Interpreter/objc_implementation.swift that tests resilient stored properties.
+// Will not execute correctly without ObjC runtime support.
+// REQUIRES: rdar109171643
+
+// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/objc_implementation.h -D TOP_LEVEL_CODE -D RESILIENCE -swift-version 5 -enable-experimental-feature CImplementation -enable-experimental-feature ObjCImplementationWithResilientStorage -target %target-future-triple) %S/objc_implementation.swift | %FileCheck %S/objc_implementation.swift --check-prefixes CHECK,CHECK-RESILIENCE
+// REQUIRES: executable_test
+// REQUIRES: objc_interop

--- a/test/Interpreter/objc_implementation_resilience.swift
+++ b/test/Interpreter/objc_implementation_resilience.swift
@@ -2,6 +2,12 @@
 // Will not execute correctly without ObjC runtime support.
 // REQUIRES: rdar109171643
 
-// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/objc_implementation.h -D TOP_LEVEL_CODE -D RESILIENCE -swift-version 5 -enable-experimental-feature CImplementation -enable-experimental-feature ObjCImplementationWithResilientStorage -target %target-future-triple) %S/objc_implementation.swift | %FileCheck %S/objc_implementation.swift --check-prefixes CHECK,CHECK-RESILIENCE
+// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/objc_implementation.h -D RESILIENCE -swift-version 5 -enable-experimental-feature CImplementation -enable-experimental-feature ObjCImplementationWithResilientStorage -target %target-future-triple %S/objc_implementation.swift) | %FileCheck %S/objc_implementation.swift --check-prefixes CHECK,CHECK-RESILIENCE
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+
+@main struct Main {
+  static func main() {
+    ImplClass.runTests()
+  }
+}

--- a/test/Interpreter/objc_implementation_resilience_objc_client.m
+++ b/test/Interpreter/objc_implementation_resilience_objc_client.m
@@ -1,0 +1,29 @@
+// Variant of Interpreter/objc_implementation_objc_client.m that tests resilient stored properties.
+// Will not execute correctly without ObjC runtime support.
+// REQUIRES: rdar109171643
+
+// REQUIRES-X: rdar101497120
+
+//
+// Build objc_implementation.framework
+//
+// RUN: %empty-directory(%t-frameworks)
+// RUN: %empty-directory(%t-frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule)
+// RUN: %empty-directory(%t-frameworks/objc_implementation.framework/Headers)
+// RUN: cp %S/Inputs/objc_implementation.modulemap %t-frameworks/objc_implementation.framework/Modules/module.modulemap
+// RUN: cp %S/Inputs/objc_implementation.h %t-frameworks/objc_implementation.framework/Headers
+// RUN: %target-build-swift-dylib(%t-frameworks/objc_implementation.framework/objc_implementation) -emit-module-path %t-frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule/%module-target-triple.swiftmodule -module-name objc_implementation -F %t-frameworks -import-underlying-module -Xlinker -install_name -Xlinker %t-frameworks/objc_implementation.framework/objc_implementation %S/objc_implementation.swift -D RESILIENCE -enable-experimental-feature CImplementation -enable-experimental-feature ObjCImplementationWithResilientStorage -target %target-future-triple
+//
+// Execute this file
+//
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/objc_implementation_objc_client.m -isysroot %sdk -F %t-frameworks -lobjc -fmodules -fobjc-arc -o %t/objc_implementation_objc_client -D RESILIENCE
+// RUN: %target-codesign %t/objc_implementation_objc_client
+// RUN: %target-run %t/objc_implementation_objc_client 2>&1 | %FileCheck %S/objc_implementation_objc_client.m --check-prefixes CHECK,CHECK-RESILIENCE
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// FIXME: This test fails in Swift CI simulators, but I have not been able to
+//        reproduce this locally.
+// REQUIRES: OS=macosx

--- a/test/Interpreter/objc_implementation_resilience_swift_client.swift
+++ b/test/Interpreter/objc_implementation_resilience_swift_client.swift
@@ -1,0 +1,39 @@
+// Variant of Interpreter/objc_implementation_swift_client.swift that tests resilient stored properties.
+// Will not execute correctly without ObjC runtime support.
+// REQUIRES: rdar109171643
+
+// Test doesn't pass on all platforms (rdar://101543397)
+// REQUIRES: OS=macosx
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+//
+// Build objc_implementation.framework
+//
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/frameworks)
+// RUN: %empty-directory(%t/frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule)
+// RUN: %empty-directory(%t/frameworks/objc_implementation.framework/Headers)
+// RUN: cp %S/Inputs/objc_implementation.modulemap %t/frameworks/objc_implementation.framework/Modules/module.modulemap
+// RUN: cp %S/Inputs/objc_implementation.h %t/frameworks/objc_implementation.framework/Headers
+// RUN: %target-build-swift-dylib(%t/frameworks/objc_implementation.framework/objc_implementation) -D RESILIENCE -enable-experimental-feature CImplementation -enable-experimental-feature ObjCImplementationWithResilientStorage -target %target-future-triple -emit-module-path %t/frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule/%module-target-triple.swiftmodule -module-name objc_implementation -F %t/frameworks -import-underlying-module -Xlinker -install_name -Xlinker %t/frameworks/objc_implementation.framework/objc_implementation %S/objc_implementation.swift
+
+//
+// Execute this file
+//
+// RUN: %empty-directory(%t/swiftmod)
+// RUN: %target-build-swift %S/objc_implementation_swift_client.swift -module-cache-path %t/swiftmod/mcp -F %t/frameworks -o %t/swiftmod/a.out -module-name main -D RESILIENCE -enable-experimental-feature ObjCImplementationWithResilientStorage -target %target-future-triple
+// RUN: %target-codesign %t/swiftmod/a.out
+// RUN: %target-run %t/swiftmod/a.out | %FileCheck %S/objc_implementation_swift_client.swift -check-prefixes CHECK,CHECK-RESILIENCE
+
+//
+// Execute again, without the swiftmodule this time
+//
+// RUN: mv %t/frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule %t/frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule.disabled
+// RUN: %empty-directory(%t/clangmod)
+// RUN: %target-build-swift %S/objc_implementation_swift_client.swift -module-cache-path %t/clangmod/mcp -F %t/frameworks -o %t/clangmod/a.out -module-name main -D RESILIENCE -enable-experimental-feature ObjCImplementationWithResilientStorage -target %target-future-triple
+// RUN: %target-codesign %t/clangmod/a.out
+// RUN: %target-run %t/clangmod/a.out | %FileCheck %S/objc_implementation_swift_client.swift --check-prefixes CHECK,CHECK-RESILIENCE
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop

--- a/test/Interpreter/objc_implementation_resilience_swift_client.swift
+++ b/test/Interpreter/objc_implementation_resilience_swift_client.swift
@@ -37,3 +37,16 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+
+@main struct Main {
+  static func main() {
+    ImplClass.runTests()
+    
+    do {
+      print("*** SwiftClientSubclass init ***")
+      let swiftClientSub = SwiftClientSubclass()
+      swiftClientSub.testSelf()
+      print("*** SwiftClientSubclass end ***")
+    }
+  }
+}

--- a/test/Interpreter/objc_implementation_swift_client.swift
+++ b/test/Interpreter/objc_implementation_swift_client.swift
@@ -58,7 +58,6 @@ class SwiftClientSubclass: ImplClass {
 #if RESILIENCE
   override class func makeResilientImpl() -> ImplClassWithResilientStoredProperty {
     SwiftResilientStoredClientSubclass()
-    fatalError()
   }
 #endif
 }

--- a/test/Interpreter/objc_implementation_swift_client.swift
+++ b/test/Interpreter/objc_implementation_swift_client.swift
@@ -12,13 +12,13 @@
 // RUN: %empty-directory(%t/frameworks/objc_implementation.framework/Headers)
 // RUN: cp %S/Inputs/objc_implementation.modulemap %t/frameworks/objc_implementation.framework/Modules/module.modulemap
 // RUN: cp %S/Inputs/objc_implementation.h %t/frameworks/objc_implementation.framework/Headers
-// RUN: %target-build-swift-dylib(%t/frameworks/objc_implementation.framework/objc_implementation) -enable-experimental-feature CImplementation -emit-module-path %t/frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule/%module-target-triple.swiftmodule -module-name objc_implementation -F %t/frameworks -import-underlying-module -Xlinker -install_name -Xlinker %t/frameworks/objc_implementation.framework/objc_implementation %S/objc_implementation.swift
+// RUN: %target-build-swift-dylib(%t/frameworks/objc_implementation.framework/objc_implementation) -enable-experimental-feature CImplementation -emit-module-path %t/frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule/%module-target-triple.swiftmodule -module-name objc_implementation -F %t/frameworks -import-underlying-module -Xlinker -install_name -Xlinker %t/frameworks/objc_implementation.framework/objc_implementation %S/objc_implementation.swift -target %target-stable-abi-triple
 
 //
 // Execute this file
 //
 // RUN: %empty-directory(%t/swiftmod)
-// RUN: %target-build-swift %s -module-cache-path %t/swiftmod/mcp -F %t/frameworks -o %t/swiftmod/a.out -module-name main
+// RUN: %target-build-swift %s -module-cache-path %t/swiftmod/mcp -F %t/frameworks -o %t/swiftmod/a.out -module-name main -target %target-stable-abi-triple
 // RUN: %target-codesign %t/swiftmod/a.out
 // RUN: %target-run %t/swiftmod/a.out | %FileCheck %s
 
@@ -27,7 +27,7 @@
 //
 // RUN: mv %t/frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule %t/frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule.disabled
 // RUN: %empty-directory(%t/clangmod)
-// RUN: %target-build-swift %s -module-cache-path %t/clangmod/mcp -F %t/frameworks -o %t/clangmod/a.out -module-name main
+// RUN: %target-build-swift %s -module-cache-path %t/clangmod/mcp -F %t/frameworks -o %t/clangmod/a.out -module-name main -target %target-stable-abi-triple
 // RUN: %target-codesign %t/clangmod/a.out
 // RUN: %target-run %t/clangmod/a.out | %FileCheck %s
 
@@ -37,34 +37,151 @@
 import Foundation
 import objc_implementation
 
-ImplClass.runTests()
-// CHECK: someMethod = ImplClass.someMethod()
-// CHECK: implProperty = 0
-// CHECK: implProperty = 42
-// CHECK: someMethod = SwiftSubclass.someMethod()
-// CHECK: implProperty = 0
-// CHECK: implProperty = 42
-// CHECK: otherProperty = 1
-// CHECK: otherProperty = 13
-// CHECK: implProperty = 42
-
-let impl = ImplClass()
-print(impl.someMethod(), impl.implProperty)
-// CHECK: ImplClass.someMethod() 0
-
 class SwiftClientSubclass: ImplClass {
-  override init() {}
+  override init() { print("SwiftClientSubclass.init() ") }
   var otherProperty = 2
-  override func someMethod() -> String { "SwiftClientSubclass.someMethod()" }
+  override func someMethod() -> String { "SwiftClientSubclass" }
+
+  override func testSelf() {
+    super.testSelf()
+    self.implProperty = 3
+    self.otherProperty = 9
+    self.printSelf(withLabel: 3)
+  }
+
+  override func printSelf(withLabel label: CInt) {
+    super.printSelf(withLabel: label)
+    let type = type(of: self)
+    print("\(type).otherProperty =", otherProperty);
+  }
+
+#if RESILIENCE
+  override class func makeResilientImpl() -> ImplClassWithResilientStoredProperty {
+    SwiftResilientStoredClientSubclass()
+    fatalError()
+  }
+#endif
 }
 
-let swiftClientSub = SwiftClientSubclass()
-print(swiftClientSub.someMethod())
-// CHECK: SwiftClientSubclass.someMethod()
-print(swiftClientSub.implProperty, swiftClientSub.otherProperty)
-// CHECK: 0 2
-swiftClientSub.implProperty = 3
-swiftClientSub.otherProperty = 9
-print(swiftClientSub.implProperty, swiftClientSub.otherProperty)
-// CHECK: 3 9
+#if RESILIENCE
+extension SwiftClientSubclass {
+  class SwiftResilientStoredClientSubclass: ImplClassWithResilientStoredProperty {
+    final var mirror2: Mirror?
+    final var afterMirrorProperty2: Int
 
+    public override init() {
+      self.mirror2 = nil
+      self.afterMirrorProperty2 = 1
+    }
+
+    override func printSelf(withLabel label: CInt) {
+      super.printSelf(withLabel: label)
+      let type = type(of: self)
+      print("\(type).mirror2 =", self.mirror2 as Any)
+      print("\(type).afterMirrorProperty2 =", self.afterMirrorProperty2)
+    }
+
+    override func mutate() {
+      super.mutate()
+      self.afterMirrorProperty2 = 43
+    }
+  }
+}
+#endif
+
+ImplClass.runTests();
+
+do {
+  print("*** SwiftClientSubclass init ***")
+  let swiftClientSub = SwiftClientSubclass()
+  swiftClientSub.testSelf()
+  print("*** SwiftClientSubclass end ***")
+}
+
+// CHECK: implFunc(1989)
+// CHECK-LABEL: *** ImplClass init ***
+// CHECK: ImplClass.init()
+// CHECK-RESILIENCE-LABEL: *** ImplClassWithResilientStoredProperty #1 ***
+// CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.mirror = nil
+// CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.afterMirrorProperty = 0
+// CHECK-RESILIENCE-LABEL: *** ImplClassWithResilientStoredProperty #2 ***
+// CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.mirror = nil
+// CHECK-RESILIENCE: ImplClassWithResilientStoredProperty.afterMirrorProperty = 42
+// CHECK-LABEL: *** ImplClass #1 ***
+// CHECK: ImplClass.someMethod() = ImplClass
+// CHECK: ImplClass.implProperty = 0
+// CHECK: ImplClass.defaultIntProperty = 17
+// CHECK: ImplClass.description = ImplClass(implProperty: 0, object: objc_implementation.LastWords)
+// CHECK-LABEL: *** ImplClass #2 ***
+// CHECK: ImplClass.someMethod() = ImplClass
+// CHECK: ImplClass.implProperty = 42
+// CHECK: ImplClass.defaultIntProperty = 17
+// CHECK: ImplClass.description = ImplClass(implProperty: 42, object: objc_implementation.LastWords)
+// CHECK-LABEL: *** ImplClass end ***
+// CHECK: ImplClass It's better to burn out than to fade away.
+// CHECK-LABEL: *** SwiftSubclass init ***
+// CHECK: SwiftSubclass.init()
+// CHECK: ImplClass.init()
+// CHECK-RESILIENCE-LABEL: *** SwiftResilientStoredSubclass #1 ***
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror = nil
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty = 0
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror2 = nil
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty2 = 1
+// CHECK-RESILIENCE-LABEL: *** SwiftResilientStoredSubclass #2 ***
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror = nil
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty = 42
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.mirror2 = nil
+// CHECK-RESILIENCE: SwiftResilientStoredSubclass.afterMirrorProperty2 = 43
+// CHECK-LABEL: *** SwiftSubclass #1 ***
+// CHECK: SwiftSubclass.someMethod() = SwiftSubclass
+// CHECK: SwiftSubclass.implProperty = 0
+// CHECK: SwiftSubclass.defaultIntProperty = 17
+// CHECK: SwiftSubclass.description = ImplClass(implProperty: 0, object: objc_implementation.LastWords)
+// CHECK: SwiftSubclass.otherProperty = 1
+// CHECK-LABEL: *** SwiftSubclass #2 ***
+// CHECK: SwiftSubclass.someMethod() = SwiftSubclass
+// CHECK: SwiftSubclass.implProperty = 42
+// CHECK: SwiftSubclass.defaultIntProperty = 17
+// CHECK: SwiftSubclass.description = ImplClass(implProperty: 42, object: objc_implementation.LastWords)
+// CHECK: SwiftSubclass.otherProperty = 1
+// CHECK-LABEL: *** SwiftSubclass #3 ***
+// CHECK: SwiftSubclass.someMethod() = SwiftSubclass
+// CHECK: SwiftSubclass.implProperty = 42
+// CHECK: SwiftSubclass.defaultIntProperty = 17
+// CHECK: SwiftSubclass.description = ImplClass(implProperty: 42, object: objc_implementation.LastWords)
+// CHECK: SwiftSubclass.otherProperty = 13
+// CHECK-LABEL: *** SwiftSubclass end ***
+// CHECK: SwiftSubclass It's better to burn out than to fade away.
+// CHECK-LABEL: *** SwiftClientSubclass init ***
+// CHECK: SwiftClientSubclass.init()
+// CHECK: ImplClass.init()
+// CHECK-RESILIENCE-LABEL: *** SwiftResilientStoredClientSubclass #1 ***
+// CHECK-RESILIENCE: SwiftResilientStoredClientSubclass.mirror = nil
+// CHECK-RESILIENCE: SwiftResilientStoredClientSubclass.afterMirrorProperty = 0
+// CHECK-RESILIENCE: SwiftResilientStoredClientSubclass.mirror2 = nil
+// CHECK-RESILIENCE: SwiftResilientStoredClientSubclass.afterMirrorProperty2 = 1
+// CHECK-RESILIENCE-LABEL: *** SwiftResilientStoredClientSubclass #2 ***
+// CHECK-RESILIENCE: SwiftResilientStoredClientSubclass.mirror = nil
+// CHECK-RESILIENCE: SwiftResilientStoredClientSubclass.afterMirrorProperty = 42
+// CHECK-RESILIENCE: SwiftResilientStoredClientSubclass.mirror2 = nil
+// CHECK-RESILIENCE: SwiftResilientStoredClientSubclass.afterMirrorProperty2 = 43
+// CHECK-LABEL: *** SwiftClientSubclass #1 ***
+// CHECK: SwiftClientSubclass.someMethod() = SwiftClientSubclass
+// CHECK: SwiftClientSubclass.implProperty = 0
+// CHECK: SwiftClientSubclass.defaultIntProperty = 17
+// CHECK: SwiftClientSubclass.description = ImplClass(implProperty: 0, object: objc_implementation.LastWords)
+// CHECK: SwiftClientSubclass.otherProperty = 2
+// CHECK-LABEL: *** SwiftClientSubclass #2 ***
+// CHECK: SwiftClientSubclass.someMethod() = SwiftClientSubclass
+// CHECK: SwiftClientSubclass.implProperty = 42
+// CHECK: SwiftClientSubclass.defaultIntProperty = 17
+// CHECK: SwiftClientSubclass.description = ImplClass(implProperty: 42, object: objc_implementation.LastWords)
+// CHECK: SwiftClientSubclass.otherProperty = 2
+// CHECK-LABEL: *** SwiftClientSubclass #3 ***
+// CHECK: SwiftClientSubclass.someMethod() = SwiftClientSubclass
+// CHECK: SwiftClientSubclass.implProperty = 3
+// CHECK: SwiftClientSubclass.defaultIntProperty = 17
+// CHECK: SwiftClientSubclass.description = ImplClass(implProperty: 3, object: objc_implementation.LastWords)
+// CHECK: SwiftClientSubclass.otherProperty = 9
+// CHECK-LABEL: *** SwiftClientSubclass end ***
+// CHECK: SwiftClientSubclass It's better to burn out than to fade away.

--- a/test/ModuleInterface/objc_implementation.swift
+++ b/test/ModuleInterface/objc_implementation.swift
@@ -16,6 +16,10 @@ import Foundation
 
 // We should never see @_objcImplementation in the header
 // NEGATIVE-NOT: @_objcImplementation
+// NEGATIVE-NOT: @implementation
+
+// @objc should be omitted on extensions
+// NEGATIVE-NOT: @objc{{.*}} extension
 
 //
 // @_objcImplementation class

--- a/test/ModuleInterface/objc_implementation.swift
+++ b/test/ModuleInterface/objc_implementation.swift
@@ -5,10 +5,10 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
 // FIXME: END -enable-source-import hackaround
 
-// RUN: %target-swift-emit-module-interface(%t/objc_implementation.swiftinterface) %s -import-underlying-module %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/objc_implementation
+// RUN: %target-swift-emit-module-interface(%t/objc_implementation.swiftinterface) %s -import-underlying-module %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/objc_implementation -target %target-stable-abi-triple
 // RUN: %FileCheck --input-file %t/objc_implementation.swiftinterface %s
 // RUN: %FileCheck --input-file %t/objc_implementation.swiftinterface --check-prefix NEGATIVE %s
-// RUN: %target-swift-typecheck-module-from-interface(%t/objc_implementation.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/objc_implementation
+// RUN: %target-swift-typecheck-module-from-interface(%t/objc_implementation.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/objc_implementation -target %target-stable-abi-triple
 
 // REQUIRES: objc_interop
 

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -1,10 +1,10 @@
 // Please keep this file in alphabetical order!
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/extensions.swiftmodule -typecheck -emit-objc-header-path %t/extensions.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
-// RUN: %FileCheck %s < %t/extensions.h
-// RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/extensions.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-sil-ownership-verifier -emit-module -o %t %s -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-sil-ownership-verifier -parse-as-library %t/extensions.swiftmodule -typecheck -emit-objc-header-path %t/extensions.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-pass=MandatoryARCOpts
+// RUN: %FileCheck %s --input-file %t/extensions.h
+// RUN: %FileCheck --check-prefix=NEGATIVE %s --input-file %t/extensions.h
 // RUN: %check-in-clang %t/extensions.h
 
 // REQUIRES: objc_interop
@@ -135,6 +135,13 @@ extension NotObjC {}
 // CHECK-NEXT: @end
 extension NSObject {
   @objc var some: Int { return 1 }
+}
+
+// CHECK-LABEL: @interface NSString (CustomName)
+// CHECK-NEXT: - (void)test3;
+// CHECK-NEXT: @end
+@objc(CustomName) extension NSString {
+  func test3() {}
 }
 
 // NEGATIVE-NOT: @class NSString;

--- a/test/PrintAsObjC/objc_implementation.swift
+++ b/test/PrintAsObjC/objc_implementation.swift
@@ -11,8 +11,8 @@
 // FIXME: END -enable-source-import hackaround
 
 
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -enable-experimental-feature CImplementation -I %S/Inputs/custom-modules -import-underlying-module -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/objc_implementation.swiftmodule -typecheck -enable-experimental-feature CImplementation -I %S/Inputs/custom-modules -emit-objc-header-path %t/objc_implementation-Swift.h -import-underlying-module -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -enable-experimental-feature CImplementation -I %S/Inputs/custom-modules -import-underlying-module -o %t %s -disable-objc-attr-requires-foundation-module -target %target-stable-abi-triple
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/objc_implementation.swiftmodule -typecheck -enable-experimental-feature CImplementation -I %S/Inputs/custom-modules -emit-objc-header-path %t/objc_implementation-Swift.h -import-underlying-module -disable-objc-attr-requires-foundation-module -target %target-stable-abi-triple
 // RUN: %FileCheck %s --input-file %t/objc_implementation-Swift.h
 // RUN: %FileCheck --check-prefix=NEGATIVE %s --input-file %t/objc_implementation-Swift.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/objc_implementation-Swift.h

--- a/test/SILGen/objc_implementation.swift
+++ b/test/SILGen/objc_implementation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -import-objc-header %S/Inputs/objc_implementation.h -swift-version 5 %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -import-objc-header %S/Inputs/objc_implementation.h -swift-version 5 %s -target %target-stable-abi-triple | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/let_properties_opts_objc.swift
+++ b/test/SILOptimizer/let_properties_opts_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name test -primary-file %s -import-objc-header %S/Inputs/let_properties_opts.h -O -wmo -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -module-name test -primary-file %s -import-objc-header %S/Inputs/let_properties_opts.h -O -wmo -emit-sil -target %target-stable-abi-triple | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/let_properties_opts_objc.swift
+++ b/test/SILOptimizer/let_properties_opts_objc.swift
@@ -16,12 +16,12 @@ public func testObjcInterface(_ x: ObjcInterface) -> Int {
   return x.i
 }
 
-// Test optimization of a private constant. This constant must be declared in a separate type without other fields.
+// Test that private @objc constants aren't optimized, but instead continue to pass through ObjC message dispatch.
 @_objcImplementation extension ObjcInterfaceConstInit {
   private let constant: Int = 0
 
   // CHECK-LABEL: sil hidden @$sSo22ObjcInterfaceConstInitC4testE0E15PrivateConstantSiyF : $@convention(method) (@guaranteed ObjcInterfaceConstInit) -> Int {
-  // CHECK: ref_element_addr [immutable] %0 : $ObjcInterfaceConstInit, #ObjcInterfaceConstInit.constant
+  // CHECK: objc_method %0 : $ObjcInterfaceConstInit, #ObjcInterfaceConstInit.constant!getter.foreign
   // CHECK-LABEL: } // end sil function '$sSo22ObjcInterfaceConstInitC4testE0E15PrivateConstantSiyF'
   final func testPrivateConstant() -> Int {
     return constant

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -566,6 +566,7 @@ Added: __swift_exceptionPersonality
 Added: _swift_willThrowTypedImpl
 Added: __swift_willThrowTypedImpl
 Added: __swift_enableSwizzlingOfAllocationAndRefCountingFunctions_forInstrumentsOnly
+Added: _swift_updatePureObjCClassMetadata
 
 // Runtime bincompat functions for Concurrency runtime to detect legacy mode
 Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -566,6 +566,7 @@ Added: __swift_exceptionPersonality
 Added: _swift_willThrowTypedImpl
 Added: __swift_willThrowTypedImpl
 Added: __swift_enableSwizzlingOfAllocationAndRefCountingFunctions_forInstrumentsOnly
+Added: _swift_updatePureObjCClassMetadata
 
 // Runtime bincompat functions for Concurrency runtime to detect legacy mode
 Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -384,6 +384,17 @@ protocol subject_containerObjCProtocol2 {
   subscript(i: String) -> Int { get set}
 }
 
+@objc(ConflictingName)
+extension subject_class1 {}
+// expected-note@-1 {{'ConflictingName' previously declared here}}
+
+@objc(ConflictingName)
+extension subject_class2 {}
+
+@objc(ConflictingName)
+extension subject_class1 {}
+// expected-warning@-1 {{extension with Objective-C category name 'ConflictingName' conflicts with previous extension with the same category name; this is an error in the Swift 6 language mode}}
+
 protocol nonObjCProtocol {
   @objc // bad-access-note-move{{nonObjCProtocol.objcRequirement()}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   func objcRequirement()
@@ -2018,6 +2029,9 @@ class BadClass1 { }
 
 @objc(Protocol:) // bad-access-note-move{{BadProto1}} expected-error{{'@objc' protocol must have a simple name}}{{15-16=}}
 protocol BadProto1 { }
+
+@objc(Extension:) // expected-error{{'@objc' extension must have a simple name}}{{16-17=}}
+extension PlainClass {}
 
 @objc(Enum:) // bad-access-note-move{{BadEnum1}} expected-error{{'@objc' enum must have a simple name}}{{11-12=}}
 enum BadEnum1: Int { case X }

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -191,6 +191,15 @@
 
 @end
 
+@interface ObjCBadClass : NSObject
+@end
+
+@interface ObjCBadClass (BadCategory1)
+@end
+
+@interface ObjCBadClass (BadCategory2)
+@end
+
 @protocol EmptyObjCProto
 @end
 

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/objc_implementation.h -enable-experimental-feature ObjCImplementation -enable-experimental-feature CImplementation
+// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/objc_implementation.h -enable-experimental-feature ObjCImplementation -enable-experimental-feature CImplementation -target %target-stable-abi-triple
 // REQUIRES: objc_interop
 
 protocol EmptySwiftProto {}

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -10,8 +10,8 @@ protocol EmptySwiftProto {}
   // FIXME: give better diagnostic expected-error@-4 {{extension for main class interface should provide implementation for property 'propertyFromHeader8'}}
   // FIXME: give better diagnostic expected-error@-5 {{extension for main class interface should provide implementation for property 'propertyFromHeader7'}}
   // FIXME: give better diagnostic expected-error@-6 {{extension for main class interface should provide implementation for instance method 'method(fromHeader3:)'}}
-  // expected-error@-7 {{'@_objcImplementation' extension cannot add conformance to 'EmptySwiftProto'; add this conformance with an ordinary extension}}
-  // expected-error@-8 {{'@_objcImplementation' extension cannot add conformance to 'EmptyObjCProto'; add this conformance in the Objective-C header}}
+  // expected-error@-7 {{'@objc @implementation' extension cannot add conformance to 'EmptySwiftProto'; add this conformance with an ordinary extension}}
+  // expected-error@-8 {{'@objc @implementation' extension cannot add conformance to 'EmptyObjCProto'; add this conformance in the Objective-C header}}
   // expected-error@-9 {{extension for main class interface should provide implementation for instance method 'extensionMethod(fromHeader2:)'}}
 
   func method(fromHeader1: CInt) {
@@ -204,12 +204,12 @@ protocol EmptySwiftProto {}
   }
 
   @nonobjc public init(notFromHeader4: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader4:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override designated initializers}}
+    // expected-error@-1 {{initializer 'init(notFromHeader4:)' is not valid in an '@objc @implementation' extension because Objective-C subclasses must be able to override designated initializers}}
     // expected-note@-2 {{add 'convenience' keyword to make this a convenience initializer}} {{12-12=convenience }}
   }
 
   @nonobjc public required init(notFromHeader5: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader5:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override required initializers}}
+    // expected-error@-1 {{initializer 'init(notFromHeader5:)' is not valid in an '@objc @implementation' extension because Objective-C subclasses must be able to override required initializers}}
     // expected-note@-2 {{replace 'required' keyword with 'convenience' to make this a convenience initializer}} {{19-27=convenience}}
   }
 
@@ -475,17 +475,17 @@ protocol EmptySwiftProto {}
 // expected-note@-1 2 {{'SwiftClass' declared here}}
 
 @objc @implementation extension SwiftClass {}
-// expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{7-23=}}
+// expected-error@-1 {{'@objc @implementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{7-23=}}
 
 @objc(WTF) @implementation extension SwiftClass {} // expected
-// expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{12-28=}}
+// expected-error@-1 {{'@objc @implementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{12-28=}}
 
 @objc @implementation extension ObjCImplRootClass {
-  // expected-error@-1 {{'@_objcImplementation' cannot be used to implement root class 'ObjCImplRootClass'; declare its superclass in the header}}
+  // expected-error@-1 {{'@objc @implementation' cannot be used to implement root class 'ObjCImplRootClass'; declare its superclass in the header}}
 }
 
 @objc @implementation extension ObjCImplGenericClass {
-  // expected-error@-1 {{'@_objcImplementation' cannot be used to implement generic class 'ObjCImplGenericClass'}}
+  // expected-error@-1 {{'@objc @implementation' cannot be used to implement generic class 'ObjCImplGenericClass'}}
 }
 
 @implementation extension ObjCBadClass {

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -229,6 +229,11 @@ protocol EmptySwiftProto {}
   // rdar://122280735 - crash when the parameter of a block property needs @escaping
   let rdar122280735: (() -> ()) -> Void = { _ in }
   // expected-error@-1 {{property 'rdar122280735' of type '(() -> ()) -> Void' does not match type '(@escaping () -> Void) -> Void' declared by the header}}
+
+  private func privateNonObjCMethod(_: EmptySwiftProto) {
+    // expected-error@-1 {{method cannot be in an @objc @implementation extension of a class (without final or @nonobjc) because the type of the parameter cannot be represented in Objective-C}}
+    // expected-note@-2 {{protocol-constrained type containing protocol 'EmptySwiftProto' cannot be represented in Objective-C}}
+  }
 }
 
 @objc(PresentAdditions) @implementation extension ObjCClass {

--- a/test/decl/ext/objc_implementation_class_extension.swift
+++ b/test/decl/ext/objc_implementation_class_extension.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -import-underlying-module -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_class_extension.modulemap
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -import-underlying-module -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_class_extension.modulemap -target %target-stable-abi-triple
 // REQUIRES: objc_interop
 
 @_implementationOnly import objc_implementation_class_extension_internal

--- a/test/decl/ext/objc_implementation_conflicts.swift
+++ b/test/decl/ext/objc_implementation_conflicts.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/objc_implementation.h
-// RUN: %target-typecheck-verify-swift -DPRIVATE_MODULE -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap
+// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/objc_implementation.h -target %target-stable-abi-triple
+// RUN: %target-typecheck-verify-swift -DPRIVATE_MODULE -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap -target %target-stable-abi-triple
 
 // REQUIRES: objc_interop
 

--- a/test/decl/ext/objc_implementation_conflicts.swift
+++ b/test/decl/ext/objc_implementation_conflicts.swift
@@ -11,7 +11,7 @@
 import objc_implementation_private
 #endif
 
-@_objcImplementation extension ObjCClass {
+@objc @implementation extension ObjCClass {
   @objc func method(fromHeader1: CInt) {
     // OK, provides an implementation for the header's method.
   }
@@ -179,7 +179,7 @@ import objc_implementation_private
   let rdar122280735: (@escaping () -> ()) -> Void = { _ in }
 }
 
-@_objcImplementation(PresentAdditions) extension ObjCClass {
+@objc(PresentAdditions) @implementation extension ObjCClass {
   @objc func categoryMethod(fromHeader3: CInt) {
     // OK
   }

--- a/test/decl/ext/objc_implementation_deployment_target.swift
+++ b/test/decl/ext/objc_implementation_deployment_target.swift
@@ -1,14 +1,19 @@
 // Hardcode x86_64 macOS because Apple Silicon was born ABI-stable
-// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/objc_implementation.h -target x86_64-apple-macosx10.14.3
+// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/objc_implementation.h -target x86_64-apple-macosx10.14.3 -enable-experimental-feature ObjCImplementation
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 
-@_objcImplementation extension ObjCImplSubclass {
+@objc @implementation extension ObjCImplSubclass {
   // expected-error@-1 {{'@implementation' of an Objective-C class requires a minimum deployment target of at least macOS 10.14.4}}
 }
 
-@_objcImplementation(Conformance) extension ObjCClass {
+@objc(Conformance) @implementation extension ObjCClass {
   // expected-error@-1 {{'@implementation' of an Objective-C class requires a minimum deployment target of at least macOS 10.14.4}}
   func requiredMethod1() {}
   func requiredMethod2() {}
+}
+
+@_objcImplementation(EmptyCategory) extension ObjCClass {
+  // expected-warning@-1 {{'@implementation' of an Objective-C class requires a minimum deployment target of at least macOS 10.14.4; this will become an error after adopting '@implementation'}}
+  // expected-warning@-2 {{'@_objcImplementation' is deprecated; use '@implementation' instead}}
 }

--- a/test/decl/ext/objc_implementation_deployment_target.swift
+++ b/test/decl/ext/objc_implementation_deployment_target.swift
@@ -1,0 +1,14 @@
+// Hardcode x86_64 macOS because Apple Silicon was born ABI-stable
+// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/objc_implementation.h -target x86_64-apple-macosx10.14.3
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+@_objcImplementation extension ObjCImplSubclass {
+  // expected-error@-1 {{'@implementation' of an Objective-C class requires a minimum deployment target of at least macOS 10.14.4}}
+}
+
+@_objcImplementation(Conformance) extension ObjCClass {
+  // expected-error@-1 {{'@implementation' of an Objective-C class requires a minimum deployment target of at least macOS 10.14.4}}
+  func requiredMethod1() {}
+  func requiredMethod2() {}
+}

--- a/test/decl/ext/objc_implementation_early_adopter.swift
+++ b/test/decl/ext/objc_implementation_early_adopter.swift
@@ -229,6 +229,11 @@ protocol EmptySwiftProto {}
   // rdar://122280735 - crash when the parameter of a block property needs @escaping
   let rdar122280735: (() -> ()) -> Void = { _ in }
   // expected-warning@-1 {{property 'rdar122280735' of type '(() -> ()) -> Void' does not match type '(@escaping () -> Void) -> Void' declared by the header}}
+
+  private func privateNonObjCMethod(_: EmptySwiftProto) {
+    // expected-warning@-1 {{method cannot be in an @objc @implementation extension of a class (without final or @nonobjc) because the type of the parameter cannot be represented in Objective-C}}
+    // expected-note@-2 {{protocol-constrained type containing protocol 'EmptySwiftProto' cannot be represented in Objective-C}}
+  }
 }
 
 @_objcImplementation(PresentAdditions) extension ObjCClass {
@@ -428,8 +433,8 @@ protocol EmptySwiftProto {}
   func nullableResult() -> Any { fatalError() } // expected-warning {{instance method 'nullableResult()' of type '() -> Any' does not match type '() -> Any?' declared by the header}}
   func nullableArgument(_: Any) {} // expected-warning {{instance method 'nullableArgument' of type '(Any) -> ()' does not match type '(Any?) -> Void' declared by the header}}
 
-  func nonPointerResult() -> CInt! { fatalError() } // expected-error{{method cannot be in an @objc @implementation extension of a class (without final or @nonobjc) because its result type cannot be represented in Objective-C}}
-  func nonPointerArgument(_: CInt!) {} // expected-error {{method cannot be in an @objc @implementation extension of a class (without final or @nonobjc) because the type of the parameter cannot be represented in Objective-C}}
+  func nonPointerResult() -> CInt! { fatalError() } // expected-warning{{method cannot be in an @objc @implementation extension of a class (without final or @nonobjc) because its result type cannot be represented in Objective-C}}
+  func nonPointerArgument(_: CInt!) {} // expected-warning {{method cannot be in an @objc @implementation extension of a class (without final or @nonobjc) because the type of the parameter cannot be represented in Objective-C}}
 }
 
 // Intentionally using `@_objcImplementation` for this test; do not upgrade!

--- a/test/decl/ext/objc_implementation_early_adopter.swift
+++ b/test/decl/ext/objc_implementation_early_adopter.swift
@@ -10,8 +10,8 @@ protocol EmptySwiftProto {}
   // FIXME: give better diagnostic expected-warning@-4 {{extension for main class interface should provide implementation for property 'propertyFromHeader8'}}
   // FIXME: give better diagnostic expected-warning@-5 {{extension for main class interface should provide implementation for property 'propertyFromHeader7'}}
   // FIXME: give better diagnostic expected-warning@-6 {{extension for main class interface should provide implementation for instance method 'method(fromHeader3:)'}}
-  // expected-warning@-7 {{'@_objcImplementation' extension cannot add conformance to 'EmptySwiftProto'; add this conformance with an ordinary extension}}
-  // expected-warning@-8 {{'@_objcImplementation' extension cannot add conformance to 'EmptyObjCProto'; add this conformance in the Objective-C header}}
+  // expected-warning@-7 {{'@objc @implementation' extension cannot add conformance to 'EmptySwiftProto'; add this conformance with an ordinary extension}}
+  // expected-warning@-8 {{'@objc @implementation' extension cannot add conformance to 'EmptyObjCProto'; add this conformance in the Objective-C header}}
   // expected-warning@-9 {{extension for main class interface should provide implementation for instance method 'extensionMethod(fromHeader2:)'}}
 
   func method(fromHeader1: CInt) {
@@ -204,12 +204,12 @@ protocol EmptySwiftProto {}
   }
 
   @nonobjc public init(notFromHeader4: CInt) {
-    // expected-warning@-1 {{initializer 'init(notFromHeader4:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override designated initializers}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader4:)' is not valid in an '@objc @implementation' extension because Objective-C subclasses must be able to override designated initializers}}
     // expected-note@-2 {{add 'convenience' keyword to make this a convenience initializer}} {{12-12=convenience }}
   }
 
   @nonobjc public required init(notFromHeader5: CInt) {
-    // expected-warning@-1 {{initializer 'init(notFromHeader5:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override required initializers}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader5:)' is not valid in an '@objc @implementation' extension because Objective-C subclasses must be able to override required initializers}}
     // expected-note@-2 {{replace 'required' keyword with 'convenience' to make this a convenience initializer}} {{19-27=convenience}}
   }
 
@@ -477,17 +477,17 @@ protocol EmptySwiftProto {}
 // expected-note@-1 2 {{'SwiftClass' declared here}}
 
 @_objcImplementation extension SwiftClass {}
-// expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{1-22=}}
+// expected-error@-1 {{'@objc @implementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{1-22=}}
 
 @_objcImplementation(WTF) extension SwiftClass {} // expected
-// expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{1-27=}}
+// expected-error@-1 {{'@objc @implementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{1-27=}}
 
 @_objcImplementation extension ObjCImplRootClass {
-  // expected-error@-1 {{'@_objcImplementation' cannot be used to implement root class 'ObjCImplRootClass'; declare its superclass in the header}}
+  // expected-error@-1 {{'@objc @implementation' cannot be used to implement root class 'ObjCImplRootClass'; declare its superclass in the header}}
 }
 
 @_objcImplementation extension ObjCImplGenericClass {
-  // expected-error@-1 {{'@_objcImplementation' cannot be used to implement generic class 'ObjCImplGenericClass'}}
+  // expected-error@-1 {{'@objc @implementation' cannot be used to implement generic class 'ObjCImplGenericClass'}}
 }
 
 //

--- a/test/decl/ext/objc_implementation_early_adopter.swift
+++ b/test/decl/ext/objc_implementation_early_adopter.swift
@@ -3,16 +3,16 @@
 
 protocol EmptySwiftProto {}
 
-@objc @implementation extension ObjCClass: EmptySwiftProto, EmptyObjCProto {
+@_objcImplementation extension ObjCClass: EmptySwiftProto, EmptyObjCProto {
   // expected-note@-1 {{previously implemented here}}
-  // expected-error@-2 {{extension for main class interface should provide implementation for instance method 'method(fromHeader4:)'}}
-  // expected-error@-3 {{extension for main class interface should provide implementation for property 'propertyFromHeader9'}}
-  // FIXME: give better diagnostic expected-error@-4 {{extension for main class interface should provide implementation for property 'propertyFromHeader8'}}
-  // FIXME: give better diagnostic expected-error@-5 {{extension for main class interface should provide implementation for property 'propertyFromHeader7'}}
-  // FIXME: give better diagnostic expected-error@-6 {{extension for main class interface should provide implementation for instance method 'method(fromHeader3:)'}}
-  // expected-error@-7 {{'@_objcImplementation' extension cannot add conformance to 'EmptySwiftProto'; add this conformance with an ordinary extension}}
-  // expected-error@-8 {{'@_objcImplementation' extension cannot add conformance to 'EmptyObjCProto'; add this conformance in the Objective-C header}}
-  // expected-error@-9 {{extension for main class interface should provide implementation for instance method 'extensionMethod(fromHeader2:)'}}
+  // expected-warning@-2 {{extension for main class interface should provide implementation for instance method 'method(fromHeader4:)'}}
+  // expected-warning@-3 {{extension for main class interface should provide implementation for property 'propertyFromHeader9'}}
+  // FIXME: give better diagnostic expected-warning@-4 {{extension for main class interface should provide implementation for property 'propertyFromHeader8'}}
+  // FIXME: give better diagnostic expected-warning@-5 {{extension for main class interface should provide implementation for property 'propertyFromHeader7'}}
+  // FIXME: give better diagnostic expected-warning@-6 {{extension for main class interface should provide implementation for instance method 'method(fromHeader3:)'}}
+  // expected-warning@-7 {{'@_objcImplementation' extension cannot add conformance to 'EmptySwiftProto'; add this conformance with an ordinary extension}}
+  // expected-warning@-8 {{'@_objcImplementation' extension cannot add conformance to 'EmptyObjCProto'; add this conformance in the Objective-C header}}
+  // expected-warning@-9 {{extension for main class interface should provide implementation for instance method 'extensionMethod(fromHeader2:)'}}
 
   func method(fromHeader1: CInt) {
     // OK, provides an implementation for the header's method.
@@ -24,7 +24,7 @@ protocol EmptySwiftProto {}
 
   func categoryMethod(fromHeader3: CInt) {
     // FIXME: should emit expected-DISABLED-error@-1 {{instance method 'categoryMethod(fromHeader3:)' should be implemented in extension for category 'PresentAdditions', not main class interface}}
-    // FIXME: expected-error@-2 {{instance method 'categoryMethod(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // FIXME: expected-warning@-2 {{instance method 'categoryMethod(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error after adopting '@implementation'}}
     // FIXME: expected-note@-3 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // FIXME: expected-note@-4 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
@@ -38,16 +38,16 @@ protocol EmptySwiftProto {}
   }
 
   func methodNot(fromHeader3: CInt) {
-    // expected-error@-1 {{instance method 'methodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // expected-warning@-1 {{instance method 'methodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error after adopting '@implementation'}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // expected-note@-3 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
 
   var methodFromHeader5: CInt
-  // expected-error@-1 {{property 'methodFromHeader5' does not match the instance method declared by the header}}
+  // expected-warning@-1 {{property 'methodFromHeader5' does not match the instance method declared by the header}}
 
   func method(fromHeader6: Double) {
-    // expected-error@-1 {{instance method 'method(fromHeader6:)' of type '(Double) -> ()' does not match type '(Int32) -> Void' declared by the header}}
+    // expected-warning@-1 {{instance method 'method(fromHeader6:)' of type '(Double) -> ()' does not match type '(Int32) -> Void' declared by the header}}
   }
 
   var propertyFromHeader1: CInt
@@ -69,10 +69,10 @@ protocol EmptySwiftProto {}
   }
 
   @objc let propertyFromHeader5: CInt
-  // expected-error@-1 {{property 'propertyFromHeader5' should be settable to match the settable property declared by the header}}
+  // expected-warning@-1 {{property 'propertyFromHeader5' should be settable to match the settable property declared by the header}}
 
   @objc var propertyFromHeader6: CInt {
-    // expected-error@-1 {{property 'propertyFromHeader6' should be settable to match the settable property declared by the header}}
+    // expected-warning@-1 {{property 'propertyFromHeader6' should be settable to match the settable property declared by the header}}
     get { return 1 }
   }
 
@@ -80,12 +80,12 @@ protocol EmptySwiftProto {}
   // FIXME: Should complain about final not fulfilling the @objc requirement
 
   func propertyFromHeader10() -> CInt {
-    // expected-error@-1 {{instance method 'propertyFromHeader10()' does not match the property declared by the header}}
+    // expected-warning@-1 {{instance method 'propertyFromHeader10()' does not match the property declared by the header}}
     return 1
   }
 
   var propertyFromHeader11: Float
-  // expected-error@-1 {{property 'propertyFromHeader11' of type 'Float' does not match type 'Int32' declared by the header}}
+  // expected-warning@-1 {{property 'propertyFromHeader11' of type 'Float' does not match type 'Int32' declared by the header}}
 
   var readonlyPropertyFromHeader1: CInt
   // OK, provides an implementation with a stored property that's nonpublicly settable
@@ -114,7 +114,7 @@ protocol EmptySwiftProto {}
   }
 
   internal var propertyNotFromHeader1: CInt
-  // expected-error@-1 {{property 'propertyNotFromHeader1' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?}}
+  // expected-warning@-1 {{property 'propertyNotFromHeader1' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?; this will become an error after adopting '@implementation'}}
   // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible property not declared in the header}} {{3-11=private}}
   // expected-note@-3 {{add 'final' to define a Swift property that cannot be overridden}} {{3-3=final }}
 
@@ -157,12 +157,12 @@ protocol EmptySwiftProto {}
 
   @objc(initFromProtocol2:)
   public init?(fromProtocol2: CInt) {
-    // expected-error@-1 {{initializer 'init(fromProtocol2:)' should be 'required' to match initializer declared by the header}} {{3-3=required }}
+    // expected-warning@-1 {{initializer 'init(fromProtocol2:)' should be 'required' to match initializer declared by the header}} {{3-3=required }}
   }
 
   @objc(initNotFromProtocol:)
   required public init?(notFromProtocol: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromProtocol:)' should not be 'required' to match initializer declared by the header}} {{3-12=}}
+    // expected-warning@-1 {{initializer 'init(notFromProtocol:)' should not be 'required' to match initializer declared by the header}} {{3-12=}}
   }
 
   class func classMethod1(_: CInt) {
@@ -170,11 +170,11 @@ protocol EmptySwiftProto {}
   }
 
   func classMethod2(_: CInt) {
-    // expected-error@-1 {{instance method 'classMethod2' does not match class method declared in header}} {{3-3=class }}
+    // expected-warning@-1 {{instance method 'classMethod2' does not match class method declared in header; this will become an error after adopting '@implementation'}} {{3-3=class }}
   }
 
   class func classMethod3(_: Float) {
-    // expected-error@-1 {{class method 'classMethod3' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
+    // expected-warning@-1 {{class method 'classMethod3' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
   }
 
   func instanceMethod1(_: CInt) {
@@ -182,34 +182,34 @@ protocol EmptySwiftProto {}
   }
 
   class func instanceMethod2(_: CInt) {
-    // expected-error@-1 {{class method 'instanceMethod2' does not match instance method declared in header}} {{3-9=}}
+    // expected-warning@-1 {{class method 'instanceMethod2' does not match instance method declared in header; this will become an error after adopting '@implementation'}} {{3-9=}}
   }
 
   public init(notFromHeader1: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader1:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader1:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible initializer not declared in the header}} {{3-9=private}}
     // expected-note@-3 {{add '@nonobjc' to define a Swift-only initializer}} {{3-3=@nonobjc }}
   }
 
   public required init(notFromHeader2: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader2:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader2:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible initializer not declared in the header}} {{3-9=private}}
     // expected-note@-3 {{add '@nonobjc' to define a Swift-only initializer}} {{3-3=@nonobjc }}
   }
 
   public convenience init(notFromHeader3: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader3:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader3:)' does not match any initializer declared in the headers for 'ObjCClass'; did you use the initializer's Swift name?}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible initializer not declared in the header}} {{3-9=private}}
     // expected-note@-3 {{add '@nonobjc' to define a Swift-only initializer}} {{3-3=@nonobjc }}
   }
 
   @nonobjc public init(notFromHeader4: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader4:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override designated initializers}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader4:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override designated initializers}}
     // expected-note@-2 {{add 'convenience' keyword to make this a convenience initializer}} {{12-12=convenience }}
   }
 
   @nonobjc public required init(notFromHeader5: CInt) {
-    // expected-error@-1 {{initializer 'init(notFromHeader5:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override required initializers}}
+    // expected-warning@-1 {{initializer 'init(notFromHeader5:)' is not valid in an '@_objcImplementation' extension because Objective-C subclasses must be able to override required initializers}}
     // expected-note@-2 {{replace 'required' keyword with 'convenience' to make this a convenience initializer}} {{19-27=convenience}}
   }
 
@@ -228,24 +228,24 @@ protocol EmptySwiftProto {}
 
   // rdar://122280735 - crash when the parameter of a block property needs @escaping
   let rdar122280735: (() -> ()) -> Void = { _ in }
-  // expected-error@-1 {{property 'rdar122280735' of type '(() -> ()) -> Void' does not match type '(@escaping () -> Void) -> Void' declared by the header}}
+  // expected-warning@-1 {{property 'rdar122280735' of type '(() -> ()) -> Void' does not match type '(@escaping () -> Void) -> Void' declared by the header}}
 }
 
-@objc(PresentAdditions) @implementation extension ObjCClass {
+@_objcImplementation(PresentAdditions) extension ObjCClass {
   // expected-note@-1 {{'PresentAdditions' previously declared here}}
-  // expected-error@-2 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader4:)'}}
-  // FIXME: give better diagnostic expected-error@-3 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader3:)'}}
+  // expected-warning@-2 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader4:)'; this will become an error after adopting '@implementation'}}
+  // FIXME: give better diagnostic expected-warning@-3 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader3:)'; this will become an error after adopting '@implementation'}}
 
   func method(fromHeader3: CInt) {
     // FIXME: should emit expected-DISABLED-error@-1 {{instance method 'method(fromHeader3:)' should be implemented in extension for main class interface, not category 'PresentAdditions'}}
-    // FIXME: expected-error@-2 {{instance method 'method(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // FIXME: expected-warning@-2 {{instance method 'method(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error after adopting '@implementation'}}
     // FIXME: expected-note@-3 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // FIXME: expected-note@-4 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
 
   var propertyFromHeader7: CInt {
     // FIXME: should emit expected-DISABLED-error@-1 {{property 'propertyFromHeader7' should be implemented in extension for main class interface, not category 'PresentAdditions'}}
-    // FIXME: expected-error@-2 {{property 'propertyFromHeader7' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?}}
+    // FIXME: expected-warning@-2 {{property 'propertyFromHeader7' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?; this will become an error after adopting '@implementation'}}
     // FIXME: expected-note@-3 {{add 'private' or 'fileprivate' to define an Objective-C-compatible property not declared in the header}} {{3-3=private }}
     // FIXME: expected-note@-4 {{add 'final' to define a Swift property that cannot be overridden}} {{3-3=final }}
     get { return 1 }
@@ -268,7 +268,7 @@ protocol EmptySwiftProto {}
   }
 
   func categoryMethodNot(fromHeader3: CInt) {
-    // expected-error@-1 {{instance method 'categoryMethodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // expected-warning@-1 {{instance method 'categoryMethodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error after adopting '@implementation'}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // expected-note@-3 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
@@ -292,11 +292,11 @@ protocol EmptySwiftProto {}
   }
 }
 
-@objc(SwiftNameTests) @implementation extension ObjCClass {
-  // expected-error@-1 {{extension for category 'SwiftNameTests' should provide implementation for instance method 'methodSwiftName6B()'}}
+@_objcImplementation(SwiftNameTests) extension ObjCClass {
+  // expected-warning@-1 {{extension for category 'SwiftNameTests' should provide implementation for instance method 'methodSwiftName6B()'; this will become an error after adopting '@implementation'}}
 
   func methodSwiftName1() {
-    // expected-error@-1 {{selector 'methodSwiftName1' for instance method 'methodSwiftName1()' not found in header; did you mean 'methodObjCName1'?}} {{3-3=@objc(methodObjCName1) }}
+    // expected-warning@-1 {{selector 'methodSwiftName1' for instance method 'methodSwiftName1()' not found in header; did you mean 'methodObjCName1'?; this will become an error after adopting '@implementation'}} {{3-3=@objc(methodObjCName1) }}
   }
 
   @objc(methodObjCName2) func methodSwiftName2() {
@@ -304,34 +304,34 @@ protocol EmptySwiftProto {}
   }
 
   func methodObjCName3() {
-    // expected-error@-1 {{selector 'methodObjCName3' used in header by instance method with a different name; did you mean 'methodSwiftName3()'?}} {{8-23=methodSwiftName3}} {{3-3=@objc(methodObjCName3) }}
+    // expected-warning@-1 {{selector 'methodObjCName3' used in header by instance method with a different name; did you mean 'methodSwiftName3()'?}} {{8-23=methodSwiftName3}} {{3-3=@objc(methodObjCName3) }}
     // FIXME: probably needs an @objc too, since the name is not explicit
   }
 
   @objc(methodWrongObjCName4) func methodSwiftName4() {
-    // expected-error@-1 {{selector 'methodWrongObjCName4' for instance method 'methodSwiftName4()' not found in header; did you mean 'methodObjCName4'?}} {{9-29=methodObjCName4}}
+    // expected-warning@-1 {{selector 'methodWrongObjCName4' for instance method 'methodSwiftName4()' not found in header; did you mean 'methodObjCName4'?; this will become an error after adopting '@implementation'}} {{9-29=methodObjCName4}}
   }
 
   @objc(methodObjCName5) func methodWrongSwiftName5() {
-    // expected-error@-1 {{selector 'methodObjCName5' used in header by instance method with a different name; did you mean 'methodSwiftName5()'?}} {{31-52=methodSwiftName5}}
+    // expected-warning@-1 {{selector 'methodObjCName5' used in header by instance method with a different name; did you mean 'methodSwiftName5()'?}} {{31-52=methodSwiftName5}}
   }
 
   @objc(methodObjCName6A) func methodSwiftName6B() {
-    // expected-error@-1 {{selector 'methodObjCName6A' used in header by instance method with a different name; did you mean 'methodSwiftName6A()'?}} {{32-49=methodSwiftName6A}}
+    // expected-warning@-1 {{selector 'methodObjCName6A' used in header by instance method with a different name; did you mean 'methodSwiftName6A()'?}} {{32-49=methodSwiftName6A}}
   }
 }
 
-@objc(AmbiguousMethods) @implementation extension ObjCClass {
-  // expected-error@-1 {{found multiple implementations that could match instance method 'ambiguousMethod4(with:)' with selector 'ambiguousMethod4WithCInt:'}}
+@_objcImplementation(AmbiguousMethods) extension ObjCClass {
+  // expected-warning@-1 {{found multiple implementations that could match instance method 'ambiguousMethod4(with:)' with selector 'ambiguousMethod4WithCInt:'; this will become an error after adopting '@implementation'}}
 
   @objc func ambiguousMethod1(with: CInt) {
-    // expected-error@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header}}
+    // expected-warning@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header; this will become an error after adopting '@implementation'}}
     // expected-note@-2 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCInt:') is a potential match; insert '@objc(ambiguousMethod1WithCInt:)' to use it}} {{8-8=(ambiguousMethod1WithCInt:)}}
     // expected-note@-3 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCChar:') is a potential match; insert '@objc(ambiguousMethod1WithCChar:)' to use it}} {{8-8=(ambiguousMethod1WithCChar:)}}
   }
 
   func ambiguousMethod1(with: CChar) {
-    // expected-error@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header}}
+    // expected-warning@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header; this will become an error after adopting '@implementation'}}
     // expected-note@-2 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCInt:') is a potential match; insert '@objc(ambiguousMethod1WithCInt:)' to use it}} {{3-3=@objc(ambiguousMethod1WithCInt:) }}
     // expected-note@-3 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCChar:') is a potential match; insert '@objc(ambiguousMethod1WithCChar:)' to use it}} {{3-3=@objc(ambiguousMethod1WithCChar:) }}
   }
@@ -342,11 +342,11 @@ protocol EmptySwiftProto {}
 
   func ambiguousMethod2(with: CChar) {
     // FIXME: OK, matches -ambiguousMethod2WithCChar: because the WithCInt: variant has been eliminated
-    // FIXME: expected-error@-2 {{selector 'ambiguousMethod2With:' for instance method 'ambiguousMethod2(with:)' not found in header; did you mean 'ambiguousMethod2WithCChar:'?}}
+    // FIXME: expected-warning@-2 {{selector 'ambiguousMethod2With:' for instance method 'ambiguousMethod2(with:)' not found in header; did you mean 'ambiguousMethod2WithCChar:'?; this will become an error after adopting '@implementation'}}
   }
 
   func ambiguousMethod3(with: CInt) {
-    // expected-error@-1 {{instance method 'ambiguousMethod3(with:)' could match several different members declared in the header}}
+    // expected-warning@-1 {{instance method 'ambiguousMethod3(with:)' could match several different members declared in the header; this will become an error after adopting '@implementation'}}
     // expected-note@-2 {{instance method 'ambiguousMethod3(with:)' (with selector 'ambiguousMethod3WithCInt:') is a potential match; insert '@objc(ambiguousMethod3WithCInt:)' to use it}} {{3-3=@objc(ambiguousMethod3WithCInt:) }}
     // expected-note@-3 {{instance method 'ambiguousMethod3(with:)' (with selector 'ambiguousMethod3WithCChar:') is a potential match; insert '@objc(ambiguousMethod3WithCChar:)' to use it}} {{3-3=@objc(ambiguousMethod3WithCChar:) }}
   }
@@ -360,7 +360,7 @@ protocol EmptySwiftProto {}
   }
 }
 
-@objc(Effects) @implementation extension ObjCClass {
+@_objcImplementation(Effects) extension ObjCClass {
   @available(SwiftStdlib 5.1, *)
   public func doSomethingAsynchronous() async throws -> Any {
     return self
@@ -394,17 +394,17 @@ protocol EmptySwiftProto {}
 
   @objc(doSomethingThatCanFailWithWeirdParameterWithHandler::)
   public func doSomethingThatCanFailWithWeirdParameter(handler: @escaping () -> Void) throws {
-    // expected-error@-1 {{instance method 'doSomethingThatCanFailWithWeirdParameter(handler:)' does not match the declaration in the header because it uses parameter #1 for the error, not parameter #2; a selector part called 'error:' can control which parameter to use}}
+    // expected-warning@-1 {{instance method 'doSomethingThatCanFailWithWeirdParameter(handler:)' does not match the declaration in the header because it uses parameter #1 for the error, not parameter #2; a selector part called 'error:' can control which parameter to use}}
   }
 
   @objc(doSomethingThatCanFailWithWeirdReturnCodeWithError:)
   public func doSomethingThatCanFailWithWeirdReturnCode() throws {
-    // expected-error@-1 {{instance method 'doSomethingThatCanFailWithWeirdReturnCode()' does not match the declaration in the header because it indicates an error by returning zero, rather than by returning non-zero}}
+    // expected-warning@-1 {{instance method 'doSomethingThatCanFailWithWeirdReturnCode()' does not match the declaration in the header because it indicates an error by returning zero, rather than by returning non-zero}}
   }
 }
 
-@objc(Conformance) @implementation extension ObjCClass {
-  // expected-error@-1 {{extension for category 'Conformance' should provide implementation for instance method 'requiredMethod2()'}}
+@_objcImplementation(Conformance) extension ObjCClass {
+  // expected-warning@-1 {{extension for category 'Conformance' should provide implementation for instance method 'requiredMethod2()'; this will become an error after adopting '@implementation'}}
   // no-error concerning 'optionalMethod2()'
 
   func requiredMethod1() {}
@@ -412,21 +412,21 @@ protocol EmptySwiftProto {}
   func optionalMethod1() {}
 }
 
-@objc(TypeMatchOptionality) @implementation extension ObjCClass {
+@_objcImplementation(TypeMatchOptionality) extension ObjCClass {
   func nullableResultAndArg(_: Any?) -> Any? { fatalError() } // no-error
   func nonnullResultAndArg(_: Any) -> Any { fatalError() } // no-error
   func nullUnspecifiedResultAndArg(_: Any!) -> Any! { fatalError() } // no-error
 
   func nonnullResult1() -> Any { fatalError() } // no-error
-  func nonnullResult2() -> Any? { fatalError() } // expected-error {{instance method 'nonnullResult2()' of type '() -> Any?' does not match type '() -> Any' declared by the header}}
+  func nonnullResult2() -> Any? { fatalError() } // expected-warning {{instance method 'nonnullResult2()' of type '() -> Any?' does not match type '() -> Any' declared by the header}}
   func nonnullResult3() -> Any! { fatalError() } // no-error (special case)
 
   func nonnullArgument1(_: Any) {} // no-error
-  func nonnullArgument2(_: Any?) {} // expected-error {{instance method 'nonnullArgument2' of type '(Any?) -> ()' does not match type '(Any) -> Void' declared by the header}}
+  func nonnullArgument2(_: Any?) {} // expected-warning {{instance method 'nonnullArgument2' of type '(Any?) -> ()' does not match type '(Any) -> Void' declared by the header}}
   func nonnullArgument3(_: Any!) {} // no-error (special case)
 
-  func nullableResult() -> Any { fatalError() } // expected-error {{instance method 'nullableResult()' of type '() -> Any' does not match type '() -> Any?' declared by the header}}
-  func nullableArgument(_: Any) {} // expected-error {{instance method 'nullableArgument' of type '(Any) -> ()' does not match type '(Any?) -> Void' declared by the header}}
+  func nullableResult() -> Any { fatalError() } // expected-warning {{instance method 'nullableResult()' of type '() -> Any' does not match type '() -> Any?' declared by the header}}
+  func nullableArgument(_: Any) {} // expected-warning {{instance method 'nullableArgument' of type '(Any) -> ()' does not match type '(Any?) -> Void' declared by the header}}
 
   func nonPointerResult() -> CInt! { fatalError() } // expected-error{{method cannot be in an @objc @implementation extension of a class (without final or @nonobjc) because its result type cannot be represented in Objective-C}}
   func nonPointerArgument(_: CInt!) {} // expected-error {{method cannot be in an @objc @implementation extension of a class (without final or @nonobjc) because the type of the parameter cannot be represented in Objective-C}}
@@ -437,142 +437,131 @@ protocol EmptySwiftProto {}
   // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{1-36=@implementation}} {{1-1=@objc(EmptyCategory) }}
 }
 
-@objc @implementation extension ObjCImplSubclass {
+@_objcImplementation extension ObjCImplSubclass {
+  // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{1-21=@implementation}} {{1-1=@objc }}
   @objc(initFromProtocol1:)
     required public init?(fromProtocol1: CInt) {
       // OK
     }
 }
 
-@objc @implementation extension ObjCBasicInitClass {
+@_objcImplementation extension ObjCBasicInitClass {
+  // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{1-21=@implementation}} {{1-1=@objc }}
   init() {
     // OK
   }
 }
 
-@objc @implementation extension ObjCClass {}
+@_objcImplementation extension ObjCClass {}
 // expected-error@-1 {{duplicate implementation of imported class 'ObjCClass'}}
 
-@objc(PresentAdditions) @implementation extension ObjCClass {}
+@_objcImplementation(PresentAdditions) extension ObjCClass {}
 // expected-warning@-1 {{extension with Objective-C category name 'PresentAdditions' conflicts with previous extension with the same category name; this is an error in the Swift 6 language mode}}
 
-@objc(MissingAdditions) @implementation extension ObjCClass {}
+@_objcImplementation(MissingAdditions) extension ObjCClass {}
 // expected-error@-1 {{could not find category 'MissingAdditions' on Objective-C class 'ObjCClass'; make sure your umbrella or bridging header imports the header that declares it}}
-// expected-note@-2 {{remove arguments to implement the main '@interface' for this class}} {{6-24=}}
+// expected-note@-2 {{remove arguments to implement the main '@interface' for this class}} {{21-39=}}
 
-@objc @implementation extension ObjCStruct {}
+@_objcImplementation extension ObjCStruct {}
 // expected-error@-1 {{'@objc' can only be applied to an extension of a class}}
 
-@objc(CantWork) @implementation extension ObjCStruct {}
+@_objcImplementation(CantWork) extension ObjCStruct {}
 // expected-error@-1 {{'@objc' can only be applied to an extension of a class}}
 
 @objc class SwiftClass {}
 // expected-note@-1 2 {{'SwiftClass' declared here}}
 
-@objc @implementation extension SwiftClass {}
-// expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{7-23=}}
+@_objcImplementation extension SwiftClass {}
+// expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{1-22=}}
 
-@objc(WTF) @implementation extension SwiftClass {} // expected
-// expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{12-28=}}
+@_objcImplementation(WTF) extension SwiftClass {} // expected
+// expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{1-27=}}
 
-@objc @implementation extension ObjCImplRootClass {
+@_objcImplementation extension ObjCImplRootClass {
   // expected-error@-1 {{'@_objcImplementation' cannot be used to implement root class 'ObjCImplRootClass'; declare its superclass in the header}}
 }
 
-@objc @implementation extension ObjCImplGenericClass {
+@_objcImplementation extension ObjCImplGenericClass {
   // expected-error@-1 {{'@_objcImplementation' cannot be used to implement generic class 'ObjCImplGenericClass'}}
-}
-
-@implementation extension ObjCBadClass {
-  // expected-error@-1 {{'@implementation' used without specifying the language being implemented}}
-  // expected-note@-2 {{add '@objc' to implement an Objective-C extension}} {{1-1=@objc }}
-}
-
-@objc @implementation(BadCategory1) extension ObjCBadClass {
-  // expected-error@-1 {{Objective-C category should be specified on '@objc', not '@implementation'}} {{22-36=}} {{6-6=(BadCategory1)}}
-}
-
-@objc(BadX) @implementation(BadCategory2) extension ObjCBadClass {
-  // expected-error@-1 {{Objective-C category should be specified on '@objc', not '@implementation'}} {{28-42=}} {{7-11=BadCategory2}}
 }
 
 //
 // @_cdecl for global functions
 //
 
-@implementation @_cdecl("CImplFunc1")
+@_objcImplementation @_cdecl("CImplFunc1")
 func CImplFunc1(_: Int32) {
   // OK
 }
 
-@implementation(BadCategory) @_cdecl("CImplFunc2")
+@_objcImplementation(BadCategory) @_cdecl("CImplFunc2")
 func CImplFunc2(_: Int32) {
-  // expected-error@-2 {{global function 'CImplFunc2' does not belong to an Objective-C category; remove the category name from this attribute}} {{16-29=}}
+  // expected-error@-2 {{global function 'CImplFunc2' does not belong to an Objective-C category; remove the category name from this attribute}} {{21-34=}}
 }
 
-@implementation @_cdecl("CImplFuncMissing")
+@_objcImplementation @_cdecl("CImplFuncMissing")
 func CImplFuncMissing(_: Int32) {
   // expected-error@-2 {{could not find imported function 'CImplFuncMissing' matching global function 'CImplFuncMissing'; make sure your umbrella or bridging header imports the header that declares it}}
 }
 
-@implementation @_cdecl("CImplFuncMismatch1")
+@_objcImplementation @_cdecl("CImplFuncMismatch1")
 func CImplFuncMismatch1(_: Float) {
-  // expected-error@-1 {{global function 'CImplFuncMismatch1' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
+  // expected-warning@-1 {{global function 'CImplFuncMismatch1' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
 }
 
-@implementation @_cdecl("CImplFuncMismatch2")
+@_objcImplementation @_cdecl("CImplFuncMismatch2")
 func CImplFuncMismatch2(_: Int32) -> Float {
-  // expected-error@-1 {{global function 'CImplFuncMismatch2' of type '(Int32) -> Float' does not match type '(Int32) -> Void' declared by the header}}
+  // expected-warning@-1 {{global function 'CImplFuncMismatch2' of type '(Int32) -> Float' does not match type '(Int32) -> Void' declared by the header}}
 }
 
-@implementation @_cdecl("CImplFuncMismatch3")
+@_objcImplementation @_cdecl("CImplFuncMismatch3")
 func CImplFuncMismatch3(_: Any?) {
   // OK
 }
 
-@implementation @_cdecl("CImplFuncMismatch4")
+@_objcImplementation @_cdecl("CImplFuncMismatch4")
 func CImplFuncMismatch4(_: Any) {
-  // expected-error@-1 {{global function 'CImplFuncMismatch4' of type '(Any) -> ()' does not match type '(Any?) -> Void' declared by the header}}
+  // expected-warning@-1 {{global function 'CImplFuncMismatch4' of type '(Any) -> ()' does not match type '(Any?) -> Void' declared by the header}}
 }
 
-@implementation @_cdecl("CImplFuncMismatch5")
+@_objcImplementation @_cdecl("CImplFuncMismatch5")
 func CImplFuncMismatch5(_: Any) {
   // OK
 }
 
-@implementation @_cdecl("CImplFuncMismatch6")
+@_objcImplementation @_cdecl("CImplFuncMismatch6")
 func CImplFuncMismatch6(_: Any!) {
   // OK, mismatch allowed
 }
 
 
-@implementation @_cdecl("CImplFuncMismatch3a")
+@_objcImplementation @_cdecl("CImplFuncMismatch3a")
 func CImplFuncMismatch3a(_: Int32) -> Any? {
   // OK
 }
 
-@implementation @_cdecl("CImplFuncMismatch4a")
+@_objcImplementation @_cdecl("CImplFuncMismatch4a")
 func CImplFuncMismatch4a(_: Int32) -> Any {
-  // expected-error@-1 {{global function 'CImplFuncMismatch4a' of type '(Int32) -> Any' does not match type '(Int32) -> Any?' declared by the header}}
+  // expected-warning@-1 {{global function 'CImplFuncMismatch4a' of type '(Int32) -> Any' does not match type '(Int32) -> Any?' declared by the header}}
 }
 
-@implementation @_cdecl("CImplFuncMismatch5a")
+@_objcImplementation @_cdecl("CImplFuncMismatch5a")
 func CImplFuncMismatch5a(_: Int32) -> Any {
   // OK
 }
 
-@implementation @_cdecl("CImplFuncMismatch6a")
+@_objcImplementation @_cdecl("CImplFuncMismatch6a")
 func CImplFuncMismatch6a(_: Int32) -> Any! {
   // OK, mismatch allowed
 }
 
-@implementation @_cdecl("CImplFuncNameMismatch1")
+@_objcImplementation @_cdecl("CImplFuncNameMismatch1")
 func mismatchedName1(_: Int32) {
   // expected-error@-2 {{could not find imported function 'CImplFuncNameMismatch1' matching global function 'mismatchedName1'; make sure your umbrella or bridging header imports the header that declares it}}
   // FIXME: Improve diagnostic for a partial match.
 }
 
-@implementation @_cdecl("mismatchedName2")
+@_objcImplementation @_cdecl("mismatchedName2")
 func CImplFuncNameMismatch2(_: Int32) {
   // expected-error@-2 {{could not find imported function 'mismatchedName2' matching global function 'CImplFuncNameMismatch2'; make sure your umbrella or bridging header imports the header that declares it}}
   // FIXME: Improve diagnostic for a partial match.
@@ -582,14 +571,14 @@ func CImplFuncNameMismatch2(_: Int32) {
 // TODO: @_cdecl for global functions imported as computed vars
 //
 var cImplComputedGlobal1: Int32 {
-  @implementation @_cdecl("CImplGetComputedGlobal1")
+  @_objcImplementation @_cdecl("CImplGetComputedGlobal1")
   get {
     // FIXME: Lookup for vars isn't working yet
     // expected-error@-3 {{could not find imported function 'CImplGetComputedGlobal1' matching getter for var 'cImplComputedGlobal1'; make sure your umbrella or bridging header imports the header that declares it}}
     return 0
   }
 
-  @implementation @_cdecl("CImplSetComputedGlobal1")
+  @_objcImplementation @_cdecl("CImplSetComputedGlobal1")
   set {
     // FIXME: Lookup for vars isn't working yet
     // expected-error@-3 {{could not find imported function 'CImplSetComputedGlobal1' matching setter for var 'cImplComputedGlobal1'; make sure your umbrella or bridging header imports the header that declares it}}
@@ -601,7 +590,7 @@ var cImplComputedGlobal1: Int32 {
 // TODO: @_cdecl for import-as-member functions
 //
 extension CImplStruct {
-  @implementation @_cdecl("CImplStructStaticFunc1")
+  @_objcImplementation @_cdecl("CImplStructStaticFunc1")
   static func staticFunc1(_: Int32) {
     // FIXME: Add underlying support for this
     // expected-error@-3 {{@_cdecl can only be applied to global functions}}

--- a/test/decl/ext/objc_implementation_features.swift
+++ b/test/decl/ext/objc_implementation_features.swift
@@ -1,17 +1,14 @@
 // REQUIRES: objc_interop
 
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -typecheck %s -import-objc-header %S/Inputs/objc_implementation.h 2>&1 | %FileCheck --check-prefixes NO,CHECK %s
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -typecheck %s -import-objc-header %S/Inputs/objc_implementation.h -enable-experimental-feature ObjCImplementation 2>&1 | %FileCheck --check-prefixes YES,CHECK %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -typecheck %s -import-objc-header %S/Inputs/objc_implementation.h 2>&1 | %FileCheck %s
 
-// NO-NOT: objc_implementation_features.swift:[[@LINE+2]]:{{[0-9]+}}: warning: '@_objcImplementation' is deprecated; use '@implementation' instead
-// YES-DAG: objc_implementation_features.swift:[[@LINE+1]]:{{[0-9]+}}: warning: '@_objcImplementation' is deprecated; use '@implementation' instead
+// CHECK-DAG: objc_implementation_features.swift:[[@LINE+1]]:{{[0-9]+}}: warning: '@_objcImplementation' is deprecated; use '@implementation' instead
 @_objcImplementation(EmptyCategory) extension ObjCClass {}
 
 // CHECK-DAG: objc_implementation_features.swift:[[@LINE+2]]:{{[0-9]+}}: warning: extension for main class interface should provide implementation for instance method 'subclassMethod(fromHeader1:)'; this will become an error after adopting '@implementation'
 // CHECK-NOT: objc_implementation_features.swift:[[@LINE+1]]:{{[0-9]+}}: warning: '@_objcImplementation' is deprecated; use '@implementation' instead
 @_objcImplementation extension ObjCSubclass {}
 
-// CHECK-DAG: objc_implementation_features.swift:[[@LINE+3]]:{{[0-9]+}}: error: extension for main class interface should provide implementation for initializer 'init()'{{$}}
-// NO-DAG: objc_implementation_features.swift:[[@LINE+2]]:{{[0-9]+}}: error: 'implementation' attribute is only valid when experimental feature ObjCImplementation is enabled
-// YES-NOT: objc_implementation_features.swift:[[@LINE+1]]:{{[0-9]+}}: error: 'implementation' attribute is only valid when experimental feature ObjCImplementation is enabled
+// CHECK-DAG: objc_implementation_features.swift:[[@LINE+2]]:{{[0-9]+}}: error: extension for main class interface should provide implementation for initializer 'init()'{{$}}
+// CHECK-NOT: objc_implementation_features.swift:[[@LINE+1]]:{{[0-9]+}}: error: 'implementation' attribute is only valid when experimental feature ObjCImplementation is enabled
 @objc @implementation extension ObjCBasicInitClass {}

--- a/test/decl/ext/objc_implementation_features.swift
+++ b/test/decl/ext/objc_implementation_features.swift
@@ -14,4 +14,4 @@
 // CHECK-DAG: objc_implementation_features.swift:[[@LINE+3]]:{{[0-9]+}}: error: extension for main class interface should provide implementation for initializer 'init()'{{$}}
 // NO-DAG: objc_implementation_features.swift:[[@LINE+2]]:{{[0-9]+}}: error: 'implementation' attribute is only valid when experimental feature ObjCImplementation is enabled
 // YES-NOT: objc_implementation_features.swift:[[@LINE+1]]:{{[0-9]+}}: error: 'implementation' attribute is only valid when experimental feature ObjCImplementation is enabled
-@implementation extension ObjCBasicInitClass {}
+@objc @implementation extension ObjCBasicInitClass {}

--- a/test/decl/ext/objc_implementation_impl_only.swift
+++ b/test/decl/ext/objc_implementation_impl_only.swift
@@ -3,7 +3,7 @@
 
 @_implementationOnly import objc_implementation_internal
 
-@_objcImplementation extension InternalObjCClass {
+@objc @implementation extension InternalObjCClass {
   @objc public func method(fromHeader1: CInt) {
     // OK
   }

--- a/test/decl/ext/objc_implementation_impl_only.swift
+++ b/test/decl/ext/objc_implementation_impl_only.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap
+// RUN: %target-typecheck-verify-swift -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap -target %target-stable-abi-triple
 // REQUIRES: objc_interop
 
 @_implementationOnly import objc_implementation_internal


### PR DESCRIPTION
* **Explanation**: Modifies objcImpl to support the approved `@objc @implementation` syntax, ban resilient stored properties that cannot be supported by the current implementation, and remove its experimental status.
* **Scope**: Affects projects using objcImpl with both the new and old syntax.
* **Issue**: rdar://126948464&129178360&129247349&129225596&130707698
* **Original PR**: #73128, #73309, #74135, #74161, #74801
* **Risk**: This has been qualified on main; there, a handful of projects that used `@_objcImplementation` needed minor source changes (e.g. moving declarations to different extensions, explicitly adding attributes). Other than those, I think the risk of *unexpected* regressions is low.
* **Testing**: Includes new unit tests. As mentioned, most of this PR has been qualified on main.
* **Reviewer**: @tshortli or @nkcsgexi, depending on the commit

-----

Cherry-picks #73128, #73309, #74135, #74161, and #74801 to release/6.0. In combination, these changes implement the approved design for SE-0436 and add it as a normal language feature. Note that with the exception of #74801 (which marks the feature non-experimental and updates diagnostic wording), these changes have been baking in main for 1-3 months.
