### PR TITLE
[cxx-interop] Run benchmarks in C++20 mode

### DIFF
--- a/benchmark/Package.swift
+++ b/benchmark/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.4
 
 import PackageDescription
 import Foundation
@@ -191,5 +191,6 @@ let p = Package(
   name: "swiftbench",
   products: products,
   targets: targets,
-  swiftLanguageVersions: [.v4]
+  swiftLanguageVersions: [.v4],
+  cxxLanguageStandard: .cxx20
 )

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -485,6 +485,7 @@ function (swift_benchmark_compile_archopts)
       set(cxx_options "")
       if ("${module_name_path}" MATCHES ".*cxx-source/.*")
         list(APPEND cxx_options "-Xfrontend" "-enable-experimental-cxx-interop" "-I" "${srcdir}/utils/CxxTests/")
+        list(APPEND cxx_options "-Xcc" "-std=c++20")
         # FIXME: https://github.com/apple/swift/issues/61453
         list(APPEND cxx_options "-Xfrontend" "-validate-tbd-against-ir=none")
       endif()
@@ -596,6 +597,7 @@ function (swift_benchmark_compile_archopts)
       "-emit-module" "-module-name" "${module_name}"
       "-I" "${objdir}"
       "-Xfrontend" "-enable-experimental-cxx-interop"
+      "-Xcc" "-std=c++20"
       "-I" "${srcdir}/utils/CxxTests/"
       "-o" "${objdir}/${module_name}.o"
       "${source}")


### PR DESCRIPTION
This will allow benchmarking Swift access to `std::span` which is a C++20 feature and therefore requires compiling with `-Xcc -std=c++20`.