### PR TITLE
6.0: [MoveOnlyAddressChecker] Exclusivity handles DeadEnds.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerTester.cpp
@@ -89,6 +89,7 @@ class MoveOnlyAddressCheckerTesterPass : public SILFunctionTransform {
     auto *dominanceAnalysis = getAnalysis<DominanceAnalysis>();
     DominanceInfo *domTree = dominanceAnalysis->get(fn);
     auto *poa = getAnalysis<PostOrderAnalysis>();
+    auto *deadEndBlocksAnalysis = getAnalysis<DeadEndBlocksAnalysis>();
 
     DiagnosticEmitter diagnosticEmitter(fn);
     llvm::SmallSetVector<MarkUnresolvedNonCopyableValueInst *, 32>
@@ -108,7 +109,8 @@ class MoveOnlyAddressCheckerTesterPass : public SILFunctionTransform {
     } else {
       borrowtodestructure::IntervalMapAllocator allocator;
       MoveOnlyAddressChecker checker{getFunction(), diagnosticEmitter,
-                                     allocator, domTree, poa};
+                                     allocator,     domTree,
+                                     poa,           deadEndBlocksAnalysis};
       madeChange = checker.completeLifetimes();
       madeChange |= checker.check(moveIntroducersToProcess);
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1473,6 +1473,8 @@ struct MoveOnlyAddressCheckerPImpl {
   /// Information about destroys that we use when inserting destroys.
   ConsumeInfo consumes;
 
+  DeadEndBlocksAnalysis *deba;
+
   /// PostOrderAnalysis used by the BorrowToDestructureTransform.
   PostOrderAnalysis *poa;
 
@@ -1482,10 +1484,11 @@ struct MoveOnlyAddressCheckerPImpl {
   MoveOnlyAddressCheckerPImpl(
       SILFunction *fn, DiagnosticEmitter &diagnosticEmitter,
       DominanceInfo *domTree, PostOrderAnalysis *poa,
+      DeadEndBlocksAnalysis *deba,
       borrowtodestructure::IntervalMapAllocator &allocator)
       : fn(fn), deleter(), canonicalizer(fn, domTree, deleter),
         addressUseState(domTree), diagnosticEmitter(diagnosticEmitter),
-        poa(poa), allocator(allocator) {
+        deba(deba), poa(poa), allocator(allocator) {
     deleter.setCallbacks(std::move(
         InstModCallbacks().onDelete([&](SILInstruction *instToDelete) {
           if (auto *mvi =
@@ -2045,7 +2048,9 @@ struct GatherUsesVisitor : public TransitiveAddressWalker<GatherUsesVisitor> {
     liveness->initializeDef(bai);
     liveness->computeSimple();
     for (auto *consumingUse : li->getConsumingUses()) {
-      if (!liveness->isWithinBoundary(consumingUse->getUser())) {
+      if (!liveness->areUsesWithinBoundary(
+              {consumingUse},
+              moveChecker.deba->get(consumingUse->getFunction()))) {
         diagnosticEmitter.emitAddressExclusivityHazardDiagnostic(
             markedValue, consumingUse->getUser());
         emittedError = true;
@@ -3976,7 +3981,7 @@ bool MoveOnlyAddressChecker::check(
   assert(moveIntroducersToProcess.size() &&
          "Must have checks to process to call this function");
   MoveOnlyAddressCheckerPImpl pimpl(fn, diagnosticEmitter, domTree, poa,
-                                    allocator);
+                                    deadEndBlocksAnalysis, allocator);
 
 #ifndef NDEBUG
   static uint64_t numProcessed = 0;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.h
@@ -18,6 +18,7 @@
 namespace swift {
 
 class PostOrderAnalysis;
+class DeadEndBlocksAnalysis;
 
 namespace siloptimizer {
 
@@ -39,6 +40,7 @@ struct MoveOnlyAddressChecker {
   borrowtodestructure::IntervalMapAllocator &allocator;
   DominanceInfo *domTree;
   PostOrderAnalysis *poa;
+  DeadEndBlocksAnalysis *deadEndBlocksAnalysis;
 
   /// \returns true if we changed the IR. To see if we emitted a diagnostic, use
   /// \p diagnosticEmitter.getDiagnosticCount().

--- a/test/SILOptimizer/moveonly_addresschecker.swift
+++ b/test/SILOptimizer/moveonly_addresschecker.swift
@@ -37,3 +37,14 @@ func testAssertLikeUseDifferentBits() {
         }
     }
 }
+
+// issue #75312
+struct S
+{
+    @usableFromInline
+    init(utf8:consuming [UInt8])
+    {
+        utf8.withUnsafeBufferPointer { _ in }
+        fatalError()
+    }
+}


### PR DESCRIPTION
**Explanation**: Handle incomplete access scopes when diagnosing exclusivity issues.

The move-only address checker diagnoses exclusivity violations by checking whether consuming uses occur within an access scope (marked by one `begin_access` instruction and some number of `end_access` instructions).  Specifically, it checks whether instructions that consume a value occur within the scope.  If they do not, it emits an error.

In dead-end regions of a function (those from which there are no function exiting paths), special care must be taken when determining whether an instruction is live when the value which defines the region does not have a "complete lifetime" (a consuming use on every path).  Access scopes do not always have complete lifetimes, so they need this special care.  To get this special care, an instance of `DeadEndBlocks` must be passed to `PrunedLiveness`.  (At the moment, it is also necessary to call `areUsesWithinBoundary` instead of `isWithinBoundary`, but that is only temporary.)

Here, the `DeadEndBlocks` instance is threaded a bit farther into the checker so that it can be passed along to `PrunedLiveness`.

The result is that consumes in dead-end blocks are correctly understood to be within the access scope when there is no `end_access` in that dead-end region.
**Scope**: Affects noncopyable code.
**Issue**: rdar://131960619
**Original PR**: https://github.com/swiftlang/swift/pull/75404
**Risk**: Low.  Amounts to passing an additional argument down in order to have an additional way to determine that an instruction is within a boundary.  Furthermore, only affects the diagnostic relating to exclusivity emitted by the checker.
**Testing**: Added test.
**Reviewer**: Kavon Farvardin ( @kavon ), Joe Groff ( @jckarter )
