### PR TITLE
[Sema] Don't parse skipped bodies when computing discriminators

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -412,7 +412,8 @@ unsigned LocalDiscriminatorsRequest::evaluate(
   ParameterList *params = nullptr;
   ParamDecl *selfParam = nullptr;
   if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
-    node = func->getBody();
+    if (!func->isBodySkipped())
+      node = func->getBody();
     selfParam = func->getImplicitSelfDecl();
     params = func->getParameters();
 

--- a/test/Frontend/skip-function-bodies-parsing.swift
+++ b/test/Frontend/skip-function-bodies-parsing.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t/stats)
+
+// RUN: %target-swift-frontend -emit-module -experimental-skip-non-inlinable-function-bodies-without-types -module-name Mod -emit-module-path %t/Mod.swiftmodule -stats-output-dir %t/stats %s
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/stats.csv %t/stats
+// RUN: %FileCheck -input-file %t/stats.csv %s
+
+// The printing implementation differs in asserts and no-asserts builds, it will
+// either print `"Parse.NumFunctionsParsed" 0` or not print it at all. Make sure
+// we don't output any non-zero value.
+// CHECK-NOT: {{"Parse.NumFunctionsParsed" [^0]}}
+
+// Make sure we skip parsing these bodies.
+public func foo(x: Int, y: Int) {}
+
+public func bar() {
+  func baz() {}
+}
+
+public struct S {
+  public func qux() {}
+}

--- a/test/Parse/issue-74561.swift
+++ b/test/Parse/issue-74561.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+
+// Make sure we can parse with and without skipping.
+// RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -emit-module -experimental-skip-non-inlinable-function-bodies -module-name Mod -emit-module-path %t/Mod.swiftmodule -diagnostic-style=llvm %s 2>&1 | %FileCheck %s
+
+// https://github.com/swiftlang/swift/issues/74561
+// Make sure we can parse this.
+#sourceLocation(file: "A", line: 3)
+public func foo(_ param: Int) {
+#sourceLocation()
+}
+
+// FIXME: This should parse correctly.
+#sourceLocation(file: "B", line: 3)
+@inlinable
+public func bar(_ param: Int) {
+#sourceLocation()
+}
+// CHECK: B:6:1: error: parameterless closing #sourceLocation() directive without prior opening #sourceLocation(file:,line:) directive


### PR DESCRIPTION
The refactoring in #68760 accidentally caused us to start parsing skipped function bodies if they have parameters when emitting modules, as the local discriminator request kicks parsing through `getBody()`. Cherry-pick part of 47ff9568db749def08007b64a5425789cb514ac3 which was never landed, ensuring we don't call `getBody` for a skipped function body.

This is meant to be a minimal low-risk change that fixes the issue in question, restoring the behavior we had in 5.10 (and currently have in Xcode 16b3). Fixing the parser skipping behavior for `#sourceLocation` will be done in a follow-up. We also ought to see if there's a better way we can enforce that skipped function bodies don't end up getting parsed, for now I've added a test.

rdar://131726797
Resolves #74561