### PR TITLE
[region-isolation] Be more aggressive about not looking through Sendable values when getting underlying objects.

### DIFF
--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1131,9 +1131,11 @@ void SILIsolationInfo::printForOneLineLogging(llvm::raw_ostream &os) const {
 // NOTE: We special case RawPointer and NativeObject to ensure they are
 // treated as non-Sendable and strict checking is applied to it.
 bool SILIsolationInfo::isNonSendableType(SILType type, SILFunction *fn) {
-  // Treat Builtin.NativeObject and Builtin.RawPointer as non-Sendable.
+  // Treat Builtin.NativeObject, Builtin.RawPointer, and Builtin.BridgeObject as
+  // non-Sendable.
   if (type.getASTType()->is<BuiltinNativeObjectType>() ||
-      type.getASTType()->is<BuiltinRawPointerType>()) {
+      type.getASTType()->is<BuiltinRawPointerType>() ||
+      type.getASTType()->is<BuiltinBridgeObjectType>()) {
     return true;
   }
 

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -201,7 +201,6 @@ extension Collection where Self: Sendable, Element: Sendable, Self.Index: Sendab
         // TODO: When we have isolation history, isolation history will be able
         // to tell us what is going on.
         group.addTask { [submitted,i] in // expected-error {{escaping closure captures non-escaping parameter 'transform'}}
-          // expected-tns-warning @-1 {{task-isolated value of type '() async throws -> SendableTuple2<Int, T>' passed as a strongly transferred parameter}}
           let _ = try await transform(self[i]) // expected-note {{captured here}}
           let value: T? = nil
           return SendableTuple2(submitted, value!)


### PR DESCRIPTION
[region-isolation] Be more aggressive about not looking through Sendable values when getting underlying objects.

Otherwise, in cases like the following, we look through the load to x.boolean and think that the closure is actually capturing x instead of y:

```swift
func testBooleanCapture(_ x: inout NonSendableKlass) {
  let y = x.boolean
  Task.detached { @MainActor [z = y] in
    print(z)
  }
}
```

rdar://131369987
