### PR TITLE
AST: Don't print `convenience` on actor initializers

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4285,15 +4285,13 @@ void PrintAST::visitConstructorDecl(ConstructorDecl *decl) {
     // Protocol extension initializers are modeled as convenience initializers,
     // but they're not written that way in source. Check if we're actually
     // printing onto a class.
-    bool isClassContext;
-    if (CurrentType) {
-      isClassContext = CurrentType->getClassOrBoundGenericClass() != nullptr;
-    } else {
-      const DeclContext *dc = decl->getDeclContext();
-      isClassContext = dc->getSelfClassDecl() != nullptr;
-    }
-    if (isClassContext) {
-      Printer.printKeyword("convenience", Options, " ");
+    ClassDecl *classDecl = CurrentType
+                               ? CurrentType->getClassOrBoundGenericClass()
+                               : decl->getDeclContext()->getSelfClassDecl();
+    if (classDecl) {
+      // Convenience intializers are also unmarked on actors.
+      if (!classDecl->isActor())
+        Printer.printKeyword("convenience", Options, " ");
     } else {
       assert(decl->getDeclContext()->getExtendedProtocolDecl() &&
              "unexpected convenience initializer");

--- a/test/ModuleInterface/actor_init.swift
+++ b/test/ModuleInterface/actor_init.swift
@@ -12,8 +12,7 @@
 // CHECK-LABEL: public actor TestActor {
 @available(SwiftStdlib 5.5, *)
 public actor TestActor {
-  // FIXME: The convenience keyword should be omitted (rdar://130926278)
-  // CHECK: public convenience init(convenience: Swift.Int)
+  // CHECK: public init(convenience: Swift.Int)
   public init(convenience: Int) {
     self.init()
   }


### PR DESCRIPTION
Although actor initializers can be classified as convenience initializers by the internals of the compiler, they are not written that way in source and should not be printed with the `convenience` keyword.

Resolves rdar://130926278.
