### PR TITLE
[6.0][Macros] Optimize 'rangeContainsTokenLocWithGeneratedSource'

### DIFF
--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -181,10 +181,13 @@ TypeRefinementContext::createForWhileStmtBody(ASTContext &Ctx, WhileStmt *S,
 /// range.
 static bool rangeContainsTokenLocWithGeneratedSource(
     SourceManager &sourceMgr, SourceRange parentRange, SourceLoc childLoc) {
-  auto parentBuffer = sourceMgr.findBufferContainingLoc(parentRange.Start);
+  if (sourceMgr.rangeContainsTokenLoc(parentRange, childLoc))
+    return true;
+
   auto childBuffer = sourceMgr.findBufferContainingLoc(childLoc);
-  while (parentBuffer != childBuffer) {
-    auto info = sourceMgr.getGeneratedSourceInfo(childBuffer);
+  while (!sourceMgr.rangeContainsTokenLoc(
+      sourceMgr.getRangeForBuffer(childBuffer), parentRange.Start)) {
+    auto *info = sourceMgr.getGeneratedSourceInfo(childBuffer);
     if (!info)
       return false;
 


### PR DESCRIPTION
Cherry-pick #75130 into release/6.0

* **Explanation**: Performance optimization. For some test case(https://github.com/apple/swift-testing/issues/502), we measured `findBufferContainingLoc()` was taking considerable amount of time in the entire compilation. This change reduces the number of calls of that function, and improves the hit-rate of the fast `lastBufferID` cache.
* **Scope**: Type refinement context construction
* **Risk**: Low. The change is small and targeted.
* **Testing**: Passes current test suite. Locally confirmed the performance improvement
* **Issues**: rdar://130478685
* **Reviewer**: Doug Gregor (@DougGregor)