### PR TITLE
[Concurrency] Fix disallowed override isolation to carry `@preconcurr…

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2828,10 +2828,6 @@ private:
     /// optional result.
     unsigned isIUO : 1;
 
-    /// Whether we're in the common case where the ActorIsolationRequest
-    /// request returned ActorIsolation::forUnspecified().
-    unsigned noActorIsolation : 1;
-
     /// Whether we've evaluated the ApplyAccessNoteRequest.
     unsigned accessNoteApplied : 1;
   } LazySemanticInfo = { };
@@ -2847,6 +2843,7 @@ private:
   friend class ActorIsolationRequest;
   friend class DynamicallyReplacedDeclRequest;
   friend class ApplyAccessNoteRequest;
+
   friend class Decl;
   SourceLoc getLocFromSource() const { return NameLoc; }
 protected:

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1537,8 +1537,7 @@ public:
 class ActorIsolationRequest :
     public SimpleRequest<ActorIsolationRequest,
                          ActorIsolation(ValueDecl *),
-                         RequestFlags::SeparatelyCached |
-                         RequestFlags::SplitCached> {
+                         RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -1548,10 +1547,8 @@ private:
   ActorIsolation evaluate(Evaluator &evaluator, ValueDecl *value) const;
 
 public:
-  // Separate.
+  // Caching
   bool isCached() const { return true; }
-  std::optional<ActorIsolation> getCachedResult() const;
-  void cacheResult(ActorIsolation value) const;
 };
 
 /// Determine whether the given function should have an isolated 'self'.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -178,7 +178,7 @@ SWIFT_REQUEST(TypeChecker, GlobalActorAttributeRequest,
               SeparatelyCached | SplitCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ActorIsolationRequest,
               ActorIsolationState(ValueDecl *),
-              SeparatelyCached | SplitCached, NoLocationInfo)
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, HasIsolatedSelfRequest,
               bool(ValueDecl *),
               Uncached, NoLocationInfo)

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2014,28 +2014,6 @@ GlobalActorAttributeRequest::cacheResult(std::optional<CustomAttrNominalPair> va
 }
 
 //----------------------------------------------------------------------------//
-// ActorIsolationRequest computation.
-//----------------------------------------------------------------------------//
-
-std::optional<ActorIsolation> ActorIsolationRequest::getCachedResult() const {
-  auto *decl = std::get<0>(getStorage());
-  if (decl->LazySemanticInfo.noActorIsolation)
-    return ActorIsolation::forUnspecified();
-
-  return decl->getASTContext().evaluator.getCachedNonEmptyOutput(*this);
-}
-
-void ActorIsolationRequest::cacheResult(ActorIsolation value) const {
-  auto *decl = std::get<0>(getStorage());
-  if (value.isUnspecified()) {
-    decl->LazySemanticInfo.noActorIsolation = 1;
-    return;
-  }
-
-  decl->getASTContext().evaluator.cacheNonEmptyOutput(*this, std::move(value));
-}
-
-//----------------------------------------------------------------------------//
 // ResolveMacroRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5290,7 +5290,12 @@ ActorIsolation ActorIsolationRequest::evaluate(
           break;
 
         case OverrideIsolationResult::Disallowed:
-          inferred = *overriddenIso;
+          if (overriddenValue->hasClangNode() &&
+              overriddenIso->isUnspecified()) {
+            inferred = overriddenIso->withPreconcurrency(true);
+          } else {
+            inferred = *overriddenIso;
+          }
           break;
         }
       }

--- a/test/ClangImporter/objc_isolation_complete.swift
+++ b/test/ClangImporter/objc_isolation_complete.swift
@@ -31,3 +31,16 @@ class IsolatedSub: NXSender {
     return mainActorState
   }
 }
+
+@objc
+@MainActor
+class Test : NSObject {
+  static var shared: Test? // expected-note {{mutation of this static property is only permitted within the actor}}
+
+  override init() {
+    super.init()
+
+    Self.shared = self
+    // expected-warning@-1 {{main actor-isolated static property 'shared' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}


### PR DESCRIPTION
…ency` bit

If ObjC member cannot be overridden due to isolation mismatch set `@preconcurrency` bit to make the diagnostic a warning instead of an error in Swift 5 mode.

Resolves: rdar://130776220

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
