### PR TITLE
Add support for lifetime dependence in parameter position

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -727,7 +727,7 @@ Types
   C-TYPE is mangled according to the Itanium ABI, and prefixed with the length.
   Non-ASCII identifiers are preserved as-is; we do not use Punycode.
 
-  function-signature ::= params-type params-type async? sendable? throws? differentiable? function-isolation? self-lifetime-dependence? // results and parameters
+  function-signature ::= params-type params-type async? sendable? throws? differentiable? function-isolation? // results and parameters
 
   params-type ::= type 'z'? 'h'?             // tuple in case of multiple parameters or a single parameter with a single tuple type
                                              // with optional inout convention, shared convention. parameters don't have labels,
@@ -749,10 +749,8 @@ Types
   differentiable ::= 'Yjd'                   // @differentiable on function type
   differentiable ::= 'Yjl'                   // @differentiable(_linear) on function type
  #if SWIFT_RUNTIME_VERSION >= 5.TBD
-  lifetime-dependence ::= 'Yli'              // inherit lifetime dependence on param
-  lifetime-dependence ::= 'Yls'              // scoped lifetime dependence on param
-  self-lifetime-dependence ::= 'YLi'         // inherit lifetime dependence on self
-  self-lifetime-dependence ::= 'YLs'         // scoped lifetime dependence on self
+  lifetime-dependence ::= 'Yli' INDEX-SUBSET '_'         // inherit lifetime dependence
+  lifetime-dependence ::= 'Yls' INDEX-SUBSET '_'         // scoped lifetime dependence
 #endif
   type-list ::= list-type '_' list-type*     // list of types
   type-list ::= empty-list

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -556,14 +556,15 @@ protected:
                                FunctionManglingKind functionMangling,
                                bool isRecursedInto = true);
 
-  void appendFunctionInputType(ArrayRef<AnyFunctionType::Param> params,
-                               LifetimeDependenceInfo lifetimeDependenceInfo,
+  void appendFunctionInputType(AnyFunctionType *fnType,
+                               ArrayRef<AnyFunctionType::Param> params,
                                GenericSignature sig,
                                const ValueDecl *forDecl = nullptr,
                                bool isRecursedInto = true);
-  void appendFunctionResultType(Type resultType,
-                                GenericSignature sig,
-                                const ValueDecl *forDecl = nullptr);
+  void appendFunctionResultType(
+      Type resultType, GenericSignature sig,
+      std::optional<LifetimeDependenceInfo> lifetimeDependence,
+      const ValueDecl *forDecl = nullptr);
 
   void appendTypeList(Type listTy, GenericSignature sig,
                       const ValueDecl *forDecl = nullptr);
@@ -573,7 +574,7 @@ protected:
                              const ValueDecl *forDecl = nullptr);
   void appendParameterTypeListElement(
       Identifier name, Type elementType, ParameterTypeFlags flags,
-      std::optional<LifetimeDependenceKind> lifetimeDependenceKind,
+      std::optional<LifetimeDependenceInfo> lifetimeDependence,
       GenericSignature sig, const ValueDecl *forDecl = nullptr);
   void appendTupleTypeListElement(Identifier name, Type elementType,
                                   GenericSignature sig,
@@ -749,8 +750,7 @@ protected:
   void appendConstrainedExistential(Type base, GenericSignature sig,
                                     const ValueDecl *forDecl);
 
-  void appendLifetimeDependenceKind(LifetimeDependenceKind kind,
-                                    bool isSelfDependence);
+  void appendLifetimeDependence(LifetimeDependenceInfo info);
 };
 
 } // end namespace Mangle

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -91,6 +91,9 @@ protected:
   /// a critical role.
   bool AllowTypedThrows = true;
 
+  /// If enabled, lifetime dependencies can be encoded in the mangled name.
+  bool AllowLifetimeDependencies = true;
+
   /// If enabled, declarations annotated with @_originallyDefinedIn are mangled
   /// as if they're part of their original module. Disabled for debug mangling,
   /// because lldb wants to find declarations in the modules they're currently

--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -364,6 +364,22 @@ public:
     return printedClangDecl.insert(d).second;
   }
 
+  void printLifetimeDependence(
+      std::optional<LifetimeDependenceInfo> lifetimeDependence) {
+    if (!lifetimeDependence.has_value()) {
+      return;
+    }
+    *this << lifetimeDependence->getString();
+  }
+
+  void printLifetimeDependenceAt(
+      ArrayRef<LifetimeDependenceInfo> lifetimeDependencies, unsigned index) {
+    if (auto lifetimeDependence =
+            getLifetimeDependenceFor(lifetimeDependencies, index)) {
+      printLifetimeDependence(*lifetimeDependence);
+    }
+  }
+
 private:
   virtual void anchor();
 };

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7482,7 +7482,8 @@ public:
 
   /// Add the given derivative function configuration.
   void addDerivativeFunctionConfiguration(const AutoDiffConfig &config);
-  std::optional<LifetimeDependenceInfo> getLifetimeDependenceInfo() const;
+  std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
+  getLifetimeDependencies() const;
 
 protected:
   // If a function has a body at all, we have either a parsed body AST node or

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7981,8 +7981,8 @@ ERROR(lifetime_dependence_invalid_self_ownership, none,
 ERROR(lifetime_dependence_only_on_function_method_init_result, none,
       "lifetime dependence specifiers may only be used on result of "
        "functions, methods, initializers", ())
-ERROR(lifetime_dependence_invalid_return_type, none,
-      "lifetime dependence can only be specified on ~Escapable results", ())
+ERROR(lifetime_dependence_invalid_type, none,
+      "lifetime dependence can only be specified on ~Escapable types", ())
 ERROR(lifetime_dependence_cannot_infer_ambiguous_candidate, none,
       "cannot infer lifetime dependence %0, multiple parameters qualifiy as a candidate", (StringRef))
  ERROR(lifetime_dependence_cannot_infer_no_candidates, none,

--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -464,16 +464,15 @@ class ASTExtInfoBuilder {
   Type globalActor;
   Type thrownError;
 
-  LifetimeDependenceInfo lifetimeDependenceInfo;
+  ArrayRef<LifetimeDependenceInfo> lifetimeDependencies;
 
   using Representation = FunctionTypeRepresentation;
 
   ASTExtInfoBuilder(unsigned bits, ClangTypeInfo clangTypeInfo,
                     Type globalActor, Type thrownError,
-                    LifetimeDependenceInfo lifetimeDependenceInfo)
+                    ArrayRef<LifetimeDependenceInfo> lifetimeDependencies)
       : bits(bits), clangTypeInfo(clangTypeInfo), globalActor(globalActor),
-        thrownError(thrownError),
-        lifetimeDependenceInfo(lifetimeDependenceInfo) {
+        thrownError(thrownError), lifetimeDependencies(lifetimeDependencies) {
     assert(isThrowing() || !thrownError);
     assert(hasGlobalActorFromBits(bits) == !globalActor.isNull());
   }
@@ -485,7 +484,7 @@ public:
       : ASTExtInfoBuilder(Representation::Swift, false, false, Type(),
                           DifferentiabilityKind::NonDifferentiable, nullptr,
                           FunctionTypeIsolation::forNonIsolated(),
-                          LifetimeDependenceInfo(),
+                          std::nullopt /* LifetimeDependenceInfo */,
                           false /*sendingResult*/) {}
 
   // Constructor for polymorphic type.
@@ -493,14 +492,14 @@ public:
       : ASTExtInfoBuilder(rep, false, throws, thrownError,
                           DifferentiabilityKind::NonDifferentiable, nullptr,
                           FunctionTypeIsolation::forNonIsolated(),
-                          LifetimeDependenceInfo(),
+                          std::nullopt /* LifetimeDependenceInfo */,
                           false /*sendingResult*/) {}
 
   // Constructor with no defaults.
   ASTExtInfoBuilder(Representation rep, bool isNoEscape, bool throws,
                     Type thrownError, DifferentiabilityKind diffKind,
                     const clang::Type *type, FunctionTypeIsolation isolation,
-                    LifetimeDependenceInfo lifetimeDependenceInfo,
+                    ArrayRef<LifetimeDependenceInfo> lifetimeDependencies,
                     bool sendingResult)
       : ASTExtInfoBuilder(
             ((unsigned)rep) | (isNoEscape ? NoEscapeMask : 0) |
@@ -510,7 +509,7 @@ public:
                 (unsigned(isolation.getKind()) << IsolationMaskOffset) |
                 (sendingResult ? SendingResultMask : 0),
             ClangTypeInfo(type), isolation.getOpaqueType(), thrownError,
-            lifetimeDependenceInfo) {}
+            lifetimeDependencies) {}
 
   void checkInvariants() const;
 
@@ -552,8 +551,8 @@ public:
   Type getGlobalActor() const { return globalActor; }
   Type getThrownError() const { return thrownError; }
 
-  LifetimeDependenceInfo getLifetimeDependenceInfo() const {
-    return lifetimeDependenceInfo;
+  ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const {
+    return lifetimeDependencies;
   }
 
   FunctionTypeIsolation::Kind getIsolationKind() const {
@@ -609,32 +608,32 @@ public:
     return ASTExtInfoBuilder((bits & ~RepresentationMask) | (unsigned)rep,
                              shouldStoreClangType(rep) ? clangTypeInfo
                                                        : ClangTypeInfo(),
-                             globalActor, thrownError, lifetimeDependenceInfo);
+                             globalActor, thrownError, lifetimeDependencies);
   }
   [[nodiscard]]
   ASTExtInfoBuilder withNoEscape(bool noEscape = true) const {
     return ASTExtInfoBuilder(
         noEscape ? (bits | NoEscapeMask) : (bits & ~NoEscapeMask),
-        clangTypeInfo, globalActor, thrownError, lifetimeDependenceInfo);
+        clangTypeInfo, globalActor, thrownError, lifetimeDependencies);
   }
   [[nodiscard]]
   ASTExtInfoBuilder withSendable(bool concurrent = true) const {
     return ASTExtInfoBuilder(
         concurrent ? (bits | SendableMask) : (bits & ~SendableMask),
-        clangTypeInfo, globalActor, thrownError, lifetimeDependenceInfo);
+        clangTypeInfo, globalActor, thrownError, lifetimeDependencies);
   }
   [[nodiscard]]
   ASTExtInfoBuilder withAsync(bool async = true) const {
     return ASTExtInfoBuilder(async ? (bits | AsyncMask) : (bits & ~AsyncMask),
                              clangTypeInfo, globalActor, thrownError,
-                             lifetimeDependenceInfo);
+                             lifetimeDependencies);
   }
   [[nodiscard]]
   ASTExtInfoBuilder withThrows(bool throws, Type thrownError) const {
     assert(throws || !thrownError);
     return ASTExtInfoBuilder(
         throws ? (bits | ThrowsMask) : (bits & ~ThrowsMask), clangTypeInfo,
-        globalActor, thrownError, lifetimeDependenceInfo);
+        globalActor, thrownError, lifetimeDependencies);
   }
 
   [[nodiscard]]
@@ -645,7 +644,7 @@ public:
   [[nodiscard]] ASTExtInfoBuilder withSendingResult(bool sending = true) const {
     return ASTExtInfoBuilder(
         sending ? (bits | SendingResultMask) : (bits & ~SendingResultMask),
-        clangTypeInfo, globalActor, thrownError, lifetimeDependenceInfo);
+        clangTypeInfo, globalActor, thrownError, lifetimeDependencies);
   }
 
   [[nodiscard]]
@@ -654,12 +653,12 @@ public:
     return ASTExtInfoBuilder(
         (bits & ~DifferentiabilityMask) |
             ((unsigned)differentiability << DifferentiabilityMaskOffset),
-        clangTypeInfo, globalActor, thrownError, lifetimeDependenceInfo);
+        clangTypeInfo, globalActor, thrownError, lifetimeDependencies);
   }
   [[nodiscard]]
   ASTExtInfoBuilder withClangFunctionType(const clang::Type *type) const {
     return ASTExtInfoBuilder(bits, ClangTypeInfo(type), globalActor,
-                             thrownError, lifetimeDependenceInfo);
+                             thrownError, lifetimeDependencies);
   }
 
   /// Put a SIL representation in the ExtInfo.
@@ -673,23 +672,22 @@ public:
     return ASTExtInfoBuilder((bits & ~RepresentationMask) | (unsigned)rep,
                              shouldStoreClangType(rep) ? clangTypeInfo
                                                        : ClangTypeInfo(),
-                             globalActor, thrownError, lifetimeDependenceInfo);
+                             globalActor, thrownError, lifetimeDependencies);
   }
 
-  [[nodiscard]]
-  ASTExtInfoBuilder withLifetimeDependenceInfo(
-      LifetimeDependenceInfo lifetimeDependenceInfo) const {
+  [[nodiscard]] ASTExtInfoBuilder withLifetimeDependencies(
+      llvm::ArrayRef<LifetimeDependenceInfo> lifetimeDependencies) const {
     return ASTExtInfoBuilder(bits, clangTypeInfo, globalActor, thrownError,
-                             lifetimeDependenceInfo);
+                             lifetimeDependencies);
   }
 
   [[nodiscard]]
   ASTExtInfoBuilder withIsolation(FunctionTypeIsolation isolation) const {
     return ASTExtInfoBuilder(
-             (bits & ~IsolationMask)
-                | (unsigned(isolation.getKind()) << IsolationMaskOffset),
-             clangTypeInfo, isolation.getOpaqueType(), thrownError,
-             lifetimeDependenceInfo);
+        (bits & ~IsolationMask) |
+            (unsigned(isolation.getKind()) << IsolationMaskOffset),
+        clangTypeInfo, isolation.getOpaqueType(), thrownError,
+        lifetimeDependencies);
   }
 
   void Profile(llvm::FoldingSetNodeID &ID) const {
@@ -697,7 +695,9 @@ public:
     ID.AddPointer(clangTypeInfo.getType());
     ID.AddPointer(globalActor.getPointer());
     ID.AddPointer(thrownError.getPointer());
-    lifetimeDependenceInfo.Profile(ID);
+    for (auto info : lifetimeDependencies) {
+      info.Profile(ID);
+    }
   }
 
   bool isEqualTo(ASTExtInfoBuilder other, bool useClangTypes) const {
@@ -705,7 +705,7 @@ public:
            (useClangTypes ? (clangTypeInfo == other.clangTypeInfo) : true) &&
            globalActor.getPointer() == other.globalActor.getPointer() &&
            thrownError.getPointer() == other.thrownError.getPointer() &&
-           lifetimeDependenceInfo == other.lifetimeDependenceInfo;
+           lifetimeDependencies == other.lifetimeDependencies;
   }
 }; // end ASTExtInfoBuilder
 
@@ -727,7 +727,8 @@ class ASTExtInfo {
   ASTExtInfo(ASTExtInfoBuilder builder) : builder(builder) {}
 
   ASTExtInfo(unsigned bits, ClangTypeInfo clangTypeInfo, Type globalActor,
-             Type thrownError, LifetimeDependenceInfo lifetimeDependenceInfo)
+             Type thrownError,
+             llvm::ArrayRef<LifetimeDependenceInfo> lifetimeDependenceInfo)
       : builder(bits, clangTypeInfo, globalActor, thrownError,
                 lifetimeDependenceInfo) {
     builder.checkInvariants();
@@ -778,8 +779,8 @@ public:
   Type getGlobalActor() const { return builder.getGlobalActor(); }
   Type getThrownError() const { return builder.getThrownError(); }
 
-  LifetimeDependenceInfo getLifetimeDependenceInfo() const {
-    return builder.getLifetimeDependenceInfo();
+  ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const {
+    return builder.getLifetimeDependencies();
   }
 
   FunctionTypeIsolation getIsolation() const { return builder.getIsolation(); }
@@ -854,9 +855,9 @@ public:
       .build();
   }
 
-  [[nodiscard]] ASTExtInfo withLifetimeDependenceInfo(
-      LifetimeDependenceInfo lifetimeDependenceInfo) const {
-    return builder.withLifetimeDependenceInfo(lifetimeDependenceInfo).build();
+  [[nodiscard]] ASTExtInfo withLifetimeDependencies(
+      ArrayRef<LifetimeDependenceInfo> lifetimeDependencies) const {
+    return builder.withLifetimeDependencies(lifetimeDependencies).build();
   }
 
   void Profile(llvm::FoldingSetNodeID &ID) const { builder.Profile(ID); }
@@ -935,15 +936,15 @@ class SILExtInfoBuilder {
 
   ClangTypeInfo clangTypeInfo;
 
-  LifetimeDependenceInfo lifetimeDependenceInfo;
+  ArrayRef<LifetimeDependenceInfo> lifetimeDependencies;
 
   using Language = SILFunctionLanguage;
   using Representation = SILFunctionTypeRepresentation;
 
   SILExtInfoBuilder(unsigned bits, ClangTypeInfo clangTypeInfo,
-                    LifetimeDependenceInfo lifetimeDependenceInfo)
+                    ArrayRef<LifetimeDependenceInfo> lifetimeDependencies)
       : bits(bits), clangTypeInfo(clangTypeInfo.getCanonical()),
-        lifetimeDependenceInfo(lifetimeDependenceInfo) {}
+        lifetimeDependencies(lifetimeDependencies) {}
 
   static constexpr unsigned makeBits(Representation rep, bool isPseudogeneric,
                                      bool isNoEscape, bool isSendable,
@@ -964,17 +965,17 @@ public:
   /// An ExtInfoBuilder for a typical Swift function: thick, @escaping,
   /// non-pseudogeneric, non-differentiable.
   SILExtInfoBuilder()
-      : SILExtInfoBuilder(makeBits(SILFunctionTypeRepresentation::Thick, false,
-                                   false, false, false, false,
-                                   SILFunctionTypeIsolation::Unknown,
-                                   DifferentiabilityKind::NonDifferentiable),
-                          ClangTypeInfo(nullptr), LifetimeDependenceInfo()) {}
+      : SILExtInfoBuilder(
+            makeBits(SILFunctionTypeRepresentation::Thick, false, false, false,
+                     false, false, SILFunctionTypeIsolation::Unknown,
+                     DifferentiabilityKind::NonDifferentiable),
+            ClangTypeInfo(nullptr), /*LifetimeDependenceInfo*/ std::nullopt) {}
 
   SILExtInfoBuilder(Representation rep, bool isPseudogeneric, bool isNoEscape,
                     bool isSendable, bool isAsync, bool isUnimplementable,
                     SILFunctionTypeIsolation isolation,
                     DifferentiabilityKind diffKind, const clang::Type *type,
-                    LifetimeDependenceInfo lifetimeDependenceInfo)
+                    ArrayRef<LifetimeDependenceInfo> lifetimeDependenceInfo)
       : SILExtInfoBuilder(makeBits(rep, isPseudogeneric, isNoEscape, isSendable,
                                    isAsync, isUnimplementable, isolation,
                                    diffKind),
@@ -990,7 +991,7 @@ public:
                                        : SILFunctionTypeIsolation::Unknown,
                                    info.getDifferentiabilityKind()),
                           info.getClangTypeInfo(),
-                          info.getLifetimeDependenceInfo()) {}
+                          info.getLifetimeDependencies()) {}
 
   void checkInvariants() const;
 
@@ -1046,8 +1047,8 @@ public:
   /// Get the underlying ClangTypeInfo value.
   ClangTypeInfo getClangTypeInfo() const { return clangTypeInfo; }
 
-  LifetimeDependenceInfo getLifetimeDependenceInfo() const {
-    return lifetimeDependenceInfo;
+  ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const {
+    return lifetimeDependencies;
   }
 
   constexpr bool hasSelfParam() const {
@@ -1100,38 +1101,38 @@ public:
     return SILExtInfoBuilder((bits & ~RepresentationMask) | (unsigned)rep,
                              shouldStoreClangType(rep) ? clangTypeInfo
                                                        : ClangTypeInfo(),
-                             lifetimeDependenceInfo);
+                             lifetimeDependencies);
   }
   [[nodiscard]]
   SILExtInfoBuilder withIsPseudogeneric(bool isPseudogeneric = true) const {
     return SILExtInfoBuilder(isPseudogeneric ? (bits | PseudogenericMask)
                                              : (bits & ~PseudogenericMask),
-                             clangTypeInfo, lifetimeDependenceInfo);
+                             clangTypeInfo, lifetimeDependencies);
   }
   [[nodiscard]]
   SILExtInfoBuilder withNoEscape(bool noEscape = true) const {
     return SILExtInfoBuilder(noEscape ? (bits | NoEscapeMask)
                                       : (bits & ~NoEscapeMask),
-                             clangTypeInfo, lifetimeDependenceInfo);
+                             clangTypeInfo, lifetimeDependencies);
   }
   [[nodiscard]]
   SILExtInfoBuilder withSendable(bool isSendable = true) const {
     return SILExtInfoBuilder(isSendable ? (bits | SendableMask)
                                         : (bits & ~SendableMask),
-                             clangTypeInfo, lifetimeDependenceInfo);
+                             clangTypeInfo, lifetimeDependencies);
   }
 
   [[nodiscard]]
   SILExtInfoBuilder withAsync(bool isAsync = true) const {
     return SILExtInfoBuilder(isAsync ? (bits | AsyncMask) : (bits & ~AsyncMask),
-                             clangTypeInfo, lifetimeDependenceInfo);
+                             clangTypeInfo, lifetimeDependencies);
   }
 
   [[nodiscard]]
   SILExtInfoBuilder withErasedIsolation(bool erased = true) const {
     return SILExtInfoBuilder(erased ? (bits | ErasedIsolationMask)
                                     : (bits & ~ErasedIsolationMask),
-                             clangTypeInfo, lifetimeDependenceInfo);
+                             clangTypeInfo, lifetimeDependencies);
   }
   [[nodiscard]]
   SILExtInfoBuilder withIsolation(SILFunctionTypeIsolation isolation) const {
@@ -1147,7 +1148,7 @@ public:
   SILExtInfoBuilder withUnimplementable(bool isUnimplementable = true) const {
     return SILExtInfoBuilder(isUnimplementable ? (bits | UnimplementableMask)
                                                : (bits & ~UnimplementableMask),
-                             clangTypeInfo, lifetimeDependenceInfo);
+                             clangTypeInfo, lifetimeDependencies);
   }
 
   [[nodiscard]]
@@ -1156,22 +1157,24 @@ public:
     return SILExtInfoBuilder(
         (bits & ~DifferentiabilityMask) |
             ((unsigned)differentiability << DifferentiabilityMaskOffset),
-        clangTypeInfo, lifetimeDependenceInfo);
+        clangTypeInfo, lifetimeDependencies);
   }
   [[nodiscard]]
   SILExtInfoBuilder withClangFunctionType(const clang::Type *type) const {
     return SILExtInfoBuilder(bits, ClangTypeInfo(type).getCanonical(),
-                             lifetimeDependenceInfo);
+                             lifetimeDependencies);
   }
-  [[nodiscard]] SILExtInfoBuilder withLifetimeDependenceInfo(
-      LifetimeDependenceInfo lifetimeDependenceInfo) const {
+  [[nodiscard]] SILExtInfoBuilder withLifetimeDependencies(
+      ArrayRef<LifetimeDependenceInfo> lifetimeDependenceInfo) const {
     return SILExtInfoBuilder(bits, clangTypeInfo, lifetimeDependenceInfo);
   }
 
   void Profile(llvm::FoldingSetNodeID &ID) const {
     ID.AddInteger(bits);
     ID.AddPointer(clangTypeInfo.getType());
-    lifetimeDependenceInfo.Profile(ID);
+    for (auto info : lifetimeDependencies) {
+      info.Profile(ID);
+    }
   }
 
   bool isEqualTo(SILExtInfoBuilder other, bool useClangTypes) const {
@@ -1198,8 +1201,8 @@ class SILExtInfo {
   SILExtInfo(SILExtInfoBuilder builder) : builder(builder) {}
 
   SILExtInfo(unsigned bits, ClangTypeInfo clangTypeInfo,
-             LifetimeDependenceInfo lifetimeDependenceInfo)
-      : builder(bits, clangTypeInfo, lifetimeDependenceInfo) {
+             llvm::ArrayRef<LifetimeDependenceInfo> lifetimeDependencies)
+      : builder(bits, clangTypeInfo, lifetimeDependencies) {
     builder.checkInvariants();
   };
 
@@ -1215,11 +1218,10 @@ public:
 
   /// A default ExtInfo but with a Thin convention.
   static SILExtInfo getThin() {
-    return SILExtInfoBuilder(SILExtInfoBuilder::Representation::Thin, false,
-                             false, false, false, false,
-                             SILFunctionTypeIsolation::Unknown,
-                             DifferentiabilityKind::NonDifferentiable, nullptr,
-                             LifetimeDependenceInfo())
+    return SILExtInfoBuilder(
+               SILExtInfoBuilder::Representation::Thin, false, false, false,
+               false, false, SILFunctionTypeIsolation::Unknown,
+               DifferentiabilityKind::NonDifferentiable, nullptr, {})
         .build();
   }
 
@@ -1265,8 +1267,8 @@ public:
 
   ClangTypeInfo getClangTypeInfo() const { return builder.getClangTypeInfo(); }
 
-  LifetimeDependenceInfo getLifetimeDependenceInfo() const {
-    return builder.getLifetimeDependenceInfo();
+  ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const {
+    return builder.getLifetimeDependencies();
   }
 
   constexpr bool hasSelfParam() const { return builder.hasSelfParam(); }
@@ -1303,8 +1305,9 @@ public:
     return builder.withUnimplementable(isUnimplementable).build();
   }
 
-  SILExtInfo withLifetimeDependenceInfo(LifetimeDependenceInfo info) const {
-    return builder.withLifetimeDependenceInfo(info);
+  SILExtInfo withLifetimeDependencies(
+      ArrayRef<LifetimeDependenceInfo> lifetimeDependencies) const {
+    return builder.withLifetimeDependencies(lifetimeDependencies);
   }
 
   void Profile(llvm::FoldingSetNodeID &ID) const { builder.Profile(ID); }

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -230,6 +230,20 @@ public:
   static std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
   get(FunctionTypeRepr *funcRepr, ArrayRef<SILParameterInfo> params,
       ArrayRef<SILResultInfo> results, DeclContext *dc);
+
+  bool operator==(const LifetimeDependenceInfo &other) const {
+    return this->isImmortal() == other.isImmortal() &&
+           this->getTargetIndex() == other.getTargetIndex() &&
+           this->getInheritIndices() == other.getInheritIndices() &&
+           this->getScopeIndices() == other.getScopeIndices();
+  }
+
+  bool operator!=(const LifetimeDependenceInfo &other) const {
+    return this->isImmortal() != other.isImmortal() &&
+           this->getTargetIndex() != other.getTargetIndex() &&
+           this->getInheritIndices() != other.getInheritIndices() &&
+           this->getScopeIndices() != other.getScopeIndices();
+  }
 };
 
 std::optional<LifetimeDependenceInfo>

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -30,8 +30,10 @@
 namespace swift {
 
 class AbstractFunctionDecl;
+class FunctionTypeRepr;
 class LifetimeDependentTypeRepr;
 class SILParameterInfo;
+class SILResultInfo;
 
 enum class ParsedLifetimeDependenceKind : uint8_t {
   Default = 0,
@@ -141,29 +143,35 @@ public:
 class LifetimeDependenceInfo {
   IndexSubset *inheritLifetimeParamIndices;
   IndexSubset *scopeLifetimeParamIndices;
+  unsigned targetIndex;
   bool immortal;
 
-  static LifetimeDependenceInfo getForParamIndex(AbstractFunctionDecl *afd,
-                                                 unsigned index,
-                                                 LifetimeDependenceKind kind);
+  static LifetimeDependenceInfo getForIndex(AbstractFunctionDecl *afd,
+                                            unsigned targetIndex,
+                                            unsigned sourceIndex,
+                                            LifetimeDependenceKind kind);
 
-  /// Builds LifetimeDependenceInfo from a swift decl
+  /// Builds LifetimeDependenceInfo on a result or parameter from a swift decl
   static std::optional<LifetimeDependenceInfo>
-  fromTypeRepr(AbstractFunctionDecl *afd);
+  fromTypeRepr(AbstractFunctionDecl *afd, LifetimeDependentTypeRepr *typeRepr,
+               unsigned targetIndex);
 
-  /// Infer LifetimeDependenceInfo
+  /// Infer LifetimeDependenceInfo on result
   static std::optional<LifetimeDependenceInfo> infer(AbstractFunctionDecl *afd);
 
+  /// Builds LifetimeDependenceInfo from SIL function type
+  static std::optional<LifetimeDependenceInfo>
+  fromTypeRepr(LifetimeDependentTypeRepr *lifetimeDependentRepr,
+               unsigned targetIndex, ArrayRef<SILParameterInfo> params,
+               DeclContext *dc);
+
 public:
-  LifetimeDependenceInfo()
-      : inheritLifetimeParamIndices(nullptr),
-        scopeLifetimeParamIndices(nullptr), immortal(false) {}
   LifetimeDependenceInfo(IndexSubset *inheritLifetimeParamIndices,
                          IndexSubset *scopeLifetimeParamIndices,
-                         bool isImmortal)
+                         unsigned targetIndex, bool isImmortal)
       : inheritLifetimeParamIndices(inheritLifetimeParamIndices),
         scopeLifetimeParamIndices(scopeLifetimeParamIndices),
-        immortal(isImmortal) {
+        targetIndex(targetIndex), immortal(isImmortal) {
     assert(isImmortal || inheritLifetimeParamIndices ||
            scopeLifetimeParamIndices);
     assert(!inheritLifetimeParamIndices ||
@@ -180,13 +188,19 @@ public:
 
   bool isImmortal() const { return immortal; }
 
+  unsigned getTargetIndex() const { return targetIndex; }
+
   bool hasInheritLifetimeParamIndices() const {
     return inheritLifetimeParamIndices != nullptr;
   }
   bool hasScopeLifetimeParamIndices() const {
     return scopeLifetimeParamIndices != nullptr;
   }
-  
+
+  IndexSubset *getInheritIndices() const { return inheritLifetimeParamIndices; }
+
+  IndexSubset *getScopeIndices() const { return scopeLifetimeParamIndices; }
+
   bool checkInherit(int index) const {
     return inheritLifetimeParamIndices
       && inheritLifetimeParamIndices->contains(index);
@@ -201,13 +215,11 @@ public:
   void Profile(llvm::FoldingSetNodeID &ID) const;
   void getConcatenatedData(SmallVectorImpl<bool> &concatenatedData) const;
 
-  std::optional<LifetimeDependenceKind>
-  getLifetimeDependenceOnParam(unsigned paramIndex);
-
   /// Builds LifetimeDependenceInfo from a swift decl, either from the explicit
   /// lifetime dependence specifiers or by inference based on types and
   /// ownership modifiers.
-  static std::optional<LifetimeDependenceInfo> get(AbstractFunctionDecl *decl);
+  static std::optional<ArrayRef<LifetimeDependenceInfo>>
+  get(AbstractFunctionDecl *decl);
 
   /// Builds LifetimeDependenceInfo from the bitvectors passes as parameters.
   static LifetimeDependenceInfo
@@ -215,11 +227,14 @@ public:
       const SmallBitVector &scopeLifetimeIndices);
 
   /// Builds LifetimeDependenceInfo from SIL
-  static std::optional<LifetimeDependenceInfo>
-  fromTypeRepr(LifetimeDependentTypeRepr *lifetimeDependentRepr,
-               SmallVectorImpl<SILParameterInfo> &params, DeclContext *dc);
+  static std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
+  get(FunctionTypeRepr *funcRepr, ArrayRef<SILParameterInfo> params,
+      ArrayRef<SILResultInfo> results, DeclContext *dc);
 };
 
+std::optional<LifetimeDependenceInfo>
+getLifetimeDependenceFor(ArrayRef<LifetimeDependenceInfo> lifetimeDependencies,
+                         unsigned index);
 } // namespace swift
 
 #endif

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -30,7 +30,7 @@
 namespace swift {
 
 class AbstractFunctionDecl;
-class LifetimeDependentReturnTypeRepr;
+class LifetimeDependentTypeRepr;
 class SILParameterInfo;
 
 enum class ParsedLifetimeDependenceKind : uint8_t {
@@ -216,7 +216,7 @@ public:
 
   /// Builds LifetimeDependenceInfo from SIL
   static std::optional<LifetimeDependenceInfo>
-  fromTypeRepr(LifetimeDependentReturnTypeRepr *lifetimeDependentRepr,
+  fromTypeRepr(LifetimeDependentTypeRepr *lifetimeDependentRepr,
                SmallVectorImpl<SILParameterInfo> &params, DeclContext *dc);
 };
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4998,25 +4998,27 @@ public:
 };
 
 class LifetimeDependenceInfoRequest
-    : public SimpleRequest<LifetimeDependenceInfoRequest,
-                           std::optional<LifetimeDependenceInfo>(
-                               AbstractFunctionDecl *),
-                           RequestFlags::SeparatelyCached |
-                           RequestFlags::SplitCached> {
+    : public SimpleRequest<
+          LifetimeDependenceInfoRequest,
+          std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>(
+              AbstractFunctionDecl *),
+          RequestFlags::SeparatelyCached | RequestFlags::SplitCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
 private:
   friend SimpleRequest;
 
-  std::optional<LifetimeDependenceInfo>
+  std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
   evaluate(Evaluator &evaluator, AbstractFunctionDecl *AFD) const;
 
 public:
   // Separate caching.
   bool isCached() const { return true; }
-  std::optional<std::optional<LifetimeDependenceInfo>> getCachedResult() const;
-  void cacheResult(std::optional<LifetimeDependenceInfo> value) const;
+  std::optional<std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>>
+  getCachedResult() const;
+  void cacheResult(
+      std::optional<llvm::ArrayRef<LifetimeDependenceInfo>> value) const;
 };
 
 class CaptureInfoRequest :

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -112,7 +112,7 @@ protected:
     NumElements : 32
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(LifetimeDependentReturnTypeRepr, TypeRepr, 32,
+  SWIFT_INLINE_BITFIELD_FULL(LifetimeDependentTypeRepr, TypeRepr, 32,
       : NumPadBits,
       NumDependencies : 32
    );
@@ -1118,7 +1118,8 @@ public:
     return T->getKind() == TypeReprKind::Ownership ||
            T->getKind() == TypeReprKind::Isolated ||
            T->getKind() == TypeReprKind::CompileTimeConst ||
-           T->getKind() == TypeReprKind::LifetimeDependentReturn ||
+           T->getKind() == TypeReprKind::LifetimeDependent ||
+           T->getKind() == TypeReprKind::Transferring ||
            T->getKind() == TypeReprKind::Sending;
   }
   static bool classof(const SpecifierTypeRepr *T) { return true; }
@@ -1531,41 +1532,40 @@ private:
   friend TypeRepr;
 };
 
-class LifetimeDependentReturnTypeRepr final
+class LifetimeDependentTypeRepr final
     : public SpecifierTypeRepr,
-      private llvm::TrailingObjects<LifetimeDependentReturnTypeRepr,
+      private llvm::TrailingObjects<LifetimeDependentTypeRepr,
                                     LifetimeDependenceSpecifier> {
   friend TrailingObjects;
 
-  size_t
-  numTrailingObjects(OverloadToken<LifetimeDependentReturnTypeRepr>) const {
-    return Bits.LifetimeDependentReturnTypeRepr.NumDependencies;
+  size_t numTrailingObjects(OverloadToken<LifetimeDependentTypeRepr>) const {
+    return Bits.LifetimeDependentTypeRepr.NumDependencies;
   }
 
 public:
-  LifetimeDependentReturnTypeRepr(
-      TypeRepr *base, ArrayRef<LifetimeDependenceSpecifier> specifiers)
-      : SpecifierTypeRepr(TypeReprKind::LifetimeDependentReturn, base,
+  LifetimeDependentTypeRepr(TypeRepr *base,
+                            ArrayRef<LifetimeDependenceSpecifier> specifiers)
+      : SpecifierTypeRepr(TypeReprKind::LifetimeDependent, base,
                           specifiers.front().getLoc()) {
     assert(base);
-    Bits.LifetimeDependentReturnTypeRepr.NumDependencies = specifiers.size();
+    Bits.LifetimeDependentTypeRepr.NumDependencies = specifiers.size();
     std::uninitialized_copy(specifiers.begin(), specifiers.end(),
                             getTrailingObjects<LifetimeDependenceSpecifier>());
   }
 
-  static LifetimeDependentReturnTypeRepr *
+  static LifetimeDependentTypeRepr *
   create(ASTContext &C, TypeRepr *base,
          ArrayRef<LifetimeDependenceSpecifier> specifiers);
 
   ArrayRef<LifetimeDependenceSpecifier> getLifetimeDependencies() const {
     return {getTrailingObjects<LifetimeDependenceSpecifier>(),
-            Bits.LifetimeDependentReturnTypeRepr.NumDependencies};
+            Bits.LifetimeDependentTypeRepr.NumDependencies};
   }
 
   static bool classof(const TypeRepr *T) {
-    return T->getKind() == TypeReprKind::LifetimeDependentReturn;
+    return T->getKind() == TypeReprKind::LifetimeDependent;
   }
-  static bool classof(const LifetimeDependentReturnTypeRepr *T) { return true; }
+  static bool classof(const LifetimeDependentTypeRepr *T) { return true; }
 
 private:
   SourceLoc getStartLocImpl() const;
@@ -1608,7 +1608,7 @@ inline bool TypeRepr::isSimple() const {
   case TypeReprKind::Sending:
   case TypeReprKind::Placeholder:
   case TypeReprKind::CompileTimeConst:
-  case TypeReprKind::LifetimeDependentReturn:
+  case TypeReprKind::LifetimeDependent:
     return true;
   }
   llvm_unreachable("bad TypeRepr kind");

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -1119,7 +1119,6 @@ public:
            T->getKind() == TypeReprKind::Isolated ||
            T->getKind() == TypeReprKind::CompileTimeConst ||
            T->getKind() == TypeReprKind::LifetimeDependent ||
-           T->getKind() == TypeReprKind::Transferring ||
            T->getKind() == TypeReprKind::Sending;
   }
   static bool classof(const SpecifierTypeRepr *T) { return true; }

--- a/include/swift/AST/TypeReprNodes.def
+++ b/include/swift/AST/TypeReprNodes.def
@@ -74,7 +74,7 @@ ABSTRACT_TYPEREPR(Specifier, TypeRepr)
 TYPEREPR(Fixed, TypeRepr)
 TYPEREPR(SILBox, TypeRepr)
 TYPEREPR(Self, TypeRepr)
-TYPEREPR(LifetimeDependentReturn, TypeRepr)
+TYPEREPR(LifetimeDependent, TypeRepr)
 LAST_TYPEREPR(Self)
 
 #undef SPECIFIER_TYPEREPR

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -417,7 +417,7 @@ protected:
     HasExtInfo : 1,
     HasClangTypeInfo : 1,
     HasThrownError : 1,
-    HasLifetimeDependenceInfo : 1,
+    HasLifetimeDependencies : 1,
     : NumPadBits,
     NumParams : 16
   );
@@ -3366,7 +3366,7 @@ protected:
       Bits.AnyFunctionType.HasThrownError =
           !Info.value().getThrownError().isNull();
       assert(!Bits.AnyFunctionType.HasThrownError || Info->isThrowing());
-      Bits.AnyFunctionType.HasLifetimeDependenceInfo =
+      Bits.AnyFunctionType.HasLifetimeDependencies =
           !Info.value().getLifetimeDependencies().empty();
       // The use of both assert() and static_assert() is intentional.
       assert(Bits.AnyFunctionType.ExtInfoBits == Info.value().getBits() &&
@@ -3379,7 +3379,7 @@ protected:
       Bits.AnyFunctionType.HasClangTypeInfo = false;
       Bits.AnyFunctionType.ExtInfoBits = 0;
       Bits.AnyFunctionType.HasThrownError = false;
-      Bits.AnyFunctionType.HasLifetimeDependenceInfo = false;
+      Bits.AnyFunctionType.HasLifetimeDependencies = false;
     }
     Bits.AnyFunctionType.NumParams = NumParams;
     assert(Bits.AnyFunctionType.NumParams == NumParams && "Params dropped!");
@@ -3426,8 +3426,8 @@ public:
     return Bits.AnyFunctionType.HasThrownError;
   }
 
-  bool hasLifetimeDependenceInfo() const {
-    return Bits.AnyFunctionType.HasLifetimeDependenceInfo;
+  bool hasLifetimeDependencies() const {
+    return Bits.AnyFunctionType.HasLifetimeDependencies;
   }
 
   ClangTypeInfo getClangTypeInfo() const;
@@ -3735,11 +3735,11 @@ class FunctionType final
   }
 
   size_t numTrailingObjects(OverloadToken<size_t>) const {
-    return hasLifetimeDependenceInfo() ? 1 : 0;
+    return hasLifetimeDependencies() ? 1 : 0;
   }
 
   size_t numTrailingObjects(OverloadToken<LifetimeDependenceInfo>) const {
-    return hasLifetimeDependenceInfo() ? getNumLifetimeDependencies() : 0;
+    return hasLifetimeDependencies() ? getNumLifetimeDependencies() : 0;
   }
 
 public:
@@ -3774,13 +3774,13 @@ public:
   }
 
   inline size_t getNumLifetimeDependencies() const {
-    if (!hasLifetimeDependenceInfo())
+    if (!hasLifetimeDependencies())
       return 0;
     return getTrailingObjects<size_t>()[0];
   }
 
   ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const {
-    if (!hasLifetimeDependenceInfo())
+    if (!hasLifetimeDependencies())
       return std::nullopt;
     return {getTrailingObjects<LifetimeDependenceInfo>(),
             getNumLifetimeDependencies()};
@@ -3905,11 +3905,11 @@ class GenericFunctionType final
   }
 
   size_t numTrailingObjects(OverloadToken<size_t>) const {
-    return hasLifetimeDependenceInfo() ? 1 : 0;
+    return hasLifetimeDependencies() ? 1 : 0;
   }
 
   size_t numTrailingObjects(OverloadToken<LifetimeDependenceInfo>) const {
-    return hasLifetimeDependenceInfo() ? getNumLifetimeDependencies() : 0;
+    return hasLifetimeDependencies() ? getNumLifetimeDependencies() : 0;
   }
 
   /// Construct a new generic function type.
@@ -3941,13 +3941,13 @@ public:
   }
 
   inline size_t getNumLifetimeDependencies() const {
-    if (!hasLifetimeDependenceInfo())
+    if (!hasLifetimeDependencies())
       return 0;
     return getTrailingObjects<size_t>()[0];
   }
 
   ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const {
-    if (!hasLifetimeDependenceInfo())
+    if (!hasLifetimeDependencies())
       return std::nullopt;
     return {getTrailingObjects<LifetimeDependenceInfo>(),
             getNumLifetimeDependencies()};
@@ -5352,12 +5352,12 @@ public:
 
   ClangTypeInfo getClangTypeInfo() const;
 
-  bool hasLifetimeDependenceInfo() const {
+  bool hasLifetimeDependencies() const {
     return NumLifetimeDependencies != 0;
   }
 
   ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const {
-    if (!hasLifetimeDependenceInfo())
+    if (!hasLifetimeDependencies())
       return std::nullopt;
     return {getTrailingObjects<LifetimeDependenceInfo>(),
             NumLifetimeDependencies};

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3792,6 +3792,10 @@ public:
                                            targetIndex);
   }
 
+  std::optional<LifetimeDependenceInfo> getLifetimeDependenceForResult() const {
+    return getLifetimeDependenceFor(getNumParams());
+  }
+
   void Profile(llvm::FoldingSetNodeID &ID) {
     std::optional<ExtInfo> info = std::nullopt;
     if (hasExtInfo())
@@ -4465,8 +4469,12 @@ public:
 
   SWIFT_DEBUG_DUMP;
   void print(llvm::raw_ostream &out,
-             const PrintOptions &options = PrintOptions()) const;
-  void print(ASTPrinter &Printer, const PrintOptions &Options) const;
+             const PrintOptions &options = PrintOptions(),
+             std::optional<LifetimeDependenceInfo> lifetimeDependence =
+                 std::nullopt) const;
+  void print(ASTPrinter &Printer, const PrintOptions &Options,
+             std::optional<LifetimeDependenceInfo> lifetimeDependence =
+                 std::nullopt) const;
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &out,
                                        SILParameterInfo type) {
     type.print(out);
@@ -5361,6 +5369,16 @@ public:
       return std::nullopt;
     return {getTrailingObjects<LifetimeDependenceInfo>(),
             NumLifetimeDependencies};
+  }
+
+  std::optional<LifetimeDependenceInfo>
+  getLifetimeDependenceFor(unsigned targetIndex) const {
+    return swift::getLifetimeDependenceFor(getLifetimeDependencies(),
+                                           targetIndex);
+  }
+
+  std::optional<LifetimeDependenceInfo> getLifetimeDependenceForResult() const {
+    return getLifetimeDependenceFor(getNumParameters());
   }
 
   /// Returns true if the function type stores a Clang type that cannot

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -389,8 +389,7 @@ NODE(AsyncRemoved)
 
 // Added in Swift 5.TBD
 NODE(ObjectiveCProtocolSymbolicReference)
-NODE(ParamLifetimeDependence)
-NODE(SelfLifetimeDependence)
+NODE(LifetimeDependence)
 
 NODE(OutlinedInitializeWithCopyNoValueWitness)
 NODE(OutlinedAssignWithTakeNoValueWitness)

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -635,7 +635,7 @@ protected:
   bool demangleBoundGenerics(Vector<NodePointer> &TypeListList,
                              NodePointer &RetroactiveConformances);
 
-  NodePointer demangleLifetimeDependenceKind(bool isSelfDependence);
+  NodePointer demangleLifetimeDependence();
 
   void dump();
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -64,6 +64,7 @@ class TypeBase;
 class SwiftPassInvocation;
 class GenericSpecializationInformation;
 class LifetimeDependenceInfo;
+class IndexSubset;
 }
 
 bool swiftModulesInitialized();
@@ -248,15 +249,45 @@ struct BridgedYieldInfoArray {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
   BridgedParameterInfo at(SwiftInt resultIndex) const;
 };
-
 struct BridgedLifetimeDependenceInfo {
-  const swift::LifetimeDependenceInfo * _Nullable info = nullptr;
+  swift::IndexSubset *_Nullable inheritLifetimeParamIndices;
+  swift::IndexSubset *_Nullable scopeLifetimeParamIndices;
+  SwiftUInt targetIndex;
+  bool immortal;
+
+#ifdef USED_IN_CPP_SOURCE
+  BridgedLifetimeDependenceInfo(swift::LifetimeDependenceInfo info)
+      : inheritLifetimeParamIndices(info.getInheritIndices()),
+        scopeLifetimeParamIndices(info.getScopeIndices()),
+        targetIndex(info.getTargetIndex()), immortal(info.isImmortal()) {}
+#endif
 
   BRIDGED_INLINE bool empty() const;
   BRIDGED_INLINE bool checkInherit(SwiftInt index) const;
   BRIDGED_INLINE bool checkScope(SwiftInt index) const;
+  BRIDGED_INLINE SwiftInt getTargetIndex() const;
 
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedOwnedString getDebugDescription() const;
+};
+
+struct BridgedLifetimeDependenceInfoArray {
+  BridgedArrayRef lifetimeDependenceInfoArray;
+
+#ifdef USED_IN_CPP_SOURCE
+  BridgedLifetimeDependenceInfoArray(
+      llvm::ArrayRef<swift::LifetimeDependenceInfo> lifetimeDependenceInfo)
+      : lifetimeDependenceInfoArray(lifetimeDependenceInfo) {}
+
+  llvm::ArrayRef<swift::LifetimeDependenceInfo> unbridged() const {
+    return lifetimeDependenceInfoArray
+        .unbridged<swift::LifetimeDependenceInfo>();
+  }
+#endif
+
+  BRIDGED_INLINE SwiftInt count() const;
+
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedLifetimeDependenceInfo
+  at(SwiftInt index) const;
 };
 
 // Temporary access to the AST type within SIL until ASTBridging provides it.
@@ -305,7 +336,8 @@ struct BridgedASTType {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
   BridgedYieldInfoArray SILFunctionType_getYields() const;
 
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedLifetimeDependenceInfo SILFunctionType_getLifetimeDependenceInfo() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedLifetimeDependenceInfoArray
+  SILFunctionType_getLifetimeDependencies() const;
 };
 
 struct BridgedType {

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -469,13 +469,14 @@ Type ASTBuilder::createFunctionType(
                                                  representation);
 
   // TODO: Handle LifetimeDependenceInfo here.
-  auto einfo = FunctionType::ExtInfoBuilder(
-                   representation, noescape, flags.isThrowing(), thrownError,
-                   resultDiffKind, clangFunctionType, isolation,
-                   LifetimeDependenceInfo(), extFlags.hasSendingResult())
-                   .withAsync(flags.isAsync())
-                   .withSendable(flags.isSendable())
-                   .build();
+  auto einfo =
+      FunctionType::ExtInfoBuilder(
+          representation, noescape, flags.isThrowing(), thrownError,
+          resultDiffKind, clangFunctionType, isolation,
+          /*LifetimeDependenceInfo*/ std::nullopt, extFlags.hasSendingResult())
+          .withAsync(flags.isAsync())
+          .withSendable(flags.isSendable())
+          .build();
 
   return FunctionType::get(funcParams, output, einfo);
 }
@@ -688,11 +689,12 @@ Type ASTBuilder::createImplFunctionType(
     clangFnType = getASTContext().getCanonicalClangFunctionType(
         funcParams, result, representation);
   }
-  auto einfo = SILFunctionType::ExtInfoBuilder(
-                   representation, flags.isPseudogeneric(), !flags.isEscaping(),
-                   flags.isSendable(), flags.isAsync(), unimplementable,
-                   isolation, diffKind, clangFnType, LifetimeDependenceInfo())
-                   .build();
+  auto einfo =
+      SILFunctionType::ExtInfoBuilder(
+          representation, flags.isPseudogeneric(), !flags.isEscaping(),
+          flags.isSendable(), flags.isAsync(), unimplementable, isolation,
+          diffKind, clangFnType, /*LifetimeDependenceInfo*/ std::nullopt)
+          .build();
 
   return SILFunctionType::get(genericSig, einfo, funcCoroutineKind,
                               funcCalleeConvention, funcParams, funcYields,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3541,8 +3541,8 @@ public:
     printFoot();
   }
 
-  void visitLifetimeDependentReturnTypeRepr(LifetimeDependentReturnTypeRepr *T,
-                                            StringRef label) {
+  void visitLifetimeDependentTypeRepr(LifetimeDependentTypeRepr *T,
+                                      StringRef label) {
     printCommon("type_lifetime_dependent_return", label);
     for (auto &dep : T->getLifetimeDependencies()) {
       printFieldRaw(

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4667,6 +4667,7 @@ void Requirement::dump(raw_ostream &out) const {
 }
 
 void SILParameterInfo::dump() const {
+  // TODO: Fix LifetimeDependenceInfo printing here.
   print(llvm::errs());
   llvm::errs() << '\n';
 }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3247,7 +3247,7 @@ void ASTMangler::appendFunctionResultType(
     appendType(resultType, sig, forDecl);
   }
 
-  if (lifetimeDependence.has_value()) {
+  if (AllowLifetimeDependencies && lifetimeDependence.has_value()) {
     appendLifetimeDependence(*lifetimeDependence);
   }
 }
@@ -3302,7 +3302,7 @@ void ASTMangler::appendParameterTypeListElement(
   if (flags.isCompileTimeConst())
     appendOperator("Yt");
 
-  if (lifetimeDependence) {
+  if (AllowLifetimeDependencies && lifetimeDependence) {
     appendLifetimeDependence(*lifetimeDependence);
   }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3052,9 +3052,11 @@ void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
                                          const ValueDecl *forDecl,
                                          FunctionManglingKind functionMangling,
                                          bool isRecursedInto) {
-  appendFunctionResultType(fn->getResult(), sig, forDecl);
-  appendFunctionInputType(fn->getParams(), fn->getLifetimeDependenceInfo(), sig,
-                          forDecl, isRecursedInto);
+  appendFunctionResultType(fn->getResult(), sig,
+                           forDecl ? fn->getLifetimeDependenceForResult(forDecl)
+                                   : std::nullopt,
+                           forDecl);
+  appendFunctionInputType(fn, fn->getParams(), sig, forDecl, isRecursedInto);
   if (fn->isAsync())
     appendOperator("Ya");
   if (fn->isSendable())
@@ -3104,18 +3106,6 @@ void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
 
   if (isRecursedInto && fn->hasSendingResult()) {
     appendOperator("YT");
-  }
-
-  if (auto *afd = dyn_cast_or_null<AbstractFunctionDecl>(forDecl)) {
-    if (afd->hasImplicitSelfDecl()) {
-      auto lifetimeDependenceKind =
-          fn->getLifetimeDependenceInfo().getLifetimeDependenceOnParam(
-              /*selfIndex*/ afd->getParameters()->size());
-      if (lifetimeDependenceKind) {
-        appendLifetimeDependenceKind(*lifetimeDependenceKind,
-                                     /*isSelfDependence*/ true);
-      }
-    }
   }
 }
 
@@ -3189,9 +3179,8 @@ getParameterFlagsForMangling(ParameterTypeFlags flags,
 }
 
 void ASTMangler::appendFunctionInputType(
-    ArrayRef<AnyFunctionType::Param> params,
-    LifetimeDependenceInfo lifetimeDependenceInfo, GenericSignature sig,
-    const ValueDecl *forDecl, bool isRecursedInto) {
+    AnyFunctionType *fnType, ArrayRef<AnyFunctionType::Param> params,
+    GenericSignature sig, const ValueDecl *forDecl, bool isRecursedInto) {
   auto defaultSpecifier = getDefaultOwnership(forDecl);
   
   switch (params.size()) {
@@ -3215,8 +3204,8 @@ void ASTMangler::appendFunctionInputType(
           Identifier(), type,
           getParameterFlagsForMangling(param.getParameterFlags(),
                                        defaultSpecifier, isRecursedInto),
-          lifetimeDependenceInfo.getLifetimeDependenceOnParam(/*paramIndex*/ 0),
-          sig, nullptr);
+          getLifetimeDependenceFor(fnType->getLifetimeDependencies(), 0), sig,
+          nullptr);
       break;
     }
 
@@ -3237,8 +3226,9 @@ void ASTMangler::appendFunctionInputType(
           Identifier(), param.getPlainType(),
           getParameterFlagsForMangling(param.getParameterFlags(),
                                        defaultSpecifier, isRecursedInto),
-          lifetimeDependenceInfo.getLifetimeDependenceOnParam(paramIndex), sig,
-          nullptr);
+          getLifetimeDependenceFor(fnType->getLifetimeDependencies(),
+                                   paramIndex),
+          sig, nullptr);
       appendListSeparator(isFirstParam);
       paramIndex++;
     }
@@ -3247,10 +3237,19 @@ void ASTMangler::appendFunctionInputType(
   }
 }
 
-void ASTMangler::appendFunctionResultType(Type resultType, GenericSignature sig,
-                                          const ValueDecl *forDecl) {
-  return resultType->isVoid() ? appendOperator("y")
-                              : appendType(resultType, sig, forDecl);
+void ASTMangler::appendFunctionResultType(
+    Type resultType, GenericSignature sig,
+    std::optional<LifetimeDependenceInfo> lifetimeDependence,
+    const ValueDecl *forDecl) {
+  if (resultType->isVoid()) {
+    appendOperator("y");
+  } else {
+    appendType(resultType, sig, forDecl);
+  }
+
+  if (lifetimeDependence.has_value()) {
+    appendLifetimeDependence(*lifetimeDependence);
+  }
 }
 
 void ASTMangler::appendTypeList(Type listTy, GenericSignature sig,
@@ -3272,7 +3271,7 @@ void ASTMangler::appendTypeList(Type listTy, GenericSignature sig,
 
 void ASTMangler::appendParameterTypeListElement(
     Identifier name, Type elementType, ParameterTypeFlags flags,
-    std::optional<LifetimeDependenceKind> lifetimeDependenceKind,
+    std::optional<LifetimeDependenceInfo> lifetimeDependence,
     GenericSignature sig, const ValueDecl *forDecl) {
   if (auto *fnType = elementType->getAs<FunctionType>())
     appendFunctionType(fnType, sig, flags.isAutoClosure(), forDecl);
@@ -3303,9 +3302,8 @@ void ASTMangler::appendParameterTypeListElement(
   if (flags.isCompileTimeConst())
     appendOperator("Yt");
 
-  if (lifetimeDependenceKind) {
-    appendLifetimeDependenceKind(*lifetimeDependenceKind,
-                                 /*isSelfDependence*/ false);
+  if (lifetimeDependence) {
+    appendLifetimeDependence(*lifetimeDependence);
   }
 
   if (!name.empty())
@@ -3314,21 +3312,18 @@ void ASTMangler::appendParameterTypeListElement(
     appendOperator("d");
 }
 
-void ASTMangler::appendLifetimeDependenceKind(LifetimeDependenceKind kind,
-                                              bool isSelfDependence) {
-  if (kind == LifetimeDependenceKind::Scope) {
-    if (isSelfDependence) {
-      appendOperator("YLs");
-    } else {
-      appendOperator("Yls");
-    }
-  } else {
-    assert(kind == LifetimeDependenceKind::Inherit);
-    if (isSelfDependence) {
-      appendOperator("YLi");
-    } else {
-      appendOperator("Yli");
-    }
+void ASTMangler::appendLifetimeDependence(LifetimeDependenceInfo info) {
+  if (auto *inheritIndices = info.getInheritIndices()) {
+    assert(!inheritIndices->isEmpty());
+    appendOperator("Yli");
+    appendIndexSubset(inheritIndices);
+    appendOperator("_");
+  }
+  if (auto *scopeIndices = info.getScopeIndices()) {
+    assert(!scopeIndices->isEmpty());
+    appendOperator("Yls");
+    appendIndexSubset(scopeIndices);
+    appendOperator("_");
   }
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4083,7 +4083,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
       Printer.printDeclResultTypePre(decl, ResultTyLoc);
       Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
       {
-        if (auto *typeRepr = dyn_cast_or_null<LifetimeDependentReturnTypeRepr>(
+        if (auto *typeRepr = dyn_cast_or_null<LifetimeDependentTypeRepr>(
                 decl->getResultTypeRepr())) {
           for (auto &dep : typeRepr->getLifetimeDependencies()) {
             Printer << " " << dep.getLifetimeDependenceSpecifierString() << " ";
@@ -4321,7 +4321,7 @@ void PrintAST::visitConstructorDecl(ConstructorDecl *decl) {
       if (decl->hasLifetimeDependentReturn()) {
         Printer << " -> ";
         auto *typeRepr =
-            cast<LifetimeDependentReturnTypeRepr>(decl->getResultTypeRepr());
+            cast<LifetimeDependentTypeRepr>(decl->getResultTypeRepr());
         for (auto &dep : typeRepr->getLifetimeDependencies()) {
           Printer << dep.getLifetimeDependenceSpecifierString() << " ";
         }

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -2385,8 +2385,7 @@ bool Traversal::visitSILBoxTypeRepr(SILBoxTypeRepr *T) {
   return false;
 }
 
-bool Traversal::visitLifetimeDependentReturnTypeRepr(
-    LifetimeDependentReturnTypeRepr *T) {
+bool Traversal::visitLifetimeDependentTypeRepr(LifetimeDependentTypeRepr *T) {
   return doIt(T->getBase());
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10794,7 +10794,7 @@ bool ConstructorDecl::isObjCZeroParameterWithLongSelector() const {
 }
 
 bool ConstructorDecl::hasLifetimeDependentReturn() const {
-  return isa_and_nonnull<LifetimeDependentReturnTypeRepr>(getResultTypeRepr());
+  return isa_and_nonnull<LifetimeDependentTypeRepr>(getResultTypeRepr());
 }
 
 DestructorDecl::DestructorDecl(SourceLoc DestructorLoc, DeclContext *Parent)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10292,8 +10292,8 @@ void AbstractFunctionDecl::addDerivativeFunctionConfiguration(
   DerivativeFunctionConfigs->insert(config);
 }
 
-std::optional<LifetimeDependenceInfo>
-AbstractFunctionDecl::getLifetimeDependenceInfo() const {
+std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
+AbstractFunctionDecl::getLifetimeDependencies() const {
   if (!isa<FuncDecl>(this) && !isa<ConstructorDecl>(this)) {
     return std::nullopt;
   }

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -193,7 +193,7 @@ LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd) {
                       ? (afd->getParameters()->size() + 1)
                       : afd->getParameters()->size();
   auto lifetimeDependentRepr =
-      cast<LifetimeDependentReturnTypeRepr>(afd->getResultTypeRepr());
+      cast<LifetimeDependentTypeRepr>(afd->getResultTypeRepr());
 
   if (hasEscapableResultOrYield(afd)) {
     diags.diagnose(lifetimeDependentRepr->getLoc(),
@@ -337,7 +337,7 @@ LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd) {
 // LifetimeDependenceInfo from the swift decl. Reason for duplicated code is the
 // apis on type and ownership is different in SIL compared to Sema.
 std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromTypeRepr(
-    LifetimeDependentReturnTypeRepr *lifetimeDependentRepr,
+    LifetimeDependentTypeRepr *lifetimeDependentRepr,
     SmallVectorImpl<SILParameterInfo> &params, DeclContext *dc) {
   auto &ctx = dc->getASTContext();
   auto &diags = ctx.Diags;
@@ -530,7 +530,7 @@ std::optional<LifetimeDependenceInfo>
 LifetimeDependenceInfo::get(AbstractFunctionDecl *afd) {
   assert(isa<FuncDecl>(afd) || isa<ConstructorDecl>(afd));
   auto *returnTypeRepr = afd->getResultTypeRepr();
-  if (isa_and_nonnull<LifetimeDependentReturnTypeRepr>(returnTypeRepr)) {
+  if (isa_and_nonnull<LifetimeDependentTypeRepr>(returnTypeRepr)) {
     return LifetimeDependenceInfo::fromTypeRepr(afd);
   }
   return LifetimeDependenceInfo::infer(afd);

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -22,6 +22,18 @@
 #include "swift/Basic/Defer.h"
 
 namespace swift {
+
+std::optional<LifetimeDependenceInfo>
+getLifetimeDependenceFor(ArrayRef<LifetimeDependenceInfo> lifetimeDependencies,
+                         unsigned index) {
+  for (auto dep : lifetimeDependencies) {
+    if (dep.getTargetIndex() == index) {
+      return dep;
+    }
+  }
+  return std::nullopt;
+}
+
 std::string LifetimeDependenceInfo::getString() const {
   std::string lifetimeDependenceString;
   auto getOnIndices = [](IndexSubset *bitvector) {
@@ -101,21 +113,25 @@ isLifetimeDependenceCompatibleWithOwnership(LifetimeDependenceKind kind,
   return false;
 }
 
-LifetimeDependenceInfo LifetimeDependenceInfo::getForParamIndex(
-    AbstractFunctionDecl *afd, unsigned index, LifetimeDependenceKind kind) {
+LifetimeDependenceInfo
+LifetimeDependenceInfo::getForIndex(AbstractFunctionDecl *afd,
+                                    unsigned targetIndex, unsigned sourceIndex,
+                                    LifetimeDependenceKind kind) {
   auto *dc = afd->getDeclContext();
   auto &ctx = dc->getASTContext();
   unsigned capacity = afd->hasImplicitSelfDecl()
                           ? (afd->getParameters()->size() + 1)
                           : afd->getParameters()->size();
-  auto indexSubset = IndexSubset::get(ctx, capacity, {index});
+  auto indexSubset = IndexSubset::get(ctx, capacity, {sourceIndex});
   if (kind == LifetimeDependenceKind::Scope) {
     return LifetimeDependenceInfo{/*inheritLifetimeParamIndices*/ nullptr,
                                   /*scopeLifetimeParamIndices*/ indexSubset,
+                                  targetIndex,
                                   /*isImmortal*/ false};
   }
   return LifetimeDependenceInfo{/*inheritLifetimeParamIndices*/ indexSubset,
                                 /*scopeLifetimeParamIndices*/ nullptr,
+                                targetIndex,
                                 /*isImmortal*/ false};
 }
 
@@ -143,15 +159,14 @@ void LifetimeDependenceInfo::getConcatenatedData(
   }
 }
 
-static bool hasEscapableResultOrYield(AbstractFunctionDecl *afd) {
+static Type getResultOrYield(AbstractFunctionDecl *afd) {
   if (auto *accessor = dyn_cast<AccessorDecl>(afd)) {
     if (accessor->isCoroutine()) {
       auto yieldTyInContext = accessor->mapTypeIntoContext(
           accessor->getStorage()->getValueInterfaceType());
-      return yieldTyInContext->isEscapable();
+      return yieldTyInContext;
     }
   }
-
   Type resultType;
   if (auto fn = dyn_cast<FuncDecl>(afd)) {
     resultType = fn->getResultInterfaceType();
@@ -159,7 +174,11 @@ static bool hasEscapableResultOrYield(AbstractFunctionDecl *afd) {
     auto ctor = cast<ConstructorDecl>(afd);
     resultType = ctor->getResultInterfaceType();
   }
-  return afd->mapTypeIntoContext(resultType)->isEscapable();
+  return afd->mapTypeIntoContext(resultType);
+}
+
+static bool hasEscapableResultOrYield(AbstractFunctionDecl *afd) {
+  return getResultOrYield(afd)->isEscapable();
 }
 
 static LifetimeDependenceKind getLifetimeDependenceKindFromDecl(
@@ -184,22 +203,15 @@ static bool isBitwiseCopyable(Type type, ASTContext &ctx) {
   return (bool)(ModuleDecl::checkConformance(type, bitwiseCopyableProtocol));
 }
 
-std::optional<LifetimeDependenceInfo>
-LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd) {
+std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromTypeRepr(
+    AbstractFunctionDecl *afd, LifetimeDependentTypeRepr *lifetimeDependentRepr,
+    unsigned targetIndex) {
   auto *dc = afd->getDeclContext();
   auto &ctx = dc->getASTContext();
   auto &diags = ctx.Diags;
   auto capacity = afd->hasImplicitSelfDecl()
                       ? (afd->getParameters()->size() + 1)
                       : afd->getParameters()->size();
-  auto lifetimeDependentRepr =
-      cast<LifetimeDependentTypeRepr>(afd->getResultTypeRepr());
-
-  if (hasEscapableResultOrYield(afd)) {
-    diags.diagnose(lifetimeDependentRepr->getLoc(),
-                   diag::lifetime_dependence_invalid_return_type);
-    return std::nullopt;
-  }
 
   SmallBitVector inheritLifetimeParamIndices(capacity);
   SmallBitVector scopeLifetimeParamIndices(capacity);
@@ -258,7 +270,8 @@ LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd) {
                        diag::lifetime_dependence_immortal_conflict_name);
       }
 
-      return LifetimeDependenceInfo(nullptr, nullptr, /*isImmortal*/ true);
+      return LifetimeDependenceInfo(nullptr, nullptr, targetIndex,
+                                    /*isImmortal*/ true);
     }
     case LifetimeDependenceSpecifier::SpecifierKind::Named: {
       bool foundParamName = false;
@@ -330,6 +343,7 @@ LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd) {
       scopeLifetimeParamIndices.any()
           ? IndexSubset::get(ctx, scopeLifetimeParamIndices)
           : nullptr,
+      targetIndex,
       /*isImmortal*/ false);
 }
 
@@ -337,8 +351,8 @@ LifetimeDependenceInfo::fromTypeRepr(AbstractFunctionDecl *afd) {
 // LifetimeDependenceInfo from the swift decl. Reason for duplicated code is the
 // apis on type and ownership is different in SIL compared to Sema.
 std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromTypeRepr(
-    LifetimeDependentTypeRepr *lifetimeDependentRepr,
-    SmallVectorImpl<SILParameterInfo> &params, DeclContext *dc) {
+    LifetimeDependentTypeRepr *lifetimeDependentRepr, unsigned targetIndex,
+    ArrayRef<SILParameterInfo> params, DeclContext *dc) {
   auto &ctx = dc->getASTContext();
   auto &diags = ctx.Diags;
   auto capacity = params.size(); // SIL parameters include self
@@ -393,6 +407,7 @@ std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromTypeRepr(
     case LifetimeDependenceSpecifier::SpecifierKind::Immortal: {
       return LifetimeDependenceInfo(/*inheritLifetimeParamIndices*/ nullptr,
                                     /*scopeLifetimeParamIndices*/ nullptr,
+                                    targetIndex,
                                     /*isImmortal*/ true);
     }
     default:
@@ -408,6 +423,7 @@ std::optional<LifetimeDependenceInfo> LifetimeDependenceInfo::fromTypeRepr(
       scopeLifetimeParamIndices.any()
           ? IndexSubset::get(ctx, scopeLifetimeParamIndices)
           : nullptr,
+      targetIndex,
       /*isImmortal*/ false);
 }
 
@@ -415,10 +431,6 @@ std::optional<LifetimeDependenceInfo>
 LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd) {
   auto *dc = afd->getDeclContext();
   auto &ctx = dc->getASTContext();
-
-  if (!ctx.LangOpts.hasFeature(Feature::NonescapableTypes)) {
-    return std::nullopt;
-  }
 
   // Disable inference if requested.
   if (!ctx.LangOpts.EnableExperimentalLifetimeDependenceInference) {
@@ -435,8 +447,10 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd) {
 
   auto &diags = ctx.Diags;
   auto returnTypeRepr = afd->getResultTypeRepr();
-  auto returnLoc = returnTypeRepr ? returnTypeRepr->getLoc()
-                                  : afd->getLoc(/* SerializedOK */ false);
+  auto returnLoc = returnTypeRepr ? returnTypeRepr->getLoc() : afd->getLoc();
+  unsigned resultIndex = afd->hasImplicitSelfDecl()
+                             ? afd->getParameters()->size() + 1
+                             : afd->getParameters()->size();
 
   auto *cd = dyn_cast<ConstructorDecl>(afd);
   if (cd && cd->isImplicit()) {
@@ -463,12 +477,13 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd) {
                      diag::lifetime_dependence_invalid_self_ownership);
       return std::nullopt;
     }
-    return LifetimeDependenceInfo::getForParamIndex(
-        afd, /*selfIndex*/ afd->getParameters()->size(), kind);
+
+    return LifetimeDependenceInfo::getForIndex(
+        afd, resultIndex, /*selfIndex */ afd->getParameters()->size(), kind);
   }
 
-  LifetimeDependenceInfo lifetimeDependenceInfo;
-  ParamDecl *candidateParam = nullptr;
+  std::optional<unsigned> candidateParamIndex;
+  std::optional<LifetimeDependenceKind> candidateLifetimeKind;
   unsigned paramIndex = 0;
   bool hasParamError = false;
   for (auto *param : *afd->getParameters()) {
@@ -489,12 +504,13 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd) {
       }
     }
 
-    auto lifetimeKind = getLifetimeDependenceKindFromType(paramTypeInContext);
-    if (!isLifetimeDependenceCompatibleWithOwnership(lifetimeKind,
+    candidateLifetimeKind =
+        getLifetimeDependenceKindFromType(paramTypeInContext);
+    if (!isLifetimeDependenceCompatibleWithOwnership(*candidateLifetimeKind,
                                                      paramOwnership, afd)) {
       continue;
     }
-    if (candidateParam) {
+    if (candidateParamIndex) {
       if (cd && afd->isImplicit()) {
         diags.diagnose(
             returnLoc,
@@ -507,12 +523,10 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd) {
                      "");
       return std::nullopt;
     }
-    candidateParam = param;
-    lifetimeDependenceInfo =
-        LifetimeDependenceInfo::getForParamIndex(afd, paramIndex, lifetimeKind);
+    candidateParamIndex = paramIndex;
   }
 
-  if (!candidateParam && !hasParamError) {
+  if (!candidateParamIndex && !hasParamError) {
     if (cd && afd->isImplicit()) {
       diags.diagnose(returnLoc,
                      diag::lifetime_dependence_cannot_infer_no_candidates,
@@ -523,32 +537,103 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd) {
                    diag::lifetime_dependence_cannot_infer_no_candidates, "");
     return std::nullopt;
   }
-  return lifetimeDependenceInfo;
+
+  return LifetimeDependenceInfo::getForIndex(
+      afd, resultIndex, *candidateParamIndex, *candidateLifetimeKind);
 }
 
-std::optional<LifetimeDependenceInfo>
+std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
 LifetimeDependenceInfo::get(AbstractFunctionDecl *afd) {
-  assert(isa<FuncDecl>(afd) || isa<ConstructorDecl>(afd));
-  auto *returnTypeRepr = afd->getResultTypeRepr();
-  if (isa_and_nonnull<LifetimeDependentTypeRepr>(returnTypeRepr)) {
-    return LifetimeDependenceInfo::fromTypeRepr(afd);
+  if (!afd->getASTContext().LangOpts.hasFeature(Feature::NonescapableTypes)) {
+    return std::nullopt;
   }
-  return LifetimeDependenceInfo::infer(afd);
+  assert(isa<FuncDecl>(afd) || isa<ConstructorDecl>(afd));
+  SmallVector<LifetimeDependenceInfo> lifetimeDependencies;
+  auto &diags = afd->getASTContext().Diags;
+
+  auto getExplicitLifetimeDependence =
+      [&](TypeRepr *typeRepr, unsigned targetIndex,
+          Type targetType) -> std::optional<LifetimeDependenceInfo> {
+    auto *lifetimeTypeRepr =
+        dyn_cast_or_null<LifetimeDependentTypeRepr>(typeRepr);
+    if (!lifetimeTypeRepr) {
+      return std::nullopt;
+    }
+    if (targetType->isEscapable()) {
+      diags.diagnose(lifetimeTypeRepr->getLoc(),
+                     diag::lifetime_dependence_invalid_type);
+      return std::nullopt;
+    }
+    return LifetimeDependenceInfo::fromTypeRepr(afd, lifetimeTypeRepr,
+                                                targetIndex);
+  };
+  auto getExplicitOrImplicitLifetimeDependence =
+      [&](TypeRepr *typeRepr, unsigned targetIndex,
+          Type targetType) -> std::optional<LifetimeDependenceInfo> {
+    if (isa_and_nonnull<LifetimeDependentTypeRepr>(typeRepr)) {
+      return getExplicitLifetimeDependence(typeRepr, targetIndex, targetType);
+    }
+    return LifetimeDependenceInfo::infer(afd);
+  };
+
+  for (unsigned targetIndex : indices(*afd->getParameters())) {
+    auto *param = (*afd->getParameters())[targetIndex];
+    auto paramType =
+        afd->mapTypeIntoContext(param->toFunctionParam().getParameterType());
+    if (auto result = getExplicitLifetimeDependence(param->getTypeRepr(),
+                                                    targetIndex, paramType)) {
+      lifetimeDependencies.push_back(*result);
+    }
+  }
+
+  auto result = getExplicitOrImplicitLifetimeDependence(
+      afd->getResultTypeRepr(),
+      afd->hasImplicitSelfDecl() ? afd->getParameters()->size() + 1
+                                 : afd->getParameters()->size(),
+      getResultOrYield(afd));
+  if (result) {
+    lifetimeDependencies.push_back(*result);
+  }
+
+  return afd->getASTContext().AllocateCopy(lifetimeDependencies);
 }
 
-std::optional<LifetimeDependenceKind>
-LifetimeDependenceInfo::getLifetimeDependenceOnParam(unsigned paramIndex) {
-  if (inheritLifetimeParamIndices) {
-    if (inheritLifetimeParamIndices->contains(paramIndex)) {
-      return LifetimeDependenceKind::Inherit;
+std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
+LifetimeDependenceInfo::get(FunctionTypeRepr *funcRepr,
+                            ArrayRef<SILParameterInfo> params,
+                            ArrayRef<SILResultInfo> results, DeclContext *dc) {
+  if (!dc->getASTContext().LangOpts.hasFeature(Feature::NonescapableTypes)) {
+    return std::nullopt;
+  }
+  SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;
+
+  auto getExplicitLifetimeDependence =
+      [&](TypeRepr *typeRepr,
+          unsigned targetIndex) -> std::optional<LifetimeDependenceInfo> {
+    auto *lifetimeTypeRepr =
+        dyn_cast_or_null<LifetimeDependentTypeRepr>(typeRepr);
+    if (!lifetimeTypeRepr) {
+      return std::nullopt;
+    }
+    return LifetimeDependenceInfo::fromTypeRepr(lifetimeTypeRepr, targetIndex,
+                                                params, dc);
+  };
+
+  auto argsTypeRepr = funcRepr->getArgsTypeRepr()->getElements();
+  for (unsigned targetIndex : indices(argsTypeRepr)) {
+    if (auto result = getExplicitLifetimeDependence(
+            argsTypeRepr[targetIndex].Type, targetIndex)) {
+      lifetimeDependencies.push_back(*result);
     }
   }
-  if (scopeLifetimeParamIndices) {
-    if (scopeLifetimeParamIndices->contains(paramIndex)) {
-      return LifetimeDependenceKind::Scope;
-    }
+
+  auto result = getExplicitLifetimeDependence(funcRepr->getResultTypeRepr(),
+                                              params.size());
+  if (result) {
+    lifetimeDependencies.push_back(*result);
   }
-  return {};
+
+  return dc->getASTContext().AllocateCopy(lifetimeDependencies);
 }
 
 } // namespace swift

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3179,7 +3179,7 @@ directReferencesForTypeRepr(Evaluator &evaluator,
   case TypeReprKind::OpaqueReturn:
   case TypeReprKind::NamedOpaqueReturn:
   case TypeReprKind::Existential:
-  case TypeReprKind::LifetimeDependentReturn:
+  case TypeReprKind::LifetimeDependent:
   case TypeReprKind::Sending:
     return result;
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2518,7 +2518,7 @@ void ExpandBodyMacroRequest::noteCycleStep(DiagnosticEngine &diags) const {
 // LifetimeDependenceInfoRequest computation.
 //----------------------------------------------------------------------------//
 
-std::optional<std::optional<LifetimeDependenceInfo>>
+std::optional<std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>>
 LifetimeDependenceInfoRequest::getCachedResult() const {
   auto *func = std::get<0>(getStorage());
 
@@ -2529,7 +2529,7 @@ LifetimeDependenceInfoRequest::getCachedResult() const {
 }
 
 void LifetimeDependenceInfoRequest::cacheResult(
-    std::optional<LifetimeDependenceInfo> result) const {
+    std::optional<llvm::ArrayRef<LifetimeDependenceInfo>> result) const {
   auto *func = std::get<0>(getStorage());
   
   if (!result) {

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -675,28 +675,28 @@ SourceLoc SILBoxTypeRepr::getLocImpl() const {
   return LBraceLoc;
 }
 
-LifetimeDependentReturnTypeRepr *LifetimeDependentReturnTypeRepr::create(
+LifetimeDependentTypeRepr *LifetimeDependentTypeRepr::create(
     ASTContext &C, TypeRepr *base,
     ArrayRef<LifetimeDependenceSpecifier> specifiers) {
   auto size = totalSizeToAlloc<LifetimeDependenceSpecifier>(specifiers.size());
   auto mem = C.Allocate(size, alignof(LifetimeDependenceSpecifier));
-  return new (mem) LifetimeDependentReturnTypeRepr(base, specifiers);
+  return new (mem) LifetimeDependentTypeRepr(base, specifiers);
 }
 
-SourceLoc LifetimeDependentReturnTypeRepr::getStartLocImpl() const {
+SourceLoc LifetimeDependentTypeRepr::getStartLocImpl() const {
   return getLifetimeDependencies().front().getLoc();
 }
 
-SourceLoc LifetimeDependentReturnTypeRepr::getEndLocImpl() const {
+SourceLoc LifetimeDependentTypeRepr::getEndLocImpl() const {
   return getLifetimeDependencies().back().getLoc();
 }
 
-SourceLoc LifetimeDependentReturnTypeRepr::getLocImpl() const {
+SourceLoc LifetimeDependentTypeRepr::getLocImpl() const {
   return getBase()->getLoc();
 }
 
-void LifetimeDependentReturnTypeRepr::printImpl(
-    ASTPrinter &Printer, const PrintOptions &Opts) const {
+void LifetimeDependentTypeRepr::printImpl(ASTPrinter &Printer,
+                                          const PrintOptions &Opts) const {
   Printer << " ";
   for (auto &dep : getLifetimeDependencies()) {
     Printer << dep.getLifetimeDependenceSpecifierString() << " ";

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3657,7 +3657,7 @@ namespace {
             /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
             /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
             /*ThrownType=*/TypeLoc(), bodyParams, genericParams, dc,
-            /*LifetimeDependentReturnTypeRepr*/ nullptr);
+            /*LifetimeDependentTypeRepr*/ nullptr);
       } else {
         auto resultTy = importedType.getType();
 
@@ -6247,12 +6247,12 @@ Decl *SwiftDeclConverter::importGlobalAsInitializer(
   }
 
   auto result = Impl.createDeclWithClangNode<ConstructorDecl>(
-      decl, AccessLevel::Public, name, /*NameLoc=*/SourceLoc(),
-      failable, /*FailabilityLoc=*/SourceLoc(),
+      decl, AccessLevel::Public, name, /*NameLoc=*/SourceLoc(), failable,
+      /*FailabilityLoc=*/SourceLoc(),
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
       parameterList, /*GenericParams=*/nullptr, dc,
-      /*LifetimeDependentReturnTypeRepr*/ nullptr);
+      /*LifetimeDependentTypeRepr*/ nullptr);
   result->setImplicitlyUnwrappedOptional(isIUO);
   result->getASTContext().evaluator.cacheOutput(InitKindRequest{result},
                                                 std::move(initKind));
@@ -6767,7 +6767,7 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
       /*Throws=*/importedName.getErrorInfo().has_value(),
       /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(), bodyParams,
       /*GenericParams=*/nullptr, const_cast<DeclContext *>(dc),
-      /*LifetimeDependentReturnTypeRepr*/ nullptr);
+      /*LifetimeDependentTypeRepr*/ nullptr);
 
   addObjCAttribute(result, selector);
   recordMemberInContext(dc, result);

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -495,7 +495,7 @@ SwiftDeclSynthesizer::createDefaultConstructor(NominalTypeDecl *structDecl) {
                       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
                       /*ThrownType=*/TypeLoc(), emptyPL,
                       /*GenericParams=*/nullptr, structDecl,
-                      /*LifetimeDependentReturnTypeRepr*/ nullptr);
+                      /*LifetimeDependentTypeRepr*/ nullptr);
 
   constructor->setAccess(AccessLevel::Public);
 
@@ -626,7 +626,7 @@ ConstructorDecl *SwiftDeclSynthesizer::createValueConstructor(
                       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
                       /*ThrownType=*/TypeLoc(), paramList,
                       /*GenericParams=*/nullptr, structDecl,
-                      /*LifetimeDependentReturnTypeRepr*/ nullptr);
+                      /*LifetimeDependentTypeRepr*/ nullptr);
 
   constructor->setAccess(AccessLevel::Public);
 
@@ -1274,7 +1274,7 @@ SwiftDeclSynthesizer::makeEnumRawValueConstructor(EnumDecl *enumDecl) {
                               /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
                               /*ThrownType=*/TypeLoc(), paramPL,
                               /*GenericParams=*/nullptr, enumDecl,
-                              /*LifetimeDependentReturnTypeRepr*/ nullptr);
+                              /*LifetimeDependentTypeRepr*/ nullptr);
   ctorDecl->setImplicit();
   ctorDecl->setAccess(AccessLevel::Public);
   ctorDecl->setBodySynthesizer(synthesizeEnumRawValueConstructorBody, enumDecl);

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -647,8 +647,7 @@ private:
     case Node::Kind::SymbolicExtendedExistentialType:
     case Node::Kind::HasSymbolQuery:
     case Node::Kind::ObjectiveCProtocolSymbolicReference:
-    case Node::Kind::ParamLifetimeDependence:
-    case Node::Kind::SelfLifetimeDependence:
+    case Node::Kind::LifetimeDependence:
     case Node::Kind::DependentGenericInverseConformanceRequirement:
       return false;
     }
@@ -906,11 +905,6 @@ private:
         Node::Kind::DifferentiableFunctionType) {
       diffKind =
           (MangledDifferentiabilityKind)node->getChild(startIndex)->getIndex();
-      ++startIndex;
-    }
-    if (node->getChild(startIndex)->getKind() ==
-        Node::Kind::SelfLifetimeDependence) {
-      print(node->getChild(startIndex), depth + 1);
       ++startIndex;
     }
 
@@ -1784,31 +1778,19 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     Printer << "@noDerivative ";
     print(Node->getChild(0), depth + 1);
     return nullptr;
-  case Node::Kind::ParamLifetimeDependence: {
-    Printer << "lifetime dependence: ";
+  case Node::Kind::LifetimeDependence: {
     auto kind = (MangledLifetimeDependenceKind)Node->getChild(0)->getIndex();
     switch (kind) {
     case MangledLifetimeDependenceKind::Inherit:
-      Printer << "inherit ";
+      Printer << "inherit lifetime dependence: ";
       break;
     case MangledLifetimeDependenceKind::Scope:
-      Printer << "scope ";
+      Printer << "scope lifetime dependence: ";
       break;
     }
     print(Node->getChild(1), depth + 1);
-    return nullptr;
-  }
-  case Node::Kind::SelfLifetimeDependence: {
-    Printer << "(self lifetime dependence: ";
-    auto kind = (MangledLifetimeDependenceKind)Node->getIndex();
-    switch (kind) {
-    case MangledLifetimeDependenceKind::Inherit:
-      Printer << "inherit) ";
-      break;
-    case MangledLifetimeDependenceKind::Scope:
-      Printer << "scope) ";
-      break;
-    }
+    Printer << " ";
+    print(Node->getChild(2), depth + 1);
     return nullptr;
   }
   case Node::Kind::NonObjCAttribute:

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1944,13 +1944,7 @@ ManglingError Remangler::mangleNoDerivative(Node *node, unsigned depth) {
   return mangleSingleChildNode(node, depth + 1); // type
 }
 
-ManglingError Remangler::mangleParamLifetimeDependence(Node *node,
-                                                       unsigned depth) {
-  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
-}
-
-ManglingError Remangler::mangleSelfLifetimeDependence(Node *node,
-                                                      unsigned depth) {
+ManglingError Remangler::mangleLifetimeDependence(Node *node, unsigned depth) {
   return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
 }
 

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -721,7 +721,7 @@ ManglingError Remangler::mangleAllocator(Node *node, unsigned depth) {
 }
 
 ManglingError Remangler::mangleArgumentTuple(Node *node, unsigned depth) {
-  Node *Child = skipType(getSingleChild(node));
+  Node *Child = skipType(node->getChild(0));
   if (Child->getKind() == Node::Kind::Tuple &&
       Child->getNumChildren() == 0) {
     Buffer << 'y';
@@ -2241,16 +2241,13 @@ ManglingError Remangler::mangleNoDerivative(Node *node, unsigned depth) {
   return ManglingError::Success;
 }
 
-ManglingError Remangler::mangleParamLifetimeDependence(Node *node,
-                                                       unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  Buffer << "Yl" << (char)node->getFirstChild()->getIndex();
-  return ManglingError::Success;
-}
-
-ManglingError Remangler::mangleSelfLifetimeDependence(Node *node,
-                                                      unsigned depth) {
-  Buffer << "YL" << (char)node->getIndex();
+ManglingError Remangler::mangleLifetimeDependence(Node *node, unsigned depth) {
+  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
+  Buffer
+      << "Yl"
+      << (char)node->getChild(0)->getIndex(); // mangle lifetime dependence kind
+  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1)); // mangle index subset
+  Buffer << "_";
   return ManglingError::Success;
 }
 

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -163,6 +163,7 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
       AllowConcurrencyStandardSubstitutions);
   llvm::SaveAndRestore<bool> savedIsolatedAny(AllowIsolatedAny);
   llvm::SaveAndRestore<bool> savedTypedThrows(AllowTypedThrows);
+  llvm::SaveAndRestore<bool> savedLifetimeDependencies(AllowLifetimeDependencies);
   if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget(
           ctx.LangOpts.Target)) {
 
@@ -178,6 +179,7 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
     if (*runtimeCompatVersion < llvm::VersionTuple(6, 0)) {
       AllowIsolatedAny = false;
       AllowTypedThrows = false;
+      AllowLifetimeDependencies = false;
     }
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -9941,7 +9941,7 @@ Parser::parseDeclInit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   }
 
   if (auto *lifetimeTyR =
-          dyn_cast_or_null<LifetimeDependentReturnTypeRepr>(FuncRetTy)) {
+          dyn_cast_or_null<LifetimeDependentTypeRepr>(FuncRetTy)) {
     auto *base = lifetimeTyR->getBase();
 
     auto isOptionalSimpleUnqualifiedIdentifier = [](TypeRepr *typeRepr,

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -59,8 +59,8 @@ Parser::ParsedTypeAttributeList::applyAttributesToType(Parser &p,
   }
 
   if (!lifetimeDependenceSpecifiers.empty()) {
-    ty = LifetimeDependentReturnTypeRepr::create(p.Context, ty,
-                                                 lifetimeDependenceSpecifiers);
+    ty = LifetimeDependentTypeRepr::create(p.Context, ty,
+                                           lifetimeDependenceSpecifiers);
   }
   return ty;
 }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2479,14 +2479,14 @@ static CanSILFunctionType getSILFunctionType(
         params, substFnInterfaceType.getResult(),
         convertRepresentation(silRep).value());
   }
-  auto silExtInfo = extInfoBuilder.withClangFunctionType(clangType)
-                        .withIsPseudogeneric(pseudogeneric)
-                        .withSendable(isSendable)
-                        .withAsync(isAsync)
-                        .withUnimplementable(unimplementable)
-                        .withLifetimeDependenceInfo(
-                            extInfoBuilder.getLifetimeDependenceInfo())
-                        .build();
+  auto silExtInfo =
+      extInfoBuilder.withClangFunctionType(clangType)
+          .withIsPseudogeneric(pseudogeneric)
+          .withSendable(isSendable)
+          .withAsync(isAsync)
+          .withUnimplementable(unimplementable)
+          .withLifetimeDependencies(extInfoBuilder.getLifetimeDependencies())
+          .build();
 
   return SILFunctionType::get(genericSig, silExtInfo, coroutineKind,
                               calleeConvention, inputs, yields,

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1813,7 +1813,7 @@ visitRecursivelyLifetimeEndingUses(
     }
     if (auto *ret = dyn_cast<ReturnInst>(use->getUser())) {
       auto fnTy = ret->getFunction()->getLoweredFunctionType();
-      assert(!fnTy->getLifetimeDependenceInfo().empty());
+      assert(!fnTy->getLifetimeDependencies().empty());
       if (!visitScopeEnd(use)) {
         return false;
       }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3910,7 +3910,7 @@ getAnyFunctionRefInterfaceType(TypeConverter &TC,
           .withSendable(funcType->isSendable())
           .withAsync(funcType->isAsync())
           .withIsolation(funcType->getIsolation())
-          .withLifetimeDependenceInfo(funcType->getLifetimeDependenceInfo())
+          .withLifetimeDependencies(funcType->getLifetimeDependencies())
           .withSendingResult(funcType->hasSendingResult())
           .build();
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3248,7 +3248,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   if (!matchFunctionIsolations(func1, func2, kind, flags, locator))
     return getTypeMatchFailure(locator);
 
-  if (func1->getLifetimeDependenceInfo() != func2->getLifetimeDependenceInfo()) {
+  if (func1->getLifetimeDependencies() != func2->getLifetimeDependencies()) {
     return getTypeMatchFailure(locator);
   }
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -325,14 +325,13 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
   
   // Create the constructor.
   DeclName name(ctx, DeclBaseName::createConstructor(), paramList);
-  auto *ctor =
-    new (ctx) ConstructorDecl(name, Loc,
-                              /*Failable=*/false, /*FailabilityLoc=*/SourceLoc(),
-                              /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                              /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
-                              /*ThrownType=*/TypeLoc(),
-                              paramList, /*GenericParams=*/nullptr, decl,
-							  /*LifetimeDependentReturnTypeRepr*/ nullptr);
+  auto *ctor = new (ctx) ConstructorDecl(
+      name, Loc,
+      /*Failable=*/false, /*FailabilityLoc=*/SourceLoc(),
+      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
+      /*ThrownType=*/TypeLoc(), paramList, /*GenericParams=*/nullptr, decl,
+      /*LifetimeDependentTypeRepr*/ nullptr);
 
   // Mark implicit.
   ctor->setImplicit();
@@ -819,18 +818,16 @@ createDesignatedInitOverride(ClassDecl *classDecl,
   // Create the initializer declaration, inheriting the name,
   // failability, and throws from the superclass initializer.
   auto implCtx = classDecl->getImplementationContext()->getAsGenericContext();
-  auto ctor =
-    new (ctx) ConstructorDecl(superclassCtor->getName(),
-                              classDecl->getBraces().Start,
-                              superclassCtor->isFailable(),
-                              /*FailabilityLoc=*/SourceLoc(),
-                              /*Async=*/superclassCtor->hasAsync(),
-                              /*AsyncLoc=*/SourceLoc(),
-                              /*Throws=*/superclassCtor->hasThrows(),
-                              /*ThrowsLoc=*/SourceLoc(),
-                              TypeLoc::withoutLoc(thrownType),
-                              bodyParams, genericParams, implCtx,
-							  /*LifetimeDependentReturnTypeRepr*/ nullptr);
+  auto ctor = new (ctx) ConstructorDecl(
+      superclassCtor->getName(), classDecl->getBraces().Start,
+      superclassCtor->isFailable(),
+      /*FailabilityLoc=*/SourceLoc(),
+      /*Async=*/superclassCtor->hasAsync(),
+      /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/superclassCtor->hasThrows(),
+      /*ThrowsLoc=*/SourceLoc(), TypeLoc::withoutLoc(thrownType), bodyParams,
+      genericParams, implCtx,
+      /*LifetimeDependentTypeRepr*/ nullptr);
 
   ctor->setImplicit();
 

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1890,7 +1890,7 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
                               /*Throws=*/true, SourceLoc(),
                               /*ThrownType=*/TypeLoc(), paramList,
                               /*GenericParams=*/nullptr, conformanceDC,
-                              /*LifetimeDependentReturnTypeRepr*/ nullptr);
+                              /*LifetimeDependentTypeRepr*/ nullptr);
   initDecl->setImplicit();
   initDecl->setSynthesized();
 

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -127,14 +127,13 @@ static ValueDecl *deriveInitDecl(DerivedConformance &derived, Type paramType,
 
   // init(rawValue:) decl
   auto *initDecl =
-    new (C) ConstructorDecl(name, SourceLoc(),
-                            /*Failable=*/true, /*FailabilityLoc=*/SourceLoc(),
-                            /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                            /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
-                            /*ThrownType=*/TypeLoc(),
-                            paramList,
-                            /*GenericParams=*/nullptr, parentDC,
-                            /*LifetimeDependentReturnTypeRepr*/ nullptr);
+      new (C) ConstructorDecl(name, SourceLoc(),
+                              /*Failable=*/true, /*FailabilityLoc=*/SourceLoc(),
+                              /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+                              /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
+                              /*ThrownType=*/TypeLoc(), paramList,
+                              /*GenericParams=*/nullptr, parentDC,
+                              /*LifetimeDependentTypeRepr*/ nullptr);
 
   initDecl->setImplicit();
 

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -433,7 +433,7 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
                               /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
                               /*ThrownType=*/TypeLoc(), paramList,
                               /*GenericParams=*/nullptr, parentDC,
-                              /*LifetimeDependentReturnTypeRepr*/ nullptr);
+                              /*LifetimeDependentTypeRepr*/ nullptr);
 
   initDecl->setImplicit();
   initDecl->setBodySynthesizer(&deriveBodyRawRepresentable_init);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2258,6 +2258,10 @@ ParamSpecifierRequest::evaluate(Evaluator &evaluator,
   if (auto isolated = dyn_cast<IsolatedTypeRepr>(nestedRepr))
     nestedRepr = isolated->getBase();
 
+  if (auto *lifetime = dyn_cast<LifetimeDependentTypeRepr>(nestedRepr)) {
+    nestedRepr = lifetime->getBase();
+  }
+
   if (auto sending = dyn_cast<SendingTypeRepr>(nestedRepr)) {
     // If we do not have an Ownership Repr and do not have a no escape type,
     // return implicit copyable consuming.
@@ -2558,7 +2562,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       resultTy = TupleType::getEmpty(AFD->getASTContext());
     }
 
-    auto lifetimeDependenceInfo = AFD->getLifetimeDependenceInfo();
+    auto lifetimeDependenceInfo = AFD->getLifetimeDependencies();
 
     // (Args...) -> Result
     Type funcTy;
@@ -2581,7 +2585,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
 
       if (lifetimeDependenceInfo.has_value()) {
         infoBuilder =
-            infoBuilder.withLifetimeDependenceInfo(*lifetimeDependenceInfo);
+            infoBuilder.withLifetimeDependencies(*lifetimeDependenceInfo);
       }
 
       auto info = infoBuilder.build();
@@ -2601,7 +2605,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       maybeAddParameterIsolation(selfInfoBuilder, {selfParam});
       if (lifetimeDependenceInfo.has_value()) {
         selfInfoBuilder =
-            selfInfoBuilder.withLifetimeDependenceInfo(*lifetimeDependenceInfo);
+            selfInfoBuilder.withLifetimeDependencies(*lifetimeDependenceInfo);
       }
 
       // FIXME: Verify ExtInfo state is correct, not working by accident.
@@ -3112,7 +3116,7 @@ ImplicitKnownProtocolConformanceRequest::evaluate(Evaluator &evaluator,
   }
 }
 
-std::optional<LifetimeDependenceInfo>
+std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
 LifetimeDependenceInfoRequest::evaluate(Evaluator &evaluator,
                                         AbstractFunctionDecl *decl) const {
   return LifetimeDependenceInfo::get(decl);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3962,7 +3962,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     }
   }
 
-  if (auto *lifetimeRepr = dyn_cast_or_null<LifetimeDependentReturnTypeRepr>(
+  if (auto *lifetimeRepr = dyn_cast_or_null<LifetimeDependentTypeRepr>(
           repr->getResultTypeRepr())) {
     diagnoseInvalid(lifetimeRepr, lifetimeRepr->getLoc(),
                     diag::lifetime_dependence_function_type);
@@ -4518,8 +4518,8 @@ bool TypeResolver::resolveSingleSILResult(
 
   options.setContext(TypeResolverContext::FunctionResult);
 
-  // Look through LifetimeDependentReturnTypeRepr.
-  // LifetimeDependentReturnTypeRepr will be processed separately when building
+  // Look through LifetimeDependentTypeRepr.
+  // LifetimeDependentTypeRepr will be processed separately when building
   // SILFunctionType.
   if (auto *lifetimeDependentTypeRepr =
           dyn_cast<LifetimeDependentTypeRepr>(repr)) {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -1072,7 +1072,7 @@ public:
 
   // Reads lifetime dependence info from type if present.
   std::optional<LifetimeDependenceInfo>
-  maybeReadLifetimeDependenceInfo(unsigned numParams);
+  maybeReadLifetimeDependence(unsigned numParams);
 
   // Reads lifetime dependence specifier from decl if present
   bool maybeReadLifetimeDependenceSpecifier(

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 880; // dead_end flag on dealloc_box
+const uint16_t SWIFTMODULE_VERSION_MINOR = 881; // Changes to LifetimeDependence
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2213,6 +2213,7 @@ namespace decls_block {
 
   using LifetimeDependenceLayout =
       BCRecordLayout<LIFETIME_DEPENDENCE,
+                     BCVBR<4>,           // targetIndex
                      BCFixed<1>,         // isImmortal
                      BCFixed<1>,         // hasInheritLifetimeParamIndices
                      BCFixed<1>,         // hasScopeLifetimeParamIndices

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2572,17 +2572,20 @@ void Serializer::writeASTBlockEntity(const DeclContext *DC) {
   }
 }
 
-void Serializer::writeLifetimeDependenceInfo(
-    LifetimeDependenceInfo lifetimeDependenceInfo) {
+void Serializer::writeLifetimeDependencies(
+    ArrayRef<LifetimeDependenceInfo> lifetimeDependencies) {
   using namespace decls_block;
   SmallVector<bool> paramIndices;
-  lifetimeDependenceInfo.getConcatenatedData(paramIndices);
+  for (auto info : lifetimeDependencies) {
+    info.getConcatenatedData(paramIndices);
 
-  auto abbrCode = DeclTypeAbbrCodes[LifetimeDependenceLayout::Code];
-  LifetimeDependenceLayout::emitRecord(
-      Out, ScratchRecord, abbrCode, lifetimeDependenceInfo.isImmortal(),
-      lifetimeDependenceInfo.hasInheritLifetimeParamIndices(),
-      lifetimeDependenceInfo.hasScopeLifetimeParamIndices(), paramIndices);
+    auto abbrCode = DeclTypeAbbrCodes[LifetimeDependenceLayout::Code];
+    LifetimeDependenceLayout::emitRecord(
+        Out, ScratchRecord, abbrCode, info.getTargetIndex(), info.isImmortal(),
+        info.hasInheritLifetimeParamIndices(),
+        info.hasScopeLifetimeParamIndices(), paramIndices);
+    paramIndices.clear();
+  }
 }
 
 #define SIMPLE_CASE(TYPENAME, VALUE) \
@@ -4587,9 +4590,9 @@ public:
 
     auto fnType = ty->getAs<AnyFunctionType>();
     if (fnType) {
-      if (auto *lifetimeDependenceInfo =
-              fnType->getLifetimeDependenceInfoOrNull()) {
-        S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo);
+      auto lifetimeDependencies = fnType->getLifetimeDependencies();
+      if (!lifetimeDependencies.empty()) {
+        S.writeLifetimeDependencies(lifetimeDependencies);
       }
     }
 
@@ -4714,9 +4717,9 @@ public:
 
     auto fnType = ty->getAs<AnyFunctionType>();
     if (fnType) {
-      if (auto *lifetimeDependenceInfo =
-              fnType->getLifetimeDependenceInfoOrNull()) {
-        S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo);
+      auto lifetimeDependencies = fnType->getLifetimeDependencies();
+      if (!lifetimeDependencies.empty()) {
+        S.writeLifetimeDependencies(lifetimeDependencies);
       }
     }
 
@@ -4884,9 +4887,9 @@ public:
 
     auto fnType = ty->getAs<AnyFunctionType>();
     if (fnType) {
-      if (auto *lifetimeDependenceInfo =
-              fnType->getLifetimeDependenceInfoOrNull()) {
-        S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo);
+      auto lifetimeDependencies = fnType->getLifetimeDependencies();
+      if (!lifetimeDependencies.empty()) {
+        S.writeLifetimeDependencies(lifetimeDependencies);
       }
     }
 
@@ -5631,9 +5634,9 @@ public:
 
     serializeFunctionTypeParams(fnTy);
 
-    if (auto *lifetimeDependenceInfo =
-            fnTy->getLifetimeDependenceInfoOrNull()) {
-      S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo);
+    auto lifetimeDependencies = fnTy->getLifetimeDependencies();
+    if (!lifetimeDependencies.empty()) {
+      S.writeLifetimeDependencies(lifetimeDependencies);
     }
   }
 
@@ -5654,9 +5657,9 @@ public:
 
     serializeFunctionTypeParams(fnTy);
 
-    if (auto *lifetimeDependenceInfo =
-            fnTy->getLifetimeDependenceInfoOrNull()) {
-      S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo);
+    auto lifetimeDependencies = fnTy->getLifetimeDependencies();
+    if (!lifetimeDependencies.empty()) {
+      S.writeLifetimeDependencies(lifetimeDependencies);
     }
   }
 
@@ -5747,9 +5750,9 @@ public:
         invocationSigID, invocationSubstMapID, patternSubstMapID,
         clangTypeID, variableData);
 
-    if (auto *lifetimeDependenceInfo =
-            fnTy->getLifetimeDependenceInfoOrNull()) {
-      S.writeLifetimeDependenceInfo(*lifetimeDependenceInfo);
+    auto lifetimeDependencies = fnTy->getLifetimeDependencies();
+    if (!lifetimeDependencies.empty()) {
+      S.writeLifetimeDependencies(lifetimeDependencies);
     }
   }
 

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -385,9 +385,9 @@ private:
   /// Writes a pack conformance.
   void writeASTBlockEntity(PackConformance *conformance);
 
-  /// Writes lifetime dependence info
-  void
-  writeLifetimeDependenceInfo(LifetimeDependenceInfo lifetimeDependenceInfo);
+  /// Writes lifetime dependencies
+  void writeLifetimeDependencies(
+      ArrayRef<LifetimeDependenceInfo> lifetimeDependenceInfo);
 
   /// Registers the abbreviation for the given decl or type layout.
   template <typename Layout>

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -454,10 +454,6 @@ $s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfM
 $sxSo8_NSRangeVRlzCRl_Cr0_llySo12ModelRequestCyxq_GIsPetWAlYl_TC ---> coroutine continuation prototype for @escaping @convention(thin) @convention(witness_method) @yield_once <A, B where A: AnyObject, B: AnyObject> @substituted <A> (@inout A) -> (@yields @inout __C._NSRange) for <__C.ModelRequest<A, B>>
 $SyyySGSS_IIxxxxx____xsIyFSySIxx_@xIxx____xxI ---> $SyyySGSS_IIxxxxx____xsIyFSySIxx_@xIxx____xxI
 $s12typed_throws15rethrowConcreteyyAA7MyErrorOYKF ---> typed_throws.rethrowConcrete() throws(typed_throws.MyError) -> ()
-$s28implicit_lifetime_dependence10BufferViewVyA2ChYlscfC ---> {T:$s28implicit_lifetime_dependence10BufferViewVyA2ChYlscfc} implicit_lifetime_dependence.BufferView.init(lifetime dependence: scope __shared implicit_lifetime_dependence.BufferView) -> implicit_lifetime_dependence.BufferView
-$s28implicit_lifetime_dependence10BufferViewVyA2CYlicfC ---> {T:$s28implicit_lifetime_dependence10BufferViewVyA2CYlicfc} implicit_lifetime_dependence.BufferView.init(lifetime dependence: inherit implicit_lifetime_dependence.BufferView) -> implicit_lifetime_dependence.BufferView
-$s28implicit_lifetime_dependence7WrapperV8getView1AA10BufferViewVyYLsF ---> implicit_lifetime_dependence.Wrapper.getView1(self lifetime dependence: scope) () -> implicit_lifetime_dependence.BufferView
-$s28implicit_lifetime_dependence7WrapperV8getView2AA10BufferViewVyYLiF ---> implicit_lifetime_dependence.Wrapper.getView2(self lifetime dependence: inherit) () -> implicit_lifetime_dependence.BufferView
 $s3red3use2fnySiyYAXE_tF ---> red.use(fn: @isolated(any) () -> Swift.Int) -> ()
 $s4testAAyAA5KlassC_ACtACnYTF ---> test.test(__owned test.Klass) -> sending (test.Klass, test.Klass)
 $s5test24testyyAA5KlassCnYuF ---> test2.test(sending __owned test2.Klass) -> ()
@@ -476,3 +472,6 @@ $s23variadic_generic_opaque2G2VyAA2S1V_AA2S2VQPGAA1PHPAeA1QHPyHC_AgaJHPyHCHX_HC 
 
 $s9MacroUser0023macro_expandswift_elFCffMX436_4_23bitwidthNumberedStructsfMf_ ---> freestanding macro expansion #1 of bitwidthNumberedStructs in module MacroUser file macro_expand.swift line 437 column 5
 $sxq_IyXd_D ---> @callee_unowned (@in_cxx A) -> (@unowned B)
+$s32def_implicit_lifetime_dependence6deriveyAA10BufferViewVYliS_ADF ---> def_implicit_lifetime_dependence.derive(def_implicit_lifetime_dependence.BufferView) -> inherit lifetime dependence: {0} def_implicit_lifetime_dependence.BufferView
+$s32def_explicit_lifetime_dependence16deriveThisOrThatyAA10BufferViewVYlsSS_AD_ADtF ---> def_explicit_lifetime_dependence.deriveThisOrThat(def_explicit_lifetime_dependence.BufferView, def_explicit_lifetime_dependence.BufferView) -> scope lifetime dependence: {0, 1} def_explicit_lifetime_dependence.BufferView
+$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat2yAA10BufferViewVYliUS_YlsSU_AD_ADntF ---> explicit_lifetime_dependence_specifiers.deriveThisOrThat2(explicit_lifetime_dependence_specifiers.BufferView, __owned explicit_lifetime_dependence_specifiers.BufferView) -> scope lifetime dependence: {0} inherit lifetime dependence: {1} explicit_lifetime_dependence_specifiers.BufferView

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -3,11 +3,11 @@
 // RUN: -enable-builtin-module \
 // RUN: -enable-experimental-feature NonescapableTypes | %FileCheck %s
 
-
 import Builtin
 
 struct BufferView : ~Escapable {
   let ptr: UnsafeRawBufferPointer
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACYlsSU_SWcfC : $@convention(method) (UnsafeRawBufferPointer, @thin BufferView.Type) -> _scope(0)  @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer) -> dependsOn(ptr) Self {
     self.ptr = ptr
   }
@@ -23,17 +23,17 @@ struct BufferView : ~Escapable {
   init(independent ptr: UnsafeRawBufferPointer) {
     self.ptr = ptr
   }
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_SaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView {
+ // CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACYlsUSU_SW_SaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) -> dependsOn(a) Self {
     self.ptr = ptr
     return self
   }
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_AA7WrapperVYlitcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @thin BufferView.Type) -> _inherit(1) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACYliUSU_SW_AA7WrapperVtcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @thin BufferView.Type) -> _inherit(1)  @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: consuming Wrapper) -> dependsOn(a) Self {
     self.ptr = ptr
     return self
   }
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_AA7WrapperVYliSaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @guaranteed Array<Int>, @thin BufferView.Type) -> _inherit(1) _scope(2) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACYliUSUU_YlsUUSU_SW_AA7WrapperVSaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @guaranteed Array<Int>, @thin BufferView.Type) -> _inherit(1) _scope(2)  @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: consuming Wrapper, _ b: borrowing Array<Int>) -> dependsOn(a) dependsOn(b) Self {
     self.ptr = ptr
     return self
@@ -58,17 +58,17 @@ func testBasic() {
   }
 }
 
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers6deriveyAA10BufferViewVADYlsF : $@convention(thin) (@guaranteed BufferView) -> _scope(0) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers6deriveyAA10BufferViewVYlsS_ADF : $@convention(thin) (@guaranteed BufferView) -> _scope(0)  @owned BufferView {
 func derive(_ x: borrowing BufferView) -> dependsOn(scoped x) BufferView {
   return BufferView(independent: x.ptr)
 }
 
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16consumeAndCreateyAA10BufferViewVYliS_ADnF : $@convention(thin) (@owned BufferView) -> _inherit(0)  @owned BufferView {
 func consumeAndCreate(_ x: consuming BufferView) -> dependsOn(x) BufferView {
   return BufferView(independent: x.ptr)
 }
 
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat1yAA10BufferViewVADYls_ADYlstF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(0, 1) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat1yAA10BufferViewVYlsSS_AD_ADtF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(0, 1)  @owned BufferView {
 func deriveThisOrThat1(_ this: borrowing BufferView, _ that: borrowing BufferView) -> dependsOn(scoped this, that) BufferView {
   if (Int.random(in: 1..<100) == 0) {
     return BufferView(independent: this.ptr)
@@ -76,7 +76,7 @@ func deriveThisOrThat1(_ this: borrowing BufferView, _ that: borrowing BufferVie
   return BufferView(independent: that.ptr)
 }
 
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat2yAA10BufferViewVADYls_ADnYlitF : $@convention(thin) (@guaranteed BufferView, @owned BufferView) -> _inherit(1) _scope(0) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat2yAA10BufferViewVYliUS_YlsSU_AD_ADntF : $@convention(thin) (@guaranteed BufferView, @owned BufferView) -> _inherit(1) _scope(0)  @owned BufferView {
 func deriveThisOrThat2(_ this: borrowing BufferView, _ that: consuming BufferView) -> dependsOn(scoped this) dependsOn(that) BufferView {
   if (Int.random(in: 1..<100) == 0) {
     return BufferView(independent: this.ptr)
@@ -91,12 +91,12 @@ struct Wrapper : ~Escapable {
   init(_ view: consuming BufferView) {
     self.view = view
   }
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers7WrapperV8getView1AA10BufferViewVyYLsF : $@convention(method) (@guaranteed Wrapper) -> _scope(0) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers7WrapperV8getView1AA10BufferViewVYlsS_yF : $@convention(method) (@guaranteed Wrapper) -> _scope(0)  @owned BufferView {
   borrowing func getView1() -> dependsOn(scoped self) BufferView {
     return view
   }
 
-// CHECK: sil hidden @$s39explicit_lifetime_dependence_specifiers7WrapperV8getView2AA10BufferViewVyYLiF : $@convention(method) (@owned Wrapper) -> _inherit(0) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers7WrapperV8getView2AA10BufferViewVYliS_yF : $@convention(method) (@owned Wrapper) -> _inherit(0)  @owned BufferView {
   consuming func getView2() -> dependsOn(self) BufferView {
     return view
   }
@@ -109,12 +109,12 @@ struct Container : ~Escapable {
  }
 }
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getConsumingViewyAA06BufferG0VAA9ContainerVnYliF : $@convention(thin) (@owned Container) -> _inherit(0) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getConsumingViewyAA06BufferG0VYliS_AA9ContainerVnF : $@convention(thin) (@owned Container) -> _inherit(0)  @owned BufferView {
 func getConsumingView(_ x: consuming Container) -> dependsOn(x) BufferView {
   return BufferView(independent: x.ptr)
 }
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getBorrowingViewyAA06BufferG0VAA9ContainerVYlsF : $@convention(thin) (@guaranteed Container) -> _scope(0) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getBorrowingViewyAA06BufferG0VYlsS_AA9ContainerVF : $@convention(thin) (@guaranteed Container) -> _scope(0)  @owned BufferView {
 func getBorrowingView(_ x: borrowing Container) -> dependsOn(scoped x) BufferView {
   return BufferView(independent: x.ptr)
 }

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -15,17 +15,17 @@ struct BufferView : ~Escapable {
     self.ptr = ptr
     self.c = c
   }
-// CHECK: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyA2ChYlicfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> _inherit(0) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyACYliSU_AChcfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> _inherit(0)  @owned BufferView {
   init(_ otherBV: borrowing BufferView) {
     self.ptr = otherBV.ptr
     self.c = otherBV.c
   }
-// CHECK: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyA2CYlicfC : $@convention(method) (@owned BufferView, @thin BufferView.Type) -> _inherit(0) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyACYliSU_ACcfC : $@convention(method) (@owned BufferView, @thin BufferView.Type) -> _inherit(0)  @owned BufferView {
   init(_ otherBV: consuming BufferView) {
     self.ptr = otherBV.ptr
     self.c = otherBV.c
   }
-// CHECK: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyACSW_SaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyACYlsUSU_SW_SaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1)  @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) {
     self.ptr = ptr
     self.c = a.count
@@ -51,7 +51,7 @@ func testBasic() {
   }
 }
 
-// CHECK: sil hidden @$s28implicit_lifetime_dependence6deriveyAA10BufferViewVADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence6deriveyAA10BufferViewVYliS_ADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0)  @owned BufferView {
 func derive(_ x: borrowing BufferView) -> BufferView {
   return BufferView(x.ptr, x.c)
 }
@@ -60,7 +60,7 @@ func derive(_ unused: Int, _ x: borrowing BufferView) -> BufferView {
   return BufferView(independent: x.ptr, x.c)
 }
 
-// CHECK: sil hidden @$s28implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVYliS_ADnF : $@convention(thin) (@owned BufferView) -> _inherit(0)  @owned BufferView {
 func consumeAndCreate(_ x: consuming BufferView) -> BufferView {
   return BufferView(independent: x.ptr, x.c)
 }
@@ -79,17 +79,16 @@ struct Wrapper : ~Escapable {
       yield &_view
     }
   }
-// CHECK: sil hidden @$s28implicit_lifetime_dependence7WrapperVyAcA10BufferViewVYlicfC : $@convention(method) (@owned BufferView, @thin Wrapper.Type) -> _inherit(0) @owned Wrapper {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperVyACYliSU_AA10BufferViewVcfC : $@convention(method) (@owned BufferView, @thin Wrapper.Type) -> _inherit(0)  @owned Wrapper {
   init(_ view: consuming BufferView) {
     self._view = view
   }
-// TODO: Investigate why it was mangled as Yli and not YLi before
-// CHECK: sil hidden @$s28implicit_lifetime_dependence7WrapperV8getView1AA10BufferViewVyKYLiF : $@convention(method) (@guaranteed Wrapper) -> _inherit(0)  (@owned BufferView, @error any Error) {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperV8getView1AA10BufferViewVYliS_yKF : $@convention(method) (@guaranteed Wrapper) -> _inherit(0)  (@owned BufferView, @error any Error) {
   borrowing func getView1() throws -> BufferView {
     return _view
   }
 
-// CHECK: sil hidden @$s28implicit_lifetime_dependence7WrapperV8getView2AA10BufferViewVyYaKYLiF : $@convention(method) @async (@owned Wrapper) -> _inherit(0)  (@owned BufferView, @error any Error) {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperV8getView2AA10BufferViewVYliS_yYaKF : $@convention(method) @async (@owned Wrapper) -> _inherit(0)  (@owned BufferView, @error any Error) {
   consuming func getView2() async throws -> BufferView {
     return _view
   }
@@ -130,7 +129,7 @@ struct GenericBufferView<Element> : ~Escapable {
   let baseAddress: Pointer
   let count: Int
 
-// CHECK: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewV11baseAddress5count9dependsOnACyxGSV_Siqd__hYlstclufC : $@convention(method) <Element><Storage> (UnsafeRawPointer, Int, @in_guaranteed Storage, @thin GenericBufferView<Element>.Type) -> _scope(2) @owned GenericBufferView<Element> {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewV11baseAddress5count9dependsOnACyxGYlsUUSU_SV_Siqd__htclufC : $@convention(method) <Element><Storage> (UnsafeRawPointer, Int, @in_guaranteed Storage, @thin GenericBufferView<Element>.Type) -> _scope(2)  @owned GenericBufferView<Element> {
   init<Storage>(baseAddress: Pointer,
                 count: Int,
                 dependsOn: borrowing Storage) {
@@ -164,7 +163,7 @@ struct GenericBufferView<Element> : ~Escapable {
   }
 }
 
-// CHECK: sil hidden @$s28implicit_lifetime_dependence23tupleLifetimeDependenceyAA10BufferViewV_ADtADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0) (@owned BufferView, @owned BufferView) {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence23tupleLifetimeDependenceyAA10BufferViewV_ADtYliS_ADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0)  (@owned BufferView, @owned BufferView) {
 func tupleLifetimeDependence(_ x: borrowing BufferView) -> (BufferView, BufferView) {
   return (BufferView(x.ptr, x.c), BufferView(x.ptr, x.c))
 }

--- a/test/SIL/lifetime_dependence_buffer_view_test.swift
+++ b/test/SIL/lifetime_dependence_buffer_view_test.swift
@@ -167,3 +167,4 @@ public func array_view_element(a: ContiguousArray<Int> , i: BufferViewIndex<Int>
 public func array_view_slice_element(a: ContiguousArray<Int> , sliceIdx: FakeRange<BufferViewIndex<Int>>, Idx: BufferViewIndex<Int>) -> Int {
   a.view[sliceIdx][Idx]
 }
+

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -28,10 +28,10 @@ public func test(pview: borrowing PView) -> dependsOn(pview) View {
   return pview.getDefault()
 }
 
-// CHECK: sil hidden @$s28lifetime_dependence_generics1PPAAE10getDefault1EQzyYLsF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> _scope(0) @out Self.E {
+// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics1PPAAE10getDefault1EQzYlsS_yF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> _scope(0)  @out Self.E {
 
-// CHECK: sil hidden @$s28lifetime_dependence_generics5PViewV4getEAA4ViewVyYLsF : $@convention(method) (PView) -> _scope(0) @owned View {
+// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics5PViewV4getEAA4ViewVYlsS_yF : $@convention(method) (PView) -> _scope(0)  @owned View {
 
-// CHECK: sil private [transparent] [thunk] @$s28lifetime_dependence_generics5PViewVAA1PA2aDP4getE1EQzyYLsFTW : $@convention(witness_method: P) (@in_guaranteed PView) -> _scope(0) @out View {
+// CHECK-LABEL: sil private [transparent] [thunk] @$s28lifetime_dependence_generics5PViewVAA1PA2aDP4getE1EQzYlsS_yFTW : $@convention(witness_method: P) (@in_guaranteed PView) -> _scope(0)  @out View {
 
-// CHECK: sil @$s28lifetime_dependence_generics4test5pviewAA4ViewVAA5PViewVYls_tF : $@convention(thin) (PView) -> _scope(0) @owned View {
+// CHECK-LABEL: sil @$s28lifetime_dependence_generics4test5pviewAA4ViewVYlsS_AA5PViewV_tF : $@convention(thin) (PView) -> _scope(0)  @owned View {

--- a/test/SIL/lifetime_dependence_param_position_test.swift
+++ b/test/SIL/lifetime_dependence_param_position_test.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend %s -emit-silgen \
+// RUN:   -enable-experimental-feature NonescapableTypes
+
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
+
+
+public struct Span<Element> : ~Escapable {
+  private var baseAddress: UnsafeRawPointer
+  public let count: Int
+  public init<Owner: ~Copyable & ~Escapable>(
+      baseAddress: UnsafeRawPointer,
+      count: Int,
+      dependsOn owner: borrowing Owner
+    ) {
+      self.init(
+        baseAddress: baseAddress, count: count, dependsOn: owner
+      )
+  }
+}
+
+extension ContiguousArray {
+  public var span: Span<Element> {
+    borrowing _read {
+      yield Span(
+        baseAddress: _baseAddressIfContiguous!, count: count, dependsOn: self
+      )
+    }
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s39lifetime_dependence_param_position_test11mayReassign4span2toyAA4SpanVySiGzYlsUS__s15ContiguousArrayVySiGtF : $@convention(thin) (@inout Span<Int>, @guaranteed ContiguousArray<Int>) -> _scope(1)  () {
+func mayReassign(span: dependsOn(to) inout Span<Int>, to: ContiguousArray<Int>) {
+  span = to.span
+}
+

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
@@ -60,11 +60,11 @@ func takeClosure(_: () -> ()) {}
 
 // No mark_dependence is needed for a inherited scope.
 //
-// CHECK-LABEL: sil hidden @$s4test14bv_borrow_copyyAA2BVVADYlsF : $@convention(thin) (@guaranteed BV) -> _scope(0) @owned BV {
+// CHECK-LABEL: sil hidden @$s4test14bv_borrow_copyyAA2BVVYlsS_ADF : $@convention(thin) (@guaranteed BV) -> _scope(0)  @owned BV {
 // CHECK:      bb0(%0 : @noImplicitCopy $BV):
 // CHECK:        apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> _inherit(0) @owned BV
 // CHECK-NEXT:   return %3 : $BV
-// CHECK-LABEL: } // end sil function '$s4test14bv_borrow_copyyAA2BVVADYlsF'
+// CHECK-LABEL: } // end sil function '$s4test14bv_borrow_copyyAA2BVVYlsS_ADF'
 func bv_borrow_copy(_ bv: borrowing BV) -> dependsOn(scoped bv) BV {
   bv_copy(bv) 
 }
@@ -72,12 +72,12 @@ func bv_borrow_copy(_ bv: borrowing BV) -> dependsOn(scoped bv) BV {
 // The mark_dependence for the borrow scope should be marked
 // [nonescaping] after diagnostics.
 //
-// CHECK-LABEL: sil hidden @$s4test010bv_borrow_C00B0AA2BVVAEYls_tF : $@convention(thin) (@guaranteed BV) -> _scope(0) @owned BV {
+// CHECK-LABEL: sil hidden @$s4test010bv_borrow_C00B0AA2BVVYlsS_AE_tF : $@convention(thin) (@guaranteed BV) -> _scope(0)  @owned BV {
 // CHECK:       bb0(%0 : @noImplicitCopy $BV):
 // CHECK:         [[R:%.*]] = apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> _scope(0) @owned BV
 // CHECK:         %{{.*}} = mark_dependence [nonescaping] [[R]] : $BV on %0 : $BV
 // CHECK-NEXT:    return %{{.*}} : $BV
-// CHECK-LABEL: } // end sil function '$s4test010bv_borrow_C00B0AA2BVVAEYls_tF'
+// CHECK-LABEL: } // end sil function '$s4test010bv_borrow_C00B0AA2BVVYlsS_AE_tF'
 func bv_borrow_borrow(bv: borrowing BV) -> dependsOn(scoped bv) BV {
   bv_borrow_copy(bv)
 }
@@ -93,14 +93,14 @@ func neint_throws(ncInt: borrowing NCInt) throws -> NEInt {
   return NEInt(owner: ncInt)
 }
 
-// CHECK-LABEL: sil hidden @$s4test9neint_try5ncIntAA5NEIntVAA5NCIntVYls_tKF : $@convention(thin) (@guaranteed NCInt) -> _scope(0)  (@owned NEInt, @error any Error) {
+// CHECK-LABEL: sil hidden @$s4test9neint_try5ncIntAA5NEIntVYlsS_AA5NCIntV_tKF : $@convention(thin) (@guaranteed NCInt) -> _scope(0)  (@owned NEInt, @error any Error) {
 // CHECK:   try_apply %{{.*}}(%0) : $@convention(thin) (@guaranteed NCInt) -> _scope(0)  (@owned NEInt, @error any Error), normal bb1, error bb2
 // CHECK: bb1([[R:%.*]] : $NEInt):
 // CHECK:   [[MD:%.*]] = mark_dependence [nonescaping] %5 : $NEInt on %0 : $NCInt
 // CHECK:   return [[MD]] : $NEInt
 // CHECK: bb2([[E:%.*]] : $any Error):
 // CHECK:   throw [[E]] : $any Error
-// CHECK-LABEL: } // end sil function '$s4test9neint_try5ncIntAA5NEIntVAA5NCIntVYls_tKF'
+// CHECK-LABEL: } // end sil function '$s4test9neint_try5ncIntAA5NEIntVYlsS_AA5NCIntV_tKF'
 func neint_try(ncInt: borrowing NCInt) throws -> NEInt {
   try neint_throws(ncInt: ncInt)
 }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope.swift
@@ -33,13 +33,13 @@ struct NC : ~Copyable {
 
 // Rewrite the mark_dependence to depend on the incoming argument rather than the nested access.
 //
-// CHECK-LABEL: sil hidden @$s4test13bv_get_mutate9containerAA2BVVAA2NCVzYls_tF : $@convention(thin) (@inout NC) -> _scope(0) @owned BV {
+// CHECK-LABEL: sil hidden @$s4test13bv_get_mutate9containerAA2BVVYlsS_AA2NCVz_tF : $@convention(thin) (@inout NC) -> _scope(0)  @owned BV {
 // CHECK: bb0(%0 : $*NC):
 // CHECK:   [[A:%.*]] = begin_access [read] [static] %0 : $*NC
 // CHECK:   [[L:%.*]] = load [[A]] : $*NC
 // CHECK:   [[R:%.*]] = apply %{{.*}}([[L]]) : $@convention(method) (@guaranteed NC) -> _scope(0) @owned BV
 // CHECK:   [[M:%.*]] = mark_dependence [nonescaping] [[R]] : $BV on %0 : $*NC
-// CHECK-LABEL: } // end sil function '$s4test13bv_get_mutate9containerAA2BVVAA2NCVzYls_tF'
+// CHECK-LABEL: } // end sil function '$s4test13bv_get_mutate9containerAA2BVVYlsS_AA2NCVz_tF'
 func bv_get_mutate(container: inout NC) -> dependsOn(container) BV {
   container.getBV()
 }

--- a/test/Sema/explicit_lifetime_dependence_specifiers1.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers1.swift
@@ -29,13 +29,13 @@ struct BufferView : ~Escapable {
     self.ptr = ptr
   }
   // TODO: Once Optional is ~Escapable, the error will go away
-  init?(_ ptr: UnsafeRawBufferPointer, _ arr: borrowing Array<Float>) -> dependsOn(arr) Self? { // expected-error{{lifetime dependence can only be specified on ~Escapable results}}
+  init?(_ ptr: UnsafeRawBufferPointer, _ arr: borrowing Array<Float>) -> dependsOn(arr) Self? { // expected-error{{lifetime dependence can only be specified on ~Escapable types}}
     if (Int.random(in: 1..<100) == 0) {
       return nil
     }
     self.ptr = ptr
   }
-  init?(_ ptr: UnsafeRawBufferPointer, _ arr: borrowing Array<String>) -> dependsOn(arr) Self? { // expected-error{{lifetime dependence can only be specified on ~Escapable results}}
+  init?(_ ptr: UnsafeRawBufferPointer, _ arr: borrowing Array<String>) -> dependsOn(arr) Self? { // expected-error{{lifetime dependence can only be specified on ~Escapable types}}
     if (Int.random(in: 1..<100) == 0) {
       return nil
     }
@@ -81,7 +81,7 @@ struct WrapperStruct {
   let k: Klass
 }
 
-func invalidLifetimeDependenceOnEscapableResult(_ w: borrowing WrapperStruct) -> dependsOn(w) Klass { // expected-error{{lifetime dependence can only be specified on ~Escapable results}}
+func invalidLifetimeDependenceOnEscapableResult(_ w: borrowing WrapperStruct) -> dependsOn(w) Klass { // expected-error{{lifetime dependence can only be specified on ~Escapable types}}
   return w.k
 }
 
@@ -129,7 +129,7 @@ func inoutParamLifetimeDependence2(_ x: inout BufferView) -> dependsOn(scoped x)
   return BufferView(x.ptr)
 }
 
-func invalidSpecifierPosition1(_ x: borrowing dependsOn(x) BufferView) -> BufferView { // expected-error{{lifetime dependence specifiers may only be used on result of functions, methods, initializers}}
+func invalidSpecifierPosition1(_ x: borrowing dependsOn(x) BufferView) -> BufferView {
   return BufferView(x.ptr)
 }
 
@@ -140,6 +140,13 @@ func invalidSpecifierPosition2(_ x: borrowing BufferView) -> BufferView {
 
 func invalidTupleLifetimeDependence(_ x: inout BufferView) -> (dependsOn(x) BufferView, BufferView) { // expected-error{{lifetime dependence specifiers cannot be applied to tuple elements}}
   return (BufferView(x.ptr), BufferView(x.ptr))
+}
+
+// TODO: Is this legal ? If not, diagnose in Sema.
+func incorrectLifetimeDependenceInParamPosition1(bv: dependsOn(bv) inout BufferView, to: ContiguousArray<Int>) {
+}
+
+func incorrectLifetimeDependenceInParamPosition1(bv: dependsOn(to) inout ContiguousArray<Int>, to: ContiguousArray<Int>) { // expected-error{{lifetime dependence can only be specified on ~Escapable types}}
 }
 
 struct Wrapper : ~Escapable {

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -25,7 +25,7 @@
  }
 
  func testTransfer(nc: consuming NC) {
-   let transferred = applyTransfer(ne: nc.ne, transfer: transfer) // expected-error{{cannot convert value of type '(NE) -> _inherit(0)  NE' to expected argument type '(NE) -> NE'}}
+   let transferred = applyTransfer(ne: nc.ne, transfer: transfer) // expected-error{{cannot convert value of type '(NE) -> _inherit(0) NE' to expected argument type '(NE) -> NE'}}
 
    _ = consume nc
    _ = transfer(transferred)
@@ -40,7 +40,7 @@
  }
 
  func testBorrow(nc: consuming NC) {
-   let borrowed = applyBorrow(nc: nc, borrow: borrow) // expected-error{{cannot convert value of type '(borrowing NC) -> _scope(0)  NE' to expected argument type '(borrowing NC) -> NE}}
+   let borrowed = applyBorrow(nc: nc, borrow: borrow) // expected-error{{cannot convert value of type '(borrowing NC) -> _scope(0) NE' to expected argument type '(borrowing NC) -> NE}}
    _ = consume nc
    _ = transfer(borrowed)
  }

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -48,9 +48,8 @@ func testFakeOptional() {
   _ = FakeOptional<Int>(())
 }
 
-// CHECK: sil @$s32def_explicit_lifetime_dependence6deriveyAA10BufferViewVADYlsF : $@convention(thin) (@guaranteed BufferView) -> _scope(0) @owned BufferView
-// CHECK: sil @$s32def_explicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView
-// CHECK: sil @$s32def_explicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADYlsF : $@convention(thin) (@guaranteed BufferView) -> _scope(0) @owned BufferView
-// CHECK: sil @$s32def_explicit_lifetime_dependence16deriveThisOrThatyAA10BufferViewVADYls_ADYlstF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(0, 1) @owned BufferView
-
-// CHECK: sil @$s32def_explicit_lifetime_dependence10BufferViewVyACSW_SaySiGhYlstcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence6deriveyAA10BufferViewVYlsS_ADF : $@convention(thin) (@guaranteed BufferView) -> _scope(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVYliS_ADnF : $@convention(thin) (@owned BufferView) -> _inherit(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVYlsS_ADF : $@convention(thin) (@guaranteed BufferView) -> _scope(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence16deriveThisOrThatyAA10BufferViewVYlsSS_AD_ADtF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(0, 1)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence10BufferViewVyACYlsUSU_SW_SaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1)  @owned BufferView

--- a/test/Serialization/implicit_lifetime_dependence.swift
+++ b/test/Serialization/implicit_lifetime_dependence.swift
@@ -60,16 +60,11 @@ func testReadMutateAccessors() {
   }
 }
 
-// CHECK: sil @$s32def_implicit_lifetime_dependence6deriveyAA10BufferViewVADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0) @owned BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence6deriveyAA10BufferViewVYliS_ADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVYliS_ADnF : $@convention(thin) (@owned BufferView) -> _inherit(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVYliS_ADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence10BufferViewVyACYliSU_AChcfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> _inherit(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence9ContainerV4viewAA10BufferViewVvg : $@convention(method) (@guaranteed Container) -> _scope(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence7WrapperV4viewAA10BufferViewVvr : $@yield_once @convention(method) (@guaranteed Wrapper) -> _inherit(0)  @yields @guaranteed BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence7WrapperV4viewAA10BufferViewVvM : $@yield_once @convention(method) (@inout Wrapper) -> _inherit(0)  @yields @inout BufferView
 
-// CHECK: sil @$s32def_implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnYliF : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView
-
-// CHECK: sil @$s32def_implicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADYliF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0) @owned BufferView
-
-// CHECK: sil @$s32def_implicit_lifetime_dependence10BufferViewVyA2ChYlicfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> _inherit(0) @owned BufferView
-
-// CHECK: sil @$s32def_implicit_lifetime_dependence9ContainerV4viewAA10BufferViewVvg : $@convention(method) (@guaranteed Container) -> _scope(0) @owned BufferView
-
-// CHECK: sil @$s32def_implicit_lifetime_dependence7WrapperV4viewAA10BufferViewVvr : $@yield_once @convention(method) (@guaranteed Wrapper) -> _inherit(0) @yields @guaranteed BufferView
-
-// CHECK: sil @$s32def_implicit_lifetime_dependence7WrapperV4viewAA10BufferViewVvM : $@yield_once @convention(method) (@inout Wrapper) -> _inherit(0) @yields @inout BufferView


### PR DESCRIPTION
Extend support for lifetime dependence in parameter position:

```swift
func mayReassign(span: dependsOn(a) inout Span<Int>, to a: ContiguousArray<Int>) {
  span = a.span()
}
```
https://github.com/swiftlang/swift-evolution/blob/e814e62c17741dfe82e2f55eb1d751157c77a853/proposals/NNNN-lifetime-dependency.md#dependent-parameters contains a detailed explanation 