### PR TITLE
[embedded] Don't produce PerfDiags when in non-WMO mode (e.g. when building during indexing)

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -150,6 +150,10 @@ public:
   /// Enables SIL-level diagnostics for NonescapableTypes.
   bool EnableLifetimeDependenceDiagnostics = true;
 
+  /// Enables SIL-level performance diagnostics (for @noLocks, @noAllocation
+  /// annotations and for Embedded Swift).
+  bool EnablePerformanceDiagnostics = true;
+
   /// Controls whether or not paranoid verification checks are run.
   bool VerifyAll = false;
 

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -805,6 +805,10 @@ private:
   void run() override {
     SILModule *module = getModule();
 
+    // Skip all performance/embedded diagnostics if not in WMO mode. Building in
+    // non-WMO mode currently results in false positives.
+    if (!module->isWholeModule()) return;
+
     PerformanceDiagnostics diagnoser(*module, getAnalysis<BasicCalleeAnalysis>());
 
     // Check that @_section, @_silgen_name is only on constant globals

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -805,9 +805,10 @@ private:
   void run() override {
     SILModule *module = getModule();
 
-    // Skip all performance/embedded diagnostics if not in WMO mode. Building in
-    // non-WMO mode currently results in false positives.
-    if (!module->isWholeModule()) return;
+    // Skip all performance/embedded diagnostics if asked. This is used from
+    // SourceKit to avoid reporting false positives when WMO is turned off for
+    // indexing purposes.
+    if (!module->getOptions().EnablePerformanceDiagnostics) return;
 
     PerformanceDiagnostics diagnoser(*module, getAnalysis<BasicCalleeAnalysis>());
 

--- a/test/SourceKit/Diagnostics/embedded_non_wmo.swift
+++ b/test/SourceKit/Diagnostics/embedded_non_wmo.swift
@@ -1,0 +1,34 @@
+// Check that when emitting diagnostics in SourceKit, we don't report false positives in PerformanceDiagnostics (because WMO is disabled).
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %sourcekitd-test -req=diags %t/file1.swift -- %t/file1.swift %t/file2.swift -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: embedded_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+//--- file1.swift
+
+func foo() {
+    bar(Int.self)
+}
+
+@main
+struct Main {
+    static func main() {
+        foo()
+    }
+}
+
+//--- file2.swift
+
+func bar<T>(_ T: T.Type) {
+    
+}
+
+// CHECK:      {
+// CHECK-NEXT:   key.diagnostics: [
+// CHECK-NEXT:   ]
+// CHECK-NEXT: }

--- a/test/SourceKit/Diagnostics/embedded_non_wmo.swift
+++ b/test/SourceKit/Diagnostics/embedded_non_wmo.swift
@@ -3,11 +3,11 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %sourcekitd-test -req=diags %t/file1.swift -- %t/file1.swift %t/file2.swift -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %sourcekitd-test -req=diags %t/file1.swift -- %t/file1.swift %t/file2.swift -enable-experimental-feature Embedded -target %target-cpu-apple-macos14 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: embedded_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: OS=macosx
 
 //--- file1.swift
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1219,6 +1219,11 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
       // flag and might thus fail, which SILGen cannot handle.
       llvm::SaveAndRestore<std::shared_ptr<std::atomic<bool>>> DisableCancellationDuringSILGen(CompIns.getASTContext().CancellationFlag, nullptr);
       SILOptions SILOpts = Invocation.getSILOptions();
+
+      // Disable PerformanceDiagnostics SIL pass, which in some cases requires
+      // WMO (e.g. for Embedded Swift diags) but SourceKit compiles without WMO.
+      SILOpts.EnablePerformanceDiagnostics = false;
+
       auto &TC = CompIns.getSILTypes();
       std::unique_ptr<SILModule> SILMod = performASTLowering(*SF, TC, SILOpts);
       if (CancellationFlag->load(std::memory_order_relaxed)) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1811,6 +1811,11 @@ static void computeDiagnostics(
     void cancelled() override {
       Receiver(RequestResult<DiagnosticsResult>::cancelled());
     }
+
+    void failed(StringRef Error) override {
+      LOG_WARN_FUNC("diagnostics failed: " << Error);
+      Receiver(RequestResult<DiagnosticsResult>::fromError(Error));
+    }
   };
 
   auto Consumer = std::make_shared<DiagnosticsConsumer>(std::move(Receiver));


### PR DESCRIPTION
This silences false positives coming from the fact that in non-WMO builds, we don't currently see function bodies of other translation units, and therefore we can't specialize+inline them.

Fixes https://github.com/apple/swift-embedded-examples/issues/48

rdar://125437187