### PR TITLE
Add buildbot profile for cross-compiling for linux-armv7 using external sysroot

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -322,7 +322,7 @@ macro(configure_sdk_unix name architectures)
   # depending on the architecture, so having a single value is the only
   # possibility right now.
   set(SWIFT_SDK_${prefix}_CXX_OVERLAY_SWIFT_COMPILE_FLAGS
-      -Xcc --gcc-toolchain=/usr
+      -Xcc --gcc-toolchain=${CMAKE_SYSROOT}/usr
     CACHE STRING "Extra flags for compiling the C++ overlay")
 
   set(_default_threading_package "pthreads")

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1105,6 +1105,76 @@ lit-args=-v
 indexstore-db=0
 sourcekit-lsp=0
 
+[preset: buildbot_linux_crosscompile_armv7,llvm]
+release
+reconfigure
+
+# Disable features
+build-swift-tools=0
+
+# Skip rules
+skip-build-cmark
+skip-early-swiftsyntax
+skip-build-llvm
+skip-build-swift
+
+build-subdir=buildbot_linux_armv7
+
+[preset: buildbot_linux_crosscompile_armv7,stdlib,corelibs]
+mixin-preset=stdlib_base_standalone
+release
+reconfigure
+
+install-swift
+install-swiftsyntax
+foundation
+libdispatch
+xctest
+install-foundation
+install-libdispatch
+install-xctest
+
+# NOTE: Backtracing does not cross compile for armv7 currently
+swift-enable-backtracing=0
+swift-stdlib-supports-backtrace-reporting=0
+
+swift-install-components=autolink-driver;compiler;clang-builtin-headers;libexec;stdlib;swift-remote-mirror;sdk-overlay;dev
+build-swift-static-stdlib
+build-swift-static-sdk-overlay
+
+# Cross compilation
+skip-local-build
+cross-compile-hosts=linux-armv7
+cross-compile-deps-path=%(sysroot)s
+cross-compile-append-host-target-to-destdir=False
+
+build-subdir=buildbot_linux_armv7
+
+# Custom flags for cross compilation
+extra-cmake-options=
+    -DCMAKE_C_FLAGS="-w -fuse-ld=lld -target armv7-unknown-linux-gnueabihf --sysroot=%(sysroot)s"
+    -DCMAKE_CXX_FLAGS="-w -fuse-ld=lld -target armv7-unknown-linux-gnueabihf --sysroot=%(sysroot)s"
+    -DCMAKE_ASM_FLAGS="-target armv7-unknown-linux-gnueabihf --sysroot=%(sysroot)s"
+
+# Set Swift flags to cross compile deps for armv7
+common-swift-flags="-use-ld=lld -target armv7-unknown-linux-gnueabihf -resource-dir %(workspace_dir)s/build/buildbot_linux_armv7/swift-linux-armv7/lib/swift -sdk %(sysroot)s"
+
+# Use lld for building Swift, set extra flags and sysroot paths
+swift-cmake-options=
+    -DSWIFT_USE_LINKER=lld
+    -DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=ON
+    -DSWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP=ON
+    -DCMAKE_SYSROOT=%(sysroot)s
+    -DSWIFT_SDK_LINUX_ARCH_armv7_PATH=%(sysroot)s
+
+install-prefix=/usr
+
+# Path to the root of the installation filesystem.
+install-destdir=%(install_destdir)s
+
+# Path to the .tar.gz package we would create.
+installable-package=%(installable_package)s
+
 [preset: buildbot_linux_armv7]
 release
 llbuild

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1386,6 +1386,10 @@ function common_swift_flags() {
         echo "error: a module cache path has not been set"
         exit 1
     fi
+
+    # Remove quotes from COMMON_SWIFT_FLAGS before using it
+    COMMON_SWIFT_FLAGS=`echo ${COMMON_SWIFT_FLAGS} | xargs`
+
     echo -n "${SWIFT_FLAGS[@]} ${COMMON_SWIFT_FLAGS} -module-cache-path \"${module_cache}\" "
 }
 

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -370,7 +370,7 @@ class Product(object):
     def get_linux_sysroot(self, platform, arch):
         if not self.is_cross_compile_target('{}-{}'.format(platform, arch)):
             return None
-        sysroot_arch, abi = self.get_linux_target_components(arch)
+        sysroot_arch, _, abi = self.get_linux_target_components(arch)
         # $ARCH-$PLATFORM-$ABI
         # E.x.: aarch64-linux-gnu
         sysroot_dirname = '{}-{}-{}'.format(sysroot_arch, platform, abi)


### PR DESCRIPTION
  - **Explanation**:
     Added new buildbot profiles that allow cross-compiling Swift 5.10 for linux-armv7. This provides 2 different build steps that must be performed to cross compile:

     - `buildbot_linux_crosscompile_armv7,llvm`
     - `buildbot_linux_crosscompile_armv7,stdlib,corelibs`

    The first step is required to get some sort of llvm-linux-x86_64 directory created in the buildbot_linux_armv7 directory, which is required for the rest of the build.

    This does require an external sysroot to be provided, but I created a guide on my blog how to do this, and also how to use the buildbot profiles: https://medium.com/@jesselzamora/cross-compiling-swift-5-10-1-for-linux-armv7-b15986c0f1bf. 

  - **Scope**:
    This mostly adds the new buildbot profiles, but also fixes an issue that prevented cross compilation starting in Swift 5.10, as well as tweaking the hardcoded `--gcc-toolchain` that prevented an external sysroot from being used to compile CXX interop modules.

    I also had to patch the `COMMON_SWIFT_FLAGS` that are passed to `-DCMAKE_Swift_FLAGS` since it was including extra quotes that made any usage of `common-swift-flags=` in the build-presets.ini file crash and burn when building libdispatch, foundation, etc.
  - **Issues**:
    - Cross compilation issue: #75341
    - CXX Interop issue: #75344
  - **Original PRs**:
     - release/5.10
  - **Risk**:
    As far as I can tell these changes should NOT negatively impact other builds, but we need to run the CIs against it.
  - **Testing**:
    All the existing CIs should be run against this to make sure that nothing was broken, especially with the CXX interop patch. 
      I tested all of this on a Raspberry Pi 3B+ running Raspberry Pi OS 12 (32-bit) and it all works great. This should be able to be replicated on other Pis and other people's systems. I did not try building these profiles on a macOS host- just on Ubuntu and Debian hosts with the correct dependencies installed.
  - **Reviewers**:
    - @MaxDesiatov 

Please feel free to suggest better ways to do things here. I did spend a lot of time figuring out what *doesn't work* but if there are other ways this can be improved and still work, I'm all ears. 