### PR TITLE
[ExplicitModule] Include `-Xcc -D` into module hash

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -517,8 +517,7 @@ public:
   std::string getClangModuleHash() const;
 
   /// Get clang import creation cc1 args for swift explicit module build.
-  std::vector<std::string>
-  getSwiftExplicitModuleDirectCC1Args(bool isInterface) const;
+  std::vector<std::string> getSwiftExplicitModuleDirectCC1Args() const;
 
   /// If we already imported a given decl successfully, return the corresponding
   /// Swift decl as an Optional<Decl *>, but if we previously tried and failed

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -729,7 +729,7 @@ namespace {
         "-working-directory=",
         "-working-directory"};
 
-  constexpr std::array<std::string_view, 16>
+  constexpr std::array<std::string_view, 15>
       knownClangDependencyIgnorablePrefiexes = {"-I",
                                                 "-F",
                                                 "-fmodule-map-file=",
@@ -744,8 +744,7 @@ namespace {
                                                 "-isystem",
                                                 "-isysroot",
                                                 "-working-directory=",
-                                                "-working-directory",
-                                                "-D"};
+                                                "-working-directory"};
 }
 
 std::vector<std::string> ClangImporterOptions::getRemappedExtraArgs(

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4079,7 +4079,7 @@ std::string ClangImporter::getClangModuleHash() const {
 }
 
 std::vector<std::string>
-ClangImporter::getSwiftExplicitModuleDirectCC1Args(bool isInterface) const {
+ClangImporter::getSwiftExplicitModuleDirectCC1Args() const {
   llvm::SmallVector<const char*> clangArgs;
   clangArgs.reserve(Impl.ClangArgs.size());
   llvm::for_each(Impl.ClangArgs, [&](const std::string &Arg) {
@@ -4128,14 +4128,6 @@ ClangImporter::getSwiftExplicitModuleDirectCC1Args(bool isInterface) const {
   auto &PPOpts = instance.getPreprocessorOpts();
   PPOpts.MacroIncludes.clear();
   PPOpts.Includes.clear();
-
-  // Clear specific options that will not affect swiftinterface compilation, but
-  // might affect main Module.
-  if (isInterface) {
-    // Interfacefile should not need `-D` but pass to main module in case it
-    // needs to directly import clang headers.
-    PPOpts.Macros.clear();
-  }
 
   if (Impl.SwiftContext.ClangImporterOpts.UseClangIncludeTree) {
     // FileSystemOptions.

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -383,8 +383,7 @@ ModuleDependencyScanner::getMainModuleDependencyInfo(ModuleDecl *mainModule) {
   std::vector<std::string> buildArgs;
   if (ScanASTContext.ClangImporterOpts.ClangImporterDirectCC1Scan) {
     buildArgs.push_back("-direct-clang-cc1-module-build");
-    for (auto &arg : clangImporter->getSwiftExplicitModuleDirectCC1Args(
-             /*isInterface=*/false)) {
+    for (auto &arg : clangImporter->getSwiftExplicitModuleDirectCC1Args()) {
       buildArgs.push_back("-Xcc");
       buildArgs.push_back(arg);
     }

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -186,8 +186,7 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
           Args.push_back("-direct-clang-cc1-module-build");
           auto *importer =
               static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
-          for (auto &Arg : importer->getSwiftExplicitModuleDirectCC1Args(
-                   /*isInterface=*/true)) {
+          for (auto &Arg : importer->getSwiftExplicitModuleDirectCC1Args()) {
             Args.push_back("-Xcc");
             Args.push_back(Arg);
           }

--- a/test/ScanDependencies/module_hash.swift
+++ b/test/ScanDependencies/module_hash.swift
@@ -18,14 +18,14 @@
 // RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-1.json Library modulePath > %t/path-1
 // RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-2.json Library modulePath > %t/path-2
 // RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-3.json Library modulePath > %t/path-3
-// RUN: diff %t/path-1 %t/path-2
+// RUN: not diff %t/path-1 %t/path-2
 // RUN: not diff %t/path-1 %t/path-3
 
 /// Check build command (exclude dependency module file path). 1 and 2 should match, but not 3.
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps-1.json Library | grep -v fmodule-file= > %t/lib-1.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps-2.json Library | grep -v fmodule-file= > %t/lib-2.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps-3.json Library | grep -v fmodule-file= > %t/lib-3.cmd
-// RUN: diff %t/lib-1.cmd %t/lib-2.cmd
+// RUN: not diff %t/lib-1.cmd %t/lib-2.cmd
 // RUN: not diff %t/lib-1.cmd %t/lib-3.cmd
 
 /// Test direct-cc1 mode.
@@ -42,12 +42,12 @@
 // RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-4.json Library modulePath > %t/path-4
 // RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-5.json Library modulePath > %t/path-5
 // RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-6.json Library modulePath > %t/path-6
-// RUN: diff %t/path-4 %t/path-5
+// RUN: not diff %t/path-4 %t/path-5
 // RUN: not diff %t/path-4 %t/path-6
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps-4.json Library | grep -v fmodule-file= > %t/lib-4.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps-5.json Library | grep -v fmodule-file= > %t/lib-5.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps-6.json Library | grep -v fmodule-file= > %t/lib-6.cmd
-// RUN: diff %t/lib-4.cmd %t/lib-5.cmd
+// RUN: not diff %t/lib-4.cmd %t/lib-5.cmd
 // RUN: not diff %t/lib-4.cmd %t/lib-6.cmd
 
 //--- main.swift


### PR DESCRIPTION
The decision to exclude `-Xcc -D` options from swift module hash actually doesn't help to solve the problem. It wouldn't reduce the module variants (or the number of swiftmodule build commands) because the command-line also encodes all the clang PCM dependencies that do get affected by `-Xcc` flags.

To avoid the false sharing and the nondeterministic build products, include most of the `-Xcc` flags, except include search path, into swift module hash.

rdar://132046247
