### PR TITLE
Fix build failure in _SynchronizationShims module

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
@@ -23,7 +23,7 @@
 #include <unistd.h>
 
 static inline __swift_uint32_t _swift_stdlib_gettid() {
-  static __thread auto tid = 0;
+  static __thread __swift_uint32_t tid = 0;
 
   if (tid == 0) {
     tid = syscall(SYS_gettid);

--- a/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
@@ -23,7 +23,7 @@
 #include <unistd.h>
 
 static inline __swift_uint32_t _swift_stdlib_gettid() {
-  static __thread tid = 0;
+  static __thread auto tid = 0;
 
   if (tid == 0) {
     tid = syscall(SYS_gettid);


### PR DESCRIPTION
When `Foundation` adds an `import Synchronization` to its module interface, we end up with build failures while building the benchmarks project due to the following issue in the _SynchronizationShims module:

```
/home/build-user/swift-nightly-install/usr/lib/swift/shims/_SynchronizationShims.h:26:19: error: a type specifier is required for all declarations
24 | 
25 | static inline __swift_uint32_t _swift_stdlib_gettid() {
26 |   static __thread tid = 0;
   |                   `- error: a type specifier is required for all declarations
27 | 
28 |   if (tid == 0) {
```

I'm uncertain why we don't see this failure on mainline, but this fixes the error so that Foundation can successfully add the `Synchronization` import without breaking downstream clients that will need to compile this clang module.