### PR TITLE
Add precondition to prevent out-of-bounds access  

### DIFF
--- a/stdlib/public/Cxx/CxxRandomAccessCollection.swift
+++ b/stdlib/public/Cxx/CxxRandomAccessCollection.swift
@@ -44,6 +44,7 @@ extension CxxRandomAccessCollection {
       // Not using CxxIterator here to avoid making a copy of the collection.
       var rawIterator = __beginUnsafe()
       rawIterator += RawIterator.Distance(index)
+      precondition(__endUnsafe() - rawIterator > 0, "C++ iterator access out of bounds")  
       yield rawIterator.pointee
     }
   }


### PR DESCRIPTION
The `subscript` function from `CxxRandomAccessCollection` did not perform any bounds-checks.
This means that C++ containers that don't provide the `operator[]` (or C++ containers used in generic contexts) didn't have bounds-checks.

Fixes rdar://126570011