### PR TITLE
Remove duplicate sccache flag

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -264,7 +264,7 @@ Build the toolchain with optimizations, debuginfo, and assertions, using Ninja:
   ```sh
   utils/build-script --skip-build-benchmarks \
     --swift-darwin-supported-archs "$(uname -m)" \
-    --sccache --release-debuginfo --swift-disable-dead-stripping \
+    --release-debuginfo --swift-disable-dead-stripping \
     --bootstrapping=hosttools
   ```
 - Linux:


### PR DESCRIPTION
Hello!

I'm trying to build the compiler, following along with the Getting Started guide. I noticed that the guide specifically suggests adding the `--sccache` flag if needed, but it is included in the example invocation.

> If you installed and want to use Sccache, add --sccache to the invocation.

I *seems* like the intention here was to omit it, and explain how to include it if desired.