### PR TITLE
[macCatalyst] Support generating macCatalyst object files

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -734,6 +734,9 @@ public:
   // Retrieve the declaration of Swift._stdlib_isOSVersionAtLeast.
   FuncDecl *getIsOSVersionAtLeastDecl() const;
 
+  // Retrieve the declaration of Swift._stdlib_isOSVersionAtLeastOrVariantVersionAtLeast.
+  FuncDecl *getIsVariantOSVersionAtLeastDecl() const;
+
   /// Look for the declaration with the given name within the
   /// passed in module.
   void lookupInModule(ModuleDecl *M, StringRef name,

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1029,6 +1029,10 @@ static void initLLVMModule(const IRGenModule &IGM, SILModule &SIL) {
     else
       assert(Module->getSDKVersion() == *IGM.Context.LangOpts.SDKVersion);
   }
+  if (IGM.Context.LangOpts.TargetVariant)
+    Module->setDarwinTargetVariantTriple(IGM.Context.LangOpts.TargetVariant->getTriple());
+  if (IGM.Context.LangOpts.VariantSDKVersion)
+    Module->setDarwinTargetVariantSDKVersion(*IGM.Context.LangOpts.VariantSDKVersion);
 
   // Set the module's string representation.
   Module->setDataLayout(IGM.DataLayout.getStringRepresentation());

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2308,6 +2308,10 @@ bool swift::writeEmptyOutputFilesFor(
       Context.getClangModuleLoader());
     llvmModule->setTargetTriple(
       clangImporter->getTargetInfo().getTargetOpts().Triple);
+    if (const auto *TVT = clangImporter->getTargetInfo().getDarwinTargetVariantTriple())
+      llvmModule->setDarwinTargetVariantTriple(TVT->getTriple());
+    if (auto TVSDKVersion = clangImporter->getTargetInfo().getDarwinTargetVariantSDKVersion())
+      llvmModule->setDarwinTargetVariantSDKVersion(*TVSDKVersion);
 
     // Add LLVM module flags.
     auto &clangASTContext = clangImporter->getClangASTContext();

--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -76,7 +76,7 @@ static void emitBackDeployIfAvailableCondition(SILGenFunction &SGF,
     SILType i1 = SILType::getBuiltinIntegerType(1, SGF.getASTContext());
     booleanTestValue = SGF.B.createIntegerLiteral(loc, i1, 1);
   } else {
-    booleanTestValue = SGF.emitOSVersionRangeCheck(loc, OSVersion);
+    booleanTestValue = SGF.emitOSVersionRangeCheck(loc, OSVersion, VersionRange::empty());
   }
 
   SGF.B.createCondBranch(loc, booleanTestValue, availableBB, unavailableBB);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1591,7 +1591,7 @@ public:
   // Patterns
   //===--------------------------------------------------------------------===//
 
-  SILValue emitOSVersionRangeCheck(SILLocation loc, const VersionRange &range);
+  SILValue emitOSVersionRangeCheck(SILLocation loc, const VersionRange &range, const VersionRange &variantRange);
   void emitStmtCondition(StmtCondition Cond, JumpDest FalseDest, SILLocation loc,
                          ProfileCounter NumTrueTaken = ProfileCounter(),
                          ProfileCounter NumFalseTaken = ProfileCounter());

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -58,7 +58,11 @@ public func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(
   _ variantMinor: Builtin.Word,
   _ variantPatch: Builtin.Word
   ) -> Builtin.Int1 {
-  return _stdlib_isOSVersionAtLeast(major, minor, patch)
+  var isAtLeast = _stdlib_isOSVersionAtLeast(major, minor, patch)
+  if !Bool(isAtLeast) {
+    isAtLeast = _stdlib_isOSVersionAtLeast(variantMajor, variantMinor, variantPatch)
+  }
+  return isAtLeast
 }
 #endif
 

--- a/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
+++ b/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
@@ -29,5 +29,5 @@ withUnsafeTemporaryAllocation(byteCount: 0x0FFF_FFFF, alignment: 1) { buffer in
 
 // CHECK-LARGE-ALLOC-DAG: [[IS_SAFE:%[0-9]+]] = {{(tail )?}}call {{(zeroext )?}}i1 @swift_stdlib_isStackAllocationSafe([[WORD]] 268435455, [[WORD]] 1)
 // CHECK-LARGE-ALLOC-DAG: br i1 [[IS_SAFE]], label %{{[0-9]+}}, label %{{[0-9]+}}
-// CHECK-LARGE-ALLOC-apple-DAG: [[IS_OS_OK:%[0-9]+]] = {{(tail )?}}call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
+// CHECK-LARGE-ALLOC-apple-DAG: [[IS_OS_OK:%[0-9]+]] = {{(tail )?}}call swiftcc i1 @"${{ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF|ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF}}"
 // CHECK-LARGE-ALLOC-apple-DAG: br i1 [[IS_OS_OK]], label %{{[0-9]+}}, label %{{[0-9]+}}

--- a/test/SILGen/availability_query_maccatalyst_zippered_canonical_versions.swift
+++ b/test/SILGen/availability_query_maccatalyst_zippered_canonical_versions.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen %s -target x86_64-apple-macosx10.52 -target-variant x86_64-apple-ios50.0-macabi | %FileCheck %s
-// RUN: %target-swift-emit-silgen %s -target x86_64-apple-ios50.0-macabi -target-variant x86_64-apple-macosx10.52 | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target x86_64-apple-macosx10.52 -target-variant x86_64-apple-ios50.0-macabi | %FileCheck %s --check-prefixes MAC,CHECK
+// RUN: %target-swift-emit-silgen %s -target x86_64-apple-ios50.0-macabi -target-variant x86_64-apple-macosx10.52 | %FileCheck %s --check-prefixes IOS,CHECK
 
 
 // REQUIRES: maccatalyst_support
@@ -10,13 +10,21 @@
 // Test for the runtime non-canonical version hack for canonical macOS versioning.
 // This will eventually change to be the correctly canonicalized version.
 
-// CHECK: [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
-// CHECK: [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 16
-// CHECK: [[MACOS_PATCH:%.*]] = integer_literal $Builtin.Word, 0
-// CHECK: [[IOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 51
-// CHECK: [[IOS_MINOR:%.*]] = integer_literal $Builtin.Word, 1
-// CHECK: [[IOS_PATCH:%.*]] = integer_literal $Builtin.Word, 2
+// MAC: [[TARGET_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
+// MAC: [[TARGET_MINOR:%.*]] = integer_literal $Builtin.Word, 16
+// MAC: [[TARGET_PATCH:%.*]] = integer_literal $Builtin.Word, 0
+// MAC: [[VARIANT_MAJOR:%.*]] = integer_literal $Builtin.Word, 51
+// MAC: [[VARIANT_MINOR:%.*]] = integer_literal $Builtin.Word, 1
+// MAC: [[VARIANT_PATCH:%.*]] = integer_literal $Builtin.Word, 2
+
+// IOS: [[TARGET_MAJOR:%.*]] = integer_literal $Builtin.Word, 51
+// IOS: [[TARGET_MINOR:%.*]] = integer_literal $Builtin.Word, 1
+// IOS: [[TARGET_PATCH:%.*]] = integer_literal $Builtin.Word, 2
+// IOS: [[VARIANT_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
+// IOS: [[VARIANT_MINOR:%.*]] = integer_literal $Builtin.Word, 16
+// IOS: [[VARIANT_PATCH:%.*]] = integer_literal $Builtin.Word, 0
+
 // CHECK: [[FUNC:%.*]] = function_ref @$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
-// CHECK: [[QUERY_RESULT:%.*]] = apply [[FUNC]]([[MACOS_MAJOR]], [[MACOS_MINOR]], [[MACOS_PATCH]], [[IOS_MAJOR]], [[IOS_MINOR]], [[IOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: [[QUERY_RESULT:%.*]] = apply [[FUNC]]([[TARGET_MAJOR]], [[TARGET_MINOR]], [[TARGET_PATCH]], [[VARIANT_MAJOR]], [[VARIANT_MINOR]], [[VARIANT_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 if #available(OSX 10.16, iOS 51.1.2, *) {
 }


### PR DESCRIPTION
This implements the missing support for macCatalyst in the open source version of Swift. It seems that years ago, the minimal support for macCatalyst was included in #29017, but except some fixes over the years, the work seemed to be blocked there, waiting for LLVM/Clang support that had not landed by the time and the open source toolchain cannot target macCatalyst.

- Implement code to access to `_stdlib_isOSVersionAtLeastOrVariantVersionAtLeast` from the stdlib.
- Implement code to choose `isOSVersionAtLeast` or `isOSVersionAtLeastOrVariantVersionAtLeast` depending on the command line being provided a target variant.
- When an availability statement need to be emitted, pass the target variant version range in order to generate the right stdlib call.
- Implement `isOSVersionAtLeastOrVariantVersionAtLeast` using the variant version information and forwarding both checks to `isOSVersionAtLeast`.
- Set the LLVM Module with the target variant information, so the code is generated correctly.
- Similar code for when the Clang importer is used.
- Modify a test that, when used precompiled modules from Xcode, uses code compiled for macCatalyst and uses the `isOSVersionAtLeastOrVariantVersionAtLeast` instead of the previously expected `isOSVersionAtLeast`. Another option is using `prefer-parseable`, which uses the "expected" stdlib function.
- Modify a test that was checking for availability in a fixed order even when the parameters in the command line were flipped. This test was probably never run in open source CI because it requires `maccatalyst_support`, which was not possible without these changes.