### PR TITLE
[6.0][region-isolation] Make "unknown pattern error" always an error.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -157,6 +157,23 @@ static Expr *inferArgumentExprFromApplyExpr(ApplyExpr *sourceApply,
 //                             MARK: Diagnostics
 //===----------------------------------------------------------------------===//
 
+/// Emit the "unknown pattern error" at the SILLocation of \p inst.
+static void diagnoseUnknownPatternError(SILInstruction *inst) {
+  if (shouldAbortOnUnknownPatternMatchError()) {
+    llvm::report_fatal_error(
+        "RegionIsolation: Aborting on unknown pattern match error");
+  }
+
+  auto &ctx = inst->getFunction()->getASTContext();
+  auto loc = inst->getLoc().getSourceLoc();
+
+  ctx.Diags.diagnose(loc, diag::regionbasedisolation_unknown_pattern);
+}
+
+static void diagnoseUnknownPatternError(Operand *op) {
+  diagnoseUnknownPatternError(op->getUser());
+}
+
 template <typename... T, typename... U>
 static InFlightDiagnostic diagnoseError(ASTContext &context, SourceLoc loc,
                                         Diag<T...> diag, U &&...args) {
@@ -731,14 +748,7 @@ public:
   }
 
   void emitUnknownPatternError() {
-    if (shouldAbortOnUnknownPatternMatchError()) {
-      llvm::report_fatal_error(
-          "RegionIsolation: Aborting on unknown pattern match error");
-    }
-
-    diagnoseError(transferOp->getUser(),
-                  diag::regionbasedisolation_unknown_pattern)
-        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseUnknownPatternError(transferOp->getUser());
   }
 
 private:
@@ -1159,12 +1169,7 @@ void TransferNonSendableImpl::emitUseAfterTransferDiagnostics() {
     // tells the user to file a bug. This importantly ensures that we can
     // guarantee that we always find the require if we successfully compile.
     if (!didEmitRequireNote) {
-      if (shouldAbortOnUnknownPatternMatchError()) {
-        llvm::report_fatal_error(
-            "RegionIsolation: Aborting on unknown pattern match error");
-      }
-
-      diagnoseError(transferOp, diag::regionbasedisolation_unknown_pattern);
+      diagnoseUnknownPatternError(transferOp);
       continue;
     }
 
@@ -1226,14 +1231,7 @@ public:
   }
 
   void emitUnknownPatternError() {
-    if (shouldAbortOnUnknownPatternMatchError()) {
-      llvm::report_fatal_error(
-          "RegionIsolation: Aborting on unknown pattern match error");
-    }
-
-    diagnoseError(getOperand()->getUser(),
-                  diag::regionbasedisolation_unknown_pattern)
-        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseUnknownPatternError(getOperand()->getUser());
   }
 
   void emitUnknownUse(SILLocation loc) {
@@ -1726,14 +1724,7 @@ public:
   }
 
   void emitUnknownPatternError() {
-    if (shouldAbortOnUnknownPatternMatchError()) {
-      llvm::report_fatal_error(
-          "RegionIsolation: Aborting on unknown pattern match error");
-    }
-
-    diagnoseError(info.functionExitingInst,
-                  diag::regionbasedisolation_unknown_pattern)
-        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseUnknownPatternError(info.functionExitingInst);
   }
 
   void emit();
@@ -1993,13 +1984,7 @@ struct DiagnosticEvaluator final
   }
 
   void handleUnknownCodePattern(const PartitionOp &op) const {
-    if (shouldAbortOnUnknownPatternMatchError()) {
-      llvm::report_fatal_error(
-          "RegionIsolation: Aborting on unknown pattern match error");
-    }
-
-    diagnoseError(op.getSourceInst(),
-                  diag::regionbasedisolation_unknown_pattern);
+    diagnoseUnknownPatternError(op.getSourceInst());
   }
 
   bool isActorDerived(Element element) const {


### PR DESCRIPTION
Explanation: This shows an actual issue with the compiler where semantically we should crash. Rather than crashing (due to the broken invariants), we emit this error so that the user gets a nice error message at the problem place and can work around it instead of just getting a mysterious crash. 

Previously, we were making this a warning in swift 5 mode... but given the issues, it makes sense to emit an error diagnostic so we get the feedback and the user cannot ship the code.

Radars:

- rdar://131482934

Original PRs:

- https://github.com/swiftlang/swift/pull/75137

Risk: Low. This is just tweaking this diagnostic to be an error instead of a warning. It is safe on the face. The only risk is that we could expose more of these issues and break a build... but we actually want to do that so we can get in fixes vs not getting notified.
Testing: N/A. We do not produce this in the tests... but this is safe on the face of it.
Reviewer: @hborla 