### PR TITLE
[6.0][Concurrency] Diagnose captures of `self` in a task created in `deinit`.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5520,6 +5520,9 @@ ERROR(non_sendable_isolated_capture,none,
 ERROR(implicit_async_let_non_sendable_capture,none,
       "capture of %1 with non-sendable type %0 in 'async let' binding",
       (Type, DeclName))
+ERROR(self_capture_deinit_task,none,
+      "capture of 'self' in a closure that outlives deinit",
+      ())
 ERROR(implicit_non_sendable_capture,none,
       "implicit capture of %1 requires that %0 conforms to `Sendable`",
       (Type, DeclName))

--- a/test/Concurrency/self_escapes_deinit.swift
+++ b/test/Concurrency/self_escapes_deinit.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -disable-availability-checking
+
+@MainActor
+class C {
+  let x: Int = 0
+
+  deinit {
+    // expected-warning@+1 {{capture of 'self' in a closure that outlives deinit; this is an error in the Swift 6 language mode}}
+    Task { @MainActor in
+      _ = self
+    }
+
+    // expected-warning@+1 {{capture of 'self' in a closure that outlives deinit; this is an error in the Swift 6 language mode}}
+    Task {
+      _ = x
+    }
+  }
+}
+
+func enqueueSomewhereElse(_ closure: @escaping @Sendable () -> Void) {}
+
+@MainActor
+class C2 {
+  let x: Int = 0
+
+  deinit {
+    // expected-warning@+1 {{capture of 'self' in a closure that outlives deinit; this is an error in the Swift 6 language mode}}
+    enqueueSomewhereElse {
+      _ = self
+    }
+
+    // expected-warning@+1 {{capture of 'self' in a closure that outlives deinit; this is an error in the Swift 6 language mode}}
+    enqueueSomewhereElse {
+      _ = self.x
+    }
+  }
+}


### PR DESCRIPTION
- **Explanation**: `self` outliving `deinit` causes a fatal error at runtime. This is a common mistake to make when creating isolated tasks inside nonisolated deinits to workaround the lack of synchronous isolated deinits in Swift 6. This change adds a new compiler error, staged in as a warning in language modes prior to Swift 6 mode, when you capture `self` in an `@escaping` closure that's also `sending` or `@Sendable`, which covers both the task creation APIs as well as `DispatchQueue.async` when used directly inside a `deinit`.
- **Scope**: Only impacts (implicit or explicit) captures of `self` in an `@escaping` closure that is also `sending` or `@Sendable` inside a `deinit`.
- **Issues**: https://github.com/swiftlang/swift/issues/72893
- **Original PRs**: https://github.com/swiftlang/swift/pull/75224
- **Risk**: Low; the new error message is staged in as a warning via `.warnUntilSwiftVersion(6)`
- **Testing**: Added new tests.
- **Reviewers**: @ktoso 