### PR TITLE
[ExplictModule] Bridgingheader chaining mode

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -208,6 +208,9 @@ ERROR(scanner_arguments_invalid, none,
 ERROR(error_scanner_extra, none,
       "failed inside dependency scanner: '%0'", (StringRef))
 
+ERROR(error_missing_chained_header, none,
+      "bridging header doesn't chain include the bridging header '%0' from module '%1'", (StringRef, StringRef))
+
 WARNING(warn_scanner_deserialize_failed, none,
         "Failed to load module scanning dependency cache from: '%0', re-building scanner cache from scratch.", (StringRef))
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1005,6 +1005,10 @@ namespace swift {
     /// invocations directly from clang cc1 args.
     bool ClangImporterDirectCC1Scan = false;
 
+    /// Whether requires user of the binary module with bridging header to chain
+    /// its bridging header.
+    bool BridgingHeaderChaining = false;
+
     /// Return a hash code of any components from these options that should
     /// contribute to a Swift Bridging PCH hash.
     llvm::hash_code getPCHHashComponents() const {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1923,6 +1923,11 @@ def experimental_clang_importer_direct_cc1_scan:
   Flags<[FrontendOption, NewDriverOnlyOption, HelpHidden]>,
   HelpText<"Enables swift driver to construct swift-frontend invocations using -direct-clang-cc1-module-build">;
 
+def experimental_chained_bridging_header_requirement:
+  Flag<["-"], "experimental-chained-bridging-header-requirement">,
+  Flags<[FrontendOption, NewDriverOnlyOption, HelpHidden]>,
+  HelpText<"Requires bridging headers from imported binary module to be chained by user">;
+
 def cache_compile_job:  Flag<["-"], "cache-compile-job">,
   Flags<[FrontendOption, NewDriverOnlyOption]>,
   HelpText<"Enable compiler caching">;

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -548,9 +548,15 @@ bool ClangImporter::addHeaderDependencies(
     // Update the cache with the new information for the module.
     cache.updateDependency(moduleID, targetModule);
   } else if (targetModule.isSwiftBinaryModule()) {
+    // If requires chaining, the source module bridging header should contain
+    // this already.
+    if (Impl.SwiftContext.ClangImporterOpts.BridgingHeaderChaining)
+      return false;
+
     auto swiftBinaryDeps = targetModule.getAsSwiftBinaryModule();
     if (!swiftBinaryDeps->headerImport.empty()) {
-      auto clangModuleDependencies = scanHeaderDependencies(swiftBinaryDeps->headerImport);
+      auto clangModuleDependencies =
+          scanHeaderDependencies(swiftBinaryDeps->headerImport);
       if (!clangModuleDependencies)
         return true;
       // TODO: CAS will require a header include tree for this.

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -902,7 +902,8 @@ computeTransitiveClosureOfExplicitDependencies(
 }
 
 static std::set<ModuleDependencyID> computeBridgingHeaderTransitiveDependencies(
-    const ModuleDependencyInfo &dep,
+    CompilerInstance &instance, const ModuleDependencyInfo &dep,
+    const std::set<ModuleDependencyID> &dependencies,
     const std::unordered_map<ModuleDependencyID, std::set<ModuleDependencyID>>
         &transitiveClosures,
     const ModuleDependenciesCache &cache) {
@@ -910,6 +911,27 @@ static std::set<ModuleDependencyID> computeBridgingHeaderTransitiveDependencies(
   auto *sourceDep = dep.getAsSwiftSourceModule();
   if (!sourceDep)
     return result;
+
+  if (instance.getInvocation()
+          .getClangImporterOptions()
+          .BridgingHeaderChaining) {
+    std::set<std::string> bridgingHeaderDeps;
+    bridgingHeaderDeps.insert(
+        sourceDep->textualModuleDetails.bridgingSourceFiles.begin(),
+        sourceDep->textualModuleDetails.bridgingSourceFiles.end());
+    for (auto &mod: dependencies) {
+      const auto &modDeps = cache.findKnownDependency(mod);
+      auto *binaryModule = modDeps.getAsSwiftBinaryModule();
+      if (!binaryModule)
+        continue;
+      if (!binaryModule->headerImport.empty() &&
+          !bridgingHeaderDeps.count(binaryModule->headerImport)) {
+        instance.getDiags().diagnose(
+            SourceLoc(), diag::error_missing_chained_header,
+            binaryModule->headerImport, mod.ModuleName);
+      }
+    }
+  }
 
   for (auto &dep : sourceDep->textualModuleDetails.bridgingModuleDependencies) {
     ModuleDependencyID modID{dep, ModuleDependencyKind::Clang};
@@ -1358,7 +1380,7 @@ static void resolveDependencyCommandLineArguments(
     std::optional<std::set<ModuleDependencyID>> bridgingHeaderDeps;
     if (modID.Kind == ModuleDependencyKind::SwiftSource)
       bridgingHeaderDeps = computeBridgingHeaderTransitiveDependencies(
-          deps, moduleTransitiveClosures, cache);
+          instance, deps, dependencyClosure, moduleTransitiveClosures, cache);
 
     if (auto E = resolveExplicitModuleInputs(modID, dependencyClosure, cache,
                                              instance, bridgingHeaderDeps))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1907,6 +1907,9 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
     Opts.ClangImporterDirectCC1Scan = true;
   }
 
+  Opts.BridgingHeaderChaining |=
+      Args.hasArg(OPT_experimental_chained_bridging_header_requirement);
+
   // If in direct clang cc1 module build mode, return early.
   if (Opts.DirectClangCC1ModuleBuild)
     return false;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -153,7 +153,10 @@ ModuleFile::loadDependenciesForFileContext(const FileUnit *file,
     if (dependency.isHeader()) {
       // The path may be empty if the file being loaded is a partial AST,
       // and the current compiler invocation is a merge-modules step.
-      if (!dependency.Core.RawPath.empty()) {
+      // Else if bridging header chaining is required, no need to import
+      // anything as the header should be brought in by PCH or bridging header.
+      if (!dependency.Core.RawPath.empty() &&
+          !ctx.ClangImporterOpts.BridgingHeaderChaining) {
         bool hadError =
             clangImporter->importHeader(dependency.Core.RawPath,
                                         file->getParentModule(),

--- a/test/CAS/import-binary-with-bridging-header.swift
+++ b/test/CAS/import-binary-with-bridging-header.swift
@@ -1,0 +1,91 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -module-name Test -O -swift-version 5 \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -import-objc-header %t/Test-Bridging.h %t/test.swift
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name User -O -I %t \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/user.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas \
+// RUN:   -import-objc-header %t/User-Bridging-Bad.h -experimental-chained-bridging-header-requirement 2>&1 | %FileCheck %s --check-prefix=CHAIN-ERROR
+// CHAIN-ERROR: error: bridging header doesn't chain include the bridging header
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name User -O -I %t \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/user.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas \
+// RUN:   -import-objc-header %t/User-Bridging.h -experimental-chained-bridging-header-requirement 2>&1 | %FileCheck %s --check-prefix=NO-ERROR --allow-empty
+// NO-ERROR-NOT: error:
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader | tail -n +2  > %t/header.cmd
+// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules %t/User-Bridging.h -O -o %t/bridging.pch
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules %t/User-Bridging.h -O -o %t/bridging.pch > %t/keys.json
+// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json %t/User-Bridging.h > %t/key
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json User > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
+// RUN: echo "\"-import-objc-header\"" >> %t/MyApp.cmd
+// RUN: echo "\"%t/bridging.pch\"" >> %t/MyApp.cmd
+// RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
+// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
+// RUN: %swift_frontend_plain @%t/shim.cmd
+
+// RUN: %target-swift-frontend  -cache-compile-job -module-name User -O -cas-path %t/cas \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -disable-implicit-swift-modules \
+// RUN:   -explicit-swift-module-map-file @%t/map.casid @%t/MyApp.cmd %t/user.swift \
+// RUN:   -emit-module -o %t/User.swiftmodule -experimental-chained-bridging-header-requirement
+
+//--- test.swift
+public class TestA: A {}
+public func test(_ : TestA) {
+    foo()
+}
+
+//--- user.swift
+import Test
+func user() {
+    var A: TestA
+    foo()
+    user();
+}
+
+//--- Test-Bridging.h
+#include "Foo.h"
+
+//--- User-other.h
+void user(void);
+
+//--- User-Bridging-Bad.h
+#include "Foo.h"
+#include "User-other.h"
+
+//--- User-Bridging.h
+#include "Test-Bridging.h"
+#include "User-other.h"
+
+//--- Foo.h
+#import "a.h"
+
+#pragma once // << pragma once only works when chaining.
+void foo(void) {} // << definition imported in both bridging header.
+
+//--- a.h
+@interface A
+@end
+
+//--- a.modulemap
+module A {
+  header "a.h"
+  export *
+}


### PR DESCRIPTION
Add a new experimental flag for better bridging header handling from a binary module dependency. The new mode requries the users of such binary module to provide bridging header that chains the bridging header from the dependencies, otherwise it will result in an scanning error.

While this requires users of the module explicitly add bridging headers from the dependencies, it has the benefits:
* Cheaper dependency scanning as bridging header will only need to be scanned once for all bridging headers discovered.
* Avoid hard to understand header import errors when importing bridging headers.
* Some compiler directives like `#pragma once` will function correctly only when bridging headers are chained together.
* Easy to be supported in swift caching mode as swift-frontend will not import clang headers that lack complete dependencies.
