### PR TITLE
[IRGen] Properly extract values in visitThrowInst for empty error

### DIFF
--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -205,3 +205,14 @@ func mayThrowAsyncTiny(x: Bool) async throws(TinyError) -> Bool {
 func callsMayThrowAsyncTiny(x: Bool) async {
   _ = try! await mayThrowAsyncTiny(x: x)
 }
+
+struct EmptyError: Error {}
+
+@available(SwiftStdlib 6.0, *)
+func mayThrowEmptyErrorAsync(x: Bool) async throws(EmptyError) -> String? {
+  guard x else {
+    throw EmptyError()
+  }
+
+  return ""
+}


### PR DESCRIPTION
rdar://132122011

For async functions we have to extract the values, which was not happening when the error type was empty.