### PR TITLE
[cxx-interop] Flip the default value of `SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -682,7 +682,7 @@ option(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY
 
 option(SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP
   "Enable experimental C++ interop modules"
-  FALSE)
+  TRUE)
 
 option(SWIFT_ENABLE_CXX_INTEROP_SWIFT_BRIDGING_HEADER
   "Install the <swift/bridging> C++ interoperability header alongside compiler"


### PR DESCRIPTION
This changes the default value of the CMake flag `SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP` from `FALSE` to `TRUE`.

C++ interop is an important part of the compiler. If necessary, it's still possible to disable it explicitly.