### PR TITLE
[Runtime] Support type descriptor map in LibPrespecialized.

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -30,14 +30,24 @@ extern swift::once_t initializeToken;
 using string = const char *;
 
 // Declare backing variables.
-#define VARIABLE(name, type, defaultValue, help) extern type name ## _variable;
+#define VARIABLE(name, type, defaultValue, help)                               \
+  extern type name##_variable;                                                 \
+  extern bool name##_isSet_variable;
 #include "../../../stdlib/public/runtime/EnvironmentVariables.def"
 
-// Define getter functions.
+// Define getter functions. This creates one function with the same name as the
+// variable which returns the value set for that variable, and second function
+// ending in _isSet which returns a boolean indicating whether the variable was
+// set at all, to allow detecting when the variable was explicitly set to the
+// same value as the default.
 #define VARIABLE(name, type, defaultValue, help)                               \
   inline type name() {                                                         \
     swift::once(initializeToken, initialize, nullptr);                         \
     return name##_variable;                                                    \
+  }                                                                            \
+  inline bool name##_isSet() {                                                 \
+    swift::once(initializeToken, initialize, nullptr);                         \
+    return name##_isSet_variable;                                              \
   }
 #include "../../../stdlib/public/runtime/EnvironmentVariables.def"
 

--- a/include/swift/Runtime/LibPrespecialized.h
+++ b/include/swift/Runtime/LibPrespecialized.h
@@ -20,6 +20,7 @@
 #include "PrebuiltStringMap.h"
 #include "swift/ABI/Metadata.h"
 #include "swift/ABI/TargetLayout.h"
+#include "swift/Demangling/Demangler.h"
 
 #define LIB_PRESPECIALIZED_TOP_LEVEL_SYMBOL_NAME "_swift_prespecializationsData"
 
@@ -36,23 +37,44 @@ struct LibPrespecializedData {
 
   typename Runtime::StoredSize optionFlags;
 
+  TargetPointer<Runtime, const void> descriptorMap;
+
   // Existing fields are above, add new fields below this point.
 
+  // The major/minor version numbers for this version of the struct.
   static constexpr uint32_t currentMajorVersion = 1;
-  static constexpr uint32_t currentMinorVersion = 3;
+  static constexpr uint32_t currentMinorVersion = 4;
 
+  // Version numbers where various fields were introduced.
   static constexpr uint32_t minorVersionWithDisabledProcessesTable = 2;
   static constexpr uint32_t minorVersionWithPointerKeyedMetadataMap = 3;
   static constexpr uint32_t minorVersionWithOptionFlags = 3;
+  static constexpr uint32_t minorVersionWithDescriptorMap = 4;
 
   // Option flags values.
   enum : typename Runtime::StoredSize {
     // When this flag is set, the runtime should default to using the
     // pointer-keyed table. When not set, default to using the name-keyed table.
     OptionFlagDefaultToPointerKeyedMap = 1ULL << 0,
+
+    // When this flag is set, the runtime should default to using the descriptor
+    // map. When not set, default to turning off the descriptor map.
+    OptionFlagDescriptorMapDefaultOn = 1ULL << 1,
+
+    // When this flag is set, descriptorMap is not comprehensive, meaning that
+    // a negative lookup result is not a definitive failure.
+    OptionFlagDescriptorMapNotComprehensive = 1ULL << 2,
   };
 
-  // Helpers for retrieving the metadata map in-process.
+  // Helpers for safely retrieving various fields. Helpers return 0 or NULL if
+  // the version number indicates that the field is not present.
+
+  typename Runtime::StoredSize getOptionFlags() const {
+    if (minorVersion < minorVersionWithOptionFlags)
+      return 0;
+    return optionFlags;
+  }
+
   static bool stringIsNull(const char *str) { return str == nullptr; }
 
   using MetadataMap = PrebuiltStringMap<const char *, Metadata *, stringIsNull>;
@@ -73,17 +95,140 @@ struct LibPrespecializedData {
     return pointerKeyedMetadataMap;
   }
 
-  typename Runtime::StoredSize getOptionFlags() const {
-    if (minorVersion < minorVersionWithOptionFlags)
-      return 0;
-    return optionFlags;
+  using DescriptorMap =
+      PrebuiltAuxDataImplicitStringMap<TargetPointer<Runtime, const void>,
+                                       uint16_t>;
+
+  const DescriptorMap *getDescriptorMap() const {
+    if (minorVersion < minorVersionWithDescriptorMap)
+      return nullptr;
+    return reinterpret_cast<const DescriptorMap *>(descriptorMap);
   }
 };
 
+enum class LibPrespecializedLookupResult {
+  // We found something.
+  Found,
+
+  // We didn't find anything, and we know it's not in the shared cache.
+  DefinitiveNotFound,
+
+  // We didn't find anything, but we couldn't rule out the shared cache. Caller
+  // must do a full search.
+  NonDefinitiveNotFound,
+};
+
 const LibPrespecializedData<InProcess> *getLibPrespecializedData();
+
 Metadata *getLibPrespecializedMetadata(const TypeContextDescriptor *description,
                                        const void *const *arguments);
 void libPrespecializedImageLoaded();
+
+std::pair<LibPrespecializedLookupResult, const TypeContextDescriptor *>
+getLibPrespecializedTypeDescriptor(Demangle::NodePointer node);
+
+/// Given the demangling referring to a particular descriptor, build the
+/// canonical simplified version of the demangling that's used for the keys in
+/// the descriptorMap. We copy across Extension and Module nodes. Type nodes are
+/// all normalized to be OtherNominalType to allow for the runtime allowing
+/// type kind mismatches on imported C types in certain cases. Other nodes are
+/// skipped.
+///
+/// The runtime always searches through duplicates in the table, and uses its
+/// own matching on all candidates, so the simplified demangling is allowed to
+/// be simplified to the point of having different descriptors sometimes produce
+/// the same demangling.
+static inline Demangle::NodePointer
+buildSimplifiedDescriptorDemangling(Demangle::NodePointer node,
+                                    Demangle::Demangler &dem) {
+  // The node that will be returned to the caller.
+  Demangle::NodePointer result = nullptr;
+
+  // The bottommost node in the result that we've generated. Additional nodes
+  // are added as children to this one.
+  Demangle::NodePointer resultBottom = nullptr;
+
+  // The current node that we're iterating over in the input node tree.
+  Demangle::NodePointer current = node;
+
+  using Kind = Demangle::Node::Kind;
+
+  // Helper to add a new node to the result. This sets `result` to the node if
+  // it hasn't already been set (indicating this is the topmost node), and adds
+  // the node as a child to `resultBottom` otherwise. `resultBottom` is updated
+  // to point to the new node.
+  auto addNode = [&](Demangle::NodePointer newNode) {
+    if (!result) {
+      result = newNode;
+    } else {
+      if (resultBottom->getKind() == Kind::Extension) {
+        resultBottom->addChild(newNode, dem);
+      } else {
+        // Shift the Identifier down, insert before it.
+        resultBottom->addChild(resultBottom->getFirstChild(), dem);
+        resultBottom->replaceChild(0, newNode);
+      }
+    }
+    resultBottom = newNode;
+  };
+
+  // Walk down the input node tree.
+  while (current) {
+    switch (current->getKind()) {
+    case Kind::Extension: {
+      // Extensions are copied across. The new extension node has the module
+      // from the original, and the second child will be added as we traverse
+      // the next node in the tree.
+      auto copy = dem.createNode(Kind::Extension);
+      auto module = current->getChild(0);
+      if (module == nullptr || module->getKind() != Kind::Module)
+        return nullptr;
+      copy->addChild(module, dem);
+      addNode(copy);
+      current = current->getChild(1);
+      break;
+    }
+    case Kind::Module: {
+      // Module contents are always in the form we want, so we can incorporate
+      // this node verbatim and terminate the walk.
+      addNode(current);
+      current = nullptr;
+      break;
+    }
+    case Kind::Protocol: {
+      // Bring Protocol nodes across verbatim, there's no fuzzy matching.
+      addNode(current);
+      current = nullptr;
+      break;
+    }
+    case Kind::OpaqueType:
+    case Kind::Class:
+    case Kind::Structure:
+    case Kind::Enum:
+    case Kind::TypeAlias:
+    case Kind::OtherNominalType: {
+      // Type nodes are copied across with the kind always set to
+      // OtherNominalType.
+      auto copy = dem.createNode(Kind::OtherNominalType);
+      auto identifier = current->getChild(1);
+      if (identifier == nullptr || identifier->getKind() != Kind::Identifier)
+        return nullptr;
+      copy->addChild(identifier, dem);
+      addNode(copy);
+      current = current->getChild(0);
+      break;
+    }
+
+    default:
+      // If we don't know about this node, continue the walk with its first
+      // child.
+      current = current->getFirstChild();
+      break;
+    }
+  }
+
+  return result;
+}
 
 } // namespace swift
 

--- a/include/swift/Runtime/PrebuiltStringMap.h
+++ b/include/swift/Runtime/PrebuiltStringMap.h
@@ -17,44 +17,18 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <optional>
 
 namespace swift {
 
-/// A map that can be pre-built out of process. Uses a fixed hash function with
-/// no per-process seeding to ensure consistent hashes between builder and user.
-///
-/// The elements are tail allocated. `byteSize` can be used to calculate the
-/// amount of memory needed. The memory must be initialized with all string
-/// values set to null. StringTy is opaque for insertion, except for using the
-/// provided stringIsNull function to check for null values.
-template <typename StringTy, typename ElemTy, bool (*stringIsNull)(StringTy)>
-struct PrebuiltStringMap {
+struct PrebuiltStringMapBase {
   uint64_t arraySize;
-
-  struct ArrayElement {
-    StringTy key;
-    ElemTy value;
-  };
-
-  ArrayElement *array() {
-    uintptr_t start = (uintptr_t)(&arraySize + 1);
-    return (ArrayElement *)start;
-  }
-
-  const ArrayElement *array() const {
-    uintptr_t start = (uintptr_t)(&arraySize + 1);
-    return (ArrayElement *)start;
-  }
-
-  static size_t byteSize(uint64_t arraySize) {
-    return sizeof(PrebuiltStringMap) + sizeof(ArrayElement) * arraySize;
-  }
 
   /// Construct an empty map. Must be constructed in memory at least as large as
   /// byteSize(arraySize). The map can hold at most arraySize-1 values.
   /// Attempting to insert more than that will result in fatal errors when
   /// inserting or retrieving values.
-  PrebuiltStringMap(uint64_t arraySize) : arraySize(arraySize) {}
+  PrebuiltStringMapBase(uint64_t arraySize) : arraySize(arraySize) {}
 
   // Based on MurmurHash2
   uint64_t hash(const void *data, size_t len) const {
@@ -116,17 +90,17 @@ struct PrebuiltStringMap {
     return hash;
   }
 
-  /// Perform the search portion of an insertion operation. Returns a pointer to
-  /// the element where string is to be inserted. The caller is responsible for
-  /// initializing the element to contain the string/value. It is assumed that
-  /// the key does not already exist in the map. If it does exist, this will
-  /// insert a useless duplicate.
-  ArrayElement *insert(const void *string, size_t len) {
+  /// Search for a matching entry in the map. `isMatch` is called with a
+  /// candidate index and returns true if there is a match at that index.
+  template <typename IsMatch>
+  std::optional<size_t> findIndex(const void *string, size_t len,
+                                  const IsMatch &isMatch) const {
     uint64_t hashValue = hash(string, len);
+
     size_t index = hashValue % arraySize;
 
     size_t numSearched = 0;
-    while (!stringIsNull(array()[index].key)) {
+    while (!isMatch(index)) {
       index = index + 1;
       if (index >= arraySize)
         index = 0;
@@ -134,12 +108,58 @@ struct PrebuiltStringMap {
       numSearched++;
       if (numSearched > arraySize) {
         assert(false &&
-               "Could not find empty element in PrebuiltStringMap::insert");
-        return nullptr;
+               "Could not find match in PrebuiltStringMapBase::findIndex");
+        return std::nullopt;
       }
     }
 
-    return &array()[index];
+    return index;
+  }
+};
+
+/// A map that can be pre-built out of process. Uses a fixed hash function with
+/// no per-process seeding to ensure consistent hashes between builder and user.
+///
+/// The elements are tail allocated. `byteSize` can be used to calculate the
+/// amount of memory needed. The memory must be initialized with all string
+/// values set to null. StringTy is opaque for insertion, except for using the
+/// provided stringIsNull function to check for null values.
+template <typename StringTy, typename ElemTy, bool (*stringIsNull)(StringTy)>
+struct PrebuiltStringMap : PrebuiltStringMapBase {
+  PrebuiltStringMap(uint64_t arraySize) : PrebuiltStringMapBase(arraySize) {}
+
+  struct ArrayElement {
+    StringTy key;
+    ElemTy value;
+  };
+
+  ArrayElement *array() {
+    uintptr_t start = (uintptr_t)(&arraySize + 1);
+    return (ArrayElement *)start;
+  }
+
+  const ArrayElement *array() const {
+    uintptr_t start = (uintptr_t)(&arraySize + 1);
+    return (ArrayElement *)start;
+  }
+
+  static size_t byteSize(uint64_t arraySize) {
+    return sizeof(PrebuiltStringMapBase) + sizeof(ArrayElement) * arraySize;
+  }
+
+  /// Perform the search portion of an insertion operation. Returns a pointer to
+  /// the element where string is to be inserted. The caller is responsible for
+  /// initializing the element to contain the string/value. It is assumed that
+  /// the key does not already exist in the map. If it does exist, this will
+  /// insert a useless duplicate.
+  ArrayElement *insert(const void *string, size_t len) {
+    auto foundIndex = findIndex(string, len, [&](size_t index) {
+      return stringIsNull(array()[index].key);
+    });
+
+    if (foundIndex)
+      return &array()[*foundIndex];
+    return nullptr;
   }
 
   ArrayElement *insert(const char *string) {
@@ -154,32 +174,109 @@ struct PrebuiltStringMap {
   }
 
   const ArrayElement *find(const char *toFind, size_t len) const {
-    uint64_t hashValue = hash(toFind, len);
+    auto equalOrNull = [&](size_t index) {
+      auto key = array()[index].key;
 
-    size_t index = hashValue % arraySize;
+      // NULL is considered a "match" as we want to stop the search on NULL too.
+      if (stringIsNull(key))
+        return true;
 
-    size_t numSearched = 0;
-    while (const char *key = array()[index].key) {
       // key is NUL terminated but toFind may not be. Check that they have equal
       // contents up to len, and check that key has a terminating NUL at the
       // right point.
       if (strncmp(key, toFind, len) == 0 && key[len] == 0)
-        return &array()[index];
+        return true;
 
-      index = index + 1;
-      if (index >= arraySize)
-        index = 0;
+      // Not NULL, not equal, keep searching.
+      return false;
+    };
+    auto foundIndex = findIndex(toFind, len, equalOrNull);
+    if (!foundIndex)
+      return nullptr;
 
-      numSearched++;
-      if (numSearched > arraySize) {
-        assert(
-            false &&
-            "Could not find match or empty element in PrebuiltStringMap::find");
-        return nullptr;
-      }
-    }
+    const auto &elementPtr = &array()[*foundIndex];
 
-    return nullptr;
+    // If the "matching" element contains a NULL then we didn't find a match.
+    if (stringIsNull(elementPtr->key))
+      return nullptr;
+
+    return elementPtr;
+  }
+};
+
+/// A pre-built map with string-based keys that are implicit, i.e. equality can
+/// be determined by looking at the values. The map contains auxiliary data
+/// stored out of line from the main elements, to avoid padding when the aux
+/// data is smaller than the alignment of the main elements.
+template <typename ElemTy, typename AuxTy>
+struct PrebuiltAuxDataImplicitStringMap : PrebuiltStringMapBase {
+  PrebuiltAuxDataImplicitStringMap(uint64_t arraySize)
+      : PrebuiltStringMapBase(arraySize) {}
+
+  static size_t byteSize(uint64_t arraySize) {
+    return sizeof(PrebuiltStringMapBase) + sizeof(ElemTy) * arraySize +
+           sizeof(AuxTy) * arraySize;
+  }
+
+  using DataPointers = std::pair<ElemTy *, AuxTy *>;
+  using DataPointersConst = std::pair<const ElemTy *, const AuxTy *>;
+
+  const ElemTy *elements() const { return (const ElemTy *)(&arraySize + 1); }
+
+  ElemTy *elements() { return (ElemTy *)(&arraySize + 1); }
+
+  const AuxTy *aux() const { return (const AuxTy *)(elements() + arraySize); }
+
+  AuxTy *aux() { return (AuxTy *)(elements() + arraySize); }
+
+  DataPointersConst pointers(size_t index) const {
+    return {&elements()[index], &aux()[index]};
+  }
+
+  DataPointers pointers(size_t index) {
+    return {&elements()[index], &aux()[index]};
+  }
+
+  /// Perform the search portion of an insertion operation. Returns pointers to
+  /// the element and aux data where the value is to be inserted. The caller is
+  /// responsible for initializing the element and aux data. It is assumed that
+  /// the key does not already exist in the map. If it does exist, this will
+  /// insert a duplicate.
+  ///
+  /// isNull is a callable passed a pair of pointers to an element and
+  /// corresponding auxiliary data, and must return true if the element is
+  /// considered NULL (empty).
+  template <typename IsNull>
+  DataPointers insert(const char *string, const IsNull &isNull) {
+    auto foundIndex = findIndex(string, strlen(string), [&](size_t index) {
+      return isNull(pointers(index));
+    });
+    if (!foundIndex)
+      return {nullptr, nullptr};
+    return pointers(*foundIndex);
+  }
+
+  /// Look up the given key in the map.
+  ///
+  /// isMatch is a callable passed a pair of pointers to the element and
+  /// auxiliary data, and must return true if the elements they point to are a
+  /// match for what's being looked up.
+  ///
+  /// isNull must return true if the elements are NULL/empty, as with insert().
+  ///
+  /// The returned pointers point to the matched element and auxiliary data, if
+  /// a match was found. They point to a NULL entry if no map was found. They
+  /// will only be NULL if the table data was malformed and no match or NULL
+  /// exists in it.
+  template <typename IsMatch, typename IsNull>
+  DataPointersConst find(const char *toFind, size_t len, const IsMatch &isMatch,
+                         const IsNull &isNull) const {
+    auto foundIndex = findIndex(toFind, len, [&](size_t index) {
+      return isNull(pointers(index)) || isMatch(pointers(index));
+    });
+    if (!foundIndex)
+      return {nullptr, nullptr};
+    return pointers(*foundIndex);
   }
 };
 

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -161,8 +161,9 @@ void printHelp(const char *extra) {
 } // end anonymous namespace
 
 // Define backing variables.
-#define VARIABLE(name, type, defaultValue, help) \
-  type swift::runtime::environment::name ## _variable = defaultValue;
+#define VARIABLE(name, type, defaultValue, help)                               \
+  type swift::runtime::environment::name##_variable = defaultValue;            \
+  bool swift::runtime::environment::name##_isSet_variable = false;
 #include "EnvironmentVariables.def"
 
 // Initialization code.
@@ -194,6 +195,11 @@ void swift::runtime::environment::initialize(void *context) {
   // us to detect some spelling mistakes by warning on unknown SWIFT_ variables.
 
   bool SWIFT_DEBUG_HELP_variable = false;
+
+  // Placeholder variable, we never use the result but the macros want to write
+  // to it.
+  bool SWIFT_DEBUG_HELP_isSet_variable = false;
+  (void)SWIFT_DEBUG_HELP_isSet_variable; // Silence warnings about unused vars.
   for (char **var = ENVIRON; *var; var++) {
     // Immediately skip anything without a SWIFT_ prefix.
     if (strncmp(*var, "SWIFT_", 6) != 0)
@@ -204,12 +210,13 @@ void swift::runtime::environment::initialize(void *context) {
     // parsed by functions named parse_<type> above. An unknown type will
     // produce an error that parse_<unknown-type> doesn't exist. Add new parsers
     // above.
-#define VARIABLE(name, type, defaultValue, help)                       \
-    if (strncmp(*var, #name "=", strlen(#name "=")) == 0) {            \
-      name ## _variable =                                              \
-        parse_ ## type(#name, *var + strlen(#name "="), defaultValue); \
-      foundVariable = true;                                            \
-    }
+#define VARIABLE(name, type, defaultValue, help)                               \
+  if (strncmp(*var, #name "=", strlen(#name "=")) == 0) {                      \
+    name##_variable =                                                          \
+        parse_##type(#name, *var + strlen(#name "="), defaultValue);           \
+    name##_isSet_variable = true;                                              \
+    foundVariable = true;                                                      \
+  }
     // SWIFT_DEBUG_HELP is not in the variables list. Parse it like the other
     // variables.
     VARIABLE(SWIFT_DEBUG_HELP, bool, false, )
@@ -238,8 +245,13 @@ void swift::runtime::environment::initialize(void *context) {
 void swift::runtime::environment::initialize(void *context) {
   // Emit a getenv call for each variable. This is less efficient but works
   // everywhere.
-#define VARIABLE(name, type, defaultValue, help) \
-  name ## _variable = parse_ ## type(#name, getenv(#name), defaultValue);
+#define VARIABLE(name, type, defaultValue, help)                               \
+  do {                                                                         \
+    const char name##_string = getenv(#name);                                  \
+    if (name##_string)                                                         \
+      name##_isSet_variable = true;                                            \
+    name##_variable = parse_##type(#name, name##_string, defaultValue);        \
+  } while (0)
 #include "EnvironmentVariables.def"
 
   // Print help if requested.

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -78,8 +78,15 @@ VARIABLE(SWIFT_BINARY_COMPATIBILITY_VERSION, uint32_t, 0,
 VARIABLE(SWIFT_DEBUG_FAILED_TYPE_LOOKUP, bool, false,
          "Enable warnings when we fail to look up a type by name.")
 
-VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED, bool, true,
-         "Enable use of prespecializations library.")
+VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_METADATA, bool, true,
+         "Enable use of metadata in prespecializations library.")
+
+VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_DESCRIPTOR_LOOKUP, bool, true,
+         "Enable use of descriptor map in prespecializations library.")
+
+VARIABLE(SWIFT_DEBUG_VALIDATE_LIB_PRESPECIALIZED_DESCRIPTOR_LOOKUP, bool, false,
+         "Validate results from the prespecializations map descriptor map by "
+         "comparing to a full scan.")
 
 VARIABLE(SWIFT_DEBUG_LIB_PRESPECIALIZED_PATH, string, "",
          "A path to a prespecializations library to use at runtime. In order "


### PR DESCRIPTION
The descriptor map is keyed by a simplified mangling that canonicalizes the differences that we accept in _contextDescriptorMatchesMangling, such as the ability to specify any kind of type with an OtherNominalType node.

This simplified mangling is not necessarily unique, but we use _contextDescriptorMatchesMangling for the final equality checking when looking up entries in the map, so occasional collisions are acceptable and get resolved when probing the table.

The table is meant to be comprehensive, so it includes all descriptors that can be looked up by name, and a negative result means the descriptor does not exist in the shared cache. We add a flag to the options that can mark it as non-definitive in case we ever need to degrade this, and fall back to a full search after a negative result.

The map encompasses the entire shared cache but we need to reject lookups for types in images that aren't loaded. The map includes an image index which allows us to cheaply query whether a given descriptor is in a loaded image or not, so we can ignore ones which are not.

TypeMetadataPrivateState now has a separate sections array for sections within the shared cache. _searchTypeMetadataRecords consults the map first. If no result is found in the map and the map is marked as comprehensive, then only the sections outside the shared cache need to be scanned.

Replace the SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED environment variable with one specifically for metadata and one for descriptor lookup so they can be controlled independently. Also add SWIFT_DEBUG_VALIDATE_LIB_PRESPECIALIZED_DESCRIPTOR_LOOKUP which consults the map and does the full scan, and ensures they produce the same result, for debugging purposes.

Remove the disablePrespecializedMetadata global and instead modify the mapConfiguration to disable prespecialized metadata when an image is loaded that overrides one in the shared cache.

rdar://113059233