### PR TITLE
[6.0] Add swift-foundation/swift-foundation-icu branch to release/6.0 checkout config

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -181,6 +181,8 @@
                 "swift-stress-tester": "release/6.0",
                 "swift-corelibs-xctest": "release/6.0",
                 "swift-corelibs-foundation": "release/6.0",
+                "swift-foundation": "main",
+                "swift-foundation-icu": "main",
                 "swift-corelibs-libdispatch": "release/6.0",
                 "swift-integration-tests": "release/6.0",
                 "swift-xcode-playground-support": "release/6.0",


### PR DESCRIPTION
Cherry pick of https://github.com/swiftlang/swift/pull/75339

Explanation: Adds an explicit branch to the update-checkout config for releease/6.0 for the swift-foundation and swift-foundation-icu repos
Scope: Affects checking out swift-foundation/swift-foundation-icu on release/6.0 builds
Original PR: https://github.com/swiftlang/swift/pull/75339
Risk: Minimal - this just specifies a branch for a checkout that is not yet used on this scheme
Testing: Testing done via swift-ci toolchain builds/testing