### PR TITLE
[Macros] Optimize 'rangeContainsTokenLocWithGeneratedSource'

### DIFF
--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -182,10 +182,13 @@ TypeRefinementContext::createForWhileStmtBody(ASTContext &Ctx, WhileStmt *S,
 /// range.
 static bool rangeContainsTokenLocWithGeneratedSource(
     SourceManager &sourceMgr, SourceRange parentRange, SourceLoc childLoc) {
-  auto parentBuffer = sourceMgr.findBufferContainingLoc(parentRange.Start);
+  if (sourceMgr.rangeContainsTokenLoc(parentRange, childLoc))
+    return true;
+
   auto childBuffer = sourceMgr.findBufferContainingLoc(childLoc);
-  while (parentBuffer != childBuffer) {
-    auto info = sourceMgr.getGeneratedSourceInfo(childBuffer);
+  while (!sourceMgr.rangeContainsTokenLoc(
+      sourceMgr.getRangeForBuffer(childBuffer), parentRange.Start)) {
+    auto *info = sourceMgr.getGeneratedSourceInfo(childBuffer);
     if (!info)
       return false;
 


### PR DESCRIPTION
* Early return for the direct `true` case.
* Instead of comparing the buffer IDs, check if the entire buffer contains the target range. This keeps `LocCache.lastBufferID` and improves the hit rate.
