### PR TITLE
[6.0] SILGen: Reabstract subexpr lvalue before ABISafeConversion.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -4570,10 +4570,19 @@ LValue SILGenLValue::visitABISafeConversionExpr(ABISafeConversionExpr *e,
                                     LValueOptions options) {
   LValue lval = visitRec(e->getSubExpr(), accessKind, options);
   auto typeData = getValueTypeData(SGF, accessKind, e);
+  auto subExprType = e->getSubExpr()->getType()->getRValueType();
+  auto loweredSubExprType = SGF.getLoweredType(subExprType);
+  
+  // Ensure the lvalue is re-abstracted to the substituted type, since that's
+  // the type with which we have ABI compatibility.
+  if (lval.getTypeOfRValue().getASTType() != loweredSubExprType.getASTType()) {
+    // Logical components always re-abstract back to the substituted
+    // type.
+    assert(lval.isLastComponentPhysical());
+    lval.addOrigToSubstComponent(loweredSubExprType);
+  }
 
-  auto OrigType = e->getSubExpr()->getType();
-
-  lval.add<UncheckedConversionComponent>(typeData, OrigType);
+  lval.add<UncheckedConversionComponent>(typeData, subExprType);
 
   return lval;
 }

--- a/test/SILGen/preconcurrency-abi-safe-conversions.swift
+++ b/test/SILGen/preconcurrency-abi-safe-conversions.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-silgen -swift-version 5 -verify %s
+// RUN: %target-swift-emit-silgen -swift-version 6 -verify %s
+
+struct Text {
+    init<S>(_: S) where S: StringProtocol {}
+}
+
+// In Swift 5, we introduce an implicit @Sendable on the closures here.
+// Make sure that doing so doesn't disrupt SILGen's lvalue emission.
+// rdar://130016855
+public struct Header<TitleContent> {
+  @preconcurrency
+  private let titleContent:  @MainActor () -> TitleContent
+
+  init(title: String) where TitleContent == Text {
+    self.titleContent = {
+      Text(title)
+    }
+  }
+
+  func testGet() -> @MainActor () -> Text
+      where TitleContent == Text {
+    return titleContent // expected-warning * {{}}
+  }
+}


### PR DESCRIPTION
Explanation: Fixes a compiler crash and/or miscompile when accessing a property of function type, in a generic context, from an extension with same-type constraints, in Swift 5 mode with implicit `@Sendable` conversions introduced.
Scope: Bug fix.
Issue: rdar://130016855
Original PR: https://github.com/swiftlang/swift/pull/75193
Risk: Low. Fixes a relatively rare problem introduced by strict concurrency checking.
Testing: Test case from bug report, Swift CI
Reviewer: @xedin 