### PR TITLE
[CrossImport][PrefixMap] Make sure overlay file is remapped if used

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -963,7 +963,8 @@ void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
     mainDep.addAuxiliaryFile(entry.second);
     cmdCopy.push_back("-swift-module-cross-import");
     cmdCopy.push_back(entry.first);
-    cmdCopy.push_back(entry.second);
+    auto overlayPath = cache.getScanService().remapPath(entry.second);
+    cmdCopy.push_back(overlayPath);
   }
   mainDep.updateCommandLine(cmdCopy);
 


### PR DESCRIPTION
When dependency scanner construct the overlay file path for the swift-frontend invocation, make sure the path is remapped if prefix map is used.

rdar://131940130