### PR TITLE
[Casting] Structs cannot conform to NSObjectProtocol

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -359,6 +359,12 @@ tryCastFromObjCBridgeableToClass(
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
   bool takeOnSuccess, bool mayDeferChecks)
 {
+  assert(srcType != destType);
+  assert(destType->getKind() == MetadataKind::Class
+	 || destType->getKind() == MetadataKind::ObjCClassWrapper
+	 || destType->getKind() == MetadataKind::ForeignClass
+	);
+
   auto srcBridgeWitness = findBridgeWitness(srcType);
   if (srcBridgeWitness == nullptr) {
     return DynamicCastResult::Failure;
@@ -375,6 +381,48 @@ tryCastFromObjCBridgeableToClass(
   } else {
     // We don't need the object anymore.
     swift_unknownObjectRelease(srcBridgedObject);
+    return DynamicCastResult::Failure;
+  }
+}
+
+
+/// As above, but cast to a class existential.
+///
+/// Caveat: Despite the name, this is also used to bridge Swift value types
+/// to Swift classes even when Obj-C is not being used.
+static DynamicCastResult
+tryCastFromObjCBridgeableToClassExistential(
+  OpaqueValue *destLocation, const Metadata *destType,
+  OpaqueValue *srcValue, const Metadata *srcType,
+  const Metadata *&destFailureType, const Metadata *&srcFailureType,
+  bool takeOnSuccess, bool mayDeferChecks)
+{
+  assert(srcType != destType);
+  assert(destType->getKind() == MetadataKind::Existential);
+  auto destExistentialType = cast<ExistentialTypeMetadata>(destType);
+  assert(destExistentialType->getRepresentation() == ExistentialTypeRepresentation::Class);
+
+  auto srcBridgeWitness = findBridgeWitness(srcType);
+  if (srcBridgeWitness == nullptr) {
+    return DynamicCastResult::Failure;
+  }
+
+  // Bridge the source value to an object (via copy)
+  auto bridgedObject =
+    srcBridgeWitness->bridgeToObjectiveC(srcValue, srcType, srcBridgeWitness);
+  auto bridgedValue = reinterpret_cast<OpaqueValue *>(&bridgedObject);
+
+  // Dynamic cast the object to the final type.
+  auto subcastResult = tryCast(destLocation, destType,
+			       bridgedValue, getNSObjectMetadata(),
+			       destFailureType, srcFailureType,
+			       /*takeOnSucess=*/ true, mayDeferChecks);
+
+  if (isSuccess(subcastResult)) {
+    return DynamicCastResult::SuccessViaCopy;
+  } else {
+    // We don't need the temporary object anymore
+    swift_unknownObjectRelease(bridgedObject);
     return DynamicCastResult::Failure;
   }
 }
@@ -2459,7 +2507,7 @@ tryCast(
     auto destExistentialType = cast<ExistentialTypeMetadata>(destType);
     if (destExistentialType->getRepresentation() == ExistentialTypeRepresentation::Class) {
       // Some types have custom Objective-C bridging support...
-      auto subcastResult = tryCastFromObjCBridgeableToClass(
+      auto subcastResult = tryCastFromObjCBridgeableToClassExistential(
         destLocation, destType, srcValue, srcType,
         destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
       if (isSuccess(subcastResult)) {

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -1092,4 +1092,47 @@ CastsTests.test("type(of:) should look through __SwiftValue")
   expectEqual(t, "S")  // Fails: currently says `__SwiftValue`
 }
 
+#if _runtime(_ObjC)
+CastsTests.test("Struct casts to NSObjectProtocol")
+{
+  func nsobject(from value: Any) -> NSObjectProtocol? {
+    return value as? NSObjectProtocol
+  }
+  struct TestStruct {}
+  @objc class TestClass: NSObject {}
+
+  let nullableStruct: TestStruct? = TestStruct()
+  let nullableStructResult = nsobject(from: nullableStruct as Any)
+  expectNil(nullableStructResult)
+
+  let nullableClass: TestClass? = TestClass()
+  let nullableClassResult = nsobject(from: nullableClass as Any)
+  expectNotNil(nullableClassResult)
+
+  let nullStruct: TestStruct? = nil
+  let nullStructResult = nsobject(from: nullStruct as Any)
+  if let inner = nullStructResult {
+    expectTrue(inner is NSNull)
+  } else {
+    expectTrue(false, String(describing:nullStructResult))
+  }    
+
+  let nullClass: TestClass? = nil
+  let nullClassResult = nsobject(from: nullClass as Any)
+  if let inner = nullClassResult {
+    expectTrue(inner is NSNull)
+  } else {
+    expectTrue(false, String(describing:nullStructResult))
+  }    
+
+  let nonnullableStruct: TestStruct = TestStruct()
+  let nonnullableStructResult = nsobject(from: nonnullableStruct as Any)
+  expectNil(nonnullableStructResult)
+
+  let nonnullableClass: TestClass = TestClass()
+  let nonnullableClassResult = nsobject(from: nonnullableClass as Any)
+  expectNotNil(nonnullableClassResult)
+}
+#endif
+
 runAllTests()


### PR DESCRIPTION
Casting a struct to NSObjectProtocol should only succeed when the struct type in question conforms to ObjectiveCBridgeable. This was partly fixed last year, but there was still a hole that would successfully cast an `Optional<S>` to NSObjectProtocol because `Optional` does implement custom Objective-C bridging in a way that managed to confused the dynamic cast engine.

More specifically, `tryCastFromObjCBridgeableToClass` was also being used to cast to class existentials.  These two cases (casting to a class or casting to a class-constrained existential) both involve the same bridge logic, but then need to follow it with an additional step to get to the final type.  Creating a new `tryCastFromObjCBridgeableToClassExistential` made it easy to separate these cases.

Resolves rdar://107559117