### PR TITLE
[test] Update a couple of Profiler tests for rebranch

### DIFF
--- a/test/Profiler/pgo_guard.swift
+++ b/test/Profiler/pgo_guard.swift
@@ -19,7 +19,7 @@
 // SIL-LABEL: // pgo_guard.guess1
 // SIL-LABEL: sil @$s9pgo_guard6guess11xs5Int32VAE_tF : $@convention(thin) (Int32) -> Int32 !function_entry_count(5002) {
 // IR-LABEL: define swiftcc i32 @"$s9pgo_guard6guess11xs5Int32VAE_tF"
-// IR-OPT-LABEL: define swiftcc i32 @"$s9pgo_guard6guess11xs5Int32VAE_tF"
+// IR-OPT-LABEL: define swiftcc{{.*}} i32 @"$s9pgo_guard6guess11xs5Int32VAE_tF"
 
 public func guess1(x: Int32) -> Int32 {
   // SIL: cond_br {{.*}} !true_count(5000) !false_count(2)

--- a/test/Profiler/pgo_if.swift
+++ b/test/Profiler/pgo_if.swift
@@ -19,7 +19,7 @@
 // SIL-LABEL: // pgo_if.guess1
 // SIL-LABEL: sil @$s6pgo_if6guess11xs5Int32VAE_tF : $@convention(thin) (Int32) -> Int32 !function_entry_count(5001) {
 // IR-LABEL: define swiftcc i32 @"$s6pgo_if6guess11xs5Int32VAE_tF"
-// IR-OPT-LABEL: define swiftcc i32 @"$s6pgo_if6guess11xs5Int32VAE_tF"
+// IR-OPT-LABEL: define swiftcc{{.*}} i32 @"$s6pgo_if6guess11xs5Int32VAE_tF"
 public func guess1(x: Int32) -> Int32 {
   // SIL: cond_br {{.*}} !true_count(5000) !false_count(1)
   // SIL-OPT: cond_br {{.*}} !true_count(5000) !false_count(1)
@@ -35,7 +35,7 @@ public func guess1(x: Int32) -> Int32 {
 // SIL-LABEL: // pgo_if.guess2
 // SIL-LABEL: sil @$s6pgo_if6guess21xs5Int32VAE_tF : $@convention(thin) (Int32) -> Int32 !function_entry_count(5001) {
 // IR-LABEL: define swiftcc i32 @"$s6pgo_if6guess21xs5Int32VAE_tF"
-// IR-OPT-LABEL: define swiftcc i32 @"$s6pgo_if6guess21xs5Int32VAE_tF"
+// IR-OPT-LABEL: define swiftcc{{.*}} i32 @"$s6pgo_if6guess21xs5Int32VAE_tF"
 public func guess2(x: Int32) -> Int32 {
   // SIL: cond_br {{.*}} !true_count(5000) !false_count(1)
   // SIL-OPT: cond_br {{.*}} !true_count(5000) !false_count(1)


### PR DESCRIPTION
On rebranch, in optimized IR, we can print the constant range of expected return values, ignore it in the match.