### PR TITLE
[cxx-interop] Add one more test for `std::function`

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/std-function.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-function.h
@@ -5,7 +5,8 @@
 #include <string>
 
 using FunctionIntToInt = std::function<int(int)>;
-using FunctionStringToString = std::function<std::string(const std::string&)>;
+using FunctionStringToString = std::function<std::string(std::string)>;
+using FunctionStringToStringConstRef = std::function<std::string(const std::string&)>;
 
 inline FunctionIntToInt getIdentityFunction() {
   return [](int x) { return x; };
@@ -16,6 +17,10 @@ inline bool isEmptyFunction(FunctionIntToInt f) { return !(bool)f; }
 inline int invokeFunction(FunctionIntToInt f, int x) { return f(x); }
 
 std::string invokeFunctionTwice(FunctionStringToString f, std::string s) {
+  return f(f(s));
+}
+
+std::string invokeFunctionTwiceConstRef(FunctionStringToStringConstRef f, std::string s) {
   return f(f(s));
 }
 

--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -57,10 +57,16 @@ StdFunctionTestSuite.test("FunctionIntToInt init from closure and pass as parame
   expectEqual(222, res)
 }
 
+StdFunctionTestSuite.test("FunctionStringToString init from closure and pass as parameter") {
+  let res = invokeFunctionTwice(.init({ $0 + std.string("abc") }),
+                                std.string("prefix"))
+  expectEqual(std.string("prefixabcabc"), res)
+}
+
 // FIXME: assertion for address-only closure params (rdar://124501345)
-//StdFunctionTestSuite.test("FunctionStringToString init from closure and pass as parameter") {
-//  let res = invokeFunctionTwice(.init({ $0 + std.string("abc") }),
-//                                std.string("prefix"))
+//StdFunctionTestSuite.test("FunctionStringToStringConstRef init from closure and pass as parameter") {
+//  let res = invokeFunctionTwiceConstRef(.init({ $0 + std.string("abc") }),
+//                                        std.string("prefix"))
 //  expectEqual(std.string("prefixabcabc"), res)
 //}
 #endif


### PR DESCRIPTION
While initializing a `std::function` that takes `const std::string&` as a parameter currently crashes, changing the parameter type to `std::string` should work fine.