### PR TITLE
Drop experimental prefixes from PackageCMO flags.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -780,10 +780,10 @@ protected:
     /// Whether this module has been built with C++ interoperability enabled.
     HasCxxInteroperability : 1,
 
-    /// Whether this module has been built with -experimental-allow-non-resilient-access.
+    /// Whether this module has been built with -allow-non-resilient-access.
     AllowNonResilientAccess : 1,
 
-    /// Whether this module has been built with -experimental-package-cmo.
+    /// Whether this module has been built with -package-cmo.
     SerializePackageEnabled : 1
   );
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -726,7 +726,7 @@ public:
     Bits.ModuleDecl.IsBuiltFromInterface = flag;
   }
 
-  /// Returns true if -experimental-allow-non-resilient-access was passed
+  /// Returns true if -allow-non-resilient-access was passed
   /// and the module is built from source.
   bool allowNonResilientAccess() const {
     return Bits.ModuleDecl.AllowNonResilientAccess &&
@@ -736,11 +736,12 @@ public:
     Bits.ModuleDecl.AllowNonResilientAccess = flag;
   }
 
-  /// Returns true if -experimental-package-cmo was passed, which
+  /// Returns true if -package-cmo was passed, which
   /// enables serialization of package, public, and inlinable decls in a
-  /// package. This requires -experimental-allow-non-resilient-access.
+  /// package. This requires -allow-non-resilient-access.
   bool serializePackageEnabled() const {
-    return Bits.ModuleDecl.SerializePackageEnabled;
+    return Bits.ModuleDecl.SerializePackageEnabled &&
+           allowNonResilientAccess();
   }
   void setSerializePackageEnabled(bool flag = true) {
     Bits.ModuleDecl.SerializePackageEnabled = flag;

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -126,12 +126,10 @@ public:
   /// Controls whether cross module optimization is enabled.
   CrossModuleOptimizationMode CMOMode = CrossModuleOptimizationMode::Off;
 
-  /// Optimization to perform default CMO within a package boundary.
-  /// Unlike the existing CMO, package CMO can be built with
-  /// -enable-library-evolution since package modules are required
-  /// to be built in the same project. To enable this optimization, the
-  /// module also needs to opt in to allow non-resilient access with
-  /// -experimental-allow-non-resilient-access.
+  /// Optimization to perform default mode CMO within a package boundary.
+  /// Package CMO can be performed for resiliently built modules as package
+  /// modules are required to be built together in the same project. To enable
+  /// this optimization, the module also needs -allow-non-resilient-access.
   bool EnableSerializePackage = false;
 
   /// Enables the emission of stack protectors in functions.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -187,9 +187,6 @@ namespace swift {
     /// Disable API availability checking.
     bool DisableAvailabilityChecking = false;
 
-    /// Enable optimization to bypass resilience checks in a package
-    bool EnableBypassResilienceInPackage = false;
-
     /// Optimization mode for unavailable declarations.
     std::optional<UnavailableDeclOptimization> UnavailableDeclOptimizationMode;
 
@@ -583,7 +580,7 @@ namespace swift {
     /// Skips decls that cannot be referenced externally.
     bool SkipNonExportableDecls = false;
 
-    /// True if -experimental-allow-non-resilient-access is passed and built
+    /// True if -allow-non-resilient-access is passed and built
     /// from source.
     bool AllowNonResilientAccess = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -519,11 +519,15 @@ def unavailable_decl_optimization_EQ : Joined<["-"], "unavailable-decl-optimizat
 
 def experimental_package_bypass_resilience : Flag<["-"], "experimental-package-bypass-resilience">,
   Flags<[FrontendOption]>,
-  HelpText<"Enable optimization to bypass resilience within a package">;
+  HelpText<"Deprecated; has no effect">;
 
 def experimental_allow_non_resilient_access : Flag<["-"], "experimental-allow-non-resilient-access">,
   Flags<[FrontendOption]>,
-  HelpText<"Allow non-resilient access by generating all contents besides exportable decls">;
+  HelpText<"Deprecated; use -allow-non-resilient-access instead">;
+
+def allow_non_resilient_access : Flag<["-"], "allow-non-resilient-access">,
+  Flags<[FrontendOption]>,
+  HelpText<"Ensures all contents are generated besides exportable decls in the binary module, so non-resilient access can be allowed">;
 
 def library_level : Separate<["-"], "library-level">,
   MetaVarName<"<level>">,
@@ -998,7 +1002,11 @@ def Oplayground : Flag<["-"], "Oplayground">, Group<O_Group>,
 
 def ExperimentalPackageCMO : Flag<["-"], "experimental-package-cmo">,
   Flags<[FrontendOption]>,
-  HelpText<"Enable optimization to perform default CMO within a package boundary">;
+  HelpText<"Deprecated; use -package-cmo instead">;
+
+def PackageCMO : Flag<["-"], "package-cmo">,
+  Flags<[FrontendOption]>,
+  HelpText<"Enable optimization to perform defalut CMO within a package boundary">;
 
 def EnbaleDefaultCMO : Flag<["-"], "enable-default-cmo">,
   Flags<[HelpHidden, FrontendOption]>,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -303,6 +303,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_suppress_remarks);
   inputArgs.AddLastArg(arguments, options::OPT_experimental_package_bypass_resilience);
   inputArgs.AddLastArg(arguments, options::OPT_ExperimentalPackageCMO);
+  inputArgs.AddLastArg(arguments, options::OPT_PackageCMO);
   inputArgs.AddLastArg(arguments, options::OPT_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_profile_use);
   inputArgs.AddLastArg(arguments, options::OPT_profile_coverage_mapping);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -786,10 +786,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnablePackageInterfaceLoad = Args.hasArg(OPT_experimental_package_interface_load) ||
                                     ::getenv("SWIFT_ENABLE_PACKAGE_INTERFACE_LOAD");
 
-  Opts.EnableBypassResilienceInPackage =
-      Args.hasArg(OPT_experimental_package_bypass_resilience) ||
-      Opts.hasFeature(Feature::ClientBypassResilientAccessInPackage);
-
   Opts.DisableAvailabilityChecking |=
       Args.hasArg(OPT_disable_availability_checking);
   if (Args.hasArg(OPT_check_api_availability_only))
@@ -1239,13 +1235,14 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.AllowNonResilientAccess =
       Args.hasArg(OPT_experimental_allow_non_resilient_access) ||
+      Args.hasArg(OPT_allow_non_resilient_access) ||
       Opts.hasFeature(Feature::AllowNonResilientAccessInPackage);
   if (Opts.AllowNonResilientAccess) {
     // Override the option to skip non-exportable decls.
     if (Opts.SkipNonExportableDecls) {
       Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
                      "-experimental-skip-non-exportable-decls",
-                     "-experimental-allow-non-resilient-access");
+                     "-allow-non-resilient-access");
       Opts.SkipNonExportableDecls = false;
     }
     // If built from interface, non-resilient access should not be allowed.
@@ -1254,7 +1251,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
             FrontendOpts.RequestedAction)) {
       Diags.diagnose(
           SourceLoc(), diag::warn_ignore_option_overriden_by,
-          "-experimental-allow-non-resilient-access",
+          "-allow-non-resilient-access",
           "-compile-module-from-interface or -typecheck-module-from-interface");
       Opts.AllowNonResilientAccess = false;
     }
@@ -1671,7 +1668,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
     if (LangOpts.AllowNonResilientAccess)
       Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
                      "-experimental-skip-non-inlinable-function-bodies-without-types",
-                     "-experimental-allow-non-resilient-access");
+                     "-allow-non-resilient-access");
     else
       Opts.SkipFunctionBodies = FunctionBodySkipping::NonInlinableWithoutTypes;
   }
@@ -1682,7 +1679,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
     if (LangOpts.AllowNonResilientAccess)
       Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
                      "-experimental-skip-non-inlinable-function-bodies",
-                     "-experimental-allow-non-resilient-access");
+                     "-allow-non-resilient-access");
     else
       Opts.SkipFunctionBodies = FunctionBodySkipping::NonInlinable;
   }
@@ -1691,7 +1688,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
     if (LangOpts.AllowNonResilientAccess)
       Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
                      "-tbd-is-installapi",
-                     "-experimental-allow-non-resilient-access");
+                     "-allow-non-resilient-access");
     else
       Opts.SkipFunctionBodies = FunctionBodySkipping::NonInlinable;
   }
@@ -1700,7 +1697,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
     if (LangOpts.AllowNonResilientAccess)
       Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
                      "-experimental-skip-all-function-bodies",
-                     "-experimental-allow-non-resilient-access");
+                     "-allow-non-resilient-access");
     else
       Opts.SkipFunctionBodies = FunctionBodySkipping::All;
   }
@@ -1774,7 +1771,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
       Opts.EnableLazyTypecheck) {
     Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
                    "-experimental-lazy-typecheck",
-                   "-experimental-allow-non-resilient-access");
+                   "-allow-non-resilient-access");
     Opts.EnableLazyTypecheck = false;
   }
 
@@ -2608,11 +2605,12 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   }
 
   if (Args.hasArg(OPT_ExperimentalPackageCMO) ||
+      Args.hasArg(OPT_PackageCMO) ||
       LangOpts.hasFeature(Feature::PackageCMO)) {
     if (!LangOpts.AllowNonResilientAccess) {
       Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
-                     "-experimental-package-cmo",
-                     "-experimental-allow-non-resilient-access");
+                     "-package-cmo",
+                     "-allow-non-resilient-access");
     } else {
       Opts.EnableSerializePackage = true;
       Opts.CMOMode = CrossModuleOptimizationMode::Default;

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -703,7 +703,7 @@ void ModuleFileSharedCore::outputDiagnosticInfo(llvm::raw_ostream &os) const {
      << " against SDK " << SDKVersion
      << ", " << (resilient? "resilient": "non-resilient");
   if (Bits.AllowNonResilientAccess)
-    os << ", built with -experimental-allow-non-resilient-access";
+    os << ", built with -allow-non-resilient-access";
   if (Bits.IsAllowModuleWithCompilerErrorsEnabled)
     os << ", built with -experimental-allow-module-with-compiler-errors";
   if (ModuleInputBuffer)

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -391,10 +391,10 @@ private:
     /// Whether this module is built with C++ interoperability enabled.
     unsigned HasCxxInteroperability : 1;
 
-    /// Whether this module is built with -experimental-allow-non-resilient-access.
+    /// Whether this module is built with -allow-non-resilient-access.
     unsigned AllowNonResilientAccess : 1;
 
-    /// Whether this module is built with -experimental-package-cmo.
+    /// Whether this module is built with -package-cmo.
     unsigned SerializePackageEnabled : 1;
 
     // Explicitly pad out to the next word boundary.

--- a/test/IRGen/package_bypass_resilience_class.swift
+++ b/test/IRGen/package_bypass_resilience_class.swift
@@ -10,7 +10,16 @@
 // RUN: -emit-tbd -emit-tbd-path %t/libCore.tbd \
 // RUN: -Xfrontend -tbd-install_name=libCore.dylib -Xfrontend -validate-tbd-against-ir=all
 
-/// Build without -experimental-allow-non-resilient-access
+/// Build with -allow-non-resilient-access
+// RUN: %target-build-swift %t/Core.swift \
+// RUN: -module-name=Core -package-name Pkg \
+// RUN: -Xfrontend -allow-non-resilient-access \
+// RUN: -enable-library-evolution -O -wmo \
+// RUN: -emit-ir -o %t/Core2.ir \
+// RUN: -emit-tbd -emit-tbd-path %t/libCore2.tbd \
+// RUN: -Xfrontend -tbd-install_name=libCore2.dylib -Xfrontend -validate-tbd-against-ir=all
+
+/// Build without -allow-non-resilient-access
 // RUN: %target-build-swift %t/Core.swift \
 // RUN: -module-name=Core -package-name Pkg \
 // RUN: -enable-library-evolution -O -wmo \
@@ -19,7 +28,9 @@
 // RUN: -Xfrontend -tbd-install_name=libCoreRes.dylib -Xfrontend -validate-tbd-against-ir=all
 
 // RUN: %FileCheck %s --check-prefixes=CHECK-COMMON,CHECK-OPT < %t/Core.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-COMMON,CHECK-OPT < %t/Core2.ir
 // RUN: %FileCheck %s --check-prefixes=CHECK-TBD-COMMON,CHECK-TBD-OPT < %t/libCore.tbd
+// RUN: %FileCheck %s --check-prefixes=CHECK-TBD-COMMON,CHECK-TBD-OPT < %t/libCore2.tbd
 // RUN: %FileCheck %s --check-prefixes=CHECK-COMMON,CHECK-RES < %t/CoreRes.ir
 // RUN: %FileCheck %s --check-prefixes=CHECK-TBD-COMMON,CHECK-TBD-RES < %t/libCoreRes.tbd
 

--- a/test/IRGen/package_resilience.swift
+++ b/test/IRGen/package_resilience.swift
@@ -1,19 +1,15 @@
 //
-// Unlike its counterparts in the other *_resilience.swift files, the goal is
-// for the package's component modules to all be considered within the same
-// resilience domain. This file ensures that we use direct access to package
-// decls at use site as much as possible with -experimental-package-bypass-resilience.
+// Tests resilient access is bypassed when package optimization flags are passed.
 //
-
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/package_resilience.swift
-// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct -experimental-allow-non-resilient-access %S/Inputs/package_types/resilient_struct.swift
-// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/Inputs/package_types/resilient_enum.swift -experimental-allow-non-resilient-access
-// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/Inputs/package_types/resilient_class.swift -experimental-allow-non-resilient-access
+// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct -allow-non-resilient-access -package-cmo %S/Inputs/package_types/resilient_struct.swift
+// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/Inputs/package_types/resilient_enum.swift -allow-non-resilient-access -package-cmo
+// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/Inputs/package_types/resilient_class.swift -allow-non-resilient-access -package-cmo
 
-// RUN: %target-swift-frontend -package-name MyPkg -module-name=package_resilience -experimental-package-bypass-resilience -enable-objc-interop -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift | %FileCheck %t/package_resilience.swift --check-prefixes=CHECK,CHECK-objc,CHECK-objc%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-%target-import-type-objc-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=7 -D#MDSIZE32=52 -D#MDSIZE64=80 -D#WORDSIZE=%target-alignment
+// RUN: %target-swift-frontend -package-name MyPkg -module-name=package_resilience -enable-objc-interop -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift | %FileCheck %t/package_resilience.swift --check-prefixes=CHECK,CHECK-objc,CHECK-objc%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-%target-import-type-objc-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=7 -D#MDSIZE32=52 -D#MDSIZE64=80 -D#WORDSIZE=%target-alignment
 
-// RUN: %target-swift-frontend -package-name MyPkg -module-name=package_resilience -experimental-package-bypass-resilience -disable-objc-interop -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift | %FileCheck %t/package_resilience.swift --check-prefixes=CHECK,CHECK-native,CHECK-native%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-native-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=4 -D#MDSIZE32=40 -D#MDSIZE64=56 -D#WORDSIZE=%target-alignment
+// RUN: %target-swift-frontend -package-name MyPkg -module-name=package_resilience  -disable-objc-interop -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift | %FileCheck %t/package_resilience.swift --check-prefixes=CHECK,CHECK-native,CHECK-native%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-native-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=4 -D#MDSIZE32=40 -D#MDSIZE64=56 -D#WORDSIZE=%target-alignment
 
 // RUN: %target-swift-frontend -package-name MyPkg -module-name=package_resilience -experimental-package-bypass-resilience -I %t -emit-ir -enable-library-evolution -O %t/package_resilience.swift -package-name MyPkg
 

--- a/test/SILGen/package_allow_non_resilient_access.swift
+++ b/test/SILGen/package_allow_non_resilient_access.swift
@@ -44,7 +44,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-1
-// CHECK-DIAG-1: warning: ignoring -experimental-skip-non-exportable-decls (overriden by -experimental-allow-non-resilient-access)
+// CHECK-DIAG-1: warning: ignoring -experimental-skip-non-exportable-decls (overriden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Override -experimental-skip-non-inlinable-function-bodies-without-types with warning
@@ -57,7 +57,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-2
-// CHECK-DIAG-2: warning: ignoring -experimental-skip-non-inlinable-function-bodies-without-types (overriden by -experimental-allow-non-resilient-access)
+// CHECK-DIAG-2: warning: ignoring -experimental-skip-non-inlinable-function-bodies-without-types (overriden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Override -experimental-skip-non-inlinable-function-bodies with warning
@@ -70,7 +70,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-3
-// CHECK-DIAG-3: warning: ignoring -experimental-skip-non-inlinable-function-bodies (overriden by -experimental-allow-non-resilient-access)
+// CHECK-DIAG-3: warning: ignoring -experimental-skip-non-inlinable-function-bodies (overriden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Override -experimental-skip-all-function-bodies with warning
@@ -83,7 +83,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-4
-// CHECK-DIAG-4: warning: ignoring -experimental-skip-all-function-bodies (overriden by -experimental-allow-non-resilient-access)
+// CHECK-DIAG-4: warning: ignoring -experimental-skip-all-function-bodies (overriden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Override -experimental-lazy-typecheck with warning
@@ -96,7 +96,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-5
-// CHECK-DIAG-5: warning: ignoring -experimental-lazy-typecheck (overriden by -experimental-allow-non-resilient-access)
+// CHECK-DIAG-5: warning: ignoring -experimental-lazy-typecheck (overriden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Override -tbd-is-installapi with warning
@@ -109,7 +109,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-TBD
-// CHECK-DIAG-TBD: warning: ignoring -tbd-is-installapi (overriden by -experimental-allow-non-resilient-access)
+// CHECK-DIAG-TBD: warning: ignoring -tbd-is-installapi (overriden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Build Utils interface files.
@@ -127,10 +127,10 @@
 // RUN: %target-swift-frontend -compile-module-from-interface \
 // RUN: -module-name Utils \
 // RUN: -package-name mpkg \
-// RUN: -experimental-allow-non-resilient-access \
+// RUN: -allow-non-resilient-access \
 // RUN: %t/Utils.package.swiftinterface -o %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-INTERFACE
-// CHECK-DIAG-INTERFACE: warning: ignoring -experimental-allow-non-resilient-access (overriden by -compile-module-from-interface or -typecheck-module-from-interface)
+// CHECK-DIAG-INTERFACE: warning: ignoring -allow-non-resilient-access (overriden by -compile-module-from-interface or -typecheck-module-from-interface)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-OFF
 // CHECK-OFF-NOT: ALLOW_NON_RESILIENT_ACCESS
 

--- a/test/SILOptimizer/package-cmo-skip-internal.swift
+++ b/test/SILOptimizer/package-cmo-skip-internal.swift
@@ -13,6 +13,15 @@
 // RUN: %FileCheck %s --check-prefixes=CHECK < %t/Lib.sil
 // RUN: %FileCheck %s --check-prefixes=CHECK-MAIN < %t/Main.sil
 
+// RUN: rm -rf %t/Lib.swiftmodule
+// RUN: %target-build-swift %t/Lib.swift \
+// RUN: -module-name=Lib -package-name Pkg \
+// RUN: -parse-as-library -emit-module -emit-module-path %t/Lib.swiftmodule -I%t \
+// RUN: -Xfrontend -package-cmo -Xfrontend -allow-non-resilient-access \
+// RUN: -O -wmo -enable-library-evolution
+// RUN: %target-sil-opt %t/Lib.swiftmodule -sil-verify-all -o %t/Lib2.sil
+// RUN: %FileCheck %s --check-prefixes=CHECK < %t/Lib2.sil
+
 
 //--- main.swift
 

--- a/test/Sema/package_resilience_bypass_exhaustive_switch.swift
+++ b/test/Sema/package_resilience_bypass_exhaustive_switch.swift
@@ -12,7 +12,7 @@
 
 // RUN: %target-swift-frontend -typecheck %t/ClientDefault.swift -I %t -swift-version 5 -package-name mypkg -verify
 
-// RUN: %target-swift-frontend -typecheck %t/ClientOptimized.swift -I %t -swift-version 5 -package-name mypkg -experimental-package-bypass-resilience -verify
+// RUN: %target-swift-frontend -typecheck %t/ClientDefault.swift -I %t -swift-version 5 -package-name mypkg -experimental-package-bypass-resilience -verify
 
 //--- Utils.swift
 
@@ -163,63 +163,3 @@ public func k(_ arg: FrozenPublicEnum) -> Int {
   }
 }
 
-
-//--- ClientOptimized.swift
-import Utils
-
-// With optimization enabled to bypass resilience checks within
-// a package boundary, public (non-frozen) or package (non-frozen)
-// enums no longer require `@unknown default` in switch stmts.
-package func f(_ arg: PkgEnum) -> Int {
-  switch arg { // no-warning
-  case .one:
-    return 1
-  case .two(let val):
-    return 2 + val
-  }
-}
-
-package func m(_ arg: FrozenPkgEnum) -> Int {
-  switch arg { // no-warning
-  case .one:
-    return 1
-  case .two(let val):
-    return 2 + val
-  }
-}
-
-package func n(_ arg: FrozenUfiPkgEnum) -> Int {
-  switch arg { // no-warning
-  case .one:
-    return 1
-  case .two(let val):
-    return 2 + val
-  }
-}
-
-package func g(_ arg: UfiPkgEnum) -> Int {
-  switch arg { // no-warning
-  case .one:
-    return 1
-  case .two(let val):
-    return 2 + val
-  }
-}
-
-public func h(_ arg: PublicEnum) -> Int {
-  switch arg { // no-warning
-  case .one:
-    return 1
-  case .two(let val):
-    return 2 + val
-  }
-}
-
-public func k(_ arg: FrozenPublicEnum) -> Int {
-  switch arg { // no-warning
-  case .one:
-    return 1
-  case .two(let val):
-    return 2 + val
-  }
-}


### PR DESCRIPTION
Deprecate `experimental-` prefixed flags with prompts to use the unprefixed ones, while allowing them to continue to work for safer migration.

Also deprecate `-experimental-package-bypass-resilience` as it's no longer needed.

rdar://131498517