### PR TITLE
[6.0][CSApply] Allow `@dynamicMemberLookup` subscripts to take sendable ke…

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5367,8 +5367,8 @@ namespace {
         auto indexType = getTypeOfDynamicMemberIndex(overload);
         Expr *argExpr = nullptr;
         if (overload.choice.isKeyPathDynamicMemberLookup()) {
-          argExpr = buildKeyPathDynamicMemberArgExpr(
-              indexType->castTo<BoundGenericType>(), componentLoc, memberLoc);
+          argExpr = buildKeyPathDynamicMemberArgExpr(indexType, componentLoc,
+                                                     memberLoc);
         } else {
           auto fieldName = overload.choice.getName().getBaseIdentifier().str();
           argExpr = buildDynamicMemberLookupArgExpr(fieldName, componentLoc,

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -833,3 +833,10 @@ public extension S3_54864 {
     get { s2_54864_instance[keyPath: member] } // expected-error {{key path with root type 'S3_54864' cannot be applied to a base of type 'S2_54864'}}
   }
 }
+
+// https://github.com/swiftlang/swift/issues/75244
+struct WithSendable {
+  subscript(dynamicMember member: KeyPath<String, Int> & Sendable) -> Bool { // Ok
+    get { false }
+  }
+}


### PR DESCRIPTION
…y path

- Explanation:

  The changes to support `& Sendable` composition with key path types adjusted `buildKeyPathDynamicMemberArgExpr` to support that but the use-site erroneously still cast index type or `BoundGenericType` as before.

- Main Branch PR: https://github.com/swiftlang/swift/pull/75265

- Resolves: https://github.com/swiftlang/swift/issues/75244, rdar://131768785

- Risk: Low (The fix is very narrow, only applies to `@dynamicMemberLookup` types and removes a forced cast where there shouldn't be one because underlying method has been switched to use `Type` as a parameter when it was updated to handle existential arguments).

- Reviewed By: @hborla

- Testing: Existing test-cases were modified and new tests were added.

(cherry picked from commit 59ec789768546437954c19ef39fa6f20b5883670)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
