### PR TITLE
Add _const to Swift declaration names of const types

### DIFF
--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -148,8 +148,11 @@ std::string swift::importer::printClassTemplateSpecializationName(
         // Use import name here so builtin types such as "int" map to their
         // Swift equivalent ("CInt").
         if (arg.getKind() == clang::TemplateArgument::Type) {
-          auto ty = arg.getAsType().getTypePtr();
-          buffer << templateNamePrinter.Visit(ty);
+          auto ty = arg.getAsType();
+          buffer << templateNamePrinter.Visit(ty.getTypePtr());
+          if (ty.isConstQualified()) {
+            buffer << "_const";
+          }
           return;
         } else if (arg.getKind() == clang::TemplateArgument::Integral) {
           buffer << "_";

--- a/test/Interop/Cxx/templates/Inputs/class-template-with-primitive-argument.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-with-primitive-argument.h
@@ -7,9 +7,23 @@ struct MagicWrapper {
   int getValuePlusArg(int arg) const { return t + arg; }
 };
 
+template<class M>
+struct DoubleWrapper {
+  M m;
+  int getValuePlusArg(int arg) const { return m.getValuePlusArg(arg); }
+};
+
 typedef MagicWrapper<int> WrappedMagicInt;
+typedef MagicWrapper<const int> WrappedMagicIntConst;
+typedef MagicWrapper<const long> WrappedMagicLongConst;
 typedef MagicWrapper<int*> WrappedMagicIntPtr;
 typedef MagicWrapper<const int*> WrappedMagicIntConstPtr;
 typedef MagicWrapper<int**> WrappedMagicIntPtrPtr;
+
+typedef DoubleWrapper<MagicWrapper<int>> DoubleWrappedInt;
+typedef DoubleWrapper<MagicWrapper<const int>> DoubleWrappedIntConst;
+typedef DoubleWrapper<MagicWrapper<const long>> DoubleWrappedLongConst;
+typedef DoubleWrapper<MagicWrapper<int*>> DoubleWrappedIntPtr;
+typedef DoubleWrapper<MagicWrapper<const int*>> DoubleWrappedIntConstPtr;
 
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_WITH_PRIMITIVE_ARGUMENT_H

--- a/test/Interop/Cxx/templates/class-template-with-primitive-argument-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-primitive-argument-module-interface.swift
@@ -4,7 +4,18 @@
 // CHECK: struct MagicWrapper<T> {
 // CHECK: }
 
+// CHECK: struct DoubleWrapper<M> {
+// CHECK: }
+
 // CHECK: typealias WrappedMagicInt = MagicWrapper<CInt>
+// CHECK: typealias WrappedMagicIntConst = MagicWrapper<CInt_const>
+// CHECK: typealias WrappedMagicLongConst = MagicWrapper<CLong_const>
 // CHECK: typealias WrappedMagicIntPtr = MagicWrapper<UnsafeMutablePointer<CInt>>
 // CHECK: typealias WrappedMagicIntConstPtr = MagicWrapper<UnsafePointer<CInt>>
 // CHECK: typealias WrappedMagicIntPtrPtr = MagicWrapper<UnsafeMutablePointer<UnsafeMutablePointer<CInt>>>
+
+// CHECK: typealias DoubleWrappedInt = DoubleWrapper<MagicWrapper<CInt>>
+// CHECK: typealias DoubleWrappedIntConst = DoubleWrapper<MagicWrapper<CInt_const>>
+// CHECK: typealias DoubleWrappedLongConst = DoubleWrapper<MagicWrapper<CLong_const>>
+// CHECK: typealias DoubleWrappedIntPtr = DoubleWrapper<MagicWrapper<UnsafeMutablePointer<CInt>>>
+// CHECK: typealias DoubleWrappedIntConstPtr = DoubleWrapper<MagicWrapper<UnsafePointer<CInt>>>


### PR DESCRIPTION
This change is necessary to differentiate between C++ const and non-const types in Swift.
For instance, `const int` and `int` would both be printed as `CInt` in Swift.
After this change, `const int` is stored as `CInt_const`

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
