### PR TITLE
[Debug] Rename DebugDescription fallback property to lldbDescription

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
@@ -232,7 +232,7 @@ extension _DebugDescriptionPropertyMacro: PeerMacro {
 
 /// The names of properties that can be converted to LLDB type summaries, in priority order.
 fileprivate let DESCRIPTION_PROPERTIES = [
-  "_debugDescription",
+  "lldbDescription",
   "debugDescription",
   "description",
 ]

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -44,12 +44,12 @@ import SwiftShims
 ///     }
 ///
 /// The `DebugDescription` macro supports both `debugDescription`, `description`,
-/// as well as a third option: a property named `_debugDescription`. The first
+/// as well as a third option: a property named `lldbDescription`. The first
 /// two are implemented when conforming to the `CustomDebugStringConvertible`
-/// and `CustomStringConvertible` protocols. The additional `_debugDescription`
+/// and `CustomStringConvertible` protocols. The additional `lldbDescription`
 /// property is useful when both `debugDescription` and `description` are
 /// implemented, but don't meet the requirements of the `DebugDescription`
-/// macro. If `_debugDescription` is implemented, `DebugDescription` choose it
+/// macro. If `lldbDescription` is implemented, `DebugDescription` choose it
 /// over `debugDescription` and `description`. Likewise, `debugDescription` is
 /// preferred over `description`.
 ///

--- a/stdlib/public/core/ObjectIdentifier+DebugDescription.swift
+++ b/stdlib/public/core/ObjectIdentifier+DebugDescription.swift
@@ -13,7 +13,7 @@
 #if !$Embedded
 @DebugDescription
 extension ObjectIdentifier {
-  var _debugDescription: String {
+  var lldbDescription: String {
     return "ObjectIdentifier(\(_value))"
   }
 }

--- a/test/Macros/DebugDescription/supported_description.swift
+++ b/test/Macros/DebugDescription/supported_description.swift
@@ -31,7 +31,7 @@ struct MyStruct2: CustomDebugStringConvertible {
 struct MyStruct3: CustomDebugStringConvertible {
   var description: String { "thirty" }
   var debugDescription: String { "eleven" }
-  var _debugDescription: String { "two" }
+  var lldbDescription: String { "two" }
 }
 // CHECK: static let _lldb_summary = (
 // CHECK:     /* version */ 1 as UInt8,


### PR DESCRIPTION
From feedback, replace the name `_debugDescription`, which was confusing because of the underscore, with `lldbDescription`. This new name also indicates that this property may contain [LLDB Summary Strings](https://lldb.llvm.org/use/variable.html#summary-strings).