### PR TITLE
[6.0][IRGen] Fix emitPrimitiveLoadPayloadAndExtraTag for CVW

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1693,7 +1693,7 @@ namespace {
           // In CVW we have to mask the extra bits, which requires us to make
           // this cast here, otherwise LLVM would optimize away the bit mask.
           if (projectedBits.getElementType()->getIntegerBitWidth() < 8) {
-            projectedBits = IGF.Builder.CreateElementBitCast(addr, IGM.Int8Ty);
+            projectedBits = IGF.Builder.CreateElementBitCast(projectedBits, IGM.Int8Ty);
           }
           extraTag = IGF.Builder.CreateLoad(projectedBits);
           auto maskBits = llvm::PowerOf2Ceil(NumExtraTagValues) - 1;

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -620,8 +620,8 @@ public enum MultiPayloadError {
 }
 
 public enum TwoPayloadInner {
-    case x(AnyObject)
-    case y(Int)
+    case x(Int)
+    case y(AnyObject)
 }
 
 public enum TwoPayloadOuter {

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -1294,12 +1294,12 @@ func testNestedTwoPayload() {
     let ptr = UnsafeMutablePointer<TwoPayloadOuter>.allocate(capacity: 1)
 
     do {
-        let x = TwoPayloadOuter.y(TwoPayloadInner.x(SimpleClass(x: 23)))
+        let x = TwoPayloadOuter.y(TwoPayloadInner.y(SimpleClass(x: 23)))
         testInit(ptr, to: x)
     }
 
     do {
-        let y = TwoPayloadOuter.y(TwoPayloadInner.x(SimpleClass(x: 1)))
+        let y = TwoPayloadOuter.y(TwoPayloadInner.y(SimpleClass(x: 1)))
 
         // CHECK: Before deinit
         print("Before deinit")


### PR DESCRIPTION
**Explanation:** When casting the projectedBits to Int8, we accidetnally passed the base addr instead of the projectedBits. This was causing the wrong bits to be read.
**Scope:** Compact value witnesses only.
**Issue:** rdar://129627898
**Original PR:** https://github.com/swiftlang/swift/pull/75270
**Risk:** Low. Only affects compact value witnesses.
**Reviewers:** @tbkka 



