### PR TITLE
[Concurrency] Isolation of ObjC declarations is preconcurrency by def…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5242,7 +5242,9 @@ ActorIsolation ActorIsolationRequest::evaluate(
 
   // Determine the default isolation for this declaration, which may still be
   // overridden by other inference rules.
-  ActorIsolation defaultIsolation = ActorIsolation::forUnspecified();
+  ActorIsolation defaultIsolation =
+      ActorIsolation::forUnspecified().withPreconcurrency(
+          value->hasClangNode());
 
   if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
     // A @Sendable function is assumed to be actor-independent.

--- a/test/ClangImporter/objc_isolation_complete.swift
+++ b/test/ClangImporter/objc_isolation_complete.swift
@@ -31,3 +31,16 @@ class IsolatedSub: NXSender {
     return mainActorState
   }
 }
+
+@objc
+@MainActor
+class Test : NSObject {
+  static var shared: Test? // expected-note {{mutation of this static property is only permitted within the actor}}
+
+  override init() {
+    super.init()
+
+    Self.shared = self
+    // expected-warning@-1 {{main actor-isolated static property 'shared' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}


### PR DESCRIPTION
…ault

Such declarations don't have an explicit attribute to indicate that they are `@preconcurrency` but default isolation as determined by `ActorIsolationRequest` should mark them as such regardless.

Resolves: rdar://130776220

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
