### PR TITLE
[6.0][Concurrency] Don't infer actor isolation from inherited conformances.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4882,8 +4882,19 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
     return std::nullopt;
 
   std::optional<ActorIsolation> foundIsolation;
-  for (auto proto :
-       nominal->getLocalProtocols(ConformanceLookupKind::NonStructural)) {
+  for (auto conformance :
+       nominal->getLocalConformances(ConformanceLookupKind::NonStructural)) {
+
+    // Don't include inherited conformances. If a conformance is inherited
+    // from a superclass, the isolation of the subclass should be inferred
+    // from the superclass, which is done directly in ActorIsolationRequest.
+    // If the superclass has opted out of global actor inference, such as
+    // by conforming to the protocol in an extension, then the subclass should
+    // not infer isolation from the protocol.
+    if (conformance->getKind() == ProtocolConformanceKind::Inherited)
+      continue;
+
+    auto *proto = conformance->getProtocol();
     switch (auto protoIsolation = getActorIsolation(proto)) {
     case ActorIsolation::ActorInstance:
     case ActorIsolation::Unspecified:

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4878,6 +4878,8 @@ getIsolationFromWitnessedRequirements(ValueDecl *value) {
 /// are directly specified on the type.
 static std::optional<ActorIsolation>
 getIsolationFromConformances(NominalTypeDecl *nominal) {
+  auto &ctx = nominal->getASTContext();
+
   if (isa<ProtocolDecl>(nominal))
     return std::nullopt;
 
@@ -4891,8 +4893,13 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
     // If the superclass has opted out of global actor inference, such as
     // by conforming to the protocol in an extension, then the subclass should
     // not infer isolation from the protocol.
-    if (conformance->getKind() == ProtocolConformanceKind::Inherited)
+    //
+    // Gate this change behind an upcoming feature flag; isolation inference
+    // changes can break source in language modes < 6.
+    if (conformance->getKind() == ProtocolConformanceKind::Inherited &&
+        ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability)) {
       continue;
+    }
 
     auto *proto = conformance->getProtocol();
     switch (auto protoIsolation = getActorIsolation(proto)) {

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -213,3 +213,13 @@ class C2: MainActorSuperclass, InferenceConflictWithSuperclass {
 }
 
 
+class ConformInExtension {}
+extension ConformInExtension: InferMainActor {}
+
+class InheritConformance: ConformInExtension {
+  func f() {}
+}
+
+func testInheritedMainActorConformance() {
+  InheritConformance().f() // okay; this is not main actor isolated
+}


### PR DESCRIPTION
  - **Explanation**: Actor isolation inference considers both protocol conformances and superclasses. If a conformance is inherited from a superclass, the isolation of the subclass should be inferred directly from the superclass; if the superclass has opted out of global actor inference from a protocol, such as by conforming to the protocol in an extension, then the subclass should not infer isolation from the protocol. So, this change skips inherited protocols as a source of isolation inference in `getIsolationFromConformances`. Isolation from a superclass is computed elsewhere (directly in `ActorIsolationRequest::evaluate`).
  - **Scope**: Only impacts isolation inference through class inheritance where the superclass conforms to a protocol annotated with a global actor in an extension.
  - **Issues**: https://github.com/swiftlang/swift/issues/74274, rdar://129540677
  - **Original PRs**: https://github.com/swiftlang/swift/pull/75122, https://github.com/swiftlang/swift/pull/75251
  - **Risk**: Low; the isolation inference change is gated behind the `GlobalActorIsolatedTypesUsability` upcoming feature flag to avoid source breaks in language modes < 6. This upcoming feature flag is new in the Swift 6 compiler, so this change only impacts flags that are new in 6.0.
  - **Testing**: Added new tests.
  - **Reviewers**: @ktoso