### PR TITLE
[cxx-interop] Export accessors of static properties to C++

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1091,7 +1091,7 @@ private:
 
     if (outputLang == OutputLanguageMode::Cxx) {
       // FIXME: Support operators.
-      if (AFD->isOperator() || (AFD->isStatic() && AFD->isImplicit()))
+      if (AFD->isOperator() || (AFD->isStatic() && AFD->isImplicit() && !isa<AccessorDecl>(AFD)))
         return;
 
       auto *typeDeclContext = dyn_cast<NominalTypeDecl>(AFD->getParent());

--- a/test/Interop/SwiftToCxx/class/swift-class-static-variables-execution.cpp
+++ b/test/Interop/SwiftToCxx/class/swift-class-static-variables-execution.cpp
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/swift-class-static-variables.swift -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-class-execution.o
+// RUN: %target-interop-build-swift %S/swift-class-static-variables.swift -o %t/swift-class-execution -Xlinker %t/swift-class-execution.o -module-name Class -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-class-execution
+// RUN: %target-run %t/swift-class-execution
+
+// REQUIRES: executable_test
+
+
+#include "class.h"
+#include <assert.h>
+#include <cstdio>
+
+using namespace Class;
+
+int main() {
+    auto x = FileUtilities::getShared();
+    assert(x.getField() == 42);
+}

--- a/test/Interop/SwiftToCxx/class/swift-class-static-variables.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-static-variables.swift
@@ -1,0 +1,13 @@
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+// RUN: %FileCheck %s < %t/class.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/class.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+public class FileUtilities {
+  public static let shared = FileUtilities()
+  public let field = 42;
+}
+
+// CHECK: SWIFT_INLINE_THUNK FileUtilities FileUtilities::getShared() {


### PR DESCRIPTION
The code wants to avoid exporting certain synthesized operators but it inadvertently also prevented exporting accessors to static properties. Fixes https://github.com/swiftlang/swift/issues/70338. 

rdar://115564118