### PR TITLE
[cxx-interop] Enable benchmarks in SwiftPM mode

### DIFF
--- a/benchmark/cxx-source/CxxSetToCollection.swift
+++ b/benchmark/cxx-source/CxxSetToCollection.swift
@@ -14,14 +14,6 @@
 // to a Swift collection.
 
 import TestsUtils
-
-#if SWIFT_PACKAGE
-// FIXME: Needs fix for https://github.com/apple/swift/issues/61547.
-
-public let benchmarks = [BenchmarkInfo]()
-
-#else
-
 import CxxStdlibPerformance
 import Cxx
 import CxxStdlib // FIXME(rdar://128520766): this import should be redundant
@@ -72,5 +64,3 @@ public func run_CxxSetOfU32_forEach(_ n: Int) {
     }
   }
 }
-
-#endif

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -14,14 +14,6 @@
 // as compared to the C++ implementation of such sum.
 
 import TestsUtils
-
-#if SWIFT_PACKAGE
-// FIXME: Needs fix for https://github.com/apple/swift/issues/61547.
-
-public let benchmarks = [BenchmarkInfo]()
-
-#else
-
 import CxxStdlibPerformance
 import Cxx
 import CxxStdlib // FIXME(rdar://128520766): this import should be redundant
@@ -127,4 +119,3 @@ public func run_CxxVectorOfU32_Sum_Swift_Reduce(_ n: Int) {
     }
     blackHole(sum)
 }
-#endif


### PR DESCRIPTION
The C++ interop benchmarks were only running when building with CMake, not with SwiftPM, because of a bug that was only triggering with SwiftPM. That bug seems to be fixed now.