### PR TITLE
[6.0🍒] NCGenerics: enforce same-source conformance rule

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7775,6 +7775,9 @@ WARNING(suppress_already_suppressed_protocol,none,
 ERROR(extension_conforms_to_invertible_and_others, none,
       "conformance to '%0' must be declared in a separate extension",
       (StringRef))
+ERROR(invertible_conformance_other_source_file,none,
+      "conformance to '%0' must occur in the same source file as %kind1",
+      (StringRef, const ValueDecl *))
 
 // -- older ones below --
 ERROR(noncopyable_parameter_requires_ownership, none,

--- a/lib/Sema/TypeCheckInvertible.cpp
+++ b/lib/Sema/TypeCheckInvertible.cpp
@@ -143,6 +143,16 @@ static void checkInvertibleConformanceCommon(DeclContext *dc,
       conformanceLoc = normalConf->getLoc();
       assert(conformanceLoc);
 
+      // Conformance must be defined in the same source file as the nominal.
+      auto conformanceDC = concrete->getDeclContext();
+      if (auto *sourceFile = conformanceDC->getOutermostParentSourceFile()) {
+        if (sourceFile != nominalDecl->getOutermostParentSourceFile()) {
+          ctx.Diags.diagnose(conformanceLoc,
+                             diag::invertible_conformance_other_source_file,
+                             getInvertibleProtocolKindName(ip), nominalDecl);
+        }
+      }
+
       auto condReqs = normalConf->getConditionalRequirements();
       hasUnconditionalConformance = condReqs.empty();
       auto *thisProto = normalConf->getProtocol();

--- a/test/Sema/copyable_conformance_diff_module.swift
+++ b/test/Sema/copyable_conformance_diff_module.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+//// Ensure we cannot add the conformance in a different module.
+
+// RUN: %target-build-swift \
+// RUN:   -swift-version 5 \
+// RUN:   -emit-module \
+// RUN:   -emit-module-path %t/GardenKit.swiftmodule \
+// RUN:   -emit-module-interface-path %t/GardenKit.swiftinterface \
+// RUN:   -enable-library-evolution \
+// RUN:   -module-name=GardenKit \
+// RUN:   %t/GardenKit.swift
+
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -verify \
+// RUN:   -I %t \
+// RUN:   %t/Visitor.swift
+
+//--- GardenKit.swift
+
+public struct Garden<Plant: ~Copyable>: ~Copyable {
+  public let plant: Plant
+  public init(_ p: consuming Plant) { plant = p }
+}
+
+//--- Visitor.swift
+
+import GardenKit
+
+// expected-error@+1 {{conformance to 'Copyable' must occur in the same source file as generic struct 'Garden'}}
+extension Garden: @retroactive Copyable where Plant: Copyable {}

--- a/test/Sema/copyable_conformance_diff_source_file.swift
+++ b/test/Sema/copyable_conformance_diff_source_file.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+//// Ensure we cannot add the conformance in a different source file.
+
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -verify \
+// RUN:   %t/Visitor.swift %t/GardenKit.swift
+
+//--- GardenKit.swift
+
+public struct Garden<Plant: ~Copyable>: ~Copyable {
+  public let plant: Plant
+  public init(_ p: consuming Plant) { plant = p }
+}
+
+//--- Visitor.swift
+
+// expected-error@+1 {{conformance to 'Copyable' must occur in the same source file as generic struct 'Garden'}}
+extension Garden: Copyable where Plant: Copyable {}


### PR DESCRIPTION
- Explanation: Retroactive conformances to Copyable were being permitted and that's nonsense. SE-427 actually says it has to be defined in the same source file, like Sendable.
- Scope: Source breaking, but easy to remedy in the legal cases.
- Issue: rdar://131486561
- Original PR: https://github.com/swiftlang/swift/pull/75141
- Risk: Low
- Testing: Swift CI.
- Reviewer: @slavapestov 