### PR TITLE
[cxx-interop] Minor refactoring: remove a redundant check

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5709,11 +5709,10 @@ void cloneImportedAttributes(ValueDecl *fromDecl, ValueDecl* toDecl) {
       break;
     }
     case DeclAttrKind::Custom: {
-      if (CustomAttr *cAttr = cast<CustomAttr>(attr)) {
-        attrs.add(CustomAttr::create(context, SourceLoc(), cAttr->getTypeExpr(),
-                                     cAttr->getInitContext(), cAttr->getArgs(),
-                                     true));
-      }
+      CustomAttr *cAttr = cast<CustomAttr>(attr);
+      attrs.add(CustomAttr::create(context, SourceLoc(), cAttr->getTypeExpr(),
+                                   cAttr->getInitContext(), cAttr->getArgs(),
+                                   true));
       break;
     }
     case DeclAttrKind::DiscardableResult: {


### PR DESCRIPTION
`cast<CustomAttr>` never returns nullptr, it either returns a non-null `CustomAttr*` or traps. This if condition was triggering a clang-tidy warning, since it is redundant.