### PR TITLE
Fix sourcekitd persistent file-locks on Windows

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -496,6 +496,12 @@ namespace swift {
     /// Enable verification when every SubstitutionMap is constructed.
     bool VerifyAllSubstitutionMaps = false;
 
+    /// If set to true, the source manager will avoid memory mapping source files
+    /// with the expectation they may change on disk. This is most useful when
+    /// opening files under sourcekitd on Windows, as memory mapping on Windows
+    /// prevents files from being written.
+    bool OpenSourcesAsVolatile = false;
+
     /// Load swiftmodule files in memory as volatile and avoid mmap.
     bool EnableVolatileModules = false;
 

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -94,6 +94,7 @@ public:
 private:
   llvm::SourceMgr LLVMSourceMgr;
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem;
+  bool EditorMode = false;
   unsigned IDEInspectionTargetBufferID = 0U;
   unsigned IDEInspectionTargetOffset;
 
@@ -164,6 +165,10 @@ public:
 
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> getFileSystem() const {
     return FileSystem;
+  }
+
+  void setEditorMode() {
+    EditorMode = true;
   }
 
   void setIDEInspectionTarget(unsigned BufferID, unsigned Offset) {

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -94,7 +94,7 @@ public:
 private:
   llvm::SourceMgr LLVMSourceMgr;
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem;
-  bool EditorMode = false;
+  bool OpenSourcesAsVolatile = false;
   unsigned IDEInspectionTargetBufferID = 0U;
   unsigned IDEInspectionTargetOffset;
 
@@ -167,8 +167,10 @@ public:
     return FileSystem;
   }
 
-  void setEditorMode() {
-    EditorMode = true;
+  // Setting this prevents SourceManager from memory mapping sources (via opening files
+  // with isVolatile=true);
+  void setOpenSourcesAsVolatile() {
+    OpenSourcesAsVolatile = true;
   }
 
   void setIDEInspectionTarget(unsigned BufferID, unsigned Offset) {

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -695,7 +695,11 @@ unsigned SourceManager::getExternalSourceBufferID(StringRef Path) {
     return It->getSecond();
   }
   unsigned Id = 0u;
-  auto InputFileOrErr = swift::vfs::getFileOrSTDIN(*getFileSystem(), Path);
+  auto InputFileOrErr =
+      swift::vfs::getFileOrSTDIN(*getFileSystem(), Path,
+                                 /* FileSize */ -1,
+                                 /* RequiresNullTerminator */ true,
+                                 /* isVolatile */ this->EditorMode);
   if (InputFileOrErr) {
     // This assertion ensures we can look up from the map in the future when
     // using the same Path.

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -699,7 +699,7 @@ unsigned SourceManager::getExternalSourceBufferID(StringRef Path) {
       swift::vfs::getFileOrSTDIN(*getFileSystem(), Path,
                                  /* FileSize */ -1,
                                  /* RequiresNullTerminator */ true,
-                                 /* isVolatile */ this->EditorMode);
+                                 /* isVolatile */ this->OpenSourcesAsVolatile);
   if (InputFileOrErr) {
     // This assertion ensures we can look up from the map in the future when
     // using the same Path.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -552,6 +552,12 @@ bool CompilerInstance::setup(const CompilerInvocation &Invoke,
   if (LangOpts.EnableModuleLoadingRemarks) {
     Invocation.getSearchPathOptions().dump(LangOpts.Target.isOSDarwin());
   }
+  
+  // If the compiler instance is managed by an IDE, inform the source manager to avoid
+  // memory-mapping source files that are likely to be mutated in an editor.
+  if (LangOpts.DiagnosticsEditorMode) {
+    this->getSourceMgr().setEditorMode();
+  }
 
   // If we expect an implicit stdlib import, load in the standard library. If we
   // either fail to find it or encounter an error while loading it, bail early. Continuing will at best

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -552,11 +552,9 @@ bool CompilerInstance::setup(const CompilerInvocation &Invoke,
   if (LangOpts.EnableModuleLoadingRemarks) {
     Invocation.getSearchPathOptions().dump(LangOpts.Target.isOSDarwin());
   }
-  
-  // If the compiler instance is managed by an IDE, inform the source manager to avoid
-  // memory-mapping source files that are likely to be mutated in an editor.
-  if (LangOpts.DiagnosticsEditorMode) {
-    this->getSourceMgr().setEditorMode();
+
+  if (LangOpts.OpenSourcesAsVolatile) {
+    this->getSourceMgr().setOpenSourcesAsVolatile();
   }
 
   // If we expect an implicit stdlib import, load in the standard library. If we

--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -225,6 +225,11 @@ bool ide::initCompilerInvocation(
   LangOpts.AttachCommentsToDecls = true;
   LangOpts.DiagnosticsEditorMode = true;
   LangOpts.CollectParsedToken = true;
+  #if defined(_WIN32)
+  // Source files that might be open in an editor should not be memory mapped on Windows,
+  // as they will become read-only.
+  LangOpts.OpenSourcesAsVolatile = true;
+  #endif
   if (LangOpts.PlaygroundTransform) {
     // The playground instrumenter changes the AST in ways that disrupt the
     // SourceKit functionality. Since we don't need the instrumenter, and all we


### PR DESCRIPTION
Fixes https://github.com/swiftlang/sourcekit-lsp/issues/644

During semantic analysis, [`swift::vfs::getFileOrSTDIN`](https://github.com/swiftlang/swift/blob/225809e3f8e9c7b1f5655a7bd31fd2f0e8d3dbb8/include/swift/Basic/FileSystem.h#L81) opens files with a default `IsVolatile=false` arg, which makes its way down through [`MemoryBuffer::getOpenFile`](https://github.com/swiftlang/llvm-project/blob/a3e142a94f13d8411ceadc72a10c68b83869ba05/llvm/lib/Support/MemoryBuffer.cpp#L539),  to [`shouldUseMmap`](https://github.com/swiftlang/llvm-project/blob/a3e142a94f13d8411ceadc72a10c68b83869ba05/llvm/lib/Support/MemoryBuffer.cpp#L358). If this function's heuristics returned true, the file would be mmapped by sourcekitd and then could no longer be saved in an open editor until sourcekitd was killed. One of the heuristics used is a file-size check to avoid memory-mapping small files, and so this issue would only trigger on large source files.

This patch propagates `LangOpts.DiagnosticsEditorMode` into `SourceManager` as a new `editorMode` boolean, that is now passed as the `IsVolatile` parameter to `swift::vfs::getFileOrSTDIN`, avoiding memory mapping files when the compiler is being invoked by sourcekitd.

Stack trace for the curious:
```
00 00000061`50af9df8 00007ff9`9708b391     KERNELBASE!wil::details::DebugBreak+0x2
01 00000061`50af9e00 00007ff9`9708d121     sourcekitdInProc!llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer,std::default_delete<llvm::MemoryBuffer> > >::ErrorOr<std::unique_ptr<llvm::MemoryBuffer,std::default_delete<llvm::MemoryBuffer> > ><std::unique_ptr<llvm::WritableMemoryBuffer,std::default_delete<llvm::WritableMemoryBuffer> > >+0x741
02 00000061`50af9f10 00007ff9`970d5a8a     sourcekitdInProc!llvm::MemoryBuffer::getOpenFile+0x41
03 00000061`50af9f70 00007ff9`970d5c47     sourcekitdInProc!llvm::vfs::Status::exists+0x15a
04 00000061`50af9fc0 00007ff9`9df9e55a     sourcekitdInProc!llvm::vfs::FileSystem::getBufferForFile+0x197
05 00000061`50afa050 00007ff9`9df93901     sourcekitdInProc!swift::vfs::getFileOrSTDIN+0x11a
06 00000061`50afa240 00007ff9`9b0a3e03     sourcekitdInProc!swift::SourceManager::getExternalSourceBufferID+0xe1
07 00000061`50afa2e0 00007ff9`9b09ac13     sourcekitdInProc!swift::Decl::getSerializedLocs+0x143
08 00000061`50afa530 00007ff9`9ab0b4e5     sourcekitdInProc!swift::Decl::getLoc+0x153
09 00000061`50afa560 00007ff9`9ab0d613     sourcekitdInProc!llvm::TinyPtrVector<swift::AssociatedTypeDecl * __ptr64>::push_back+0xe35
0a 00000061`50afa880 00007ff9`9aaffdcb     sourcekitdInProc!llvm::PointerIntPair<swift::Type,2,unsigned int,llvm::PointerLikeTypeTraits<swift::Type>,llvm::PointerIntPairInfo<swift::Type,2,llvm::PointerLikeTypeTraits<swift::Type> > >::setPointerAndInt+0x10d3
0b 00000061`50afb290 00007ff9`9a7b91ea     sourcekitdInProc!swift::ResolveTypeWitnessesRequest::evaluate+0xcb
0c 00000061`50afb970 00007ff9`9a85969c     sourcekitdInProc!swift::SimpleRequest<swift::ResolveTypeWitnessesRequest,std::tuple<> __cdecl(swift::NormalProtocolConformance * __ptr64),2>::evaluateRequest+0x1a
0d 00000061`50afb9a0 00007ff9`9a858958     sourcekitdInProc!swift::Evaluator::getResultUncached<swift::ResolveTypeWitnessesRequest,`swift::evaluateOrDefault<swift::ResolveTypeWitnessesRequest>'::`2'::<lambda_1> >+0x1fc
0e 00000061`50afbad0 00007ff9`9a868c4c     sourcekitdInProc!swift::Evaluator::getResultCached<swift::ResolveTypeWitnessesRequest,`swift::evaluateOrDefault<swift::ResolveTypeWitnessesRequest>'::`2'::<lambda_1>,0>+0x178
0f 00000061`50afbb80 00007ff9`9a865a74     sourcekitdInProc!swift::TypeChecker::checkConformancesInContext+0x299c
10 00000061`50afbe50 00007ff9`9a866a1f     sourcekitdInProc!swift::ConformanceChecker::checkActorIsolation+0x1004
11 00000061`50afc0f0 00007ff9`9ab389b0     sourcekitdInProc!swift::TypeChecker::checkConformancesInContext+0x76f
12 00000061`50afc950 00007ff9`9ab33eea     sourcekitdInProc!swift::TypeChecker::typeCheckDecl+0x65f0
13 00000061`50afcc00 00007ff9`9ab3241f     sourcekitdInProc!swift::TypeChecker::typeCheckDecl+0x1b2a
14 00000061`50afcec0 00007ff9`9a7e1d01     sourcekitdInProc!swift::TypeChecker::typeCheckDecl+0x5f
15 00000061`50afcf00 00007ff9`9a7ba0ca     sourcekitdInProc!swift::TypeCheckSourceFileRequest::evaluate+0x151
16 00000061`50afcfd0 00007ff9`9a7da3e3     sourcekitdInProc!swift::SimpleRequest<swift::TypeCheckSourceFileRequest,std::tuple<> __cdecl(swift::SourceFile * __ptr64),12>::evaluateRequest+0x1a
17 00000061`50afd000 00007ff9`9a7e5ed8     sourcekitdInProc!swift::Evaluator::getResultUncached<swift::TypeCheckSourceFileRequest,`swift::evaluateOrDefault<swift::TypeCheckSourceFileRequest>'::`2'::<lambda_1> >+0x1f3
18 00000061`50afd130 00007ff9`99565b4c     sourcekitdInProc!swift::performTypeChecking+0x168
19 00000061`50afd1b0 00007ff9`9956dde8     sourcekitdInProc!swift::evaluator::DependencyRecorder::beginRequest<swift::IDEInspectionFileRequest>+0xec
1a 00000061`50afd1e0 00007ff9`995728d5     sourcekitdInProc!swift::CompilerInstance::forEachFileToTypeCheck+0x128
1b 00000061`50afd220 00007ff9`96e6b159     sourcekitdInProc!swift::CompilerInstance::performSema+0x95
1c 00000061`50afd2c0 00007ff9`96bf328e     sourcekitdInProc!llvm::SmallVectorImpl<std::shared_ptr<SourceKit::SwiftASTConsumer> >::erase+0x1b69
1d 00000061`50aff720 00007ff9`96bf32be     sourcekitdInProc!SourceKit::WorkQueue::Impl::release+0x8e
1e 00000061`50aff750 00007ffa`8c3c9333     sourcekitdInProc!llvm::thread::ThreadProxy<std::tuple<void (__cdecl*)(void * __ptr64),void * __ptr64> >+0xe
1f 00000061`50aff780 00007ffa`38c7786e     ucrtbase!thread_start<unsigned int (__cdecl*)(void *),1>+0x93
20 00000061`50aff7b0 00007ffa`8cc2257d     vfbasics!AVrfpStandardThreadFunction+0x4e
21 00000061`50aff7f0 00007ffa`8ef0af28     KERNEL32!BaseThreadInitThunk+0x1d
22 00000061`50aff820 00000000`00000000     ntdll!RtlUserThreadStart+0x28
```