### PR TITLE
[cxx-interop] Re-enable benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -209,11 +209,9 @@ set(SWIFT_BENCH_MODULES
     single-source/WordCount
     single-source/XorLoop
     cxx-source/CreateObjects
-    # Disabled for rdar://128520766
-    # cxx-source/CxxSetToCollection
+    cxx-source/CxxSetToCollection
     cxx-source/CxxStringConversion
-    # Disabled for rdar://128520766
-    # cxx-source/CxxVectorSum
+    cxx-source/CxxVectorSum
     # TODO: rdar://92120528
     # cxx-source/ReadAccessor
 )

--- a/benchmark/cxx-source/CxxSetToCollection.swift
+++ b/benchmark/cxx-source/CxxSetToCollection.swift
@@ -24,6 +24,7 @@ public let benchmarks = [BenchmarkInfo]()
 
 import CxxStdlibPerformance
 import Cxx
+import CxxStdlib // FIXME(rdar://128520766): this import should be redundant
 
 public let benchmarks = [
   BenchmarkInfo(

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -24,6 +24,7 @@ public let benchmarks = [BenchmarkInfo]()
 
 import CxxStdlibPerformance
 import Cxx
+import CxxStdlib // FIXME(rdar://128520766): this import should be redundant
 
 public let benchmarks = [
   BenchmarkInfo(


### PR DESCRIPTION
This adds an `import CxxStdlib` statement which fixes compilation. It should be redundant, but it works around a bug that got exposed by an change in explicit modules (rdar://128520766).

This will bring back the performance numbers while the underlying issue is being investigated.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
