### PR TITLE
Tests: Drop maccatalyst_support requirement for several tests

### DIFF
--- a/test/Parse/ConditionalCompilation/macabiTargetEnv.swift
+++ b/test/Parse/ConditionalCompilation/macabiTargetEnv.swift
@@ -1,7 +1,7 @@
-// RUN: %swift -swift-version 4 -typecheck %s -verify -target x86_64-apple-ios12.0-macabi -parse-stdlib
-// RUN: %swift-ide-test -swift-version 4 -test-input-complete -source-filename=%s -target x86_64-apple-ios12.0-macabi
+// RUN: %swift -swift-version 4 -typecheck %s -verify -target %target-cpu-apple-ios12.0-macabi -parse-stdlib
+// RUN: %swift-ide-test -swift-version 4 -test-input-complete -source-filename=%s -target %target-cpu-apple-ios12.0-macabi
 
-// REQUIRES: maccatalyst_support
+// REQUIRES: OS=macosx || OS=maccatalyst
 
 #if targetEnvironment(macabi) // expected-warning {{'macabi' has been renamed to 'macCatalyst'}} {{23-29=macCatalyst}}
 func underMacABI() {

--- a/test/Sema/availability_refinement_contexts_target_min_inlining_maccatalyst.swift
+++ b/test/Sema/availability_refinement_contexts_target_min_inlining_maccatalyst.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -target %target-cpu-apple-ios14.4-macabi -typecheck -dump-type-refinement-contexts -target-min-inlining-version min %s > %t.dump 2>&1
 // RUN: %FileCheck --strict-whitespace %s < %t.dump
 
-// REQUIRES: maccatalyst_support
+// REQUIRES: OS=macosx || OS=maccatalyst
 
 // Verify that -target-min-inlining-version min implies 13.1 on macCatalyst.
 

--- a/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst_is_deprecated.swift
+++ b/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst_is_deprecated.swift
@@ -1,8 +1,8 @@
 // REQUIRES: maccatalyst_support
 
 // RUN: %empty-directory(%t.mod)
-// RUN: %swift -emit-module -target x86_64-apple-ios13.1-macabi -o %t.mod/availability.swiftmodule %s -parse-as-library -emit-module-doc-path %t.mod/availability.swiftdoc
-// RUN: %sourcekitd-test -req=doc-info -module availability -- -target x86_64-apple-ios13.1-macabi -I %t.mod | %FileCheck %s
+// RUN: %swift -emit-module -target %target-cpu-apple-ios13.1-macabi -o %t.mod/availability.swiftmodule %s -parse-as-library -emit-module-doc-path %t.mod/availability.swiftdoc
+// RUN: %sourcekitd-test -req=doc-info -module availability -- -target %target-cpu-apple-ios13.1-macabi -I %t.mod | %FileCheck %s
 
 @available(macCatalyst, deprecated: 20.0)
 public func deprecatedInFutureVersion_catalyst() {}

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -1,6 +1,6 @@
-// RUN: %swift -typecheck -verify -parse-stdlib -target x86_64-apple-ios51.0-macabi %s
+// RUN: %swift -typecheck -verify -parse-stdlib -target %target-cpu-apple-ios51.0-macabi %s
 
-// REQUIRES: maccatalyst_support
+// REQUIRES: OS=macosx || OS=maccatalyst
 
 @available(macCatalyst, introduced: 1.0, deprecated: 2.0, obsoleted: 9.0,
            message: "you don't want to do that anyway")


### PR DESCRIPTION
As much as possible, we should avoid using `REQUIRES: maccatalyst_support` since tests restricted this way are not run in PR tests. Many tests that exercise macCatalyst behaviors can be run in a macOS configuration, without full macCatalyst standard library support.

Also, adopt `%target-cpu` lit substitution where appropriate to avoid needless standard library module rebuilds when running tests locally.