### PR TITLE
Correct discrepancies in the package interface file lookup.

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -618,9 +618,6 @@ std::string SerializedModuleBaseName::getName(file_types::ID fileTy) const {
 std::optional<std::string>
 SerializedModuleBaseName::getPackageInterfacePathIfInSamePackage(
     llvm::vfs::FileSystem &fs, ASTContext &ctx) const {
-  if (!ctx.LangOpts.EnablePackageInterfaceLoad)
-    return std::nullopt;
-
   std::string packagePath{
       getName(file_types::TY_PackageSwiftModuleInterfaceFile)};
 
@@ -667,8 +664,12 @@ SerializedModuleBaseName::findInterfacePath(llvm::vfs::FileSystem &fs,
   if (!fs.exists(interfacePath))
     return std::nullopt;
 
-  // If there is a package name, try look for the package interface.
-  if (!ctx.LangOpts.PackageName.empty()) {
+  // If there is a package name, try to look for the package interface,
+  // which can only be loaded if -experimental-package-interface-load
+  // is passed to the client, so fall back to private/public interface
+  // if not.
+  if (!ctx.LangOpts.PackageName.empty() &&
+      ctx.LangOpts.EnablePackageInterfaceLoad) {
     if (auto maybePackageInterface =
             getPackageInterfacePathIfInSamePackage(fs, ctx))
       return *maybePackageInterface;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -664,15 +664,15 @@ SerializedModuleBaseName::findInterfacePath(llvm::vfs::FileSystem &fs,
   if (!fs.exists(interfacePath))
     return std::nullopt;
 
-  // If there is a package name, try to look for the package interface,
-  // which can only be loaded if -experimental-package-interface-load
-  // is passed to the client, so fall back to private/public interface
-  // if not.
+  // If both -package-name and -experimental-package-interface-load
+  // are passed to the client, try to look for the package interface
+  // to load; if either flag is missing, fall back to loading private
+  // or public interface.
   if (!ctx.LangOpts.PackageName.empty() &&
       ctx.LangOpts.EnablePackageInterfaceLoad) {
-    if (auto maybePackageInterface =
+    if (auto found =
             getPackageInterfacePathIfInSamePackage(fs, ctx))
-      return *maybePackageInterface;
+      return *found;
 
     // If package interface is not found, check if we can load the
     // public/private interface file by checking:

--- a/test/ModuleInterface/load_package_interface.swift
+++ b/test/ModuleInterface/load_package_interface.swift
@@ -25,12 +25,13 @@
 
 // CHECK-LOAD-PKG-ENABLED: loaded module 'Bar'; source: '{{.*}}Bar.package.swiftinterface', loaded: '{{.*}}Bar-{{.*}}.swiftmodule'
 
-/// Client should not load a package interface module without the flag or the env var
+/// Client should not load a package interface without the flag or the env var above;
+/// in such case, private swiftinterface is loaded but an error should be thrown in typecheck.
 // RUN: not %target-swift-frontend -typecheck %t/Client.swift -I %t \
 // RUN:   -package-name barpkg \
 // RUN:   -Rmodule-loading 2> %t/load-pkg-off.output
 // RUN: %FileCheck -check-prefix=CHECK-LOAD-PKG-OFF %s < %t/load-pkg-off.output
-// CHECK-LOAD-PKG-OFF: no such module 'Bar'
+// CHECK-LOAD-PKG-OFF: error: module 'Bar' is in package 'barpkg' but was built from a non-package interface; modules of the same package can only be loaded if built from source or package interface:{{.*}}Bar.private.swiftinterface
 
 /// Client loads a private interface since the package-name is different from the loaded module's.
 // RUN: not %target-swift-frontend -typecheck %t/Client.swift -I %t \

--- a/test/ScanDependencies/package_interface.swift
+++ b/test/ScanDependencies/package_interface.swift
@@ -9,8 +9,10 @@
 // RUN:   -emit-private-module-interface-path %t/Bar.private.swiftinterface \
 // RUN:   -emit-package-module-interface-path %t/Bar.package.swiftinterface
 
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -o %t/deps.json -I %t -experimental-package-interface-load \
-// RUN:   %t/Client.swift -module-name Client -package-name barpkg -swift-version 5
+// RUN: %target-swift-frontend -scan-dependencies \
+// RUN: -module-load-mode prefer-interface -o %t/deps.json -I %t \
+// RUN: -experimental-package-interface-load -swift-version 5 \
+// RUN: %t/Client.swift -module-name Client -package-name barpkg
 // RUN: %FileCheck %s --input-file=%t/deps.json --check-prefix CHECK --check-prefix CHECK-PACKAGE
 
 /// When package name doesn't match or not used, it should find private interface.
@@ -18,20 +20,23 @@
 // RUN:   %t/Client.swift -module-name Client -package-name foopkg -swift-version 5
 // RUN: %FileCheck %s --input-file=%t/deps2.json --check-prefix CHECK --check-prefix CHECK-PRIVATE
 
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -o %t/deps3.json -I %t -experimental-package-interface-load \
-// RUN:   %t/Client.swift -module-name Client -swift-version 5
+// RUN: %target-swift-frontend -scan-dependencies \
+// RUN: -module-load-mode prefer-interface -o %t/deps3.json -I %t \
+// RUN: -experimental-package-interface-load -swift-version 5 \
+// RUN: %t/Client.swift -module-name Client
 // RUN: %FileCheck %s --input-file=%t/deps3.json --check-prefix CHECK --check-prefix CHECK-PRIVATE
 
-/// If -experimental-package-interface-load is not used but in the same package, it should find the binary module
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -I %t \
-// RUN:   %t/Client.swift -module-name Client -package-name barpkg -swift-version 5 | \
-// RUN:   %FileCheck %s --check-prefix CHECK-BINARY
+/// If -experimental-package-interface-load is not used but in the same package, it should find private interface.
+// RUN: %target-swift-frontend -scan-dependencies \
+// RUN: -module-load-mode prefer-interface -o %t/deps4.json -I %t \
+// RUN: -swift-version 5 \
+// RUN: %t/Client.swift -module-name Client -package-name barpkg | \
+// RUN: %FileCheck %s --input-file=%t/deps4.json --check-prefix CHECK-PRIVATE
 
 // CHECK: "swift": "Bar"
 // CHECK: "modulePath": "{{.*}}{{/|\\}}Bar-{{.*}}.swiftmodule"
 // CHECK-PACKAGE: "moduleInterfacePath": "{{.*}}{{/|\\}}Bar.package.swiftinterface"
 // CHECK-PRIVATE: "moduleInterfacePath": "{{.*}}{{/|\\}}Bar.private.swiftinterface"
-// CHECK-BINARY: "swiftPrebuiltExternal": "Bar"
 
 //--- Bar.swift
 public enum PubEnum {

--- a/test/Serialization/load_package_module.swift
+++ b/test/Serialization/load_package_module.swift
@@ -31,7 +31,7 @@
 
 // RUN: not %target-swift-frontend -typecheck %t/ClientLoadInterface.swift -package-name libPkg -I %t 2> %t/resultY.output
 // RUN: %FileCheck %s -check-prefix CHECK-Y < %t/resultY.output
-// CHECK-Y: error: no such module 'LibInterface'
+// CHECK-Y: error: module 'LibInterface' is in package 'libPkg' but was built from a non-package interface; modules of the same package can only be loaded if built from source or package interface: {{.*}}LibInterface.private.swiftinterface
 
 
 //--- Lib.swift


### PR DESCRIPTION
Add a check for the client side flag which explcitly opts in to loading the package interface, besides whether package-name is empty or in the same package.

rdar://131393508
