### PR TITLE
[cxx-interop] Forward declare classes

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -325,8 +325,6 @@ private:
 
     if (outputLang == OutputLanguageMode::Cxx) {
       // FIXME: Non objc class.
-      // FIXME: forward decl should be handled by ModuleWriter.
-      ClangValueTypePrinter::forwardDeclType(os, CD, owningPrinter);
       ClangClassTypePrinter(os).printClassTypeDecl(
           CD, [&]() { printMembers(CD->getMembers()); }, owningPrinter);
       recordEmittedDeclInCurrentCxxLexicalScope(CD);

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -15,6 +15,7 @@
 
 #include "OutputLanguageMode.h"
 
+#include "swift/AST/Decl.h"
 #include "swift/AST/Type.h"
 // for OptionalTypeKind
 #include "swift/ClangImporter/ClangImporter.h"

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -41,7 +41,6 @@ public:
   /// corresponds to the given structure or enum declaration.
   void printValueTypeDecl(const NominalTypeDecl *typeDecl,
                           llvm::function_ref<void(void)> bodyPrinter,
-
                           DeclAndTypePrinter &declAndTypePrinter);
 
   /// Print the use of a C++ struct/enum parameter value as it's passed to the

--- a/test/Interop/SwiftToCxx/class/swift-class-ordering.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-ordering.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Class -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/class.h)
+
+public class SwiftNode {
+}
+
+public struct SwiftLinkedList {
+  public var head: SwiftNode
+}


### PR DESCRIPTION
The code already forward declared structs and enums. This patch extends the logic to also forward declare classes. Unfortunately, there were some fallout because some traits ended up defined multiple times for some classes, so the code is now extended to only conditionally emit these traits if no forward declaration was emitted for the type yet.

rdar://124022242
