### PR TITLE
[Concurrency] Don't infer actor isolation from inherited conformances.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4648,8 +4648,19 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
     return std::nullopt;
 
   std::optional<ActorIsolation> foundIsolation;
-  for (auto proto :
-       nominal->getLocalProtocols(ConformanceLookupKind::NonStructural)) {
+  for (auto conformance :
+       nominal->getLocalConformances(ConformanceLookupKind::NonStructural)) {
+
+    // Don't include inherited conformances. If a conformance is inherited
+    // from a superclass, the isolation of the subclass should be inferred
+    // from the superclass, which is done directly in ActorIsolationRequest.
+    // If the superclass has opted out of global actor inference, such as
+    // by conforming to the protocol in an extension, then the subclass should
+    // not infer isolation from the protocol.
+    if (conformance->getKind() == ProtocolConformanceKind::Inherited)
+      continue;
+
+    auto *proto = conformance->getProtocol();
     switch (auto protoIsolation = getActorIsolation(proto)) {
     case ActorIsolation::ActorInstance:
     case ActorIsolation::Unspecified:

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -213,3 +213,13 @@ class C2: MainActorSuperclass, InferenceConflictWithSuperclass {
 }
 
 
+class ConformInExtension {}
+extension ConformInExtension: InferMainActor {}
+
+class InheritConformance: ConformInExtension {
+  func f() {}
+}
+
+func testInheritedMainActorConformance() {
+  InheritConformance().f() // okay; this is not main actor isolated
+}


### PR DESCRIPTION
If a conformance is inherited from a superclass, the isolation of the subclass should be inferred directly from the superclass. If the superclass has opted out of global actor inference from a protocol, such as by conforming to the protocol in an extension, then the subclass should not infer isolation from the protocol.


Resolves: https://github.com/swiftlang/swift/issues/74274, rdar://129540677