### PR TITLE
[Runtime][Win32] Fix fatalError() backtraces.

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -102,25 +102,31 @@ static bool getSymbolNameAddr(llvm::StringRef libraryName,
   // providing failure status instead of just returning the original string like
   // swift demangle.
 #if defined(_WIN32)
-  char szUndName[1024];
-  DWORD dwResult;
-  dwResult = _swift_win32_withDbgHelpLibrary([&] (HANDLE hProcess) -> DWORD {
-    if (!hProcess) {
-      return 0;
-    }
+  const char *szSymbolName = syminfo.getSymbolName();
 
-    DWORD dwFlags = UNDNAME_COMPLETE;
+  // UnDecorateSymbolName() will not fail for Swift symbols, so detect them
+  // up-front and let Swift handle them.
+  if (!Demangle::isMangledName(syminfo.getSymbolName())) {
+    char szUndName[1024];
+    DWORD dwResult;
+    dwResult = _swift_win32_withDbgHelpLibrary([&] (HANDLE hProcess) -> DWORD {
+      if (!hProcess) {
+        return 0;
+      }
+
+      DWORD dwFlags = UNDNAME_COMPLETE;
 #if !defined(_WIN64)
-    dwFlags |= UNDNAME_32_BIT_DECODE;
+      dwFlags |= UNDNAME_32_BIT_DECODE;
 #endif
 
-    return UnDecorateSymbolName(syminfo.getSymbolName(), szUndName,
-                                sizeof(szUndName), dwFlags);
-  });
+      return UnDecorateSymbolName(syminfo.getSymbolName(), szUndName,
+                                  sizeof(szUndName), dwFlags);
+    });
 
-  if (dwResult) {
-    symbolName += szUndName;
-    return true;
+    if (dwResult) {
+      symbolName += szUndName;
+      return true;
+    }
   }
 #else
   int status;
@@ -151,6 +157,9 @@ void swift::dumpStackTraceEntry(unsigned index, void *framePC,
 #if SWIFT_STDLIB_SUPPORTS_BACKTRACE_REPORTING && SWIFT_STDLIB_HAS_DLADDR
   auto syminfo = SymbolInfo::lookup(framePC);
   if (!syminfo.has_value()) {
+    constexpr const char *format = "%-4u %-34s 0x%0.16tx\n";
+    fprintf(stderr, format, index, "<unknown>",
+            reinterpret_cast<uintptr_t>(framePC));
     return;
   }
 
@@ -159,7 +168,12 @@ void swift::dumpStackTraceEntry(unsigned index, void *framePC,
   // is not provided in the header so that it requires linking with
   // libSupport.a.
   llvm::StringRef libraryName{syminfo->getFilename()};
+
+#ifdef _WIN32
+  libraryName = libraryName.substr(libraryName.rfind('\\')).substr(1);
+#else
   libraryName = libraryName.substr(libraryName.rfind('/')).substr(1);
+#endif
 
   // Next we get the symbol name that we are going to use in our backtrace.
   std::string symbolName;
@@ -179,6 +193,11 @@ void swift::dumpStackTraceEntry(unsigned index, void *framePC,
     symbolName = "<unavailable>";
   }
 
+  const char *libraryNameStr = libraryName.data();
+
+  if (!libraryNameStr)
+    libraryNameStr = "<unknown>";
+
   // We do not use %p here for our pointers since the format is implementation
   // defined. This makes it logically impossible to check the output. Forcing
   // hexadecimal solves this issue.
@@ -187,11 +206,11 @@ void swift::dumpStackTraceEntry(unsigned index, void *framePC,
   // This gives enough info to reconstruct identical debugging target after
   // this process terminates.
   if (shortOutput) {
-    fprintf(stderr, "%s`%s + %td", libraryName.data(), symbolName.c_str(),
+    fprintf(stderr, "%s`%s + %td", libraryNameStr, symbolName.c_str(),
             offset);
   } else {
     constexpr const char *format = "%-4u %-34s 0x%0.16" PRIxPTR " %s + %td\n";
-    fprintf(stderr, format, index, libraryName.data(), symbolAddr,
+    fprintf(stderr, format, index, libraryNameStr, symbolAddr,
             symbolName.c_str(), offset);
   }
 #else

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -106,7 +106,7 @@ static bool getSymbolNameAddr(llvm::StringRef libraryName,
 
   // UnDecorateSymbolName() will not fail for Swift symbols, so detect them
   // up-front and let Swift handle them.
-  if (!Demangle::isMangledName(syminfo.getSymbolName())) {
+  if (!Demangle::isMangledName(szSymbolName)) {
     char szUndName[1024];
     DWORD dwResult;
     dwResult = _swift_win32_withDbgHelpLibrary([&] (HANDLE hProcess) -> DWORD {
@@ -119,7 +119,7 @@ static bool getSymbolNameAddr(llvm::StringRef libraryName,
       dwFlags |= UNDNAME_32_BIT_DECODE;
 #endif
 
-      return UnDecorateSymbolName(syminfo.getSymbolName(), szUndName,
+      return UnDecorateSymbolName(szSymbolName, szUndName,
                                   sizeof(szUndName), dwFlags);
     });
 

--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -31,6 +31,7 @@ using namespace swift;
 #if defined(_WIN32)
 static LazyMutex mutex;
 static HANDLE dbgHelpHandle = nullptr;
+static bool isDbgHelpInitialized = false;
 
 void _swift_win32_withDbgHelpLibrary(
   void (* body)(HANDLE hProcess, void *context), void *context) {
@@ -54,8 +55,7 @@ void _swift_win32_withDbgHelpLibrary(
     }
 
     // If we have not previously initialized the Debug Help library, do so now.
-    bool isDbgHelpInitialized = false;
-    if (dbgHelpHandle) {
+    if (dbgHelpHandle && !isDbgHelpInitialized) {
       isDbgHelpInitialized = SymInitialize(dbgHelpHandle, nullptr, true);
     }
 

--- a/stdlib/public/runtime/SymbolInfo.cpp
+++ b/stdlib/public/runtime/SymbolInfo.cpp
@@ -17,6 +17,7 @@
 #define NOMINMAX
 #include <Windows.h>
 #include <DbgHelp.h>
+#include <psapi.h>
 #elif SWIFT_STDLIB_HAS_DLADDR
 #include <dlfcn.h>
 #endif
@@ -29,7 +30,7 @@ using namespace swift;
 
 const char *SymbolInfo::getFilename() const {
 #if defined(_WIN32) && !defined(__CYGWIN__)
-  return nullptr;
+  return _moduleFileName;
 #elif SWIFT_STDLIB_HAS_DLADDR
   return _info.dli_fname;
 #else
@@ -39,7 +40,7 @@ const char *SymbolInfo::getFilename() const {
 
 const void *SymbolInfo::getBaseAddress() const {
 #if defined(_WIN32) && !defined(__CYGWIN__)
-  return reinterpret_cast<const void *>(_package.si.ModBase);
+  return _moduleBaseAddress;
 #elif SWIFT_STDLIB_HAS_DLADDR
   return _info.dli_fbase;
 #else
@@ -49,7 +50,7 @@ const void *SymbolInfo::getBaseAddress() const {
 
 const char *SymbolInfo::getSymbolName() const {
 #if defined(_WIN32) && !defined(__CYGWIN__)
-  return _package.si.Name;
+  return _symbolName;
 #elif SWIFT_STDLIB_HAS_DLADDR
   return _info.dli_sname;
 #else
@@ -59,7 +60,7 @@ const char *SymbolInfo::getSymbolName() const {
 
 const void *SymbolInfo::getSymbolAddress() const {
 #if defined(_WIN32) && !defined(__CYGWIN__)
-  return reinterpret_cast<const void *>(_package.si.Address);
+  return _symbolAddress;
 #elif SWIFT_STDLIB_HAS_DLADDR
   return _info.dli_saddr;
 #else
@@ -67,34 +68,111 @@ const void *SymbolInfo::getSymbolAddress() const {
 #endif
 }
 
-std::optional<SymbolInfo> SymbolInfo::lookup(const void *address) {
-  std::optional<SymbolInfo> result;
+#if defined(_WIN32) && !defined(__CYGWIN__)
+struct Win32ModuleInfo {
+  const char *name;
+  const void *base;
 
+  Win32ModuleInfo(const char *n, const void *b) : name(n), base(b) {}
+};
+
+// Get the filename and base of the module that contains the specified
+// address.  N.B. This returns a malloc()ed copy of the filename in the
+// Win32ModuleInfo struct; you are responsible for freeing that.
+static Win32ModuleInfo moduleInfoFromAddress(const void *address) {
+  HMODULE hModule;
+  if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                        | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                         (LPCTSTR)address,
+                         &hModule)) {
+    MODULEINFO mi;
+
+    if (!GetModuleInformation(GetCurrentProcess(), hModule,
+                              &mi, sizeof(mi))) {
+      ::memset(&mi, 0, sizeof(mi));
+    }
+
+    WCHAR wszBuffer[256];
+    LPWSTR pwszFileName = wszBuffer;
+    DWORD dwCapacity = sizeof(wszBuffer) / sizeof(WCHAR);
+    DWORD dwRet = GetModuleFileNameW(hModule, pwszFileName, dwCapacity);
+
+    if (dwRet == dwCapacity) {
+      dwCapacity = 512;
+
+      pwszFileName = (LPWSTR)::malloc(sizeof(WCHAR) * dwCapacity);
+      while (true) {
+        dwRet = GetModuleFileNameW(hModule, pwszFileName, dwCapacity);
+        if (dwRet != dwCapacity)
+          break;
+
+        dwCapacity *= 2;
+
+        pwszFileName = (LPWSTR)::realloc(pwszFileName,
+                                         sizeof(WCHAR) * dwCapacity);
+      }
+    }
+
+    if (dwRet == 0) {
+      if (pwszFileName != wszBuffer)
+        ::free(pwszFileName);
+
+      return Win32ModuleInfo(::strdup("<unknown>"), mi.lpBaseOfDll);
+    }
+
+    const char *result = _swift_win32_copyUTF8FromWide(pwszFileName);
+
+    if (pwszFileName != wszBuffer)
+      ::free((void *)pwszFileName);
+
+    return Win32ModuleInfo(result, mi.lpBaseOfDll);
+  } else {
+    return Win32ModuleInfo(::strdup("<unknown>"), nullptr);
+  }
+}
+#endif
+
+std::optional<SymbolInfo> SymbolInfo::lookup(const void *address) {
 #if defined(__wasm__)
   // Currently, Wasm doesn't have a standard stable ABI for exporting address <->
   // symbol table, it's work in progress. Also, there is no API to access such
   // information from Wasm binary side. It's accessible only from host VM.
   // See https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md
 #elif defined(_WIN32) && !defined(__CYGWIN__)
+  Win32ModuleInfo moduleInfo = moduleInfoFromAddress(address);
+  SYMBOL_INFO_PACKAGE package;
+  BOOL bRet;
+
+  package.si.SizeOfStruct = sizeof(SYMBOL_INFO);
+  package.si.MaxNameLen = MAX_SYM_NAME;
+
   _swift_win32_withDbgHelpLibrary([&] (HANDLE hProcess) {
     if (!hProcess) {
-        return;
+      bRet = false;
+      return;
     }
 
-    SymbolInfo info;
-    info._package.si.SizeOfStruct = sizeof(SYMBOL_INFO);
-    info._package.si.MaxNameLen = MAX_SYM_NAME;
-    if (SymFromAddr(hProcess, reinterpret_cast<const DWORD64>(address),
-                    nullptr, &info._package.si)) {
-      result = info;
-    }
+    bRet = SymFromAddr(hProcess, reinterpret_cast<const DWORD64>(address),
+                       nullptr, &package.si);
   });
+
+  if (bRet) {
+    return SymbolInfo((const void *)package.si.Address,
+                      ::strdup(package.si.Name),
+                      moduleInfo.name,
+                      moduleInfo.base);
+  } else {
+    return SymbolInfo(address,
+                      nullptr,
+                      moduleInfo.name,
+                      moduleInfo.base);
+  }
 #elif SWIFT_STDLIB_HAS_DLADDR
   SymbolInfo info;
   if (dladdr(address, &info._info)) {
-    result = info;
+    return info;
   }
 #endif
 
-  return result;
+  return {};
 }

--- a/stdlib/public/runtime/SymbolInfo.cpp
+++ b/stdlib/public/runtime/SymbolInfo.cpp
@@ -77,7 +77,7 @@ struct Win32ModuleInfo {
 };
 
 // Get the filename and base of the module that contains the specified
-// address.  N.B. This returns a malloc()ed copy of the filename in the
+// address.  N.B. This returns a `malloc`-ed copy of the filename in the
 // Win32ModuleInfo struct; you are responsible for freeing that.
 static Win32ModuleInfo moduleInfoFromAddress(const void *address) {
   HMODULE hModule;
@@ -89,12 +89,12 @@ static Win32ModuleInfo moduleInfoFromAddress(const void *address) {
 
     if (!GetModuleInformation(GetCurrentProcess(), hModule,
                               &mi, sizeof(mi))) {
-      ::memset(&mi, 0, sizeof(mi));
+      ZeroMemory(&mi, sizeof(mi));
     }
 
     WCHAR wszBuffer[256];
     LPWSTR pwszFileName = wszBuffer;
-    DWORD dwCapacity = sizeof(wszBuffer) / sizeof(WCHAR);
+    DWORD dwCapacity = sizeof(wszBuffer) / sizeof(*wszBuffer);
     DWORD dwRet = GetModuleFileNameW(hModule, pwszFileName, dwCapacity);
 
     if (dwRet == dwCapacity) {

--- a/stdlib/public/runtime/SymbolInfo.cpp
+++ b/stdlib/public/runtime/SymbolInfo.cpp
@@ -72,8 +72,6 @@ const void *SymbolInfo::getSymbolAddress() const {
 struct Win32ModuleInfo {
   const char *name;
   const void *base;
-
-  Win32ModuleInfo(const char *n, const void *b) : name(n), base(b) {}
 };
 
 // Get the filename and base of the module that contains the specified
@@ -117,7 +115,7 @@ static Win32ModuleInfo moduleInfoFromAddress(const void *address) {
       if (pwszFileName != wszBuffer)
         ::free(pwszFileName);
 
-      return Win32ModuleInfo(::strdup("<unknown>"), mi.lpBaseOfDll);
+      return { ::strdup("<unknown>"), mi.lpBaseOfDll };
     }
 
     const char *result = _swift_win32_copyUTF8FromWide(pwszFileName);
@@ -125,9 +123,9 @@ static Win32ModuleInfo moduleInfoFromAddress(const void *address) {
     if (pwszFileName != wszBuffer)
       ::free((void *)pwszFileName);
 
-    return Win32ModuleInfo(result, mi.lpBaseOfDll);
+    return { result, mi.lpBaseOfDll };
   } else {
-    return Win32ModuleInfo(::strdup("<unknown>"), nullptr);
+    return { ::strdup("<unknown>"), nullptr };
   }
 }
 #endif

--- a/stdlib/public/runtime/SymbolInfo.h
+++ b/stdlib/public/runtime/SymbolInfo.h
@@ -61,38 +61,40 @@ private:
       _moduleFileName(moduleFileName),
       _moduleBaseAddress(moduleBaseAddress)
   {}
+
+  void initializeFrom(const SymbolInfo &other) {
+    _symbolAddress = other._symbolAddress;
+    _symbolName = ::strdup(other._symbolName);
+    _moduleFileName = ::strdup(other._moduleFileName);
+    _moduleBaseAddress = other._moduleBaseAddress;
+  }
+
+  void deinitialize() {
+    ::free((void *)_moduleFileName);
+    ::free((void *)_symbolName);
+    _moduleFileName = nullptr;
+    _symbolName = nullptr;
+  }
 #endif
 
 public:
-  SymbolInfo() {}
-
 #if defined(_WIN32) && !defined(__CYGWIN__)
+  SymbolInfo() : _symbolName(nullptr), _moduleFileName(nullptr) {}
+
   SymbolInfo(const SymbolInfo &other) {
-    _symbolName = nullptr;
-    _moduleFileName = nullptr;
-    *this = other;
+    initializeFrom(other);
   }
   SymbolInfo(SymbolInfo &&other) {
     *this = std::move(other);
   }
   ~SymbolInfo() {
-    if (_moduleFileName)
-      ::free((void *)_moduleFileName);
-    if (_symbolName)
-      ::free((void *)_symbolName);
+    deinitialize();
   }
 
   SymbolInfo &operator=(const SymbolInfo &other) {
     if (this != &other) {
-      if (_moduleFileName)
-        ::free((void *)_moduleFileName);
-      if (_symbolName)
-        ::free((void *)_symbolName);
-
-      _symbolAddress = other._symbolAddress;
-      _symbolName = ::strdup(other._symbolName);
-      _moduleFileName = ::strdup(other._moduleFileName);
-      _moduleBaseAddress = other._moduleBaseAddress;
+      deinitialize();
+      initializeFrom(other);
     }
 
     return *this;
@@ -109,6 +111,8 @@ public:
 
     return *this;
   }
+#else
+  SymbolInfo() {}
 #endif
 
   /// Get the file name of the image where the symbol was found.


### PR DESCRIPTION
We were calling `SymInitialize()` multiple times, which is wrong, which was making the `SymbolInfo::lookup()` call fail.  Also, we weren't fetching the module names, so we should do that too.

rdar://130992923
