### PR TITLE
[6.0][AST/Sema] Make it possible to use init accessors in inlinable initializers

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6855,8 +6855,8 @@ ERROR(frozen_attr_on_internal_type,
 
 ERROR(usable_from_inline_attr_with_explicit_access,
       none, "'@usableFromInline' attribute can only be applied to internal or package "
-      "declarations, but %0 is %select{private|fileprivate|%error|package|public|open}1",
-      (DeclName, AccessLevel))
+      "declarations, but %kind0 is %select{private|fileprivate|%error|package|public|open}1",
+      (const ValueDecl *, AccessLevel))
 
 WARNING(inlinable_implies_usable_from_inline,none,
         "'@usableFromInline' attribute has no effect on '@inlinable' %kind0",

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -352,11 +352,6 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
         }
       }
 
-      if (auto *accessor = dyn_cast<AccessorDecl>(D)) {
-        if (accessor->isInitAccessor() && !options.PrintForSIL)
-          return false;
-      }
-
       return ShouldPrintChecker::shouldPrint(D, options);
     }
   };

--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -65,8 +65,8 @@ AccessLevelRequest::evaluate(Evaluator &evaluator, ValueDecl *D) const {
       // These are only needed to synthesize the setter.
       return AccessLevel::Private;
     case AccessorKind::Init:
-      // These are only called from designated initializers.
-      return AccessLevel::Private;
+      // These are only called from within the same module.
+      return AccessLevel::Internal;
     }
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3206,7 +3206,7 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
       VD->getFormalAccess() != AccessLevel::Package) {
     diagnoseAndRemoveAttr(attr,
                           diag::usable_from_inline_attr_with_explicit_access,
-                          VD->getName(), VD->getFormalAccess());
+                          VD, VD->getFormalAccess());
     return;
   }
 

--- a/test/Compatibility/attr_usableFromInline_swift4.swift
+++ b/test/Compatibility/attr_usableFromInline_swift4.swift
@@ -2,10 +2,10 @@
 // RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4 -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
 @usableFromInline private func privateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'privateVersioned()' is private}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but global function 'privateVersioned()' is private}}
 
 @usableFromInline fileprivate func fileprivateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'fileprivateVersioned()' is fileprivate}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but global function 'fileprivateVersioned()' is fileprivate}}
 
 @usableFromInline internal func internalVersioned() {}
 // OK
@@ -14,11 +14,11 @@
 // OK
 
 @usableFromInline public func publicVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but global function 'publicVersioned()' is public}}
 
 internal class InternalClass {
   @usableFromInline public func publicVersioned() {}
-  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
+  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but instance method 'publicVersioned()' is public}}
 }
 
 fileprivate class filePrivateClass {

--- a/test/Compatibility/attr_usableFromInline_swift42.swift
+++ b/test/Compatibility/attr_usableFromInline_swift42.swift
@@ -2,10 +2,10 @@
 // RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4.2 -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
 @usableFromInline private func privateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'privateVersioned()' is private}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but global function 'privateVersioned()' is private}}
 
 @usableFromInline fileprivate func fileprivateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'fileprivateVersioned()' is fileprivate}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but global function 'fileprivateVersioned()' is fileprivate}}
 
 @usableFromInline internal func internalVersioned() {}
 // OK
@@ -14,12 +14,12 @@
 // OK
 
 @usableFromInline public func publicVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but global function 'publicVersioned()' is public}}
 
 internal class InternalClass {
   // expected-note@-1 2{{type declared here}}
   @usableFromInline public func publicVersioned() {}
-  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
+  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but instance method 'publicVersioned()' is public}}
 }
 
 fileprivate class filePrivateClass {

--- a/test/Interpreter/inlinable_init_accessors.swift
+++ b/test/Interpreter/inlinable_init_accessors.swift
@@ -1,0 +1,79 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-build-swift %t/src/Library.swift -swift-version 5 -emit-module -emit-library \
+// RUN:    -enable-library-evolution \
+// RUN:    -module-name Library \
+// RUN:    -o %t/%target-library-name(Library) \
+// RUN:    -emit-module-interface-path %t/Library.swiftinterface
+
+// RUN: %target-codesign %t/%target-library-name(Library)
+
+// RUN: %target-build-swift -I %t -L %t -l Library %t/src/main.swift %target-rpath(%t) -o %t/main.out
+// RUN: %target-codesign %t/main.out
+// RUN: %target-run %t/main.out %t/%target-library-name(Library) 2>&1 | %FileCheck %t/src/main.swift
+
+// RUN: rm %t/Library.swiftmodule
+
+// RUN: %target-build-swift -I %t -L %t -l Library %t/src/main.swift %target-rpath(%t) -o %t/main.out
+// RUN: %target-codesign %t/main.out
+// RUN: %target-run %t/main.out %t/%target-library-name(Library) 2>&1 | %FileCheck %t/src/main.swift
+
+// REQUIRES: executable_test
+
+//--- Library.swift
+@frozen
+public struct Inlinable {
+  var _x: Int
+
+  public var x: Int {
+    @usableFromInline
+    @storageRestrictions(initializes: _x)
+    init {
+      self._x = newValue
+    }
+
+    get {
+      _x
+    }
+  }
+
+  @inlinable
+  public init(x: Int) {
+    self.x = x
+  }
+}
+
+@frozen
+public struct Transparent {
+  @usableFromInline
+  var _x: Int
+
+  public var x: Int {
+    @_alwaysEmitIntoClient
+    @storageRestrictions(initializes: _x)
+    init {
+      self._x = newValue
+    }
+
+    get {
+      _x
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  public init(x: Int) {
+    self.x = x
+  }
+}
+
+//--- main.swift
+import Library
+
+let inlinable = Inlinable(x: 42)
+print("Inlinable.x = \(inlinable.x)")
+// CHECK: Inlinable.x = 42
+
+let transparent = Transparent(x: -1)
+print("Transparent.x = \(transparent.x)")
+// CHECK: Transparent.x = -1

--- a/test/ModuleInterface/init_accessors.swift
+++ b/test/ModuleInterface/init_accessors.swift
@@ -1,0 +1,123 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+/// Build the library A
+// RUN: %target-swift-frontend -emit-module %t/src/A.swift \
+// RUN:   -module-name A -swift-version 5 -enable-library-evolution \
+// RUN:   -emit-module-path %t/A.swiftmodule \
+// RUN:   -emit-module-interface-path %t/A.swiftinterface
+
+// RUN: %FileCheck %t/src/A.swift < %t/A.swiftinterface
+
+// Build the client using module
+// RUN: %target-swift-emit-sil -verify -module-name Client -I %t %t/src/Client.swift | %FileCheck %t/src/Client.swift
+
+// RUN: rm %t/A.swiftmodule
+
+// Re-build the client using interface
+// RUN: %target-swift-emit-sil -verify -module-name Client -I %t %t/src/Client.swift | %FileCheck %t/src/Client.swift
+
+// REQUIRES: asserts
+
+//--- A.swift
+@frozen
+public struct Inlinable {
+  var _x: Int
+
+// CHECK:      public var x: Swift.Int {
+// CHECK-NEXT:    @usableFromInline
+// CHECK-NEXT:    @storageRestrictions(initializes: _x) init
+// CHECK-NEXT:    get
+// CHECK-NEXT  }
+
+  public var x: Int {
+    @usableFromInline
+    @storageRestrictions(initializes: _x)
+    init {
+      self._x = newValue
+    }
+
+    get {
+      _x
+    }
+  }
+
+  @inlinable
+  public init(x: Int) {
+    self.x = x
+  }
+}
+
+public struct Internal {
+// CHECK:      public var y: Swift.Int {
+// CHECK-NEXT:   get
+// CHECK-NEXT: }
+
+  public var y: Int {
+    init {
+    }
+
+    get { 0 }
+  }
+
+  init(y: Int) {
+    self.y = y
+  }
+}
+
+@frozen
+public struct Transparent {
+   @usableFromInline
+   var _x: Int
+
+// CHECK:      public var x: Swift.Int {
+// CHECK-NEXT:   @_alwaysEmitIntoClient @storageRestrictions(initializes: _x) init {
+// CHECK-NEXT:     self._x = newValue
+// CHECK-NEXT:   }
+// CHECK-NEXT:   get
+// CHECK-NEXT  }
+
+  public var x: Int {
+    @_alwaysEmitIntoClient
+    @storageRestrictions(initializes: _x)
+    init {
+      self._x = newValue
+    }
+
+    get {
+      _x
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  public init(x: Int) {
+    self.x = x
+  }
+}
+
+//--- Client.swift
+import A
+
+// CHECK-LABEL: sil hidden @$s6Client15testTransparentyyF : $@convention(thin) () -> ()
+// CHECK: [[X:%.*]] = struct $Int (%1 : $Builtin.Int64)
+// CHECK-NEXT: // function_ref Transparent.init(x:)
+// CHECK-NEXT: [[TRANSPARENT_REF:%.*]] = function_ref @$s1A11TransparentV1xACSi_tcfC : $@convention(method) (Int, @thin Transparent.Type) -> Transparent
+// CHECK-NEXT: apply [[TRANSPARENT_REF]]([[X]], %0) : $@convention(method) (Int, @thin Transparent.Type) -> Transparent
+func testTransparent() {
+  _ = Transparent(x: 42)
+}
+
+// CHECK-LABEL: sil shared @$s1A11TransparentV1xACSi_tcfC : $@convention(method) (Int, @thin Transparent.Type) -> Transparent
+
+// CHECK-LABEL: sil hidden @$s6Client13testInlinableyyF : $@convention(thin) () -> ()
+// CHECK: [[X:%.*]] = struct $Int (%1 : $Builtin.Int64)
+// CHECK-NEXT: // function_ref Inlinable.init(x:)
+// CHECK-NEXT: [[INLINABLE_REF:%.*]] = function_ref @$s1A9InlinableV1xACSi_tcfC : $@convention(method) (Int, @thin Inlinable.Type) -> Inlinable
+// CHECK-NEXT: apply [[INLINABLE_REF]]([[X]], %0) : $@convention(method) (Int, @thin Inlinable.Type) -> Inlinable
+func testInlinable() {
+  _ = Inlinable(x: 42)
+}
+
+// CHECK-LABEL: sil @$s1A9InlinableV1xACSi_tcfC : $@convention(method) (Int, @thin Inlinable.Type) -> Inlinable
+
+// CHECK-LABEL: sil shared @$s1A11TransparentV1xSivi : $@convention(thin) (Int, @thin Transparent.Type) -> @out Int

--- a/test/SILOptimizer/init_accessors.swift
+++ b/test/SILOptimizer/init_accessors.swift
@@ -10,7 +10,7 @@ struct TestInit {
   var full: (Int, Int)
 
   var point: (Int, Int) {
-    // CHECK-LABEL: sil private [ossa] @$s14init_accessors8TestInitV5pointSi_Sitvi : $@convention(thin) (Int, Int, @inout Int, @thin TestInit.Type) -> (@out Int, @out (Int, Int))
+    // CHECK-LABEL: sil hidden [ossa] @$s14init_accessors8TestInitV5pointSi_Sitvi : $@convention(thin) (Int, Int, @inout Int, @thin TestInit.Type) -> (@out Int, @out (Int, Int))
     // CHECK: bb0([[Y_REF:%.*]] : $*Int, [[FULL_REF:%.*]] : $*(Int, Int), [[X_VAL:%.*]] : $Int, [[Y_VAL:%.*]] : $Int, [[X_REF:%.*]] : $*Int, [[METATYPE:%.*]] : $@thin TestInit.Type):
     //
     // CHECK: [[INITIAL_VALUE:%.*]] = tuple ([[X_VAL]] : $Int, [[Y_VAL]] : $Int)
@@ -230,7 +230,7 @@ class TestClass {
   var y: (Int, [String])
 
   var data: (Int, (Int, [String])) {
-    // CHECK-LABEL: sil private [ossa] @$s14init_accessors9TestClassC4dataSi_Si_SaySSGttvi : $@convention(thin) (Int, Int, @owned Array<String>, @thick TestClass.Type) -> (@out Int, @out (Int, Array<String>))
+    // CHECK-LABEL: sil hidden [ossa] @$s14init_accessors9TestClassC4dataSi_Si_SaySSGttvi : $@convention(thin) (Int, Int, @owned Array<String>, @thick TestClass.Type) -> (@out Int, @out (Int, Array<String>))
     // CHECK: bb0([[X_REF:%.*]] : $*Int, [[Y_REF:%.*]] : $*(Int, Array<String>), [[X_VAL:%.*]] : $Int, [[Y_VAL_0:%.*]] : $Int, [[Y_VAL_1:%.*]] : @owned $Array<String>, [[METATYPE:%.*]] : $@thick TestClass.Type):
     //
     // CHECK: ([[X_VAL:%.*]], [[Y_VAL:%.*]]) = destructure_tuple {{.*}} : $(Int, (Int, Array<String>))
@@ -277,7 +277,7 @@ struct TestGeneric<T, U> {
   var b: T
   var c: U
 
-  // CHECK-LABEL: sil private [ossa] @$s14init_accessors11TestGenericV4datax_xtvi : $@convention(thin) <T, U> (@in T, @in T, @inout U, @thin TestGeneric<T, U>.Type) -> (@out T, @out T)
+  // CHECK-LABEL: sil hidden [ossa] @$s14init_accessors11TestGenericV4datax_xtvi : $@convention(thin) <T, U> (@in T, @in T, @inout U, @thin TestGeneric<T, U>.Type) -> (@out T, @out T)
   //
   // CHECK: bb0([[A_REF:%.*]] : $*T, [[B_REF:%.*]] : $*T, [[A_VALUE:%.*]] : $*T, [[B_VALUE:%.*]] : $*T, [[C_REF:%.*]] : $*U, [[METATYPE:%.*]] : $@thin TestGeneric<T, U>.Type):
   //
@@ -326,7 +326,7 @@ struct TestGenericTuple<T, U> {
   var a: T
   var b: (T, U)
 
-  // CHECK-LABEL: sil private [ossa] @$s14init_accessors16TestGenericTupleV4datax_x_q_ttvi : $@convention(thin) <T, U> (@in T, @in T, @in U, @thin TestGenericTuple<T, U>.Type) -> (@out T, @out (T, U)) {
+  // CHECK-LABEL: sil hidden [ossa] @$s14init_accessors16TestGenericTupleV4datax_x_q_ttvi : $@convention(thin) <T, U> (@in T, @in T, @in U, @thin TestGenericTuple<T, U>.Type) -> (@out T, @out (T, U)) {
   //
   // CHECK: bb0([[A_REF:%.*]] : $*T, [[B_REF:%.*]] : $*(T, U), [[A_VALUE:%.*]] : $*T, [[B_VALUE:%.*]] : $*T, [[C_VALUE:%.*]] : $*U, [[METATYPE:%.*]] : $@thin TestGenericTuple<T, U>.Type):
   //

--- a/test/attr/attr_alwaysEmitIntoClient.swift
+++ b/test/attr/attr_alwaysEmitIntoClient.swift
@@ -16,3 +16,30 @@ public func publicFunction() {}
   versionedFunction()
   publicFunction()
 }
+
+public struct TestInitAccessors {
+  var _x: Int
+
+  public var x: Int {
+    @storageRestrictions(initializes: _x)
+    init { // expected-note 2 {{init acecssor for property 'x' is not '@usableFromInline' or public}}
+      self._x = newValue
+    }
+
+    get {
+      self._x
+    }
+
+     set {}
+   }
+
+   @_alwaysEmitIntoClient
+   public init(x: Int) {
+     self.x = 0 // expected-error {{init acecssor for property 'x' is internal and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+   }
+
+   @inlinable
+   public init() {
+     self.x = 0 // expected-error {{init acecssor for property 'x' is internal and cannot be referenced from an '@inlinable' function}}
+   }
+}

--- a/test/attr/attr_usableFromInline.swift
+++ b/test/attr/attr_usableFromInline.swift
@@ -2,10 +2,10 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-testing -package-name myPkg
 
 @usableFromInline private func privateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'privateVersioned()' is private}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but global function 'privateVersioned()' is private}}
 
 @usableFromInline fileprivate func fileprivateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'fileprivateVersioned()' is fileprivate}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but global function 'fileprivateVersioned()' is fileprivate}}
 
 @usableFromInline internal func internalVersioned() {}
 // OK
@@ -17,7 +17,7 @@
 // OK
 
 @usableFromInline public func publicVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but global function 'publicVersioned()' is public}}
 
 // expected-note@+1 3{{global function 'internalFunc()' is not '@usableFromInline' or public}}
 internal func internalFunc() {}
@@ -55,13 +55,13 @@ package func packageInlinableFunc() {
 package class PackageClass {
   // expected-note@-1 *{{type declared here}}
   @usableFromInline public func publicVersioned() {}
-  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
+  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but instance method 'publicVersioned()' is public}}
 }
 
 internal class InternalClass {
   // expected-note@-1 2{{type declared here}}
   @usableFromInline public func publicVersioned() {}
-  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
+  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but instance method 'publicVersioned()' is public}}
 }
 
 fileprivate class filePrivateClass {
@@ -333,4 +333,22 @@ public struct TestGenericSubscripts {
 
   @usableFromInline package func pkgNonGenericWhereClause() where T : PackageProtocol {}
   // expected-error@-1 {{type referenced from a generic requirement of a '@usableFromInline' instance method must be '@usableFromInline' or public}}
+}
+
+public struct IncorrectInitUse {
+  public var x: Int {
+    @usableFromInline
+    // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but getter for property 'x' is public}}
+    get { 0 }
+
+    @usableFromInline
+    // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but setter for property 'x' is public}}
+    set { }
+  }
+
+  @usableFromInline
+  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but initializer 'init(x:)' is public}}
+  public init(x: Int) {
+    self.x = x
+  }
 }


### PR DESCRIPTION
- Explanation:

  Fixes a SILGen crash-on-invalid when init accessors are referenced in inlinable initialzers without explicit `@usableFromInline` attribute.

  - Make init accessors `internal`
  - Require explicit `@usableFromInline` on init accessor when property is used in a designated inlinable initializer
  - Improve diagnostics when `@usableFromInline` is applied to a declaration without a name (i.e. accessor/init)

- Main Branch PR: https://github.com/swiftlang/swift/pull/75191

- Resolves: rdar://129318806

- Risk: Low (Diagnoses invalid code instead of crashing and allows more uses of init accessors in accordance with the proposal).

- Reviewed By: @tshortli 

- Testing: Existing test-cases were modified and new tests were added.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
