### PR TITLE
[cxx-interop] Fix the printing of types with generic arguments

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -16,6 +16,7 @@
 #include "OutputLanguageMode.h"
 
 #include "swift/AST/Decl.h"
+#include "swift/AST/Module.h"
 #include "swift/AST/Type.h"
 // for OptionalTypeKind
 #include "swift/ClangImporter/ClangImporter.h"
@@ -116,6 +117,9 @@ public:
 
   void print(const Decl *D);
   void print(Type ty);
+
+  /// Prints the name of the type including generic arguments.
+  void printTypeName(raw_ostream &os, Type ty, const ModuleDecl *moduleContext);
 
   void printAvailability(raw_ostream &os, const Decl *D);
 

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1760,3 +1760,13 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::getTypeRepresentation(
   return typePrinter.visit(ty, OptionalTypeKind::OTK_None,
                            /*isInOutParam=*/false);
 }
+
+void DeclAndTypeClangFunctionPrinter::printTypeName(
+    Type ty, const ModuleDecl *moduleContext) {
+  CFunctionSignatureTypePrinterModifierDelegate delegate;
+  CFunctionSignatureTypePrinter typePrinter(
+      os, cPrologueOS, typeMapping, OutputLanguageMode::Cxx, interopContext,
+      delegate, moduleContext, declPrinter,
+      FunctionSignatureTypeUse::TypeReference);
+  typePrinter.visit(ty, std::nullopt, /*isInOut=*/false);
+}

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -170,6 +170,9 @@ public:
                         DeclAndTypePrinter &declPrinter,
                         const ModuleDecl *emittedModule, Type ty);
 
+  /// Prints the name of the type including generic arguments.
+  void printTypeName(Type ty, const ModuleDecl *moduleContext);
+
 private:
   void printCxxToCFunctionParameterUse(Type type, StringRef name,
                                        const ModuleDecl *moduleContext,

--- a/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.cpp
+++ b/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.cpp
@@ -52,6 +52,19 @@ int main() {
         assert(c.getX() == 5678);
     }
 
+    {
+      auto c = C::init(5);
+      auto arr = swift::Array<C>::init(c, 2);
+      auto f = F::b(arr);
+      assert(f.getB().getCount() == 2);
+    }
+
+    {
+      auto arr = swift::Array<swift::Int>::init(42, 2);
+      auto g = G<swift::Int>::b(arr);
+      assert(g.getB().getCount() == 2);
+    }
+
     assert(getRetainCount(c) == 1);
     return 0;
 }

--- a/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
@@ -29,6 +29,16 @@ extension E {
   }
 }
 
+public enum F {
+  case a(Int)
+  case b([C])
+}
+
+public enum G<T> {
+  case a(Int)
+  case b([T])
+}
+
 // CHECK:      SWIFT_INLINE_THUNK E E::_impl_c::operator()(const C& val) const {
 // CHECK-NEXT:   auto result = E::_make();
 // CHECK-NEXT:   auto op = swift::_impl::_impl_RefCountedClass::copyOpaquePointer(val);
@@ -47,3 +57,23 @@ extension E {
 
 // CHECK: SWIFT_INLINE_THUNK bool E::matchesIntValue(swift::Int value) const {
 // CHECK-NEXT: return _impl::$s5Enums1EO15matchesIntValueySbSiF(value, _impl::swift_interop_passDirect_Enums_uint64_t_0_8_uint8_t_8_9(_getOpaquePointer()));
+
+// CHECK: SWIFT_INLINE_THUNK swift::Array<C> F::getB() const {
+// CHECK-NEXT:    if (!isB()) abort();
+// CHECK-NEXT:    alignas(F) unsigned char buffer[sizeof(F)];
+// CHECK-NEXT:    auto *thisCopy = new(buffer) F(*this);
+// CHECK-NEXT:    char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:    return swift::_impl::implClassFor<swift::Array<C>>::type::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:      swift::_impl::implClassFor<swift::Array<C>>::type::initializeWithTake(result, payloadFromDestruction);
+// CHECK-NEXT:    });
+// CHECK-NEXT:  }
+
+// CHECK:   SWIFT_INLINE_THUNK swift::Array<T_0_0> G<T_0_0>::getB() const {
+// CHECK-NEXT:     if (!isB()) abort();
+// CHECK-NEXT:     alignas(G) unsigned char buffer[sizeof(G)];
+// CHECK-NEXT:     auto *thisCopy = new(buffer) G(*this);
+// CHECK-NEXT:     char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:     return swift::_impl::implClassFor<swift::Array<T_0_0>>::type::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:       swift::_impl::implClassFor<swift::Array<T_0_0>>::type::initializeWithTake(result, payloadFromDestruction);
+// CHECK-NEXT:     });
+// CHECK-NEXT:   }


### PR DESCRIPTION
Previously the code got the declaration for types with generic arguments and the printer used the declaration. This was a lossy operation, we printed the type with generic parameters instead of the arguments. This patch makes sure we print the type with the arguments. Unfortunately, the code structure is not the most clear, type printing is currently inherently part of the function signature printing. This code path needs to be factored out in the future to make the code easier to understand.

rdar://130679337
