### PR TITLE
[test] Guard AVR test with CODEGENERATOR=AVR

### DIFF
--- a/test/embedded/avr/testStdlibFunctioning.swift
+++ b/test/embedded/avr/testStdlibFunctioning.swift
@@ -1,6 +1,7 @@
 // RUN: %swift-frontend -typecheck %s -target avr-none-none-elf \
 // RUN:   -wmo -enable-experimental-feature Embedded
 // REQUIRES: embedded_stdlib_cross_compiling
+// REQUIRES: CODEGENERATOR=AVR
 
 import Swift
 


### PR DESCRIPTION
This test is only relevant for the AVR target, so it should be guarded with the CODEGENERATOR=AVR condition to avoid running it when the target is not enabled in llvm-targets-to-build.

Wasm CI does not build the target to reduce CI time https://ci.swift.org/job/oss-swift-pr-test-crosscompile-wasm-ubuntu-20_04/1187/console