### PR TITLE
ModuleInterface: Avoid crashing on invalid extensions in lazy typechecking mode

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_FRONTEND_MODULEINTERFACESUPPORT_H
 #define SWIFT_FRONTEND_MODULEINTERFACESUPPORT_H
 
+#include "swift/AST/PrintOptions.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Version.h"
 #include "llvm/Support/Regex.h"

--- a/test/ModuleInterface/lazy-typecheck-errors.swift
+++ b/test/ModuleInterface/lazy-typecheck-errors.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/Test.swiftinterface) -module-name Test %s -experimental-lazy-typecheck -verify
+
+extension DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
+  public func method() {}
+}

--- a/test/Serialization/lazy-typecheck-errors.swift
+++ b/test/Serialization/lazy-typecheck-errors.swift
@@ -32,3 +32,7 @@ public var varWithImplicitInvalidType = (1 as InvalidType)
 // expected-serialization-remark@-3 {{serialization skipped for invalid type}}
 
 public var _: InvalidType
+
+extension InvalidType {
+  public func method() {}
+}


### PR DESCRIPTION
With `-experimental-lazy-typecheck` specified during module interface emission, `collectProtocols()` may be the first piece of code to request the extended type for a given extension and it therefore needs to ignore invalid extensions and ensure that diagnostics are emitted.

Also, add some `PrettyStackTrace` coverage to `ModuleInterfaceSupport.cpp` to make investigating future issues easier.

Resolves rdar://126232836.
