### PR TITLE
[lit] Make it so that all tests in all Cxx interop directories are marked with REQUIRES: cxx_interop.

### DIFF
--- a/test/Interop/CxxToSwiftToCxx/lit.local.cfg
+++ b/test/Interop/CxxToSwiftToCxx/lit.local.cfg
@@ -1,1 +1,7 @@
+# Make it so that all of the tests in this directory are disabled if we do not
+# have the feature 'cxx_interop'. This essentially is REQUIRE: cxx_interop in
+# every file in this directory.
+if 'cxx_interop' not in config.available_features:
+     config.unsupported = True
+
 config.suffixes = ['.swift', '.cpp', '.mm']

--- a/test/Interop/CxxToSwiftToObjcxx/lit.local.cfg
+++ b/test/Interop/CxxToSwiftToObjcxx/lit.local.cfg
@@ -1,1 +1,6 @@
+# Make it so that all of the tests in this directory are disabled if we do not
+# have the feature 'cxx_interop'. This essentially is REQUIRE: cxx_interop in
+# every file in this directory.
+if 'cxx_interop' not in config.available_features:
+     config.unsupported = True
 config.suffixes = ['.swift', '.cpp', '.mm']

--- a/test/Interop/ObjCToSwiftToObjCxx/lit.local.cfg
+++ b/test/Interop/ObjCToSwiftToObjCxx/lit.local.cfg
@@ -1,1 +1,7 @@
+# Make it so that all of the tests in this directory are disabled if we do not
+# have the feature 'cxx_interop'. This essentially is REQUIRE: cxx_interop in
+# every file in this directory.
+if 'cxx_interop' not in config.available_features:
+     config.unsupported = True
+
 config.suffixes = ['.swift', '.cpp', '.mm']

--- a/test/Interop/SwiftToCxx/lit.local.cfg
+++ b/test/Interop/SwiftToCxx/lit.local.cfg
@@ -1,1 +1,7 @@
+# Make it so that all of the tests in this directory are disabled if we do not
+# have the feature 'cxx_interop'. This essentially is REQUIRE: cxx_interop in
+# every file in this directory.
+if 'cxx_interop' not in config.available_features:
+     config.unsupported = True
+
 config.suffixes = ['.swift', '.cpp', '.mm']

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -165,6 +165,8 @@ if "@SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB@" == "TRUE":
     config.available_features.add('embedded_stdlib')
 if "@SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING@" == "TRUE":
     config.available_features.add('embedded_stdlib_cross_compiling')
+if "@SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP@" == "TRUE":
+    config.available_features.add('cxx_interop')
 
 config.swift_freestanding_is_darwin = "@SWIFT_FREESTANDING_IS_DARWIN@" == "TRUE"
 config.swift_stdlib_use_relative_protocol_witness_tables = "@SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES@" == "TRUE"


### PR DESCRIPTION
Otherwise, one gets lit test failures if one compiles with cxx interop disabled.
