### PR TITLE
[IRGen] Don't apply direct error return to functions with indirect result

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4405,6 +4405,9 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
     auto *eltTy = elt->getType();
     if (nativeTy->isIntOrPtrTy() && eltTy->isIntOrPtrTy() &&
         nativeTy->getPrimitiveSizeInBits() != eltTy->getPrimitiveSizeInBits()) {
+      if (nativeTy->isPointerTy() && eltTy == IGF.IGM.IntPtrTy) {
+        return IGF.Builder.CreateIntToPtr(elt, nativeTy);
+      }
       return IGF.Builder.CreateTruncOrBitCast(elt, nativeTy);
     }
     return elt;

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -140,3 +140,13 @@ func directErrorMergePtrAndInt(x: Bool, y: AnyObject) throws(SmallError) -> (Any
 
   return try directErrorMergePtrAndInt(x: !x, y: y)
 }
+
+// This used to crash at compile time, because it was trying to use a direct
+// error return in combination with an indirect result, which is illegal.
+func genericThrows<T>(x: Bool, y: T) throws(SmallError) -> T {
+  guard x else {
+    throw SmallError(x: 1)
+  }
+
+  return y
+}

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -127,3 +127,16 @@ func mayThrow(x: Bool, y: AnyObject) throws(MyError) -> (Float, Int32, Float) {
   }
   return (3.0, 4, 5.0)
 }
+
+// CHECK: define hidden swiftcc { i64, i64 } @"$s12typed_throws25directErrorMergePtrAndInt1x1yyXl_SitSb_yXltAA05SmallD0VYKF"
+// CHECK:   [[RES:%.*]] = call swiftcc { i64, i64 } @"$s12typed_throws25directErrorMergePtrAndInt1x1yyXl_SitSb_yXltAA05SmallD0VYKF"
+// CHECK:   [[R0:%.*]] = extractvalue { i64, i64 } [[RES]], 0
+// CHECK:   inttoptr i64 [[R0]] to ptr
+// CHECK: }
+func directErrorMergePtrAndInt(x: Bool, y: AnyObject) throws(SmallError) -> (AnyObject, Int) {
+  guard x else {
+    throw SmallError(x: 1)
+  }
+
+  return try directErrorMergePtrAndInt(x: !x, y: y)
+}


### PR DESCRIPTION
rdar://130971168

Having direct and indirect results on the same function is illegal.