### PR TITLE
[NFC] GettingStarted: Remove `--skip-<os>` flags from build script command

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -265,7 +265,7 @@ Build the toolchain with optimizations, debuginfo, and assertions, using Ninja:
 - macOS:
   ```sh
   utils/build-script --skip-build-benchmarks \
-    --skip-ios --skip-watchos --skip-tvos --skip-xros --swift-darwin-supported-archs "$(uname -m)" \
+    --swift-darwin-supported-archs "$(uname -m)" \
     --sccache --release-debuginfo --swift-disable-dead-stripping \
     --bootstrapping=hosttools
   ```


### PR DESCRIPTION
These flags are dead weight because the options they disable default to false:

https://github.com/swiftlang/swift/blob/59f44f9d0f26d0d392a0626914a6dd0de6be7ddf/utils/build_swift/tests/expected_options.py#L213
https://github.com/swiftlang/swift/blob/59f44f9d0f26d0d392a0626914a6dd0de6be7ddf/utils/build_swift/tests/expected_options.py#L321
https://github.com/swiftlang/swift/blob/59f44f9d0f26d0d392a0626914a6dd0de6be7ddf/utils/build_swift/tests/expected_options.py#L325
https://github.com/swiftlang/swift/blob/59f44f9d0f26d0d392a0626914a6dd0de6be7ddf/utils/build_swift/tests/expected_options.py#L327