### PR TITLE
[6.0][region-isolation] Be more aggressive about not looking through Sendable values when getting underlying objects.

### DIFF
--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -377,6 +377,11 @@ static SILValue getUnderlyingTrackedObjectValue(SILValue value) {
 }
 
 static UnderlyingTrackedValueInfo getUnderlyingTrackedValue(SILValue value) {
+  // Before a check if the value we are attempting to access is Sendable. In
+  // such a case, just return early.
+  if (!SILIsolationInfo::isNonSendableType(value))
+    return UnderlyingTrackedValueInfo(value);
+
   // Look through a project_box, so that we process it like its operand object.
   if (auto *pbi = dyn_cast<ProjectBoxInst>(value)) {
     value = pbi->getOperand();
@@ -385,6 +390,7 @@ static UnderlyingTrackedValueInfo getUnderlyingTrackedValue(SILValue value) {
   if (!value->getType().isAddress()) {
     SILValue underlyingValue = getUnderlyingTrackedObjectValue(value);
 
+    // If we do not have a load inst, just return the value.
     if (!isa<LoadInst, LoadBorrowInst>(underlyingValue)) {
       return UnderlyingTrackedValueInfo(underlyingValue);
     }

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1130,9 +1130,11 @@ void SILIsolationInfo::printForOneLineLogging(llvm::raw_ostream &os) const {
 // NOTE: We special case RawPointer and NativeObject to ensure they are
 // treated as non-Sendable and strict checking is applied to it.
 bool SILIsolationInfo::isNonSendableType(SILType type, SILFunction *fn) {
-  // Treat Builtin.NativeObject and Builtin.RawPointer as non-Sendable.
+  // Treat Builtin.NativeObject, Builtin.RawPointer, and Builtin.BridgeObject as
+  // non-Sendable.
   if (type.getASTType()->is<BuiltinNativeObjectType>() ||
-      type.getASTType()->is<BuiltinRawPointerType>()) {
+      type.getASTType()->is<BuiltinRawPointerType>() ||
+      type.getASTType()->is<BuiltinBridgeObjectType>()) {
     return true;
   }
 

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -201,7 +201,6 @@ extension Collection where Self: Sendable, Element: Sendable, Self.Index: Sendab
         // TODO: When we have isolation history, isolation history will be able
         // to tell us what is going on.
         group.addTask { [submitted,i] in // expected-error {{escaping closure captures non-escaping parameter 'transform'}}
-          // expected-tns-warning @-1 {{task-isolated value of type '() async throws -> SendableTuple2<Int, T>' passed as a strongly transferred parameter}}
           let _ = try await transform(self[i]) // expected-note {{captured here}}
           let value: T? = nil
           return SendableTuple2(submitted, value!)

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -18,6 +18,7 @@ class NonSendableKlass { // expected-complete-note 51{{}}
   // expected-typechecker-only-note @-1 3{{}}
   // expected-tns-note @-2 {{}}
   var field: NonSendableKlass? = nil
+  var boolean: Bool = false
 
   init() {}
   init(_ x: NonSendableKlass) {
@@ -1331,9 +1332,9 @@ func varSendableNonTrivialLetTupleFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
-  let z = test.1 // expected-tns-note {{access can happen concurrently}}
+  let z = test.1
   useValue(z)
-  useValue(test)
+  useValue(test) // expected-tns-note {{access can happen concurrently}}
 }
 
 func varNonSendableNonTrivialLetTupleFieldTest() async {
@@ -1812,4 +1813,15 @@ func testThatGlobalActorTakesPrecedenceOverActorIsolationOnMethods() async {
 
   // Meaning we would get an error here.
   Task { @MainActor in print(ns) }
+}
+
+// Shouldn't get any errors from x.
+//
+// We used to look through the access to x.boolean and think that the closure
+// was capturing x instead of y.
+func testBooleanCapture(_ x: inout NonSendableKlass) {
+  let y = x.boolean
+  Task.detached { @MainActor [z = y] in
+    print(z)
+  }
 }


### PR DESCRIPTION
Explanation: Otherwise, in cases like the following, we look through the load to x.boolean and think that the closure is actually capturing x instead of y:

```swift
func testBooleanCapture(_ x: inout NonSendableKlass) {
  let y = x.boolean
  Task.detached { @MainActor [z = y] in
    print(z)
  }
}
```

Radars:

- rdar://131369987

Original PRs:

- https://github.com/swiftlang/swift/pull/75131

Risk: Low. This is a really simple change that just causes us to exit early if we early find a Sendable value while looking for underlying values. The rest of the pass already ignores Sendable values, so it cannot cause any issues. The only thing that can happen is we ignore more values (since we properly see that they are Sendable when we thought they were non-Sendable previously)
Testing: Added/Ran tests
Reviewer: N/A