### PR TITLE
[IRGen] Skip async context params before handling direct error return…

### DIFF
--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -188,3 +188,20 @@ func throwsGenericAsync<T: Error>(x: Bool, y: T) async throws(T) -> Int {
 
   return 32
 }
+
+enum TinyError: Error {
+  case a
+}
+
+@available(SwiftStdlib 6.0, *)
+func mayThrowAsyncTiny(x: Bool) async throws(TinyError) -> Bool {
+  guard x else {
+    throw .a
+  }
+  return false
+}
+
+@available(SwiftStdlib 6.0, *)
+func callsMayThrowAsyncTiny(x: Bool) async {
+  _ = try! await mayThrowAsyncTiny(x: x)
+}


### PR DESCRIPTION
… values

rdar://131960281

We need to skip the async context params, otherwise we load the wrong parameters.
