### PR TITLE
[6.0][Concurrency] Don't warn about re-stating inherited unavailable conformances to `Sendable`.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6186,7 +6186,11 @@ bool swift::checkSendableConformance(
     return false;
 
   // If this is an always-unavailable conformance, there's nothing to check.
-  if (auto ext = dyn_cast<ExtensionDecl>(conformanceDC)) {
+  // We always use the root conformance for this check, because inherited
+  // conformances need to walk back to the original declaration for the
+  // superclass conformance to find an unavailable attribute.
+  if (auto ext = dyn_cast<ExtensionDecl>(
+          conformance->getRootConformance()->getDeclContext())) {
     if (AvailableAttr::isUnavailable(ext))
       return false;
   }

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -380,6 +380,14 @@ final class C7<T>: Sendable { }
 
 class C9: Sendable { } // expected-warning{{non-final class 'C9' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
 
+@available(*, unavailable)
+extension HasUnavailableSendable : @unchecked Sendable { }
+
+class HasUnavailableSendable {
+}
+
+class NoRestated: HasUnavailableSendable {} // okay
+
 @globalActor
 struct SomeActor {
   static let shared = A1()


### PR DESCRIPTION
  - **Explanation**: The compiler warns on classes that inherit `@unchecked Sendable` conformances and don't re-state the conformance so that the programmer is aware that they're responsible for upholding the promises of `Sendable` without the compiler's help. This checking was completely skipped for inherited, unavailable `Sendable` conformances until https://github.com/swiftlang/swift/pull/75223. This exposed a bug where the unavailable check was not done on the root conformance, which lead to bogus warnings that subclasses must restate the `@unchecked Sendable` conformance:

    ```swift
    @available(*, unavailable)
    extension Foo : @unchecked Sendable { }

    class Foo {}

    class Bar: Foo {} // warning: class 'Bar' must restate inherited '@unchecked Sendable' conformance
    ```
  
    The fix is to look for unavailable attributes on the root conformance's decl context.
  - **Scope**: Only impacts inherited, unavailable conformances to `Sendable`.
  - **Issues**: rdar://132059160
  - **Original PRs**: https://github.com/swiftlang/swift/pull/75359
  - **Risk**: Low; this change effectively replaces a `conformance->getDeclContext()` argument with `conformance->getRootConformance()->getDeclContext()`, and the only effect is skipping warnings.
  - **Testing**: Added a new test exercising the lack of warning.
  - **Reviewers**: TBD