### PR TITLE
[Debug] Add user friendly diagnostic when @DebugDescription is attached to a generic

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -64,6 +64,7 @@ import SwiftShims
 ///   and other arbitrary computation are not supported. Of note, conditional
 ///   logic and computed properties are not supported.
 /// * Overloaded string interpolation cannot be used.
+@attached(member)
 @attached(memberAttribute)
 public macro DebugDescription() =
   #externalMacro(module: "SwiftMacros", type: "DebugDescriptionMacro")

--- a/test/Macros/DebugDescription/error_generic_definition.swift
+++ b/test/Macros/DebugDescription/error_generic_definition.swift
@@ -1,0 +1,12 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -verify -plugin-path %swift-plugin-dir
+
+// expected-error @+1 {{cannot be attached to a generic definition}}
+@DebugDescription
+struct MyGeneric<T> {
+  var debugDescription: String {
+    "zero zero zero"
+  }
+}


### PR DESCRIPTION
  - **Explanation**:
Emit a user friendly diagnostic when `@DebugDescription` is attached to a generic type definition.
  - **Scope**:
This will not break existing code. Use of `@DebugDescription` previously produced an unhelpful error diagnostic, this change makes the error diagnostic clear.
  - **Original PRs**:
https://github.com/swiftlang/swift/pull/75307
  - **Risk**:
No risk.
  - **Testing**:
Swift tests, CI
  - **Reviewers**:
@hborla, @stephentyrone, @DougGregor 