### PR TITLE
AST: Add a `IgnoreMissingImports` option to name lookup

### DIFF
--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -60,6 +60,10 @@ enum NLOptions : unsigned {
   /// This lookup should only return macro declarations.
   NL_OnlyMacros = 1 << 8,
 
+  /// Include members that would otherwise be filtered out because they come
+  /// from a module that has not been imported.
+  NL_IgnoreMissingImports = 1 << 9,
+
   /// The default set of options used for qualified name lookup.
   ///
   /// FIXME: Eventually, add NL_ProtocolMembers to this, once all of the

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -249,7 +249,10 @@ enum class UnqualifiedLookupFlags {
   ModuleLookup           = 1 << 8,
   /// This lookup should discard 'Self' requirements in protocol extension
   /// 'where' clauses.
-  DisregardSelfBounds    = 1 << 9
+  DisregardSelfBounds    = 1 << 9,
+  /// This lookup should include members that would otherwise be filtered out
+  /// because they come from a module that has not been imported.
+  IgnoreMissingImports = 1 << 10,
 };
 
 using UnqualifiedLookupOptions = OptionSet<UnqualifiedLookupFlags>;

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1923,11 +1923,14 @@ public:
 };
 
 class AllowInaccessibleMember final : public AllowInvalidMemberRef {
+  bool IsMissingImport;
+
   AllowInaccessibleMember(ConstraintSystem &cs, Type baseType,
                           ValueDecl *member, DeclNameRef name,
-                          ConstraintLocator *locator)
+                          ConstraintLocator *locator, bool isMissingImport)
       : AllowInvalidMemberRef(cs, FixKind::AllowInaccessibleMember, baseType,
-                              member, name, locator) {}
+                              member, name, locator),
+        IsMissingImport(isMissingImport) {}
 
 public:
   std::string getName() const override {
@@ -1942,7 +1945,8 @@ public:
 
   static AllowInaccessibleMember *create(ConstraintSystem &cs, Type baseType,
                                          ValueDecl *member, DeclNameRef name,
-                                         ConstraintLocator *locator);
+                                         ConstraintLocator *locator,
+                                         bool isMissingImport);
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowInaccessibleMember;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1975,6 +1975,10 @@ struct MemberLookupResult {
     /// The member is inaccessible (e.g. a private member in another file).
     UR_Inaccessible,
 
+    /// The member is not visible because it comes from a module that was not
+    /// imported.
+    UR_MissingImport,
+
     /// This is a `WritableKeyPath` being used to look up read-only member,
     /// used in situations involving dynamic member lookup via keypath,
     /// because it's not known upfront what access capability would the

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2363,9 +2363,11 @@ static bool isAcceptableLookupResult(const DeclContext *dc,
     if (!decl->isAccessibleFrom(dc, /*forConformance*/ false,
                                 allowUsableFromInline))
       return false;
+  }
 
-    // Check that there is some import in the originating context that
-    // makes this decl visible.
+  // Check that there is some import in the originating context that makes this
+  // decl visible.
+  if (!(options & NL_IgnoreMissingImports)) {
     if (missingExplicitImportForMemberDecl(dc, decl))
       return false;
   }
@@ -3983,7 +3985,8 @@ bool IsCallAsFunctionNominalRequest::evaluate(Evaluator &evaluator,
   // that will be checked when we actually try to solve with a `callAsFunction`
   // member access.
   SmallVector<ValueDecl *, 4> results;
-  auto opts = NL_QualifiedDefault | NL_ProtocolMembers | NL_IgnoreAccessControl;
+  auto opts = NL_QualifiedDefault | NL_ProtocolMembers |
+              NL_IgnoreAccessControl | NL_IgnoreMissingImports;
   dc->lookupQualified(decl, DeclNameRef(ctx.Id_callAsFunction),
                       decl->getLoc(), opts, results);
 
@@ -4138,8 +4141,11 @@ void swift::simple_display(llvm::raw_ostream &out, NLOptions options) {
     FLAG(NL_RemoveOverridden)
     FLAG(NL_IgnoreAccessControl)
     FLAG(NL_OnlyTypes)
-    FLAG(NL_OnlyMacros)
     FLAG(NL_IncludeAttributeImplements)
+    FLAG(NL_IncludeUsableFromInline)
+    FLAG(NL_ExcludeMacroExpansions)
+    FLAG(NL_OnlyMacros)
+    FLAG(NL_IgnoreMissingImports)
 #undef FLAG
   };
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -596,6 +596,8 @@ NLOptions UnqualifiedLookupFactory::computeBaseNLOptions(
     baseNLOptions |= NL_OnlyMacros;
   if (options.contains(Flags::IgnoreAccessControl))
     baseNLOptions |= NL_IgnoreAccessControl;
+  if (options.contains(Flags::IgnoreMissingImports))
+    baseNLOptions |= NL_IgnoreMissingImports;
   return baseNLOptions;
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6068,14 +6068,15 @@ static void lookupRelatedFuncs(AbstractFunctionDecl *func,
   else
     swiftName = func->getName();
 
+  NLOptions options = NL_IgnoreAccessControl | NL_IgnoreMissingImports;
   if (auto ty = func->getDeclContext()->getSelfNominalTypeDecl()) {
     ty->lookupQualified({ ty }, DeclNameRef(swiftName), func->getLoc(),
-                        NL_QualifiedDefault | NL_IgnoreAccessControl, results);
+                        NL_QualifiedDefault | options, results);
   }
   else {
     auto mod = func->getDeclContext()->getParentModule();
     mod->lookupQualified(mod, DeclNameRef(swiftName), func->getLoc(),
-                         NL_RemoveOverridden | NL_IgnoreAccessControl, results);
+                         NL_RemoveOverridden | options, results);
   }
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6187,11 +6187,12 @@ bool InaccessibleMemberFailure::diagnoseAsError() {
   }
 
   auto loc = nameLoc.isValid() ? nameLoc.getStartLoc() : ::getLoc(anchor);
-  auto accessLevel = Member->getFormalAccessScope().accessLevelForDiagnostics();
-  if (accessLevel == AccessLevel::Public &&
-      diagnoseMissingImportForMember(Member, getDC(), loc))
+  if (IsMissingImport) {
+    diagnoseMissingImportForMember(Member, getDC(), loc);
     return true;
+  }
 
+  auto accessLevel = Member->getFormalAccessScope().accessLevelForDiagnostics();
   if (auto *CD = dyn_cast<ConstructorDecl>(Member)) {
     emitDiagnosticAt(loc, diag::init_candidate_inaccessible,
                      CD->getResultInterfaceType(), accessLevel)

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1638,11 +1638,13 @@ private:
 /// ```
 class InaccessibleMemberFailure final : public FailureDiagnostic {
   ValueDecl *Member;
+  bool IsMissingImport;
 
 public:
   InaccessibleMemberFailure(const Solution &solution, ValueDecl *member,
-                            ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator), Member(member) {}
+                            ConstraintLocator *locator, bool isMissingImport)
+      : FailureDiagnostic(solution, locator), Member(member),
+        IsMissingImport(isMissingImport) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1152,16 +1152,16 @@ MoveOutOfOrderArgument *MoveOutOfOrderArgument::create(
 
 bool AllowInaccessibleMember::diagnose(const Solution &solution,
                                        bool asNote) const {
-  InaccessibleMemberFailure failure(solution, getMember(), getLocator());
+  InaccessibleMemberFailure failure(solution, getMember(), getLocator(),
+                                    IsMissingImport);
   return failure.diagnose(asNote);
 }
 
-AllowInaccessibleMember *
-AllowInaccessibleMember::create(ConstraintSystem &cs, Type baseType,
-                                ValueDecl *member, DeclNameRef name,
-                                ConstraintLocator *locator) {
-  return new (cs.getAllocator())
-      AllowInaccessibleMember(cs, baseType, member, name, locator);
+AllowInaccessibleMember *AllowInaccessibleMember::create(
+    ConstraintSystem &cs, Type baseType, ValueDecl *member, DeclNameRef name,
+    ConstraintLocator *locator, bool isMissingImport) {
+  return new (cs.getAllocator()) AllowInaccessibleMember(
+      cs, baseType, member, name, locator, isMissingImport);
 }
 
 bool AllowAnyObjectKeyPathRoot::diagnose(const Solution &solution,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10454,30 +10454,45 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   if (result.ViableCandidates.empty() && result.UnviableCandidates.empty() &&
       includeInaccessibleMembers) {
     NameLookupOptions lookupOptions = defaultMemberLookupOptions;
-    
-    // Ignore access control so we get candidates that might have been missed
-    // before.
-    lookupOptions |= NameLookupFlags::IgnoreAccessControl;
 
-    auto lookup =
-        TypeChecker::lookupMember(DC, instanceTy, memberName,
-                                  memberLoc, lookupOptions);
-    for (auto entry : lookup) {
-      auto *cand = entry.getValueDecl();
+    // Local function that looks up additional candidates using the given lookup
+    // options, recording the results as unviable candidates.
+    auto lookupUnviable =
+        [&](NameLookupOptions lookupOptions,
+            MemberLookupResult::UnviableReason reason) -> bool {
+      auto lookup = TypeChecker::lookupMember(DC, instanceTy, memberName,
+                                              memberLoc, lookupOptions);
+      for (auto entry : lookup) {
+        auto *cand = entry.getValueDecl();
 
-      // If the result is invalid, skip it.
-      if (cand->isInvalid()) {
-        result.markErrorAlreadyDiagnosed();
-        return result;
+        // If the result is invalid, skip it.
+        if (cand->isInvalid()) {
+          result.markErrorAlreadyDiagnosed();
+          break;
+        }
+
+        if (excludedDynamicMembers.count(cand))
+          continue;
+
+        result.addUnviable(getOverloadChoice(cand, /*isBridged=*/false,
+                                             /*isUnwrappedOptional=*/false),
+                           reason);
       }
 
-      if (excludedDynamicMembers.count(cand))
-        continue;
+      return !lookup.empty();
+    };
 
-      result.addUnviable(getOverloadChoice(cand, /*isBridged=*/false,
-                                           /*isUnwrappedOptional=*/false),
-                         MemberLookupResult::UR_Inaccessible);
-    }
+    // Ignore access control so we get candidates that might have been missed
+    // before.
+    if (lookupUnviable(lookupOptions | NameLookupFlags::IgnoreAccessControl,
+                       MemberLookupResult::UR_Inaccessible))
+      return result;
+
+    // Ignore missing import statements in order to find more candidates that
+    // might have been missed before.
+    if (lookupUnviable(lookupOptions | NameLookupFlags::IgnoreMissingImports,
+                       MemberLookupResult::UR_MissingImport))
+      return result;
   }
   
   return result;
@@ -10678,9 +10693,11 @@ static ConstraintFix *fixMemberRef(
     }
 
     case MemberLookupResult::UR_Inaccessible:
+    case MemberLookupResult::UR_MissingImport:
       assert(choice.isDecl());
-      return AllowInaccessibleMember::create(cs, baseTy, choice.getDecl(),
-                                             memberName, locator);
+      return AllowInaccessibleMember::create(
+          cs, baseTy, choice.getDecl(), memberName, locator,
+          *reason == MemberLookupResult::UR_MissingImport);
 
     case MemberLookupResult::UR_UnavailableInExistential: {
       return choice.isDecl()

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1155,7 +1155,8 @@ static void collectNonOveriddenSuperclassInits(
   superclassDecl->synthesizeSemanticMembersIfNeeded(
     DeclBaseName::createConstructor());
 
-  NLOptions subOptions = (NL_QualifiedDefault | NL_IgnoreAccessControl);
+  NLOptions subOptions =
+      (NL_QualifiedDefault | NL_IgnoreAccessControl | NL_IgnoreMissingImports);
   SmallVector<ValueDecl *, 4> lookupResults;
   subclass->lookupQualified(
       superclassDecl, DeclNameRef::createConstructor(),

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -221,6 +221,8 @@ convertToUnqualifiedLookupOptions(NameLookupOptions options) {
     newOptions |= UnqualifiedLookupFlags::IncludeUsableFromInline;
   if (options.contains(NameLookupFlags::ExcludeMacroExpansions))
     newOptions |= UnqualifiedLookupFlags::ExcludeMacroExpansions;
+  if (options.contains(NameLookupFlags::IgnoreMissingImports))
+    newOptions |= UnqualifiedLookupFlags::IgnoreMissingImports;
 
   return newOptions;
 }
@@ -324,6 +326,8 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   NLOptions subOptions = (NL_QualifiedDefault | NL_ProtocolMembers);
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
     subOptions |= NL_IgnoreAccessControl;
+  if (options.contains(NameLookupFlags::IgnoreMissingImports))
+    subOptions |= NL_IgnoreMissingImports;
 
   // We handle our own overriding/shadowing filtering.
   subOptions &= ~NL_RemoveOverridden;
@@ -420,6 +424,8 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
 
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
     subOptions |= NL_IgnoreAccessControl;
+  if (options.contains(NameLookupFlags::IgnoreMissingImports))
+    subOptions |= NL_IgnoreMissingImports;
   if (options.contains(NameLookupFlags::IncludeUsableFromInline))
     subOptions |= NL_IncludeUsableFromInline;
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -158,6 +158,9 @@ enum class NameLookupFlags {
   IncludeUsableFromInline = 1 << 2,
   /// This lookup should exclude any names introduced by macro expansions.
   ExcludeMacroExpansions = 1 << 3,
+  /// Whether to include members that would otherwise be filtered out because
+  /// they come from a module that has not been imported.
+  IgnoreMissingImports = 1 << 4,
 };
 
 /// A set of options that control name lookup.

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
@@ -3,12 +3,15 @@ import members_A
 
 extension X {
   public func XinB() { }
+  package func XinB_package() { }
 
   public var propXinB: Bool { return true }
+  package var propXinB_package: Bool { return true }
 
   public static func >>>(a: Self, b: Self) -> Self { b }
 
   public struct NestedInB {}
+  package struct NestedInB_package {}
 }
 
 extension Y {
@@ -18,5 +21,9 @@ extension Y {
 }
 
 public enum EnumInB {
+  case caseInB
+}
+
+package enum EnumInB_package {
   case caseInB
 }

--- a/test/NameLookup/members_transitive.swift
+++ b/test/NameLookup/members_transitive.swift
@@ -7,7 +7,7 @@
 // RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 5 -package-name TestPackage -enable-experimental-feature MemberImportVisibility -verify-additional-prefix member-visibility-
 
 import members_C
-// expected-member-visibility-note 6{{add import of module 'members_B'}}{{1-1=import members_B\n}}
+// expected-member-visibility-note 11{{add import of module 'members_B'}}{{1-1=import members_B\n}}
 
 
 func testExtensionMembers(x: X, y: Y<Z>) {
@@ -15,7 +15,7 @@ func testExtensionMembers(x: X, y: Y<Z>) {
   y.YinA()
 
   x.XinB() // expected-member-visibility-error{{instance method 'XinB()' is not available due to missing import of defining module 'members_B'}}
-  x.XinB_package() // expected-member-visibility-error{{'XinB_package' is inaccessible due to 'package' protection level}}
+  x.XinB_package() // expected-member-visibility-error{{instance method 'XinB_package()' is not available due to missing import of defining module 'members_B'}}
   y.YinB() // expected-member-visibility-error{{instance method 'YinB()' is not available due to missing import of defining module 'members_B'}}
 
   x.XinC()
@@ -38,7 +38,7 @@ extension X {
     return (
       propXinA,
       propXinB, // expected-member-visibility-error{{property 'propXinB' is not available due to missing import of defining module 'members_B'}}
-      propXinB_package, // expected-member-visibility-error{{'propXinB_package' is inaccessible due to 'package' protection level}}
+      propXinB_package, // expected-member-visibility-error{{property 'propXinB_package' is not available due to missing import of defining module 'members_B}}
       propXinC
     )
   }
@@ -46,19 +46,19 @@ extension X {
   func testNestedTypes() {
     _ = NestedInA.self
     _ = NestedInB.self // expected-member-visibility-error{{struct 'NestedInB' is not available due to missing import of defining module 'members_B'}}
-    _ = NestedInB_package.self // expected-member-visibility-error{{'NestedInB_package' is inaccessible due to 'package' protection level}}
+    _ = NestedInB_package.self // expected-member-visibility-error{{struct 'NestedInB_package' is not available due to missing import of defining module 'members_B'}}
     _ = NestedInC.self
   }
 
   var nestedInA: NestedInA { fatalError() }
   var nestedInB: NestedInB { fatalError() } // expected-member-visibility-error{{struct 'NestedInB' is not available due to missing import of defining module 'members_B'}}
-  var nestedInB_package: NestedInB_package { fatalError() } // expected-member-visibility-error{{'NestedInB_package' is inaccessible due to 'package' protection level}}
+  var nestedInB_package: NestedInB_package { fatalError() } // expected-member-visibility-error{{struct 'NestedInB_package' is not available due to missing import of defining module 'members_B'}}
   var nestedInC: NestedInC { fatalError() }
 }
 
 extension X.NestedInA {}
 extension X.NestedInB {} // expected-member-visibility-error{{struct 'NestedInB' is not available due to missing import of defining module 'members_B'}}
-extension X.NestedInB_package {} // expected-member-visibility-error{{'NestedInB_package' is inaccessible due to 'package' protection level}}
+extension X.NestedInB_package {} // expected-member-visibility-error{{struct 'NestedInB_package' is not available due to missing import of defining module 'members_B'}}
 extension X.NestedInC {}
 
 func testTopLevelTypes() {

--- a/test/NameLookup/members_transitive.swift
+++ b/test/NameLookup/members_transitive.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/MemberImportVisibility/members_A.swift
-// RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/MemberImportVisibility/members_B.swift
+// RUN: %target-swift-frontend -emit-module -I %t -o %t -package-name TestPackage %S/Inputs/MemberImportVisibility/members_B.swift
 // RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/MemberImportVisibility/members_C.swift
-// RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 5
-// RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 6
-// RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 5 -enable-experimental-feature MemberImportVisibility -verify-additional-prefix member-visibility-
+// RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 5 -package-name TestPackage
+// RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 6 -package-name TestPackage
+// RUN: %target-swift-frontend -typecheck %s -I %t -verify -swift-version 5 -package-name TestPackage -enable-experimental-feature MemberImportVisibility -verify-additional-prefix member-visibility-
 
 import members_C
 // expected-member-visibility-note 6{{add import of module 'members_B'}}{{1-1=import members_B\n}}
@@ -15,6 +15,7 @@ func testExtensionMembers(x: X, y: Y<Z>) {
   y.YinA()
 
   x.XinB() // expected-member-visibility-error{{instance method 'XinB()' is not available due to missing import of defining module 'members_B'}}
+  x.XinB_package() // expected-member-visibility-error{{'XinB_package' is inaccessible due to 'package' protection level}}
   y.YinB() // expected-member-visibility-error{{instance method 'YinB()' is not available due to missing import of defining module 'members_B'}}
 
   x.XinC()
@@ -33,10 +34,11 @@ func testOperatorMembers(x: X, y: Y<Z>) {
 }
 
 extension X {
-  var testProperties: (Bool, Bool, Bool) {
+  var testProperties: (Bool, Bool, Bool, Bool) {
     return (
       propXinA,
       propXinB, // expected-member-visibility-error{{property 'propXinB' is not available due to missing import of defining module 'members_B'}}
+      propXinB_package, // expected-member-visibility-error{{'propXinB_package' is inaccessible due to 'package' protection level}}
       propXinC
     )
   }
@@ -44,20 +46,24 @@ extension X {
   func testNestedTypes() {
     _ = NestedInA.self
     _ = NestedInB.self // expected-member-visibility-error{{struct 'NestedInB' is not available due to missing import of defining module 'members_B'}}
+    _ = NestedInB_package.self // expected-member-visibility-error{{'NestedInB_package' is inaccessible due to 'package' protection level}}
     _ = NestedInC.self
   }
 
   var nestedInA: NestedInA { fatalError() }
   var nestedInB: NestedInB { fatalError() } // expected-member-visibility-error{{struct 'NestedInB' is not available due to missing import of defining module 'members_B'}}
+  var nestedInB_package: NestedInB_package { fatalError() } // expected-member-visibility-error{{'NestedInB_package' is inaccessible due to 'package' protection level}}
   var nestedInC: NestedInC { fatalError() }
 }
 
 extension X.NestedInA {}
 extension X.NestedInB {} // expected-member-visibility-error{{struct 'NestedInB' is not available due to missing import of defining module 'members_B'}}
+extension X.NestedInB_package {} // expected-member-visibility-error{{'NestedInB_package' is inaccessible due to 'package' protection level}}
 extension X.NestedInC {}
 
 func testTopLevelTypes() {
   _ = EnumInA.self
   _ = EnumInB.self // expected-error{{cannot find 'EnumInB' in scope}}
+  _ = EnumInB_package.self // expected-error{{cannot find 'EnumInB_package' in scope}}
   _ = EnumInC.self
 }

--- a/test/NameLookup/members_transitive_multifile.swift
+++ b/test/NameLookup/members_transitive_multifile.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/MemberImportVisibility/members_A.swift
-// RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/MemberImportVisibility/members_B.swift
+// RUN: %target-swift-frontend -emit-module -I %t -o %t -package-name TestPackage %S/Inputs/MemberImportVisibility/members_B.swift
 // RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/MemberImportVisibility/members_C.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %t/A.swift %t/B.swift %t/C.swift -I %t -verify -swift-version 5
 // RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %t/A.swift %t/B.swift %t/C.swift -I %t -verify -swift-version 6

--- a/test/SPI/client_reuse_spi.swift
+++ b/test/SPI/client_reuse_spi.swift
@@ -20,8 +20,8 @@
 //--- C.swift
 
 @_spi(B) import B
-// expected-note{{add import of module 'A'}}{{1-1=@_spi(A) import A\n}}
+
 var a = foo() // OK
-a.bar() // expected-error{{instance method 'bar()' is not available due to missing import of defining module 'A'}}
+a.bar() // expected-error{{'bar' is inaccessible due to '@_spi' protection level}}
 
 var b = SecretStruct() // expected-error{{cannot find 'SecretStruct' in scope}}


### PR DESCRIPTION
Control enforcement of member import visibility requirements via a new option, instead of piggy-backing on the existing `IgnoreAccessControl` option. Adopt the option when doing fallback lookups for unviable members so that the compiler can diagnose the reason that a member is inaccessible more reliably. Previously, with `MemberImportVisibility` enabled decls with the package access level could be mis-diagnosed as inaccessible due to their access level when really they were inaccessible due to a missing import.
    
Resolves rdar://131501862.
