### PR TITLE
[6.0]Allow enabling embedded Swift without WMO when not generating SIL

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1537,7 +1537,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       HadError = true;
     }
 
-    if (!FrontendOpts.InputsAndOutputs.isWholeModule()) {
+    if (!FrontendOpts.InputsAndOutputs.isWholeModule() && FrontendOptions::doesActionGenerateSIL(FrontendOpts.RequestedAction)) {
       Diags.diagnose(SourceLoc(), diag::wmo_with_embedded);
       HadError = true;
     }

--- a/test/embedded/wmo-with-embedded-diag.swift
+++ b/test/embedded/wmo-with-embedded-diag.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-frontend -typecheck -parse-stdlib %s -enable-experimental-feature Embedded
-// RUN: not %target-swift-frontend -typecheck -parse-stdlib %s -primary-file %s -enable-experimental-feature Embedded 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -c %s -o %t -module-name wmowithembedded -parse-stdlib -enable-experimental-feature Embedded
+// RUN: not %target-swift-frontend -c %s -o %t -module-name wmowithembedded -parse-stdlib -primary-file %s -enable-experimental-feature Embedded 2>&1 | %FileCheck %s
 
-// RUN: %target-swiftc_driver -typecheck -parse-stdlib %s -Xfrontend -disable-objc-interop -enable-experimental-feature Embedded -wmo
-// RUN: not %target-swiftc_driver -typecheck -parse-stdlib %s -Xfrontend -disable-objc-interop -enable-experimental-feature Embedded 2>&1 | %FileCheck %s
+// RUN: %target-swiftc_driver -c %s -o %t -module-name wmowithembedded -parse-stdlib -Xfrontend -disable-objc-interop -enable-experimental-feature Embedded -wmo
+// RUN: not %target-swiftc_driver -c %s -o %t -module-name wmowithembedded -parse-stdlib -Xfrontend -disable-objc-interop -enable-experimental-feature Embedded 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 


### PR DESCRIPTION
This allows modes like -index-file to work the same way they do when not using embedded Swift

Explanation: Avoid emitting an error that embedded Swift requires WMO if not generating SIL. This allows modes like -index-file to work in the natural way.
Scope: Behavior change is restricted to building embedded Swift.
Original PRs:
Risk: Low. This change is scoped to embedded Swift, and makes an existing check more permissive
Reviewers: @bnbarham 