### PR TITLE
tests: add a missing `REQUIRES: executable_test` in SILOptimizer/stack-promotion-crash.swift

### DIFF
--- a/test/SILOptimizer/stack-promotion-crash.swift
+++ b/test/SILOptimizer/stack-promotion-crash.swift
@@ -6,6 +6,8 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
+// REQUIRES: executable_test
+
 //--- module.modulemap
 
 module CModule {


### PR DESCRIPTION
Therefore the test failed on non-executing device jobs

rdar://131519168
