### PR TITLE
[6.0🍒] NCGenerics: handle failure to load stdlib

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1255,6 +1255,14 @@ ASTContext::synthesizeInvertibleProtocolDecl(InvertibleProtocolKind ip) const {
     return proto;
 
   ModuleDecl *stdlib = getStdlibModule();
+  if (stdlib && stdlib->failedToLoad()) {
+    stdlib = nullptr; // Use the Builtin module instead.
+
+    // Ensure we emitted an error diagnostic!
+    if (!Diags.hadAnyError())
+      Diags.diagnose(SourceLoc(), diag::serialization_load_failed, "Swift");
+  }
+
   FileUnit *file = nullptr;
   if (stdlib) {
     file = &stdlib->getFiles()[0]->getOrCreateSynthesizedFile();


### PR DESCRIPTION
- Explanation: More gracefully handle cases where the stdlib module `failedToLoad`, but without allowing compilation to proceed without an error.
- Scope: Very limited; a defensive check.
- Issue: rdar://129092011
- Original PR: https://github.com/swiftlang/swift/pull/75211
- Risk: Very low. A case that previously would segfault will now emit an error diagnostic and proceed using the Builtin module instead.
- Testing: None.
- Reviewer: @tbkka 