### PR TITLE
[6.0] [Index] Mark accessors as implicit in modules

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1013,6 +1013,9 @@ private:
     return true;
   }
 
+  /// Whether the given decl should be marked implicit in the index data.
+  bool hasImplicitRole(Decl *D);
+
   bool initIndexSymbol(ValueDecl *D, SourceLoc Loc, bool IsRef,
                        IndexSymbol &Info);
   bool initIndexSymbol(ExtensionDecl *D, ValueDecl *ExtendedD, SourceLoc Loc,
@@ -1737,6 +1740,21 @@ bool IndexSwiftASTWalker::reportImplicitConformance(ValueDecl *witness, ValueDec
   return finishCurrentEntity();
 }
 
+bool IndexSwiftASTWalker::hasImplicitRole(Decl *D) {
+  if (D->isImplicit())
+    return true;
+
+  // Parsed accessors should be treated as implicit in a module since they won't
+  // have bodies in the generated interface (even if inlinable), and aren't
+  // useful symbols to jump to (the variable itself should be used instead).
+  // Currently generated interfaces don't even record USRs for them, so
+  // findUSRRange will always fail for them.
+  if (isa<AccessorDecl>(D) && IsModuleFile)
+    return true;
+
+  return false;
+}
+
 bool IndexSwiftASTWalker::initIndexSymbol(ValueDecl *D, SourceLoc Loc,
                                           bool IsRef, IndexSymbol &Info) {
   assert(D);
@@ -1768,7 +1786,7 @@ bool IndexSwiftASTWalker::initIndexSymbol(ValueDecl *D, SourceLoc Loc,
     addContainedByRelationIfContained(Info);
   } else {
     Info.roles |= (unsigned)SymbolRole::Definition;
-    if (D->isImplicit())
+    if (hasImplicitRole(D))
       Info.roles |= (unsigned)SymbolRole::Implicit;
     if (auto Group = D->getGroupName())
       Info.group = Group.value();

--- a/test/Index/index_module_accessors.swift
+++ b/test/Index/index_module_accessors.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Mod.swiftmodule -module-name Mod %s
+// RUN: %target-swift-ide-test -print-indexed-symbols -module-to-print Mod -source-filename %s -I %t | %FileCheck %s
+
+// rdar://130775560 - Make sure the accessors are marked implicit in the index
+// data for the module.
+public struct S {
+  // CHECK-DAG: instance-property/Swift | x | s:3Mod1SV1xSivp | Def,RelChild
+  // CHECK-DAG: instance-method/acc-get/Swift | getter:x | s:3Mod1SV1xSivg | Def,Impl,RelChild,RelAcc
+  public let x = 0
+
+  // CHECK-DAG: instance-property/Swift | y | s:3Mod1SV1ySivp | Def,RelChild
+  // CHECK-DAG: instance-method/acc-get/Swift | getter:y | s:3Mod1SV1ySivg | Def,Impl,RelChild,RelAcc
+  public var y: Int {
+    0
+  }
+
+  // CHECK-DAG: instance-property/Swift | z | s:3Mod1SV1zSivp | Def,RelChild
+  // CHECK-DAG: instance-method/acc-get/Swift | getter:z | s:3Mod1SV1zSivg | Def,Impl,RelChild,RelAcc
+  // CHECK-DAG: instance-method/acc-set/Swift | setter:z | s:3Mod1SV1zSivs | Def,Impl,RelChild,RelAcc
+  public var z: Int {
+    get { 0 }
+    set {}
+  }
+
+  // CHECK-DAG: instance-property/Swift | a | s:3Mod1SV1aSivp | Def,RelChild
+  // CHECK-DAG: instance-method/acc-get/Swift | getter:a | s:3Mod1SV1aSivg | Def,Impl,RelChild,RelAcc
+  public var a: Int {
+    @inlinable
+    get { 0 }
+  }
+}

--- a/test/SourceKit/Indexing/Inputs/test_module.index.response
+++ b/test/SourceKit/Indexing/Inputs/test_module.index.response
@@ -94,15 +94,15 @@
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.name: "getter:value",
               key.usr: "s:11test_module16ComputedPropertyC5valueSivg",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.name: "setter:value",
               key.usr: "s:11test_module16ComputedPropertyC5valueSivs",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.public


### PR DESCRIPTION
*6.0 cherry-pick of #74991*

- Explanation: Marks accessors as implicit in indexed modules
- Scope: Affects the indexing of accessors in modules
- Issue: rdar://130775560
- Risk: Low, the change is very straightforward and only affects the index
- Testing: Added tests to test suite
- Reviewer: Ben Barham