### PR TITLE
Bug fixes and improvements for DoubleWidth prototype

### DIFF
--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -310,6 +310,7 @@ extension DoubleWidth : FixedWidthInteger {
   public func multipliedReportingOverflow(
     by rhs: DoubleWidth
   ) -> (partialValue: DoubleWidth, overflow: Bool) {
+    let (carry, product) = multipliedFullWidth(by: rhs)
     let partialValue = DoubleWidth(truncatingIfNeeded: product)
     // Overflow has occured if carry is not just the sign-extension of
     // partialValue (which is zero when Base is unsigned).

--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -310,18 +310,11 @@ extension DoubleWidth : FixedWidthInteger {
   public func multipliedReportingOverflow(
     by rhs: DoubleWidth
   ) -> (partialValue: DoubleWidth, overflow: Bool) {
-    let (carry, product) = multipliedFullWidth(by: rhs)
-    let result = DoubleWidth(truncatingIfNeeded: product)
-    
-    let isNegative = DoubleWidth.isSigned &&
-      (self < (0 as DoubleWidth)) != (rhs < (0 as DoubleWidth))
-    let didCarry = isNegative
-      ? carry != ~(0 as DoubleWidth)
-      : carry != (0 as DoubleWidth)
-    let hadPositiveOverflow =
-      DoubleWidth.isSigned && !isNegative && product.leadingZeroBitCount == 0
-
-    return (result, didCarry || hadPositiveOverflow)
+    let partialValue = DoubleWidth(truncatingIfNeeded: product)
+    // Overflow has occured if carry is not just the sign-extension of
+    // partialValue (which is zero when Base is unsigned).
+    let overflow = carry != (partialValue >> DoubleWidth.bitWidth)
+    return (partialValue, overflow)
   }
 
   public func quotientAndRemainder(
@@ -473,18 +466,21 @@ extension DoubleWidth : FixedWidthInteger {
 
   /// Returns this value "masked" by its bit width.
   ///
-  /// "Masking" notionally involves repeatedly incrementing or decrementing this
-  /// value by `self.bitWidth` until the result is contained in the range
-  /// `0..<self.bitWidth`.
+  /// "Masking" notionally involves repeatedly incrementing or decrementing
+  /// this value by `self.bitWidth` until the result is contained in the
+  /// range `0..<self.bitWidth`.
   internal func _masked() -> DoubleWidth {
-    // FIXME(integers): test types with bit widths that aren't powers of 2
+    let bits = DoubleWidth(DoubleWidth.bitWidth)
     if DoubleWidth.bitWidth.nonzeroBitCount == 1 {
-      return self & DoubleWidth(DoubleWidth.bitWidth &- 1)
+      return self & (bits &- 1)
     }
-    if DoubleWidth.isSigned && self._storage.high < (0 as High) {
-      return self % DoubleWidth(DoubleWidth.bitWidth) + self
-    }
-    return self % DoubleWidth(DoubleWidth.bitWidth)
+    let reduced = self % bits
+    // bitWidth is always positive, but the value being reduced might have
+    // been negative, in which case reduced will also be negative. We need
+    // the representative in [0, bitWidth), so conditionally add the count
+    // to get the positive residue.
+    if Base.isSigned && reduced < 0 { return reduced &+ bits }
+    return reduced
   }
 
   public static func &<<=(lhs: inout DoubleWidth, rhs: DoubleWidth) {
@@ -554,6 +550,31 @@ binaryOperators = [
     lhs = result
   }
 % end
+
+  public static func &+(
+    lhs: DoubleWidth, rhs: DoubleWidth
+  ) -> DoubleWidth {
+    let (low, carry) = lhs.low.addingReportingOverflow(rhs.low)
+    let high = lhs.high &+ rhs.high &+ (carry ? 1 : 0)
+    return DoubleWidth(high, low)
+  }
+
+  public static func &-(
+    lhs: DoubleWidth, rhs: DoubleWidth
+  ) -> DoubleWidth {
+    let (low, borrow) = lhs.low.subtractingReportingOverflow(rhs.low)
+    let high = lhs.high &- rhs.high &- (borrow ? 1 : 0)
+    return DoubleWidth(high, low)
+  }
+
+  public static func &*(
+    lhs: DoubleWidth, rhs: DoubleWidth
+  ) -> DoubleWidth {
+    let p00 = lhs.low.multipliedFullWidth(by: rhs.low)
+    let p10 = lhs.high &* Base(truncatingIfNeeded: rhs.low)
+    let p01 = Base(truncatingIfNeeded: lhs.low) &* rhs.high
+    return DoubleWidth(p10 &+ p01 &+ Base(truncatingIfNeeded: p00.high), p00.low)
+  }
 
   public init(_truncatingBits bits: UInt) {
     _storage.low = Low(_truncatingBits: bits)


### PR DESCRIPTION
Previously multipliedReportingOverflow and masking shifts were implemented incorrectly for signed types and non-power-of-two bitWidths, respectively. Address those two bugs and additional implement &+, &-, and &*.