### PR TITLE
Fix objcImpl SILGen crash with initial value

### DIFF
--- a/test/SILGen/Inputs/objc_implementation.h
+++ b/test/SILGen/Inputs/objc_implementation.h
@@ -9,4 +9,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface Rdar114874429 : NSObject
+
+- (instancetype)init;
+
+@property (readonly) NSInteger prop;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/test/SILGen/objc_implementation.swift
+++ b/test/SILGen/objc_implementation.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -emit-silgen -import-objc-header %S/Inputs/objc_implementation.h -swift-version 5 %s -target %target-stable-abi-triple | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -import-objc-header %S/Inputs/objc_implementation.h -swift-version 5 %s -target %target-stable-abi-triple > %t
+// RUN: %FileCheck --input-file %t %s
+// RUN: %FileCheck --input-file %t --check-prefix NEGATIVE %s
 
 // REQUIRES: objc_interop
 
@@ -10,4 +12,18 @@
   // CHECK-LABEL: sil{{.*}} @$sSo9ImplClassC19objc_implementationEABycfc : $@convention(method) (@owned ImplClass) -> @owned ImplClass {
   // CHECK:         function_ref @$ss25_unimplementedInitializer9className04initD04file4line6columns5NeverOs12StaticStringV_A2JS2utF
   // CHECK:       } // end sil function '$sSo9ImplClassC19objc_implementationEABycfc'
+}
+
+//
+// objcImpl class with an initial value expression referencing a nonpublic
+// function (rdar://114874429)
+//
+
+internal func internalFunc() -> Int { 42 }
+
+@objc @implementation extension Rdar114874429 {
+  let prop: Int = internalFunc()
+
+  // CHECK-LABEL : sil{{.*}}@$sSo13Rdar114874429C19objc_implementationE4propSivpfi :
+  // NEGATIVE-NOT: sil{{.*}} [serialized] {{.*}}@$sSo13Rdar114874429C19objc_implementationE4propSivpfi :
 }


### PR DESCRIPTION
The initial value expressions of stored properties in objcImpl classes were being incorrectly marked as serializable. As a result, the compiler would crash with a SIL verification failure if one of them called a non-public function or initializer.

Fix this problem by not marking these initial value expression functions as serializable. Code in other modules should not call them anyway, since they think of the class as a pure ObjC class.

Fixes rdar://114874429.