### PR TITLE
Throws Prediction + HotColdSplitting

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -475,6 +475,9 @@ public:
 
   unsigned UseFragileResilientProtocolWitnesses : 1;
 
+  // Whether to run the HotColdSplitting pass when optimizing.
+  unsigned EnableHotColdSplit : 1;
+
   /// The number of threads for multi-threaded code generation.
   unsigned NumThreads = 0;
 
@@ -564,6 +567,7 @@ public:
         DisableReadonlyStaticObjects(false), CollocatedMetadataFunctions(false),
         ColocateTypeDescriptors(true), UseRelativeProtocolWitnessTables(false),
         UseFragileResilientProtocolWitnesses(false),
+        EnableHotColdSplit(false),
         CmdArgs(), SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All),
         PlatformCCallingConvention(llvm::CallingConv::C), UseCASBackend(false),

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -118,6 +118,10 @@ public:
   /// Controls whether to run async demotion pass.
   bool EnableAsyncDemotion = false;
 
+  /// Controls whether to always assume that functions rarely throw an Error
+  /// within the optimizer. This influences static branch prediction.
+  bool EnableThrowsPrediction = false;
+
   /// Should we run any SIL performance optimizations
   ///
   /// Useful when you want to enable -O LLVM opts but not -O SIL opts.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -540,6 +540,11 @@ def enable_spec_devirt : Flag<["-"], "enable-spec-devirt">,
 def enable_async_demotion : Flag<["-"], "enable-experimental-async-demotion">,
   HelpText<"Enables an optimization pass to demote async functions.">;
 
+def enable_throws_prediction : Flag<["-"], "enable-throws-prediction">,
+  HelpText<"Enables optimization assumption that functions rarely throw errors.">;
+def disable_throws_prediction : Flag<["-"], "disable-throws-prediction">,
+  HelpText<"Disables optimization assumption that functions rarely throw errors.">;
+
 def disable_access_control : Flag<["-"], "disable-access-control">,
   HelpText<"Don't respect access control restrictions">;
 def enable_access_control : Flag<["-"], "enable-access-control">,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1310,6 +1310,13 @@ def disable_fragile_resilient_protocol_witnesses :
   Flag<["-"], "disable-fragile-relative-protocol-tables">,
   HelpText<"Disable relative protocol witness tables">;
 
+def enable_split_cold_code :
+  Flag<["-"], "enable-split-cold-code">,
+  HelpText<"Enable splitting of cold code when optimizing">;
+def disable_split_cold_code :
+  Flag<["-"], "disable-split-cold-code">,
+  HelpText<"Disable splitting of cold code when optimizing">;
+
 def enable_new_llvm_pass_manager :
   Flag<["-"], "enable-new-llvm-pass-manager">,
   HelpText<"Enable the new llvm pass manager">;

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -555,10 +555,13 @@ public:
       ArrayRef<SILValue> args, SILBasicBlock *normalBB, SILBasicBlock *errorBB,
       ApplyOptions options = ApplyOptions(),
       const GenericSpecializationInformation *specializationInfo = nullptr,
-      std::optional<ApplyIsolationCrossing> isolationCrossing = std::nullopt) {
+      std::optional<ApplyIsolationCrossing> isolationCrossing = std::nullopt,
+      ProfileCounter normalCount = ProfileCounter(),
+      ProfileCounter errorCount = ProfileCounter()) {
     return insertTerminator(TryApplyInst::create(
         getSILDebugLocation(loc), callee, subs, args, normalBB, errorBB,
-        options, *F, specializationInfo, isolationCrossing));
+        options, *F, specializationInfo, isolationCrossing,
+        normalCount, errorCount));
   }
 
   PartialApplyInst *createPartialApply(

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -10968,7 +10968,8 @@ private:
 
 protected:
   TryApplyInstBase(SILInstructionKind valueKind, SILDebugLocation Loc,
-                   SILBasicBlock *normalBB, SILBasicBlock *errorBB);
+                   SILBasicBlock *normalBB, SILBasicBlock *errorBB,
+                   ProfileCounter normalCount, ProfileCounter errorCount);
 
 public:
   SuccessorListTy getSuccessors() {
@@ -10988,6 +10989,11 @@ public:
   const SILBasicBlock *getNormalBB() const { return DestBBs[NormalIdx]; }
   SILBasicBlock *getErrorBB() { return DestBBs[ErrorIdx]; }
   const SILBasicBlock *getErrorBB() const { return DestBBs[ErrorIdx]; }
+
+  /// The number of times the Normal branch was executed
+  ProfileCounter getNormalBBCount() const { return DestBBs[NormalIdx].getCount(); }
+  /// The number of times the Error branch was executed
+  ProfileCounter getErrorBBCount() const { return DestBBs[ErrorIdx].getCount(); }
 };
 
 /// TryApplyInst - Represents the full application of a function that
@@ -11005,7 +11011,9 @@ class TryApplyInst final
                SILBasicBlock *normalBB, SILBasicBlock *errorBB,
                ApplyOptions options,
                const GenericSpecializationInformation *specializationInfo,
-               std::optional<ApplyIsolationCrossing> isolationCrossing);
+               std::optional<ApplyIsolationCrossing> isolationCrossing,
+               ProfileCounter normalCount,
+               ProfileCounter errorCount);
 
   static TryApplyInst *
   create(SILDebugLocation debugLoc, SILValue callee,
@@ -11013,7 +11021,9 @@ class TryApplyInst final
          SILBasicBlock *normalBB, SILBasicBlock *errorBB, ApplyOptions options,
          SILFunction &parentFunction,
          const GenericSpecializationInformation *specializationInfo,
-         std::optional<ApplyIsolationCrossing> isolationCrossing);
+         std::optional<ApplyIsolationCrossing> isolationCrossing,
+         ProfileCounter normalCount,
+         ProfileCounter errorCount);
 };
 
 /// DifferentiableFunctionInst - creates a `@differentiable` function-typed

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -290,6 +290,10 @@ struct SILOptOptions {
                     llvm::cl::desc("Enables an optimization pass to demote async functions."));
 
   llvm::cl::opt<bool>
+  EnableThrowsPrediction = llvm::cl::opt<bool>("enable-throws-prediction",
+                     llvm::cl::desc("Enables optimization assumption that functions rarely throw errors."));
+
+  llvm::cl::opt<bool>
   EnableMoveInoutStackProtection = llvm::cl::opt<bool>("enable-move-inout-stack-protector",
                     llvm::cl::desc("Enable the stack protector by moving values to temporaries."));
 
@@ -847,6 +851,7 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
 
   SILOpts.EnableSpeculativeDevirtualization = options.EnableSpeculativeDevirtualization;
   SILOpts.EnableAsyncDemotion = options.EnableAsyncDemotion;
+  SILOpts.EnableThrowsPrediction = options.EnableThrowsPrediction;
   SILOpts.IgnoreAlwaysInline = options.IgnoreAlwaysInline;
   SILOpts.EnableOSSAModules = options.EnableOSSAModules;
   SILOpts.EnableSILOpaqueValues = options.EnableSILOpaqueValues;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3362,6 +3362,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Args.hasFlag(OPT_enable_fragile_resilient_protocol_witnesses,
                  OPT_disable_fragile_resilient_protocol_witnesses,
                  Opts.UseFragileResilientProtocolWitnesses);
+  Opts.EnableHotColdSplit =
+      Args.hasFlag(OPT_enable_split_cold_code,
+                   OPT_disable_split_cold_code,
+                   Opts.EnableHotColdSplit);
   Opts.EnableLargeLoadableTypesReg2Mem =
       Args.hasFlag(OPT_enable_large_loadable_types_reg2mem,
                    OPT_disable_large_loadable_types_reg2mem,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2597,6 +2597,9 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       OPT_enable_sil_opaque_values, OPT_disable_sil_opaque_values, false);
   Opts.EnableSpeculativeDevirtualization |= Args.hasArg(OPT_enable_spec_devirt);
   Opts.EnableAsyncDemotion |= Args.hasArg(OPT_enable_async_demotion);
+  Opts.EnableThrowsPrediction = Args.hasFlag(
+      OPT_enable_throws_prediction, OPT_disable_throws_prediction,
+      Opts.EnableThrowsPrediction);
   Opts.EnableActorDataRaceChecks |= Args.hasFlag(
       OPT_enable_actor_data_race_checks,
       OPT_disable_actor_data_race_checks, /*default=*/false);

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -357,6 +357,12 @@ void IRGenThunk::emit() {
     llvm::Value *nil = llvm::ConstantPointerNull::get(
         cast<llvm::PointerType>(errorValue->getType()));
     auto *hasError = IGF.Builder.CreateICmpNE(errorValue, nil);
+
+    // Predict no error is thrown.
+    hasError =
+        IGF.IGM.getSILModule().getOptions().EnableThrowsPrediction ?
+        IGF.Builder.CreateExpectCond(IGF.IGM, hasError, false) : hasError;
+
     IGF.Builder.CreateCondBr(hasError, errorBB, successBB);
 
     IGF.Builder.emitBlock(errorBB);

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -410,6 +410,11 @@ public:
                                name);
   }
 
+  // Creates an @llvm.expect.i1 call, where the value should be an i1 type.
+  llvm::CallInst *CreateExpectCond(IRGenModule &IGM,
+                                   llvm::Value *value,
+                                   bool expectedValue, const Twine &name = "");
+
   /// Call the trap intrinsic. If optimizations are enabled, an inline asm
   /// gadget is emitted before the trap. The gadget inhibits transforms which
   /// merge trap calls together, which makes debugging crashes easier.

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -211,6 +211,7 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
   bool RunSwiftSpecificLLVMOptzns =
       !Opts.DisableSwiftSpecificLLVMOptzns && !Opts.DisableLLVMOptzns;
 
+  bool DoHotColdSplit = false;
   PTO.CallGraphProfile = false;
 
   llvm::OptimizationLevel level = llvm::OptimizationLevel::O0;
@@ -221,6 +222,7 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
     PTO.LoopVectorization = true;
     PTO.SLPVectorization = true;
     PTO.MergeFunctions = true;
+    DoHotColdSplit = Opts.EnableHotColdSplit;
     level = llvm::OptimizationLevel::Os;
   } else {
     level = llvm::OptimizationLevel::O0;
@@ -258,6 +260,8 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
   PB.registerLoopAnalyses(LAM);
   PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
   ModulePassManager MPM;
+
+  PB.setEnableHotColdSplitting(DoHotColdSplit);
 
   if (RunSwiftSpecificLLVMOptzns) {
     PB.registerScalarOptimizerLateEPCallback(

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4636,6 +4636,12 @@ void IRGenSILFunction::visitYieldInst(swift::YieldInst *i) {
   // Branch to the appropriate destination.
   auto unwindBB = getLoweredBB(i->getUnwindBB()).bb;
   auto resumeBB = getLoweredBB(i->getResumeBB()).bb;
+
+  // Predict no unwind happens.
+  isUnwind =
+      IGM.getSILModule().getOptions().EnableThrowsPrediction ?
+      Builder.CreateExpectCond(IGM, isUnwind, false) : isUnwind;
+
   Builder.CreateCondBr(isUnwind, unwindBB, resumeBB);
 }
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1573,6 +1573,10 @@ public:
     visitApplyInstBase(AI);
     *this << ", normal " << Ctx.getID(AI->getNormalBB());
     *this << ", error " << Ctx.getID(AI->getErrorBB());
+    if (AI->getNormalBBCount())
+      *this << " !normal_count(" << AI->getNormalBBCount().getValue() << ")";
+    if (AI->getErrorBBCount())
+      *this << " !error_count(" << AI->getErrorBBCount().getValue() << ")";
   }
 
   void visitPartialApplyInst(PartialApplyInst *CI) {

--- a/test/IRGen/cold_split.swift
+++ b/test/IRGen/cold_split.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend %s -module-name=test -emit-assembly \
+// RUN:   -enable-throws-prediction -O -enable-split-cold-code \
+// RUN:       | %FileCheck --check-prefix CHECK-ENABLED %s
+
+//// Test disabling just the pass doesn't yield a split.
+// RUN: %target-swift-frontend %s -module-name=test -emit-assembly \
+// RUN:   -enable-throws-prediction -O -disable-split-cold-code \
+// RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
+
+//// Test disabling optimization entirely doesn't yield a split.
+// RUN: %target-swift-frontend %s -module-name=test -emit-assembly \
+// RUN:   -enable-throws-prediction -enable-split-cold-code \
+// RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
+
+
+// CHECK-ENABLED: cold
+
+// CHECK-DISABLED-NOT: cold
+
+enum MyError: Error { case err }
+
+func getRandom(_ b: Bool) throws -> Int {
+    if b {
+        return Int.random(in: 0..<1024)
+    } else {
+        throw MyError.err
+    }
+}
+
+public func numberWithLogging(_ b: Bool) -> Int {
+    do {
+        return try getRandom(b)
+    } catch {
+        print("Log: random number generator failed with b=\(b)")
+        return 1337
+    }
+}

--- a/test/SILOptimizer/throws_prediction.swift
+++ b/test/SILOptimizer/throws_prediction.swift
@@ -1,0 +1,122 @@
+// RUN: %target-swift-frontend %s \
+// RUN:   -disable-availability-checking \
+// RUN:   -enable-throws-prediction \
+// RUN:   -sil-verify-all -module-name=test -emit-sil \
+// RUN:       | %FileCheck --check-prefix CHECK-SIL %s
+
+// RUN: %target-swift-frontend %s \
+// RUN:   -disable-availability-checking \
+// RUN:   -enable-throws-prediction \
+// RUN:   -sil-verify-all -module-name=test -emit-irgen \
+// RUN:       | %FileCheck --check-prefix CHECK-IR %s
+
+// RUN: %target-swift-frontend %s \
+// RUN:   -disable-availability-checking \
+// RUN:   -disable-throws-prediction \
+// RUN:   -sil-verify-all -module-name=test -emit-sil \
+// RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
+
+// CHECK-DISABLED-NOT: normal_count
+
+enum MyError: Error { case err }
+
+func throwy1() throws {}
+func throwy2() throws(MyError) { }
+func throwy3() async throws -> Int { 0 }
+func throwy4() async throws(MyError) -> Int { 1 }
+
+// CHECK-SIL-LABEL: sil hidden @$s4test0A13TryPredictionyySbF
+// CHECK-SIL: try_apply {{.*}} @error any Error{{.*}} !normal_count(1999) !error_count(0)
+// CHECK-SIL: try_apply {{.*}} @error MyError{{.*}} !normal_count(1999) !error_count(0)
+
+// CHECK-IR-LABEL: define hidden swiftcc void @"$s4test0A13TryPredictionyySbF"
+// CHECK-IR:   call swiftcc void @"$s4test7throwy1yyKF"
+// CHECK-IR:   [[ERROR_PTR:%.*]] = load ptr, ptr %swifterror
+// CHECK-IR:   [[HAVE_ERROR:%.*]] = icmp ne ptr [[ERROR_PTR]], null
+// CHECK-IR:   br i1 [[HAVE_ERROR]], {{.*}} !prof [[PREFER_FALSE:![0-9]+]]
+
+// CHECK-IR:   call swiftcc void @"$s4test7throwy2yyAA7MyErrorOYKF"
+// CHECK-IR:   [[ERROR_PTR:%.*]] = load ptr, ptr %swifterror
+// CHECK-IR:   [[HAVE_ERROR:%.*]] = icmp ne ptr [[ERROR_PTR]], null
+// CHECK-IR:   br i1 [[HAVE_ERROR]], {{.*}} !prof [[PREFER_FALSE:![0-9]+]]
+func testTryPrediction(_ b: Bool) {
+  do {
+    try throwy1()
+    try throwy2()
+  } catch {
+    print("hi")
+  }
+}
+
+// CHECK-SIL-LABEL: sil hidden @$s4test0A21AsyncThrowsPredictionSiyYaF
+// CHECK-SIL: function_ref @$s4test7throwy3SiyYaKF
+// CHECK-SIL: try_apply {{.*}} @error any Error{{.*}} !normal_count(1999) !error_count(0)
+
+// CHECK-IR-LABEL: define hidden swifttailcc void @"$s4test0A21AsyncThrowsPredictionSiyYaF"
+// CHECK-IR:   [[ERROR_PTR:%.*]] = load ptr, ptr %swifterror
+// CHECK-IR:   [[HAVE_ERROR:%.*]] = icmp ne ptr [[ERROR_PTR]], null
+// CHECK-IR:   br i1 [[HAVE_ERROR]], {{.*}} !prof [[PREFER_FALSE:![0-9]+]]
+func testAsyncThrowsPrediction() async -> Int {
+    if let x = try? await throwy3() {
+        return x
+    }
+    return 1337
+}
+
+// CHECK-SIL-LABEL: sil hidden @$s4test0A28Async_TYPED_ThrowsPredictionSiyYaAA7MyErrorOYKF
+// CHECK-SIL: try_apply {{.*}} @error MyError{{.*}} !normal_count(1999) !error_count(0)
+// CHECK-SIL: try_apply {{.*}} @error MyError{{.*}} !normal_count(1999) !error_count(0)
+// CHECK-SIL: try_apply {{.*}} @error MyError{{.*}} !normal_count(1999) !error_count(0)
+
+// CHECK-IR-LABEL: define hidden swifttailcc void @"$s4test0A28Async_TYPED_ThrowsPredictionSiyYaAA7MyErrorOYKF"
+// CHECK-IR:   [[ERROR_PTR:%.*]] = load ptr, ptr %swifterror
+// CHECK-IR:   [[HAVE_ERROR:%.*]] = icmp ne ptr [[ERROR_PTR]], null
+// CHECK-IR:   br i1 [[HAVE_ERROR]], {{.*}} !prof [[PREFER_FALSE:![0-9]+]]
+//
+// CHECK-IR:   [[ERROR_PTR:%.*]] = load ptr, ptr %swifterror
+// CHECK-IR:   [[HAVE_ERROR:%.*]] = icmp ne ptr [[ERROR_PTR]], null
+// CHECK-IR:   br i1 [[HAVE_ERROR]], {{.*}} !prof [[PREFER_FALSE:![0-9]+]]
+//
+// CHECK-IR:   [[ERROR_PTR:%.*]] = load ptr, ptr %swifterror
+// CHECK-IR:   [[HAVE_ERROR:%.*]] = icmp ne ptr [[ERROR_PTR]], null
+// CHECK-IR:   br i1 [[HAVE_ERROR]], {{.*}} !prof [[PREFER_FALSE:![0-9]+]]
+func testAsync_TYPED_ThrowsPrediction() async throws(MyError) -> Int {
+    let x = try await throwy4()
+    let y = try await throwy4()
+    let z = try await throwy4()
+    return x + y + z
+}
+
+
+func getRandom(_ b: Bool) throws -> Int {
+    if b {
+        return Int.random(in: 0..<1024)
+    } else {
+        throw MyError.err
+    }
+}
+
+// CHECK-SIL-LABEL: sil hidden @$s4test20sequenceOfNormalTrysySiSb_S2btKF
+// CHECK-SIL: try_apply {{.*}} @error any Error{{.*}} !normal_count(1999) !error_count(0)
+// CHECK-SIL: try_apply {{.*}} @error any Error{{.*}} !normal_count(1999) !error_count(0)
+// CHECK-SIL: try_apply {{.*}} @error any Error{{.*}} !normal_count(1999) !error_count(0)
+
+// CHECK-IR-LABEL: define hidden swiftcc i64 @"$s4test20sequenceOfNormalTrysySiSb_S2btKF"
+// CHECK-IR:   [[HAVE_ERROR:%.*]] = icmp ne ptr {{%.*}}, null
+// CHECK-IR:   br i1 [[HAVE_ERROR]], {{.*}} !prof [[PREFER_FALSE:![0-9]+]]
+//
+// CHECK-IR:   [[HAVE_ERROR:%.*]] = icmp ne ptr {{%.*}}, null
+// CHECK-IR:   br i1 [[HAVE_ERROR]], {{.*}} !prof [[PREFER_FALSE:![0-9]+]]
+//
+// CHECK-IR:   [[HAVE_ERROR:%.*]] = icmp ne ptr {{%.*}}, null
+// CHECK-IR:   br i1 [[HAVE_ERROR]], {{.*}} !prof [[PREFER_FALSE:![0-9]+]]
+func sequenceOfNormalTrys(_ b1: Bool,
+                          _ b2: Bool,
+                          _ b3: Bool) throws -> Int {
+    let x = try getRandom(b1)
+    let y = try getRandom(b2)
+    let z = try getRandom(b3)
+    return x + y + z
+}
+
+// CHECK-IR: [[PREFER_FALSE]] = !{!"branch_weights", i32 1, i32 2000}


### PR DESCRIPTION
It's reasonable to statically assume that errors are not typically thrown by functions. By making this assumption, we can annotate blocks of code dealing with errors as cold in LLVM. This aids in block layout among other things.