### PR TITLE
[CS] A couple of minor diagnostic improvements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -208,6 +208,9 @@ ERROR(cannot_match_unresolved_expr_pattern_with_value,none,
 ERROR(cannot_match_value_with_pattern,none,
       "pattern of type %1 cannot match %0",
       (Type, Type))
+ERROR(pattern_does_not_conform_to_match,none,
+      "pattern of type %0 does not conform to expected match type %1",
+      (Type, Type))
 
 ERROR(cannot_reference_compare_types,none,
       "cannot check reference equality of functions; operands here have types "

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6505,6 +6505,13 @@ bool MissingContextualConformanceFailure::diagnoseAsError() {
       break;
     }
 
+    case ConstraintLocator::EnumPatternImplicitCastMatch: {
+      emitDiagnostic(diag::pattern_does_not_conform_to_match, getFromType(),
+                     getToType())
+          .highlight(getSourceRange());
+      return true;
+    }
+
     default:
       break;
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9124,7 +9124,7 @@ bool InvalidWeakAttributeUse::diagnoseAsError() {
                        ReferenceOwnership::Weak, varType);
 
   auto typeRange = var->getTypeSourceRangeForDiagnostics();
-  if (varType->hasSimpleTypeRepr()) {
+  if (varType->lookThroughSingleOptionalType()->hasSimpleTypeRepr()) {
     diagnostic.fixItInsertAfter(typeRange.End, "?");
   } else {
     diagnostic.fixItInsert(typeRange.Start, "(")

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6667,6 +6667,11 @@ bool ConstraintSystem::repairFailures(
     if (lhs->isPlaceholder() || rhs->isPlaceholder())
       return true;
 
+    // If we're converting to an existential, we'll diagnose failures in
+    // the conformance constraint.
+    if (hasConversionOrRestriction(ConversionRestrictionKind::Existential))
+      return false;
+
     conversionsOrFixes.push_back(ContextualMismatch::create(
         *this, lhs, rhs, getConstraintLocator(locator)));
     break;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1421,6 +1421,11 @@ bool swift::checkOverrides(ValueDecl *decl) {
     return false;
   }
 
+  // Don't bother checking any further for invalid decls since they won't match
+  // anything.
+  if (decl->isInvalid())
+    return true;
+
   // Set up matching, but bail out if there's nothing to match.
   OverrideMatcher matcher(decl);
   if (!matcher) return false;

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -791,3 +791,17 @@ do {
     }
   }
 }
+
+func testMatchingNonErrorConformingTypeInClosure(_ x: any Error) {
+  enum E {
+    case e
+  }
+  _ = {
+    switch x {
+    case E.e: // expected-error {{pattern of type 'E' does not conform to expected match type 'Error'}}
+      break
+    default:
+      break
+    }
+  }
+}

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -191,6 +191,12 @@ weak var weak16 : Class!
 
 @weak var weak17 : Class? // expected-error {{'weak' is a declaration modifier, not an attribute}} {{1-2=}}
 
+class SomeClass {}
+protocol SomeProtocol {}
+_ = {
+  // Make sure the fix-it here includes the parens
+  weak var x: SomeClass & SomeProtocol // expected-error {{'weak' variable should have optional type '(any SomeClass & SomeProtocol)?'}} {{15-15=(}} {{39-39=)?}}
+}
 
 @_exported var exportVar: Int // expected-error {{@_exported may only be used on 'import' declarations}}{{1-12=}}
 @_exported func exportFunc() {} // expected-error {{@_exported may only be used on 'import' declarations}}{{1-12=}}

--- a/test/decl/circularity.swift
+++ b/test/decl/circularity.swift
@@ -86,10 +86,9 @@ class C3: G1<A>, P {
     // expected-error@-2 {{cannot find type 'A' in scope}}
     // expected-note@-3 2{{through reference here}}
     override func run(a: A) {}
-    // expected-error@-1 {{method does not override any method from its superclass}}
-    // expected-error@-2 {{circular reference}}
-    // expected-note@-3 2 {{through reference here}}
-    // expected-note@-4 {{while resolving type 'A'}}
+    // expected-error@-1 {{circular reference}}
+    // expected-note@-2 2 {{through reference here}}
+    // expected-note@-3 {{while resolving type 'A'}}
 }
 
 // Another case that triggers circular override checking.

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -414,3 +414,13 @@ open class OpenDerivedFinal : OpenBase {
 open class OpenDerivedStatic : OpenBase {
   override public static func classMethod() {}
 }
+
+// When override matching an invalid decl, avoid emitting
+// another error saying it doesn't override anything.
+class OverrideTypoBaseClass {
+  func foo(_ x: Int) {}
+}
+class OverrideTypoSubclass: OverrideTypoBaseClass {
+  override func foo(_ x: Itn) {} // expected-error {{cannot find type 'Itn' in scope}}
+}
+

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -156,7 +156,7 @@ func twelve() {
   twelve_helper { (a, b) in // expected-error {{invalid conversion from throwing function of type '(Int, Int) throws -> ()' to non-throwing function type '(Int, Int) -> ()'}}
     do {
       try thrower()
-    } catch Twelve.Payload(a...b) {
+    } catch Twelve.Payload(a...b) { // expected-error {{pattern of type 'Twelve' does not conform to expected match type 'Error'}}
     }
   }
 }


### PR DESCRIPTION
- Avoid diagnosing overrides for invalid decls
- Fix paren fix-it logic for non-optional `weak`
- Better diagnose conformance failures for EnumElementPatterns