### PR TITLE
[6.0] ModuleInterface: Print -target-variant flag in .swiftinterface files

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1353,7 +1353,7 @@ def target_cpu : Separate<["-"], "target-cpu">, Flags<[FrontendOption, ModuleInt
   HelpText<"Generate code for a particular CPU variant">;
 
 def target_variant : Separate<["-"], "target-variant">,
-  Flags<[FrontendOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Generate 'zippered' code for macCatalyst that can run on the specified"
            " variant target triple in addition to the main -target triple">;
 

--- a/test/ModuleInterface/target-variant.swift
+++ b/test/ModuleInterface/target-variant.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/TargetVariant.swiftinterface) %s -module-name TargetVariant -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi
+// RUN: %target-swift-typecheck-module-from-interface(%t/TargetVariant.swiftinterface) -module-name TargetVariant
+// RUN: %FileCheck %s < %t/TargetVariant.swiftinterface
+
+// REQUIRES: OS=macosx
+
+// CHECK: swift-module-flags
+// CHECK-SAME: -target {{.*}}-apple-macosx13
+// CHECK-SAME: -target-variant {{.*}}-apple-ios16-macabi
+
+// CHECK: public func test()
+public func test() {}

--- a/test/SIL/availability_query_maccatalyst_zippered_inlined.swift
+++ b/test/SIL/availability_query_maccatalyst_zippered_inlined.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Library.swift -swift-version 5 -enable-library-evolution -module-name Library -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -o %t -emit-module-interface-path %t/Library.swiftinterface
+// RUN: %target-swift-frontend -emit-sil %t/main.swift -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -I %t | %FileCheck %t/main.swift
+
+// Remove the .swiftmodule and test again with the library module built from interface.
+
+// RUN: rm %t/Library.swiftmodule
+// RUN: %target-swift-frontend -emit-sil %t/main.swift -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -I %t | %FileCheck %t/main.swift
+
+// REQUIRES: maccatalyst_support
+
+//--- Library.swift
+
+public func foo() {}
+
+@_alwaysEmitIntoClient
+public func test() {
+  if #available(macOS 14, iOS 17, *) {
+    foo()
+  }
+}
+
+//--- main.swift
+
+import Library
+
+test()
+
+// CHECK-LABEL: sil shared @$s7Library4testyyF
+// CHECK: [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 14
+// CHECK: [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK: [[MACOS_PATCH:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK: [[IOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 17
+// CHECK: [[IOS_MINOR:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK: [[IOS_PATCH:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK: [[FUNC:%.*]] = function_ref @$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: [[QUERY_RESULT:%.*]] = apply [[FUNC]]([[MACOS_MAJOR]], [[MACOS_MINOR]], [[MACOS_PATCH]], [[IOS_MAJOR]], [[IOS_MINOR]], [[IOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1


### PR DESCRIPTION
- **Explanation:** The `-target-variant` flag was accidentally omitted from the compiler flags printed in `.swiftinterface` files, causing zippered modules containing inlinable `if #available` checks and `@backDeployed` declarations to be miscompiled when compiled from interface.
- **Scope:** This miscompile manifests in Swift Testing's use of the `withValue()` to manage a `@TaskLocal`. Without the fix, a test compiled for macCatalyst and using Swift Testing could crash unexpectedly when running on an older version of macOS. Any macCatalyst app using any `@backDeployed` API could run into similar issues, and `@backDeployed` was adopted heavily in commonly used APIs.
- **Issue/Radar:** rdar://130094532
- **Original PR:** https://github.com/swiftlang/swift/pull/75349
- **Risk:** Medium. I am confident that adding `-target-variant` to `.swiftinterfaces` is correct. However, doing so may reveal other issues since we do not have experience with libraries including this flag correctly.
- **Testing:** New regression tests were added to the compiler test suite.
- **Reviewer:** @mikeash @xymus @artemcm @nkcsgexi
