### PR TITLE
[Driver] Pass `-lld-allow-duplicate-weak` for coverage on Windows

### DIFF
--- a/test/Profiler/coverage_inlined_counters.swift
+++ b/test/Profiler/coverage_inlined_counters.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t/out)
+// RUN: split-file %s %t
+
+// rdar://129337999 - Make sure we can link without issues.
+
+// The legacy driver does not support doing this in one invocation, so split it
+// up for compatibility with both the legacy and new driver.
+// RUN: %target-build-swift -c %t/a.swift -profile-generate -profile-coverage-mapping -parse-as-library -module-name A -o %t/out/a.swift.o
+// RUN: %target-build-swift -emit-module %t/a.swift -profile-generate -profile-coverage-mapping -parse-as-library -module-name A -emit-module-path %t/out/A.swiftmodule
+
+// RUN: %target-build-swift %t/b.swift -profile-generate -profile-coverage-mapping -o %t/main -module-name B -I %t/out %t/out/a.swift.o
+
+// Test again using only the old driver.
+// RUN: %empty-directory(%t/out)
+// RUN: env SWIFT_USE_OLD_DRIVER=1 %target-build-swift -c %t/a.swift -profile-generate -profile-coverage-mapping -parse-as-library -module-name A -o %t/out/a.swift.o
+// RUN: env SWIFT_USE_OLD_DRIVER=1 %target-build-swift -emit-module %t/a.swift -profile-generate -profile-coverage-mapping -parse-as-library -module-name A -emit-module-path %t/out/A.swiftmodule
+// RUN: env SWIFT_USE_OLD_DRIVER=1 %target-build-swift %t/b.swift -profile-generate -profile-coverage-mapping -o %t/main -module-name B -I %t/out %t/out/a.swift.o
+
+// REQUIRES: profile_runtime
+
+//--- a.swift
+@_transparent
+public func foo() {}
+
+//--- b.swift
+import A
+
+foo()

--- a/test/Profiler/coverage_inlined_counters_exec.swift
+++ b/test/Profiler/coverage_inlined_counters_exec.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t/out)
+// RUN: split-file %s %t
+
+// rdar://129337999 - Make sure we can link without issues.
+
+// The legacy driver does not support doing this in one invocation, so split it
+// up for compatibility with both the legacy and new driver.
+// RUN: %target-build-swift -c %t/a.swift -profile-generate -profile-coverage-mapping -parse-as-library -module-name A -o %t/out/a.swift.o
+// RUN: %target-build-swift -emit-module %t/a.swift -profile-generate -profile-coverage-mapping -parse-as-library -module-name A -emit-module-path %t/out/A.swiftmodule
+
+// RUN: %target-build-swift %t/b.swift -profile-generate -profile-coverage-mapping -o %t/main -module-name B -I %t/out %t/out/a.swift.o
+
+// RUN: %target-codesign %t/main
+// RUN: env %env-LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
+
+// RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
+
+// The implicit-check-not here ensures we match all recorded line counts.
+// RUN: %llvm-cov show %t/main -instr-profile=%t/default.profdata | %FileCheck --implicit-check-not "{{[ ]*\|[ ]*[0-9]+}}" %s
+
+// REQUIRES: profile_runtime
+// REQUIRES: executable_test
+
+//--- a.swift
+@_transparent
+public func foo() {}
+// CHECK: 1|public func foo() {}
+
+//--- b.swift
+import A
+
+foo()
+// CHECK: 1|foo()

--- a/test/Profiler/lit.local.cfg
+++ b/test/Profiler/lit.local.cfg
@@ -1,0 +1,6 @@
+# Make a local copy of the environment.
+config.environment = dict(config.environment)
+
+# Prefer the new driver for profiling tests
+del config.environment['SWIFT_USE_OLD_DRIVER']
+del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']


### PR DESCRIPTION
Legacy driver version of swiftlang/swift-driver#1655 + an integration test for both the legacy and new driver.

rdar://129337999