### PR TITLE
[embedded] Add QEMU-based testing configs for ARM and AVR for runtime testing

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -286,6 +286,9 @@ foreach(SDK ${SWIFT_SDKS})
         set(SWIFT_HAVE_LIBXML2 FALSE)
       endif()
 
+      set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM FALSE)
+      set(VARIANT_EXTERNAL_EMBEDDED_DEVICE)
+
       swift_configure_lit_site_cfg(
           "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
           "${test_bin_dir}/lit.site.cfg"
@@ -523,6 +526,28 @@ foreach(SDK ${SWIFT_SDKS})
     endforeach()
   endforeach()
 endforeach()
+
+if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
+  set(VARIANT_SUFFIX "-embedded-armv7")
+  set(VARIANT_TRIPLE "armv7em-none-none-eabi")
+  set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM TRUE)
+  set(VARIANT_EXTERNAL_EMBEDDED_DEVICE "arm-qemu-stm32f4")
+  set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
+  swift_configure_lit_site_cfg(
+      "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
+      "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
+      "test${VARIANT_SUFFIX}.lit.site.cfg")
+
+  set(VARIANT_SUFFIX "-embedded-avr")
+  set(VARIANT_TRIPLE "avr-none-none-elf")
+  set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM TRUE)
+  set(VARIANT_EXTERNAL_EMBEDDED_DEVICE "avr-qemu-atmega2560")
+  set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
+  swift_configure_lit_site_cfg(
+      "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
+      "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
+      "test${VARIANT_SUFFIX}.lit.site.cfg")
+endif()
 
 # Add shortcuts for the default variant.
 foreach(test_mode ${TEST_MODES})

--- a/test/Driver/LegacyDriver/lit.local.cfg
+++ b/test/Driver/LegacyDriver/lit.local.cfg
@@ -3,5 +3,5 @@ config.environment = dict(config.environment)
 
 # Remove the settings that force tests to use the old driver so that tests
 # in this directory can set `SWIFT_USE_NEW_DRIVER` to test those code paths.
-del config.environment['SWIFT_USE_OLD_DRIVER']
-del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']
+if 'SWIFT_USE_OLD_DRIVER' in config.environment: del config.environment['SWIFT_USE_OLD_DRIVER']
+if 'SWIFT_AVOID_WARNING_USING_OLD_DRIVER' in config.environment: del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']

--- a/test/Profiler/lit.local.cfg
+++ b/test/Profiler/lit.local.cfg
@@ -2,5 +2,5 @@
 config.environment = dict(config.environment)
 
 # Prefer the new driver for profiling tests
-del config.environment['SWIFT_USE_OLD_DRIVER']
-del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']
+if 'SWIFT_USE_OLD_DRIVER' in config.environment: del config.environment['SWIFT_USE_OLD_DRIVER']
+if 'SWIFT_AVOID_WARNING_USING_OLD_DRIVER' in config.environment: del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']

--- a/test/embedded/hello.swift
+++ b/test/embedded/hello.swift
@@ -1,0 +1,8 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -runtime-compatibility-version none -wmo) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+
+print("Hello, Embedded Swift!")
+
+// CHECK: Hello, Embedded Swift!

--- a/test/embedded/hello.swift
+++ b/test/embedded/hello.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf
 
 print("Hello, Embedded Swift!")
 

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -14,3 +14,6 @@ if config.target_sdk_name == 'macosx':
 if 'embedded_stdlib' not in config.available_features:
   config.unsupported = True
 
+config.environment = dict(config.environment)
+if 'SWIFT_USE_OLD_DRIVER' in config.environment: del config.environment['SWIFT_USE_OLD_DRIVER']
+if 'SWIFT_AVOID_WARNING_USING_OLD_DRIVER' in config.environment: del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2105,6 +2105,10 @@ elif config.external_embedded_platform:
         config.swift_symbolgraph_extract,
         '-target', config.variant_triple,
         mcp_opt])
+    config.target_swift_synthesize_interface = ' '.join([
+        config.swift_synthesize_interface,
+        '-target', config.variant_triple,
+        mcp_opt])
     config.target_swift_ide_test = (
         '%s -target %s %s %s %s %s' %
         (config.swift_ide_test, config.variant_triple, config.resource_dir_opt,

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -348,6 +348,7 @@ config.swift_demangle_yamldump = inferSwiftBinary('swift-demangle-yamldump')
 config.swift_demangle = inferSwiftBinary('swift-demangle')
 config.benchmark_o = inferSwiftBinary('Benchmark_O')
 config.benchmark_driver = inferSwiftBinary('Benchmark_Driver')
+config.lld = inferSwiftBinary('lld')
 config.wasm_ld = inferSwiftBinary('wasm-ld')
 config.swift_plugin_server = inferSwiftBinary('swift-plugin-server')
 config.swift_parse_test = inferSwiftBinary('swift-parse-test')
@@ -451,6 +452,8 @@ if run_os == 'openbsd' and run_cpu == 'amd64':
 run_ptrsize = '64' if ('64' in run_cpu or run_cpu == "s390x") else '32'
 if run_cpu == 'arm64_32':
   run_ptrsize = '32'
+if run_cpu == 'avr':
+  run_ptrsize = '16'
 
 run_ptrauth = 'ptrauth' if run_cpu == 'arm64e' else 'noptrauth'
 run_endian = 'little' if run_cpu != 's390x' else 'big'
@@ -2051,6 +2054,86 @@ elif run_os == 'wasi':
 
     # The Swift interpreter is not available when targeting WebAssembly/WASI.
     config.available_features.discard('swift_interpreter')
+
+elif config.external_embedded_platform:
+    lit_config.note("Testing embedded platform " + config.variant_triple)
+    
+    config.target_object_format = "elf"
+    config.target_sdk_name = "embedded"
+    config.target_runtime = "native"
+    config.target_shared_library_prefix = 'lib'
+    config.target_shared_library_suffix = ".so"
+    config.target_library_path_var = "LD_LIBRARY_PATH"
+
+    config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
+
+    embedded_test_support = os.path.join(config.swift_utils, 'embedded-test-support/embedded-test-support.py')
+    PATH = config.environment['PATH']
+
+    device = config.external_embedded_device
+    embedded_swift_flags = subprocess.check_output([embedded_test_support, "--device", device, "print-swift-flags"], env=config.environment).rstrip().decode('utf-8')
+    embedded_swift_frontend_flags = subprocess.check_output([embedded_test_support, "--device", device, "print-swift-frontend-flags"], env=config.environment).rstrip().decode('utf-8')
+    embedded_clang_flags = subprocess.check_output([embedded_test_support, "--device", device, "print-c-flags"], env=config.environment).rstrip().decode('utf-8')
+
+    config.target_build_swift = ' '.join([
+        config.swiftc,
+        '-target', config.variant_triple,
+        embedded_swift_flags,
+        mcp_opt, config.swift_test_options,
+        config.swift_driver_test_options, swift_execution_tests_extra_flags])
+    config.target_codesign = "echo"
+    config.target_build_swift_dylib = (
+        "%s -parse-as-library -emit-library -static -o '\\1'"
+        % (config.target_build_swift))
+    config.target_add_rpath = ''
+    config.target_swift_frontend = ' '.join([
+        config.swift_frontend,
+        '-target', config.variant_triple, embedded_swift_frontend_flags,
+        config.resource_dir_opt, mcp_opt,
+        config.swift_test_options, config.swift_frontend_test_options])
+    subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
+    subst_target_swift_frontend_mock_sdk_after = ""
+    config.target_run = embedded_test_support + ' --device %s run --elf-file ' % device
+    config.target_env_prefix = ''
+
+    config.target_sil_opt = (
+        '%s -target %s %s %s %s' %
+        (config.sil_opt, config.variant_triple, config.resource_dir_opt, mcp_opt, config.sil_test_options))
+    subst_target_sil_opt_mock_sdk = config.target_sil_opt
+    subst_target_sil_opt_mock_sdk_after = ""
+    config.target_swift_symbolgraph_extract = ' '.join([
+        config.swift_symbolgraph_extract,
+        '-target', config.variant_triple,
+        mcp_opt])
+    config.target_swift_ide_test = (
+        '%s -target %s %s %s %s %s' %
+        (config.swift_ide_test, config.variant_triple, config.resource_dir_opt,
+         mcp_opt, ccp_opt, config.swift_ide_test_test_options))
+    subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
+    subst_target_swift_ide_test_mock_sdk_after = ""
+    config.target_swiftc_driver = (
+        "%s -target %s -toolchain-stdlib-rpath %s %s" %
+        (config.swiftc, config.variant_triple, config.resource_dir_opt, mcp_opt))
+    config.target_stdlib_swiftc_driver = config.target_swiftc_driver
+    config.target_swift_modulewrap = (
+        '%s -modulewrap -target %s' %
+        (config.swiftc, config.variant_triple))
+    config.target_swift_emit_pcm = (
+        '%s -emit-pcm -target %s' %
+        (config.swiftc, config.variant_triple))
+    config.target_clang = (
+        "%s -target %s %s %s" %
+        (config.clang, config.variant_triple, embedded_clang_flags, clang_mcp_opt))
+    config.target_ld = (
+        "%s -L%r" %
+        (config.lld, make_path(test_resource_dir, config.target_sdk_name)))
+
+    config.available_features.discard('swift_interpreter')
+
+    config.excludes += ['Unit']
+
+    if 'SWIFT_USE_OLD_DRIVER' in config.environment: del config.environment['SWIFT_USE_OLD_DRIVER']
+    if 'SWIFT_AVOID_WARNING_USING_OLD_DRIVER' in config.environment: del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']
 
 else:
     lit_config.fatal("Don't know how to define target_run and "

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -29,6 +29,8 @@ config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.variant_triple = "@VARIANT_TRIPLE@"
 config.variant_sdk = "@VARIANT_SDK@"
 config.variant_suffix = "@VARIANT_SUFFIX@"
+config.external_embedded_platform = "@VARIANT_EXTERNAL_EMBEDDED_PLATFORM@" == "TRUE"
+config.external_embedded_device = "@VARIANT_EXTERNAL_EMBEDDED_DEVICE@"
 config.swiftlib_dir = "@LIT_SWIFTLIB_DIR@"
 config.swift_test_results_dir = \
     lit_config.params.get("swift_test_results_dir", "@SWIFT_TEST_RESULTS_DIR@")

--- a/utils/embedded-test-support/arm-qemu-stm32f1/linkerscript.ld
+++ b/utils/embedded-test-support/arm-qemu-stm32f1/linkerscript.ld
@@ -1,0 +1,13 @@
+MEMORY
+{
+   flash  : ORIGIN = 0x08000000, LENGTH = 32K
+   sram   : ORIGIN = 0x20000000, LENGTH = 8K
+}
+
+SECTIONS
+{
+   .text     : { *(.vectors*) ; *(.text*) } > flash
+   .bss      : { *(.bss*) } > sram
+   .data     : { *(.data*) } > sram
+   /DISCARD/ : { *(.swift_modhash*) }
+}

--- a/utils/embedded-test-support/arm-qemu-stm32f1/support.c
+++ b/utils/embedded-test-support/arm-qemu-stm32f1/support.c
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <stddef.h>
+#include <stdint.h>
+
+int main(int argc, char *argv[]);
+void qemu_exit(void);
+int puts(const char *);
+
+__attribute__((noreturn))
+void reset(void) {
+  main(0, NULL);
+  qemu_exit();
+  __builtin_trap();
+}
+
+void interrupt(void) {
+  puts("INTERRUPT\n");
+  qemu_exit();
+  while (1) {
+  }
+}
+
+__attribute__((aligned(4))) char stack[2048];
+
+__attribute((used))
+__attribute((section(".vectors"))) void *vector_table[114] = {
+    (void *)&stack[2048 - 4],  // initial SP
+    reset,                 // Reset
+
+    interrupt,  // NMI
+    interrupt,  // HardFault
+    interrupt,  // MemManage
+    interrupt,  // BusFault
+    interrupt,  // UsageFault
+
+    0  // NULL for all the other handlers
+};
+
+void qemu_exit() {
+  register uintptr_t a asm("r0") = 0x18;
+  register uintptr_t b asm("r1") = 0x20026;
+  __asm__ volatile("BKPT #0xAB" : : "r"(a), "r"(b));
+}
+
+int putchar(int c) {
+  // STM32F1 specific location of USART1 and its DR register
+  *(volatile uint32_t *)(0x40013800 + 0x04) = c;
+  return c;
+}

--- a/utils/embedded-test-support/arm-qemu-stm32f1/support.c
+++ b/utils/embedded-test-support/arm-qemu-stm32f1/support.c
@@ -48,9 +48,10 @@ __attribute((section(".vectors"))) void *vector_table[114] = {
 };
 
 void qemu_exit() {
-  register uintptr_t a asm("r0") = 0x18;
-  register uintptr_t b asm("r1") = 0x20026;
-  __asm__ volatile("BKPT #0xAB" : : "r"(a), "r"(b));
+  __asm__ volatile("mov r0, #0x18");
+  __asm__ volatile("movw r1, #0x0026");
+  __asm__ volatile("movt r1, #0x2"); // construct 0x20026 in r1
+  __asm__ volatile("bkpt #0xab");
 }
 
 int putchar(int c) {

--- a/utils/embedded-test-support/arm-qemu-stm32f1/support.c
+++ b/utils/embedded-test-support/arm-qemu-stm32f1/support.c
@@ -54,6 +54,9 @@ void qemu_exit() {
 }
 
 int putchar(int c) {
+  // This is only valid in an emulator (QEMU), and it's skipping a proper configuration of the UART device
+  // and waiting for a "ready to transit" state.
+
   // STM32F1 specific location of USART1 and its DR register
   *(volatile uint32_t *)(0x40013800 + 0x04) = c;
   return c;

--- a/utils/embedded-test-support/arm-qemu-stm32f4/linkerscript.ld
+++ b/utils/embedded-test-support/arm-qemu-stm32f4/linkerscript.ld
@@ -1,0 +1,13 @@
+MEMORY
+{
+   flash  : ORIGIN = 0x08000000, LENGTH = 32K
+   sram   : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+SECTIONS
+{
+   .text     : { *(.vectors*) ; *(.text*) } > flash
+   .bss      : { *(.bss*) } > sram
+   .data     : { *(.data*) } > sram
+   /DISCARD/ : { *(.swift_modhash*) }
+}

--- a/utils/embedded-test-support/arm-qemu-stm32f4/support.c
+++ b/utils/embedded-test-support/arm-qemu-stm32f4/support.c
@@ -54,6 +54,9 @@ void qemu_exit() {
 }
 
 int putchar(int c) {
+  // This is only valid in an emulator (QEMU), and it's skipping a proper configuration of the UART device
+  // and waiting for a "ready to transit" state.
+
   // STM32F4 specific location of USART1 and its DR register
   *(volatile uint32_t *)(0x40011000 + 0x04) = c;
   return c;

--- a/utils/embedded-test-support/arm-qemu-stm32f4/support.c
+++ b/utils/embedded-test-support/arm-qemu-stm32f4/support.c
@@ -48,9 +48,10 @@ __attribute((section(".vectors"))) void *vector_table[114] = {
 };
 
 void qemu_exit() {
-  register uintptr_t a asm("r0") = 0x18;
-  register uintptr_t b asm("r1") = 0x20026;
-  __asm__ volatile("BKPT #0xAB" : : "r"(a), "r"(b));
+  __asm__ volatile("mov r0, #0x18");
+  __asm__ volatile("movw r1, #0x0026");
+  __asm__ volatile("movt r1, #0x2"); // construct 0x20026 in r1
+  __asm__ volatile("bkpt #0xab");
 }
 
 int putchar(int c) {

--- a/utils/embedded-test-support/arm-qemu-stm32f4/support.c
+++ b/utils/embedded-test-support/arm-qemu-stm32f4/support.c
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <stddef.h>
+#include <stdint.h>
+
+int main(int argc, char *argv[]);
+void qemu_exit(void);
+int puts(const char *);
+
+__attribute__((noreturn))
+void reset(void) {
+  main(0, NULL);
+  qemu_exit();
+  __builtin_trap();
+}
+
+void interrupt(void) {
+  puts("INTERRUPT\n");
+  qemu_exit();
+  while (1) {
+  }
+}
+
+__attribute__((aligned(4))) char stack[8192];
+
+__attribute((used))
+__attribute((section(".vectors"))) void *vector_table[114] = {
+    (void *)&stack[8192 - 4],  // initial SP
+    reset,                 // Reset
+
+    interrupt,  // NMI
+    interrupt,  // HardFault
+    interrupt,  // MemManage
+    interrupt,  // BusFault
+    interrupt,  // UsageFault
+
+    0  // NULL for all the other handlers
+};
+
+void qemu_exit() {
+  register uintptr_t a asm("r0") = 0x18;
+  register uintptr_t b asm("r1") = 0x20026;
+  __asm__ volatile("BKPT #0xAB" : : "r"(a), "r"(b));
+}
+
+int putchar(int c) {
+  // STM32F4 specific location of USART1 and its DR register
+  *(volatile uint32_t *)(0x40011000 + 0x04) = c;
+  return c;
+}

--- a/utils/embedded-test-support/avr-qemu-atmega2560/linkerscript.ld
+++ b/utils/embedded-test-support/avr-qemu-atmega2560/linkerscript.ld
@@ -1,0 +1,15 @@
+MEMORY
+{
+   flash_boot  : ORIGIN = 0x00000000, LENGTH = 0x200
+   flash_sram  : ORIGIN = 0x00000200, LENGTH = 7K
+   flash_stack : ORIGIN = 0x00001e00, LENGTH = 1K
+   flash_text  : ORIGIN = 0x00002200, LENGTH = 32K
+}
+
+SECTIONS
+{
+   .boot     : { *(.start) } > flash_boot
+   .data     : { *(.bss*) ; *(.data*) ; *(.rodata*) } > flash_sram
+   .text     : { *(.text*) } > flash_text
+   /DISCARD/ : { *(.swift_modhash*) }
+}

--- a/utils/embedded-test-support/avr-qemu-atmega2560/support.c
+++ b/utils/embedded-test-support/avr-qemu-atmega2560/support.c
@@ -32,8 +32,7 @@ void usart_init() {
   *((volatile char *)0xc1) = 1 << 3; // enable TX on UART0
 }
 
-__attribute__((used))
-static inline void *memcpy_flash_to_sram(void *restrict dst, const void __attribute__((__address_space__(1))) *restrict src, size_t n) {
+void *memcpy_flash_to_sram(void *restrict dst, const void __attribute__((__address_space__(1))) *restrict src, size_t n) {
   for (int i = 0; i < n; i++) {
     ((char *)dst)[i] = ((char __attribute__((__address_space__(1))) *)src)[i];
   }
@@ -46,6 +45,9 @@ void copy_data_from_flash_to_sram() {
 }
 
 int putchar(int c) {
+  // This is only valid in an emulator (QEMU), and it's skipping a proper configuration of the UART device
+  // and waiting for a "ready to transit" state.
+
   // AVR's UART0 DR register
   *((volatile char *)0xc6) = c;
   return c;

--- a/utils/embedded-test-support/avr-qemu-atmega2560/support.c
+++ b/utils/embedded-test-support/avr-qemu-atmega2560/support.c
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <stddef.h>
+#include <stdint.h>
+
+__attribute__((naked))
+__attribute__((section(".start")))
+void start() {
+  // stack is 0x1e00 ..< 0x2200 (1 kB), see linkerscript.ld
+  // set SP to 0x21ff, last byte of SRAM
+  asm volatile("ldi r16, 0xff");
+  asm volatile("out 0x3d, r16");
+  asm volatile("ldi r16, 0x21");
+  asm volatile("out 0x3e, r16");
+  asm volatile("call copy_data_from_flash_to_sram");
+  asm volatile("call usart_init");
+  asm volatile("call main");
+  asm volatile("call halt");
+}
+
+void usart_init() {
+  *((volatile char *)0xc1) = 1 << 3; // enable TX on UART0
+}
+
+__attribute__((used))
+static inline void *memcpy_flash_to_sram(void *restrict dst, const void __attribute__((__address_space__(1))) *restrict src, size_t n) {
+  for (int i = 0; i < n; i++) {
+    ((char *)dst)[i] = ((char __attribute__((__address_space__(1))) *)src)[i];
+  }
+  return dst;
+}
+
+void copy_data_from_flash_to_sram() {
+  // Copy data segment from 0x200-program-space to 0x200-data-space, 7 kB in size (see linkerscript.ld)
+  memcpy_flash_to_sram((void *)0x200, (void __attribute__((__address_space__(1))) *)0x200, 7 * 1024);
+}
+
+int putchar(int c) {
+  // AVR's UART0 DR register
+  *((volatile char *)0xc6) = c;
+  return c;
+}
+
+int puts(const char *);
+void halt(void) {
+  puts("HALT\n");
+  asm("break");
+}
+
+void abort(void) {
+  asm("break");
+}

--- a/utils/embedded-test-support/demo.c
+++ b/utils/embedded-test-support/demo.c
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdint.h>
+#include <stddef.h>
+
+void *malloc(size_t count);
+
+int global1 = 42;
+int global2 = 777;
+
+void *global_with_reloc = &global1;
+
+__attribute__((noinline))
+int recur(int p, int n) {
+  if (p == 0) return 1;
+  global2++;
+  return recur(p - n, n) + 1;
+}
+
+__attribute__((noinline))
+void *testheap() {
+  void *p = malloc(12);
+  *(uint32_t *)p = 1234;
+  return p;
+}
+
+
+int puts(const char *);
+int main() {
+  puts("Hello Embedded Swift!\n");
+  puts("-- printing works\n");
+  int res = recur(10, 1);
+  if (res == 11) 
+    puts("-- stack works\n");
+  else
+    puts("???\n");
+
+  if (global1 == 42)
+    puts("-- global1 works\n");
+  else
+    puts("???\n");
+
+  if (global2 == 787)
+    puts("-- global2 works\n");
+  else
+    puts("???\n");
+
+  if ((void *)global_with_reloc == (void *)&global1)
+    puts("-- global_with_reloc works\n");
+  else
+    puts("???\n");
+
+  if (*(int *)global_with_reloc == 42)
+    puts("-- global_with_reloc has right value\n");
+  else
+    puts("???\n");
+
+  void *p = testheap();
+  if (*(uint32_t *)p == 1234)
+    puts("-- heap work\n");
+  else
+    puts("???\n");
+
+  puts("DONE!\n");
+
+  return 0;
+}

--- a/utils/embedded-test-support/embedded-test-support.py
+++ b/utils/embedded-test-support/embedded-test-support.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# flake8: noqa
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2024 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import argparse
+import os
+import subprocess
+import tempfile
+import pathlib
+
+
+MY_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def shell(cmd):
+    return subprocess.check_output(["bash", "-c", cmd])
+
+
+def shell_print(cmd):
+    print(cmd)
+    subprocess.check_call(["bash", "-c", cmd])
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--device', choices=sorted([d for d in os.listdir(MY_DIR) if os.path.isdir(MY_DIR + "/" + d)]), required=True)
+    parser.add_argument('command', choices=['run', 'demo-run', 'print-c-flags', 'print-swift-flags', 'print-swift-frontend-flags'])
+    parser.add_argument('--elf-file')
+
+    args = parser.parse_args()
+
+    if args.device == "arm-qemu-stm32f1":
+        target = "armv7em-none-none-eabi"
+        qemu_binary = "qemu-system-arm"
+        qemu_machine = "stm32vldiscovery"
+        mmcu = ""
+        entry_point = "vector_table"
+        semihosting = True
+        qemu_mode = "-kernel"
+        always_optimize_for_size = False
+    elif args.device == "arm-qemu-stm32f4":
+        target = "armv7em-none-none-eabi"
+        qemu_binary = "qemu-system-arm"
+        qemu_machine = "netduinoplus2"
+        mmcu = ""
+        entry_point = "vector_table"
+        semihosting = True
+        qemu_mode = "-kernel"
+        always_optimize_for_size = False
+    elif args.device == "avr-qemu-atmega2560":
+        target = "avr-none-none-elf"
+        qemu_binary = "qemu-system-avr"
+        qemu_machine = "mega2560"
+        mmcu = "-mmcu=atmega2560"
+        entry_point = "start"
+        semihosting = False
+        qemu_mode = "-bios"
+        always_optimize_for_size = True
+    else:
+        assert False
+
+    tmpdir = tempfile.gettempdir()
+
+    cflags = ""
+    cflags += " -nostdlib"
+    cflags += " -ffunction-sections -fdata-sections"
+    cflags += " -ffreestanding"
+    cflags += " -O2"
+    cflags += " -g"
+    cflags += f" {mmcu}"
+
+    supportfile = tmpdir + "/" + target + "-support.o"
+    shell(f"clang -target {target} {cflags} -c {MY_DIR}/{args.device}/support.c -o {supportfile}")
+
+    libcfile = tmpdir + "/" + target + "-libc.o"
+    shell(f"clang -target {target} {cflags} -c {MY_DIR}/libc.c -o {libcfile}")
+
+    demo_o_file = tmpdir + "/" + target + "-demo.o"
+    shell(f"clang -target {target} {cflags} -c {MY_DIR}/demo.c -o {demo_o_file}")
+
+    cflags += f" {supportfile} {libcfile}"
+
+    swift_frontend_flags = ""
+    swift_frontend_flags += " -disable-stack-protector -function-sections"
+    if mmcu != "": swift_frontend_flags += f" -Xcc {mmcu}"
+
+    swift_flags = ""
+    swift_flags += " -Xfrontend -disable-stack-protector -Xfrontend -function-sections -use-ld=lld"
+    swift_flags += " -Xclang-linker -nostdlib -Xlinker --gc-sections"
+    swift_flags += f" {supportfile} {libcfile}"
+    swift_flags += f" -Xlinker -T -Xlinker {MY_DIR}/{args.device}/linkerscript.ld -Xlinker -e -Xlinker {entry_point}"
+    if mmcu != "": swift_flags += f" -Xcc {mmcu}"
+    if always_optimize_for_size: swift_flags += " -Osize"
+
+    cflags += " -fuse-ld=lld"
+    cflags += " -nostdlib"
+    cflags += " -Xlinker --gc-sections"
+    cflags += f" -Xlinker -T -Xlinker {MY_DIR}/{args.device}/linkerscript.ld"
+    cflags += f" -Wl,-e,{entry_point}"
+
+    if args.command == "print-swift-flags":
+        print(swift_flags)
+
+    elif args.command == "print-swift-frontend-flags":
+        print(swift_frontend_flags)
+
+    elif args.command == "print-c-flags":
+        print(cflags)
+
+    elif args.command == "run":
+        if args.elf_file is None:
+            print("Must specify --elf-file <...>")
+            exit(1)
+
+        qemu_command = f"{qemu_binary} -M {qemu_machine} -nographic {qemu_mode} {args.elf_file} {'-semihosting' if semihosting else ''}"
+        shell_print(f"expect -c 'spawn {qemu_command}; expect -timeout 5 -re \"HALT\"'")
+
+    elif args.command == "demo-run":
+        elffile = tmpdir + "/" + target + ".elf"
+        shell(f"clang -target {target} {cflags} {demo_o_file} -o {elffile}")
+
+        qemu_command = f"{qemu_binary} -M {qemu_machine} -nographic {qemu_mode} {elffile} {'-semihosting' if semihosting else ''}"
+        shell_print(f"expect -c 'spawn {qemu_command}; expect -timeout 5 -re \"HALT\"'")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/embedded-test-support/libc.c
+++ b/utils/embedded-test-support/libc.c
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdint.h>
+#include <stddef.h>
+
+int putchar(int c);
+
+int puts(const char *p) {
+  while (*p) {
+    putchar(*(p++));
+  }
+  return 0;
+}
+
+#define HEAP_SIZE (1 * 1024)
+
+__attribute__((aligned(4)))
+char heap[HEAP_SIZE] = {};
+
+size_t next_heap_index = 0;
+
+void *calloc(size_t count, size_t size) {
+  if (next_heap_index + count * size > HEAP_SIZE) {
+    puts("HEAP EXHAUSTED\n");
+    __builtin_trap();
+  }
+  void *p = &heap[next_heap_index];
+  next_heap_index += count * size;
+  return p;
+}
+
+void *malloc(size_t count) {
+  return calloc(count, 1);
+}
+
+int posix_memalign(void **memptr, size_t alignment, size_t size) {
+  *memptr = calloc(size + alignment, 1);
+  if (((uintptr_t)*memptr) % alignment == 0) return 0;
+  *(uintptr_t *)memptr += alignment - ((uintptr_t)*memptr % alignment);
+  return 0;
+}
+
+void free(void *ptr) {
+  // never free
+}
+
+__attribute__((used))
+void *memset(void *b, int c, size_t len) {
+  for (int i = 0; i < len; i++) {
+    ((char *)b)[i] = c;
+  }
+  return b;
+}
+
+__attribute__((used))
+void *memcpy(void *restrict dst, const void *restrict src, size_t n) {
+  for (int i = 0; i < n; i++) {
+    ((char *)dst)[i] = ((char *)src)[i];
+  }
+  return dst;
+}
+
+__attribute__((used))
+int memcmp(const void *s1, const void *s2, size_t n) {
+  for (int i = 0; i < n; i++) {
+    char diff = ((char *)s2)[i] - ((char *)s1)[i];
+    if (diff != 0) return diff;
+  }
+  return 0;
+}
+
+__attribute__((used))
+void *memmove(void *dst, const void *src, size_t n) {
+  if ((uintptr_t)dst > (uintptr_t)src) {
+    for (int i = 0; i < n; i++) {
+      ((char *)dst)[i] = ((char *)src)[i];
+    }
+    return dst;
+  } else {
+    for (int i = n - 1; i >= 0; i--) {
+      ((char *)dst)[i] = ((char *)src)[i];
+    }
+    return dst;
+  }
+}
+
+void *__aeabi_memmove(void *dst, const void *src, size_t n) {
+  return memmove(dst, src, n);
+}
+
+int rand(void) {
+#if UINTPTR_MAX == UINT16_MAX
+  static int seed = 0x3691;
+  seed *= 0x3691;
+  seed ^= 0x3692;
+#else
+  static int seed = 0x19283691;
+  seed *= 0x19283691;
+  seed ^= 0x81723692;
+#endif
+  return seed;
+}
+
+void arc4random_buf(void *buf, size_t nbytes) {
+  for (int i = 0; i < nbytes; i++) { ((char *)buf)[i] = rand(); }
+}


### PR DESCRIPTION
This PR adds lit test configurations that execute runtime tests inside QEMU, one at a time, in the "baremetal" mode of QEMU.

More concretely:
- A lit configuration can now be "EXTERNAL_EMBEDDED_PLATFORM", which means that compilation, linking and execution will consult a new test support tool called `embedded-test-support.py` and ask for compiler flags, linker flags and execution for a particular device type.
- For ARM and AVR CPUs, a super minimal baremetal runtime support is added (interrupt vectors, stack setup code, linker script, etc.) and used for building valid standalone firmwares for each lit test.
- The embedded-test-support.py script is intended to be easily extensible with new devices, CPU architectures, and even other simulators besides QEMU.
- All Embedded Swift tests (in the `test/embedded/` directory) now opt-in to the new Swift Driver (as the old driver is not really maintained anymore and has unfixed bugs).

Currently, this setup is not going to run automatically anywhere. It will only be available for manual usage by (1) enabling SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING, and (2) running tests e.g. with:
```
$ ../llvm-macosx-arm64/bin/llvm-lit -v ./test-embedded-armv7 --filter embedded/
```

Not all the embedded tests pass under the ARM and AVR configs, but the plan is to fix them (or disable when appropriate) and eventually start running these test configurations in Swift CI.