### PR TITLE
Platform: add UserEnv module to WinSDK

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -468,6 +468,12 @@ module WinSDK [system] {
     link "User32.Lib"
   }
 
+  module UserEnv {
+    header "UserEnv.h"
+    export *
+    link "UserEnv.Lib"
+  }
+
   module WER {
     header "WerApi.h"
     export *


### PR DESCRIPTION
This allows access to the `GetUserProfileDirectoryW` API which is required for the swift-foundation implementation on Windows.

(cherry picked from commit 5919346b32c286b132a3224c6e8f49e053170131)

**Explanation**: Add a new submodule for API access on Windows
**Scope**: This impacts only the WinSDK module, which is Windows specific.
**Issue**:
**Original PR**: #73008
**Risk**: If the WinSDK module is not tested, it could result in the module breaking which would make Swift nearly unusable on Windows.
**Testing**: CI testing which will build modules with WinSDK
**Reviewer**: @jmschonfeld