### PR TITLE
[6.0][Concurrency] New runtime entrypoint and SPI to warn about isolation violations

### DIFF
--- a/include/swift/ABI/ExecutorOptions.h
+++ b/include/swift/ABI/ExecutorOptions.h
@@ -1,0 +1,104 @@
+//===-- ExecutorOptions.h - ABI structures for executor options -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Swift ABI describing executor options.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_EXECUTOR_OPTIONS_H
+#define SWIFT_ABI_EXECUTOR_OPTIONS_H
+
+#include "swift/ABI/Executor.h"
+#include "swift/ABI/HeapObject.h"
+#include "swift/ABI/Metadata.h"
+#include "swift/ABI/MetadataValues.h"
+#include "swift/ABI/TaskLocal.h"
+#include "swift/Basic/STLExtras.h"
+#include "swift/Runtime/Config.h"
+#include "llvm/Support/Casting.h"
+
+namespace swift {
+
+/// The abstract base class for all options that may be used
+/// to configure how we should "check" an executor..
+class ExecutorCheckOptionRecord {
+public:
+  ExecutorCheckOptionRecordFlags Flags;
+  ExecutorCheckOptionRecord* _Nullable Parent;
+
+  ExecutorCheckOptionRecord(
+      ExecutorCheckOptionRecordKind kind, ExecutorCheckOptionRecordFlags flags,
+      ExecutorCheckOptionRecord *_Nullable parent = nullptr)
+      : Parent(parent) {
+    flags.setKind(kind);
+    Flags = flags;
+  }
+
+  ExecutorCheckOptionRecord(const ExecutorCheckOptionRecord &) = delete;
+  ExecutorCheckOptionRecord &operator=(const ExecutorCheckOptionRecord &) = delete;
+
+  ExecutorCheckOptionRecordKind getKind() const {
+    return Flags.getKind();
+  }
+
+  bool isTaskLocalAllocated() const {
+    return Flags.isTaskLocalAllocated();
+  }
+
+  ExecutorCheckOptionRecord* _Nullable getParent() const {
+    return Parent;
+  }
+
+  /// Appropriately destroys the record using a task-local deallocation or free(),
+  /// depending on how it was created.
+  void destroy();
+};
+
+
+/******************************************************************************/
+/************************ EXECUTOR CHECK OPTIONS ******************************/
+/******************************************************************************/
+
+/// Represents the #function, #file, #line that are often used when performing
+/// executor checks, and may be used in providing better diagnostic logs.
+class SourceLocationExecutorCheckOptionRecord : public ExecutorCheckOptionRecord {
+public:
+  const char * _Nonnull FunctionName;
+  const char * _Nonnull File;
+  const uintptr_t Line;
+  const uintptr_t Column;
+
+  SourceLocationExecutorCheckOptionRecord(
+      ExecutorCheckOptionRecordFlags flags, const char *_Nonnull functionName,
+      const char *_Nonnull file, uintptr_t line, uintptr_t column,
+      ExecutorCheckOptionRecord *_Nullable Parent)
+      : ExecutorCheckOptionRecord(
+            ExecutorCheckOptionRecordKind::SourceLocation, flags, Parent),
+        FunctionName(functionName), File(file), Line(line), Column(column) {}
+
+  static bool classof(const ExecutorCheckOptionRecord * _Nonnull record) {
+    return record->getKind() == ExecutorCheckOptionRecordKind::SourceLocation;
+  }
+};
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+ExecutorCheckOptionRecord* _Nonnull swift_task_makeExecutorCheckOption_sourceLocation(
+        const char* _Nonnull functionName, const char* _Nonnull file,
+        uintptr_t line, uintptr_t column, ExecutorCheckOptionRecord* _Nullable parent);
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_destroyExecutorCheckOptions(ExecutorCheckOptionRecord * _Nonnull options);
+
+
+} // end namespace swift
+
+#endif // SWIFT_ABI_EXECUTOR_OPTIONS_H

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2590,6 +2590,57 @@ public:
                                 setIsDiscardingTask)
 };
 
+/// Flags for checking "current" executor creation.
+class ExecutorCheckFlags : public FlagSet<size_t> {
+public:
+  enum {
+    ExecutorCheck_dontCrash = 0,
+  };
+
+  explicit constexpr ExecutorCheckFlags(size_t bits) : FlagSet(bits) {}
+  constexpr ExecutorCheckFlags() {}
+
+  FLAGSET_DEFINE_FLAG_ACCESSORS(ExecutorCheck_dontCrash,
+                                getDontCrash,
+                                setDontCrash)
+};
+
+
+enum class ExecutorCheckOptionRecordKind : uint8_t {
+  /// Source location where the check was initiated from, may be used in further
+  /// improving crash/warning message, when available.
+  SourceLocation = 1,
+};
+
+/// Flags for executor check option records.
+class ExecutorCheckOptionRecordFlags : public FlagSet<size_t> {
+public:
+  enum {
+    Kind           = 0,
+    Kind_width     = 8,
+    // Set when the record was able to be task local allocated
+    // (as opposed to malloc-allocated).
+    //
+    // While we could bet on the record being destroyed in the same context as
+    // it was created, synchronously, betting on the same task being there when
+    // we destroy... this flag helps diagnose in case something would be
+    // misused with records, and codifies this assumption.
+    ExecutorCheckOptionRecord_TaskLocalAllocated     = 8,
+  };
+
+  explicit ExecutorCheckOptionRecordFlags(size_t bits) : FlagSet(bits) {}
+  constexpr ExecutorCheckOptionRecordFlags() {}
+  ExecutorCheckOptionRecordFlags(ExecutorCheckOptionRecordKind kind) {
+    setKind(kind);
+  }
+
+  FLAGSET_DEFINE_FIELD_ACCESSORS(Kind, Kind_width, ExecutorCheckOptionRecordKind,
+                                 getKind, setKind)
+  FLAGSET_DEFINE_FLAG_ACCESSORS(ExecutorCheckOptionRecord_TaskLocalAllocated,
+                                isTaskLocalAllocated,
+                                setIsTaskLocalAllocated)
+};
+
 /// Flags for schedulable jobs.
 class JobFlags : public FlagSet<uint32_t> {
 public:

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -18,6 +18,7 @@
 #define SWIFT_RUNTIME_CONCURRENCY_H
 
 #include "swift/ABI/AsyncLet.h"
+#include "swift/ABI/ExecutorOptions.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/TaskGroup.h"
 
@@ -789,11 +790,24 @@ SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_hook)(
     int clock, Job *job,
     swift_task_enqueueGlobalWithDeadline_original original);
 
-typedef SWIFT_CC(swift) void (*swift_task_checkIsolated_original)(SerialExecutorRef executor);
+typedef SWIFT_CC(swift) void (*swift_task_checkIsolated_original)(
+    SerialExecutorRef executor);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift) void (*swift_task_checkIsolated_hook)(
     SerialExecutorRef executor, swift_task_checkIsolated_original original);
 
+typedef SWIFT_CC(swift) void (*swift_task_checkOnExpectedExecutor_original)(
+    SerialExecutorRef expectedExecutor,
+    const char *message, int messageLen,
+    ExecutorCheckOptionRecord* options,
+    ExecutorCheckFlags flags);
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift) void (*swift_task_checkOnExpectedExecutor_hook)(
+    SerialExecutorRef expectedExecutor,
+    const char *message, int messageLen,
+    ExecutorCheckOptionRecord* options,
+    ExecutorCheckFlags flags,
+    swift_task_checkOnExpectedExecutor_original original);
 
 typedef SWIFT_CC(swift) bool (*swift_task_isOnExecutor_original)(
     HeapObject *executor,
@@ -966,12 +980,19 @@ SerialExecutorRef swift_task_getMainExecutor(void);
 /// they should be created as "forever" alive singletons, or otherwise
 /// guarantee their lifetime extends beyond all potential uses of them by tasks.
 ///
-/// Runtime availability: Swift 9999
+/// Runtime availability: Swift 6.0
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 TaskExecutorRef swift_task_getPreferredTaskExecutor(void);
 
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 bool swift_task_isCurrentExecutor(SerialExecutorRef executor);
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_checkOnExpectedExecutor(
+    SerialExecutorRef serialExecutor,
+    const char *message, int messageLen,
+    ExecutorCheckOptionRecord* options,
+    ExecutorCheckFlags flags);
 
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_reportUnexpectedExecutor(

--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -57,6 +57,10 @@ SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations();
 // Concurrency library can call.
 SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverride();
 
+// Wrapper around SWIFT_LOG_ISOLATION_WARNING_MODE_OVERRIDE that the
+// Concurrency library can call.
+SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyLogIsolationWarningModeOverride();
+
 } // end namespace environment
 } // end namespace runtime
 } // end namespace swift

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -136,6 +136,15 @@ OVERRIDE_ACTOR(task_isCurrentExecutor, bool,
                SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                swift::, (SerialExecutorRef executor), (executor))
 
+OVERRIDE_ACTOR(task_checkOnExpectedExecutor, void,
+               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+               swift::,
+               (SerialExecutorRef serialExecutor,
+                const char *message, int messageLen,
+                ExecutorCheckOptionRecord* options,
+                ExecutorCheckFlags flags),
+               (serialExecutor, message, messageLen, options, flags))
+
 OVERRIDE_ACTOR(task_switch, void,
                SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
                swift::, (SWIFT_ASYNC_CONTEXT AsyncContext *resumeToContext,

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -22,6 +22,8 @@
 #include "../CompatibilityOverride/CompatibilityOverride.h"
 #include "swift/ABI/Actor.h"
 #include "swift/ABI/Task.h"
+#include "swift/ABI/ExecutorOptions.h"
+#include "swift/Basic/Defer.h"
 #include "TaskPrivate.h"
 #include "swift/Basic/HeaderFooterLayout.h"
 #include "swift/Basic/PriorityQueue.h"
@@ -73,6 +75,11 @@
 #if defined(_WIN32)
 #include <io.h>
 #endif
+
+#if defined(__APPLE__)
+#include <os/log.h>
+#endif
+
 
 #if SWIFT_OBJC_INTEROP
 extern "C" void *objc_autoreleasePoolPush();
@@ -359,6 +366,17 @@ const char *__swift_runtime_env_useLegacyNonCrashingExecutorChecks() {
 #endif
 }
 
+// Shimming call to Swift runtime because Swift Embedded does not have
+// these symbols defined.
+const char *__swift_runtime_env_logIsolationWarningMode() {
+#if SWIFT_STDLIB_HAS_ENVIRON && !SWIFT_CONCURRENCY_EMBEDDED
+  return swift::runtime::environment::
+      concurrencyLogIsolationWarningModeOverride();
+#else
+  return nullptr;
+#endif
+}
+
 // Done this way because of the interaction with the initial value of
 // 'unexpectedExecutorLogLevel'
 bool swift_bincompat_useLegacyNonCrashingExecutorChecks() {
@@ -387,6 +405,32 @@ static void checkIsCurrentExecutorMode(void *context) {
                                         : Swift6_UseCheckIsolated_AllowCrash;
 }
 
+#if defined(__APPLE__)
+#define SWIFT_LOG_APPLE_RUNTIME_ISSUES_SUBSYSTEM "com.apple.runtime-issues"
+#define SWIFT_LOG_ACTOR_CATEGORY "Actor"
+os_log_t IsolationWarningLog;
+#endif
+
+static void initIsolationWarningOsLog(void *context) {
+#if defined(__APPLE__)
+  IsolationWarningLog = os_log_create(SWIFT_LOG_APPLE_RUNTIME_ISSUES_SUBSYSTEM,
+                                      SWIFT_LOG_ACTOR_CATEGORY);
+#endif
+}
+
+/// Forces stderr logging of isolation warnings,
+/// in addition to the os_log warning issued on apple platforms.
+bool LogIsolationWarningStderr = false;
+static void initLogIsolationWarningStderr(void *context) {
+  // Potentially, override the platform detected mode, primarily used in tests.
+  if (const char *modeStr =
+          __swift_runtime_env_logIsolationWarningMode()) {
+    if (strcmp(modeStr, "stderr") == 0) {
+      LogIsolationWarningStderr = true;
+    }
+  } // no override, use the default
+}
+
 // Implemented in Swift to avoid some annoying hard-coding about
 // TaskExecutor's protocol witness table.  We could inline this
 // with effort, though.
@@ -401,20 +445,17 @@ extern "C" SWIFT_CC(swift) void _swift_task_enqueueOnExecutor(
     Job *job, HeapObject *executor, const Metadata *executorType,
     const SerialExecutorWitnessTable *wtable);
 
-SWIFT_CC(swift)
-static bool swift_task_isCurrentExecutorImpl(SerialExecutorRef expectedExecutor) {
+static bool swift_task_isCurrentExecutorCommon(
+    SerialExecutorRef expectedExecutor,
+    IsCurrentExecutorCheckMode checkMode,
+    ExecutorCheckOptionRecord *options,
+    ExecutorCheckFlags flags) {
   auto current = ExecutorTrackingInfo::current();
 
-  // To support old applications on apple platforms which assumed this call
-  // does not crash, try to use a more compatible mode for those apps.
-  //
-  // We only allow returning `false` directly from this function when operating
-  // in 'Legacy_NoCheckIsolated_NonCrashing' mode. If allowing crashes, we
-  // instead must call into 'checkIsolated' or crash directly.
-  //
-  // Whenever we confirm an executor equality, we can return true, in any mode.
-  static swift::once_t checkModeToken;
-  swift::once(checkModeToken, checkIsCurrentExecutorMode, nullptr);
+  if (flags.getDontCrash()) {
+    SWIFT_TASK_DEBUG_LOG("Override executor check mode with flag: don't crash; flags: %d", flags);
+    checkMode = Legacy_NoCheckIsolated_NonCrashing;
+  }
 
   if (!current) {
     // We have no current executor, i.e. we are running "outside" of Swift
@@ -432,7 +473,7 @@ static bool swift_task_isCurrentExecutorImpl(SerialExecutorRef expectedExecutor)
 
     // Otherwise, as last resort, let the expected executor check using
     // external means, as it may "know" this thread is managed by it etc.
-    if (isCurrentExecutorMode == Swift6_UseCheckIsolated_AllowCrash) {
+    if (checkMode == Swift6_UseCheckIsolated_AllowCrash) {
       swift_task_checkIsolated(expectedExecutor); // will crash if not same context
 
       // checkIsolated did not crash, so we are on the right executor, after all!
@@ -470,7 +511,7 @@ static bool swift_task_isCurrentExecutorImpl(SerialExecutorRef expectedExecutor)
   // the crashing 'dispatch_assert_queue(main queue)' which will either crash
   // or confirm we actually are on the main queue; or the custom expected
   // executor has a chance to implement a similar queue check.
-  if (isCurrentExecutorMode == Legacy_NoCheckIsolated_NonCrashing) {
+  if (checkMode == Legacy_NoCheckIsolated_NonCrashing) {
     if ((expectedExecutor.isMainExecutor() && !currentExecutor.isMainExecutor()) ||
         (!expectedExecutor.isMainExecutor() && currentExecutor.isMainExecutor())) {
       return false;
@@ -531,7 +572,7 @@ static bool swift_task_isCurrentExecutorImpl(SerialExecutorRef expectedExecutor)
   // Note that this only works because the closure in assumeIsolated is
   // synchronous, and will not cause suspensions, as that would require the
   // presence of a Task.
-  if (isCurrentExecutorMode == Swift6_UseCheckIsolated_AllowCrash) {
+  if (checkMode == Swift6_UseCheckIsolated_AllowCrash) {
     swift_task_checkIsolated(expectedExecutor); // will crash if not same context
 
     // The checkIsolated call did not crash, so we are on the right executor.
@@ -540,8 +581,152 @@ static bool swift_task_isCurrentExecutorImpl(SerialExecutorRef expectedExecutor)
 
   // In the end, since 'checkIsolated' could not be used, so we must assume
   // that the executors are not the same context.
-  assert(isCurrentExecutorMode == Legacy_NoCheckIsolated_NonCrashing);
+  assert(checkMode == Legacy_NoCheckIsolated_NonCrashing);
   return false;
+}
+
+SWIFT_CC(swift)
+static bool swift_task_isCurrentExecutorImpl(SerialExecutorRef expectedExecutor) {
+  // To support old applications on apple platforms which assumed this call
+  // does not crash, try to use a more compatible mode for those apps.
+  //
+  // We only allow returning `false` directly from this function when operating
+  // in 'Legacy_NoCheckIsolated_NonCrashing' mode. If allowing crashes, we
+  // instead must call into 'checkIsolated' or crash directly.
+  //
+  // Whenever we confirm an executor equality, we can return true, in any mode.
+  static swift::once_t checkModeToken;
+  swift::once(checkModeToken, checkIsCurrentExecutorMode, nullptr);
+
+  return swift_task_isCurrentExecutorCommon(
+      expectedExecutor,
+      /*mode=*/isCurrentExecutorMode,
+      /*options=*/nullptr,
+      /*flags=*/ExecutorCheckFlags());
+}
+
+#define ISOLATION_WARNING_FORMAT "Unexpected actor isolation, expected %p%s but was %sisolated%s %p%s, in %s at %s:%lu:%lu! %.*s\n"
+
+static void logIsolationWarning(
+    SerialExecutorRef currentExecutor, SerialExecutorRef expectedExecutor,
+    const char *message, int messageLen,
+    const char *function, const char *file, uintptr_t line, uintptr_t column) {
+  assert(message);
+  assert(function);
+  assert(file);
+
+  static swift::once_t initializeOsLogToken;
+  swift::once(initializeOsLogToken, initIsolationWarningOsLog, nullptr);
+
+  static swift::once_t initializeLogIsolationWarningStderrToken;
+  swift::once(initializeLogIsolationWarningStderrToken, initLogIsolationWarningStderr, nullptr);
+
+  auto getActorTypeName = [](SerialExecutorRef ref) {
+    char *nameBuf = nullptr;
+    if (ref.isDefaultActor()) {
+      auto tyName = swift_getTypeName(swift_getObjectType(ref.getDefaultActor()), true);
+      asprintf(&nameBuf, " (default actor %.*s)", (int)tyName.length, tyName.data);
+    } else if (!ref.isGeneric() && !ref.isMainExecutor()) {
+      // we have the executor reference; consider printing type name (if possible)
+      asprintf(&nameBuf, " (custom SerialExecutor)");
+    }
+    return nameBuf;
+  };
+
+  char *currentActorName = getActorTypeName(currentExecutor);
+  SWIFT_DEFER { free(currentActorName); };
+  char *expectedActorName = getActorTypeName(expectedExecutor);
+  SWIFT_DEFER { free(expectedActorName); };
+
+#if defined(__APPLE__)
+  os_log_fault(IsolationWarningLog,
+               ISOLATION_WARNING_FORMAT,
+               // expected isolation
+               expectedExecutor.getIdentity(),
+               expectedActorName ? expectedActorName
+                                 : expectedExecutor.getIdentityDebugName(),
+               // current isolation
+               currentExecutor.getIdentity() == 0 ? "non" : "",
+               currentExecutor.getIdentity() ? " to" : "",
+               currentExecutor.getIdentity(),
+               currentActorName ? currentActorName
+                                : currentExecutor.getIdentityDebugName(),
+               // message and location details
+               function, file, line, column,
+               messageLen, message);
+#endif
+  if (LogIsolationWarningStderr) {
+    fprintf(stderr, ISOLATION_WARNING_FORMAT,
+            // expected isolation
+            expectedExecutor.getIdentity(),
+            expectedActorName ? expectedActorName
+                              : expectedExecutor.getIdentityDebugName(),
+            // current isolation
+            currentExecutor.getIdentity() == 0 ? "non" : "",
+            currentExecutor.getIdentity() ? " to" : "",
+            currentExecutor.getIdentity(),
+            currentActorName ? currentActorName
+                             : currentExecutor.getIdentityDebugName(),
+            // message and location details
+            function, file, line, column, messageLen, message);
+    fflush(stderr);
+  }
+}
+
+/// SPI(ConcurrencyDiagnostics)
+///
+/// Attempt to check the current executor against the expected without crashing!
+SWIFT_CC(swift)
+static void swift_task_checkOnExpectedExecutorImpl(
+    SerialExecutorRef expectedExecutor,
+    const char *message, int messageLen,
+    ExecutorCheckOptionRecord *options,
+    ExecutorCheckFlags flags) {
+  // assert(flags.getDontCrash() && "check... API expects non crashing option"); // FIXME
+
+  // Regardless of the runtime check mode, we will never invoke `checkIsolated`
+  // (and thus potentially crash) when calling from here, because we need to
+  // issue a warning after all.
+  auto isSameExecutor = swift_task_isCurrentExecutorCommon(
+      expectedExecutor,
+      /*mode=*/Legacy_NoCheckIsolated_NonCrashing,
+      /*options=*/options,
+      /*flags=*/flags);
+
+  // Swift executor checks determined executor equality, don't issue a warning.
+  if (isSameExecutor) {
+    return;
+  }
+
+  // TODO(dispatch): when able to, invoke dispatch SPI which can check "is this the right queue?"
+  //    and if it isn't, would log a warning. We should prevent "our" logging logic if we invoked dispatch
+  //    as it may have logged -- the condition here is if the executor specifically was a dispatch queue.
+
+  auto trackingInfo = ExecutorTrackingInfo::current();
+  auto currentExecutor =
+      (trackingInfo ? trackingInfo->getActiveExecutor()
+                    : SerialExecutorRef::generic());
+
+  const char *functionName = nullptr;
+  const char *file = nullptr;
+  uintptr_t line = 0;
+  uintptr_t column = 0;
+  for (auto _option = options; _option; _option = _option->getParent()) {
+    switch (_option->getKind()) {
+    case ExecutorCheckOptionRecordKind::SourceLocation: {
+      auto option = cast<SourceLocationExecutorCheckOptionRecord>(_option);
+      functionName = option->FunctionName;
+      file = option->File;
+      line = option->Line;
+      column = option->Column;
+      break;
+    }
+    }
+  }
+
+  logIsolationWarning(currentExecutor, expectedExecutor,
+                      message, messageLen,
+                      functionName, file, line, column);
 }
 
 /// Logging level for unexpected executors:

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -471,6 +471,52 @@ func _checkExpectedExecutor(_filenameStart: Builtin.RawPointer,
 @_silgen_name("swift_task_getJobTaskId")
 internal func _getJobTaskId(_ job: UnownedJob) -> UInt64
 
+/// SPI which allows to warn but not crash about executing on unexpected executor or dispatch queue.
+@_unavailableInEmbedded
+@_spi(ConcurrencyDiagnostics)
+@available(SwiftStdlib 6.0, *)
+public func _warnOnUnexpectedExecutor(
+  expected actor: any Actor,
+  message: @autoclosure () -> String,
+  file: StaticString = #fileID, line: Int = #line, column: Int = #column,
+  function: StaticString = #function) {
+  let _message = message()
+  let messageCount = CInt(_message.count)
+  var _file = file
+  var _function = function
+
+  let flags = createExecutorCheckFlags(dontCrash: true)
+
+  _message.withCString { messageBuf -> Void in
+    _file.withUTF8Buffer { fileBuf -> Void in
+      _function.withUTF8Buffer { functionBuf -> Void in
+
+        let options = _makeExecutorCheckOption_sourceLocation(
+          function: functionBuf.baseAddress!,
+          file: fileBuf.baseAddress!, line: line, column: column,
+          parent: nil)
+        defer { _destroyExecutorCheckOptions(options) }
+
+        _checkOnExpectedExecutor(
+          expectedSerialExecutor: actor.unownedExecutor,
+          message: messageBuf, messageLength: CInt(messageCount),
+          options: options,
+          flags: flags)
+      }
+    }
+  }
+}
+
+@available(SwiftStdlib 6.0, *)
+@_alwaysEmitIntoClient
+func createExecutorCheckFlags(dontCrash: Bool) -> Int {
+  var bits = 0
+  if dontCrash {
+    bits |= 1
+  }
+  return bits
+}
+
 @available(SwiftStdlib 5.9, *)
 @_silgen_name("_task_serialExecutor_isSameExclusiveExecutionContext")
 internal func _task_serialExecutor_isSameExclusiveExecutionContext<E>(current currentExecutor: E, executor: E) -> Bool
@@ -530,6 +576,31 @@ internal func _enqueueOnTaskExecutor<E>(job unownedJob: UnownedJob, executor: E)
   executor.enqueue(unownedJob)
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 }
+
+@_spi(ConcurrencyDiagnostics)
+@available(SwiftStdlib 6.0, *)
+@_silgen_name("swift_task_checkOnExpectedExecutor")
+public func _checkOnExpectedExecutor(
+  expectedSerialExecutor: UnownedSerialExecutor,
+  message: UnsafePointer<Int8>, messageLength: CInt,
+  options: UnsafeRawBufferPointer?,
+  flags: Int)
+
+@available(SwiftStdlib 6.0, *)
+@_silgen_name("swift_task_makeExecutorCheckOption_sourceLocation")
+internal func _makeExecutorCheckOption_sourceLocation(
+  function: UnsafePointer<UInt8>,
+  file: UnsafePointer<UInt8>,
+  line: Int,
+  column: Int,
+  parent: UnsafeRawBufferPointer?
+) -> UnsafeRawBufferPointer?
+
+@available(SwiftStdlib 6.0, *)
+@_silgen_name("swift_task_destroyExecutorCheckOptions")
+internal func _destroyExecutorCheckOptions(
+  _ option: UnsafeRawBufferPointer?
+)
 
 #if SWIFT_CONCURRENCY_USES_DISPATCH
 // This must take a DispatchQueueShim, not something like AnyObject,

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -57,6 +57,8 @@ extension SerialExecutor {
       return
     }
 
+    // TODO: make message record and use checkOnExecutor with it and "crash" flag
+
     let expectationCheck = _taskIsCurrentExecutor(self.asUnownedSerialExecutor().executor)
 
     /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
@@ -105,6 +107,8 @@ extension Actor {
     guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
       return
     }
+
+    // TODO: make message record and use checkOnExecutor with it and "crash" flag
 
     // NOTE: This method will CRASH in new runtime versions,
     // if it would have previously returned `false`.

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -150,7 +150,6 @@ extension MainActor {
     /// as this is our "safe" version of this API.
     let executor: Builtin.Executor = Self.shared.unownedExecutor.executor
     guard _taskIsCurrentExecutor(executor) else {
-      // TODO: offer information which executor we actually got
       fatalError("Incorrect actor executor assumption; Expected same executor as \(self).", file: file, line: line)
     }
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1777,6 +1777,11 @@ SWIFT_CC(swift)
 static void swift_task_startOnMainActorImpl(AsyncTask* task) {
   AsyncTask * originalTask = _swift_task_clearCurrent();
   SerialExecutorRef mainExecutor = swift_task_getMainExecutor();
+
+  // NOTE: The swift_task_isCurrentExecutor call will crash if on unexpected
+  // executor, rather than returning false, in Swift 6. This is because
+  // calling into checkIsolated which cannot return true/false, and
+  // e.g. Dispatch implementations of it using `dispatchPrecondition`.
   if (!swift_task_isCurrentExecutor(mainExecutor))
     swift_Concurrency_fatalError(0, "Not on the main executor");
   swift_retain(task);

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -51,6 +51,8 @@ extension DistributedActor {
       return
     }
 
+    // TODO: make message record and use checkOnExecutor with it and "crash" flag
+
     let unownedExecutor = self.unownedExecutor
     let expectationCheck = _taskIsCurrentExecutor(unownedExecutor._executor)
 

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -276,3 +276,7 @@ SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations() {
 SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyIsCurrentExecutorLegacyModeOverride() {
   return runtime::environment::SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE();
 }
+
+SWIFT_RUNTIME_STDLIB_SPI const char *concurrencyLogIsolationWarningModeOverride() {
+  return runtime::environment::SWIFT_LOG_ISOLATION_WARNING_MODE_OVERRIDE();
+}

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -131,4 +131,9 @@ VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
          " 'legacy' (Legacy behavior), "
          " 'swift6' (Swift 6.0+ behavior)")
 
+VARIABLE(SWIFT_LOG_ISOLATION_WARNING_MODE_OVERRIDE, string, "",
+         "Allows configuring additional isolation warning modes. "
+         "Legal values are: "
+         " 'stderr' (Enables stderr logging)")
+
 #undef VARIABLE

--- a/test/Concurrency/Runtime/warn_unexpected_isolation_spi.swift
+++ b/test/Concurrency/Runtime/warn_unexpected_isolation_spi.swift
@@ -1,0 +1,135 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library -plugin-path %swift-plugin-dir %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy SWIFT_LOG_ISOLATION_WARNING_MODE_OVERRIDE=stderr %target-run %t/a.out 2>&1 | %FileCheck %s --dump-input=always
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+// REQUIRES: libdispatch
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+import Dispatch
+@_spi(ConcurrencyDiagnostics) import _Concurrency
+
+final class NaiveQueueExecutor: SerialExecutor {
+  init() {}
+
+  public func enqueue(_ job: consuming ExecutorJob) {
+    job.runSynchronously(on: self.asUnownedSerialExecutor())
+  }
+
+  public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+
+  func checkIsolated() {
+    fatalError("Should not be invoked for warning-only SPI")
+  }
+}
+
+actor SomeDefaultActor {
+  nonisolated func checkNonisolatedFunc(line: Int) async {
+    _warnOnUnexpectedExecutor(expected: self, message: "Whoops, nonisolated but expected self", line: line)
+  }
+
+  func checkIsolatedFunc(line: Int) async {
+    _warnOnUnexpectedExecutor(expected: self, message: "Whoops!", line: line)
+  }
+}
+
+actor ActorOnNaiveQueueExecutor {
+  let executor: NaiveQueueExecutor
+
+  init() {
+    self.executor = NaiveQueueExecutor()
+  }
+
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    self.executor.asUnownedSerialExecutor()
+  }
+
+  nonisolated func checkNonisolatedFuncOnQueueActor(line: Int) async {
+    _warnOnUnexpectedExecutor(expected: self, message: "Whoops, nonisolated but expected self", line: line)
+  }
+
+  func checkIsolatedFunc(line: Int) async {
+    _warnOnUnexpectedExecutor(expected: self, message: "Whoops!", line: line)
+  }
+}
+
+@MainActor
+func checkMainActorFunc(expected: any Actor, line: Int) async {
+  _warnOnUnexpectedExecutor(expected: expected, message: "Whoops, MainActor but expected actor", line: line)
+}
+
+func checkOtherActorFuncExpectedMainActor(other: isolated (any Actor), line: Int) async {
+  _warnOnUnexpectedExecutor(expected: MainActor.shared, message: "Whoops, MainActor but expected actor", line: line)
+}
+
+@main struct Main {
+  static func main() async {
+    let defaultActor = SomeDefaultActor()
+    let queueWrappedActor = ActorOnNaiveQueueExecutor()
+
+    // NOTE: Watch out for matching nil/0x0, as it seems 0x0 gets formatted as nil on Linux, so match both.
+
+    await defaultActor.checkNonisolatedFunc(line: #line)
+    // CHECK: Unexpected actor isolation, expected [[DEFAULT_ACTOR:0x.*]] (default actor a.SomeDefaultActor)
+    // CHECK-SAME: but was nonisolated [[NONISOLATED:(0x.*)|.nil.]] (GenericExecutor),
+    // CHECK-SAME: in checkNonisolatedFunc(line:)
+    // CHECK-SAME: at a/warn_unexpected_isolation_spi.swift:[[@LINE-4]]:[[COLUMN:.*]]!
+    // CHECK-SAME: Whoops, nonisolated but expected self
+
+
+    await checkMainActorFunc(expected: defaultActor, line: #line)
+    // CHECK: Unexpected actor isolation, expected [[DEFAULT_ACTOR:0x.*]] (default actor a.SomeDefaultActor)
+    // CHECK-SAME: but was isolated to [[MAIN_ACTOR:0x.*]] (MainActorExecutor),
+    // CHECK-SAME: in checkMainActorFunc(expected:line:)
+    // CHECK-SAME: at a/warn_unexpected_isolation_spi.swift:[[@LINE-4]]:[[COLUMN:.*]]!
+    // CHECK-SAME: Whoops, MainActor but expected actor
+
+    await defaultActor.checkIsolatedFunc(line: #line)
+    // OK
+
+    await queueWrappedActor.checkNonisolatedFuncOnQueueActor(line: #line)
+    // CHECK: Unexpected actor isolation, expected [[QUEUE_ACTOR:0x.*]] (custom SerialExecutor)
+    // CHECK-SAME: but was nonisolated [[GENERIC_EXEC:.nil.|0x0]] (GenericExecutor)
+    // CHECK-SAME: in checkNonisolatedFuncOnQueueActor(line:)
+    // CHECK-SAME: at a/warn_unexpected_isolation_spi.swift:[[@LINE-4]]:[[COLUMN:.*]]!
+    // CHECK-SAME: Whoops, nonisolated but expected self
+
+    await checkMainActorFunc(expected: queueWrappedActor, line: #line)
+    // CHECK: Unexpected actor isolation, expected [[QUEUE_ACTOR]] (custom SerialExecutor)
+    // CHECK-SAME: but was isolated to [[MAIN_ACTOR]] (MainActorExecutor),
+    // CHECK-SAME: in checkMainActorFunc(expected:line:)
+    // CHECK-SAME: at a/warn_unexpected_isolation_spi.swift:[[@LINE-4]]:[[COLUMN:.*]]!
+    // CHECK-SAME: Whoops, MainActor but expected actor
+
+    await queueWrappedActor.checkIsolatedFunc(line: #line)
+    // OK
+
+    // Expecting main actor, but running on something else
+    await checkOtherActorFuncExpectedMainActor(other: defaultActor, line: #line)
+    // CHECK: Unexpected actor isolation, expected [[MAIN_ACTOR]] (MainActorExecutor)
+    // CHECK-SAME: but was isolated to [[DEFAULT_ACTOR:0x.*]] (default actor a.SomeDefaultActor),
+    // CHECK-SAME: in checkOtherActorFuncExpectedMainActor(other:line:)
+    // CHECK-SAME: at a/warn_unexpected_isolation_spi.swift:[[@LINE-4]]:[[COLUMN:.*]]!
+    // CHECK-SAME: Whoops, MainActor but expected actor
+
+    await checkOtherActorFuncExpectedMainActor(other: queueWrappedActor, line: #line)
+    // CHECK: Unexpected actor isolation, expected [[MAIN_ACTOR]] (MainActorExecutor)
+    // CHECK-SAME: but was isolated to [[QUEUE_ACTOR:0x.*]] (custom SerialExecutor),
+    // CHECK-SAME: in checkOtherActorFuncExpectedMainActor(other:line:)
+    // CHECK-SAME: at a/warn_unexpected_isolation_spi.swift:[[@LINE-4]]:[[COLUMN:.*]]!
+    // CHECK-SAME: Whoops, MainActor but expected actor
+
+    print("Done")
+    // CHECK: Done
+  }
+}

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -331,3 +331,10 @@ Added: _$ss9TaskLocalC13withValueImpl_9operation9isolation4file4lineqd__xn_qd__y
 // Swift.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, isolation: isolated Swift.Actor?, file: Swift.String, line: Swift.UInt) async throws -> A1
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlF
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlFTu
+
+// Add new executor checking entry point that could issue warnings
+// Swift._warnOnUnexpectedExecutor(expected: Swift.Actor, message: @autoclosure () -> Swift.String, file: Swift.StaticString, line: Swift.Int, column: Swift.Int, function: Swift.StaticString) -> ()
+Added: _$ss25_warnOnUnexpectedExecutor8expected7message4file4line6column8functionyScA_p_SSyXKs12StaticStringVS2iAItF
+Added: _swift_task_makeExecutorCheckOption_sourceLocation
+Added: _swift_task_checkOnExpectedExecutor
+Added: _swift_task_destroyExecutorCheckOptions

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -330,3 +330,10 @@ Added: _$ss9TaskLocalC13withValueImpl_9operation9isolation4file4lineqd__xn_qd__y
 // Swift.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, isolation: isolated Swift.Actor?, file: Swift.String, line: Swift.UInt) async throws -> A1
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlF
 Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlFTu
+
+// Add new executor checking entry point that could issue warnings
+// +Swift._checkOnExpectedExecutor(expected: Swift.Actor, message: @autoclosure () -> Swift.String, file: Swift.StaticString, line: Swift.Int, column: Swift.Int, function: Swift.StaticString) -> ()
+Added: _$ss24_checkOnExpectedExecutor8expected7message4file4line6column8functionyScA_p_SSyXKs12StaticStringVS2iAItF
+Added: _swift_task_makeExecutorCheckOption_sourceLocation
+Added: _swift_task_checkOnExpectedExecutor
+Added: _swift_task_destroyExecutorCheckOptions

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -573,3 +573,8 @@ Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks
 
 // Add add SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE
 Added: _concurrencyIsCurrentExecutorLegacyModeOverride
+//String.init<Encoding: Unicode.Encoding>(_immortalCocoaString: AnyObject, count: Int, encoding: Encoding.Type)
+Added: _$sSS20_immortalCocoaString5count8encodingSSyXl_Sixmtcs16_UnicodeEncodingRzlufC
+
+// Add add SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE
+Added: _concurrencyLogIsolationWarningModeOverride

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -355,12 +355,14 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_startOnMainActorImpl) {
   swift_task_startOnMainActor(nullptr);
 }
 
-#if RUN_ASYNC_MAIN_DRAIN_QUEUE_TEST
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_checkOnExpectedExecutorImpl) {
   swift_task_checkOnExpectedExecutor(SerialExecutorRef::generic(),
                                      /*message=*/nullptr, 0,
                                      nullptr, ExecutorCheckFlags());
 }
+
+#if RUN_ASYNC_MAIN_DRAIN_QUEUE_TEST
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_asyncMainDrainQueue) {
 
   auto runner = [](void *) -> void * {
     swift_task_asyncMainDrainQueue();


### PR DESCRIPTION
TODO: pick latest revision after review


**Description**: This introduces a new very extensible / configurable runtime entrypoint for isolation checking. We could use it to issue warnings about executing on "unexpected" executor; and could potentially extend it to perform similar checks. This runtime function takes options and flags, so we can configure it depending on future use. This is void returning, unlike the existing runtime funcs which return `bool` but are forced into "crash only" behavior because of underlying implementation reasons -- we could clean this up in the future, and use THIS function as the crashing one, so the function signature does not lie anymore.
**Scope/Impact**: Just adding new SPI and runtime entrypoint, no impact on existing functions or runtime behavior.
**Risk:** Low, only adding runtime entrypoint, without changing existing methods using executor checks.
**Testing**: CI testing
**Reviewed by**: tbd

**Original PR:** https://github.com/swiftlang/swift/pull/75200
**Radar:** TODO