### PR TITLE
[6.0][CrossImport][PrefixMap] Make sure overlay file is remapped if used

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -950,7 +950,8 @@ void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
     mainDep.addAuxiliaryFile(entry.second);
     cmdCopy.push_back("-swift-module-cross-import");
     cmdCopy.push_back(entry.first);
-    cmdCopy.push_back(entry.second);
+    auto overlayPath = cache.getScanService().remapPath(entry.second);
+    cmdCopy.push_back(overlayPath);
   }
   mainDep.updateCommandLine(cmdCopy);
 


### PR DESCRIPTION
Explanation: when prefix map for dependency scanner is used and a cross import overlay is discovered, scanner needs to remap the overlay file so swift-frontend can find the cross-import file during compilation.
Scope: This affect swift caching build that uses a prefix mapping to canonicalize path so it can get cache hit regardless of source/SDK location. This fixes a build error when cross module import is found during a prefix mapped compilation task.
Issue: rdar://131940130
Original PR: https://github.com/swiftlang/swift/pull/75303
Reviewer: @benlangmuir 
Risk: Very Low. The code path only used by swift caching build backed by a CAS.
Test: UnitTest included.