### PR TITLE
[ScanDependencies] Fix a memory leak in dependency graph

### DIFF
--- a/lib/DependencyScan/DependencyScanJSON.cpp
+++ b/lib/DependencyScan/DependencyScanJSON.cpp
@@ -247,7 +247,7 @@ static void
 writeMacroDependencies(llvm::raw_ostream &out,
                        const swiftscan_macro_dependency_set_t *macro_deps,
                        unsigned indentLevel, bool trailingComma) {
-  if (macro_deps->count == 0)
+  if (!macro_deps)
     return;
 
   out.indent(indentLevel * 2);

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -214,9 +214,6 @@ static swiftscan_dependency_graph_t generateHollowDiagnosticOutput(
   // Hollow info details
   swiftscan_module_details_s *hollowDetails = new swiftscan_module_details_s;
   hollowDetails->kind = SWIFTSCAN_DEPENDENCY_INFO_SWIFT_TEXTUAL;
-  swiftscan_macro_dependency_set_t *hollowMacroSet = new swiftscan_macro_dependency_set_t;
-  hollowMacroSet->count = 0;
-  hollowMacroSet->macro_dependencies = nullptr;
   hollowDetails->swift_textual_details = {c_string_utils::create_null(),
                                           c_string_utils::create_empty_set(),
                                           c_string_utils::create_null(),
@@ -232,7 +229,7 @@ static swiftscan_dependency_graph_t generateHollowDiagnosticOutput(
                                           c_string_utils::create_null(),
                                           c_string_utils::create_null(),
                                           c_string_utils::create_null(),
-                                          hollowMacroSet};
+                                          nullptr};
   hollowMainModuleInfo->details = hollowDetails;
 
   // Empty Link Library set

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -591,12 +591,10 @@ static void bridgeDependencyIDs(const ArrayRef<ModuleDependencyID> dependencies,
 
 static swiftscan_macro_dependency_set_t *createMacroDependencySet(
     const std::map<std::string, MacroPluginDependency> &macroDeps) {
+  if (macroDeps.empty())
+    return nullptr;
+
   swiftscan_macro_dependency_set_t *set = new swiftscan_macro_dependency_set_t;
-  if (macroDeps.empty()) {
-    set->count = 0;
-    set->macro_dependencies = nullptr;
-    return set;
-  }
   set->count = macroDeps.size();
   set->macro_dependencies = new swiftscan_macro_dependency_t[set->count];
   unsigned SI = 0;

--- a/tools/libSwiftScan/libSwiftScan.cpp
+++ b/tools/libSwiftScan/libSwiftScan.cpp
@@ -31,12 +31,16 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(DependencyScanningTool, swiftscan_scanner_t)
 //=== Private Cleanup Functions -------------------------------------------===//
 void swiftscan_macro_dependency_dispose(
     swiftscan_macro_dependency_set_t *macro) {
+  if (!macro)
+    return;
+
   for (unsigned i = 0; i < macro->count; ++i) {
     swiftscan_string_dispose(macro->macro_dependencies[i]->moduleName);
     swiftscan_string_dispose(macro->macro_dependencies[i]->libraryPath);
     swiftscan_string_dispose(macro->macro_dependencies[i]->executablePath);
     delete macro->macro_dependencies[i];
   }
+  delete[] macro->macro_dependencies;
   delete macro;
 }
 


### PR DESCRIPTION
Fix a memory leak from https://github.com/swiftlang/swift/pull/75134.