### PR TITLE
[main] Add swift-foundation/swift-foundation-icu branch to release/6.0 checkout config

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -189,6 +189,8 @@
                 "swift-stress-tester": "release/6.0",
                 "swift-corelibs-xctest": "release/6.0",
                 "swift-corelibs-foundation": "release/6.0",
+                "swift-foundation": "main",
+                "swift-foundation-icu": "main",
                 "swift-corelibs-libdispatch": "release/6.0",
                 "swift-integration-tests": "release/6.0",
                 "swift-xcode-playground-support": "release/6.0",


### PR DESCRIPTION
This adds an explicit branch to the release/6.0 checkouts for swift-foundation and swift-foundation-icu (the `main` branch, since those repos have not branched for Swift 6