### PR TITLE
[IRGen] Apply int to ptr conversion for direct error returns if neces…

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4405,6 +4405,9 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
     auto *eltTy = elt->getType();
     if (nativeTy->isIntOrPtrTy() && eltTy->isIntOrPtrTy() &&
         nativeTy->getPrimitiveSizeInBits() != eltTy->getPrimitiveSizeInBits()) {
+      if (nativeTy->isPointerTy() && eltTy == IGF.IGM.IntPtrTy) {
+        return IGF.Builder.CreateIntToPtr(elt, nativeTy);
+      }
       return IGF.Builder.CreateTruncOrBitCast(elt, nativeTy);
     }
     return elt;

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -127,3 +127,16 @@ func mayThrow(x: Bool, y: AnyObject) throws(MyError) -> (Float, Int32, Float) {
   }
   return (3.0, 4, 5.0)
 }
+
+// CHECK: define hidden swiftcc { i64, i64 } @"$s12typed_throws25directErrorMergePtrAndInt1x1yyXl_SitSb_yXltAA05SmallD0VYKF"
+// CHECK:   [[RES:%.*]] = call swiftcc { i64, i64 } @"$s12typed_throws25directErrorMergePtrAndInt1x1yyXl_SitSb_yXltAA05SmallD0VYKF"
+// CHECK:   [[R0:%.*]] = extractvalue { i64, i64 } [[RES]], 0
+// CHECK:   inttoptr i64 [[R0]] to ptr
+// CHECK: }
+func directErrorMergePtrAndInt(x: Bool, y: AnyObject) throws(SmallError) -> (AnyObject, Int) {
+  guard x else {
+    throw SmallError(x: 1)
+  }
+
+  return try directErrorMergePtrAndInt(x: !x, y: y)
+}


### PR DESCRIPTION
…sary

rdar://131494255

When merging a ptr into an int value for direct error return, we have to properly convert it back to a pointer at the callsite
