### PR TITLE
[6.0][Concurrency] Fix disallowed override isolation to carry `@preconcurr…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5274,7 +5274,12 @@ ActorIsolation ActorIsolationRequest::evaluate(
           break;
 
         case OverrideIsolationResult::Disallowed:
-          inferred = *overriddenIso;
+          if (overriddenValue->hasClangNode() &&
+              overriddenIso->isUnspecified()) {
+            inferred = overriddenIso->withPreconcurrency(true);
+          } else {
+            inferred = *overriddenIso;
+          }
           break;
         }
       }

--- a/test/ClangImporter/objc_isolation_complete.swift
+++ b/test/ClangImporter/objc_isolation_complete.swift
@@ -31,3 +31,16 @@ class IsolatedSub: NXSender {
     return mainActorState
   }
 }
+
+@objc
+@MainActor
+class Test : NSObject {
+  static var shared: Test? // expected-note {{mutation of this static property is only permitted within the actor}}
+
+  override init() {
+    super.init()
+
+    Self.shared = self
+    // expected-warning@-1 {{main actor-isolated static property 'shared' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+  }
+}


### PR DESCRIPTION
…ency` bit

- Explanation:

Fixes a source compatibility regression in `complete` checking mode.
 
If ObjC member cannot be overridden due to isolation mismatch set `@preconcurrency` bit to make the diagnostic a warning instead of an error in Swift 5 mode.

- Main Branch PR: https://github.com/swiftlang/swift/pull/75087

- Resolves: rdar://130776220

- Risk: Low

- Reviewed By: @hborla 

- Testing: New tests were added to the suite.


(cherry picked from commit f7d3230535fa4c840c728718d6f5154c6a4bcd16)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
