### PR TITLE
[Index] Record relations for pseudo accessors

### DIFF
--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -539,3 +539,28 @@ func containerFunc() {
   // CHECK:      [[@LINE-16]]:15 | function/acc-get/Swift | getter:y | {{.*}} | Ref,Call,Impl,RelCall,RelCont | rel: 1
   // CHECK-NEXT: RelCall,RelCont | function/Swift | containerFunc()
 }
+
+// rdar://131749546 - Make sure we record the override relation for the
+// pseudo accessor for 'x'.
+class BaseClass {
+  var x = 0
+  // CHECK:      [[@LINE-1]]:7 | instance-property/Swift | x | s:14swift_ide_test9BaseClassC1xSivp | Def,RelChild | rel: 1
+  // CHECK:      [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:x | s:14swift_ide_test9BaseClassC1xSivg | Def,Dyn,Impl,RelChild,RelAcc | rel: 1
+  // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | x | s:14swift_ide_test9BaseClassC1xSivp
+  // CHECK:      [[@LINE-4]]:7 | instance-method/acc-set/Swift | setter:x | s:14swift_ide_test9BaseClassC1xSivs | Def,Dyn,Impl,RelChild,RelAcc | rel: 1
+  // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | x | s:14swift_ide_test9BaseClassC1xSivp
+}
+class Subclass: BaseClass {
+  override var x: Int {
+    // CHECK:      [[@LINE-1]]:16 | instance-property/Swift | x | s:14swift_ide_test8SubclassC1xSivp | Def,RelChild,RelOver | rel: 2
+    // CHECK-NEXT:   RelOver | instance-property/Swift | x | s:14swift_ide_test9BaseClassC1xSivp
+    get { 0 }
+    // CHECK:      [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:x | s:14swift_ide_test8SubclassC1xSivg | Def,Dyn,RelChild,RelOver,RelAcc | rel: 2
+    // CHECK-NEXT:   RelOver | instance-method/acc-get/Swift | getter:x | s:14swift_ide_test9BaseClassC1xSivg
+    // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | x | s:14swift_ide_test8SubclassC1xSivp
+    set {}
+    // CHECK:      [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:x | s:14swift_ide_test8SubclassC1xSivs | Def,Dyn,RelChild,RelOver,RelAcc | rel: 2
+    // CHECK-NEXT:   RelOver | instance-method/acc-set/Swift | setter:x | s:14swift_ide_test9BaseClassC1xSivs
+    // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | x | s:14swift_ide_test8SubclassC1xSivp
+  }
+}


### PR DESCRIPTION
I recently accidentally broke this in #72930, make sure we carve out an exception for pseudo accessors in `shouldIndex` such that we record e.g override relations for them.

rdar://131749546