### PR TITLE
Re-add ICU as a valid remote

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -101,6 +101,9 @@
         "curl": {
           "remote": { "id": "curl/curl" }
         },
+        "icu": {
+          "remote": { "id": "unicode-org/icu" }
+        },
         "libxml2": {
           "remote": { "id": "gnome/libxml2" }
         },


### PR DESCRIPTION
When I removed ICU, I removed it from the list of remotes and its branch from the `main` config, however the `release/6.0` config still needs this remote and it turns out that when running tests on repos other than the swiftlang/swift repo, CI checks out the `main` branch of the swift repo and runs update-checkout from that to update the checkout to `release/6.0`. This means that we still need ICU as a valid remote on the `main` branch, but we can leave it out of the list of repos for the `main` object in the JSON file so it doesn't get checked out when building against the "main" scheme