### PR TITLE
[6.0] Move main/6.0 windows Foundation builds to separate branch (#75073)

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1428,7 +1428,7 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
 
     $env:CTEST_OUTPUT_ON_FAILURE = 1
     Build-CMakeProject `
-      -Src $SourceCache\swift-corelibs-foundation `
+      -Src $SourceCache\swift-corelibs-foundation-windows `
       -Bin $FoundationBinaryCache `
       -InstallTo "$($Arch.SDKInstallRoot)\usr" `
       -Arch $Arch `

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -38,6 +38,8 @@
             "remote": { "id": "apple/swift-corelibs-xctest" } },
         "swift-corelibs-foundation": {
             "remote": { "id": "apple/swift-corelibs-foundation" } },  
+        "swift-corelibs-foundation-windows": {
+            "remote": { "id": "apple/swift-corelibs-foundation" } },  
         "swift-foundation-icu": {
             "remote": { "id": "apple/swift-foundation-icu" } },  
         "swift-foundation": {
@@ -130,6 +132,7 @@
                 "swift-stress-tester": "main",
                 "swift-corelibs-xctest": "main",
                 "swift-corelibs-foundation": "main",
+                "swift-corelibs-foundation-windows": "windows/main",
                 "swift-foundation-icu": "main",
                 "swift-foundation": "main",
                 "swift-corelibs-libdispatch": "main",
@@ -181,6 +184,7 @@
                 "swift-stress-tester": "release/6.0",
                 "swift-corelibs-xctest": "release/6.0",
                 "swift-corelibs-foundation": "release/6.0",
+                "swift-corelibs-foundation-windows": "windows/release/6.0",
                 "swift-corelibs-libdispatch": "release/6.0",
                 "swift-integration-tests": "release/6.0",
                 "swift-xcode-playground-support": "release/6.0",


### PR DESCRIPTION
Cherry pick of https://github.com/swiftlang/swift/pull/75073

Explanation: Adds a new swift-corelibs-foundation checkout of the `windows/*` branch and updates the windows build script to use this checkout
Scope: Affects building Foundation on windows
Original PR: https://github.com/swiftlang/swift/pull/75073
Risk: Minimal - this should have no impact until the standard and `windows/*` branches diverge
Testing: Testing done via swift-ci testing
Reviewer: @parkera 