### PR TITLE
[test] Use the just-built Clang when using new driver

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -368,6 +368,11 @@ config.link = lit.util.which('link', config.environment.get('PATH', '')) or     
 
 config.color_output = lit_config.params.get('color_output', None) is not None
 
+# Tell the (new) driver to invoke the Clang we've inferred. The
+# legacy driver uses ld by default.
+config.environment['SWIFT_DRIVER_CLANG_EXEC'] = config.clang
+config.environment['SWIFT_DRIVER_CLANGXX_EXEC'] = config.clangxx
+
 # Find the resource directory.  Assume it's near the swift compiler if not set.
 test_resource_dir = lit_config.params.get('test_resource_dir')
 config.resource_dir_opt = ""


### PR DESCRIPTION
Make sure we execute the just-built Clang for linking jobs in the new driver. This ensures we link against the correct compiler-rt libraries.

rdar://132122596