### PR TITLE
[cxx-interop] Support optional generic cases in enums

### DIFF
--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -622,7 +622,7 @@ void ClangValueTypePrinter::printTypeGenericTraits(
   os << "namespace swift SWIFT_PRIVATE_ATTR {\n";
 
   if (typeDecl->hasClangNode()) {
-    /// Print a reference to the type metadata fucntion for a C++ type.
+    /// Print a reference to the type metadata function for a C++ type.
     ClangSyntaxPrinter(os).printNamespace(
         cxx_synthesis::getCxxImplNamespaceName(), [&](raw_ostream &os) {
           ClangSyntaxPrinter(os).printCTypeMetadataTypeFunction(
@@ -696,20 +696,23 @@ void ClangValueTypePrinter::printTypeGenericTraits(
     os << "> = true;\n";
   }
 
-  // FIXME: generic support.
-  if (!typeDecl->hasClangNode() && typeMetadataFuncRequirements.empty()) {
+  if (!typeDecl->hasClangNode()) {
     assert(NTD);
-    os << "template<>\n";
+    if (printer.printNominalTypeOutsideMemberDeclTemplateSpecifiers(NTD))
+      os << "template<>\n";
     os << "struct";
     declAndTypePrinter.printAvailability(os, typeDecl);
     os << " implClassFor<";
     printer.printBaseName(typeDecl->getModuleContext());
     os << "::";
-    printer.printBaseName(typeDecl);
+    printer.printNominalTypeReference(NTD, moduleContext);
     os << "> { using type = ";
     printer.printBaseName(typeDecl->getModuleContext());
     os << "::" << cxx_synthesis::getCxxImplNamespaceName() << "::";
     printCxxImplClassName(os, NTD);
+    if (NTD->isGeneric())
+      printer.printGenericSignatureParams(
+          NTD->getGenericSignature().getCanonicalSignature());
     os << "; };\n";
   }
   os << "} // namespace\n";

--- a/test/Interop/SwiftToCxx/generics/generic-enum-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-execution.cpp
@@ -123,6 +123,13 @@ int main() {
     // CHECK-NEXT: after some
     // CHECK-NEXT: destroy-TracksDeinit
   }
+  {
+    auto opt = swift::Optional<int>::some(14);
+    auto x = GenericCustomType<int>::success(opt);
+    auto y = x;
+    assert(y.isSuccess());
+    assert(y.getSuccess().getSome() == 14);
+  }
   puts("EOF");
   // CHECK-NEXT: EOF
   return 0;

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Generics -clang-header-expose-decls=all-public -emit-clang-header-path %t/generics.h
+// RUN: %target-swift-frontend %s -typecheck -module-name Generics -enable-experimental-cxx-interop -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
 // RUN: %check-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
@@ -95,6 +95,16 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 }
 
 // CHECK: namespace Generics SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Generics") {
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: #ifdef __cpp_concepts
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: #endif
+// CHECK-NEXT: class SWIFT_SYMBOL("s:8Generics17GenericCustomTypeO") GenericCustomType;
+
+// CHECK: static inline const constexpr bool isOpaqueLayout<Generics::GenericCustomType<T_0_0>> = true;
+
+// CHECK: template<class T_0_0>
 
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
@@ -217,6 +227,8 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #endif
 // CHECK-NEXT:   _impl::$s8Generics14takeGenericOptyyAA0cD0OyxGlF(_impl::_impl_GenericOpt<T_0_0>::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT: }
+
+// CHECK: SWIFT_INLINE_THUNK  bool GenericCustomType<T_0_0>::isFailure() const {
 
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -285,6 +285,11 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif // __cpp_concepts
 // CHECK-NEXT: static inline const constexpr bool isOpaqueLayout<Generics::GenericPair<T_0_0, T_0_1>> = true;
+// CHECK-NEXT: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: #ifdef __cpp_concepts
+// CHECK-NEXT:  requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: #endif // __cpp_concepts
+// CHECK-NEXT: struct implClassFor<Generics::GenericPair<T_0_0, T_0_1>> { using type = Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>; }
 // CHECK-NEXT: } // namespace
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -48,6 +48,7 @@
 
 // CHECK: template<class T_0_0>
 // CHECK: template<class T_0_0>
+// CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif


### PR DESCRIPTION
This PR implements proper support for optional generic associated values in enum cases. Most of the code changes are supporting generic types in more contexts in the printer, the rest are making sure we handle the null pointer case when we try to get the declaration from the type that represents a generic parameter.

rdar://131112273