### PR TITLE
Revert swift-corelibs-foundation-windows checkout

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1669,15 +1669,8 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
     }
 
     $env:CTEST_OUTPUT_ON_FAILURE = 1
-    if ($env:CI) {
-      # Use the windows-specific checkout on CI that provides
-      # a checkout that does not yet use swift-foundation.
-      $RepoName = "swift-corelibs-foundation-windows";
-    } else {
-      $RepoName = "swift-corelibs-foundation";
-    }
     Build-CMakeProject `
-      -Src $SourceCache\$RepoName `
+      -Src $SourceCache\swift-corelibs-foundation `
       -Bin $FoundationBinaryCache `
       -InstallTo $InstallPath `
       -Arch $Arch `

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -42,8 +42,6 @@
             "remote": { "id": "apple/swift-corelibs-xctest" } },
         "swift-corelibs-foundation": {
             "remote": { "id": "apple/swift-corelibs-foundation" } },  
-        "swift-corelibs-foundation-windows": {
-            "remote": { "id": "apple/swift-corelibs-foundation" } },  
         "swift-foundation-icu": {
             "remote": { "id": "apple/swift-foundation-icu" } },  
         "swift-foundation": {
@@ -140,7 +138,6 @@
                 "swift-stress-tester": "main",
                 "swift-corelibs-xctest": "main",
                 "swift-corelibs-foundation": "main",
-                "swift-corelibs-foundation-windows": "windows/main",
                 "swift-foundation-icu": "main",
                 "swift-foundation": "main",
                 "swift-corelibs-libdispatch": "main",
@@ -192,7 +189,6 @@
                 "swift-stress-tester": "release/6.0",
                 "swift-corelibs-xctest": "release/6.0",
                 "swift-corelibs-foundation": "release/6.0",
-                "swift-corelibs-foundation-windows": "windows/release/6.0",
                 "swift-corelibs-libdispatch": "release/6.0",
                 "swift-integration-tests": "release/6.0",
                 "swift-xcode-playground-support": "release/6.0",


### PR DESCRIPTION
We've been able to sort out the Windows issues and we can now land the Foundation re-core in parallel on Windows and Linux removing the need for a separate checkout