### PR TITLE
[6.0][ConformanceLookup] Don't allow skipping inherited unavailable conformances in favor of explicit available ones.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3127,6 +3127,9 @@ WARNING(witness_deprecated,none,
         "protocol %1%select{|: %2}2",
         (const ValueDecl *, Identifier, StringRef))
 
+WARNING(unavailable_conformance,none,
+        "conformance of %0 to protocol %1 is already unavailable",
+        (Type, Identifier))
 ERROR(redundant_conformance,none,
       "redundant conformance of %0 to protocol %1", (Type, Identifier))
 ERROR(redundant_conformance_conditional,none,

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -596,47 +596,31 @@ ConformanceLookupTable::Ordering ConformanceLookupTable::compareConformances(
     }
   }
 
-  // If only one of the conformances is unconditionally available on the
-  // current deployment target, pick that one.
-  //
-  // FIXME: Conformance lookup should really depend on source location for
-  // this to be 100% correct.
-  // FIXME: When a class and an extension with the same availability declare the
-  // same conformance, this silently takes the class and drops the extension.
-  if (lhs->getDeclContext()->isAlwaysAvailableConformanceContext() !=
-      rhs->getDeclContext()->isAlwaysAvailableConformanceContext()) {
-    return (lhs->getDeclContext()->isAlwaysAvailableConformanceContext()
-            ? Ordering::Before
-            : Ordering::After);
+  // Unavailable Sendable conformances cannot be replaced by available ones.
+  if (!lhs->getProtocol()->isMarkerProtocol()) {
+    // If only one of the conformances is unconditionally available on the
+    // current deployment target, pick that one.
+    //
+    // FIXME: Conformance lookup should really depend on source location for
+    // this to be 100% correct.
+    // FIXME: When a class and an extension with the same availability declare the
+    // same conformance, this silently takes the class and drops the extension.
+    if (lhs->getDeclContext()->isAlwaysAvailableConformanceContext() !=
+        rhs->getDeclContext()->isAlwaysAvailableConformanceContext()) {
+      return (lhs->getDeclContext()->isAlwaysAvailableConformanceContext()
+              ? Ordering::Before
+              : Ordering::After);
+    }
   }
 
   // If one entry is fixed and the other is not, we have our answer.
   if (lhs->isFixed() != rhs->isFixed()) {
-    auto isReplaceableOrMarker = [](ConformanceEntry *entry) -> bool {
-      ConformanceEntryKind kind = entry->getRankingKind();
-      if (isReplaceable(kind))
-        return true;
-
-      // Allow replacement of an explicit conformance to a marker protocol.
-      // (This permits redundant explicit declarations of `Sendable`.)
-      //
-      // FIXME: We need to warn on attempts to make an unavailable Sendable
-      // conformance available, which does not work.
-      //
-      // We probably also want to warn if there is an existing, explicit
-      // conformance, so clients are prompted to remove retroactive unchecked
-      // Sendable conformances when the proper Sendable conformance is added
-      // in the original module.
-      return (kind == ConformanceEntryKind::Explicit
-              && entry->getProtocol()->isMarkerProtocol());
-    };
-
     // If the non-fixed conformance is not replaceable, we have a failure to
     // diagnose.
     // FIXME: We should probably diagnose if they have different constraints.
-    diagnoseSuperseded = (lhs->isFixed() && !isReplaceableOrMarker(rhs)) ||
-                         (rhs->isFixed() && !isReplaceableOrMarker(lhs));
-      
+    diagnoseSuperseded = (lhs->isFixed() && !isReplaceable(rhs->getRankingKind())) ||
+                         (rhs->isFixed() && !isReplaceable(lhs->getRankingKind()));
+
     return lhs->isFixed() ? Ordering::Before : Ordering::After;
   }
 

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -287,7 +287,8 @@ bool ProtocolConformanceRef::hasUnavailableConformance() const {
 
   // Check whether this conformance is on an unavailable extension.
   auto concrete = getConcrete();
-  auto ext = dyn_cast<ExtensionDecl>(concrete->getDeclContext());
+  auto *dc = concrete->getRootConformance()->getDeclContext();
+  auto ext = dyn_cast<ExtensionDecl>(dc);
   if (ext && AvailableAttr::isUnavailable(ext))
     return true;
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6464,9 +6464,6 @@ ProtocolConformance *swift::deriveImplicitSendableConformance(
       auto inheritedConformance = classModule->checkConformance(
           classDecl->mapTypeIntoContext(superclass),
           proto, /*allowMissing=*/false);
-      if (inheritedConformance.hasUnavailableConformance())
-        inheritedConformance = ProtocolConformanceRef::forInvalid();
-
       if (inheritedConformance) {
         inheritedConformance = inheritedConformance
             .mapConformanceOutOfContext();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6393,8 +6393,16 @@ ProtocolConformance *swift::deriveImplicitSendableConformance(
 
   // Local function to form the implicit conformance.
   auto formConformance = [&](const DeclAttribute *attrMakingUnavailable)
-        -> NormalProtocolConformance * {
+        -> ProtocolConformance * {
     DeclContext *conformanceDC = nominal;
+
+    // FIXME: @_nonSendable should be a builtin extension macro. This behavior
+    // of explanding the unavailable conformance during implicit Sendable
+    // derivation means that clients can unknowingly ignore unavailable Sendable
+    // Sendable conformances from the original module added via @_nonSendable
+    // because they are not expanded if an explicit conformance is found via
+    // conformance lookup. So, if a retroactive, unchecked Sendable conformance
+    // is written, no redundant conformance warning is emitted.
     if (attrMakingUnavailable) {
       // Conformance availability is currently tied to the declaring extension.
       // FIXME: This is a hack--we should give conformances real availability.
@@ -6422,6 +6430,18 @@ ProtocolConformance *swift::deriveImplicitSendableConformance(
         file->getOrCreateSynthesizedFile().addTopLevelDecl(extension);
 
       conformanceDC = extension;
+
+      // Let the conformance lookup table register the conformance
+      // from the extension. Otherwise, we'll end up with redundant
+      // conformances between the explicit conformance from the extension
+      // and the conformance synthesized below.
+      SmallVector<ProtocolConformance *, 2> conformances;
+      nominal->lookupConformance(proto, conformances);
+      for (auto conformance : conformances) {
+        if (conformance->getDeclContext() == conformanceDC) {
+          return conformance;
+        }
+      }
     }
 
     auto conformance = ctx.getNormalConformance(

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6263,20 +6263,56 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
     // protocol, just warn; we'll pick up the original conformance.
     auto existingModule = diag.ExistingDC->getParentModule();
     auto extendedNominal = diag.ExistingDC->getSelfNominalTypeDecl();
-    if (existingModule != dc->getParentModule() &&
-        (existingModule->getName() ==
-           extendedNominal->getParentModule()->getName() ||
+    auto definingModule = extendedNominal->getParentModule()->getName();
+    bool conformanceInOrigModule =
+        (existingModule->getName() == definingModule ||
          existingModule == diag.Protocol->getParentModule() ||
-         existingModule->getName().is("CoreGraphics"))) {
+         existingModule->getName().is("CoreGraphics"));
+
+    // Redundant Sendable conformances are always warnings.
+    auto knownProtocol = diag.Protocol->getKnownProtocolKind();
+    bool isSendable = knownProtocol == KnownProtocolKind::Sendable;
+    // Try to find an inherited Sendable conformance if there is one.
+    if (isSendable && !SendableConformance) {
+      SmallVector<ProtocolConformance *, 2> conformances;
+      nominal->lookupConformance(diag.Protocol, conformances);
+      for (auto conformance : conformances) {
+        if (isa<InheritedProtocolConformance>(conformance))
+          SendableConformance = conformance;
+      }
+    }
+
+    if ((existingModule != dc->getParentModule() && conformanceInOrigModule) ||
+        isSendable) {
       // Warn about the conformance.
-      auto diagID = differentlyConditional
-                        ? diag::redundant_conformance_adhoc_conditional
-                        : diag::redundant_conformance_adhoc;
-      Context.Diags.diagnose(diag.Loc, diagID, dc->getDeclaredInterfaceType(),
-                             diag.Protocol->getName(),
-                             existingModule->getName() ==
-                                 extendedNominal->getParentModule()->getName(),
-                             existingModule->getName());
+      if (isSendable && SendableConformance &&
+          isa<InheritedProtocolConformance>(SendableConformance)) {
+        // Allow re-stated unchecked conformances to Sendable in subclasses
+        // as long as the inherited conformance isn't unavailable.
+        auto *conformance = SendableConformance->getRootConformance();
+        auto *decl = conformance->getDeclContext()->getAsDecl();
+        if (!AvailableAttr::isUnavailable(decl)) {
+          continue;
+        }
+
+        Context.Diags.diagnose(diag.Loc, diag::unavailable_conformance,
+                               nominal->getDeclaredInterfaceType(),
+                               diag.Protocol->getName());
+      } else if (existingModule == dc->getParentModule()) {
+        Context.Diags.diagnose(diag.Loc, diag::redundant_conformance,
+                               nominal->getDeclaredInterfaceType(),
+                               diag.Protocol->getName())
+          .limitBehavior(DiagnosticBehavior::Warning);
+      } else {
+        auto diagID = differentlyConditional
+                          ? diag::redundant_conformance_adhoc_conditional
+                          : diag::redundant_conformance_adhoc;
+        Context.Diags.diagnose(diag.Loc, diagID, dc->getDeclaredInterfaceType(),
+                               diag.Protocol->getName(),
+                               existingModule->getName() ==
+                                   extendedNominal->getParentModule()->getName(),
+                               existingModule->getName());
+      }
 
       // Complain about any declarations in this extension whose names match
       // a requirement in that protocol.

--- a/test/Concurrency/Inputs/SendableConformances.swift
+++ b/test/Concurrency/Inputs/SendableConformances.swift
@@ -5,3 +5,5 @@ public class NonSendableClass {}
 extension NonSendableClass: @unchecked Sendable {}
 
 public struct SendableStruct: Sendable {}
+
+public struct AnotherSendableStruct: Sendable {}

--- a/test/Concurrency/Inputs/SendableConformances.swift
+++ b/test/Concurrency/Inputs/SendableConformances.swift
@@ -1,0 +1,7 @@
+
+public class NonSendableClass {}
+
+@available(*, unavailable)
+extension NonSendableClass: @unchecked Sendable {}
+
+public struct SendableStruct: Sendable {}

--- a/test/Concurrency/redundant_sendable_conformance.swift
+++ b/test/Concurrency/redundant_sendable_conformance.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/SendableConformances.swiftmodule -module-name SendableConformances %S/Inputs/SendableConformances.swift
+
+// RUN: %target-swift-frontend -typecheck %s -verify -swift-version 6 -I %t
+
+// REQUIRES: concurrency
+
+import SendableConformances
+
+typealias RequireSendable<T: Sendable> = T
+
+extension NonSendableClass: @retroactive @unchecked Sendable {}
+// expected-warning@-1 {{conformance of 'NonSendableClass' to protocol 'Sendable' was already stated in the type's module 'SendableConformances'}}
+
+typealias CheckNonSendableClass = RequireSendable<NonSendableClass>
+// expected-error@-1 {{conformance of 'NonSendableClass' to 'Sendable' is unavailable}}
+
+extension SendableStruct: @retroactive @unchecked Sendable {}
+// expected-warning@-1 {{conformance of 'SendableStruct' to protocol 'Sendable' was already stated in the type's module 'SendableConformances'}}

--- a/test/Concurrency/redundant_sendable_conformance.swift
+++ b/test/Concurrency/redundant_sendable_conformance.swift
@@ -13,7 +13,12 @@ extension NonSendableClass: @retroactive @unchecked Sendable {}
 // expected-warning@-1 {{conformance of 'NonSendableClass' to protocol 'Sendable' was already stated in the type's module 'SendableConformances'}}
 
 typealias CheckNonSendableClass = RequireSendable<NonSendableClass>
-// expected-error@-1 {{conformance of 'NonSendableClass' to 'Sendable' is unavailable}}
 
 extension SendableStruct: @retroactive @unchecked Sendable {}
 // expected-warning@-1 {{conformance of 'SendableStruct' to protocol 'Sendable' was already stated in the type's module 'SendableConformances'}}
+
+@available(*, unavailable)
+extension AnotherSendableStruct: @retroactive @unchecked Sendable {}
+// expected-warning@-1 {{conformance of 'AnotherSendableStruct' to protocol 'Sendable' was already stated in the type's module 'SendableConformances'}}
+
+typealias CheckAnotherSendableStruct = RequireSendable<AnotherSendableStruct>

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -113,8 +113,8 @@ struct WrapClass<T: NSClass> {
 
 extension WrapClass: Sendable where T: Sendable { }
 
-// Make sure we don't inherit the unavailable Sendable conformance from
-// our superclass.
+// expected-warning@+2 {{conformance of 'SendableSubclass' to protocol 'Sendable' is already unavailable}}
+// expected-note@+1 {{'SendableSubclass' inherits conformance to protocol 'Sendable' from superclass here}}
 class SendableSubclass: NSClass, @unchecked Sendable { }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -102,7 +102,10 @@ public actor MyActor: MyProto {
 }
 
 // Make sure the generic signature doesn't minimize away Sendable requirements.
-@_nonSendable class NSClass { }
+class NSClass { }
+
+@available(*, unavailable)
+extension NSClass: @unchecked Sendable {} // expected-note {{conformance of 'NSClass' to 'Sendable' has been explicitly marked unavailable here}}
 
 struct WrapClass<T: NSClass> {
   var t: T
@@ -116,7 +119,7 @@ class SendableSubclass: NSClass, @unchecked Sendable { }
 
 @available(SwiftStdlib 5.1, *)
 func testSubclassing(obj: SendableSubclass) async {
-  acceptCV(obj) // okay!
+  acceptCV(obj) // expected-warning {{conformance of 'NSClass' to 'Sendable' is unavailable; this is an error in the Swift 6 language mode}}
 }
 
 

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -180,7 +180,7 @@ extension SendableExtSub: @unchecked Sendable {}
 
 // Still want to know about same-class redundancy
 class MultiConformance: @unchecked Sendable {} // expected-note {{'MultiConformance' declares conformance to protocol 'Sendable' here}}
-extension MultiConformance: @unchecked Sendable {} // expected-error {{redundant conformance of 'MultiConformance' to protocol 'Sendable'}}
+extension MultiConformance: @unchecked Sendable {} // expected-warning {{redundant conformance of 'MultiConformance' to protocol 'Sendable'}}
 
 @available(SwiftStdlib 5.1, *)
 actor MyActor {


### PR DESCRIPTION
- **Explanation**: This change fixes an issue where the compiler did not issue redundant conformance warnings when a client tries to add a retroactive `@unchecked Sendable` conformance when the library has already added an unavailable `Sendable` conformance.

   Note that this change still does not warn if the original unavailable conformance is declared with `@_nonSendable` due to the way `@_nonSendable` expansion happens during implicit `Sendable` derivation, after no explicit conformance has been found.
- **Scope**: Only impacts redundant conformances where at least one of the conformances is unavailable.
- **Issues**: rdar://124423524
- **Original PRs**: https://github.com/swiftlang/swift/pull/75135
- **Risk**: Low; the redundant conformance diagnostics added by this change are downgraded to warnings unconditionally. This allows libraries to stage in unavailable conformances to `Sendable` later on, and clients that have already added a retroactive `@unchecked Sendable` conformance will receive a warning when they rebuild. Conformance lookup will still choose the available conformance to avoid breaking source compatibility in places where the client code uses the type in a way that requires an available conformance to `Sendable`.
- **Testing**: Added new tests. Passed source compatibility on the `main` PR.
- **Reviewers**: @ktoso 