### PR TITLE
[NFC] PrunedLiveness: Clarified boundary API.

### DIFF
--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -617,10 +617,13 @@ protected:
   bool isAvailableOut(SILBasicBlock *block, DeadEndBlocks &deadEndBlocks) const;
   bool isInstructionAvailable(SILInstruction *user,
                               DeadEndBlocks &deadEndBlocks) const;
+  /// Whether \p user is within the liveness boundary (never extended into
+  /// dead-end regions).
+  bool isWithinLivenessBoundary(SILInstruction *inst) const;
   /// Whether \p user is within the boundary extended from live regions into
   /// dead-end regions up to the availability boundary.
   bool isWithinExtendedBoundary(SILInstruction *user,
-                                DeadEndBlocks *deadEndBlocks) const;
+                                DeadEndBlocks &deadEndBlocks) const;
 
 public:
   /// Add \p inst to liveness which uses the def as indicated by \p usage.
@@ -660,7 +663,12 @@ public:
 
   /// Check if \p inst occurs in between the definition this def and the
   /// liveness boundary.
-  bool isWithinBoundary(SILInstruction *inst) const;
+  ///
+  /// Pass \p deadEndBlocks when the defs' lifetime isn't known to be complete.
+  /// When passed, the liveness boundary is understood to extend into dead-end
+  /// regions.
+  bool isWithinBoundary(SILInstruction *inst,
+                        DeadEndBlocks *deadEndBlocks) const;
 
   /// Returns true when all \p uses are between this def and the liveness
   /// boundary \p deadEndBlocks is optional.

--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -131,7 +131,8 @@ static void visitUsersOutsideLinearLivenessBoundary(
       continue;
     }
     auto *user = pair.first;
-    if (linearLiveness.getLiveness().isWithinBoundary(user)) {
+    if (linearLiveness.getLiveness().isWithinBoundary(
+            user, /*deadEndBlocks=*/nullptr)) {
       continue;
     }
     visitor(user);

--- a/lib/SIL/Utils/ScopedAddressUtils.cpp
+++ b/lib/SIL/Utils/ScopedAddressUtils.cpp
@@ -202,7 +202,8 @@ bool swift::hasOtherStoreBorrowsInLifetime(StoreBorrowInst *storeBorrow,
 
   for (auto *otherStoreBorrow : otherStoreBorrows) {
     // Return true, if otherStoreBorrow was in \p storeBorrow's scope
-    if (liveness->isWithinBoundary(otherStoreBorrow)) {
+    if (liveness->isWithinBoundary(otherStoreBorrow,
+                                   /*deadEndBlocks=*/nullptr)) {
       return true;
     }
   }

--- a/lib/SIL/Verifier/LoadBorrowImmutabilityChecker.cpp
+++ b/lib/SIL/Verifier/LoadBorrowImmutabilityChecker.cpp
@@ -337,7 +337,7 @@ bool LoadBorrowImmutabilityAnalysis::isImmutableInScope(
       continue;
     }
 
-    if (borrowLiveness.isWithinBoundary(write)) {
+    if (borrowLiveness.isWithinBoundary(write, /*deadEndBlocks=*/nullptr)) {
       llvm::errs() << "Write: " << *write;
       return false;
     }

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -516,7 +516,7 @@ bool SILValueOwnershipChecker::checkDeadEnds(
   }
   auto allWithinBoundary = true;
   for (auto *use : regularUses) {
-    if (!liveness.isWithinBoundary(use->getUser())) {
+    if (!liveness.isWithinBoundary(use->getUser(), /*deadEndBlocks=*/nullptr)) {
       allWithinBoundary |= errorBuilder.handleMalformedSIL([&] {
         llvm::errs()
             << "Owned value without lifetime ending uses whose regular use "

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2714,7 +2714,7 @@ public:
                                   LinearLiveness::DoNotIncludeExtensions);
     linearLiveness.compute();
     auto &liveness = linearLiveness.getLiveness();
-    require(!liveness.isWithinBoundary(I),
+    require(!liveness.isWithinBoundary(I, /*deadEndBlocks=*/nullptr),
             "extend_lifetime use within unextended linear liveness boundary!?");
     PrunedLivenessBoundary boundary;
     liveness.computeBoundary(boundary);
@@ -2789,7 +2789,8 @@ public:
       if (scopedAddress.isScopeEndingUse(use)) {
         continue;
       }
-      if (!scopedAddressLiveness->isWithinBoundary(user)) {
+      if (!scopedAddressLiveness->isWithinBoundary(user,
+                                                   /*deadEndBlocks=*/nullptr)) {
         llvm::errs() << "User found outside scope: " << *user;
         return false;
       }

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -364,7 +364,7 @@ static bool isStoreCopy(SILValue value) {
     if (summary.innerBorrowKind != InnerBorrowKind::Contained) {
       return true;
     }
-    if (!liveness.isWithinBoundary(storeInst)) {
+    if (!liveness.isWithinBoundary(storeInst, /*deadEndBlocks=*/nullptr)) {
       return true;
     }
     return false;

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -892,7 +892,8 @@ static SILValue tryRewriteToPartialApplyStack(
         if (!origUse->getUser()->mayWriteToMemory()) {
           return true;
         }
-        if (closureLiveness.isWithinBoundary(origUse->getUser())) {
+        if (closureLiveness.isWithinBoundary(origUse->getUser(),
+                                             /*deadEndBlocks=*/nullptr)) {
           origIsUnmodifiedDuringClosureLifetime = false;
           LLVM_DEBUG(llvm::dbgs() << "-- original has other possibly writing "
                                      "use during closure lifetime\n";

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -499,7 +499,8 @@ bool ConsumeOperatorCopyableValuesChecker::check() {
         mvi->setAllowsDiagnostics(false);
 
         LLVM_DEBUG(llvm::dbgs() << "Move Value: " << *mvi);
-        if (livenessInfo.liveness->isWithinBoundary(mvi)) {
+        if (livenessInfo.liveness->isWithinBoundary(
+                mvi, /*deadEndBlocks=*/nullptr)) {
           LLVM_DEBUG(llvm::dbgs() << "    WithinBoundary: Yes!\n");
           emitDiagnosticForMove(lexicalValue, varName, mvi);
         } else {

--- a/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
@@ -322,7 +322,7 @@ static bool isOutOfLifetime(SILInstruction *inst, SSAPrunedLiveness &liveness) {
   // impossible that a use of the object is not a potential load. So we would
   // always see a potential load if the lifetime of the object goes beyond the
   // store_weak.
-  return !liveness.isWithinBoundary(inst);
+  return !liveness.isWithinBoundary(inst, /*deadEndBlocks=*/nullptr);
 }
 
 /// Reports a warning if the stored object \p storedObj is never loaded within

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2052,8 +2052,8 @@ struct GatherUsesVisitor : public TransitiveAddressWalker<GatherUsesVisitor> {
     liveness->initializeDef(bai);
     liveness->computeSimple();
     for (auto *consumingUse : li->getConsumingUses()) {
-      if (!liveness->areUsesWithinBoundary(
-              {consumingUse},
+      if (!liveness->isWithinBoundary(
+              consumingUse->getUser(),
               moveChecker.deba->get(consumingUse->getFunction()))) {
         diagnosticEmitter.emitAddressExclusivityHazardDiagnostic(
             markedValue, consumingUse->getUser());

--- a/lib/SILOptimizer/Mandatory/ReferenceBindingTransform.cpp
+++ b/lib/SILOptimizer/Mandatory/ReferenceBindingTransform.cpp
@@ -111,7 +111,7 @@ struct ValidateAllUsesWithinLiveness : public AccessUseVisitor {
     if (isa<EndAccessInst>(user))
       return true;
 
-    if (liveness.isWithinBoundary(user)) {
+    if (liveness.isWithinBoundary(user, /*deadEndBlocks=*/nullptr)) {
       LLVM_DEBUG(llvm::dbgs() << "User in boundary: " << *user);
       diagnose(op->getUser(),
                diag::sil_referencebinding_src_used_within_inout_scope);

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -259,7 +259,7 @@ void CanonicalizeOSSALifetime::extendLivenessToDeadEnds() {
   SSAPrunedLiveness completeLiveness(*liveness, &discoveredBlocks);
 
   for (auto destroy : destroys) {
-    if (liveness->isWithinBoundary(destroy))
+    if (liveness->isWithinBoundary(destroy, /*deadEndBlocks=*/nullptr))
       continue;
     completeLiveness.updateForUse(destroy, /*lifetimeEnding*/ true);
   }
@@ -592,7 +592,7 @@ void CanonicalizeOSSALifetime::visitExtendedUnconsumedBoundary(
 
 #ifndef NDEBUG
   for (auto *consume : consumes) {
-    assert(!liveness->isWithinBoundary(consume));
+    assert(!liveness->isWithinBoundary(consume, /*deadEndBlocks=*/nullptr));
   }
 #endif
 


### PR DESCRIPTION
When checking whether an instruction is contained in a liveness boundary, a pointer to a DeadEndBlocks instance must always be passed. When the pointer is null, it is only checked that the instruction occurs within the direct live region.  When the pointer is non-null, it is checked whether the instruction occurs within the region obtained by extending the live region up to the availability boundary within dead-end regions that are adjacent to the non-lifetime-ending portion of the liveness boundary.
