### PR TITLE
[6.0] Fix build failure in _SynchronizationShims module

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
@@ -23,7 +23,7 @@
 #include <unistd.h>
 
 static inline __swift_uint32_t _swift_stdlib_gettid() {
-  static __thread tid = 0;
+  static __thread __swift_uint32_t tid = 0;
 
   if (tid == 0) {
     tid = syscall(SYS_gettid);


### PR DESCRIPTION
Cherry pick of https://github.com/swiftlang/swift/pull/75205

Explanation: Updates the _SynchronizationShims module to prevent build failures when implicitly imported by Swift clients
Scope: Affects building clients of the Synchronization module
Original PR: https://github.com/swiftlang/swift/pull/75205
Risk: Minimal - this is a minor, build-time-only change that can be effectively tested in CI
Testing: Testing done via swift-ci toolchain builds
Reviewer: @azoy