### PR TITLE
Use associated objects to attach contiguous array buffers to lazy ones

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -9,6 +9,7 @@ set(sources
   LibcOverlayShims.h
   LibcShims.h
   MetadataSections.h
+  ObjCShims.h
   Random.h
   RefCount.h
   Reflection.h

--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -37,6 +37,17 @@ typedef signed long _swift_shims_CFIndex;
 typedef unsigned long _swift_shims_objc_associationPolicy;
 #endif
 
+#if !FOUNDATION_HELPER_FILE
+//`value` is actually `id`, but we need it to not import as `Any`
+extern void
+objc_setAssociatedObject(id _Nonnull object, const void * _Nonnull key,
+                         const void * _Nullable value, _swift_shims_objc_associationPolicy policy);
+//return type is actually `id`, but we need it to not import as `Any`
+extern const void * _Nullable
+objc_getAssociatedObject(id _Nonnull object, const void * _Nonnull key);
+
+#endif
+
 // Consider creating SwiftMacTypes.h for these
 typedef unsigned char _swift_shims_Boolean;
 typedef __swift_uint8_t _swift_shims_UInt8;
@@ -76,14 +87,6 @@ _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
 SWIFT_RUNTIME_STDLIB_API
 __swift_uint8_t
 _swift_stdlib_dyld_is_objc_constant_string(const void * _Nonnull addr);
-
-SWIFT_RUNTIME_STDLIB_API
-id
-_swift_stdlib_objc_getAssociatedObject(id _Nonnull obj, const void * _Nonnull key);
-  
-SWIFT_RUNTIME_STDLIB_API
-void
-_swift_stdlib_objc_setAssociatedObject(id _Nonnull obj, const void * _Nonnull key, id _Nullable value, _swift_shims_objc_associationPolicy policy);
 
 #endif // __OBJC2__
 

--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -37,19 +37,6 @@ typedef signed long _swift_shims_CFIndex;
 
 #endif
 
-#if !FOUNDATION_HELPER_FILE
-
-extern void objc_setAssociatedObject(void);
-extern id _Nullable
-objc_getAssociatedObject(id _Nonnull object, const void * _Nonnull key);
-int objc_sync_enter(id _Nonnull object);
-int objc_sync_exit(id _Nonnull object);
-
-static void * _Nonnull getSetAssociatedObjectPtr() {
-  return (void *)&objc_setAssociatedObject;
-}
-#endif
-
 // Consider creating SwiftMacTypes.h for these
 typedef unsigned char _swift_shims_Boolean;
 typedef __swift_uint8_t _swift_shims_UInt8;

--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -74,7 +74,15 @@ _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
 SWIFT_RUNTIME_STDLIB_API
 __swift_uint8_t
 _swift_stdlib_dyld_is_objc_constant_string(const void * _Nonnull addr);
+
+SWIFT_RUNTIME_STDLIB_API
+id
+_swift_stdlib_objc_getAssociatedObject(id _Nonnull obj, const void * _Nonnull key);
   
+SWIFT_RUNTIME_STDLIB_API
+void
+_swift_stdlib_objc_setAssociatedObject(id _Nonnull obj, const void * _Nonnull key, id value, uintptr_t policy);
+
 #endif // __OBJC2__
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -30,9 +30,11 @@ extern "C" {
 #if __LLP64__
 typedef unsigned long long _swift_shims_CFHashCode;
 typedef signed long long _swift_shims_CFIndex;
+typedef unsigned long long _swift_shims_objc_associationPolicy;
 #else
 typedef unsigned long _swift_shims_CFHashCode;
 typedef signed long _swift_shims_CFIndex;
+typedef unsigned long _swift_shims_objc_associationPolicy;
 #endif
 
 // Consider creating SwiftMacTypes.h for these
@@ -81,7 +83,7 @@ _swift_stdlib_objc_getAssociatedObject(id _Nonnull obj, const void * _Nonnull ke
   
 SWIFT_RUNTIME_STDLIB_API
 void
-_swift_stdlib_objc_setAssociatedObject(id _Nonnull obj, const void * _Nonnull key, id value, uintptr_t policy);
+_swift_stdlib_objc_setAssociatedObject(id _Nonnull obj, const void * _Nonnull key, id _Nullable value, _swift_shims_objc_associationPolicy policy);
 
 #endif // __OBJC2__
 

--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -38,12 +38,10 @@ typedef unsigned long _swift_shims_objc_associationPolicy;
 #endif
 
 #if !FOUNDATION_HELPER_FILE
-//`value` is actually `id`, but we need it to not import as `Any`
 extern void
 objc_setAssociatedObject(id _Nonnull object, const void * _Nonnull key,
-                         const void * _Nullable value, _swift_shims_objc_associationPolicy policy);
-//return type is actually `id`, but we need it to not import as `Any`
-extern const void * _Nullable
+                         id _Nullable value, _swift_shims_objc_associationPolicy policy);
+extern id _Nullable
 objc_getAssociatedObject(id _Nonnull object, const void * _Nonnull key);
 int objc_sync_enter(id _Nonnull object);
 int objc_sync_exit(id _Nonnull object);

--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -30,21 +30,24 @@ extern "C" {
 #if __LLP64__
 typedef unsigned long long _swift_shims_CFHashCode;
 typedef signed long long _swift_shims_CFIndex;
-typedef unsigned long long _swift_shims_objc_associationPolicy;
+
 #else
 typedef unsigned long _swift_shims_CFHashCode;
 typedef signed long _swift_shims_CFIndex;
-typedef unsigned long _swift_shims_objc_associationPolicy;
+
 #endif
 
 #if !FOUNDATION_HELPER_FILE
-extern void
-objc_setAssociatedObject(id _Nonnull object, const void * _Nonnull key,
-                         id _Nullable value, _swift_shims_objc_associationPolicy policy);
+
+extern void objc_setAssociatedObject(void);
 extern id _Nullable
 objc_getAssociatedObject(id _Nonnull object, const void * _Nonnull key);
 int objc_sync_enter(id _Nonnull object);
 int objc_sync_exit(id _Nonnull object);
+
+static void * _Nonnull getSetAssociatedObjectPtr() {
+  return (void *)&objc_setAssociatedObject;
+}
 #endif
 
 // Consider creating SwiftMacTypes.h for these

--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -45,7 +45,8 @@ objc_setAssociatedObject(id _Nonnull object, const void * _Nonnull key,
 //return type is actually `id`, but we need it to not import as `Any`
 extern const void * _Nullable
 objc_getAssociatedObject(id _Nonnull object, const void * _Nonnull key);
-
+int objc_sync_enter(id _Nonnull object);
+int objc_sync_exit(id _Nonnull object);
 #endif
 
 // Consider creating SwiftMacTypes.h for these

--- a/stdlib/public/SwiftShims/swift/shims/ObjCShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/ObjCShims.h
@@ -1,0 +1,48 @@
+//===--- ObjCShims.h - Access to libobjc for the core stdlib ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Using the ObjectiveC module in the core stdlib would create a
+//  circular dependency, so instead we import these declarations as
+//  part of SwiftShims.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_SHIMS_OBJCSHIMS_H
+#define SWIFT_STDLIB_SHIMS_OBJCSHIMS_H
+
+#include "SwiftStdint.h"
+#include "Visibility.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __OBJC2__
+
+extern void objc_setAssociatedObject(void);
+extern id _Nullable
+objc_getAssociatedObject(id _Nonnull object, const void * _Nonnull key);
+int objc_sync_enter(id _Nonnull object);
+int objc_sync_exit(id _Nonnull object);
+
+static void * _Nonnull getSetAssociatedObjectPtr() {
+  return (void *)&objc_setAssociatedObject;
+}
+
+#endif // __OBJC2__
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // SWIFT_STDLIB_SHIMS_COREFOUNDATIONSHIMS_H
+

--- a/stdlib/public/SwiftShims/swift/shims/ObjCShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/ObjCShims.h
@@ -29,13 +29,16 @@ extern "C" {
 #ifdef __OBJC2__
 
 extern void objc_setAssociatedObject(void);
-extern id _Nullable
-objc_getAssociatedObject(id _Nonnull object, const void * _Nonnull key);
+extern void objc_getAssociatedObject(void);
 int objc_sync_enter(id _Nonnull object);
 int objc_sync_exit(id _Nonnull object);
 
 static void * _Nonnull getSetAssociatedObjectPtr() {
   return (void *)&objc_setAssociatedObject;
+}
+
+static void * _Nonnull getGetAssociatedObjectPtr() {
+  return (void *)&objc_getAssociatedObject;
 }
 
 #endif // __OBJC2__

--- a/stdlib/public/SwiftShims/swift/shims/module.modulemap
+++ b/stdlib/public/SwiftShims/swift/shims/module.modulemap
@@ -1,6 +1,7 @@
 module SwiftShims {
   header "AssertionReporting.h"
   header "CoreFoundationShims.h"
+  header "ObjCShims.h"
   header "EmbeddedShims.h"
   header "FoundationShims.h"
   header "GlobalObjects.h"

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -569,10 +569,10 @@ extension _ArrayBuffer {
 
   @inlinable
   static var associationKey: UnsafeRawPointer {
-    withUnsafePointer(to: &_emptyArrayStorage) {
+    withUnsafePointer(to: _emptyArrayStorage) {
       //emptyArrayStorage is immortal so this doesn't dangle
       //also we never dereference it
-      $0
+      UnsafeRawPointer($0)
     }
   }
   
@@ -590,7 +590,7 @@ extension _ArrayBuffer {
     }
     if let associatedBuffer = _swift_stdlib_objc_getAssociatedObject(
       owner,
-      associationKey
+      _ArrayBuffer.associationKey
     ) {
       let contigBuffer = unsafeBitCast(
         associatedBuffer,
@@ -603,7 +603,7 @@ extension _ArrayBuffer {
       let contig = ContiguousArray(self)
       _swift_stdlib_objc_setAssociatedObject(
         owner,
-        associationKey,
+        _ArrayBuffer.associationKey,
         contig._buffer,
         0o1401 //OBJC_ASSOCIATION_RETAIN
       )

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -584,9 +584,17 @@ extension _ArrayBuffer {
       to: (@convention(c)(
         AnyObject,
         UnsafeRawPointer
+      ) -> AnyObject?).self
+    )
+    // swiftc gets upset if we go straight to returning Unmanaged<AnyObject>?
+    let typedNonRetainingGetter = unsafeBitCast(
+      typedGetter,
+      to: (@convention(c)(
+        AnyObject,
+        UnsafeRawPointer
       ) -> Unmanaged<AnyObject>?).self
     )
-    if let assoc = typedGetter(
+    if let assoc = typedNonRetainingGetter(
       _storage.objCInstance,
       _ArrayBuffer.associationKey
     ) {

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -575,14 +575,14 @@ extension _ArrayBuffer {
   
   @inlinable @_alwaysEmitIntoClient
   internal func getAssociatedBuffer() -> _ContiguousArrayBuffer<Element>? {
-    let getter = objc_getAssociatedObject as @convention(c)(
-      Any,
-      UnsafeRawPointer
-    ) -> Any?
-    let typedGetterType = (@convention(c)(AnyObject, UnsafeRawPointer)
-      -> UnsafeRawPointer?).self
-    let typedGetter = unsafeBitCast(getter, to: typedGetterType)
-    if let assocPtr = typedGetter(
+    let getter = unsafeBitCast(
+      getGetAssociatedObjectPtr(),
+      to: (@convention(c)(
+        AnyObject,
+        UnsafeRawPointer
+      ) -> UnsafeRawPointer?).self
+    )
+    if let assocPtr = getter(
       _storage.objCInstance,
       _ArrayBuffer.associationKey
     ) {

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -571,13 +571,13 @@ extension _ArrayBuffer {
     }
   }
 
-  @inlinable
+  @inlinable @_alwaysEmitIntoClient
   static var associationKey: UnsafeRawPointer {
     //Doesn't need to be a valid pointer
     UnsafeRawPointer(OpaquePointer(bitPattern: 0x1).unsafelyUnwrapped)
   }
   
-  @inlinable
+  @inlinable @_alwaysEmitIntoClient
   internal func getAssociatedBuffer() -> _ContiguousArrayBuffer<Element>? {
     let getter = objc_getAssociatedObject as @convention(c)(
       Any,
@@ -603,24 +603,15 @@ extension _ArrayBuffer {
     return nil
   }
   
-  @inlinable
+  @inlinable @_alwaysEmitIntoClient
   internal func setAssociatedBuffer(_ buffer: _ContiguousArrayBuffer<Element>) {
-    let setter = objc_setAssociatedObject as @convention(c)(
-      Any,
+    let setter = unsafeBitCast(getSetAssociatedObjectPtr(), to: (@convention(c)(
+      AnyObject,
       UnsafeRawPointer,
-      Any?,
+      AnyObject?,
       UInt
-    ) -> Void
-    let typedSetter = unsafeBitCast(
-      setter,
-      to: (@convention(c)(
-        AnyObject,
-        UnsafeRawPointer,
-        AnyObject?,
-        UInt
-      ) -> Void).self
-    )
-    typedSetter(
+    ) -> Void).self)
+    setter(
       _storage.objCInstance,
       _ArrayBuffer.associationKey,
       buffer._storage,
@@ -628,7 +619,7 @@ extension _ArrayBuffer {
     )
   }
   
-  @inlinable @inline(never)
+  @_alwaysEmitIntoClient @inline(never)
   internal func withUnsafeBufferPointer_nonNative<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R {

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -579,28 +579,15 @@ extension _ArrayBuffer {
       Any,
       UnsafeRawPointer
     ) -> Any?
-    let typedGetter = unsafeBitCast(
-      getter,
-      to: (@convention(c)(
-        AnyObject,
-        UnsafeRawPointer
-      ) -> AnyObject?).self
-    )
-    // swiftc gets upset if we go straight to returning Unmanaged<AnyObject>?
-    let typedNonRetainingGetter = unsafeBitCast(
-      typedGetter,
-      to: (@convention(c)(
-        AnyObject,
-        UnsafeRawPointer
-      ) -> Unmanaged<AnyObject>?).self
-    )
-    if let assoc = typedNonRetainingGetter(
+    let typedGetterType = (@convention(c)(AnyObject, UnsafeRawPointer)
+      -> UnsafeRawPointer?).self
+    let typedGetter = unsafeBitCast(getter, to: typedGetterType)
+    if let assocPtr = typedGetter(
       _storage.objCInstance,
       _ArrayBuffer.associationKey
     ) {
-      let buffer = unsafeBitCast(
-        assoc,
-        to: _ContiguousArrayStorage<Element>.self
+      let buffer = assocPtr.loadUnaligned(
+        as: _ContiguousArrayStorage<Element>.self
       )
       return _ContiguousArrayBuffer(buffer)
     }

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -573,8 +573,8 @@ extension _ArrayBuffer {
 
   @inlinable @_alwaysEmitIntoClient
   static var associationKey: UnsafeRawPointer {
-    //Doesn't need to be a valid pointer
-    UnsafeRawPointer(OpaquePointer(bitPattern: 0x1).unsafelyUnwrapped)
+    //We never dereference this, we just need an address to use as a unique key
+    UnsafeRawPointer(Builtin.addressof(&_swiftEmptyArrayStorage))
   }
   
   @inlinable @_alwaysEmitIntoClient

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -51,12 +51,16 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
 
   @usableFromInline
   internal var endIndex: Int {
-    return core.count
+    @_effects(releasenone) get {
+      core.count
+    }
   }
 
   @usableFromInline
   internal subscript(i: Int) -> AnyObject {
-    return core.objectAt(i)
+    @_effects(releasenone) get {
+      core.objectAt(i)
+    }
   }
 
   @usableFromInline

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -112,5 +112,16 @@ _swift_stdlib_dyld_is_objc_constant_string(const void *addr) {
           && SWIFT_RUNTIME_WEAK_USE(_dyld_is_objc_constant(dyld_objc_string_kind, addr))) ? 1 : 0;
 }
 
+id _Nonnull
+_swift_stdlib_objc_getAssociatedObject(id _Nonnull obj, const void * _Nonnull key) {
+  return objc_getAssociatedObject(obj, key);
+}
+
+void
+_swift_stdlib_objc_setAssociatedObject(id _Nonnull obj, const void * _Nonnull key, id _Nullable value, _swift_shims_objc_associationPolicy policy) {
+  objc_setAssociatedObject(obj, key, value, (objc_AssociationPolicy)policy);
+}
+
+
 #endif
 

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -16,6 +16,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+
+#define FOUNDATION_HELPER_FILE 1
 #include "swift/Runtime/Config.h"
 
 #if SWIFT_OBJC_INTEROP
@@ -110,16 +112,6 @@ __swift_uint8_t
 _swift_stdlib_dyld_is_objc_constant_string(const void *addr) {
   return (SWIFT_RUNTIME_WEAK_CHECK(_dyld_is_objc_constant)
           && SWIFT_RUNTIME_WEAK_USE(_dyld_is_objc_constant(dyld_objc_string_kind, addr))) ? 1 : 0;
-}
-
-id _Nonnull
-_swift_stdlib_objc_getAssociatedObject(id _Nonnull obj, const void * _Nonnull key) {
-  return objc_getAssociatedObject(obj, key);
-}
-
-void
-_swift_stdlib_objc_setAssociatedObject(id _Nonnull obj, const void * _Nonnull key, id _Nullable value, _swift_shims_objc_associationPolicy policy) {
-  objc_setAssociatedObject(obj, key, value, (objc_AssociationPolicy)policy);
 }
 
 

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -16,8 +16,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-#define FOUNDATION_HELPER_FILE 1
 #include "swift/Runtime/Config.h"
 
 #if SWIFT_OBJC_INTEROP


### PR DESCRIPTION
This uses ObjC runtime trickery to allow us to get an inner pointer with lifetime bounded to the array buffer from every array, rather than just from native ones

Fixes rdar://132124808