### PR TITLE
[Conformance] Always downgrade redundant conformances to marker protocols to a warning.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6276,7 +6276,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
     }
 
     if ((existingModule != dc->getParentModule() && conformanceInOrigModule) ||
-        isSendable) {
+        diag.Protocol->isMarkerProtocol()) {
       // Warn about the conformance.
       if (isSendable && SendableConformance &&
           isa<InheritedProtocolConformance>(SendableConformance)) {

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -138,7 +138,7 @@ struct Burrito<Filling: ~Copyable>: ~Copyable {}
 extension Burrito: Alias {} // expected-error {{conformance to 'Copyable' must be declared in a separate extension}}
 // expected-note@-1 {{'Burrito<Filling>' declares conformance to protocol 'Copyable' here}}
 
-extension Burrito: Copyable & Edible & P {} // expected-error {{redundant conformance of 'Burrito<Filling>' to protocol 'Copyable'}}
+extension Burrito: Copyable & Edible & P {} // expected-warning {{redundant conformance of 'Burrito<Filling>' to protocol 'Copyable'}}
 
 struct Blah<T: ~Copyable>: ~Copyable {}
 extension Blah: P, Q, Copyable, R {} // expected-error {{generic struct 'Blah' required to be 'Copyable' but is marked with '~Copyable'}}

--- a/test/decl/protocol/conforms/redundant_conformance.swift
+++ b/test/decl/protocol/conforms/redundant_conformance.swift
@@ -86,3 +86,10 @@ class Class3 {
 class SomeMockClass: Class3.ProviderThree { // okay
   var someInt: Int = 5
 }
+
+
+class ImplicitCopyable {}
+
+class InheritImplicitCopyable: ImplicitCopyable, Copyable {}
+// expected-warning@-1 {{redundant conformance of 'InheritImplicitCopyable' to protocol 'Copyable'}}
+// expected-note@-2 {{'InheritImplicitCopyable' inherits conformance to protocol 'Copyable' from superclass here}}


### PR DESCRIPTION
Previous compiler versions allowed this, so we should stage the change in as a warning. This was already a warning across modules, so this change only impacts redundant conformances to marker protocols within a module. This code also isn't particularly harmful, because marker protocols don't have requirements, so there isn't the same risk of unexpected behavior as other redundant conformances.