### PR TITLE
[IRGen] Support movesAsLike for the array variant of @_rawLayout

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -1033,15 +1033,17 @@ forms are currently accepted:
 
 - `@_rawLayout(size: N, alignment: M)` specifies the type's size and alignment
   in bytes.
-- `@_rawLayout(like: T)` specifies the type's size and alignment should be
-  equal to the type `T`'s.
-- `@_rawLayout(likeArrayOf: T, count: N)` specifies the type's size should be
-  `MemoryLayout<T>.stride * N` and alignment should match `T`'s, like an
-  array of N contiguous elements of `T` in memory.
-- `@_rawLayout(like: T, movesAsLike)` specifies the type's size and alignment
-  should be equal to the type `T`'s. It also guarantees that moving a value of
-  this raw layout type will have the same move semantics as the type it's like.
-  This is important for things like ObjC weak references and non-trivial move
+- `@_rawLayout(like: T(, movesAsLike))` specifies the type's size and alignment
+  should be equal to the type `T`'s. An optional `movesAsLike` parameter can be
+  passed to guarantee that moving a value of this raw layout type will have the
+  same move semantics as the type it's like. This is important for things like
+  ObjC weak references and non-trivial move constructors in C++.
+- `@_rawLayout(likeArrayOf: T, count: N(, movesAsLike))` specifies the type's
+  size should be `MemoryLayout<T>.stride * N` and alignment should match `T`'s,
+  like an array of N contiguous elements of `T` in memory. An optional
+  `movesAsLike` parameter can be passed to guarantee that moving a value of this
+  raw layout type will have the same move semantics as the type it's like. This
+  is important for things like ObjC weak references and non-trivial move
   constructors in C++.
 
 A notable difference between `@_rawLayout(like: T)` and

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2553,11 +2553,12 @@ public:
         MovesAsLike(movesAsLike) {}
 
   /// Construct a `@_rawLayout(likeArrayOf: T, count: N)` attribute.
-  RawLayoutAttr(TypeRepr *LikeType, unsigned Count, SourceLoc AtLoc,
-                SourceRange Range)
+  RawLayoutAttr(TypeRepr *LikeType, unsigned Count, bool movesAsLike,
+                SourceLoc AtLoc, SourceRange Range)
       : DeclAttribute(DeclAttrKind::RawLayout, AtLoc, Range,
                       /*implicit*/ false),
-        LikeType(LikeType), SizeOrCount(Count), Alignment(0) {}
+        LikeType(LikeType), SizeOrCount(Count), Alignment(0),
+        MovesAsLike(movesAsLike) {}
 
   /// Construct a `@_rawLayout(size: N, alignment: M)` attribute.
   RawLayoutAttr(unsigned Size, unsigned Alignment, SourceLoc AtLoc,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4039,6 +4039,15 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         return makeParserSuccess();
       }
       
+      bool movesAsLike = false;
+
+      // @_rawLayout(likeArrayOf: T, count: N, movesAsLike)
+      if (consumeIf(tok::comma) && Tok.isAny(tok::identifier) &&
+          !parseSpecificIdentifier("movesAsLike",
+            diag::attr_rawlayout_expected_label, "movesAsLike")) {
+        movesAsLike = true;
+      }
+
       SourceLoc rParenLoc;
       if (!consumeIf(tok::r_paren, rParenLoc)) {
         diagnose(Tok.getLoc(), diag::attr_expected_rparen,
@@ -4046,7 +4055,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         return makeParserSuccess();
       }
       
-      attr = new (Context) RawLayoutAttr(likeType.get(), count,
+      attr = new (Context) RawLayoutAttr(likeType.get(), count, movesAsLike,
                                          AtLoc, SourceRange(Loc, rParenLoc));
     } else {
       diagnose(Loc, diag::attr_rawlayout_expected_label,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6354,7 +6354,7 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
                                            SourceRange());
             break;
           } else {
-            Attr = new (ctx) RawLayoutAttr(typeRepr, rawSize,
+            Attr = new (ctx) RawLayoutAttr(typeRepr, rawSize, movesAsLike,
                                            SourceLoc(),
                                            SourceRange());
             break;

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -190,6 +190,50 @@ struct ConcreteIntMoveAsLike: ~Copyable {
   let cell: CellThatMovesAsLike<Int32>
 }
 
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}25SmallVectorOf2MovesAsLikeVWV" = {{.*}} %swift.vwtable
+// initializeWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout25SmallVectorOf2MovesAsLikeVwtk
+// assignWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout25SmallVectorOf2MovesAsLikeVwta
+// size
+// CHECK-SAME:  , {{i64|i32}} 0
+// stride
+// CHECK-SAME:  , {{i64|i32}} 0
+// flags: alignment 0, incomplete
+// CHECK-SAME:  , <i32 0x400000>
+@_rawLayout(likeArrayOf: T, count: 2, movesAsLike)
+struct SmallVectorOf2MovesAsLike<T: ~Copyable>: ~Copyable {}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}30ConcreteSmallVectorMovesAsLikeVWV" = {{.*}} %swift.vwtable
+// initializeWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout30ConcreteSmallVectorMovesAsLikeVwtk
+// assignWithTake
+// CHECK-SAME:  , ptr @"$s10raw_layout30ConcreteSmallVectorMovesAsLikeVwta
+// size
+// CHECK-SAME:  , {{i64|i32}} 2
+// stride
+// CHECK-SAME:  , {{i64|i32}} 2
+// flags: not copyable, not bitwise takable, not pod, not inline
+// CHECK-SAME:  , <i32 0x930000>
+struct ConcreteSmallVectorMovesAsLike: ~Copyable {
+  let vector: SmallVectorOf2MovesAsLike<NonBitwiseTakableCXXType>
+}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}33ConcreteSmallVectorIntMovesAsLikeVWV" = {{.*}} %swift.vwtable
+// initializeWithTake
+// CHECK-SAME:  , ptr @__swift_memcpy8_4
+// assignWithTake
+// CHECK-SAME:  , ptr @__swift_memcpy8_4
+// size
+// CHECK-SAME:  , {{i64|i32}} 8
+// stride
+// CHECK-SAME:  , {{i64|i32}} 8
+// flags: alignment 3, not copyable
+// CHECK-SAME:  , <i32 0x800003>
+struct ConcreteSmallVectorIntMovesAsLike: ~Copyable {
+  let vector: SmallVectorOf2MovesAsLike<Int32>
+}
+
 sil @use_lock : $@convention(thin) (@in_guaranteed Lock) -> () {
 entry(%L: $*Lock):
     return undef : $()
@@ -217,7 +261,9 @@ entry(%0 : $*Cell<T>):
     return %2 : $UnsafeMutablePointer<T>
 }
 
-// Dependent layout metadata initialization:
+//===----------------------------------------------------------------------===//
+// Dependent layout metadata initialization
+//===----------------------------------------------------------------------===//
 
 // Cell<T>
 
@@ -241,32 +287,133 @@ entry(%0 : $*Cell<T>):
 // CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}14SmallVectorBufVMr"(ptr %"SmallVectorBuf<T>", ptr {{.*}}, ptr {{.*}})
 // CHECK: call void @swift_initRawStructMetadata(ptr %"SmallVectorBuf<T>", {{i64|i32}} 0, ptr {{%.*}}, {{i64|i32}} 8)
 
+//===----------------------------------------------------------------------===//
 // Ensure that 'movesAsLike' is correctly calling the underlying type's move constructor
+//===----------------------------------------------------------------------===//
 
+//===----------------------------------------------------------------------===//
 // CellThatMovesAsLike<T> initializeWithTake
+//===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout19CellThatMovesAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %"CellThatMovesAsLike<T>")
 // CHECK: [[T_ADDR:%.*]] = getelementptr inbounds ptr, ptr %"CellThatMovesAsLike<T>", {{i64|i32}} 2
 // CHECK-NEXT: [[T:%.*]] = load ptr, ptr [[T_ADDR]]
 // CHECK: {{%.*}} = call ptr %InitializeWithTake(ptr {{.*}} %dest, ptr {{.*}} %src, ptr [[T]])
 
+//===----------------------------------------------------------------------===//
 // CellThatMovesAsLike<T> assignWithTake
+//===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout19CellThatMovesAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %"CellThatMovesAsLike<T>")
 // CHECK: [[T_ADDR:%.*]] = getelementptr inbounds ptr, ptr %"CellThatMovesAsLike<T>", {{i64|i32}} 2
 // CHECK-NEXT: [[T:%.*]] = load ptr, ptr [[T_ADDR]]
 // CHECK: {{%.*}} = call ptr %AssignWithTake(ptr {{.*}} %dest, ptr {{.*}} %src, ptr [[T]])
 
+//===----------------------------------------------------------------------===//
 // ConcreteMoveAsLike initializeWithTake
+//===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
 // CHECK: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
 
+// Make sure we call destroy on src
+// CHECK: call ptr @{{.*}}(ptr [[SRC_CELL]])
+
+//===----------------------------------------------------------------------===//
 // ConcreteMoveAsLike assignWithTake
+//===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
+
+// Make sure we call destroy on dest
+// CHECK: call ptr @{{.*}}(ptr [[DEST_CELL]])
 // CHECK: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
+
+// Make sure we call destroy on src
+// CHECK: call ptr @{{.*}}(ptr [[SRC_CELL]])
+
+//===----------------------------------------------------------------------===//
+// SmallVectorOf2MovesAsLike<T> initializeWithTake
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout25SmallVectorOf2MovesAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %"SmallVectorOf2MovesAsLike<T>")
+// CHECK: [[T_ADDR:%.*]] = getelementptr inbounds ptr, ptr %"SmallVectorOf2MovesAsLike<T>", {{i64|i32}} 2
+// CHECK-NEXT: [[T:%.*]] = load ptr, ptr [[T_ADDR]]
+// CHECK: [[STRIDE_GEP:%.*]] = getelementptr inbounds %swift.vwtable, ptr {{%.*}}, i32 0, i32 9
+// CHECK-NEXT: [[STRIDE:%.*]] = load {{i64|i32}}, ptr [[STRIDE_GEP]]
+// CHECK: [[OFFSET_0:%.*]] = mul i64 0, [[STRIDE]]
+// CHECK-NEXT: [[SRC_ELT_0:%.*]] = getelementptr inbounds i8, ptr %src, {{i64|i32}} [[OFFSET_0]]
+// CHECK-NEXT: [[DEST_ELT_0:%.*]] = getelementptr inbounds i8, ptr %dest, {{i64|i32}} [[OFFSET_0]]
+// CHECK: {{%.*}} = call ptr %InitializeWithTake(ptr {{.*}} [[DEST_ELT_0]], ptr {{.*}} [[SRC_ELT_0]], ptr [[T]])
+// CHECK: [[OFFSET_1:%.*]] = mul i64 1, [[STRIDE]]
+// CHECK-NEXT: [[SRC_ELT_1:%.*]] = getelementptr inbounds i8, ptr %src, {{i64|i32}} [[OFFSET_1]]
+// CHECK-NEXT: [[DEST_ELT_1:%.*]] = getelementptr inbounds i8, ptr %dest, {{i64|i32}} [[OFFSET_1]]
+// CHECK: {{%.*}} = call ptr %InitializeWithTake(ptr {{.*}} [[DEST_ELT_1]], ptr {{.*}} [[SRC_ELT_1]], ptr [[T]])
+
+//===----------------------------------------------------------------------===//
+// SmallVectorOf2MovesAsLike<T> assignWithTake
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout25SmallVectorOf2MovesAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %"SmallVectorOf2MovesAsLike<T>")
+// CHECK: [[T_ADDR:%.*]] = getelementptr inbounds ptr, ptr %"SmallVectorOf2MovesAsLike<T>", {{i64|i32}} 2
+// CHECK-NEXT: [[T:%.*]] = load ptr, ptr [[T_ADDR]]
+// CHECK: [[STRIDE_GEP:%.*]] = getelementptr inbounds %swift.vwtable, ptr {{%.*}}, i32 0, i32 9
+// CHECK-NEXT: [[STRIDE:%.*]] = load {{i64|i32}}, ptr [[STRIDE_GEP]]
+// CHECK: [[OFFSET_0:%.*]] = mul i64 0, [[STRIDE]]
+// CHECK-NEXT: [[SRC_ELT_0:%.*]] = getelementptr inbounds i8, ptr %src, {{i64|i32}} [[OFFSET_0]]
+// CHECK-NEXT: [[DEST_ELT_0:%.*]] = getelementptr inbounds i8, ptr %dest, {{i64|i32}} [[OFFSET_0]]
+// CHECK: {{%.*}} = call ptr %AssignWithTake(ptr {{.*}} [[DEST_ELT_0]], ptr {{.*}} [[SRC_ELT_0]], ptr [[T]])
+// CHECK: [[OFFSET_1:%.*]] = mul i64 1, [[STRIDE]]
+// CHECK-NEXT: [[SRC_ELT_1:%.*]] = getelementptr inbounds i8, ptr %src, {{i64|i32}} [[OFFSET_1]]
+// CHECK-NEXT: [[DEST_ELT_1:%.*]] = getelementptr inbounds i8, ptr %dest, {{i64|i32}} [[OFFSET_1]]
+// CHECK: {{%.*}} = call ptr %AssignWithTake(ptr {{.*}} [[DEST_ELT_1]], ptr {{.*}} [[SRC_ELT_1]], ptr [[T]])
+
+//===----------------------------------------------------------------------===//
+// ConcreteSmallVectorMovesAsLike initializeWithTake
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout30ConcreteSmallVectorMovesAsLikeVwtk"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteSmallVectorMovesAsLike)
+// CHECK: [[DEST_VECTOR:%.*]] = getelementptr inbounds %T10raw_layout30ConcreteSmallVectorMovesAsLikeV, ptr %dest, i32 0, i32 0
+// CHECK: [[SRC_VECTOR:%.*]] = getelementptr inbounds %T10raw_layout30ConcreteSmallVectorMovesAsLikeV, ptr %src, i32 0, i32 0
+// CHECK: [[SRC_0:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[SRC_VECTOR]], {{i64|i32}} 0
+// CHECK-NEXT: [[DEST_0:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[DEST_VECTOR]], {{i64|i32}} 0
+// CHECK-NEXT: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_0]], ptr [[SRC_0]])
+
+// Make sure we call destroy on source[0]
+// CHECK: call ptr @{{.*}}(ptr [[SRC_0]])
+// CHECK: [[SRC_1:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[SRC_VECTOR]], {{i64|i32}} 1
+// CHECK-NEXT: [[DEST_1:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[DEST_VECTOR]], {{i64|i32}} 1
+// CHECK-NEXT: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_1]], ptr [[SRC_1]])
+
+// Make sure we call destroy on source[1]
+// CHECK: call ptr @{{.*}}(ptr [[SRC_1]])
+
+//===----------------------------------------------------------------------===//
+// ConcreteSmallVectorMovesAsLike assignWithTake
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout30ConcreteSmallVectorMovesAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteSmallVectorMovesAsLike)
+// CHECK: [[DEST_VECTOR:%.*]] = getelementptr inbounds %T10raw_layout30ConcreteSmallVectorMovesAsLikeV, ptr %dest, i32 0, i32 0
+// CHECK: [[SRC_VECTOR:%.*]] = getelementptr inbounds %T10raw_layout30ConcreteSmallVectorMovesAsLikeV, ptr %src, i32 0, i32 0
+// CHECK: [[SRC_0:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[SRC_VECTOR]], {{i64|i32}} 0
+// CHECK-NEXT: [[DEST_0:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[DEST_VECTOR]], {{i64|i32}} 0
+
+// Make sure we call destroy on dest[0]
+// CHECK-NEXT: call ptr @{{.*}}(ptr [[DEST_0]])
+// CHECK-NEXT: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_0]], ptr [[SRC_0]])
+
+// Make sure we call destroy on source[0]
+// CHECK: call ptr @{{.*}}(ptr [[SRC_0]])
+// CHECK: [[SRC_1:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[SRC_VECTOR]], {{i64|i32}} 1
+// CHECK-NEXT: [[DEST_1:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[DEST_VECTOR]], {{i64|i32}} 1
+
+// Make sure we call destroy on dest[1]
+// CHECK-NEXT: call ptr @{{.*}}(ptr [[DEST_1]])
+// CHECK-NEXT: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_1]], ptr [[SRC_1]])
+
+// Make sure we call destroy on source[1]
+// CHECK: call ptr @{{.*}}(ptr [[SRC_1]])

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -318,9 +318,6 @@ entry(%0 : $*Cell<T>):
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
 // CHECK: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
 
-// Make sure we call destroy on src
-// CHECK: call ptr @{{.*}}(ptr [[SRC_CELL]])
-
 //===----------------------------------------------------------------------===//
 // ConcreteMoveAsLike assignWithTake
 //===----------------------------------------------------------------------===//
@@ -328,13 +325,7 @@ entry(%0 : $*Cell<T>):
 // CHECK-LABEL: define {{.*}} ptr @"$s10raw_layout18ConcreteMoveAsLikeVwta"(ptr {{.*}} %dest, ptr {{.*}} %src, ptr %ConcreteMoveAsLike)
 // CHECK: [[DEST_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %dest, i32 0, i32 0
 // CHECK: [[SRC_CELL:%.*]] = getelementptr inbounds %T10raw_layout18ConcreteMoveAsLikeV, ptr %src, i32 0, i32 0
-
-// Make sure we call destroy on dest
-// CHECK: call ptr @{{.*}}(ptr [[DEST_CELL]])
 // CHECK: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_CELL]], ptr [[SRC_CELL]])
-
-// Make sure we call destroy on src
-// CHECK: call ptr @{{.*}}(ptr [[SRC_CELL]])
 
 //===----------------------------------------------------------------------===//
 // SmallVectorOf2MovesAsLike<T> initializeWithTake
@@ -382,15 +373,9 @@ entry(%0 : $*Cell<T>):
 // CHECK: [[SRC_0:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[SRC_VECTOR]], {{i64|i32}} 0
 // CHECK-NEXT: [[DEST_0:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[DEST_VECTOR]], {{i64|i32}} 0
 // CHECK-NEXT: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_0]], ptr [[SRC_0]])
-
-// Make sure we call destroy on source[0]
-// CHECK: call ptr @{{.*}}(ptr [[SRC_0]])
 // CHECK: [[SRC_1:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[SRC_VECTOR]], {{i64|i32}} 1
 // CHECK-NEXT: [[DEST_1:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[DEST_VECTOR]], {{i64|i32}} 1
 // CHECK-NEXT: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_1]], ptr [[SRC_1]])
-
-// Make sure we call destroy on source[1]
-// CHECK: call ptr @{{.*}}(ptr [[SRC_1]])
 
 //===----------------------------------------------------------------------===//
 // ConcreteSmallVectorMovesAsLike assignWithTake
@@ -401,19 +386,7 @@ entry(%0 : $*Cell<T>):
 // CHECK: [[SRC_VECTOR:%.*]] = getelementptr inbounds %T10raw_layout30ConcreteSmallVectorMovesAsLikeV, ptr %src, i32 0, i32 0
 // CHECK: [[SRC_0:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[SRC_VECTOR]], {{i64|i32}} 0
 // CHECK-NEXT: [[DEST_0:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[DEST_VECTOR]], {{i64|i32}} 0
-
-// Make sure we call destroy on dest[0]
-// CHECK-NEXT: call ptr @{{.*}}(ptr [[DEST_0]])
-// CHECK-NEXT: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_0]], ptr [[SRC_0]])
-
-// Make sure we call destroy on source[0]
-// CHECK: call ptr @{{.*}}(ptr [[SRC_0]])
+// CHECK: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_0]], ptr [[SRC_0]])
 // CHECK: [[SRC_1:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[SRC_VECTOR]], {{i64|i32}} 1
 // CHECK-NEXT: [[DEST_1:%.*]] = getelementptr inbounds %TSo24NonBitwiseTakableCXXTypeV, ptr [[DEST_VECTOR]], {{i64|i32}} 1
-
-// Make sure we call destroy on dest[1]
-// CHECK-NEXT: call ptr @{{.*}}(ptr [[DEST_1]])
-// CHECK-NEXT: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_1]], ptr [[SRC_1]])
-
-// Make sure we call destroy on source[1]
-// CHECK: call ptr @{{.*}}(ptr [[SRC_1]])
+// CHECK: {{invoke void|invoke ptr|call ptr}} @{{.*}}(ptr [[DEST_1]], ptr [[SRC_1]])


### PR DESCRIPTION
This is similar to https://github.com/swiftlang/swift/pull/73955, but for the `likeArrayOf` variant. Note that all elements within the array _must_ be initialized.