### PR TITLE
[stdlib][public][core] Fix indentation in `Array`

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -329,7 +329,7 @@ extension Array {
   @_effects(notEscaping self.**)
   public // @testable
   func _hoistableIsNativeTypeChecked() -> Bool {
-   return _buffer.arrayPropertyIsNativeTypeChecked
+    return _buffer.arrayPropertyIsNativeTypeChecked
   }
 
   @inlinable


### PR DESCRIPTION
Fix indentation from 1 space to 2 spaces.