### PR TITLE
[Dependency Scanning][NFC] Associate single-shot scanner service lifetime with the owning compilation instance's `ASTContext`

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1272,15 +1272,15 @@ bool swift::dependencies::scanDependencies(CompilerInstance &instance) {
   std::string path = opts.InputsAndOutputs.getSingleOutputFilename();
   // `-scan-dependencies` invocations use a single new instance
   // of a module cache
-  SwiftDependencyScanningService service;
+  SwiftDependencyScanningService *service = Context.Allocate<SwiftDependencyScanningService>();
   if (opts.ReuseDependencyScannerCache)
-    deserializeDependencyCache(instance, service);
+    deserializeDependencyCache(instance, *service);
 
-  if (service.setupCachingDependencyScanningService(instance))
+  if (service->setupCachingDependencyScanningService(instance))
     return true;
 
   ModuleDependenciesCache cache(
-      service, instance.getMainModule()->getNameStr().str(),
+      *service, instance.getMainModule()->getNameStr().str(),
       instance.getInvocation().getFrontendOptions().ExplicitModulesOutputPath,
       instance.getInvocation().getModuleScanningHash());
 
@@ -1291,7 +1291,7 @@ bool swift::dependencies::scanDependencies(CompilerInstance &instance) {
   // Serialize the dependency cache if -serialize-dependency-scan-cache
   // is specified
   if (opts.SerializeDependencyScannerCache)
-    serializeDependencyCache(instance, service);
+    serializeDependencyCache(instance, *service);
 
   if (dependenciesOrErr.getError())
     return true;
@@ -1315,9 +1315,9 @@ bool swift::dependencies::prescanDependencies(CompilerInstance &instance) {
   std::string path = opts.InputsAndOutputs.getSingleOutputFilename();
   // `-scan-dependencies` invocations use a single new instance
   // of a module cache
-  SwiftDependencyScanningService singleUseService;
+  SwiftDependencyScanningService *singleUseService = Context.Allocate<SwiftDependencyScanningService>();
   ModuleDependenciesCache cache(
-      singleUseService, instance.getMainModule()->getNameStr().str(),
+      *singleUseService, instance.getMainModule()->getNameStr().str(),
       instance.getInvocation().getFrontendOptions().ExplicitModulesOutputPath,
       instance.getInvocation().getModuleScanningHash());
 

--- a/test/ScanDependencies/error_path.swift
+++ b/test/ScanDependencies/error_path.swift
@@ -3,9 +3,6 @@
 // REQUIRES: objc_interop
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 2>&1 | %FileCheck %s
 
-// There is a use-after-free in ScanDependencies rdar://131388478
-// XFAIL: asan
-
 import P
 
 // CHECK:      {{.*}}{{/|\\}}Z.swiftinterface:3:8: error: Unable to find module dependency: 'missing_module'

--- a/test/ScanDependencies/error_source_locations.swift
+++ b/test/ScanDependencies/error_source_locations.swift
@@ -7,9 +7,6 @@ import P
 import FooBar
 
 
-// There is a use-after-free in ScanDependencies rdar://131388478
-// XFAIL: asan
-
 // CHECK:      {{.*}}{{/|\\}}error_source_locations.swift:7:8: error: Unable to find module dependency: 'FooBar'
 // CHECK-NEXT: 5 |
 // CHECK-NEXT: 6 | import P


### PR DESCRIPTION
Resolves rdar://131388478
