### PR TITLE
[Distributed] Handle #isolation param in DA as known to not cross isolation

### DIFF
--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -106,6 +106,8 @@ VarDecl *
 swift::getDistributedActorAsLocalActorComputedProperty(ModuleDecl *module) {
   auto &C = module->getASTContext();
   auto DA = C.getDistributedActorDecl();
+  if (!DA)
+    return nullptr;
   auto extension = findDistributedActorAsActorExtension(DA);
 
   if (!extension)

--- a/test/Distributed/Inputs/FakeDistributedActorSystems.swift
+++ b/test/Distributed/Inputs/FakeDistributedActorSystems.swift
@@ -548,7 +548,7 @@ extension ActorAddress {
     return bytes
   }
   func fromBytes(_ bytes: [UInt8]) throws -> ActorAddress {
-    let address = String(cString: bytes)
+    let address = String(decoding: bytes, as: UTF8.self)
     return Self.init(parse: address)
   }
 }

--- a/test/Distributed/Runtime/distributed_actor_isolation_passing.swift
+++ b/test/Distributed/Runtime/distributed_actor_isolation_passing.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -parse-as-library -swift-version 6 -target %target-swift-abi-5.9-triple -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift %S/../Inputs/CustomSerialExecutorAvailability.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+//import StdlibUnittest
+import Distributed
+
+@available(SwiftStdlib 5.9, *)
+distributed actor Tester {
+
+  typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  distributed func check() async {
+    // should correctly infer not to be crossing isolation boundary:
+    pass()
+    passOptional()
+
+    pass(isolatedToActor: self.asLocalActor)
+    passOptional(isolatedToActor: self.asLocalActor)
+
+    // Not supported: the parameter must be exactly the 'self.asLocalActor'
+    // as otherwise we don't know where the value came from and if it's really
+    // self we're calling from; We'd need more sophisticated analysis to make it work.
+    //    let myself = self.asLocalActor
+    //    pass(isolatedToActor: myself)
+  }
+}
+
+@available(SwiftStdlib 5.9, *)
+func passOptional(isolatedToActor: isolated (any Actor)? = #isolation) {
+  isolatedToActor!.preconditionIsolated("Expected to be executing on actor \(isolatedToActor!)")
+}
+
+@available(SwiftStdlib 5.9, *)
+func pass(isolatedToActor: isolated (any Actor) = #isolation) {
+  isolatedToActor.preconditionIsolated("Expected to be executing on actor \(isolatedToActor)")
+}
+
+@main struct Main {
+  static func main() async {
+    if #available(SwiftStdlib 5.9, *) {
+      let system = LocalTestingDistributedActorSystem()
+      let tester = Tester(actorSystem: system)
+
+      try! await tester.check()
+    }
+  }
+}


### PR DESCRIPTION

The isolation checker was assuming that one can only be isolated to a specific var, but that's not true for distributed actors -- because the default parameter emitted by #isolation is a method call -- converting the self into an any Actor.

We must handle this in isolation checker in order to avoid thinking we're crossing isolation boundaries and making methods implicitly async etc, when we're actually not.

resolves rdar://131874709
