### PR TITLE
[stdlib] Correct documentation formatting in CompilerProtocols

### DIFF
--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -117,7 +117,7 @@ public protocol RawRepresentable<RawValue> {
   ///     }
   ///
   ///     print(PaperSize(rawValue: "Legal"))
-  ///     // Prints "Optional("PaperSize.Legal")"
+  ///     // Prints "Optional(PaperSize.Legal)"
   ///
   ///     print(PaperSize(rawValue: "Tabloid"))
   ///     // Prints "nil"
@@ -658,7 +658,7 @@ public protocol ExpressibleByArrayLiteral {
 ///
 ///     let countryCodes = ["BR": "Brazil", "GH": "Ghana",
 ///                         "JP": "Japan", "US": "United States"]
-///     // 'countryCodes' has type [String: String]
+///     // 'countryCodes' has type '[String: String]'
 ///
 ///     print(countryCodes["BR"]!)
 ///     // Prints "Brazil"


### PR DESCRIPTION
Hi. I corrected some doc formatting in the `stdlib > CompilerProtocols.swift` file.
Please check out the changes. Thanks!

cc. @amartini51