### PR TITLE
Ensure that a `@_unsafeInheritExecutor` function does not depend on `#isolation`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4000,6 +4000,9 @@ ERROR(inherits_executor_without_async,none,
 ERROR(isolation_in_inherits_executor,none,
       "#isolation%select{| (introduced by a default argument)}0 cannot be used "
       "within an '@_unsafeInheritExecutor' function", (bool))
+ERROR(unsafe_inherits_executor_deprecated,none,
+        "@_unsafeInheritExecutor attribute is deprecated; consider an "
+        "'isolated' parameter defaulted to '#isolation' instead", ())
 
 ERROR(lifetime_invalid_global_scope,none, "%0 is only valid on methods",
       (DeclAttribute))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3997,6 +3997,9 @@ ERROR(reasync_without_async_parameter,none,
 
 ERROR(inherits_executor_without_async,none,
       "non-async functions cannot inherit an executor", ())
+ERROR(isolation_in_inherits_executor,none,
+      "#isolation%select{| (introduced by a default argument)}0 cannot be used "
+      "within an '@_unsafeInheritExecutor' function", (bool))
 
 ERROR(lifetime_invalid_global_scope,none, "%0 is only valid on methods",
       (DeclAttribute))

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -293,6 +293,13 @@ LookupResult &ConstraintSystem::lookupMember(Type base, DeclNameRef name,
   result = TypeChecker::lookupMember(DC, base, name, loc,
                                      defaultMemberLookupOptions);
 
+  // If we are in an @_unsafeInheritExecutor context, swap out
+  // declarations for their _unsafeInheritExecutor_ counterparts if they
+  // exist.
+  if (enclosingUnsafeInheritsExecutor(DC)) {
+    introduceUnsafeInheritExecutorReplacements(DC, base, loc, *result);
+  }
+
   // If we aren't performing dynamic lookup, we're done.
   if (!*result || !base->isAnyObject())
     return *result;

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeChecker.h"
+#include "TypeCheckConcurrency.h"
 #include "TypeCheckType.h"
 #include "TypoCorrection.h"
 #include "swift/AST/ASTVisitor.h"
@@ -736,6 +737,14 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
           isa<TypeDecl>(ResultValues.front())) {
         return buildTypeExpr(cast<TypeDecl>(ResultValues.front()));
       }
+    }
+
+    // If we are in an @_unsafeInheritExecutor context, swap out
+    // declarations for their _unsafeInheritExecutor_ counterparts if they
+    // exist.
+    if (enclosingUnsafeInheritsExecutor(DC)) {
+      introduceUnsafeInheritExecutorReplacements(
+          DC, UDRE->getNameLoc().getBaseNameLoc(), ResultValues);
     }
 
     return buildRefExpr(ResultValues, DC, UDRE->getNameLoc(),

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7279,6 +7279,13 @@ void AttributeChecker::visitUnsafeInheritExecutorAttr(
   auto fn = cast<FuncDecl>(D);
   if (!fn->isAsyncContext()) {
     diagnose(attr->getLocation(), diag::inherits_executor_without_async);
+  } else {
+    bool inConcurrencyModule = D->getDeclContext()->getParentModule()->getName()
+        .str().equals("_Concurrency");
+    auto diag = fn->diagnose(diag::unsafe_inherits_executor_deprecated);
+    diag.warnUntilSwiftVersion(6);
+    diag.limitBehaviorIf(inConcurrencyModule, DiagnosticBehavior::Warning);
+    replaceUnsafeInheritExecutorWithDefaultedIsolationParam(fn, diag);
   }
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1999,6 +1999,103 @@ bool swift::isAsyncDecl(ConcreteDeclRef declRef) {
   return false;
 }
 
+/// Find an enclosing function that has @
+static AbstractFunctionDecl *enclosingUnsafeInheritsExecutor(
+    const DeclContext *dc) {
+  for (; dc; dc = dc->getParent()) {
+    if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
+      if (func->getAttrs().hasAttribute<UnsafeInheritExecutorAttr>()) {
+        return const_cast<AbstractFunctionDecl *>(func);
+      }
+
+      return nullptr;
+    }
+
+    if (isa<AbstractClosureExpr>(dc))
+      return nullptr;
+
+    if (dc->isTypeContext())
+      return nullptr;
+  }
+
+  return nullptr;
+}
+
+/// Adjust the location used for diagnostics about #isolation to account for
+/// the fact that they show up in macro expansions.
+///
+/// Returns a pair containing the updated location and whether it's part of
+/// a default argument.
+static std::pair<SourceLoc, bool> adjustPoundIsolationDiagLoc(
+    CurrentContextIsolationExpr *isolationExpr,
+    ModuleDecl *module
+) {
+  // Not part of a macro expansion.
+  SourceLoc diagLoc = isolationExpr->getLoc();
+  auto sourceFile = module->getSourceFileContainingLocation(diagLoc);
+  if (!sourceFile)
+    return { diagLoc, false };
+  auto macroExpansionRange = sourceFile->getMacroInsertionRange();
+  if (macroExpansionRange.Start.isInvalid())
+    return { diagLoc, false };
+
+  diagLoc = macroExpansionRange.Start;
+
+  // If this is from a default argument, note that and go one more
+  // level "out" to the place where the default argument was
+  // introduced.
+  auto expansionSourceFile = module->getSourceFileContainingLocation(diagLoc);
+  if (!expansionSourceFile ||
+      expansionSourceFile->Kind != SourceFileKind::DefaultArgument)
+    return { diagLoc, false };
+
+  return {
+    expansionSourceFile->getNodeInEnclosingSourceFile().getStartLoc(),
+    true
+  };
+}
+
+/// Replace the @_unsafeInheritExecutor with a defaulted isolation
+/// parameter.
+static void replaceUnsafeInheritExecutorWithDefaultedIsolationParam(
+    AbstractFunctionDecl *func, InFlightDiagnostic &diag) {
+  auto attr = func->getAttrs().getAttribute<UnsafeInheritExecutorAttr>();
+  assert(attr && "Caller didn't validate the presence of the attribute");
+
+  // Look for the place where we should insert the new 'isolation' parameter.
+  // We insert toward the back, but skip over any parameters that have function
+  // type.
+  unsigned insertionPos = func->getParameters()->size();
+  while (insertionPos > 0) {
+    Type paramType = func->getParameters()->get(insertionPos - 1)->getInterfaceType();
+    if (paramType->lookThroughSingleOptionalType()->is<AnyFunctionType>()) {
+      --insertionPos;
+      continue;
+    }
+
+    break;
+  }
+
+  // Determine the text to insert. We put the commas before and after, then
+  // slice them away depending on whether we have parameters before or after.
+  StringRef newParameterText = ", isolation: isolated (any Actor)? = #isolation, ";
+  if (insertionPos == 0)
+    newParameterText = newParameterText.drop_front(2);
+  if (insertionPos == func->getParameters()->size())
+    newParameterText = newParameterText.drop_back(2);
+
+  // Determine where to insert the new parameter.
+  SourceLoc insertionLoc;
+  if (insertionPos < func->getParameters()->size()) {
+    insertionLoc = func->getParameters()->get(insertionPos)->getStartLoc();
+  } else {
+    insertionLoc = func->getParameters()->getRParenLoc();
+  }
+
+  diag.fixItRemove(attr->getRangeWithAt());
+  diag.fixItInsert(insertionLoc, newParameterText);
+}
+
 /// Check if it is safe for the \c globalActor qualifier to be removed from
 /// \c ty, when the function value of that type is isolated to that actor.
 ///
@@ -3744,6 +3841,25 @@ namespace {
 
     void recordCurrentContextIsolation(
         CurrentContextIsolationExpr *isolationExpr) {
+      // #isolation does not work within an `@_unsafeInheritExecutor` function.
+      if (auto func = enclosingUnsafeInheritsExecutor(getDeclContext())) {
+        // This expression is always written as a macro #isolation in source,
+        // so find the enclosing macro expansion expression's location.
+        SourceLoc diagLoc;
+        bool inDefaultArgument;
+        std::tie(diagLoc, inDefaultArgument) = adjustPoundIsolationDiagLoc(
+            isolationExpr, getDeclContext()->getParentModule());
+
+        bool inConcurrencyModule = getDeclContext()->getParentModule()->getName()
+            .str().equals("_Concurrency");
+
+        auto diag = ctx.Diags.diagnose(diagLoc,
+                                       diag::isolation_in_inherits_executor,
+                                       inDefaultArgument);
+        diag.limitBehaviorIf(inConcurrencyModule, DiagnosticBehavior::Warning);
+        replaceUnsafeInheritExecutorWithDefaultedIsolationParam(func, diag);
+      }
+
       // If an actor has already been assigned, we're done.
       if (isolationExpr->getActor())
         return;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2054,9 +2054,7 @@ static std::pair<SourceLoc, bool> adjustPoundIsolationDiagLoc(
   };
 }
 
-/// Replace the @_unsafeInheritExecutor with a defaulted isolation
-/// parameter.
-static void replaceUnsafeInheritExecutorWithDefaultedIsolationParam(
+void swift::replaceUnsafeInheritExecutorWithDefaultedIsolationParam(
     AbstractFunctionDecl *func, InFlightDiagnostic &diag) {
   auto attr = func->getAttrs().getAttribute<UnsafeInheritExecutorAttr>();
   assert(attr && "Caller didn't validate the presence of the attribute");

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3894,6 +3894,10 @@ namespace {
 
     void recordCurrentContextIsolation(
         CurrentContextIsolationExpr *isolationExpr) {
+      // If an actor has already been assigned, we're done.
+      if (isolationExpr->getActor())
+        return;
+
       // #isolation does not work within an `@_unsafeInheritExecutor` function.
       if (auto func = enclosingUnsafeInheritsExecutor(getDeclContext())) {
         // This expression is always written as a macro #isolation in source,
@@ -3910,10 +3914,6 @@ namespace {
         diag.limitBehaviorIf(inConcurrencyModule, DiagnosticBehavior::Warning);
         replaceUnsafeInheritExecutorWithDefaultedIsolationParam(func, diag);
       }
-
-      // If an actor has already been assigned, we're done.
-      if (isolationExpr->getActor())
-        return;
 
       auto loc = isolationExpr->getLoc();
       auto isolation = getActorIsolationOfContext(

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2111,17 +2111,18 @@ void swift::introduceUnsafeInheritExecutorReplacements(
   // Make sure at least some of the entries are functions in the _Concurrency
   // module.
   ModuleDecl *concurrencyModule = nullptr;
+  DeclBaseName baseName;
   for (auto decl: decls) {
     if (isReplaceable(decl)) {
       concurrencyModule = decl->getDeclContext()->getParentModule();
+      baseName = decl->getName().getBaseName();
       break;
     }
   }
   if (!concurrencyModule)
     return;
 
-  // Dig out the name.
-  auto baseName = decls.front()->getName().getBaseName();
+  // Ignore anything with a special name.
   if (baseName.isSpecial())
     return;
 
@@ -2146,6 +2147,60 @@ void swift::introduceUnsafeInheritExecutorReplacements(
   for (const auto &lookupResult: lookup) {
     if (auto decl = lookupResult.getValueDecl())
       decls.push_back(decl);
+  }
+}
+
+void swift::introduceUnsafeInheritExecutorReplacements(
+    const DeclContext *dc, Type base, SourceLoc loc, LookupResult &lookup) {
+  if (lookup.empty())
+    return;
+
+  auto baseNominal = base->getAnyNominal();
+  if (!baseNominal || !inConcurrencyModule(baseNominal))
+    return;
+
+  auto isReplaceable = [&](ValueDecl *decl) {
+    return isa<FuncDecl>(decl) && inConcurrencyModule(decl->getDeclContext());
+  };
+
+  // Make sure at least some of the entries are functions in the _Concurrency
+  // module.
+  ModuleDecl *concurrencyModule = nullptr;
+  DeclBaseName baseName;
+  for (auto &result: lookup) {
+    auto decl = result.getValueDecl();
+    if (isReplaceable(decl)) {
+      concurrencyModule = decl->getDeclContext()->getParentModule();
+      baseName = decl->getBaseName();
+      break;
+    }
+  }
+  if (!concurrencyModule)
+    return;
+
+  // Ignore anything with a special name.
+  if (baseName.isSpecial())
+    return;
+
+  // Look for entities with the _unsafeInheritExecutor_ prefix on the name.
+  ASTContext &ctx = base->getASTContext();
+  Identifier newIdentifier = ctx.getIdentifier(
+      ("_unsafeInheritExecutor_" + baseName.getIdentifier().str()).str());
+
+  LookupResult replacementLookup = TypeChecker::lookupMember(
+      const_cast<DeclContext *>(dc), base, DeclNameRef(newIdentifier), loc,
+      defaultMemberLookupOptions);
+  if (replacementLookup.innerResults().empty())
+    return;
+
+  // Drop all of the _Concurrency entries in favor of the ones found by this
+  // lookup.
+  lookup.filter([&](const LookupResultEntry &entry, bool) {
+    return !isReplaceable(entry.getValueDecl());
+  });
+
+  for (const auto &entry: replacementLookup.innerResults()) {
+    lookup.add(entry, /*isOuter=*/false);
   }
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2093,6 +2093,62 @@ void swift::replaceUnsafeInheritExecutorWithDefaultedIsolationParam(
   diag.fixItInsert(insertionLoc, newParameterText);
 }
 
+/// Whether this declaration context is in the _Concurrency module.
+static bool inConcurrencyModule(const DeclContext *dc) {
+  return dc->getParentModule()->getName().str().equals("_Concurrency");
+}
+
+void swift::introduceUnsafeInheritExecutorReplacements(
+    const DeclContext *dc, SourceLoc loc, SmallVectorImpl<ValueDecl *> &decls) {
+  if (decls.empty())
+    return;
+
+  auto isReplaceable = [&](ValueDecl *decl) {
+    return isa<FuncDecl>(decl) && inConcurrencyModule(decl->getDeclContext()) &&
+        decl->getDeclContext()->isModuleScopeContext();
+  };
+
+  // Make sure at least some of the entries are functions in the _Concurrency
+  // module.
+  ModuleDecl *concurrencyModule = nullptr;
+  for (auto decl: decls) {
+    if (isReplaceable(decl)) {
+      concurrencyModule = decl->getDeclContext()->getParentModule();
+      break;
+    }
+  }
+  if (!concurrencyModule)
+    return;
+
+  // Dig out the name.
+  auto baseName = decls.front()->getName().getBaseName();
+  if (baseName.isSpecial())
+    return;
+
+  // Look for entities with the _unsafeInheritExecutor_ prefix on the name.
+  ASTContext &ctx = decls.front()->getASTContext();
+  Identifier newIdentifier = ctx.getIdentifier(
+      ("_unsafeInheritExecutor_" + baseName.getIdentifier().str()).str());
+
+  NameLookupOptions lookupOptions = defaultUnqualifiedLookupOptions;
+  LookupResult lookup = TypeChecker::lookupUnqualified(
+      const_cast<DeclContext *>(dc), DeclNameRef(newIdentifier), loc,
+      lookupOptions);
+  if (!lookup)
+    return;
+
+  // Drop all of the _Concurrency entries in favor of the ones found by this
+  // lookup.
+  decls.erase(std::remove_if(decls.begin(), decls.end(), [&](ValueDecl *decl) {
+                return isReplaceable(decl);
+              }),
+              decls.end());
+  for (const auto &lookupResult: lookup) {
+    if (auto decl = lookupResult.getValueDecl())
+      decls.push_back(decl);
+  }
+}
+
 /// Check if it is safe for the \c globalActor qualifier to be removed from
 /// \c ty, when the function value of that type is isolated to that actor.
 ///
@@ -3847,9 +3903,7 @@ namespace {
         std::tie(diagLoc, inDefaultArgument) = adjustPoundIsolationDiagLoc(
             isolationExpr, getDeclContext()->getParentModule());
 
-        bool inConcurrencyModule = getDeclContext()->getParentModule()->getName()
-            .str().equals("_Concurrency");
-
+        bool inConcurrencyModule = ::inConcurrencyModule(getDeclContext());
         auto diag = ctx.Diags.diagnose(diagLoc,
                                        diag::isolation_in_inherits_executor,
                                        inDefaultArgument);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1999,8 +1999,7 @@ bool swift::isAsyncDecl(ConcreteDeclRef declRef) {
   return false;
 }
 
-/// Find an enclosing function that has @
-static AbstractFunctionDecl *enclosingUnsafeInheritsExecutor(
+AbstractFunctionDecl *swift::enclosingUnsafeInheritsExecutor(
     const DeclContext *dc) {
   for (; dc; dc = dc->getParent()) {
     if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -651,6 +651,11 @@ bool diagnoseApplyArgSendability(
 /// If the enclosing function has @_unsafeInheritExecutorAttr, return it.
 AbstractFunctionDecl *enclosingUnsafeInheritsExecutor(const DeclContext *dc);
 
+/// Add Fix-Its to the given function to replace the @_unsafeInheritExecutor
+/// attribute with a defaulted isolation parameter.
+void replaceUnsafeInheritExecutorWithDefaultedIsolationParam(
+    AbstractFunctionDecl *func, InFlightDiagnostic &diag);
+
 } // end namespace swift
 
 namespace llvm {

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -656,6 +656,18 @@ AbstractFunctionDecl *enclosingUnsafeInheritsExecutor(const DeclContext *dc);
 void replaceUnsafeInheritExecutorWithDefaultedIsolationParam(
     AbstractFunctionDecl *func, InFlightDiagnostic &diag);
 
+/// Replace any functions in this list that were found in the _Concurrency
+/// module and have _unsafeInheritExecutor_-prefixed versions with those
+/// _unsafeInheritExecutor_-prefixed versions.
+///
+/// This function is an egregious hack that allows us to introduce the
+/// #isolation-based versions of functions into the concurrency library
+/// without breaking clients that use @_unsafeInheritExecutor. Since those
+/// clients can't use #isolation (it doesn't work with @_unsafeInheritExecutor),
+/// we route them to the @_unsafeInheritExecutor versions implicitly.
+void introduceUnsafeInheritExecutorReplacements(
+    const DeclContext *dc, SourceLoc loc, SmallVectorImpl<ValueDecl *> &decls);
+
 } // end namespace swift
 
 namespace llvm {

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -648,6 +648,9 @@ bool isPotentiallyIsolatedActor(
 bool diagnoseApplyArgSendability(
     swift::ApplyExpr *apply, const DeclContext *declContext);
 
+/// If the enclosing function has @_unsafeInheritExecutorAttr, return it.
+AbstractFunctionDecl *enclosingUnsafeInheritsExecutor(const DeclContext *dc);
+
 } // end namespace swift
 
 namespace llvm {

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -44,6 +44,7 @@ class EnumElementDecl;
 class Expr;
 class FuncDecl;
 class Initializer;
+class LookupResult;
 class PatternBindingDecl;
 class ProtocolConformance;
 class TopLevelCodeDecl;
@@ -667,6 +668,18 @@ void replaceUnsafeInheritExecutorWithDefaultedIsolationParam(
 /// we route them to the @_unsafeInheritExecutor versions implicitly.
 void introduceUnsafeInheritExecutorReplacements(
     const DeclContext *dc, SourceLoc loc, SmallVectorImpl<ValueDecl *> &decls);
+
+/// Replace any functions in this list that were found in the _Concurrency
+/// module as a member on "base" and have _unsafeInheritExecutor_-prefixed
+/// versions with those _unsafeInheritExecutor_-prefixed versions.
+///
+/// This function is an egregious hack that allows us to introduce the
+/// #isolation-based versions of functions into the concurrency library
+/// without breaking clients that use @_unsafeInheritExecutor. Since those
+/// clients can't use #isolation (it doesn't work with @_unsafeInheritExecutor),
+/// we route them to the @_unsafeInheritExecutor versions implicitly.
+void introduceUnsafeInheritExecutorReplacements(
+    const DeclContext *dc, Type base, SourceLoc loc, LookupResult &result);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3289,6 +3289,11 @@ FuncDecl *TypeChecker::getForEachIteratorNextFunction(
   if (!nextElement)
     return ctx.getAsyncIteratorNext();
 
+  // If the enclosing function has @_unsafeInheritsExecutor, then #isolation
+  // does not work and we need to avoid relying on it.
+  if (enclosingUnsafeInheritsExecutor(dc))
+    return ctx.getAsyncIteratorNext();
+
   // If availability checking is disabled, use next(_:).
   if (ctx.LangOpts.DisableAvailabilityChecking || loc.isInvalid())
     return nextElement;

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -300,11 +300,10 @@ public func withCheckedContinuation<T>(
 }
 
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
 @_unsafeInheritExecutor // ABI compatibility with Swift 5.1
 @_unavailableInEmbedded
 @_silgen_name("$ss23withCheckedContinuation8function_xSS_yScCyxs5NeverOGXEtYalF")
-internal func __abi_withCheckedContinuation<T>(
+public func _unsafeInheritExecutor_withCheckedContinuation<T>(
   function: String = #function,
   _ body: (CheckedContinuation<T, Never>) -> Void
 ) async -> T {
@@ -361,11 +360,10 @@ public func withCheckedThrowingContinuation<T>(
 }
 
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
 @_unsafeInheritExecutor // ABI compatibility with Swift 5.1
 @_unavailableInEmbedded
 @_silgen_name("$ss31withCheckedThrowingContinuation8function_xSS_yScCyxs5Error_pGXEtYaKlF")
-internal func __abi_withCheckedThrowingContinuation<T>(
+public func _unsafeInheritExecutor_withCheckedThrowingContinuation<T>(
   function: String = #function,
   _ body: (CheckedContinuation<T, Error>) -> Void
 ) async throws -> T {

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -299,6 +299,12 @@ public func withCheckedContinuation<T>(
   }
 }
 
+// Note: hack to stage out @_unsafeInheritExecutor forms of various functions
+// in favor of #isolation. The _unsafeInheritExecutor_ prefix is meaningful
+// to the type checker.
+//
+// This function also doubles as an ABI-compatibility shim predating the
+// introduction of #isolation.
 @available(SwiftStdlib 5.1, *)
 @_unsafeInheritExecutor // ABI compatibility with Swift 5.1
 @_unavailableInEmbedded
@@ -359,6 +365,12 @@ public func withCheckedThrowingContinuation<T>(
   }
 }
 
+// Note: hack to stage out @_unsafeInheritExecutor forms of various functions
+// in favor of #isolation. The _unsafeInheritExecutor_ prefix is meaningful
+// to the type checker.
+//
+// This function also doubles as an ABI-compatibility shim predating the
+// introduction of #isolation.
 @available(SwiftStdlib 5.1, *)
 @_unsafeInheritExecutor // ABI compatibility with Swift 5.1
 @_unavailableInEmbedded

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -730,21 +730,23 @@ public func withUnsafeThrowingContinuation<T>(
   }
 }
 
-// HACK: a version of withUnsafeContinuation that uses the unsafe
-// @_unsafeInheritExecutor.
+// Note: hack to stage out @_unsafeInheritExecutor forms of various functions
+// in favor of #isolation. The _unsafeInheritExecutor_ prefix is meaningful
+// to the type checker.
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 @_unsafeInheritExecutor
 public func _unsafeInheritExecutor_withUnsafeContinuation<T>(
   _ fn: (UnsafeContinuation<T, Never>) -> Void
-) async -> T {
+) async -> sending T {
   return await Builtin.withUnsafeContinuation {
     fn(UnsafeContinuation<T, Never>($0))
   }
 }
 
-// HACK: a version of withUnsafeThrowingContinuation that uses the unsafe
-// @_unsafeInheritExecutor.
+// Note: hack to stage out @_unsafeInheritExecutor forms of various functions
+// in favor of #isolation. The _unsafeInheritExecutor_ prefix is meaningful
+// to the type checker.
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 @_unsafeInheritExecutor

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -730,6 +730,32 @@ public func withUnsafeThrowingContinuation<T>(
   }
 }
 
+// HACK: a version of withUnsafeContinuation that uses the unsafe
+// @_unsafeInheritExecutor.
+@available(SwiftStdlib 5.1, *)
+@_alwaysEmitIntoClient
+@_unsafeInheritExecutor
+public func _unsafeInheritExecutor_withUnsafeContinuation<T>(
+  _ fn: (UnsafeContinuation<T, Never>) -> Void
+) async -> T {
+  return await Builtin.withUnsafeContinuation {
+    fn(UnsafeContinuation<T, Never>($0))
+  }
+}
+
+// HACK: a version of withUnsafeThrowingContinuation that uses the unsafe
+// @_unsafeInheritExecutor.
+@available(SwiftStdlib 5.1, *)
+@_alwaysEmitIntoClient
+@_unsafeInheritExecutor
+public func _unsafeInheritExecutor_withUnsafeThrowingContinuation<T>(
+  _ fn: (UnsafeContinuation<T, Error>) -> Void
+) async throws -> sending T {
+  return try await Builtin.withUnsafeThrowingContinuation {
+    fn(UnsafeContinuation<T, Error>($0))
+  }
+}
+
 /// A hack to mark an SDK that supports swift_continuation_await.
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -63,6 +63,17 @@ public func withTaskCancellationHandler<T>(
 }
 
 @available(SwiftStdlib 5.1, *)
+@_alwaysEmitIntoClient
+@_unsafeInheritExecutor
+@available(*, deprecated, renamed: "withTaskCancellationHandler(operation:onCancel:)")
+public func _unsafeInheritExecutor_withTaskCancellationHandler<T>(
+  handler: @Sendable () -> Void,
+  operation: () async throws -> T
+) async rethrows -> T {
+  try await withTaskCancellationHandler(operation: operation, onCancel: handler)
+}
+
+@available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
   @available(*, deprecated, message: "`Task.withCancellationHandler` has been replaced by `withTaskCancellationHandler` and will be removed shortly.")
   @_alwaysEmitIntoClient

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -62,6 +62,9 @@ public func withTaskCancellationHandler<T>(
   try await withTaskCancellationHandler(operation: operation, onCancel: handler)
 }
 
+// Note: hack to stage out @_unsafeInheritExecutor forms of various functions
+// in favor of #isolation. The _unsafeInheritExecutor_ prefix is meaningful
+// to the type checker.
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 @_unsafeInheritExecutor

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -84,9 +84,8 @@ public func withTaskCancellationHandler<T>(
 
 @_unsafeInheritExecutor // ABI compatibility with Swift 5.1
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
 @_silgen_name("$ss27withTaskCancellationHandler9operation8onCancelxxyYaKXE_yyYbXEtYaKlF")
-internal func __abi_withTaskCancellationHandler<T>(
+public func _unsafeInheritExecutor_withTaskCancellationHandler<T>(
   operation: () async throws -> T,
   onCancel handler: @Sendable () -> Void
 ) async rethrows -> T {

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -82,6 +82,12 @@ public func withTaskCancellationHandler<T>(
   return try await operation()
 }
 
+// Note: hack to stage out @_unsafeInheritExecutor forms of various functions
+// in favor of #isolation. The _unsafeInheritExecutor_ prefix is meaningful
+// to the type checker.
+//
+// This function also doubles as an ABI-compatibility shim predating the
+// introduction of #isolation.
 @_unsafeInheritExecutor // ABI compatibility with Swift 5.1
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("$ss27withTaskCancellationHandler9operation8onCancelxxyYaKXE_yyYbXEtYaKlF")

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -215,14 +215,21 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
       file: file, line: line)
   }
 
-  @usableFromInline
+  // Note: hack to stage out @_unsafeInheritExecutor forms of various functions
+  // in favor of #isolation. The _unsafeInheritExecutor_ prefix is meaningful
+  // to the type checker.
+  //
+  // This function also doubles as an ABI-compatibility shim predating the
+  // introduction of #isolation.
   @discardableResult
   @_unsafeInheritExecutor // ABI compatibility with Swift 5.1
   @available(SwiftStdlib 5.1, *)
   @_silgen_name("$ss9TaskLocalC9withValue_9operation4file4lineqd__x_qd__yYaKXESSSutYaKlF")
-  internal func __abi_withValue<R>(_ valueDuringOperation: Value,
-                                   operation: () async throws -> R,
-                                   file: String = #fileID, line: UInt = #line) async rethrows -> R {
+  public func _unsafeInheritExecutor_withValue<R>(
+    _ valueDuringOperation: Value,
+    operation: () async throws -> R,
+    file: String = #fileID, line: UInt = #line
+  ) async rethrows -> R {
     return try await withValueImpl(valueDuringOperation, operation: operation, file: file, line: line)
   }
 

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -78,3 +78,34 @@ func unsafeCallerAvoidsNewLoop(x: some AsyncSequence<Int, Never>) async throws {
 
   for try await _ in x { }
 }
+
+// -------------------------------------------------------------------------
+// Type checker hack to use _unsafeInheritExecutor_-prefixed versions of
+// some concurrency library functions.
+// -------------------------------------------------------------------------
+
+@_unsafeInheritExecutor
+func unsafeCallerAvoidsNewLoop() async throws {
+  // expected-warning@-1{{@_unsafeInheritExecutor attribute is deprecated; consider an 'isolated' parameter defaulted to '#isolation' instead}}
+
+  _ = await withUnsafeContinuation { (continuation: UnsafeContinuation<Int, Never>) in
+    continuation.resume(returning: 5)
+  }
+
+  _ = try await withUnsafeThrowingContinuation { (continuation: UnsafeContinuation<Int, any Error>) in
+    continuation.resume(returning: 5)
+  }
+
+  _ = await withCheckedContinuation { (continuation: CheckedContinuation<Int, Never>) in
+    continuation.resume(returning: 5)
+  }
+
+  _ = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, any Error>) in
+    continuation.resume(returning: 5)
+  }
+
+  _ = await withTaskCancellationHandler {
+    5
+  } onCancel: {
+  }
+}

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=targeted
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -emit-sil -o /dev/null -verify -disable-availability-checking %s
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=targeted
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=complete
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: asserts
 
@@ -83,6 +83,11 @@ func unsafeCallerAvoidsNewLoop(x: some AsyncSequence<Int, Never>) async throws {
 // some concurrency library functions.
 // -------------------------------------------------------------------------
 
+enum TL {
+  @TaskLocal
+  static var string: String = "<undefined>"
+}
+
 @_unsafeInheritExecutor
 func unsafeCallerAvoidsNewLoop() async throws {
   // expected-warning@-1{{@_unsafeInheritExecutor attribute is deprecated; consider an 'isolated' parameter defaulted to '#isolation' instead}}
@@ -106,5 +111,9 @@ func unsafeCallerAvoidsNewLoop() async throws {
   _ = await withTaskCancellationHandler {
     5
   } onCancel: {
+  }
+
+  TL.$string.withValue("hello") {
+    print(TL.string)
   }
 }

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -53,7 +53,6 @@ func unsafeCallerA(x: Int) async {
 
   await inheritsIsolationProperly()
   // expected-error@-1{{#isolation (introduced by a default argument) cannot be used within an '@_unsafeInheritExecutor' function}}{{50:1-24=}}{{51:26-26=, isolation: isolated (any Actor)? = #isolation}}
-t 6)
 }
 
 @_unsafeInheritExecutor

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -11,6 +11,7 @@ func testNonAsync() {}
 
 @_unsafeInheritExecutor
 func testAsync() async {}
+// expected-warning@-1{{@_unsafeInheritExecutor attribute is deprecated; consider an 'isolated' parameter defaulted to '#isolation' instead}}
 
 struct A {
   // expected-error @+1 {{@_unsafeInheritExecutor may only be used on 'func' declarations}}
@@ -23,6 +24,7 @@ struct A {
 
   @_unsafeInheritExecutor
   func testAsync() async {}
+  // expected-warning@-1{{@_unsafeInheritExecutor attribute is deprecated; consider an 'isolated' parameter defaulted to '#isolation' instead}}
 }
 
 
@@ -32,6 +34,7 @@ class NonSendableObject {
 
 @_unsafeInheritExecutor
 func useNonSendable(object: NonSendableObject) async {}
+// expected-warning@-1{{@_unsafeInheritExecutor attribute is deprecated; consider an 'isolated' parameter defaulted to '#isolation' instead; this is an error in the Swift 6 language mode}}{{35:1-24=}}{{36:46-46=, isolation: isolated (any Actor)? = #isolation}}
 
 actor MyActor {
   var object = NonSendableObject()
@@ -46,23 +49,32 @@ func inheritsIsolationProperly(isolation: isolated (any Actor)? = #isolation) as
 // @_unsafeInheritExecutor does not work with #isolation
 @_unsafeInheritExecutor
 func unsafeCallerA(x: Int) async {
+  // expected-warning@-1{{@_unsafeInheritExecutor attribute is deprecated; consider an 'isolated' parameter defaulted to '#isolation' instead}}
+
   await inheritsIsolationProperly()
-  // expected-error@-1{{#isolation (introduced by a default argument) cannot be used within an '@_unsafeInheritExecutor' function}}{{47:1-24=}}{{48:26-26=, isolation: isolated (any Actor)? = #isolation}}
+  // expected-error@-1{{#isolation (introduced by a default argument) cannot be used within an '@_unsafeInheritExecutor' function}}{{50:1-24=}}{{51:26-26=, isolation: isolated (any Actor)? = #isolation}}
+t 6)
 }
 
 @_unsafeInheritExecutor
 func unsafeCallerB() async {
+  // expected-warning@-1{{@_unsafeInheritExecutor attribute is deprecated; consider an 'isolated' parameter defaulted to '#isolation' instead}}
+
   await inheritsIsolationProperly(isolation: #isolation)
-  // expected-error@-1{{#isolation cannot be used within an '@_unsafeInheritExecutor' function}}{{53:1-24=}}{{54:20-20=isolation: isolated (any Actor)? = #isolation}}
+  // expected-error@-1{{#isolation cannot be used within an '@_unsafeInheritExecutor' function}}{{58:1-24=}}{{59:20-20=isolation: isolated (any Actor)? = #isolation}}
 }
 
 @_unsafeInheritExecutor
 func unsafeCallerC(x: Int, fn: () -> Void, fn2: () -> Void) async {
+  // expected-warning@-1{{@_unsafeInheritExecutor attribute is deprecated; consider an 'isolated' parameter defaulted to '#isolation' instead}}
+
   await inheritsIsolationProperly()
-  // expected-error@-1{{#isolation (introduced by a default argument) cannot be used within an '@_unsafeInheritExecutor' function}}{{59:1-24=}}{{60:28-28=, isolation: isolated (any Actor)? = #isolation, }}
+  // expected-error@-1{{#isolation (introduced by a default argument) cannot be used within an '@_unsafeInheritExecutor' function}}{{66:1-24=}}{{67:28-28=, isolation: isolated (any Actor)? = #isolation, }}
 }
 
 @_unsafeInheritExecutor
 func unsafeCallerAvoidsNewLoop(x: some AsyncSequence<Int, Never>) async throws {
+  // expected-warning@-1{{@_unsafeInheritExecutor attribute is deprecated; consider an 'isolated' parameter defaulted to '#isolation' instead}}
+
   for try await _ in x { }
 }

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -63,7 +63,6 @@ func unsafeCallerC(x: Int, fn: () -> Void, fn2: () -> Void) async {
 }
 
 @_unsafeInheritExecutor
-func unsafeCallerB(x: some AsyncSequence<Int, Never>) async {
-  for await _ in x { }
-  // expected-error@-1 2{{#isolation cannot be used within an `@_unsafeInheritExecutor` function}}
+func unsafeCallerAvoidsNewLoop(x: some AsyncSequence<Int, Never>) async throws {
+  for try await _ in x { }
 }

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -113,7 +113,10 @@ func unsafeCallerAvoidsNewLoop() async throws {
   } onCancel: {
   }
 
-  TL.$string.withValue("hello") {
+  await TL.$string.withValue("hello") {
     print(TL.string)
   }
+
+  func operation() async throws -> Int { 7 }
+  try await TL.$string.withValue("hello", operation: operation)
 }

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -39,3 +39,31 @@ actor MyActor {
     await useNonSendable(object: self.object)
   }
 }
+
+// Note: the tests below are line-number-sensitive.
+func inheritsIsolationProperly(isolation: isolated (any Actor)? = #isolation) async { }
+
+// @_unsafeInheritExecutor does not work with #isolation
+@_unsafeInheritExecutor
+func unsafeCallerA(x: Int) async {
+  await inheritsIsolationProperly()
+  // expected-error@-1{{#isolation (introduced by a default argument) cannot be used within an '@_unsafeInheritExecutor' function}}{{47:1-24=}}{{48:26-26=, isolation: isolated (any Actor)? = #isolation}}
+}
+
+@_unsafeInheritExecutor
+func unsafeCallerB() async {
+  await inheritsIsolationProperly(isolation: #isolation)
+  // expected-error@-1{{#isolation cannot be used within an '@_unsafeInheritExecutor' function}}{{53:1-24=}}{{54:20-20=isolation: isolated (any Actor)? = #isolation}}
+}
+
+@_unsafeInheritExecutor
+func unsafeCallerC(x: Int, fn: () -> Void, fn2: () -> Void) async {
+  await inheritsIsolationProperly()
+  // expected-error@-1{{#isolation (introduced by a default argument) cannot be used within an '@_unsafeInheritExecutor' function}}{{59:1-24=}}{{60:28-28=, isolation: isolated (any Actor)? = #isolation, }}
+}
+
+@_unsafeInheritExecutor
+func unsafeCallerB(x: some AsyncSequence<Int, Never>) async {
+  for await _ in x { }
+  // expected-error@-1 2{{#isolation cannot be used within an `@_unsafeInheritExecutor` function}}
+}


### PR DESCRIPTION
An `@_unsafeInheritExecutor` function is unsafe because it doesn't really "inherit" the executor, it just avoids immediately hopping off the executor. That means that using `#isolation` within such a function is fundamentally broken. Ban the use of `#isolation` within such a function, providing a Fix-It that removes the `@_unsafeInheritExecutor` attribute and adds a defaulted parameter

    isolation: (any Actor)? = #isolation

instead. That's the real, safe pattern that we want going forward. We take the extra step of diagnosing `@_unsafeInheritExecutor` as an error in Swift 6, downgraded to a warning in Swift 5. There's no place for this misfeature going forward, since we have a proper solution in the language.

Unfortunately, the async `for..in` loop injects an `#isolation` when used with the `next(isolation:)`, so avoid using `next(isolation:)` when inside a `@_unsafeInheritExecutor` function, because that would immediately break.

Even more unfortunately, the move from `@_unsafeInheritExecutor` to `#isolation` for the with*Continuation functions in the concurrency library breaks code that is using `@_unsafeInheritExecutor` and calling these APIs. This currently causes silent breakage (which manifest as runtime crashes), and with this change detected by the compiler as an error. However, we don't want to outright break such code, so we have a workaround. It's ugly, and you might want to stop reading now.

Introduce _unsafeInheritExecutor_-prefixed versions of the `with*Continuation` and `withTaskCancellationHandler` APIs into
the _Concurrency library that use `@_unsafeInheritExecutor`. Then, teach the type checker to swap in these `_unsafeInheritExecutor_`-prefixed versions in lieu of the originals when they are called from an `@_unsafeInheritExecutor` function. This allows existing code using `@_unsafeInheritExecutor` with these APIs to continue working as it has before, albeit with a warning that `@_unsafeInheritExecutor` has been removed.

Fixes rdar://131151376.