### PR TITLE
[Concurrency] Remove the global actor check when allowing 'nonisolated' on mutable Sendable storage.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7005,15 +7005,13 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
     if (var->hasStorage()) {
       {
         // 'nonisolated' can not be applied to mutable stored properties unless
-        // qualified as 'unsafe', or is of a Sendable type on a
-        // globally-isolated value type.
+        // qualified as 'unsafe', or is of a Sendable type on a Sendable
+        // value type.
         bool canBeNonisolated = false;
-        if (dc->isTypeContext()) {
-          if (auto nominal = dc->getSelfStructDecl()) {
-            if (!var->isStatic() && type->isSendableType() &&
-                getActorIsolation(nominal).isGlobalActor()) {
-              canBeNonisolated = true;
-            }
+        if (auto nominal = dc->getSelfStructDecl()) {
+          if (nominal->getDeclaredTypeInContext()->isSendableType() &&
+              !var->isStatic() && type->isSendableType()) {
+            canBeNonisolated = true;
           }
         }
 

--- a/test/Concurrency/mutable_storage_nonisolated.swift
+++ b/test/Concurrency/mutable_storage_nonisolated.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+class NonSendable {}
+
+struct ImplicitlySendable {
+  var x: Int
+  nonisolated var y: Int // okay
+}
+
+struct ImplicitlyNonSendable {
+  let x: NonSendable
+  // expected-note@+1 {{convert 'y' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
+  nonisolated var y: Int // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+}
+
+public struct PublicSendable: Sendable {
+  nonisolated var x: Int // okay
+}
+
+public struct PublicNonSendable {
+  // expected-note@+1 {{convert 'x' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
+  nonisolated var x: Int // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+}

--- a/test/Concurrency/nonisolated_access.swift
+++ b/test/Concurrency/nonisolated_access.swift
@@ -19,6 +19,13 @@
 @MainActor
 public protocol P {}
 
+@frozen
+public struct ImplicitlySendable {
+  nonisolated public var prop: Bool = true
+
+  nonisolated public init() {}
+}
+
 public struct S: P {
   nonisolated public var x: Int = 0
 
@@ -32,5 +39,7 @@ actor A {
   func test() {
     var s = S()
     s.x += 0 // okay
+    var sendable = ImplicitlySendable()
+    sendable.prop = false // okay
   }
 }


### PR DESCRIPTION
The global actor check was redundant, so remove it. Added more tests to the testing suite to verify that `nonisolated` is allowed on implicitly Sendable structs.

Also make sure that on non-Sendable structs, `nonisolated` is still not allowed on any mutable storage

Resolves rdar://131339439.
