### PR TITLE
[cxx-interop][rebranch] Print `inline` instead of `static inline` for template specializations

### DIFF
--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -586,7 +586,7 @@ void ClangValueTypePrinter::printTypePrecedingGenericTraits(
 
   if (printer.printNominalTypeOutsideMemberDeclTemplateSpecifiers(typeDecl))
     os << "template<>\n";
-  os << "static inline const constexpr bool isUsableInGenericContext<";
+  os << "inline const constexpr bool isUsableInGenericContext<";
   printer.printNominalTypeReference(typeDecl,
                                     /*moduleContext=*/nullptr);
   os << "> = ";
@@ -635,7 +635,7 @@ void ClangValueTypePrinter::printTypeGenericTraits(
   if (typeDecl->hasClangNode()) {
     // FIXME: share the code.
     os << "template<>\n";
-    os << "static inline const constexpr bool isUsableInGenericContext<";
+    os << "inline const constexpr bool isUsableInGenericContext<";
     printer.printClangTypeReference(typeDecl->getClangDecl());
     os << "> = true;\n";
   }
@@ -670,7 +670,7 @@ void ClangValueTypePrinter::printTypeGenericTraits(
 
   if (typeDecl->hasClangNode()) {
     os << "template<>\n";
-    os << "static inline const constexpr bool isSwiftBridgedCxxRecord<";
+    os << "inline const constexpr bool isSwiftBridgedCxxRecord<";
     printer.printClangTypeReference(typeDecl->getClangDecl());
     os << "> = true;\n";
   }
@@ -679,7 +679,7 @@ void ClangValueTypePrinter::printTypeGenericTraits(
     assert(NTD && "not a nominal type?");
     if (printer.printNominalTypeOutsideMemberDeclTemplateSpecifiers(NTD))
       os << "template<>\n";
-    os << "static inline const constexpr bool isValueType<";
+    os << "inline const constexpr bool isValueType<";
     printer.printBaseName(typeDecl->getModuleContext());
     os << "::";
     printer.printNominalTypeReference(NTD, moduleContext);
@@ -690,7 +690,7 @@ void ClangValueTypePrinter::printTypeGenericTraits(
     assert(!isa<ClassDecl>(typeDecl) && !typeDecl->hasClangNode());
     if (printer.printNominalTypeOutsideMemberDeclTemplateSpecifiers(NTD))
       os << "template<>\n";
-    os << "static inline const constexpr bool isOpaqueLayout<";
+    os << "inline const constexpr bool isOpaqueLayout<";
     printer.printNominalTypeReference(NTD,
                                       /*moduleContext=*/nullptr);
     os << "> = true;\n";

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -202,7 +202,7 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
     }
 
     os << "template<>\n";
-    os << "static inline const constexpr bool isUsableInGenericContext<"
+    os << "inline const constexpr bool isUsableInGenericContext<"
        << typeInfo.name << "> = true;\n\n";
 
     os << "template<>\nstruct TypeMetadataTrait<" << typeInfo.name << "> {\n"

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -217,7 +217,7 @@ public struct Strct {
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<ns::NonTrivialTemplateInt> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<ns::NonTrivialTemplateInt> = true;
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplateInt> {
 // CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
@@ -226,7 +226,7 @@ public struct Strct {
 // CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isSwiftBridgedCxxRecord<ns::NonTrivialTemplateInt> = true;
+// CHECK-NEXT: inline const constexpr bool isSwiftBridgedCxxRecord<ns::NonTrivialTemplateInt> = true;
 // CHECK-NEXT: } // namespace
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
@@ -256,7 +256,7 @@ public struct Strct {
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<ns::NonTrivialTemplateTrivial> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<ns::NonTrivialTemplateTrivial> = true;
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplateTrivial> {
 // CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
@@ -265,7 +265,7 @@ public struct Strct {
 // CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isSwiftBridgedCxxRecord<ns::NonTrivialTemplateTrivial> = true;
+// CHECK-NEXT: inline const constexpr bool isSwiftBridgedCxxRecord<ns::NonTrivialTemplateTrivial> = true;
 // CHECK-NEXT: } // namespace
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift

--- a/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
@@ -38,7 +38,7 @@ public final class ClassWithIntField {
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Class::ClassWithIntField> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<Class::ClassWithIntField> = true;
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
 

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
@@ -40,7 +40,7 @@
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
 
-// CHECK: static inline const constexpr bool isUsableInGenericContext<void *> = true;
+// CHECK: inline const constexpr bool isUsableInGenericContext<void *> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<void *> {
@@ -50,7 +50,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<swift::Int> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<swift::Int> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<swift::Int> {
@@ -60,7 +60,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<swift::UInt> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<swift::UInt> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<swift::UInt> {

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
@@ -104,7 +104,7 @@
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<bool> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<bool> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<bool> {
@@ -114,7 +114,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<int8_t> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<int8_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<int8_t> {
@@ -124,7 +124,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<uint8_t> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<uint8_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<uint8_t> {
@@ -134,7 +134,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<int16_t> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<int16_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<int16_t> {
@@ -144,7 +144,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<uint16_t> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<uint16_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<uint16_t> {
@@ -154,7 +154,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<int32_t> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<int32_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<int32_t> {
@@ -164,7 +164,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<uint32_t> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<uint32_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<uint32_t> {
@@ -174,7 +174,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<int64_t> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<int64_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<int64_t> {
@@ -184,7 +184,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<uint64_t> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<uint64_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<uint64_t> {
@@ -194,7 +194,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<float> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<float> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<float> {
@@ -204,7 +204,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<double> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<double> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<double> {
@@ -214,7 +214,7 @@
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<void *> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<void *> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<void *> {

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -102,7 +102,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #endif
 // CHECK-NEXT: class SWIFT_SYMBOL("s:8Generics17GenericCustomTypeO") GenericCustomType;
 
-// CHECK: static inline const constexpr bool isOpaqueLayout<Generics::GenericCustomType<T_0_0>> = true;
+// CHECK: inline const constexpr bool isOpaqueLayout<Generics::GenericCustomType<T_0_0>> = true;
 
 // CHECK: template<class T_0_0>
 
@@ -116,7 +116,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Generics::GenericOpt<T_0_0>> = isUsableInGenericContext<T_0_0>;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<Generics::GenericOpt<T_0_0>> = isUsableInGenericContext<T_0_0>;
 
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -210,7 +210,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif // __cpp_concepts
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Generics::GenericPair<T_0_0, T_0_1>> = isUsableInGenericContext<T_0_0> && isUsableInGenericContext<T_0_1>;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<Generics::GenericPair<T_0_0, T_0_1>> = isUsableInGenericContext<T_0_0> && isUsableInGenericContext<T_0_1>;
 
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: #ifdef __cpp_concepts
@@ -284,12 +284,12 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif // __cpp_concepts
-// CHECK-NEXT: static inline const constexpr bool isValueType<Generics::GenericPair<T_0_0, T_0_1>> = true;
+// CHECK-NEXT: inline const constexpr bool isValueType<Generics::GenericPair<T_0_0, T_0_1>> = true;
 // CHECK-NEXT: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif // __cpp_concepts
-// CHECK-NEXT: static inline const constexpr bool isOpaqueLayout<Generics::GenericPair<T_0_0, T_0_1>> = true;
+// CHECK-NEXT: inline const constexpr bool isOpaqueLayout<Generics::GenericPair<T_0_0, T_0_1>> = true;
 // CHECK-NEXT: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT:  requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>

--- a/test/Interop/SwiftToCxx/generics/generic-type-traits-fwd.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-type-traits-fwd.swift
@@ -31,10 +31,10 @@ public struct LaterGeneric<T> {
 // CHECK: class SWIFT_SYMBOL("s:8Generics12LaterGenericV") LaterGeneric;
 
 // CHECK: class SWIFT_SYMBOL("s:8Generics16ComesFirstStructV") ComesFirstStruct;
-// CHECK: static inline const constexpr bool isUsableInGenericContext<Generics::ComesFirstStruct> = true;
+// CHECK: inline const constexpr bool isUsableInGenericContext<Generics::ComesFirstStruct> = true;
 
 // CHECK: class SWIFT_SYMBOL("s:8Generics14ComesFirstEnumO") ComesFirstEnum;
-// CHECK: static inline const constexpr bool isUsableInGenericContext<Generics::ComesFirstEnum> = true;
+// CHECK: inline const constexpr bool isUsableInGenericContext<Generics::ComesFirstEnum> = true;
 
 // CHECK: class SWIFT_SYMBOL("s:8Generics14ComesFirstEnumO") ComesFirstEnum final {
 // CHECK: LaterGeneric<ComesFirstEnum> returnsLaterOpt() const SWIFT_SYMBOL("s:8Generics14ComesFirstEnumO15returnsLaterOptAA0F7GenericVyACGyF");

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
@@ -30,7 +30,7 @@ public struct FirstSmallStruct {
 // CHECK: class SWIFT_SYMBOL("s:7Structs16FirstSmallStructV") FirstSmallStruct;
 
 // CHECK: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Structs::FirstSmallStruct> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<Structs::FirstSmallStruct> = true;
 
 // CHECK: class SWIFT_SYMBOL("s:7Structs16FirstSmallStructV") FirstSmallStruct final {
 // CHECK-NEXT: public:
@@ -91,9 +91,9 @@ public struct FirstSmallStruct {
 // CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isValueType<Structs::FirstSmallStruct> = true;
+// CHECK-NEXT: inline const constexpr bool isValueType<Structs::FirstSmallStruct> = true;
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isOpaqueLayout<Structs::FirstSmallStruct> = true;
+// CHECK-NEXT: inline const constexpr bool isOpaqueLayout<Structs::FirstSmallStruct> = true;
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct implClassFor<Structs::FirstSmallStruct> { using type = Structs::_impl::_impl_FirstSmallStruct; };
 // CHECK-NEXT: } // namespace

--- a/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
@@ -16,7 +16,7 @@
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Structs::StructWithIntField> = true;
+// CHECK-NEXT: inline const constexpr bool isUsableInGenericContext<Structs::StructWithIntField> = true;
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
 
@@ -112,7 +112,7 @@
 // CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isValueType<Structs::StructWithIntField> = true;
+// CHECK-NEXT: inline const constexpr bool isValueType<Structs::StructWithIntField> = true;
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct implClassFor<Structs::StructWithIntField> { using type = Structs::_impl::_impl_StructWithIntField; };
 // CHECK-NEXT: } // namespace


### PR DESCRIPTION
This fixes a number of test failures in reverse C++ interop.

Clang's behavior was changed in https://github.com/llvm/llvm-project/pull/93873, and it no longer accepts the C++ headers that Swift generates.

rdar://132283247