### PR TITLE
[6.0][Conformance] Always downgrade redundant conformances to marker protocols to a warning.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6283,7 +6283,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
     }
 
     if ((existingModule != dc->getParentModule() && conformanceInOrigModule) ||
-        isSendable) {
+        diag.Protocol->isMarkerProtocol()) {
       // Warn about the conformance.
       if (isSendable && SendableConformance &&
           isa<InheritedProtocolConformance>(SendableConformance)) {

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -143,7 +143,7 @@ struct Burrito<Filling: ~Copyable>: ~Copyable {}
 extension Burrito: Alias {} // expected-error {{conformance to 'Copyable' must be declared in a separate extension}}
 // expected-note@-1 {{'Burrito<Filling>' declares conformance to protocol 'Copyable' here}}
 
-extension Burrito: Copyable & Edible & P {} // expected-error {{redundant conformance of 'Burrito<Filling>' to protocol 'Copyable'}}
+extension Burrito: Copyable & Edible & P {} // expected-warning {{redundant conformance of 'Burrito<Filling>' to protocol 'Copyable'}}
 
 struct Blah<T: ~Copyable>: ~Copyable {}
 extension Blah: P, Q, Copyable, R {} // expected-error {{generic struct 'Blah' required to be 'Copyable' but is marked with '~Copyable'}}

--- a/test/decl/protocol/conforms/redundant_conformance.swift
+++ b/test/decl/protocol/conforms/redundant_conformance.swift
@@ -86,3 +86,10 @@ class Class3 {
 class SomeMockClass: Class3.ProviderThree { // okay
   var someInt: Int = 5
 }
+
+
+class ImplicitCopyable {}
+
+class InheritImplicitCopyable: ImplicitCopyable, Copyable {}
+// expected-warning@-1 {{redundant conformance of 'InheritImplicitCopyable' to protocol 'Copyable'}}
+// expected-note@-2 {{'InheritImplicitCopyable' inherits conformance to protocol 'Copyable' from superclass here}}


### PR DESCRIPTION
  - **Explanation**: Compiler versions <= 6.0 allowed redundant conformances to marker protocols within the same module. To diagnose attempts to change the un-availability of a conformance to `Sendable`, https://github.com/swiftlang/swift/pull/75223 made a change to not allow superseding marker protocol conformances, which inadvertently broke cases where a redundant conformance to `Copyable` was written within a module.
    ```swift
    class C {}

    class C2: C, Copyable {} // error: redundant conformance to Copyable
    ```

    To avoid a source break, this change downgrades redundant conformances to marker protocols to warnings always. This code also isn't particularly harmful, because marker protocols don't have requirements, so there isn't the same risk of unexpected behavior as other redundant conformances. There's no particular need for this diagnostic to be an error.
  - **Scope**: Only impacts redundant conformances to marker protocols within the same module.
  - **Issues**: rdar://132346903
  - **Original PRs**: https://github.com/swiftlang/swift/pull/75425
  - **Risk**: Low; this change only opts more cases into the "downgrade to warning" path for redundant conformance diagnostics. Specifically, it replaces a check for `Sendable` to a check that the protocol is a marker protocol.
  - **Testing**: Added a new test case.
  - **Reviewers**: @DougGregor 