### PR TITLE
[Concurrency] Consider isolated key-path components when computing the required isolation of a stored property initializer.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3938,6 +3938,12 @@ namespace {
             if (result == ActorReferenceResult::SameConcurrencyDomain)
               break;
 
+            // An isolated key-path component requires being formed in the same
+            // isolation domain. Record the required isolation here if we're
+            // computing the isolation of a stored property initializer.
+            if (refineRequiredIsolation(isolation))
+              break;
+
             LLVM_FALLTHROUGH;
           }
 

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-upcoming-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature IsolatedDefaultValues -enable-upcoming-feature RegionBasedIsolation %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature IsolatedDefaultValues -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature InferSendableFromCaptures %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -281,4 +280,40 @@ struct InitAccessors {
 
 struct CError: Error, RawRepresentable {
   var rawValue: CInt
+}
+
+// Consider isolated key-paths when computing initializer isolation
+
+@MainActor
+class UseIsolatedKeyPath {
+  let kp: KeyPath<UseIsolatedKeyPath, Nested> = \.x // okay
+
+  // expected-error@+1 {{default argument cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
+  let kp2: KeyPath<UseIsolatedKeyPath, Bool> = \.x.y // okay
+
+  var x: Nested = .init()
+
+  class Nested {
+    @SomeGlobalActor var y: Bool = true
+  }
+}
+
+@MainActor
+protocol InferMainActor {}
+
+struct UseIsolatedPropertyWrapperInit: InferMainActor {
+  @Wrapper(\.value) var value: Int // okay
+
+  // expected-warning@+1 {{global actor 'SomeGlobalActor'-isolated default value in a main actor-isolated context; this is an error in the Swift 6 language mode}}
+  @Wrapper(\.otherValue) var otherValue: Int
+}
+
+@propertyWrapper struct Wrapper<T> {
+  init(_: KeyPath<Values, T>) {}
+  var wrappedValue: T { fatalError() }
+}
+
+struct Values {
+  @MainActor var value: Int { 0 }
+  @SomeGlobalActor var otherValue: Int { 0 }
 }


### PR DESCRIPTION
This allows isolated key-path components to be used in stored property initializers when the stored property itself is isolated to the same global actor.

Resolves: https://github.com/swiftlang/swift/issues/72181