### PR TITLE
[build-script] NFC: Update URL of Swift repository in message.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -778,7 +778,7 @@ def main_normal():
             "navigation or editing purposes, but are not a recommended means "
             "to building, running or debugging. For a full-fledged Xcode "
             "workflow using these generated projects, see "
-            "https://github.com/apple/swift/blob/main/docs/HowToGuides/"
+            "https://github.com/swiftlang/swift/blob/main/docs/HowToGuides/"
             "GettingStarted.md#using-ninja-with-xcode"
         )
         print()


### PR DESCRIPTION
Since [Swift project had adopted new GitHub organization](https://www.swift.org/blog/swiftlang-github/), the URL of this repository was changed.
This PR fixes the URL in 'build-script'.

-----
While there are more than 1000 old URL descriptions(`https://github.com/apple/swift/*`) in this repository, changing them at once may be an excessively huge commit.
That's why this PR contains only one commit.
As a side note, 'GettingStarted.md' has been already updated by [another PR](https://github.com/swiftlang/swift/pull/75159).
