### PR TITLE
[6.0] `@_extern` is an experimental feature.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -186,7 +186,6 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(RetroactiveAttribute, 364, "@retroactive")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ExtensionMacroAttr, 0, "@attached(extension)")
 LANGUAGE_FEATURE(TypedThrows, 413, "Typed throws")
 CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE(OptionalIsolatedParameters, 420, "Optional isolated parameters")
-SUPPRESSIBLE_LANGUAGE_FEATURE(Extern, 0, "@_extern")
 LANGUAGE_FEATURE(ExpressionMacroDefaultArguments, 422, "Expression macro as caller-side default argument")
 LANGUAGE_FEATURE(BuiltinStoreRaw, 0, "Builtin.storeRaw")
 LANGUAGE_FEATURE(BuiltinCreateTask, 0, "Builtin.createTask and Builtin.createDiscardingTask")
@@ -388,6 +387,8 @@ EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(DebugDescriptionMacro, true)
 EXPERIMENTAL_FEATURE(ReinitializeConsumeInMultiBlockDefer, false)
 
 EXPERIMENTAL_FEATURE(SE427NoInferenceOnExtension, false)
+
+EXPERIMENTAL_FEATURE(Extern, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -338,10 +338,6 @@ static bool usesFeatureOptionalIsolatedParameters(Decl *decl) {
   return false;
 }
 
-static bool usesFeatureExtern(Decl *decl) {
-  return decl->getAttrs().hasAttribute<ExternAttr>();
-}
-
 static bool usesFeatureAssociatedTypeImplements(Decl *decl) {
   return isa<TypeDecl>(decl) && decl->getAttrs().hasAttribute<ImplementsAttr>();
 }
@@ -698,6 +694,7 @@ UNINTERESTING_FEATURE(NonfrozenEnumExhaustivity)
 UNINTERESTING_FEATURE(BorrowingSwitch)
 
 UNINTERESTING_FEATURE(ClosureIsolation)
+UNINTERESTING_FEATURE(Extern)
 
 static bool usesFeatureConformanceSuppression(Decl *decl) {
   auto *nominal = dyn_cast<NominalTypeDecl>(decl);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2266,7 +2266,8 @@ static bool isCCompatibleFuncDecl(FuncDecl *FD) {
 }
 
 void AttributeChecker::visitExternAttr(ExternAttr *attr) {
-  if (!Ctx.LangOpts.hasFeature(Feature::Extern)) {
+  if (!Ctx.LangOpts.hasFeature(Feature::Extern)
+      && !D->getModuleContext()->isStdlibModule()) {
     diagnoseAndRemoveAttr(attr, diag::attr_extern_experimental);
     return;
   }

--- a/test/ModuleInterface/extern_attr.swift
+++ b/test/ModuleInterface/extern_attr.swift
@@ -4,23 +4,11 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 
-// CHECK:      #if compiler(>=5.3) && $Extern
-// CHECK-NEXT:   @_extern(c) public func externalCFunc()
-// CHECK-NEXT: #else
-// CHECK-NEXT:   public func externalCFunc()
-// CHECK-NEXT: #endif
+// CHECK:   @_extern(c) public func externalCFunc()
 @_extern(c) public func externalCFunc()
 
-// CHECK:      #if compiler(>=5.3) && $Extern
-// CHECK-NEXT:   @_extern(c, "renamedCFunc") public func externalRenamedCFunc()
-// CHECK-NEXT: #else
-// CHECK-NEXT:   public func externalRenamedCFunc()
-// CHECK-NEXT: #endif
+// CHECK:   @_extern(c, "renamedCFunc") public func externalRenamedCFunc()
 @_extern(c, "renamedCFunc") public func externalRenamedCFunc()
 
-// CHECK:      #if compiler(>=5.3) && $Extern
-// CHECK-NEXT:   @_extern(wasm, module: "m", name: "f") public func wasmImportedFunc()
-// CHECK-NEXT: #else
-// CHECK-NEXT:  public func wasmImportedFunc()
-// CHECK-NEXT: #endif
+// CHECK:   @_extern(wasm, module: "m", name: "f") public func wasmImportedFunc()
 @_extern(wasm, module: "m", name: "f") public func wasmImportedFunc()

--- a/test/embedded/array-to-pointer.swift
+++ b/test/embedded/array-to-pointer.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-swift-frontend %s -enable-experimental-feature Extern -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/main.o %t/print.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/arrays.swift
+++ b/test/embedded/arrays.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-swift-frontend -enable-experimental-feature Extern %s -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/main.o %t/print.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/collection.swift
+++ b/test/embedded/collection.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-feature Embedded -enforce-exclusivity=none %s -c -o %t/a.o
+// RUN: %target-swift-frontend -enable-experimental-feature Extern -enable-experimental-feature Embedded -enforce-exclusivity=none %s -c -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/custom-print.swift
+++ b/test/embedded/custom-print.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-feature Embedded -enforce-exclusivity=none %s -c -o %t/a.o
+// RUN: %target-swift-frontend -enable-experimental-feature Extern -enable-experimental-feature Embedded -enforce-exclusivity=none %s -c -o %t/a.o
 // RUN: %target-clang %t/a.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/dependencies-no-allocations.swift
+++ b/test/embedded/dependencies-no-allocations.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-feature Embedded -no-allocations %s -c -o %t/a.o
+// RUN: %target-swift-frontend -enable-experimental-feature Extern -enable-experimental-feature Embedded -no-allocations %s -c -o %t/a.o
 
 // RUN: grep DEP\: %s | sed 's#// DEP\: ##' | sort > %t/allowed-dependencies.txt
 

--- a/test/embedded/dependencies.swift
+++ b/test/embedded/dependencies.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded %s -c -o %t/a.o
+// RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Extern -enable-experimental-feature Embedded %s -c -o %t/a.o
 
 // RUN: grep DEP\: %s | sed 's#// DEP\: ##' | sort > %t/allowed-dependencies.txt
 

--- a/test/embedded/deserialize-vtables.swift
+++ b/test/embedded/deserialize-vtables.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Extern -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Extern -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Osize -enable-experimental-feature Extern -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/lto.swift
+++ b/test/embedded/lto.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -lto=llvm-full %s -enable-experimental-feature Embedded -emit-bc -o %t/a.o
+// RUN: %target-swift-frontend -enable-experimental-feature Extern -lto=llvm-full %s -enable-experimental-feature Embedded -emit-bc -o %t/a.o
 // RUN: %target-clang %t/a.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/modules-globals-exec.swift
+++ b/test/embedded/modules-globals-exec.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+// RUN: %target-swift-frontend -enable-experimental-feature Extern -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -enable-experimental-feature Extern -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/modules-print-exec.swift
+++ b/test/embedded/modules-print-exec.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+// RUN: %target-swift-frontend -enable-experimental-feature Extern -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -enable-experimental-feature Extern -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/runtime.swift
+++ b/test/embedded/runtime.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Extern -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Extern -O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Extern -Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test


### PR DESCRIPTION
Explanation: `@_extern` was accidentally enabled as a mainline feature even though it's experimental. This restores its experimental status.
Scope: Bug fix.
Issue: rdar://132013078
Original PR: https://github.com/swiftlang/swift/pull/75334
Risk: Low. Projects shouldn't be using `@_extern`, but if they are, they have to `-enable-experimental-feature Extern`.
Testing: Swift CI
Reviewer: @tshortli