### PR TITLE
[AVR] standard library support for AVR

### DIFF
--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -109,6 +109,7 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name)
   if (GYB_ARCH)
     set_if_arch_bitness(ptr_size
       ARCH "${GYB_ARCH}"
+      CASE_16_BIT "2"
       CASE_32_BIT "4"
       CASE_64_BIT "8")
     set(extra_gyb_flags "-DCMAKE_SIZEOF_VOID_P=${ptr_size}")

--- a/cmake/modules/SwiftSetIfArchBitness.cmake
+++ b/cmake/modules/SwiftSetIfArchBitness.cmake
@@ -2,11 +2,13 @@ function(set_if_arch_bitness var_name)
   cmake_parse_arguments(
       SIA # prefix
       "" # options
-      "ARCH;CASE_32_BIT;CASE_64_BIT" # single-value args
+      "ARCH;CASE_16_BIT;CASE_32_BIT;CASE_64_BIT" # single-value args
       "" # multi-value args
       ${ARGN})
 
-  if("${SIA_ARCH}" STREQUAL "i386" OR
+  if("${SIA_ARCH}" STREQUAL "avr")
+      set("${var_name}" "${SIA_CASE_16_BIT}" PARENT_SCOPE)
+  elseif("${SIA_ARCH}" STREQUAL "i386" OR
      "${SIA_ARCH}" STREQUAL "i686" OR
      "${SIA_ARCH}" STREQUAL "x86" OR
      "${SIA_ARCH}" STREQUAL "armv4t" OR

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -110,6 +110,7 @@ static const SupportedConditionalValue SupportedConditionalCompilationEndianness
 };
 
 static const SupportedConditionalValue SupportedConditionalCompilationPointerBitWidths[] = {
+  "_16",
   "_32",
   "_64"
 };
@@ -568,7 +569,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   }
 
   // Set the "_pointerBitWidth" platform condition.
-  if (Target.isArch32Bit()) {
+  if (Target.isArch16Bit()) {
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_16");
+  } else if (Target.isArch32Bit()) {
     addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_32");
   } else if (Target.isArch64Bit()) {
     addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_64");

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -290,14 +290,14 @@ getSwiftStdlibType(const clang::TypedefNameDecl *D,
     break;
 
   case MappedCTypeKind::UnsignedWord:
-    if (ClangTypeSize != 64 && ClangTypeSize != 32)
+    if (ClangTypeSize != 64 && ClangTypeSize != 32 && ClangTypeSize != 16)
       return std::make_pair(Type(), "");
     if (!ClangType->isUnsignedIntegerType())
       return std::make_pair(Type(), "");
     break;
 
   case MappedCTypeKind::SignedWord:
-    if (ClangTypeSize != 64 && ClangTypeSize != 32)
+    if (ClangTypeSize != 64 && ClangTypeSize != 32 && ClangTypeSize != 16)
       return std::make_pair(Type(), "");
     if (!ClangType->isSignedIntegerType())
       return std::make_pair(Type(), "");

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -214,6 +214,12 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
       "wasm64    wasm64-unknown-none-wasm    wasm64-unknown-none-wasm"
     )
   endif()
+
+  if("AVR" IN_LIST LLVM_TARGETS_TO_BUILD)
+    list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+      "avr  avr-none-none-elf    avr-none-none-elf"
+    )
+  endif()  
 endif()
 
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)

--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -142,6 +142,11 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     list(GET list 0 arch)
     list(GET list 1 mod)
     list(GET list 2 triple)
+
+    # Disable the Synchronization library on AVR for now.
+    if("${arch}" MATCHES "avr")
+      continue()
+    endif()
     
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")

--- a/stdlib/public/core/AtomicInt.swift.gyb
+++ b/stdlib/public/core/AtomicInt.swift.gyb
@@ -74,6 +74,9 @@ internal func _swift_stdlib_atomicCompareExchangeStrongInt(
 #elseif _pointerBitWidth(_32)
   let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int32(
     target._rawValue, expected.pointee._value, desired._value)
+#elseif _pointerBitWidth(_16)
+  let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int16(
+    target._rawValue, expected.pointee._value, desired._value)
 #else
 #error("Unknown platform")
 #endif
@@ -93,6 +96,9 @@ func _swift_stdlib_atomicLoadInt(
 #elseif _pointerBitWidth(_32)
   let value = Builtin.atomicload_seqcst_Int32(target._rawValue)
   return Int(value)
+#elseif _pointerBitWidth(_16)
+  let value = Builtin.atomicload_seqcst_Int16(target._rawValue)
+  return Int(value)
 #else
 #error("Unknown platform")
 #endif
@@ -106,6 +112,8 @@ internal func _swift_stdlib_atomicStoreInt(
   Builtin.atomicstore_seqcst_Int64(target._rawValue, desired._value)
 #elseif _pointerBitWidth(_32)
   Builtin.atomicstore_seqcst_Int32(target._rawValue, desired._value)
+#elseif _pointerBitWidth(_16)
+  Builtin.atomicstore_seqcst_Int16(target._rawValue, desired._value)
 #else
 #error("Unknown platform")
 #endif
@@ -128,13 +136,17 @@ func _swift_stdlib_atomicFetch${operation}Int(
   let value = _swift_stdlib_atomicFetch${operation}Int32(
     object: rawTarget.assumingMemoryBound(to: Int32.self),
     operand: Int32(operand))
+#elseif _pointerBitWidth(_16)
+  let value = _swift_stdlib_atomicFetch${operation}Int16(
+    object: rawTarget.assumingMemoryBound(to: Int16.self),
+    operand: Int16(operand))
 #else
 #error("Unknown platform")
 #endif
   return Int(value)
 }
 
-%   for bits in [ 32, 64 ]:
+%   for bits in [ 16, 32, 64 ]:
 
 // Warning: no overflow checking.
 @usableFromInline // used by SwiftPrivate._stdlib_AtomicInt

--- a/stdlib/public/core/AtomicInt.swift.gyb
+++ b/stdlib/public/core/AtomicInt.swift.gyb
@@ -74,9 +74,6 @@ internal func _swift_stdlib_atomicCompareExchangeStrongInt(
 #elseif _pointerBitWidth(_32)
   let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int32(
     target._rawValue, expected.pointee._value, desired._value)
-#elseif _pointerBitWidth(_16)
-  let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int16(
-    target._rawValue, expected.pointee._value, desired._value)
 #else
 #error("Unknown platform")
 #endif
@@ -96,9 +93,6 @@ func _swift_stdlib_atomicLoadInt(
 #elseif _pointerBitWidth(_32)
   let value = Builtin.atomicload_seqcst_Int32(target._rawValue)
   return Int(value)
-#elseif _pointerBitWidth(_16)
-  let value = Builtin.atomicload_seqcst_Int16(target._rawValue)
-  return Int(value)
 #else
 #error("Unknown platform")
 #endif
@@ -112,8 +106,6 @@ internal func _swift_stdlib_atomicStoreInt(
   Builtin.atomicstore_seqcst_Int64(target._rawValue, desired._value)
 #elseif _pointerBitWidth(_32)
   Builtin.atomicstore_seqcst_Int32(target._rawValue, desired._value)
-#elseif _pointerBitWidth(_16)
-  Builtin.atomicstore_seqcst_Int16(target._rawValue, desired._value)
 #else
 #error("Unknown platform")
 #endif
@@ -136,17 +128,13 @@ func _swift_stdlib_atomicFetch${operation}Int(
   let value = _swift_stdlib_atomicFetch${operation}Int32(
     object: rawTarget.assumingMemoryBound(to: Int32.self),
     operand: Int32(operand))
-#elseif _pointerBitWidth(_16)
-  let value = _swift_stdlib_atomicFetch${operation}Int16(
-    object: rawTarget.assumingMemoryBound(to: Int16.self),
-    operand: Int16(operand))
 #else
 #error("Unknown platform")
 #endif
   return Int(value)
 }
 
-%   for bits in [ 16, 32, 64 ]:
+%   for bits in [ 32, 64 ]:
 
 // Warning: no overflow checking.
 @usableFromInline // used by SwiftPrivate._stdlib_AtomicInt

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -429,6 +429,8 @@ internal var _objectPointerIsObjCBit: UInt {
     return 0x4000_0000_0000_0000
 #elseif _pointerBitWidth(_32)
     return 0x0000_0002
+#elseif _pointerBitWidth(_16)
+    return 0x0000
 #else
 #error("Unknown platform")
 #endif

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -25,10 +25,14 @@ public typealias CUnsignedChar = UInt8
 public typealias CUnsignedShort = UInt16
 
 /// The C 'unsigned int' type.
+#if  _pointerBitWidth(_16)
+public typealias CUnsignedInt = UInt
+#else
 public typealias CUnsignedInt = UInt32
+#endif
 
 /// The C 'unsigned long' type.
-#if os(Windows) && (arch(x86_64) || arch(arm64))
+#if (os(Windows) && (arch(x86_64) || arch(arm64))) || _pointerBitWidth(_16)
 public typealias CUnsignedLong = UInt32
 #else
 public typealias CUnsignedLong = UInt
@@ -44,10 +48,14 @@ public typealias CSignedChar = Int8
 public typealias CShort = Int16
 
 /// The C 'int' type.
+#if  _pointerBitWidth(_16)
+public typealias CInt = Int
+#else
 public typealias CInt = Int32
+#endif
 
 /// The C 'long' type.
-#if os(Windows) && (arch(x86_64) || arch(arm64))
+#if (os(Windows) && (arch(x86_64) || arch(arm64))) || _pointerBitWidth(_16)
 public typealias CLong = Int32
 #else
 public typealias CLong = Int

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -41,9 +41,12 @@ public struct HeapObject {
 #if _pointerBitWidth(_64)
   static let doNotFreeBit = Int(bitPattern: 0x8000_0000_0000_0000)
   static let refcountMask = Int(bitPattern: 0x7fff_ffff_ffff_ffff)
-#else
+#elseif _pointerBitWidth(_32)
   static let doNotFreeBit = Int(bitPattern: 0x8000_0000)
   static let refcountMask = Int(bitPattern: 0x7fff_ffff)
+#elseif _pointerBitWidth(_16)
+  static let doNotFreeBit = Int(bitPattern: 0x8000)
+  static let refcountMask = Int(bitPattern: 0x7fff)
 #endif
 
   // Note: The immortalRefCount value of -1 is also hard-coded in IRGen in `irgen::emitConstantObject`.
@@ -55,8 +58,10 @@ public struct HeapObject {
 
 #if _pointerBitWidth(_64)
   static let bridgeObjectToPlainObjectMask = UInt(0x8fff_ffff_ffff_fff8)
-#else
+#elseif _pointerBitWidth(_32)
   static let bridgeObjectToPlainObjectMask = UInt(0xffff_ffff)
+#elseif _pointerBitWidth(_16)
+  static let bridgeObjectToPlainObjectMask = UInt(0xffff)
 #endif
 }
 

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -164,6 +164,8 @@ extension Hasher {
       combine(UInt64(truncatingIfNeeded: value))
 #elseif _pointerBitWidth(_32)
       combine(UInt32(truncatingIfNeeded: value))
+#elseif _pointerBitWidth(_16)
+      combine(UInt16(truncatingIfNeeded: value))
 #else
 #error("Unknown platform")
 #endif
@@ -439,7 +441,7 @@ public struct Hasher {
     _internalInvariant(UInt.bitWidth == UInt64.bitWidth)
     state.compress(UInt64(truncatingIfNeeded: value))
     let tbc = _TailBuffer(tail: 0, byteCount: 8)
-#elseif _pointerBitWidth(_32)
+#elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
     _internalInvariant(UInt.bitWidth < UInt64.bitWidth)
     let tbc = _TailBuffer(
       tail: UInt64(truncatingIfNeeded: value),

--- a/stdlib/public/core/Int128.swift
+++ b/stdlib/public/core/Int128.swift
@@ -456,6 +456,8 @@ extension Int128: BinaryInteger {
     UInt(Builtin.trunc_Int128_Int64(_value))
 #elseif _pointerBitWidth(_32)
     UInt(Builtin.trunc_Int128_Int32(_value))
+#elseif _pointerBitWidth(_16)
+    UInt(Builtin.trunc_Int128_Int16(_value))
 #else
 #error("Unsupported platform")
 #endif

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1659,7 +1659,9 @@ ${assignmentOperatorComment(x.operator, True)}
   @_transparent
   public // @testable
   init(_ _v: Builtin.Word) {
-% if BuiltinName == 'Int32':
+% if BuiltinName == 'Int16':
+    self._value = Builtin.truncOrBitCast_Word_Int16(_v)
+% elif BuiltinName == 'Int32':
     self._value = Builtin.truncOrBitCast_Word_Int32(_v)
 % elif BuiltinName == 'Int64':
     self._value = Builtin.${z}extOrBitCast_Word_Int64(_v)
@@ -1669,7 +1671,9 @@ ${assignmentOperatorComment(x.operator, True)}
   @_transparent
   public // @testable
   var _builtinWordValue: Builtin.Word {
-% if BuiltinName == 'Int32':
+% if BuiltinName == 'Int16':
+    return Builtin.${z}extOrBitCast_Int16_Word(_value)
+% elif BuiltinName == 'Int32':
     return Builtin.${z}extOrBitCast_Int32_Word(_value)
 % elif BuiltinName == 'Int64':
     return Builtin.truncOrBitCast_Int64_Word(_value)

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -79,7 +79,7 @@ internal struct _SmallString {
 extension _SmallString {
   @inlinable @inline(__always)
   internal static var capacity: Int {
-#if _pointerBitWidth(_32)
+#if _pointerBitWidth(_32) || _pointerBitWidth(_16)
     return 10
 #elseif os(Android) && arch(arm64)
     return 14

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -201,7 +201,7 @@ extension _StringGuts {
     the runtime is depending on this, update Reflection.mm and \
     this if you change it
     """)
-    #elseif _pointerBitWidth(_32)
+    #elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
     _internalInvariant(MemoryLayout<String>.size == 12, """
     the runtime is depending on this, update Reflection.mm and \
     this if you change it

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -54,7 +54,7 @@ fileprivate struct _CapacityAndFlags {
   // in the bottom 48 bits, and flags in the top 16.
   fileprivate var _storage: UInt64
 
-#if _pointerBitWidth(_32)
+#if _pointerBitWidth(_32) || _pointerBitWidth(_16)
   fileprivate init(realCapacity: Int, flags: UInt16) {
     let realCapUInt = UInt64(UInt(bitPattern: realCapacity))
     _internalInvariant(realCapUInt == realCapUInt & _CountAndFlags.countMask)
@@ -263,7 +263,7 @@ final internal class __StringStorage
 
   @inline(__always)
   internal var count: Int { _countAndFlags.count }
-#elseif _pointerBitWidth(_32)
+#elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
   // The total allocated storage capacity. Note that this includes the required
   // nul-terminator.
   private var _realCapacity: Int
@@ -325,7 +325,7 @@ extension __StringStorage {
 #if _pointerBitWidth(_64)
     storage._capacityAndFlags = capAndFlags
     storage._countAndFlags = countAndFlags
-#elseif _pointerBitWidth(_32)
+#elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
     storage._realCapacity = capAndFlags._realCapacity
     storage._count = countAndFlags.count
     storage._countFlags = countAndFlags.flags
@@ -372,7 +372,7 @@ extension __StringStorage {
     let countAndFlags = _CountAndFlags(mortalCount: count, isASCII: false)
     #if _pointerBitWidth(_64)
     storage._countAndFlags = countAndFlags
-    #elseif _pointerBitWidth(_32)
+    #elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
     storage._count = countAndFlags.count
     storage._countFlags = countAndFlags.flags
     #else
@@ -527,7 +527,7 @@ extension __StringStorage {
       mortalCount: newCount, isASCII: newIsASCII)
 #if _pointerBitWidth(_64)
     self._countAndFlags = countAndFlags
-#elseif _pointerBitWidth(_32)
+#elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
     self._count = countAndFlags.count
     self._countFlags = countAndFlags.flags
 #else
@@ -675,7 +675,7 @@ final internal class __SharedStringStorage
 
 #if _pointerBitWidth(_64)
   internal var _countAndFlags: _StringObject.CountAndFlags
-#elseif _pointerBitWidth(_32)
+#elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
   internal var _count: Int
   internal var _countFlags: UInt16
 
@@ -702,7 +702,7 @@ final internal class __SharedStringStorage
     self.immortal = true
 #if _pointerBitWidth(_64)
     self._countAndFlags = countAndFlags
-#elseif _pointerBitWidth(_32)
+#elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
     self._count = countAndFlags.count
     self._countFlags = countAndFlags.flags
 #else
@@ -731,7 +731,7 @@ final internal class __SharedStringStorage
     self.immortal = false
 #if _pointerBitWidth(_64)
     self._countAndFlags = countAndFlags
-#elseif _pointerBitWidth(_32)
+#elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
     self._count = countAndFlags.count
     self._countFlags = countAndFlags.flags
 #else

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -451,6 +451,8 @@ extension UInt128: BinaryInteger {
     UInt(Builtin.trunc_Int128_Int64(_value))
 #elseif _pointerBitWidth(_32)
     UInt(Builtin.trunc_Int128_Int32(_value))
+#elseif _pointerBitWidth(_16)
+    UInt(Builtin.trunc_Int128_Int16(_value))
 #else
 #error("Unsupported platform")
 #endif

--- a/stdlib/public/stubs/Unicode/CMakeLists.txt
+++ b/stdlib/public/stubs/Unicode/CMakeLists.txt
@@ -14,6 +14,10 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       continue()
     endif()
 
+    if("${arch}" MATCHES "avr")
+      continue()
+    endif()
+
     if (SWIFT_HOST_VARIANT STREQUAL "linux")
       set(extra_c_compile_flags -ffreestanding)
     elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")

--- a/test/Parse/ConditionalCompilation/avrTarget.swift
+++ b/test/Parse/ConditionalCompilation/avrTarget.swift
@@ -1,6 +1,6 @@
 // RUN: %swift -typecheck %s -verify -target avr-none-none -disable-objc-interop -parse-stdlib
 
-#if arch(avr) && os(none) && _runtime(_Native) && _endian(little)
+#if arch(avr) && os(none) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_16)
 class C {}
 var x = C()
 #endif

--- a/test/embedded/avr/testStdlibFunctioning.swift
+++ b/test/embedded/avr/testStdlibFunctioning.swift
@@ -1,5 +1,5 @@
 // RUN: %swift-frontend -emit-ir %s -target avr-none-none-elf \
-//   -wmo -enable-experimental-feature Embedded
+// RUN:   -wmo -enable-experimental-feature Embedded
 // REQUIRES: embedded_stdlib_cross_compiling
 
 import Swift

--- a/test/embedded/avr/testStdlibFunctioning.swift
+++ b/test/embedded/avr/testStdlibFunctioning.swift
@@ -1,0 +1,11 @@
+// RUN: %swift-frontend -emit-ir %s -target avr-none-none-elf \
+//   -wmo -enable-experimental-feature Embedded
+// REQUIRES: embedded_stdlib_cross_compiling
+
+import Swift
+
+#if arch(avr) && os(none) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_16)
+let i: Int = 1
+#endif
+
+var j = i

--- a/test/embedded/avr/testStdlibFunctioning.swift
+++ b/test/embedded/avr/testStdlibFunctioning.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-frontend -emit-ir %s -target avr-none-none-elf \
+// RUN: %swift-frontend -typecheck %s -target avr-none-none-elf \
 // RUN:   -wmo -enable-experimental-feature Embedded
 // REQUIRES: embedded_stdlib_cross_compiling
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Standard library support for AVR
- when compiling embedded cross compile target standard libraries, include AVR
- add 16-bit pointer as a conditional compilation condition and get the void pointer size right for gyb sources

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
@kubamracek this is the first attempt to get the standard library compiling

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
