### PR TITLE
[6.0] [Index] Record relations for pseudo accessors

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1055,6 +1055,26 @@ private:
     return {{line, col, inGeneratedBuffer}};
   }
 
+  bool shouldIndexImplicitDecl(const ValueDecl *D, bool IsRef) const {
+    // We index implicit constructors.
+    if (isa<ConstructorDecl>(D))
+      return true;
+
+    // Allow references to implicit getter & setter AccessorDecls on
+    // non-implicit storage, these are "pseudo accessors".
+    if (auto *AD = dyn_cast<AccessorDecl>(D)) {
+      if (!IsRef)
+        return false;
+
+      auto Kind = AD->getAccessorKind();
+      if (Kind != AccessorKind::Get && Kind != AccessorKind::Set)
+        return false;
+
+      return shouldIndex(AD->getStorage(), IsRef);
+    }
+    return false;
+  }
+
   bool shouldIndex(const ValueDecl *D, bool IsRef) const {
     if (D->isImplicit() && isa<VarDecl>(D) && IsRef) {
       // Bypass the implicit VarDecls introduced in CaseStmt bodies by using the
@@ -1062,7 +1082,7 @@ private:
       D = cast<VarDecl>(D)->getCanonicalVarDecl();
     }
 
-    if (D->isImplicit() && !isa<ConstructorDecl>(D))
+    if (D->isImplicit() && !shouldIndexImplicitDecl(D, IsRef))
       return false;
 
     // Do not handle non-public imported decls.

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -539,3 +539,28 @@ func containerFunc() {
   // CHECK:      [[@LINE-16]]:15 | function/acc-get/Swift | getter:y | {{.*}} | Ref,Call,Impl,RelCall,RelCont | rel: 1
   // CHECK-NEXT: RelCall,RelCont | function/Swift | containerFunc()
 }
+
+// rdar://131749546 - Make sure we record the override relation for the
+// pseudo accessor for 'x'.
+class BaseClass {
+  var x = 0
+  // CHECK:      [[@LINE-1]]:7 | instance-property/Swift | x | s:14swift_ide_test9BaseClassC1xSivp | Def,RelChild | rel: 1
+  // CHECK:      [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:x | s:14swift_ide_test9BaseClassC1xSivg | Def,Dyn,Impl,RelChild,RelAcc | rel: 1
+  // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | x | s:14swift_ide_test9BaseClassC1xSivp
+  // CHECK:      [[@LINE-4]]:7 | instance-method/acc-set/Swift | setter:x | s:14swift_ide_test9BaseClassC1xSivs | Def,Dyn,Impl,RelChild,RelAcc | rel: 1
+  // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | x | s:14swift_ide_test9BaseClassC1xSivp
+}
+class Subclass: BaseClass {
+  override var x: Int {
+    // CHECK:      [[@LINE-1]]:16 | instance-property/Swift | x | s:14swift_ide_test8SubclassC1xSivp | Def,RelChild,RelOver | rel: 2
+    // CHECK-NEXT:   RelOver | instance-property/Swift | x | s:14swift_ide_test9BaseClassC1xSivp
+    get { 0 }
+    // CHECK:      [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:x | s:14swift_ide_test8SubclassC1xSivg | Def,Dyn,RelChild,RelOver,RelAcc | rel: 2
+    // CHECK-NEXT:   RelOver | instance-method/acc-get/Swift | getter:x | s:14swift_ide_test9BaseClassC1xSivg
+    // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | x | s:14swift_ide_test8SubclassC1xSivp
+    set {}
+    // CHECK:      [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:x | s:14swift_ide_test8SubclassC1xSivs | Def,Dyn,RelChild,RelOver,RelAcc | rel: 2
+    // CHECK-NEXT:   RelOver | instance-method/acc-set/Swift | setter:x | s:14swift_ide_test9BaseClassC1xSivs
+    // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | x | s:14swift_ide_test8SubclassC1xSivp
+  }
+}


### PR DESCRIPTION
*6.0 cherry-pick of #75241*

- Explanation: Fixes a regression where we would no longer report any relations for pseudo accessors
- Scope: Affects the indexing of relations for pseudo accessors
- Issue: rdar://131749546
- Risk: Low, the fix is straightforward and limited in scope
- Testing: Added tests to test suite
- Reviewer: Ben Barham