### PR TITLE
[Mem2Reg] Bail on address-only types.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -2192,6 +2192,12 @@ bool MemoryToRegisters::promoteAllocation(AllocStackInst *alloc,
     return true;
   }
 
+  // The value stored into an alloc_stack whose type address-only can never be
+  // represented in a register.  Bail out.
+  if (alloc->getType().isAddressOnly(f)) {
+    return false;
+  }
+
   // For AllocStacks that are only used within a single basic blocks, use
   // the linear sweep to remove the AllocStack.
   if (inSingleBlock) {

--- a/test/SILOptimizer/mem2reg.sil
+++ b/test/SILOptimizer/mem2reg.sil
@@ -2,6 +2,7 @@
 
 import Builtin
 import Swift
+import _Concurrency
 
 //////////////////
 // Declarations //
@@ -545,5 +546,35 @@ bb0:
   %empty = tuple ()
   %14 = tuple (%empty : $(), %13 : $())
   dealloc_stack %11 : $*(Builtin.BridgeObject, ())
+  return undef : $()
+}
+
+typealias ResilientTy = CheckedContinuation<(), Error>
+
+// CHECK-LABEL: sil @dont_promote_addronly_aggregate : {{.*}} {
+// CHECK:         alloc_stack
+// CHECK-LABEL: } // end sil function 'dont_promote_addronly_aggregate'
+sil @dont_promote_addronly_aggregate : $@convention(thin) () -> () {
+bb0:
+  %11 = alloc_stack $Pair<ResilientTy, ()>
+  %12 = struct_element_addr %11 : $*Pair<ResilientTy, ()>, #Pair.u
+  %13 = load %12 : $*()
+  %empty = tuple ()
+  %14 = tuple (%empty : $(), %13 : $())
+  dealloc_stack %11 : $*Pair<ResilientTy, ()>
+  return undef : $()
+}
+
+// CHECK-LABEL: sil @dont_promote_addronly_aggregate_2 : {{.*}} {
+// CHECK:         alloc_stack
+// CHECK-LABEL: } // end sil function 'dont_promote_addronly_aggregate_2'
+sil @dont_promote_addronly_aggregate_2 : $@convention(thin) <T> () -> () {
+bb0:
+  %11 = alloc_stack $Pair<T, ()>
+  %12 = struct_element_addr %11 : $*Pair<T, ()>, #Pair.u
+  %13 = load %12 : $*()
+  %empty = tuple ()
+  %14 = tuple (%empty : $(), %13 : $())
+  dealloc_stack %11 : $*Pair<T, ()>
   return undef : $()
 }


### PR DESCRIPTION
It is impossible to have a value of address-only type, so don't try promoting.

rdar://131882748
