### PR TITLE
Introduce `-warn-soft-deprecated` option

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -462,6 +462,9 @@ namespace swift {
     /// Diagnose implicit 'override'.
     bool WarnImplicitOverrides = false;
 
+    /// Diagnose use of declarations that are soft-deprecated.
+    bool WarnSoftDeprecated = false;
+
     /// Diagnose uses of NSCoding with classes that have unstable mangled names.
     bool EnableNSKeyedArchiverDiagnostics = true;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -838,6 +838,11 @@ def warn_implicit_overrides :
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Warn about implicit overrides of protocol members">;
 
+def warn_soft_deprecated :
+  Flag<["-"], "warn-soft-deprecated">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, HelpHidden]>,
+  HelpText<"Warn when soft-deprecated declarations are referenced">;
+
 def typo_correction_limit : Separate<["-"], "typo-correction-limit">,
   Flags<[FrontendOption, HelpHidden]>,
   MetaVarName<"<n>">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1168,6 +1168,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.WarnImplicitOverrides =
     Args.hasArg(OPT_warn_implicit_overrides);
 
+  Opts.WarnSoftDeprecated = Args.hasArg(OPT_warn_soft_deprecated);
+
   Opts.EnableNSKeyedArchiverDiagnostics =
       Args.hasFlag(OPT_enable_nskeyedarchiver_diagnostics,
                    OPT_disable_nskeyedarchiver_diagnostics,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2214,8 +2214,16 @@ void TypeChecker::diagnosePotentialUnavailability(
 }
 
 const AvailableAttr *TypeChecker::getDeprecated(const Decl *D) {
-  if (auto *Attr = D->getAttrs().getDeprecated(D->getASTContext()))
+  auto &Ctx = D->getASTContext();
+  if (auto *Attr = D->getAttrs().getDeprecated(Ctx))
     return Attr;
+
+  if (Ctx.LangOpts.WarnSoftDeprecated) {
+    // When -warn-soft-deprecated is specified, treat any declaration that is
+    // deprecated in the future as deprecated.
+    if (auto *Attr = D->getAttrs().getSoftDeprecated(Ctx))
+      return Attr;
+  }
 
   // Treat extensions methods as deprecated if their extension
   // is deprecated.

--- a/test/Sema/availability_soft_deprecated.swift
+++ b/test/Sema/availability_soft_deprecated.swift
@@ -1,0 +1,46 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -warn-soft-deprecated -verify-additional-prefix soft-deprecated-
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=xros
+
+@available(*, deprecated)
+func alwaysDeprecated() {}
+
+@available(macOS, deprecated: 1.0)
+@available(iOS, deprecated: 1.0)
+@available(tvOS, deprecated: 1.0)
+@available(watchOS, deprecated: 1.0)
+@available(visionOS, deprecated: 1.0)
+func deprecatedEarly() {}
+
+@available(macOS, deprecated: 10000)
+@available(iOS, deprecated: 10000)
+@available(tvOS, deprecated: 10000)
+@available(watchOS, deprecated: 10000)
+@available(visionOS, deprecated: 10000)
+func deprecatedFarFuture() {}
+
+protocol Proto {}
+struct HasSoftDeprecatedConformanceToProto {}
+
+@available(macOS, deprecated: 10000)
+@available(iOS, deprecated: 10000)
+@available(tvOS, deprecated: 10000)
+@available(watchOS, deprecated: 10000)
+@available(visionOS, deprecated: 10000)
+extension HasSoftDeprecatedConformanceToProto: Proto {}
+
+func test() {
+  alwaysDeprecated() // expected-warning {{'alwaysDeprecated()' is deprecated}}
+  deprecatedEarly() // expected-warning {{'deprecatedEarly()' was deprecated in}}
+  deprecatedFarFuture() // expected-soft-deprecated-warning {{'deprecatedFarFuture()' was deprecated in}}
+  let _: any Proto = HasSoftDeprecatedConformanceToProto() // expected-soft-deprecated-warning {{conformance of 'HasSoftDeprecatedConformanceToProto' to 'Proto' was deprecated in}}
+}
+
+@available(*, deprecated)
+func testDeprecated() {
+  alwaysDeprecated()
+  deprecatedEarly()
+  deprecatedFarFuture()
+  let _: any Proto = HasSoftDeprecatedConformanceToProto()
+}


### PR DESCRIPTION
When `-warn-soft-deprecated` is specified, diagnose references to declarations that are deprecated in future OS versions.
    
Resolves rdar://130424183.