### PR TITLE
[6.0] [stdlib] Adopt inout sending for Mutex

### DIFF
--- a/stdlib/public/Synchronization/Mutex/Mutex.swift
+++ b/stdlib/public/Synchronization/Mutex/Mutex.swift
@@ -85,7 +85,7 @@ extension Mutex where Value: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public borrowing func withLock<Result: ~Copyable, E: Error>(
-    _ body: @Sendable (inout Value) throws(E) -> sending Result
+    _ body: (inout sending Value) throws(E) -> sending Result
   ) throws(E) -> sending Result {
     handle._lock()
 
@@ -132,7 +132,7 @@ extension Mutex where Value: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public borrowing func withLockIfAvailable<Result: ~Copyable, E: Error>(
-    _ body: @Sendable (inout Value) throws(E) -> sending Result
+    _ body: (inout sending Value) throws(E) -> sending Result
   ) throws(E) -> sending Result? {
     guard handle._tryLock() else {
       return nil


### PR DESCRIPTION
This is a cherry pick of https://github.com/swiftlang/swift/pull/74946

* **Explanation**: Changes the `Mutex.withLock` and `Mutex.withLockIfAvailable` functions to take closures that pass `inout sending` instead of requiring `@Sendable` closures.
* **Main** **Branch** **PR**: https://github.com/swiftlang/swift/pull/74946
* **Resolves**: rdar://131956057
* **Risk**: Low. `Mutex` has not been adopted yet, so there should be no uses of it currently. This change should be completely source compatible as a `@Sendable` closure is more restrictive than a non-`@Sendable` closure. `inout sending` should allow for previously disallowed code to now be accepted as it just looses the restrictions.
* **Reviewed** **By**: N/A
* **Testing**: Existing tests were executed and still pass after this change meaning this does not break existing code and should allow for new patterns to exist.