### PR TITLE
[6.0][Attr] Add a missing return statement at the end of `allowSymbolLinkageMarkers`

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2335,6 +2335,8 @@ static bool allowSymbolLinkageMarkers(ASTContext &ctx, Decl *D) {
       macroDecl->getName().getBaseIdentifier()
           .str().equals("_DebugDescriptionProperty"))
     return true;
+
+  return false;
 }
 
 void AttributeChecker::visitUsedAttr(UsedAttr *attr) {


### PR DESCRIPTION
  - **Explanation**: Add a missing return statement to the end of the `allowSymbolLinkageMarkers`. The default here should be `false`.
  - **Scope**: Only impacts the use of symbol linkage markers inside attached macro expansions. Without this change, the compiler may allow them to be used in contexts they shouldn't.
  - **Issues**: rdar://131980669
  - **Original PRs**: https://github.com/swiftlang/swift/pull/75331
  - **Risk**: Low; this change just adds a return statement at the end of a function that was missing one.
  - **Testing**: Passed existing macro tests.
  - **Reviewers**: @kastiglione