### PR TITLE
[immediate] Leak SwiftJIT to avoid unmapping metadata memory

### DIFF
--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -333,6 +333,11 @@ int swift::RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
 
   auto Result = (*JIT)->runMain(CmdLine);
 
+  // It is not safe to unmap memory that has been registered with the swift or
+  // objc runtime. Currently the best way to avoid that is to leak the JIT.
+  // FIXME: Replace with "detach" llvm/llvm-project#56714.
+  (void)JIT->release();
+
   if (!Result) {
     logError(Result.takeError());
     return -1;


### PR DESCRIPTION
It's not safe to unmap memory that has been registered with the swift/objc runtimes. For now, avoid this by leaking the JIT object. In the future we should be able to detach the JIT from the allocated memory, or be more fine-grained about which memory needs to be preserved and which can be freed.

rdar://128432487