### PR TITLE
Fix LifetimeDependenceDiagnostics to handle invalid SIL types

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -195,7 +195,11 @@ extension LifetimeDependence {
     if arg.isIndirectResult {
       return nil
     }
-    self.scope = Scope(base: arg, context)!
+    guard let scope = Scope(base: arg, context) else {
+      // Ignore invalid argument types.
+      return nil
+    }
+    self.scope = scope
     self.dependentValue = arg
   }
 
@@ -309,7 +313,7 @@ extension LifetimeDependence.Scope {
       }
       self = scope
     case .none:
-      // lifetime dependence requires a nontrivial value"
+      // lifetime dependence requires a nontrivial value
       return nil
     case .unowned:
       self = .unknown(base)

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -65,6 +65,8 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
 
   public var isMoveOnly: Bool { bridged.isMoveOnly() }
 
+  // Note that invalid types are not considered Escapable. This makes it difficult to make any assumptions about
+  // nonescapable types.
   public func isEscapable(in function: Function) -> Bool {
     bridged.isEscapable(function.bridged)
   }

--- a/test/SIL/lazy_typecheck.swift
+++ b/test/SIL/lazy_typecheck.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-sil %s -parse-as-library -enable-library-evolution -module-name Test -experimental-lazy-typecheck -verify
+
+// SIL diagnostics should not crash on invalid types.
+final class C {
+  private let x: Nonexistent // expected-error {{cannot find type 'Nonexistent' in scope}}
+
+  init(x: Nonexistent) { // expected-error {{cannot find type 'Nonexistent' in scope}}
+    self.x = x
+  }
+}


### PR DESCRIPTION
Invalid types are not considered Escapable. This makes it difficult to make any assumptions about nonescapable types.

Fixes rdar://132348528 (Fix LifetimeDependenceDiagnostics to handle invalid SIL types)
