### PR TITLE
[Sema] Allow @_section/@_used in concrete generic context

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2385,7 +2385,10 @@ void AttributeChecker::visitUsedAttr(UsedAttr *attr) {
   if (D->getDeclContext()->isLocalContext())
     diagnose(attr->getLocation(), diag::attr_only_at_non_local_scope,
              attr->getAttrName());
-  else if (D->getDeclContext()->isGenericContext())
+  else if (D->getDeclContext()->isGenericContext() &&
+           !D->getDeclContext()
+                ->getGenericSignatureOfContext()
+                ->areAllParamsConcrete())
     diagnose(attr->getLocation(), diag::attr_only_at_non_generic_scope,
              attr->getAttrName());
   else if (auto *VarD = dyn_cast<VarDecl>(D)) {
@@ -2412,7 +2415,10 @@ void AttributeChecker::visitSectionAttr(SectionAttr *attr) {
   if (D->getDeclContext()->isLocalContext())
     return; // already diagnosed
 
-  if (D->getDeclContext()->isGenericContext())
+  if (D->getDeclContext()->isGenericContext() &&
+      !D->getDeclContext()
+           ->getGenericSignatureOfContext()
+           ->areAllParamsConcrete())
     diagnose(attr->getLocation(), diag::attr_only_at_non_generic_scope,
              attr->getAttrName());
   else if (auto *VarD = dyn_cast<VarDecl>(D)) {

--- a/test/IRGen/section_errors.swift
+++ b/test/IRGen/section_errors.swift
@@ -31,6 +31,13 @@ struct MyStruct4<T> {
   }
 }
 
+struct MyStruct5<T> {
+}
+
+extension MyStruct5 where T == Never {
+  @_used @_section("__TEXT,__mysection") static let static3: Int = 1 // ok
+}
+
 @_section("__TEXT,__mysection") // expected-error {{'@_section' attribute cannot be applied to this declaration}}
 struct SomeStruct {}
 


### PR DESCRIPTION
Allow `@_section` and `@_used` to be used in fully constrained extensions.

This aligns with the existing behavior of static properties of generic types. The following is valid:

```swift
extension Array where Element == Int {
  static let specificConstant = 41
}
```

However, adding `@_section` or `@_used` to the above property, will result in an error diagnostic.

This change updates the logic of `@_section`/`@_used` to allow their use when the generic context is fully concrete.