### PR TITLE
[6.0][Basic] Don't rewrite source buffer copy multiple times

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -71,7 +71,7 @@ public:
 
   /// The name of the source file on disk that was created to hold the
   /// contents of this file for external clients.
-  StringRef onDiskBufferCopyFileName = StringRef();
+  mutable StringRef onDiskBufferCopyFileName = StringRef();
 
   /// Contains the ancestors of this source buffer, starting with the root source
   /// buffer and ending at this source buffer.
@@ -209,8 +209,7 @@ public:
   bool hasGeneratedSourceInfo(unsigned bufferID);
 
   /// Retrieve the generated source information for the given buffer.
-  std::optional<GeneratedSourceInfo>
-  getGeneratedSourceInfo(unsigned bufferID) const;
+  const GeneratedSourceInfo *getGeneratedSourceInfo(unsigned bufferID) const;
 
   /// Retrieve the list of ancestors of the given source buffer, starting with
   /// the root buffer and proceding to the given buffer ID at the end.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -906,7 +906,7 @@ ModuleDecl::getOriginalLocation(SourceLoc loc) const {
 
   SourceLoc startLoc = loc;
   unsigned startBufferID = bufferID;
-  while (std::optional<GeneratedSourceInfo> info =
+  while (const GeneratedSourceInfo *info =
              SM.getGeneratedSourceInfo(bufferID)) {
     switch (info->kind) {
 #define MACRO_ROLE(Name, Description)  \

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -287,7 +287,8 @@ StringRef SourceManager::getIdentifierForBuffer(
   // If this is generated source code, and we're supposed to force it to disk
   // so external clients can see it, do so now.
   if (ForceGeneratedSourceToDisk) {
-    if (auto generatedInfo = getGeneratedSourceInfo(bufferID)) {
+    if (const GeneratedSourceInfo *generatedInfo =
+            getGeneratedSourceInfo(bufferID)) {
       // We only care about macros, so skip everything else.
       if (generatedInfo->kind == GeneratedSourceInfo::ReplacedFunctionBody ||
           generatedInfo->kind == GeneratedSourceInfo::PrettyPrinted ||
@@ -402,12 +403,12 @@ bool SourceManager::hasGeneratedSourceInfo(unsigned bufferID) {
   return GeneratedSourceInfos.count(bufferID);
 }
 
-std::optional<GeneratedSourceInfo>
+const GeneratedSourceInfo *
 SourceManager::getGeneratedSourceInfo(unsigned bufferID) const {
   auto known = GeneratedSourceInfos.find(bufferID);
   if (known == GeneratedSourceInfos.end())
-    return std::nullopt;
-  return known->second;
+    return nullptr;
+  return &known->second;
 }
 
 namespace {

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -284,7 +284,7 @@ static DeclContext *getInnermostFunctionContext(DeclContext *DC) {
 }
 
 /// Return location of the macro expansion and the macro name.
-static MacroInfo getMacroInfo(GeneratedSourceInfo &Info,
+static MacroInfo getMacroInfo(const GeneratedSourceInfo &Info,
                               DeclContext *FunctionDC) {
   MacroInfo Result(Info.generatedSourceRange.getStart(),
                    Info.originalSourceRange.getStart());


### PR DESCRIPTION
Cherry-pick #75115 into `release/6.0`

* **Explanation**: When writing out a macro-synthesized buffer to the file system, the file name is supposed to be recorded in the source manager. Previously however, the logic setting the file name was updating the _copy_ of the information, not the actual information in the source manager. This change fixes that issue by returning the pointer to the information instead of the copy.
* **Scope**: Macros
* **Risk**: Low. Other places using the function should keep working.
* **Testing**: Passes current test suite. No test update because there's no "visible" behavior change.
* **Issues**: rdar://130478685
* **Reviewer**: Ben Barham (@bnbarham), Doug Gregor (@DougGregor)

