### PR TITLE
[DNM][IRGen] Ignore marker protocols while deciding polymorphic convention

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -386,6 +386,16 @@ void PolymorphicConvention::considerParameter(SILParameterInfo param,
                                               bool isSelfParameter) {
   auto type = param.getArgumentType(IGM.getSILModule(), FnType,
                                     IGM.getMaximalTypeExpansionContext());
+
+  // Strip all of the marker protocols because they don't exist at runtime
+  // and cannot be factored into a convention.
+  if (auto *existential = type->getAs<ExistentialType>()) {
+    if (auto *PCT = existential->getConstraintType()
+                        ->getAs<ProtocolCompositionType>()) {
+      type = PCT->withoutMarkerProtocols()->getCanonicalType();
+    }
+  }
+
   switch (param.getConvention()) {
       // Indirect parameters do give us a value we can use, but right now
       // we don't bother, for no good reason. But if this is 'self',
@@ -686,6 +696,14 @@ bindParameterSource(SILParameterInfo param, unsigned paramIndex,
     return;
 
   CanType paramType = getArgTypeInContext(paramIndex);
+
+  // Strip marker protocols to match what happens in `considerParameter`.
+  if (auto *existential = paramType->getAs<ExistentialType>()) {
+    if (auto *PCT = existential->getConstraintType()
+                        ->getAs<ProtocolCompositionType>()) {
+      paramType = PCT->withoutMarkerProtocols()->getCanonicalType();
+    }
+  }
 
   // If the parameter is a thick metatype, bind it directly.
   // TODO: objc metatypes?

--- a/test/IRGen/protocol_compositions_with_marker_protocols_in_parameter_positions.swift
+++ b/test/IRGen/protocol_compositions_with_marker_protocols_in_parameter_positions.swift
@@ -1,0 +1,60 @@
+// RUN: %target-swift-frontend -module-name marker_test -emit-ir %s -swift-version 5  -disable-availability-checking | %IRGenFileCheck %s
+
+// REQUIRES: concurrency
+
+public protocol P<Output> {
+  associatedtype Output
+}
+
+struct Aux {
+}
+
+extension Aux {
+  public struct Test<Root : P, Output> : P {
+    public let root: Root
+    public let keyPath: KeyPath<Root.Output, Output> & Sendable
+
+    // CHECK-LABEL: define hidden swiftcc void @"$s11marker_test3AuxV4TestV4root7keyPathAEy_xq_Gx_s8Sendable_s03KeyG0Cy6OutputQzq_GXctcfC"(ptr noalias sret(%swift.opaque) %0, ptr noalias %1, ptr %2, ptr %Root, ptr %Root.P)
+    // CHECK: [[OUTPUT_ADDR:%.*]] = getelementptr inbounds i8, ptr %3, i64 {{.*}}
+    // CHECK-NEXT: %Output = load ptr, ptr [[OUTPUT_ADDR]]
+    // CHECK-NEXT: store ptr %Output, ptr %Output2
+    // CHECK-NEXT: call swiftcc %swift.metadata_response @"$s11marker_test3AuxV4TestVMa"(i64 0, ptr %Root, ptr %Output, ptr %Root.P)
+    public init(root: Root, keyPath: Swift.KeyPath<Root.Output, Output> & Sendable) {
+      self.root = root
+      self.keyPath = keyPath
+    }
+  }
+
+  // ! - Note that build<Root, Value> and build_no_sendable<Root, Value> should be the same.
+
+  // CHECK-LABEL: define hidden swiftcc void @"$s11marker_test3AuxV5build4root7keyPathAC4TestVy_xq_Gx_s03KeyG0Cy6OutputQzq_GtAA1PRzr0_lFZ"(ptr noalias sret(%swift.opaque) %0, ptr noalias %1, ptr %2, ptr %Root, ptr %Root.P)
+  // CHECK: [[WTABLE_ADDR:%.*]] = getelementptr inbounds ptr, ptr %Root, i64 -1
+  // CHECK-NEXT: %Root.valueWitnesses = load ptr, ptr [[WTABLE_ADDR]]
+  // CHECK: [[WTABLE_SIZE:%.*]] = getelementptr inbounds %swift.vwtable, ptr %Root.valueWitnesses, i32 0, i32 8
+  // CHECK-NEXT: %size = load i64, ptr [[WTABLE_SIZE]]
+  // CHECK-NEXT: [[WTABLE:%.*]] = alloca i8, i64 %size
+  // CHECK: %base = load i64, ptr @"$ss7KeyPathCMo"
+  // CHECK-NEXT: [[KEYPATH_BASE_OFFSET:%.*]] = add i64 %base, 0
+  // CHECK-NEXT: [[OUTPUT_ADDR:%.*]] = getelementptr inbounds i8, ptr %3, i64 [[KEYPATH_BASE_OFFSET]]
+  // CHECK-NEXT: %Root.Output = load ptr, ptr [[OUTPUT_ADDR]]
+  // CHECK: call swiftcc void @"$s11marker_test3AuxV4TestV4root7keyPathAEy_xq_Gx_s8Sendable_s03KeyG0Cy6OutputQzq_GXctcfC"(ptr noalias sret(%swift.opaque) %0, ptr noalias [[WTABLE]], ptr %2, ptr %Root, ptr %Root.P)
+  @preconcurrency
+  public static func build<Root, Value>(root: Root, keyPath: KeyPath<Root.Output, Value> & Sendable) -> Aux.Test<Root, Value> {
+    Test(root: root, keyPath: keyPath)
+  }
+
+  // CHECK-LABEL: define hidden swiftcc void @"$s11marker_test3AuxV17build_no_sendable4root7keyPathAC4TestVy_xq_Gx_s8Sendable_s03KeyI0Cy6OutputQzq_GXctAA1PRzr0_lFZ"(ptr noalias sret(%swift.opaque) %0, ptr noalias %1, ptr %2, ptr %Root, ptr %Root.P)
+  // CHECK: [[WTABLE_ADDR:%.*]] = getelementptr inbounds ptr, ptr %Root, i64 -1
+  // CHECK-NEXT: %Root.valueWitnesses = load ptr, ptr [[WTABLE_ADDR]]
+  // CHECK: [[WTABLE_SIZE:%.*]] = getelementptr inbounds %swift.vwtable, ptr %Root.valueWitnesses, i32 0, i32 8
+  // CHECK-NEXT: %size = load i64, ptr [[WTABLE_SIZE]]
+  // CHECK-NEXT: [[WTABLE:%.*]] = alloca i8, i64 %size
+  // CHECK: %base = load i64, ptr @"$ss7KeyPathCMo"
+  // CHECK-NEXT: [[KEYPATH_BASE_OFFSET:%.*]] = add i64 %base, 0
+  // CHECK-NEXT: [[OUTPUT_ADDR:%.*]] = getelementptr inbounds i8, ptr %3, i64 [[KEYPATH_BASE_OFFSET]]
+  // CHECK-NEXT: %Root.Output = load ptr, ptr [[OUTPUT_ADDR]]
+  // CHECK: call swiftcc void @"$s11marker_test3AuxV4TestV4root7keyPathAEy_xq_Gx_s8Sendable_s03KeyG0Cy6OutputQzq_GXctcfC"(ptr noalias sret(%swift.opaque) %0, ptr noalias [[WTABLE]], ptr %2, ptr %Root, ptr %Root.P)
+  public static func build_no_sendable<Root, Value>(root: Root, keyPath: KeyPath<Root.Output, Value> & Sendable) -> Aux.Test<Root, Value> {
+    Test(root: root, keyPath: keyPath)
+  }
+}


### PR DESCRIPTION
Strip marker protocols from protocol compositions because 
they don't exist at runtime and so cannot affect the convention.
This also makes sure that ABI stays the same even after some 
parameters start using `& <marker protocol>` in their types.

Resolves: rdar://131764614

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
