### PR TITLE
[Debug] Escape LLDB syntax in debugDescription

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
@@ -13,6 +13,7 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftDiagnostics
+import _StringProcessing
 
 public enum DebugDescriptionMacro {}
 public enum _DebugDescriptionPropertyMacro {}
@@ -158,12 +159,20 @@ extension _DebugDescriptionPropertyMacro: PeerMacro {
       return []
     }
 
+    // LLDB syntax is not allowed in debugDescription/description.
+    let allowLLDBSyntax = onlyBinding.name == "lldbDescription"
+
     // Iterate the string's segments, and convert property expressions into LLDB variable references.
     var summarySegments: [String] = []
     for segment in descriptionString.segments {
       switch segment {
       case let .stringSegment(segment):
-        summarySegments.append(segment.content.text)
+        var literal = segment.content.text
+        if !allowLLDBSyntax {
+          // To match debugDescription/description, escape `$` characters. LLDB must treat them as a literals they are.
+          literal = literal.escapedForLLDB()
+        }
+        summarySegments.append(literal)
       case let .expressionSegment(segment):
         guard let onlyLabeledExpr = segment.expressions.only, onlyLabeledExpr.label == nil else {
           // This catches `appendInterpolation` overrides.
@@ -470,6 +479,28 @@ extension String {
       return nil
     }
     self = string
+  }
+}
+
+extension String {
+  fileprivate func escapedForLLDB() -> String {
+    guard #available(macOS 13, *) else {
+      guard self.firstIndex(of: "$") != nil else {
+        return self
+      }
+
+      var result = ""
+      for char in self {
+        if char == "$" {
+          result.append("\\$")
+        } else {
+          result.append(char)
+        }
+      }
+      return result
+    }
+
+    return self.replacing("$", with: "\\$")
   }
 }
 

--- a/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
@@ -232,7 +232,7 @@ extension _DebugDescriptionPropertyMacro: PeerMacro {
 
 /// The names of properties that can be converted to LLDB type summaries, in priority order.
 fileprivate let DESCRIPTION_PROPERTIES = [
-  "_debugDescription",
+  "lldbDescription",
   "debugDescription",
   "description",
 ]

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -44,12 +44,12 @@ import SwiftShims
 ///     }
 ///
 /// The `DebugDescription` macro supports both `debugDescription`, `description`,
-/// as well as a third option: a property named `_debugDescription`. The first
+/// as well as a third option: a property named `lldbDescription`. The first
 /// two are implemented when conforming to the `CustomDebugStringConvertible`
-/// and `CustomStringConvertible` protocols. The additional `_debugDescription`
+/// and `CustomStringConvertible` protocols. The additional `lldbDescription`
 /// property is useful when both `debugDescription` and `description` are
 /// implemented, but don't meet the requirements of the `DebugDescription`
-/// macro. If `_debugDescription` is implemented, `DebugDescription` choose it
+/// macro. If `lldbDescription` is implemented, `DebugDescription` choose it
 /// over `debugDescription` and `description`. Likewise, `debugDescription` is
 /// preferred over `description`.
 ///

--- a/stdlib/public/core/ObjectIdentifier+DebugDescription.swift
+++ b/stdlib/public/core/ObjectIdentifier+DebugDescription.swift
@@ -13,7 +13,7 @@
 #if !$Embedded
 @DebugDescription
 extension ObjectIdentifier {
-  var _debugDescription: String {
+  var lldbDescription: String {
     return "ObjectIdentifier(\(_value))"
   }
 }

--- a/test/Macros/DebugDescription/dollar_handling.swift
+++ b/test/Macros/DebugDescription/dollar_handling.swift
@@ -1,0 +1,30 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature DebugDescriptionMacro -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %FileCheck %s < %t/expansions-dump.txt
+
+@DebugDescription
+struct MyStruct {
+  var name: String = "thirty"
+  var debugDescription: String { "${\(self.name)}" }
+}
+// CHECK: static let _lldb_summary = (
+// CHECK:     /* version */ 1 as UInt8,
+// CHECK:     /* record size */ 32 as UInt8,
+// CHECK:     /* "main.MyStruct" */ 14 as UInt8, 109 as UInt8, 97 as UInt8, 105 as UInt8, 110 as UInt8, 46 as UInt8, 77 as UInt8, 121 as UInt8, 83 as UInt8, 116 as UInt8, 114 as UInt8, 117 as UInt8, 99 as UInt8, 116 as UInt8, 0 as UInt8,
+// CHECK:     /* "\${${var.name}}" */ 16 as UInt8, 92 as UInt8, 36 as UInt8, 123 as UInt8, 36 as UInt8, 123 as UInt8, 118 as UInt8, 97 as UInt8, 114 as UInt8, 46 as UInt8, 110 as UInt8, 97 as UInt8, 109 as UInt8, 101 as UInt8, 125 as UInt8, 125 as UInt8, 0 as UInt8
+// CHECK: )
+
+@DebugDescription
+class MyClass {
+  var name: String = "thirty"
+  var lldbDescription: String { "${var.name}" }
+}
+// CHECK: static let _lldb_summary = (
+// CHECK:     /* version */ 1 as UInt8,
+// CHECK:     /* record size */ 27 as UInt8,
+// CHECK:     /* "main.MyClass" */ 13 as UInt8, 109 as UInt8, 97 as UInt8, 105 as UInt8, 110 as UInt8, 46 as UInt8, 77 as UInt8, 121 as UInt8, 67 as UInt8, 108 as UInt8, 97 as UInt8, 115 as UInt8, 115 as UInt8, 0 as UInt8,
+// CHECK:     /* "${var.name}" */ 12 as UInt8, 36 as UInt8, 123 as UInt8, 118 as UInt8, 97 as UInt8, 114 as UInt8, 46 as UInt8, 110 as UInt8, 97 as UInt8, 109 as UInt8, 101 as UInt8, 125 as UInt8, 0 as UInt8
+// CHECK: )
+

--- a/test/Macros/DebugDescription/supported_description.swift
+++ b/test/Macros/DebugDescription/supported_description.swift
@@ -31,7 +31,7 @@ struct MyStruct2: CustomDebugStringConvertible {
 struct MyStruct3: CustomDebugStringConvertible {
   var description: String { "thirty" }
   var debugDescription: String { "eleven" }
-  var _debugDescription: String { "two" }
+  var lldbDescription: String { "two" }
 }
 // CHECK: static let _lldb_summary = (
 // CHECK:     /* version */ 1 as UInt8,


### PR DESCRIPTION
When using `@DebugDescription`, only allow use of [LLDB Summary Strings](https://lldb.llvm.org/use/variable.html#summary-strings) syntax from `lldbDescription` properties. When `@DebugDescription` is applied to existing `debugDescription` properties, escape any `$`, as the output of `debugDescription` is never interpreted by LLDB.

Depends on #75305 