### PR TITLE
[cxx-interop] Support generic types with isValueType trait

### DIFF
--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -675,14 +675,14 @@ void ClangValueTypePrinter::printTypeGenericTraits(
     os << "> = true;\n";
   }
 
-  if (!isa<ClassDecl>(typeDecl) && !typeDecl->hasClangNode() &&
-      typeMetadataFuncRequirements.empty()) {
-    // FIXME: generic support.
-    os << "template<>\n";
+  if (!isa<ClassDecl>(typeDecl) && !typeDecl->hasClangNode()) {
+    assert(NTD && "not a nominal type?");
+    if (printer.printNominalTypeOutsideMemberDeclTemplateSpecifiers(NTD))
+      os << "template<>\n";
     os << "static inline const constexpr bool isValueType<";
     printer.printBaseName(typeDecl->getModuleContext());
     os << "::";
-    printer.printBaseName(typeDecl);
+    printer.printNominalTypeReference(NTD, moduleContext);
     os << "> = true;\n";
   }
   if (isOpaqueLayout) {

--- a/test/Interop/SwiftToCxx/generics/generic-struct-as-generic-func-arg-in-cpp.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-as-generic-func-arg-in-cpp.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/generics.swift -typecheck -module-name Generics -enable-experimental-cxx-interop -emit-clang-header-path %t/Generics-Swift.h
+
+// RUN: %target-interop-build-clangxx -fno-exceptions -std=gnu++20 -c %t/generics.cpp -I %t -o %t/generics.o
+// RUN: %target-build-swift %t/generics.swift -o %t/generics -Xlinker %t/generics.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+//--- generics.swift
+
+public struct MyClass<T> {
+    public var a: T
+    public init(_ p: T) { self.a = p }
+}
+
+public func genericFunc<T>(_ p: T) -> T {
+    return p
+}
+
+//--- generics.cpp
+
+#include "Generics-Swift.h"
+using namespace Generics;
+
+int main() {
+  auto c = MyClass<int>::init(10);
+  auto result = genericFunc<MyClass<int>>(c);
+}

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -284,6 +284,11 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif // __cpp_concepts
+// CHECK-NEXT: static inline const constexpr bool isValueType<Generics::GenericPair<T_0_0, T_0_1>> = true;
+// CHECK-NEXT: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: #ifdef __cpp_concepts
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: #endif // __cpp_concepts
 // CHECK-NEXT: static inline const constexpr bool isOpaqueLayout<Generics::GenericPair<T_0_0, T_0_1>> = true;
 // CHECK-NEXT: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: #ifdef __cpp_concepts

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -49,6 +49,7 @@
 // CHECK: template<class T_0_0>
 // CHECK: template<class T_0_0>
 // CHECK: template<class T_0_0>
+// CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif


### PR DESCRIPTION
In some circumstances the missing trait resulted in picking the wrong branch of some compile time conditionals resulting in code that would not compile.

rdar://126709253
