### PR TITLE
[cxx-interop] Mark constructor Span(baseAddress, count) deprecated

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1218,6 +1218,10 @@ void swift::conformToCxxSpanIfNeeded(ClangImporter::Implementation &impl,
       impl.importDecl(constructorDecl, impl.CurrentVersion);
   if (!importedConstructor)
     return;
+
+  auto attr = AvailableAttr::createPlatformAgnostic(importedConstructor->getASTContext(), "use 'init(_:)' instead.", "", PlatformAgnosticAvailabilityKind::Deprecated);
+  importedConstructor->getAttrs().add(attr);
+
   decl->addMember(importedConstructor);
 
   impl.addSynthesizedTypealias(decl, ctx.Id_Element,

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++20 2>&1
+
+// FIXME swift-ci linux tests do not support std::span
+// UNSUPPORTED: OS=linux-gnu
+
+import StdSpan
+
+let arr: [Int32] = [1, 2, 3]
+arr.withUnsafeBufferPointer { ubpointer in
+    let _ = ConstSpan(ubpointer) // okay
+    let _ = ConstSpan(ubpointer.baseAddress!, ubpointer.count) 
+    // expected-warning@-1 {{'init(_:_:)' is deprecated: use 'init(_:)' instead.}}
+}


### PR DESCRIPTION
This constructor is unsafe. We make it deprecated to discourage its use.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
