### PR TITLE
[6.0][Concurrency] Allow sendability mismatches while overriding `@preconcurrency` properties in Swift 5 mode

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -347,6 +347,8 @@ enum class TypeMatchFlags {
   AllowCompatibleOpaqueTypeArchetypes = 1 << 5,
   /// Ignore the @Sendable attributes on functions when matching types.
   IgnoreFunctionSendability = 1 << 6,
+  /// Ignore `any Sendable` and compositions with Sendable protocol.
+  IgnoreSendability = 1 << 7,
 };
 using TypeMatchOptions = OptionSet<TypeMatchFlags>;
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3309,6 +3309,37 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
                opaque1->getInterfaceType()->getCanonicalType()->matches(
                    opaque2->getInterfaceType()->getCanonicalType(), matchMode);
 
+  if (matchMode.contains(TypeMatchFlags::IgnoreSendability)) {
+    // Support `any Sendable` -> `Any` matching inside generic types
+    // e.g. collections and optionals (i.e. `[String: (any Sendable)?]`).
+    if (auto *generic1 = t1->getAs<BoundGenericType>()) {
+      if (auto *generic2 = t2->getAs<BoundGenericType>()) {
+        if (generic1->getDecl() == generic2->getDecl()) {
+          auto genericArgs1 = generic1->getGenericArgs();
+          auto genericArgs2 = generic2->getGenericArgs();
+
+          if (genericArgs1.size() == genericArgs2.size() &&
+              llvm::all_of(llvm::zip_equal(genericArgs1, genericArgs2),
+                           [&](const auto &elt) -> bool {
+                             return matches(
+                                 std::get<0>(elt)->getCanonicalType(),
+                                 std::get<1>(elt)->getCanonicalType(),
+                                 matchMode, ParameterPosition::NotParameter,
+                                 OptionalUnwrapping::None);
+                           }))
+            return true;
+        }
+      }
+    }
+
+    // Attempting to match `any Sendable` by `Any` is allowed in this mode.
+    if (t1->isAny()) {
+      auto *PD = dyn_cast_or_null<ProtocolDecl>(t2->getAnyNominal());
+      if (PD && PD->isSpecificProtocol(KnownProtocolKind::Sendable))
+        return true;
+    }
+  }
+
   return false;
 }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1203,6 +1203,30 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
   Type declTy = getDeclComparisonType();
   Type owningTy = dc->getDeclaredInterfaceType();
   auto isClassContext = classDecl != nullptr;
+  bool allowsSendabilityMismatches =
+      attempt == OverrideCheckingAttempt::MismatchedSendability ||
+      (attempt == OverrideCheckingAttempt::PerfectMatch &&
+       baseDecl->preconcurrency());
+  bool mismatchedOnSendability = false;
+
+  auto diagnoseSendabilityMismatch = [&]() {
+    SendableCheckContext fromContext(decl->getDeclContext(),
+                                     SendableCheck::Explicit);
+    auto baseDeclClass = baseDecl->getDeclContext()->getSelfClassDecl();
+
+    diagnoseSendabilityErrorBasedOn(
+        baseDeclClass, fromContext, [&](DiagnosticBehavior limit) {
+          diags
+              .diagnose(decl, diag::override_sendability_mismatch,
+                        decl->getName())
+              .limitBehaviorUntilSwiftVersion(limit, 6)
+              .limitBehaviorIf(
+                  fromContext.preconcurrencyBehavior(baseDeclClass));
+          diags.diagnose(baseDecl, diag::overridden_here);
+          return false;
+        });
+  };
+
   if (declIUOAttr == matchDeclIUOAttr && declTy->isEqual(baseTy)) {
     // Nothing to do.
 
@@ -1263,30 +1287,47 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
     CanType parentPropertyCanTy =
       parentPropertyTy->getReducedType(
         decl->getInnermostDeclContext()->getGenericSignatureOfContext());
-    if (!propertyTy->matches(parentPropertyCanTy,
-                             TypeMatchFlags::AllowOverride)) {
-      diags.diagnose(property, diag::override_property_type_mismatch,
-                     property->getName(), propertyTy, parentPropertyTy);
-      noteFixableMismatchedTypes(decl, baseDecl);
-      diags.diagnose(baseDecl, diag::property_override_here);
-      return true;
+
+    TypeMatchOptions options;
+    options |= TypeMatchFlags::AllowOverride;
+    if (!propertyTy->matches(parentPropertyCanTy, options)) {
+      if (allowsSendabilityMismatches) {
+        options |= TypeMatchFlags::IgnoreSendability;
+        options |= TypeMatchFlags::IgnoreFunctionSendability;
+
+        mismatchedOnSendability =
+            propertyTy->matches(parentPropertyCanTy, options);
+      }
+
+      if (!mismatchedOnSendability) {
+        diags.diagnose(property, diag::override_property_type_mismatch,
+                       property->getName(), propertyTy, parentPropertyTy);
+        noteFixableMismatchedTypes(decl, baseDecl);
+        diags.diagnose(baseDecl, diag::property_override_here);
+        return true;
+      }
     }
 
     // Differing only in Optional vs. ImplicitlyUnwrappedOptional is fine.
-    bool IsSilentDifference = false;
+    bool optionalVsIUO = false;
     if (auto propertyTyNoOptional = propertyTy->getOptionalObjectType())
       if (auto parentPropertyTyNoOptional =
               parentPropertyTy->getOptionalObjectType())
         if (propertyTyNoOptional->isEqual(parentPropertyTyNoOptional))
-          IsSilentDifference = true;
+          optionalVsIUO = true;
 
     // The overridden property must not be mutable.
     if (cast<AbstractStorageDecl>(baseDecl)->supportsMutation() &&
-        !IsSilentDifference) {
+        !(optionalVsIUO || mismatchedOnSendability)) {
       diags.diagnose(property, diag::override_mutable_covariant_property,
                   property->getName(), parentPropertyTy, propertyTy);
       diags.diagnose(baseDecl, diag::property_override_here);
       return true;
+    }
+
+    if (mismatchedOnSendability && !emittedMatchError) {
+      diagnoseSendabilityMismatch();
+      return checkSingleOverride(decl, baseDecl);
     }
   }
 
@@ -1294,19 +1335,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
     return true;
 
   if (attempt == OverrideCheckingAttempt::MismatchedSendability) {
-    SendableCheckContext fromContext(decl->getDeclContext(),
-                                     SendableCheck::Explicit);
-    auto baseDeclClass = baseDecl->getDeclContext()->getSelfClassDecl();
-
-    diagnoseSendabilityErrorBasedOn(baseDeclClass, fromContext,
-                                    [&](DiagnosticBehavior limit) {
-      diags.diagnose(decl, diag::override_sendability_mismatch,
-                     decl->getName())
-        .limitBehaviorUntilSwiftVersion(limit, 6)
-        .limitBehaviorIf(fromContext.preconcurrencyBehavior(baseDeclClass));
-      diags.diagnose(baseDecl, diag::overridden_here);
-      return false;
-    });
+    diagnoseSendabilityMismatch();
   }
   // Catch-all to make sure we don't silently accept something we shouldn't.
   else if (attempt != OverrideCheckingAttempt::PerfectMatch) {

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -252,3 +252,53 @@ extension MainActorPreconcurrency: NotIsolated {
     }
   }
 }
+
+// Override matching with @preconcurrency properties.
+do {
+  class Base {
+    @preconcurrency
+    open var test1 : ([any Sendable])? // expected-note {{overridden declaration is here}}
+
+    @preconcurrency
+    open var test2: [String: [Int: any Sendable]] // expected-note {{overridden declaration is here}}
+
+    @preconcurrency
+    open var test3: any Sendable // expected-note {{overridden declaration is here}}
+
+    @preconcurrency
+    open var test4: (((Any)?) -> Void)? { // expected-note {{overridden declaration is here}}
+      nil
+    }
+
+    init() {
+      self.test1 = nil
+      self.test2 = [:]
+      self.test3 = 42
+    }
+  }
+
+  class Test : Base {
+    override var test1: [Any]? {
+      // expected-warning@-1 {{declaration 'test1' has a type with different sendability from any potential overrides; this is an error in the Swift 6 language mode}}
+      get { nil }
+      set { }
+    }
+
+    override var test2: [String: [Int: Any]] {
+      // expected-warning@-1 {{declaration 'test2' has a type with different sendability from any potential overrides; this is an error in the Swift 6 language mode}}
+      get { [:] }
+      set {}
+    }
+
+    override var test3: Any {
+      // expected-warning@-1 {{declaration 'test3' has a type with different sendability from any potential overrides; this is an error in the Swift 6 language mode}}
+      get { 42 }
+      set { }
+    }
+
+    override var test4: (((any Sendable)?) -> Void)? {
+      // expected-warning@-1 {{declaration 'test4' has a type with different sendability from any potential overrides; this is an error in the Swift 6 language mode}}
+      nil
+    }
+  }
+}

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -112,3 +112,53 @@ func aFailedExperiment(@_unsafeSendable _ body: @escaping () -> Void) { }
 
 func anothingFailedExperiment(@_unsafeMainActor _ body: @escaping () -> Void) { }
 // expected-warning@-1{{'_unsafeMainActor' attribute has been removed in favor of @preconcurrency}}
+
+// Override matching with @preconcurrency properties.
+do {
+  class Base {
+    @preconcurrency
+    open var test1 : ([any Sendable])? // expected-note {{overridden declaration is here}}
+
+    @preconcurrency
+    open var test2: [String: [Int: any Sendable]] // expected-note {{overridden declaration is here}}
+
+    @preconcurrency
+    open var test3: any Sendable // expected-note {{overridden declaration is here}}
+
+    @preconcurrency
+    open var test4: (((Any)?) -> Void)? { // expected-note {{overridden declaration is here}}
+      nil
+    }
+
+    init() {
+      self.test1 = nil
+      self.test2 = [:]
+      self.test3 = 42
+    }
+  }
+
+  class Test : Base {
+    override var test1: [Any]? {
+      // expected-error@-1 {{declaration 'test1' has a type with different sendability from any potential overrides}}
+      get { nil }
+      set { }
+    }
+
+    override var test2: [String: [Int: Any]] {
+      // expected-error@-1 {{declaration 'test2' has a type with different sendability from any potential overrides}}
+      get { [:] }
+      set {}
+    }
+
+    override var test3: Any {
+      // expected-error@-1 {{declaration 'test3' has a type with different sendability from any potential overrides}}
+      get { 42 }
+      set { }
+    }
+
+    override var test4: (((any Sendable)?) -> Void)? {
+      // expected-error@-1 {{declaration 'test4' has a type with different sendability from any potential overrides}}
+      nil
+    }
+  }
+}


### PR DESCRIPTION
- Explanation:

  Downgrade a mismatch on `any Sendable` -> `Any` to a warning until
  Swift 6 to enable class authors to introduce concurrency annotations
  to overridable properties.

- Main Branch PR: https://github.com/swiftlang/swift/pull/75062

- Resolves: rdar://122193606

- Risk: Low

- Reviewed By: @hborla, @ktoso 

- Testing: Existing test-cases were modified and new tests were added.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
