### PR TITLE
NFC: add missing return

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3107,6 +3107,7 @@ static bool checkInverseGenericsCastingAvailability(Type srcType,
           refDC);
     }
   }
+  return false;
 }
 
 static bool checkTypeMetadataAvailabilityInternal(CanType type,


### PR DESCRIPTION
Forgot to return a false in the case of uninteresting type. The bool mainly controls short-circuiting behavior in diagnosis. This should be an NFC.

resolves rdar://131340490