### PR TITLE
[6.0] tests: add a missing `REQUIRES: executable_test` in SILOptimizer/stack-promotion-crash.swift

### DIFF
--- a/test/SILOptimizer/stack-promotion-crash.swift
+++ b/test/SILOptimizer/stack-promotion-crash.swift
@@ -6,6 +6,8 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
+// REQUIRES: executable_test
+
 //--- module.modulemap
 
 module CModule {


### PR DESCRIPTION
* **Explanation**: Fixes a test which was added in https://github.com/swiftlang/swift/pull/74982
* **Risk**: Zero. Just fixes a test
* **Issue**: rdar://131519168
* **Reviewer**:  @shahmishal
* **Main branch PR**: https://github.com/swiftlang/swift/pull/75169
