### PR TITLE
LocalVariableUtils: handle projections inside initializers.

### DIFF
--- a/test/SILOptimizer/lifetime_dependence/initializer.swift
+++ b/test/SILOptimizer/lifetime_dependence/initializer.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -o /dev/null \
+// RUN:   -verify \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NonescapableTypes
+
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
+
+struct Span<T>: ~Escapable {
+  private var base: UnsafePointer<T>
+  private var count: Int
+
+  @_unsafeNonescapableResult
+  init(base: UnsafePointer<T>, count: Int) {
+    self.base = base
+    self.count = count
+  }
+
+  init<S>(base: UnsafePointer<T>, count: Int, generic: borrowing S) -> dependsOn(generic) Self {
+    self.base = base
+    self.count = count
+  }
+}
+
+struct Wrapper<T: BitwiseCopyable>: ~Escapable {
+  private let span: Span<T>
+
+  init(span: borrowing Span<T>) {
+    self.span = copy span
+  }
+}
+
+struct SuperWrapper<T: BitwiseCopyable>: ~Escapable {
+  private let wrapper: Wrapper<T>
+
+  // An extra field forces a projection on 'self' within the initializer without any access scope.
+  var depth: Int = 0
+
+  // Make sure that LocalVariableUtils can successfully analyze 'self'. That's required to determine that the assignment
+  // of `wrapper` is returned without escaping
+  init(span: borrowing Span<T>) {
+    self.wrapper = Wrapper(span: span)
+  }
+}


### PR DESCRIPTION
These projections don't have access scopes, so the utility was treating them like escapes.

Fixes: rdar://131499478 (Difficulties composing non-escapable types)
