### PR TITLE
[sending] Change suppression to use __owned instead of consuming.

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3661,7 +3661,7 @@ static void printParameterFlags(ASTPrinter &printer,
       // at +1. By not printing sending, we would be changing the API
       // potentially to take the parameter at +0 instead of +1. To work around
       // this, print out consuming so that we preserve the +1 parameter.
-      printer.printKeyword("consuming", options, " ");
+      printer.printKeyword("__owned", options, " ");
     }
   }
 

--- a/test/Concurrency/sending_conditional_suppression.swift
+++ b/test/Concurrency/sending_conditional_suppression.swift
@@ -9,9 +9,9 @@ public class NonSendableKlass {}
 // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
 // CHECK-NEXT: public func transferArgTest(_ x: sending test.NonSendableKlass)
 // CHECK-NEXT: #else
-// When we suppress, we preserve +1 by marking the parameter as consuming. Otherwise, we
+// When we suppress, we preserve +1 by marking the parameter as __owned. Otherwise, we
 // be breaking ABI.
-// CHECK-NEXT: public func transferArgTest(_ x: consuming test.NonSendableKlass)
+// CHECK-NEXT: public func transferArgTest(_ x: __owned test.NonSendableKlass)
 // CHECK-NEXT: #endif
 public func transferArgTest(_ x: sending NonSendableKlass) {}
 
@@ -25,14 +25,14 @@ public func transferResultTest() -> sending NonSendableKlass { fatalError() }
 // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
 // CHECK-NEXT: public func transferArgAndResultTest(_ x: test.NonSendableKlass, _ y: sending test.NonSendableKlass, _ z: test.NonSendableKlass) -> sending test.NonSendableKlass
 // CHECK-NEXT: #else
-// CHECK-NEXT: public func transferArgAndResultTest(_ x: test.NonSendableKlass, _ y: consuming test.NonSendableKlass, _ z: test.NonSendableKlass) -> test.NonSendableKlass
+// CHECK-NEXT: public func transferArgAndResultTest(_ x: test.NonSendableKlass, _ y: __owned test.NonSendableKlass, _ z: test.NonSendableKlass) -> test.NonSendableKlass
 // CHECK-NEXT: #endif
 public func transferArgAndResultTest(_ x: NonSendableKlass, _ y: sending NonSendableKlass, _ z: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
 
 // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
 // CHECK-NEXT: public func argEmbeddedInType(_ fn: (sending test.NonSendableKlass) -> ())
 // CHECK-NEXT: #else
-// CHECK-NEXT: public func argEmbeddedInType(_ fn: (consuming test.NonSendableKlass) -> ())
+// CHECK-NEXT: public func argEmbeddedInType(_ fn: (__owned test.NonSendableKlass) -> ())
 // CHECK-NEXT: #endif
 public func argEmbeddedInType(_ fn: (sending NonSendableKlass) -> ()) {}
 
@@ -46,7 +46,7 @@ public func resultEmbeddedInType(_ fn: () -> sending NonSendableKlass) {}
 // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
 // CHECK-NEXT: public func argAndResultEmbeddedInType(_ fn: (test.NonSendableKlass, sending test.NonSendableKlass, test.NonSendableKlass) -> sending test.NonSendableKlass)
 // CHECK-NEXT: #else
-// CHECK-NEXT: public func argAndResultEmbeddedInType(_ fn: (test.NonSendableKlass, consuming test.NonSendableKlass, test.NonSendableKlass) -> test.NonSendableKlass)
+// CHECK-NEXT: public func argAndResultEmbeddedInType(_ fn: (test.NonSendableKlass, __owned test.NonSendableKlass, test.NonSendableKlass) -> test.NonSendableKlass)
 // CHECK-NEXT: #endif
 public func argAndResultEmbeddedInType(_ fn: (NonSendableKlass, sending NonSendableKlass, NonSendableKlass) -> sending NonSendableKlass) {}
 
@@ -54,7 +54,7 @@ public class TestInKlass {
   // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
   // CHECK-NEXT: public func testKlassArg(_ x: sending test.NonSendableKlass)
   // CHECK-NEXT: #else
-  // CHECK-NEXT: public func testKlassArg(_ x: consuming test.NonSendableKlass)
+  // CHECK-NEXT: public func testKlassArg(_ x: __owned test.NonSendableKlass)
   // CHECK-NEXT: #endif
   public func testKlassArg(_ x: sending NonSendableKlass) { fatalError() }
 
@@ -68,7 +68,7 @@ public class TestInKlass {
   // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
   // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: sending test.NonSendableKlass, z: test.NonSendableKlass) -> sending test.NonSendableKlass
   // CHECK-NEXT: #else
-  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: consuming test.NonSendableKlass, z: test.NonSendableKlass) -> test.NonSendableKlass
+  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: __owned test.NonSendableKlass, z: test.NonSendableKlass) -> test.NonSendableKlass
   // CHECK-NEXT: #endif
   public func testKlassArgAndResult(_ x: NonSendableKlass, _ y: sending NonSendableKlass, z: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
 }
@@ -77,7 +77,7 @@ public struct TestInStruct {
   // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
   // CHECK-NEXT: public func testKlassArg(_ x: sending test.NonSendableKlass)
   // CHECK-NEXT: #else
-  // CHECK-NEXT: public func testKlassArg(_ x: consuming test.NonSendableKlass)
+  // CHECK-NEXT: public func testKlassArg(_ x: __owned test.NonSendableKlass)
   // CHECK-NEXT: #endif
   public func testKlassArg(_ x: sending NonSendableKlass) { fatalError() }
 
@@ -91,7 +91,7 @@ public struct TestInStruct {
   // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
   // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: sending test.NonSendableKlass, z: test.NonSendableKlass) -> sending test.NonSendableKlass
   // CHECK-NEXT: #else
-  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: consuming test.NonSendableKlass, z: test.NonSendableKlass) -> test.NonSendableKlass
+  // CHECK-NEXT: public func testKlassArgAndResult(_ x: test.NonSendableKlass, _ y: __owned test.NonSendableKlass, z: test.NonSendableKlass) -> test.NonSendableKlass
   // CHECK-NEXT: #endif
   public func testKlassArgAndResult(_ x: NonSendableKlass, _ y: sending NonSendableKlass, z: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
 
@@ -114,7 +114,7 @@ public struct TestInStruct {
   // CHECK-NEXT: internal func testUsableFromInlineKlassArg(_ x: sending test.NonSendableKlass)
   // CHECK-NEXT: #else
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal func testUsableFromInlineKlassArg(_ x: consuming test.NonSendableKlass)
+  // CHECK-NEXT: internal func testUsableFromInlineKlassArg(_ x: __owned test.NonSendableKlass)
   // CHECK-NEXT: #endif
   @usableFromInline func testUsableFromInlineKlassArg(_ x: sending NonSendableKlass) { fatalError() }
 
@@ -133,7 +133,7 @@ public struct TestInStruct {
   // CHECK-NEXT: internal func testUsableFromInlineKlassArgAndResult(_ x: test.NonSendableKlass, _ y: sending test.NonSendableKlass, z: test.NonSendableKlass) -> sending test.NonSendableKlass
   // CHECK-NEXT: #else
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal func testUsableFromInlineKlassArgAndResult(_ x: test.NonSendableKlass, _ y: consuming test.NonSendableKlass, z: test.NonSendableKlass) -> test.NonSendableKlass
+  // CHECK-NEXT: internal func testUsableFromInlineKlassArgAndResult(_ x: test.NonSendableKlass, _ y: __owned test.NonSendableKlass, z: test.NonSendableKlass) -> test.NonSendableKlass
   // CHECK-NEXT: #endif
   @usableFromInline
   func testUsableFromInlineKlassArgAndResult(_ x: NonSendableKlass, _ y: sending NonSendableKlass, z: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
@@ -161,7 +161,7 @@ public struct TestInStruct {
   // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
   // CHECK-NEXT: public var publicVarFieldFunctionArg: (sending test.NonSendableKlass) -> ()
   // CHECK-NEXT: #else
-  // CHECK-NEXT: public var publicVarFieldFunctionArg: (consuming test.NonSendableKlass) -> ()
+  // CHECK-NEXT: public var publicVarFieldFunctionArg: (__owned test.NonSendableKlass) -> ()
   // CHECK-NEXT: #endif
   public var publicVarFieldFunctionArg: (sending NonSendableKlass) -> ()
 
@@ -170,7 +170,7 @@ public struct TestInStruct {
   // CHECK-NEXT: internal var internalVarFieldFunctionArg: (sending test.NonSendableKlass) -> ()
   // CHECK-NEXT: #else
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal var internalVarFieldFunctionArg: (consuming test.NonSendableKlass) -> ()
+  // CHECK-NEXT: internal var internalVarFieldFunctionArg: (__owned test.NonSendableKlass) -> ()
   // CHECK-NEXT: #endif
   @usableFromInline
   var internalVarFieldFunctionArg: (sending NonSendableKlass) -> ()
@@ -178,7 +178,7 @@ public struct TestInStruct {
   // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults
   // CHECK-NEXT: public let publicLetFieldFunctionArg: (sending test.NonSendableKlass) -> ()
   // CHECK-NEXT: #else
-  // CHECK-NEXT: public let publicLetFieldFunctionArg: (consuming test.NonSendableKlass) -> ()
+  // CHECK-NEXT: public let publicLetFieldFunctionArg: (__owned test.NonSendableKlass) -> ()
   // CHECK-NEXT: #endif
   public let publicLetFieldFunctionArg: (sending NonSendableKlass) -> ()
 
@@ -187,7 +187,7 @@ public struct TestInStruct {
   // CHECK-NEXT: internal let internalLetFieldFunctionArg: (sending test.NonSendableKlass) -> ()
   // CHECK-NEXT: #else
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal let internalLetFieldFunctionArg: (consuming test.NonSendableKlass) -> ()
+  // CHECK-NEXT: internal let internalLetFieldFunctionArg: (__owned test.NonSendableKlass) -> ()
   // CHECK-NEXT: #endif
   @usableFromInline
   let internalLetFieldFunctionArg: (sending NonSendableKlass) -> ()
@@ -226,7 +226,7 @@ public struct TestInStruct {
 // CHECK-LABEL: #if compiler(>=5.3) && $SendingArgsAndResults // Suppression Count: 25
 // CHECK-NEXT: public var publicGlobal: (sending test.NonSendableKlass) -> ()
 // CHECK-NEXT: #else
-// CHECK-NEXT: public var publicGlobal: (consuming test.NonSendableKlass) -> ()
+// CHECK-NEXT: public var publicGlobal: (__owned test.NonSendableKlass) -> ()
 // CHECK-NEXT: #endif
 public var publicGlobal: (sending NonSendableKlass) -> () = { x in fatalError() }
 
@@ -235,7 +235,7 @@ public var publicGlobal: (sending NonSendableKlass) -> () = { x in fatalError() 
 // CHECK-NEXT: internal var usableFromInlineGlobal: (sending test.NonSendableKlass) -> ()
 // CHECK-NEXT: #else
 // CHECK-NEXT: @usableFromInline
-// CHECK-NEXT: internal var usableFromInlineGlobal: (consuming test.NonSendableKlass) -> ()
+// CHECK-NEXT: internal var usableFromInlineGlobal: (__owned test.NonSendableKlass) -> ()
 // CHECK-NEXT: #endif
 @usableFromInline
 internal var usableFromInlineGlobal: (sending NonSendableKlass) -> () = { x in fatalError() }


### PR DESCRIPTION
The reason why I am doing this is that consuming could cause no implicit copy errors. Instead __owned will just potentially cause an error if someone assigns into sending.

rdar://131066640
