### PR TITLE
[6.0] SILGen: Skip function bodies with errors in lazy typechecking mode

### DIFF
--- a/test/SILGen/lazy_typecheck_errors.swift
+++ b/test/SILGen/lazy_typecheck_errors.swift
@@ -53,3 +53,8 @@ public class DerivedFromNonExistent: NonExistent {
 
   public func method() {}
 }
+
+@inlinable public func hasErrorInBody() {
+  nonExistent()
+  // expected-error@-1 {{cannot find 'nonExistent' in scope}}
+}


### PR DESCRIPTION
- **Explanation:** The SILGen pipeline expects function bodies to have been successfully type checked and will usually crash if it attempts to emit SIL for a function that has errors. In lazy typechecking mode, function bodies are type checked on-demand and therefore bodies containing errors can make it to SILGen. To avoid crashing in this scenario, move function body typechecking earlier in lazy typechecking mode and then skip SIL generation whenever any errors have been recorded in the `ASTContext`.
- **Scope:** Affects module emission in builds with lazy typechecking enabled. Fixing this for 6.0 is important because the crashes that occur otherwise make qualification difficult because they obscure project issues.
- **Issue/Radar:** rdar://130777647
- **Original PR:** https://github.com/swiftlang/swift/pull/74837
- **Risk:** Low. The new logic only has an effect when lazy typechecking is enabled, reducing its scope.
- **Testing:** New test case added.
- **Reviewer:** @jckarter 
