### PR TITLE
Introduce `@unsafe` and the ability to prohibit use of unsafe entities

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -500,7 +500,13 @@ SIMPLE_DECL_ATTR(sensitive, Sensitive,
   OnStruct | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   159)
 
-LAST_DECL_ATTR(PreInverseGenerics)
+SIMPLE_DECL_ATTR(unsafe, Unsafe,
+  OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType |
+  UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
+  160)
+
+LAST_DECL_ATTR(Unsafe)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7969,24 +7969,24 @@ NOTE(sending_function_result_with_sending_param_note, none,
 //------------------------------------------------------------------------------
 ERROR(unsafe_attr_disabled,none,
       "attribute requires '-enable-experimental-feature AllowUnsafeAttribute'", ())
-ERROR(override_safe_withunsafe,none,
+WARNING(override_safe_withunsafe,none,
       "override of safe %0 with unsafe %0", (DescriptiveDeclKind))
-ERROR(witness_unsafe,none,
+WARNING(witness_unsafe,none,
      "unsafe %0 %1 cannot satisfy safe requirement",
       (DescriptiveDeclKind, DeclName))
-ERROR(type_witness_unsafe,none,
+WARNING(type_witness_unsafe,none,
       "unsafe type %0 cannot satisfy safe associated type %1",
       (Type, DeclName))
-ERROR(unchecked_conformance_is_unsafe,none,
+WARNING(unchecked_conformance_is_unsafe,none,
       "@unchecked conformance involves unsafe code", ())
-ERROR(unowned_unsafe_is_unsafe,none,
+WARNING(unowned_unsafe_is_unsafe,none,
       "unowned(unsafe) involves unsafe code", ())
-ERROR(nonisolated_unsafe_is_unsafe,none,
+WARNING(nonisolated_unsafe_is_unsafe,none,
       "nonisolated(unsafe) involves unsafe code", ())
-ERROR(reference_to_unsafe_decl,none,
+WARNING(reference_to_unsafe_decl,none,
       "%select{reference|call}0 to unsafe %kindbase1",
       (bool, const ValueDecl *))
-ERROR(reference_to_unsafe_typed_decl,none,
+WARNING(reference_to_unsafe_typed_decl,none,
       "%select{reference|call}0 to %kindbase1 involves unsafe type %2",
       (bool, const ValueDecl *, Type))
 NOTE(unsafe_decl_here,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7964,5 +7964,25 @@ NOTE(sending_function_result_with_sending_param_note, none,
      "isolation domain through a result of an invocation of value",
      ())
 
+//------------------------------------------------------------------------------
+// MARK: Strict Safety Diagnostics
+//------------------------------------------------------------------------------
+ERROR(unsafe_attr_disabled,none,
+      "attribute requires '-enable-experimental-feature AllowUnsafeAttribute'", ())
+ERROR(override_safe_withunsafe,none,
+      "override of safe %0 with unsafe %0", (DescriptiveDeclKind))
+ERROR(witness_unsafe,none,
+     "unsafe %0 %1 cannot satisfy safe requirement",
+      (DescriptiveDeclKind, DeclName))
+ERROR(unchecked_conformance_is_unsafe,none,
+      "@unchecked conformance involves unsafe code", ())
+ERROR(unowned_unsafe_is_unsafe,none,
+      "unowned(unsafe) involves unsafe code", ())
+ERROR(nonisolated_unsafe_is_unsafe,none,
+      "nonisolated(unsafe) involves unsafe code", ())
+ERROR(reference_to_unsafe_decl,none,
+      "%select{reference|call}0 to unsafe %kindbase1",
+      (bool, const ValueDecl *))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7974,6 +7974,9 @@ ERROR(override_safe_withunsafe,none,
 ERROR(witness_unsafe,none,
      "unsafe %0 %1 cannot satisfy safe requirement",
       (DescriptiveDeclKind, DeclName))
+ERROR(type_witness_unsafe,none,
+      "unsafe type %0 cannot satisfy safe associated type %1",
+      (Type, DeclName))
 ERROR(unchecked_conformance_is_unsafe,none,
       "@unchecked conformance involves unsafe code", ())
 ERROR(unowned_unsafe_is_unsafe,none,
@@ -7983,6 +7986,11 @@ ERROR(nonisolated_unsafe_is_unsafe,none,
 ERROR(reference_to_unsafe_decl,none,
       "%select{reference|call}0 to unsafe %kindbase1",
       (bool, const ValueDecl *))
+ERROR(reference_to_unsafe_typed_decl,none,
+      "%select{reference|call}0 to %kindbase1 involves unsafe type %2",
+      (bool, const ValueDecl *, Type))
+NOTE(unsafe_decl_here,none,
+     "unsafe %kindbase0 declared here", (const ValueDecl *))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5065,6 +5065,24 @@ public:
   bool isCached() const { return true; }
 };
 
+class IsUnsafeRequest
+    : public SimpleRequest<IsUnsafeRequest,
+                           bool(Decl *decl),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, Decl *decl) const;
+
+public:
+  bool isCached() const { return true; }
+  std::optional<bool> getCachedResult() const;
+  void cacheResult(bool value) const;
+};
+
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -593,3 +593,6 @@ SWIFT_REQUEST(TypeChecker, CaptureInfoRequest,
 SWIFT_REQUEST(TypeChecker, ParamCaptureInfoRequest,
               CaptureInfo(ParamDecl *),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsUnsafeRequest,
+              bool(Decl *),
+              SeparatelyCached, NoLocationInfo)

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -185,7 +185,10 @@ public:
     /// Contains a PackArchetypeType. Also implies HasPrimaryArchetype.
     HasPackArchetype = 0x20000,
 
-    Last_Property = HasPackArchetype
+    /// Whether this type contains an unsafe type.
+    IsUnsafe = 0x040000,
+
+    Last_Property = IsUnsafe
   };
   enum { BitWidth = countBitsUsed(Property::Last_Property) };
 
@@ -265,6 +268,8 @@ public:
   bool hasPack() const { return Bits & HasPack; }
 
   bool hasPackArchetype() const { return Bits & HasPackArchetype; }
+
+  bool isUnsafe() const { return Bits & IsUnsafe; }
 
   /// Does a type with these properties structurally contain a
   /// parameterized existential type?
@@ -431,12 +436,12 @@ protected:
     NumProtocols : 16
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 7+29,
+  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 7+28,
     /// Type variable options.
     Options : 7,
     : NumPadBits,
     /// The unique number assigned to this type variable.
-    ID : 29
+    ID : 28
   );
 
   SWIFT_INLINE_BITFIELD_FULL(ErrorUnionType, TypeBase, 32,
@@ -707,6 +712,11 @@ public:
   /// Whether the type contains a PackArchetypeType.
   bool hasPackArchetype() const {
     return getRecursiveProperties().hasPackArchetype();
+  }
+
+  /// Whether the type contains an @unsafe type in it anywhere.
+  bool isUnsafe() const {
+    return getRecursiveProperties().isUnsafe();
   }
 
   /// Determine whether the type involves a primary, pack or local archetype.
@@ -6637,7 +6647,8 @@ private:
                        GenericEnvironment *GenericEnv,
                        Type InterfaceType,
                        ArrayRef<ProtocolDecl *> ConformsTo,
-                       Type Superclass, LayoutConstraint Layout);
+                       Type Superclass, LayoutConstraint Layout,
+                       RecursiveTypeProperties Properties);
 };
 BEGIN_CAN_TYPE_WRAPPER(PrimaryArchetypeType, ArchetypeType)
 END_CAN_TYPE_WRAPPER(PrimaryArchetypeType, ArchetypeType)
@@ -6918,7 +6929,8 @@ public:
 private:
   PackArchetypeType(const ASTContext &Ctx, GenericEnvironment *GenericEnv,
                     Type InterfaceType, ArrayRef<ProtocolDecl *> ConformsTo,
-                    Type Superclass, LayoutConstraint Layout, PackShape Shape);
+                    Type Superclass, LayoutConstraint Layout, PackShape Shape,
+                    RecursiveTypeProperties properties);
 };
 BEGIN_CAN_TYPE_WRAPPER(PackArchetypeType, ArchetypeType)
 END_CAN_TYPE_WRAPPER(PackArchetypeType, ArchetypeType)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -405,8 +405,8 @@ EXPERIMENTAL_FEATURE(TrailingComma, false)
 /// Allow the @unsafe attribute.
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(AllowUnsafeAttribute, true)
 
-/// Disallow use of unsafe code.
-EXPERIMENTAL_FEATURE(DisallowUnsafe, true)
+/// Warn on use of unsafe constructs.
+EXPERIMENTAL_FEATURE(WarnUnsafe, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -396,10 +396,17 @@ EXPERIMENTAL_FEATURE(ReinitializeConsumeInMultiBlockDefer, false)
 
 EXPERIMENTAL_FEATURE(SE427NoInferenceOnExtension, true)
 
+
 EXPERIMENTAL_FEATURE(Extern, true)
 
 // Enable trailing comma for comma-separated lists.
 EXPERIMENTAL_FEATURE(TrailingComma, false)
+
+/// Allow the @unsafe attribute.
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(AllowUnsafeAttribute, true)
+
+/// Disallow use of unsafe code.
+EXPERIMENTAL_FEATURE(DisallowUnsafe, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3056,6 +3056,15 @@ suppressingFeatureBitwiseCopyable2(PrintOptions &options,
   options.ExcludeAttrList.resize(originalExcludeAttrCount);
 }
 
+static void
+suppressingFeatureAllowUnsafeAttribute(PrintOptions &options,
+                                       llvm::function_ref<void()> action) {
+  unsigned originalExcludeAttrCount = options.ExcludeAttrList.size();
+  options.ExcludeAttrList.push_back(DeclAttrKind::Unsafe);
+  action();
+  options.ExcludeAttrList.resize(originalExcludeAttrCount);
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1015,6 +1015,13 @@ bool Decl::preconcurrency() const {
   return false;
 }
 
+bool Decl::isUnsafe() const {
+  return evaluateOrDefault(
+      getASTContext().evaluator,
+      IsUnsafeRequest{const_cast<Decl *>(this)},
+      false);
+}
+
 Type AbstractFunctionDecl::getThrownInterfaceType() const {
   if (!getThrownTypeRepr())
     return ThrownType.getType();

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -230,7 +230,7 @@ static bool usesFeatureAllowUnsafeAttribute(Decl *decl) {
   return decl->getAttrs().hasAttribute<UnsafeAttr>();
 }
 
-UNINTERESTING_FEATURE(DisallowUnsafe)
+UNINTERESTING_FEATURE(WarnUnsafe)
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -226,6 +226,12 @@ UNINTERESTING_FEATURE(ReinitializeConsumeInMultiBlockDefer)
 UNINTERESTING_FEATURE(SE427NoInferenceOnExtension)
 UNINTERESTING_FEATURE(TrailingComma)
 
+static bool usesFeatureAllowUnsafeAttribute(Decl *decl) {
+  return decl->getAttrs().hasAttribute<UnsafeAttr>();
+}
+
+UNINTERESTING_FEATURE(DisallowUnsafe)
+
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet
 // ----------------------------------------------------------------------------

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2597,3 +2597,20 @@ void ParamCaptureInfoRequest::cacheResult(CaptureInfo info) const {
   auto *param = std::get<0>(getStorage());
   param->setDefaultArgumentCaptureInfo(info);
 }
+
+//----------------------------------------------------------------------------//
+// IsUnsafeRequest computation.
+//----------------------------------------------------------------------------//
+
+std::optional<bool> IsUnsafeRequest::getCachedResult() const {
+  auto *decl = std::get<0>(getStorage());
+  if (!decl->isUnsafeComputed())
+    return std::nullopt;
+
+  return decl->isUnsafeRaw();
+}
+
+void IsUnsafeRequest::cacheResult(bool value) const {
+  auto *decl = std::get<0>(getStorage());
+  decl->setUnsafe(value);
+}

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -252,6 +252,7 @@ extension ASTGenVisitor {
         .testable,
         .transparent,
         .uiApplicationMain,
+        .unsafe,
         .unsafeInheritExecutor,
         .unsafeNoObjCTaggedPointer,
         .unsafeNonEscapableResult,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8105,6 +8105,14 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
         continue;
       }
 
+      if (swiftAttr->getAttribute() == "unsafe") {
+        if (!SwiftContext.LangOpts.hasFeature(Feature::AllowUnsafeAttribute))
+          continue;
+        auto attr = new (SwiftContext) UnsafeAttr(/*implicit=*/false);
+        MappedDecl->getAttrs().add(attr);
+        continue;
+      }
+
       // Dig out a buffer with the attribute text.
       unsigned bufferID = getClangSwiftAttrSourceBuffer(
           swiftAttr->getAttribute());

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -393,8 +393,6 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
             // Don't hoist nested '#if'.
             continue;
           Entries.push_back(Entry);
-          if (Entry.is<Decl *>())
-            Entry.get<Decl *>()->setEscapedFromIfConfig(true);
         }
       } else {
         NeedParseErrorRecovery = true;

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -34,6 +34,7 @@
 #include "DerivedConformances.h"
 #include "TypeAccessScopeChecker.h"
 #include "TypeChecker.h"
+#include "TypeCheckType.h"
 
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
@@ -342,6 +343,22 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
     }
 
     typeDecl = aliasDecl;
+  }
+
+  // If we're disallowing unsafe code, check for an unsafe type witness.
+  if (ctx.LangOpts.hasFeature(Feature::DisallowUnsafe) &&
+      !assocType->isUnsafe() && type->isUnsafe()) {
+    SourceLoc loc = typeDecl->getLoc();
+    if (loc.isInvalid())
+      loc = conformance->getLoc();
+    diagnoseUnsafeType(ctx,
+                       loc,
+                       type,
+                       [&](Type specificType) {
+      ctx.Diags.diagnose(
+          loc, diag::type_witness_unsafe, specificType, assocType->getName());
+      assocType->diagnose(diag::decl_declared_here, assocType);
+    });
   }
 
   // Record the type witness.

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -346,7 +346,7 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
   }
 
   // If we're disallowing unsafe code, check for an unsafe type witness.
-  if (ctx.LangOpts.hasFeature(Feature::DisallowUnsafe) &&
+  if (ctx.LangOpts.hasFeature(Feature::WarnUnsafe) &&
       !assocType->isUnsafe() && type->isUnsafe()) {
     SourceLoc loc = typeDecl->getLoc();
     if (loc.isInvalid())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4900,7 +4900,7 @@ Type TypeChecker::checkReferenceOwnershipAttr(VarDecl *var, Type type,
 
   // unowned(unsafe) is unsafe (duh).
   if (ownershipKind == ReferenceOwnership::Unmanaged &&
-      ctx.LangOpts.hasFeature(Feature::DisallowUnsafe)) {
+      ctx.LangOpts.hasFeature(Feature::WarnUnsafe)) {
     Diags.diagnose(attr->getLocation(), diag::unowned_unsafe_is_unsafe);
   }
 
@@ -7100,7 +7100,7 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
 
   // nonisolated(unsafe) is unsafe, but only under strict concurrency.
   if (attr->isUnsafe() &&
-      Ctx.LangOpts.hasFeature(Feature::DisallowUnsafe) &&
+      Ctx.LangOpts.hasFeature(Feature::WarnUnsafe) &&
       Ctx.LangOpts.StrictConcurrencyLevel == StrictConcurrency::Complete)
     Ctx.Diags.diagnose(attr->getLocation(), diag::nonisolated_unsafe_is_unsafe);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3193,3 +3193,22 @@ SourceFile::getIfConfigClausesWithin(SourceRange outer) const {
       });
   return llvm::ArrayRef(lower, upper - lower);
 }
+
+//----------------------------------------------------------------------------//
+// IsUnsafeRequest
+//----------------------------------------------------------------------------//
+
+bool IsUnsafeRequest::evaluate(Evaluator &evaluator, Decl *decl) const {
+  // If it's marked @unsafe, it's unsafe.
+  if (decl->getAttrs().hasAttribute<UnsafeAttr>())
+    return true;
+
+  // Inference: A member of an @unsafe type is also unsafe.
+  if (auto enclosingDC = decl->getDeclContext()) {
+    if (auto enclosingNominal = enclosingDC->getSelfNominalTypeDecl())
+      if (enclosingNominal->isUnsafe())
+        return true;
+  }
+
+  return false;
+}

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1733,7 +1733,7 @@ namespace  {
     void visitObjCAttr(ObjCAttr *attr) {}
 
     void visitUnsafeAttr(UnsafeAttr *attr) {
-      if (!Base->getASTContext().LangOpts.hasFeature(Feature::DisallowUnsafe))
+      if (!Base->getASTContext().LangOpts.hasFeature(Feature::WarnUnsafe))
         return;
 
       if (Override->isUnsafe() && !Base->isUnsafe()) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1731,6 +1731,17 @@ namespace  {
     }
 
     void visitObjCAttr(ObjCAttr *attr) {}
+
+    void visitUnsafeAttr(UnsafeAttr *attr) {
+      if (!Base->getASTContext().LangOpts.hasFeature(Feature::DisallowUnsafe))
+        return;
+
+      if (Override->isUnsafe() && !Base->isUnsafe()) {
+        Diags.diagnose(Override, diag::override_safe_withunsafe,
+                       Base->getDescriptiveKind());
+        Diags.diagnose(Base, diag::overridden_here);
+      }
+    }
   };
 } // end anonymous namespace
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2430,7 +2430,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
 
   // @unchecked conformances are considered unsafe in strict concurrency mode.
   if (conformance->isUnchecked() &&
-      Context.LangOpts.hasFeature(Feature::DisallowUnsafe) &&
+      Context.LangOpts.hasFeature(Feature::WarnUnsafe) &&
       Context.LangOpts.StrictConcurrencyLevel == StrictConcurrency::Complete) {
     Context.Diags.diagnose(ComplainLoc, diag::unchecked_conformance_is_unsafe);
   }
@@ -5032,7 +5032,7 @@ void ConformanceChecker::resolveValueWitnesses() {
 
       // If we're disallowing unsafe code, check for an unsafe witness to a
       // safe requirement.
-      if (C.LangOpts.hasFeature(Feature::DisallowUnsafe) &&
+      if (C.LangOpts.hasFeature(Feature::WarnUnsafe) &&
           witness->isUnsafe() && !requirement->isUnsafe()) {
         witness->diagnose(diag::witness_unsafe,
                           witness->getDescriptiveKind(),

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2428,6 +2428,13 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
       ComplainLoc, diag::unchecked_conformance_not_special, ProtoType);
   }
 
+  // @unchecked conformances are considered unsafe in strict concurrency mode.
+  if (conformance->isUnchecked() &&
+      Context.LangOpts.hasFeature(Feature::DisallowUnsafe) &&
+      Context.LangOpts.StrictConcurrencyLevel == StrictConcurrency::Complete) {
+    Context.Diags.diagnose(ComplainLoc, diag::unchecked_conformance_is_unsafe);
+  }
+
   bool allowImpliedConditionalConformance = false;
   if (Proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
     // In -swift-version 5 mode, a conditional conformance to a protocol can imply
@@ -5021,6 +5028,15 @@ void ConformanceChecker::resolveValueWitnesses() {
             requirement,
             Conformance->getWitnessUncached(requirement)
               .withEnterIsolation(*enteringIsolation));
+      }
+
+      // If we're disallowing unsafe code, check for an unsafe witness to a
+      // safe requirement.
+      if (C.LangOpts.hasFeature(Feature::DisallowUnsafe) &&
+          witness->isUnsafe() && !requirement->isUnsafe()) {
+        witness->diagnose(diag::witness_unsafe,
+                          witness->getDescriptiveKind(),
+                          witness->getName());
       }
 
       // Objective-C checking for @objc requirements.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6422,13 +6422,13 @@ Type ExplicitCaughtTypeRequest::evaluate(
   llvm_unreachable("Unhandled catch node");
 }
 
-bool swift::diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
+void swift::diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
                                llvm::function_ref<void(Type)> diagnose) {
-  if (!ctx.LangOpts.hasFeature(Feature::DisallowUnsafe))
-    return false;
+  if (!ctx.LangOpts.hasFeature(Feature::WarnUnsafe))
+    return;
 
   if (!type->isUnsafe())
-    return false;
+    return;
 
   // Look for a specific @unsafe nominal type.
   Type specificType;
@@ -6436,7 +6436,7 @@ bool swift::diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
     if (auto typeDecl = type->getAnyNominal()) {
       if (typeDecl->isUnsafe()) {
         specificType = type;
-        return true;
+        return false;
       }
     }
 
@@ -6450,6 +6450,4 @@ bool swift::diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
       specificTypeDecl->diagnose(diag::unsafe_decl_here, specificTypeDecl);
     }
   }
-
-  return true;
 }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -688,10 +688,7 @@ bool diagnoseMissingOwnership(ParamSpecifier ownership,
 
 /// If the given type involves an unsafe type, diagnose it by calling the
 /// diagnose function with the most specific unsafe type that can be provided.
-///
-/// \returns \c true if the type was unsafe and we are diagnosing unsafe types
-/// here.
-bool diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
+void diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
                         llvm::function_ref<void(Type)> diagnose);
 
 } // end namespace swift

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -686,6 +686,14 @@ bool diagnoseMissingOwnership(ParamSpecifier ownership,
                               TypeRepr *repr, Type ty,
                               const TypeResolution &resolution);
 
+/// If the given type involves an unsafe type, diagnose it by calling the
+/// diagnose function with the most specific unsafe type that can be provided.
+///
+/// \returns \c true if the type was unsafe and we are diagnosing unsafe types
+/// here.
+bool diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
+                        llvm::function_ref<void(Type)> diagnose);
+
 } // end namespace swift
 
 #endif /* SWIFT_SEMA_TYPE_CHECK_TYPE_H */

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -628,6 +628,7 @@ function(_compile_swift_files
   list(APPEND swift_flags "-enable-experimental-feature" "NoncopyableGenerics2")
   list(APPEND swift_flags "-enable-experimental-feature" "SuppressedAssociatedTypes")
   list(APPEND swift_flags "-enable-experimental-feature" "SE427NoInferenceOnExtension")
+  list(APPEND swift_flags "-enable-experimental-feature" "AllowUnsafeAttribute")
 
   if(SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES)
     list(APPEND swift_flags "-enable-experimental-feature" "NonescapableTypes")

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS
   "-enable-experimental-feature"
   "IsolatedAny"
-)
+  )
 
 list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
   "-D__STDC_WANT_LIB_EXT1__=1")

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -480,6 +480,7 @@ extension JobPriority: Comparable {
 /// without making other changes.
 @available(SwiftStdlib 5.1, *)
 @frozen
+@unsafe
 public struct UnsafeContinuation<T, E: Error>: Sendable {
   @usableFromInline internal var context: Builtin.RawUnsafeContinuation
 
@@ -683,6 +684,7 @@ internal func _resumeUnsafeThrowingContinuationWithError<T>(
 /// - SeeAlso: `withCheckedThrowingContinuation(function:_:)`
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
+@unsafe
 public func withUnsafeContinuation<T>(
   isolation: isolated (any Actor)? = #isolation,
   _ fn: (UnsafeContinuation<T, Never>) -> Void
@@ -719,6 +721,7 @@ public func withUnsafeContinuation<T>(
 /// - SeeAlso: `withCheckedThrowingContinuation(function:_:)`
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
+@unsafe
 public func withUnsafeThrowingContinuation<T>(
   isolation: isolated (any Actor)? = #isolation,
   _ fn: (UnsafeContinuation<T, Error>) -> Void

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -1033,6 +1033,7 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) async throws -> 
 /// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
 /// [tspl]: https://docs.swift.org/swift-book/
 @available(SwiftStdlib 5.1, *)
+@unsafe
 public struct UnsafeCurrentTask {
   internal let _task: Builtin.NativeObject
 

--- a/stdlib/public/Synchronization/Mutex/Mutex.swift
+++ b/stdlib/public/Synchronization/Mutex/Mutex.swift
@@ -175,6 +175,7 @@ extension _MutexHandle {
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
+  @unsafe
   public borrowing func unsafeLock() {
     _lock()
   }
@@ -182,6 +183,7 @@ extension _MutexHandle {
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
+  @unsafe
   public borrowing func unsafeTryLock() -> Bool {
     _tryLock()
   }
@@ -189,6 +191,7 @@ extension _MutexHandle {
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
+  @unsafe
   public borrowing func unsafeUnlock() {
     _unlock()
   }

--- a/stdlib/public/Volatile/Volatile.swift
+++ b/stdlib/public/Volatile/Volatile.swift
@@ -29,6 +29,7 @@ public struct VolatileMappedRegister<Pointee> {
   let _rawPointer: Builtin.RawPointer
 
   @_transparent
+  @unsafe
   public init(unsafeBitPattern: UInt) {
      self._rawPointer = Builtin.inttoptr_Word(unsafeBitPattern._builtinWordValue)
   }

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -91,6 +91,7 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
 /// Returns: A new instance of type `U`, cast from `x`.
 @inlinable // unsafe-performance
 @_transparent
+@unsafe
 public func unsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {
   _precondition(MemoryLayout<T>.size == MemoryLayout<U>.size,
     "Can't unsafeBitCast between types of different sizes")
@@ -242,6 +243,7 @@ internal func _isClassOrObjCExistential<T>(_ x: T.Type) -> Bool {
 /// be either a class or a class protocol. Either T, U, or both may be
 /// optional references.
 @_transparent
+@unsafe
 public func _unsafeReferenceCast<T, U>(_ x: T, to: U.Type) -> U {
   return Builtin.castReference(x)
 }
@@ -265,12 +267,14 @@ public func _unsafeReferenceCast<T, U>(_ x: T, to: U.Type) -> U {
 ///   - type: The type `T` to which `x` is cast.
 /// - Returns: The instance `x`, cast to type `T`.
 @_transparent
+@unsafe
 public func unsafeDowncast<T: AnyObject>(_ x: AnyObject, to type: T.Type) -> T {
   _debugPrecondition(x is T, "invalid unsafeDowncast")
   return Builtin.castReference(x)
 }
 
 @_transparent
+@unsafe
 public func _unsafeUncheckedDowncast<T: AnyObject>(_ x: AnyObject, to type: T.Type) -> T {
   _internalInvariant(x is T, "invalid unsafeDowncast")
   return Builtin.castReference(x)
@@ -331,6 +335,7 @@ public func _onFastPath() {
 // Optimizer hint that the condition is true. The condition is unchecked.
 // The builtin acts as an opaque instruction with side-effects.
 @usableFromInline @_transparent
+@unsafe
 func _uncheckedUnsafeAssume(_ condition: Bool) {
   _ = Builtin.assume_Int1(condition._value)
 }

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -150,6 +150,7 @@ public typealias CBool = Bool
 /// Opaque pointers are used to represent C pointers to types that
 /// cannot be represented in Swift, such as incomplete struct types.
 @frozen
+@unsafe
 public struct OpaquePointer {
   @usableFromInline
   internal var _rawValue: Builtin.RawPointer

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -155,6 +155,7 @@ public func _getTypeByMangledNameInContext(
 /// Prevents performance diagnostics in the passed closure.
 @_alwaysEmitIntoClient
 @_semantics("no_performance_analysis")
+@unsafe
 public func _unsafePerformance<T>(_ c: () -> T) -> T {
   return c()
 }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -338,6 +338,7 @@ extension Optional {
   ///   will never be equal to `nil` and only after you've tried using the
   ///   postfix `!` operator.
   @inlinable
+  @unsafe
   public var unsafelyUnwrapped: Wrapped {
     @inline(__always)
     get {

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -15,6 +15,7 @@
 /// When you use this type, you become partially responsible for
 /// keeping the object alive.
 @frozen
+@unsafe
 public struct Unmanaged<Instance: AnyObject> {
   @usableFromInline
   internal unowned(unsafe) var _value: Instance

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -30,6 +30,7 @@
 /// collection with an `${Self}` instance copies the instances out of the
 /// referenced memory and into the new collection.
 @frozen // unsafe-performance
+@unsafe
 public struct Unsafe${Mutable}BufferPointer<Element: ~Copyable>: Copyable {
 
   @usableFromInline

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -204,6 +204,7 @@
 ///       let numberPointer = UnsafePointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen // unsafe-performance
+@unsafe
 public struct UnsafePointer<Pointee: ~Copyable>: Copyable {
 
   /// The underlying raw (untyped) pointer.
@@ -655,6 +656,7 @@ extension UnsafePointer where Pointee: ~Copyable {
 ///       let numberPointer = UnsafeMutablePointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen // unsafe-performance
+@unsafe
 public struct UnsafeMutablePointer<Pointee: ~Copyable>: Copyable {
   /// The underlying raw (untyped) pointer.
   @_preInverseGenerics

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -95,6 +95,7 @@
 ///     destBytes[0..<n] = someBytes[n..<(n + n)]
 % end
 @frozen
+@unsafe
 public struct Unsafe${Mutable}RawBufferPointer {
   @usableFromInline
   internal let _position, _end: Unsafe${Mutable}RawPointer?

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -168,6 +168,7 @@
 ///       let numberPointer = UnsafeRawPointer(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen
+@unsafe
 public struct UnsafeRawPointer: _Pointer {
 
   public typealias Pointee = UInt8
@@ -773,6 +774,7 @@ extension UnsafeRawPointer {
 ///       let numberPointer = UnsafeMutableRawPointer(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen
+@unsafe
 public struct UnsafeMutableRawPointer: _Pointer {
 
   public typealias Pointee = UInt8

--- a/test/Unsafe/Inputs/module.modulemap
+++ b/test/Unsafe/Inputs/module.modulemap
@@ -1,0 +1,3 @@
+module unsafe_decls {
+  header "unsafe_decls.h"
+}

--- a/test/Unsafe/Inputs/unsafe_decls.h
+++ b/test/Unsafe/Inputs/unsafe_decls.h
@@ -3,3 +3,5 @@ void unsafe_c_function(void) __attribute__((swift_attr("unsafe")));
 struct __attribute__((swift_attr("unsafe"))) UnsafeType {
   int field;
 };
+
+void print_ints(int *ptr, int count);

--- a/test/Unsafe/Inputs/unsafe_decls.h
+++ b/test/Unsafe/Inputs/unsafe_decls.h
@@ -1,0 +1,5 @@
+void unsafe_c_function(void) __attribute__((swift_attr("unsafe")));
+
+struct __attribute__((swift_attr("unsafe"))) UnsafeType {
+  int field;
+};

--- a/test/Unsafe/Inputs/unsafe_swift_decls.swift
+++ b/test/Unsafe/Inputs/unsafe_swift_decls.swift
@@ -1,0 +1,13 @@
+@unsafe public struct PointerType { } // expected-note{{'PointerType' declared here}}
+
+public func getPointers() -> [PointerType] { [] }
+
+public struct HasAPointerType {
+  public typealias Ptr = PointerType
+}
+
+public protocol Ptrable {
+  associatedtype Ptr
+}
+
+extension HasAPointerType: Ptrable { }

--- a/test/Unsafe/interface_printing.swift
+++ b/test/Unsafe/interface_printing.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -module-name unsafe -emit-module -o %t/unsafe.swiftmodule -emit-module-interface-path - %s -enable-experimental-feature AllowUnsafeAttribute | %FileCheck %s
+
+// CHECK: #if compiler(>=5.3) && $AllowUnsafeAttribute
+// CHECK: @unsafe public func testFunction()
+// CHECK: #else
+// CHECK: public func testFunction()
+// CHECK: #endif
+@unsafe public func testFunction() { }

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -1,0 +1,64 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature DisallowUnsafe
+
+// Make sure everything compiles without error when unsafe code is allowed.
+// RUN: %target-swift-frontend -typecheck -enable-experimental-feature AllowUnsafeAttribute %s
+
+// -----------------------------------------------------------------------
+// Witness matching
+// -----------------------------------------------------------------------
+protocol P {
+  func f()
+  @unsafe func g()
+}
+
+struct XP: P {
+  @unsafe func f() { } // expected-error{{unsafe instance method 'f()' cannot satisfy safe requirement}}
+  @unsafe func g() { }
+}
+
+// -----------------------------------------------------------------------
+// Overrides
+// -----------------------------------------------------------------------
+class Super {
+  func f() { }
+  @unsafe func g() { }
+}
+
+class Sub: Super {
+  @unsafe override func f() { }
+  @unsafe override func g() { }  
+}
+
+// -----------------------------------------------------------------------
+// Owned pointers
+// -----------------------------------------------------------------------
+struct SuperHolder {
+  unowned var s1: Super
+  unowned(unsafe) var s2: Super // expected-error{{unowned(unsafe) involves unsafe code}}
+}
+
+// -----------------------------------------------------------------------
+// Inheritance of @unsafe
+// -----------------------------------------------------------------------
+@unsafe class UnsafeSuper { // expected-note 2{{'UnsafeSuper' declared here}}
+  func f() { } // expected-note{{'f()' declared here}}
+};
+
+class UnsafeSub: UnsafeSuper { } // expected-error{{reference to unsafe class 'UnsafeSuper'}}
+
+// -----------------------------------------------------------------------
+// Declaration references
+// -----------------------------------------------------------------------
+@unsafe func unsafeF() { } // expected-note{{'unsafeF()' declared here}}
+@unsafe var unsafeVar: Int = 0 // expected-note{{'unsafeVar' declared here}}
+
+@unsafe struct PointerType { } // expected-note{{'PointerType' declared here}}
+
+func testMe(
+  _ pointer: PointerType, // expected-error{{reference to unsafe struct 'PointerType'}}
+  _ unsafeSuper: UnsafeSuper // expected-error{{reference to unsafe class 'UnsafeSuper'}}
+) { 
+  unsafeF() // expected-error{{call to unsafe global function 'unsafeF'}}
+  _ = unsafeVar // expected-error{{reference to unsafe var 'unsafeVar'}}
+  unsafeSuper.f() // expected-error{{call to unsafe instance method 'f'}}
+}

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/unsafe_swift_decls.swiftmodule %S/Inputs/unsafe_swift_decls.swift -enable-experimental-feature AllowUnsafeAttribute
 
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature DisallowUnsafe -I %t
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature WarnUnsafe -I %t
 
 // Make sure everything compiles without error when unsafe code is allowed.
 // RUN: %target-swift-frontend -typecheck -enable-experimental-feature AllowUnsafeAttribute %s -I %t
@@ -17,7 +17,7 @@ protocol P {
 }
 
 struct XP: P {
-  @unsafe func f() { } // expected-error{{unsafe instance method 'f()' cannot satisfy safe requirement}}
+  @unsafe func f() { } // expected-warning{{unsafe instance method 'f()' cannot satisfy safe requirement}}
   @unsafe func g() { }
 }
 
@@ -29,7 +29,7 @@ protocol Ptrable2 {
   associatedtype Ptr // expected-note{{'Ptr' declared here}}
 }
 
-extension HasAPointerType: Ptrable2 { } // expected-error{{unsafe type 'HasAPointerType.Ptr' (aka 'PointerType') cannot satisfy safe associated type 'Ptr'}}
+extension HasAPointerType: Ptrable2 { } // expected-warning{{unsafe type 'HasAPointerType.Ptr' (aka 'PointerType') cannot satisfy safe associated type 'Ptr'}}
 
 // -----------------------------------------------------------------------
 // Overrides
@@ -49,7 +49,7 @@ class Sub: Super {
 // -----------------------------------------------------------------------
 struct SuperHolder {
   unowned var s1: Super
-  unowned(unsafe) var s2: Super // expected-error{{unowned(unsafe) involves unsafe code}}
+  unowned(unsafe) var s2: Super // expected-warning{{unowned(unsafe) involves unsafe code}}
 }
 
 // -----------------------------------------------------------------------
@@ -59,7 +59,7 @@ struct SuperHolder {
   func f() { } // expected-note{{'f()' declared here}}
 };
 
-class UnsafeSub: UnsafeSuper { } // expected-error{{reference to unsafe class 'UnsafeSuper'}}
+class UnsafeSub: UnsafeSuper { } // expected-warning{{reference to unsafe class 'UnsafeSuper'}}
 
 // -----------------------------------------------------------------------
 // Declaration references
@@ -68,14 +68,14 @@ class UnsafeSub: UnsafeSuper { } // expected-error{{reference to unsafe class 'U
 @unsafe var unsafeVar: Int = 0 // expected-note{{'unsafeVar' declared here}}
 
 func testMe(
-  _ pointer: PointerType, // expected-error{{reference to unsafe struct 'PointerType'}}
-  _ unsafeSuper: UnsafeSuper // expected-error{{reference to unsafe class 'UnsafeSuper'}}
+  _ pointer: PointerType, // expected-warning{{reference to unsafe struct 'PointerType'}}
+  _ unsafeSuper: UnsafeSuper // expected-warning{{reference to unsafe class 'UnsafeSuper'}}
   // expected-note@-1{{'unsafeSuper' declared here}}
 ) { 
-  unsafeF() // expected-error{{call to unsafe global function 'unsafeF'}}
-  _ = unsafeVar // expected-error{{reference to unsafe var 'unsafeVar'}}
-  unsafeSuper.f() // expected-error{{call to unsafe instance method 'f'}}
-  // expected-error@-1{{reference to parameter 'unsafeSuper' involves unsafe type 'UnsafeSuper'}}
+  unsafeF() // expected-warning{{call to unsafe global function 'unsafeF'}}
+  _ = unsafeVar // expected-warning{{reference to unsafe var 'unsafeVar'}}
+  unsafeSuper.f() // expected-warning{{call to unsafe instance method 'f'}}
+  // expected-warning@-1{{reference to parameter 'unsafeSuper' involves unsafe type 'UnsafeSuper'}}
 
-  _ = getPointers() // expected-error{{call to global function 'getPointers' involves unsafe type 'PointerType'}}
+  _ = getPointers() // expected-warning{{call to global function 'getPointers' involves unsafe type 'PointerType'}}
 }

--- a/test/Unsafe/unsafe_concurrency.swift
+++ b/test/Unsafe/unsafe_concurrency.swift
@@ -1,15 +1,15 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature DisallowUnsafe -enable-experimental-feature StrictConcurrency
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature WarnUnsafe -enable-experimental-feature StrictConcurrency
 
 // REQUIRES: concurrency
 
-// expected-error@+1{{@unchecked conformance involves unsafe code}}
+// expected-warning@+1{{@unchecked conformance involves unsafe code}}
 class C: @unchecked Sendable {
   var counter: Int = 0
 }
 
 @available(SwiftStdlib 5.1, *)
 func f() async {
-  // expected-error@+1{{nonisolated(unsafe) involves unsafe code}}
+  // expected-warning@+1{{nonisolated(unsafe) involves unsafe code}}
   nonisolated(unsafe) var counter = 0
   Task.detached {
     counter += 1

--- a/test/Unsafe/unsafe_concurrency.swift
+++ b/test/Unsafe/unsafe_concurrency.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature DisallowUnsafe -enable-experimental-feature StrictConcurrency
+
+// REQUIRES: concurrency
+
+// expected-error@+1{{@unchecked conformance involves unsafe code}}
+class C: @unchecked Sendable {
+  var counter: Int = 0
+}
+
+@available(SwiftStdlib 5.1, *)
+func f() async {
+  // expected-error@+1{{nonisolated(unsafe) involves unsafe code}}
+  nonisolated(unsafe) var counter = 0
+  Task.detached {
+    counter += 1
+  }
+  counter += 1
+  print(counter)
+}
+

--- a/test/Unsafe/unsafe_disallowed.swift
+++ b/test/Unsafe/unsafe_disallowed.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift
+
+@unsafe func f() { }
+// expected-error@-1{{attribute requires '-enable-experimental-feature AllowUnsafeAttribute'}}
+

--- a/test/Unsafe/unsafe_imports.swift
+++ b/test/Unsafe/unsafe_imports.swift
@@ -1,11 +1,11 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature DisallowUnsafe -I %S/Inputs
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature WarnUnsafe -I %S/Inputs
 
 import unsafe_decls
 
-func testUnsafe(_ ut: UnsafeType) { // expected-error{{reference to unsafe struct 'UnsafeType'}}
-  unsafe_c_function() // expected-error{{call to unsafe global function 'unsafe_c_function'}}
+func testUnsafe(_ ut: UnsafeType) { // expected-warning{{reference to unsafe struct 'UnsafeType'}}
+  unsafe_c_function() // expected-warning{{call to unsafe global function 'unsafe_c_function'}}
 
   var array: [CInt] = [1, 2, 3, 4, 5]
   print_ints(&array, CInt(array.count))
-  // expected-error@-1{{call to global function 'print_ints' involves unsafe type 'UnsafeMutablePointer<Int32>'}}  
+  // expected-warning@-1{{call to global function 'print_ints' involves unsafe type 'UnsafeMutablePointer<Int32>'}}
 }

--- a/test/Unsafe/unsafe_imports.swift
+++ b/test/Unsafe/unsafe_imports.swift
@@ -4,4 +4,8 @@ import unsafe_decls
 
 func testUnsafe(_ ut: UnsafeType) { // expected-error{{reference to unsafe struct 'UnsafeType'}}
   unsafe_c_function() // expected-error{{call to unsafe global function 'unsafe_c_function'}}
+
+  var array: [CInt] = [1, 2, 3, 4, 5]
+  print_ints(&array, CInt(array.count))
+  // expected-error@-1{{call to global function 'print_ints' involves unsafe type 'UnsafeMutablePointer<Int32>'}}  
 }

--- a/test/Unsafe/unsafe_imports.swift
+++ b/test/Unsafe/unsafe_imports.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature DisallowUnsafe -I %S/Inputs
+
+import unsafe_decls
+
+func testUnsafe(_ ut: UnsafeType) { // expected-error{{reference to unsafe struct 'UnsafeType'}}
+  unsafe_c_function() // expected-error{{call to unsafe global function 'unsafe_c_function'}}
+}

--- a/test/Unsafe/unsafe_stdlib.swift
+++ b/test/Unsafe/unsafe_stdlib.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature DisallowUnsafe
+
+// Make sure everything compiles without error when unsafe code is allowed.
+// RUN: %target-swift-frontend -typecheck -enable-experimental-feature AllowUnsafeAttribute %s
+
+func test(
+  x: OpaquePointer, // expected-error{{reference to unsafe struct 'OpaquePointer'}}
+  other: UnsafeMutablePointer<Int> // expected-error{{reference to unsafe generic struct 'UnsafeMutablePointer'}}
+) {
+  var array = [1, 2, 3]
+  // expected-error@+1{{call to instance method 'withUnsafeBufferPointer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
+  array.withUnsafeBufferPointer{ buffer in // expected-note{{'buffer' declared here}}
+    print(buffer) // expected-error{{reference to parameter 'buffer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
+  }
+  array.append(4)
+  _ = array
+}

--- a/test/Unsafe/unsafe_stdlib.swift
+++ b/test/Unsafe/unsafe_stdlib.swift
@@ -1,16 +1,16 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature AllowUnsafeAttribute -enable-experimental-feature DisallowUnsafe
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature WarnUnsafe
 
 // Make sure everything compiles without error when unsafe code is allowed.
-// RUN: %target-swift-frontend -typecheck -enable-experimental-feature AllowUnsafeAttribute %s
+// RUN: %target-swift-frontend -typecheck -enable-experimental-feature AllowUnsafeAttribute -warnings-as-errors %s
 
 func test(
-  x: OpaquePointer, // expected-error{{reference to unsafe struct 'OpaquePointer'}}
-  other: UnsafeMutablePointer<Int> // expected-error{{reference to unsafe generic struct 'UnsafeMutablePointer'}}
+  x: OpaquePointer, // expected-warning{{reference to unsafe struct 'OpaquePointer'}}
+  other: UnsafeMutablePointer<Int> // expected-warning{{reference to unsafe generic struct 'UnsafeMutablePointer'}}
 ) {
   var array = [1, 2, 3]
-  // expected-error@+1{{call to instance method 'withUnsafeBufferPointer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
+  // expected-warning@+1{{call to instance method 'withUnsafeBufferPointer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
   array.withUnsafeBufferPointer{ buffer in // expected-note{{'buffer' declared here}}
-    print(buffer) // expected-error{{reference to parameter 'buffer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
+    print(buffer) // expected-warning{{reference to parameter 'buffer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
   }
   array.append(4)
   _ = array

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -360,3 +360,18 @@ Func ContiguousArray.withUnsafeBufferPointer(_:) is now without @rethrows
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has generic signature change from <Element, R> to <Element, R, E where E : Swift.Error>
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has parameter 0 type change from (inout Swift.UnsafeMutableBufferPointer<Element>) throws -> R to (inout Swift.UnsafeMutableBufferPointer<Element>) throws(E) -> R
 Func ContiguousArray.withUnsafeMutableBufferPointer(_:) is now without @rethrows
+
+// Adoption of @unsafe
+Func unsafeBitCast(_:to:) is now with @unsafe
+Func unsafeDowncast(_:to:) is now with @unsafe
+Struct OpaquePointer is now with @unsafe
+Struct Unmanaged is now with @unsafe
+Struct UnsafeBufferPointer is now with @unsafe
+Struct UnsafeMutableBufferPointer is now with @unsafe
+Struct UnsafeMutablePointer is now with @unsafe
+Struct UnsafeMutableRawBufferPointer is now with @unsafe
+Struct UnsafeMutableRawPointer is now with @unsafe
+Struct UnsafePointer is now with @unsafe
+Struct UnsafeRawBufferPointer is now with @unsafe
+Struct UnsafeRawPointer is now with @unsafe
+Var Optional.unsafelyUnwrapped is now with @unsafe

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -3,3 +3,18 @@
 // NOTE: Most differences from the baseline are common across all architectures
 // should go into stability-stdlib-source-base.swift.expected. Only capture
 // x86_64-specific differences from the baseline here.
+
+// Adoption of @unsafe
+Func unsafeBitCast(_:to:) is now with @unsafe
+Func unsafeDowncast(_:to:) is now with @unsafe
+Struct OpaquePointer is now with @unsafe
+Struct Unmanaged is now with @unsafe
+Struct UnsafeBufferPointer is now with @unsafe
+Struct UnsafeMutableBufferPointer is now with @unsafe
+Struct UnsafeMutablePointer is now with @unsafe
+Struct UnsafeMutableRawBufferPointer is now with @unsafe
+Struct UnsafeMutableRawPointer is now with @unsafe
+Struct UnsafePointer is now with @unsafe
+Struct UnsafeRawBufferPointer is now with @unsafe
+Struct UnsafeRawPointer is now with @unsafe
+Var Optional.unsafelyUnwrapped is now with @unsafe

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -3,18 +3,3 @@
 // NOTE: Most differences from the baseline are common across all architectures
 // should go into stability-stdlib-source-base.swift.expected. Only capture
 // x86_64-specific differences from the baseline here.
-
-// Adoption of @unsafe
-Func unsafeBitCast(_:to:) is now with @unsafe
-Func unsafeDowncast(_:to:) is now with @unsafe
-Struct OpaquePointer is now with @unsafe
-Struct Unmanaged is now with @unsafe
-Struct UnsafeBufferPointer is now with @unsafe
-Struct UnsafeMutableBufferPointer is now with @unsafe
-Struct UnsafeMutablePointer is now with @unsafe
-Struct UnsafeMutableRawBufferPointer is now with @unsafe
-Struct UnsafeMutableRawPointer is now with @unsafe
-Struct UnsafePointer is now with @unsafe
-Struct UnsafeRawBufferPointer is now with @unsafe
-Struct UnsafeRawPointer is now with @unsafe
-Var Optional.unsafelyUnwrapped is now with @unsafe


### PR DESCRIPTION
Allow any declaration to be marked with `@unsafe`, meaning that it involves unsafe code. This also extends to C declarations marked with the `swift_attr("unsafe")` attribute.

Under a separate experimental flag (`WarnUnsafe`), warn about any attempt to use an `@unsafe` declaration, type, or any unsafe language feature (such as `unowned(unsafe)`, `@unchecked Sendable`). This defines a "safe" mode in Swift that prohibits memory-unsafe constructs. These language features are considered unsafe:

* `@unchecked Sendable`: diagnosed only when strict concurrency is enabled.
* `unowned(unsafe)`
* `nonisolated(unsafe)`: diagnosed only when strict concurrency is enabled.

An `@unsafe` declaration cannot:
* Override a safe declaration.
* Witness a safe requirement.
* Be referenced from code that has strict checking enabled.

Annotate all of the `Unsafe*` types and `unsafe` functions in the standard library (including concurrency, synchronization, etc.) as `@unsafe`. This includes:
* `Unsafe(Mutable)(Raw)(Buffer)Pointer`
* `OpaquePointer`
* `Unmanaged`
* `unsafeBitCast`, `unsafeDowncast`
* `Optional.unsafelyUnwrapped`
* `UnsafeContinuation`, `withUnsafe(Throwing)Continuation`
* `UnsafeCurrentTask`
* `Mutex`'s `unsafeTryLock`, `unsafeLock`, `unsafeUnlock`
* `VolatileMappedRegister.init(unsafeBitPattern:)`

There are a large number of APIs that *could* be explicitly marked `@unsafe` because they traffic in unsafe types. This isn't strictly necessary, because the language design will diagnose attempts to use these entities when in the safe mode, so I've opted to keep the set of changes smaller by omitting them.

I'm tracking this idea via rdar://133963224