### PR TITLE
[cxx-interop] Fix test failure for arm64e test

### DIFF
--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-arm64e.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-arm64e.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %S/swift-class-virtual-method-dispatch.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
 // RUN: %FileCheck %s < %t/class.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/class.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/class.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // REQUIRES: CPU=arm64e
 


### PR DESCRIPTION
This is a fallout from emitting Swift StdLib dependencies when all public decls are emitted. This was not found before because the test was not executed by the CI.

rdar://131556373
