### PR TITLE
[6.0 🍒][Dependency Scanning] Avoid configuration (and reset) of LLVM Options by the scanner

### DIFF
--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -35,11 +35,6 @@ llvm::ErrorOr<swiftscan_string_ref_t> getTargetInfo(ArrayRef<const char *> Comma
                                                     const char *main_executable_path) {
   llvm::sys::SmartScopedLock<true> Lock(TargetInfoMutex);
 
-  // We must reset option occurrences because we are handling an unrelated
-  // command-line to those possibly parsed before using the same tool.
-  // We must do so because LLVM options parsing is done using a managed
-  // static `GlobalParser`.
-  llvm::cl::ResetAllOptionOccurrences();
   // Parse arguments.
   std::string CommandString;
   for (const auto *c : Command) {
@@ -267,8 +262,7 @@ llvm::ErrorOr<ScanQueryInstance>
 DependencyScanningTool::initScannerForAction(
     ArrayRef<const char *> Command, StringRef WorkingDirectory) {
   // The remainder of this method operates on shared state in the
-  // scanning service and global LLVM state with:
-  // llvm::cl::ResetAllOptionOccurrences
+  // scanning service
   llvm::sys::SmartScopedLock<true> Lock(DependencyScanningToolStateLock);
   return initCompilerInstanceForScan(Command, WorkingDirectory);
 }
@@ -296,11 +290,6 @@ DependencyScanningTool::initCompilerInstanceForScan(
   if (WorkingDirectory.empty())
     llvm::sys::fs::current_path(WorkingDirectory);
 
-  // We must reset option occurrences because we are handling an unrelated
-  // command-line to those possibly parsed before using the same tool.
-  // We must do so because LLVM options parsing is done using a managed
-  // static `GlobalParser`.
-  llvm::cl::ResetAllOptionOccurrences();
   // Parse/tokenize arguments.
   std::string CommandString;
   for (const auto *c : CommandArgs) {

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1136,11 +1136,6 @@ forEachBatchEntry(CompilerInstance &invocationInstance,
       // those of the current scanner invocation.
       updateCachedInstanceOpts(*pInstance, invocationInstance, entry.arguments);
     } else {
-      // We must reset option occurrences because we are handling an unrelated command-line
-      // to those parsed before. We must do so because LLVM options parsing is done
-      // using a managed static `GlobalParser`.
-      llvm::cl::ResetAllOptionOccurrences();
-
       // Create a new instance by the arguments and save it in the map.
       auto newService = std::make_unique<SwiftDependencyScanningService>();
       auto newInstance = std::make_unique<CompilerInstance>();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -659,15 +659,21 @@ bool CompilerInstance::setUpVirtualFileSystemOverlays() {
 }
 
 void CompilerInstance::setUpLLVMArguments() {
-  // Honor -Xllvm.
-  if (!Invocation.getFrontendOptions().LLVMArgs.empty()) {
-    llvm::SmallVector<const char *, 4> Args;
-    Args.push_back("swift (LLVM option parsing)");
-    for (unsigned i = 0, e = Invocation.getFrontendOptions().LLVMArgs.size();
-         i != e; ++i)
-      Args.push_back(Invocation.getFrontendOptions().LLVMArgs[i].c_str());
-    Args.push_back(nullptr);
-    llvm::cl::ParseCommandLineOptions(Args.size()-1, Args.data());
+  // Dependency scanning has no need for LLVM options, and
+  // must not use `llvm::cl::` utilities operating on global state
+  // since dependency scanning is multi-threaded.
+  if (Invocation.getFrontendOptions().RequestedAction !=
+      FrontendOptions::ActionType::ScanDependencies) {
+    // Honor -Xllvm.
+    if (!Invocation.getFrontendOptions().LLVMArgs.empty()) {
+      llvm::SmallVector<const char *, 4> Args;
+      Args.push_back("swift (LLVM option parsing)");
+      for (unsigned i = 0, e = Invocation.getFrontendOptions().LLVMArgs.size();
+           i != e; ++i)
+        Args.push_back(Invocation.getFrontendOptions().LLVMArgs[i].c_str());
+      Args.push_back(nullptr);
+      llvm::cl::ParseCommandLineOptions(Args.size()-1, Args.data());
+    }
   }
 }
 


### PR DESCRIPTION
- **Explanation:** The scanning action does not have any need for handling `-llvm` options, since it will never perform any code-gen. LLVM option processing relies on global option parsing structures, and the scanner has needed to carefully attempt to synchronize access to them. This change guards the configuration of LLVM options to not happen at all for dependency scanning actions, and removes calls to `llvm::cl::ResetAllOptionOccurrences()` that were previously needed. Before this change, in a context where the same `libSwiftScan` instance was being used for many concurrent scans, initialization of LLVM options has the potential to lead to data races. 

- **Scope:** This change affects Swift compilations with Explicit Module Builds enabled. It is a non-functional change to the dependency scanner's maintenance of compiler-internal data structures.. 

- **Risk:** Low. Explicit Module Builds are currently opt-in, and this change primarily guards (disables) execution of code which previously had the potential to cause data races. 

- **Original PR:** https://github.com/swiftlang/swift/pull/75146

- **Testing:** SwiftDriver has a concurrent dependency scanning [stress-test](https://github.com/swiftlang/swift-driver/blob/f4709ef5022c7e970e55ff4c40f504e4c6330f5d/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift#L1727) which will exercise this change. Additionally, this change was used to build a collection of large projects to verify overall scanner functionality.

- **Issue/Radar:** rdar://120754696

- **Reviewed By:** @tshortli @cachemeifyoucan 
