### PR TITLE
[windows][build.ps1] only use swift-corelibs-foundation-windows checkout

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1668,8 +1668,15 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
     }
 
     $env:CTEST_OUTPUT_ON_FAILURE = 1
+    if ($env:CI) {
+      # Use the windows-specific checkout on CI that provides
+      # a checkout that does not yet use swift-foundation.
+      $RepoName = "swift-corelibs-foundation-windows";
+    } else {
+      $RepoName = "swift-corelibs-foundation";
+    }
     Build-CMakeProject `
-      -Src $SourceCache\swift-corelibs-foundation-windows `
+      -Src $SourceCache\$RepoName `
       -Bin $FoundationBinaryCache `
       -InstallTo $InstallPath `
       -Arch $Arch `


### PR DESCRIPTION
in CI

https://github.com/swiftlang/swift/pull/75073 has broken a local toolchain build on windows using build.ps1,
as the local build does not use update_checkout on windows, and thus does not checkout swift-corelibs-foundation-windows.
