### PR TITLE
[cxx-interop] Add stack trace entry for the safety heuristic

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7366,6 +7366,10 @@ static bool hasNonCopyableAttr(const clang::RecordDecl *decl) {
 /// Recursively checks that there are no pointers in any fields or base classes.
 /// Does not check C++ records with specific API annotations.
 static bool hasPointerInSubobjects(const clang::CXXRecordDecl *decl) {
+  clang::PrettyStackTraceDecl trace(decl, clang::SourceLocation(),
+                                    decl->getASTContext().getSourceManager(),
+                                    "looking for pointers in subobjects of");
+
   // Probably a class template that has not yet been specialized:
   if (!decl->getDefinition())
     return false;


### PR DESCRIPTION
To better investigate reports of an infinite recursion in `hasPointerInSubobjects`, let's add a pretty stack trace entry to get more readable crash reports.

rdar://131366982