### PR TITLE
[Concurrency] rework test to use StdlibUnittest rather than "not"

### DIFF
--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_main_customExecutorOnMain_swift6_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_main_customExecutorOnMain_swift6_mode.swift
@@ -1,8 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
+
 // RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %target-run %t/a.out
-// RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy not --crash %target-run %t/a.out
+// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %{python} %S/../../Inputs/not.py "%target-run %t/a.out"
+
+// NOTE: not.py is used above instead of "not --crash" because %target-run
+// doesn't pass through the crash, and `not` may not be available when running
+// on a remote host. See also test/backtrace.swift.
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_main_customExecutorOnMain_swift6_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_main_customExecutorOnMain_swift6_mode.swift
@@ -3,11 +3,7 @@
 // RUN: %target-codesign %t/a.out
 
 // RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6 %target-run %t/a.out
-// RUN: env SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %{python} %S/../../Inputs/not.py "%target-run %t/a.out"
-
-// NOTE: not.py is used above instead of "not --crash" because %target-run
-// doesn't pass through the crash, and `not` may not be available when running
-// on a remote host. See also test/backtrace.swift.
+// RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/a.out
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -27,6 +23,22 @@
 // UNSUPPORTED: single_threaded_concurrency
 
 import Dispatch
+import StdlibUnittest
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Android)
+import Android
+#elseif os(WASI)
+import WASILibc
+#elseif os(Windows)
+import CRT
+import WinSDK
+#endif
 
 @available(SwiftStdlib 6.0, *)
 final class NaiveOnMainQueueExecutor: SerialExecutor {
@@ -72,12 +84,26 @@ actor ActorOnNaiveOnMainQueueExecutor {
 
 @main struct Main {
   static func main() async {
-    if #available(SwiftStdlib 6.0, *) {
-      let actor = ActorOnNaiveOnMainQueueExecutor()
-      await actor.checkPreconditionIsolated()
-      // CHECK: Before preconditionIsolated
-      // CHECK-NEXT: checkIsolated: pretend it is ok!
-      // CHECK-NEXT: After preconditionIsolated
+    let tests = TestSuite(#file)
+
+    let varName = "SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE"
+    guard let _mode = getenv(varName) else {
+      fatalError("Env variable required by test was not set: \(varName)")
     }
+    let mode = String(validatingCString: _mode)!
+
+    if #available(SwiftStdlib 6.0, *) {
+      tests.test("test preconditionIsolated in mode: \(mode)") {
+        if (mode == "legacy") {
+          expectCrashLater()
+        } // else, swift6 mode should not crash
+
+
+        let actor = ActorOnNaiveOnMainQueueExecutor()
+        await actor.checkPreconditionIsolated()
+      }
+    }
+
+    await runAllTestsAsync()
   }
 }


### PR DESCRIPTION
On some platforms this test was failing even though the test output was all correct -- this leads me to suspect the "not" did not work as expected with remote hosts. Some other tests use not.py to work around this: 

 > // RUN: env SWIFT_BACKTRACE=enable=no %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | %{python} %utils/backtrace-check
> 
> // NOTE: not.py is used above instead of "not --crash" because %target-run
> // doesn't pass through the crash, and `not` may not be available when running
> // on a remote host.
> 
> // This is not supported on watchos, ios, or tvos
> // UNSUPPORTED: OS=watchos
> // UNSUPPORTED: OS=ios
> // UNSUPPORTED: OS=tvos

but that seems unsupported on platforms... so instead, let's try the stdlib tests with crash later.

Resolves rdar://131490298

 