### PR TITLE
[ASTPrinter] Print `some` as a keyword

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -7182,7 +7182,7 @@ public:
       }
 
       // Print based on the type.
-      Printer << "some ";
+      Printer.printKeyword("some", Options, /*Suffix=*/" ");
       auto archetypeType = decl->getDeclContext()->mapTypeIntoContext(
           decl->getDeclaredInterfaceType())->castTo<ArchetypeType>();
       auto constraintType = archetypeType->getExistentialType();

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/SomeProtocol.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/SomeProtocol.swift
@@ -57,8 +57,16 @@ public func doSomethingElse(with param: some SomeProtocol & OtherProtocol) {}
 // CHECK-NEXT:          "spelling": "param"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": ": some "
+// CHECK-NEXT:            "kind": "text",
+// CHECK-NEXT:            "spelling": ": "
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "kind": "keyword",
+// CHECK-NEXT:            "spelling": "some"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "kind": "text",
+// CHECK-NEXT:            "spelling": " "
 // CHECK-NEXT:        },
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "kind": "typeIdentifier",
@@ -107,8 +115,16 @@ public func doSomethingElse(with param: some SomeProtocol & OtherProtocol) {}
 // MULTI-NEXT:          "spelling": "param"
 // MULTI-NEXT:        },
 // MULTI-NEXT:        {
-// MULTI-NEXT:          "kind": "text",
-// MULTI-NEXT:          "spelling": ": some "
+// MULTI-NEXT:            "kind": "text",
+// MULTI-NEXT:            "spelling": ": "
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:            "kind": "keyword",
+// MULTI-NEXT:            "spelling": "some"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:            "kind": "text",
+// MULTI-NEXT:            "spelling": " "
 // MULTI-NEXT:        },
 // MULTI-NEXT:        {
 // MULTI-NEXT:          "kind": "typeIdentifier",


### PR DESCRIPTION
This is consistent with how the TypeRepr is printed.