### PR TITLE
Downgrade the error about `#isolation` in `@_unsafeInheritExecutor` when the concurrency library is old

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3967,6 +3967,20 @@ namespace {
       return nullptr;
     }
 
+    /// Check whether there are _unsafeInheritExecutor_ workarounds in the
+    /// given _Concurrency module.
+    static bool hasUnsafeInheritExecutorWorkarounds(
+        DeclContext *dc, SourceLoc loc
+      ) {
+      ASTContext &ctx = dc->getASTContext();
+      Identifier name =
+          ctx.getIdentifier("_unsafeInheritExecutor_withUnsafeContinuation");
+      NameLookupOptions lookupOptions = defaultUnqualifiedLookupOptions;
+      LookupResult lookup = TypeChecker::lookupUnqualified(
+          dc, DeclNameRef(name), loc, lookupOptions);
+      return !lookup.empty();
+    }
+
     void recordCurrentContextIsolation(
         CurrentContextIsolationExpr *isolationExpr) {
       // If an actor has already been assigned, we're done.
@@ -3987,6 +4001,12 @@ namespace {
                                        diag::isolation_in_inherits_executor,
                                        inDefaultArgument);
         diag.limitBehaviorIf(inConcurrencyModule, DiagnosticBehavior::Warning);
+
+        if (!inConcurrencyModule &&
+            !hasUnsafeInheritExecutorWorkarounds(func, func->getLoc())) {
+          diag.limitBehavior(DiagnosticBehavior::Warning);
+        }
+
         replaceUnsafeInheritExecutorWithDefaultedIsolationParam(func, diag);
       }
 


### PR DESCRIPTION
The introduction of the error concerning use of `#isolation` within an `@_unsafeInheritExecutor` function was carefully staged between the concurrency library and compiler to avoid breaking source compatibility. However, it is a source compatibility break when dealing certain revisions of the concurrency library that adopted `#isolation` prior to the compiler error. Detect when the _Concurrency library doesn't have the necessary workarounds in it and downgrade the error to a warning.

Fixes rdar://132023573.

