### PR TITLE
Revert "[region-isolation] Make "unknown pattern error" always an error

### DIFF
--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -158,23 +158,6 @@ static Expr *inferArgumentExprFromApplyExpr(ApplyExpr *sourceApply,
 //                             MARK: Diagnostics
 //===----------------------------------------------------------------------===//
 
-/// Emit the "unknown pattern error" at the SILLocation of \p inst.
-static void diagnoseUnknownPatternError(SILInstruction *inst) {
-  if (shouldAbortOnUnknownPatternMatchError()) {
-    llvm::report_fatal_error(
-        "RegionIsolation: Aborting on unknown pattern match error");
-  }
-
-  auto &ctx = inst->getFunction()->getASTContext();
-  auto loc = inst->getLoc().getSourceLoc();
-
-  ctx.Diags.diagnose(loc, diag::regionbasedisolation_unknown_pattern);
-}
-
-static void diagnoseUnknownPatternError(Operand *op) {
-  diagnoseUnknownPatternError(op->getUser());
-}
-
 template <typename... T, typename... U>
 static InFlightDiagnostic diagnoseError(ASTContext &context, SourceLoc loc,
                                         Diag<T...> diag, U &&...args) {
@@ -749,7 +732,14 @@ public:
   }
 
   void emitUnknownPatternError() {
-    diagnoseUnknownPatternError(transferOp->getUser());
+    if (shouldAbortOnUnknownPatternMatchError()) {
+      llvm::report_fatal_error(
+          "RegionIsolation: Aborting on unknown pattern match error");
+    }
+
+    diagnoseError(transferOp->getUser(),
+                  diag::regionbasedisolation_unknown_pattern)
+        .limitBehaviorIf(getBehaviorLimit());
   }
 
 private:
@@ -1170,7 +1160,12 @@ void TransferNonSendableImpl::emitUseAfterTransferDiagnostics() {
     // tells the user to file a bug. This importantly ensures that we can
     // guarantee that we always find the require if we successfully compile.
     if (!didEmitRequireNote) {
-      diagnoseUnknownPatternError(transferOp);
+      if (shouldAbortOnUnknownPatternMatchError()) {
+        llvm::report_fatal_error(
+            "RegionIsolation: Aborting on unknown pattern match error");
+      }
+
+      diagnoseError(transferOp, diag::regionbasedisolation_unknown_pattern);
       continue;
     }
 
@@ -1232,7 +1227,14 @@ public:
   }
 
   void emitUnknownPatternError() {
-    diagnoseUnknownPatternError(getOperand()->getUser());
+    if (shouldAbortOnUnknownPatternMatchError()) {
+      llvm::report_fatal_error(
+          "RegionIsolation: Aborting on unknown pattern match error");
+    }
+
+    diagnoseError(getOperand()->getUser(),
+                  diag::regionbasedisolation_unknown_pattern)
+        .limitBehaviorIf(getBehaviorLimit());
   }
 
   void emitUnknownUse(SILLocation loc) {
@@ -1725,7 +1727,14 @@ public:
   }
 
   void emitUnknownPatternError() {
-    diagnoseUnknownPatternError(info.functionExitingInst);
+    if (shouldAbortOnUnknownPatternMatchError()) {
+      llvm::report_fatal_error(
+          "RegionIsolation: Aborting on unknown pattern match error");
+    }
+
+    diagnoseError(info.functionExitingInst,
+                  diag::regionbasedisolation_unknown_pattern)
+        .limitBehaviorIf(getBehaviorLimit());
   }
 
   void emit();
@@ -1985,7 +1994,13 @@ struct DiagnosticEvaluator final
   }
 
   void handleUnknownCodePattern(const PartitionOp &op) const {
-    diagnoseUnknownPatternError(op.getSourceInst());
+    if (shouldAbortOnUnknownPatternMatchError()) {
+      llvm::report_fatal_error(
+          "RegionIsolation: Aborting on unknown pattern match error");
+    }
+
+    diagnoseError(op.getSourceInst(),
+                  diag::regionbasedisolation_unknown_pattern);
   }
 
   bool isActorDerived(Element element) const {


### PR DESCRIPTION
This reverts commit b63781f7ba7796a8ad20b79c56f1ad961eac6286.

We found some cases where due to malformed IR that we allow through due to either us compiling for strict-concurrency=complete+swift-5 or swift-6 + preconcurrency, that we can actually have actor isolation mismatch. I am going to in a subsequent commit add a better phrasing here. But for now, just undo the conversion from error -> warning.

rdar://131757602
