### PR TITLE
🌸 Fix objcImpl SILGen crash with initial value

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -855,7 +855,17 @@ SerializedKind_t SILDeclRef::getSerializedKind() const {
   // marked as @frozen.
   if (isStoredPropertyInitializer() || (isPropertyWrapperBackingInitializer() &&
                                         d->getDeclContext()->isTypeContext())) {
-    auto *nominal = cast<NominalTypeDecl>(d->getDeclContext()->getImplementedObjCContext());
+    auto *nominal = dyn_cast<NominalTypeDecl>(d->getDeclContext());
+
+    // If this isn't in a nominal, it must be in an @objc @implementation
+    // extension. We don't serialize those since clients outside the module
+    // don't think of these as Swift classes.
+    if (!nominal) {
+      assert(isa<ExtensionDecl>(d->getDeclContext()) &&
+             cast<ExtensionDecl>(d->getDeclContext())->isObjCImplementation());
+      return IsNotSerialized;
+    }
+
     auto scope =
       nominal->getFormalAccessScope(/*useDC=*/nullptr,
                                     /*treatUsableFromInlineAsPublic=*/true);

--- a/test/SILGen/Inputs/objc_implementation.h
+++ b/test/SILGen/Inputs/objc_implementation.h
@@ -9,4 +9,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface Rdar114874429 : NSObject
+
+- (instancetype)init;
+
+@property (readonly) NSInteger prop;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/test/SILGen/objc_implementation.swift
+++ b/test/SILGen/objc_implementation.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -emit-silgen -import-objc-header %S/Inputs/objc_implementation.h -swift-version 5 %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -import-objc-header %S/Inputs/objc_implementation.h -swift-version 5 %s > %t
+// RUN: %FileCheck --input-file %t %s
+// RUN: %FileCheck --input-file %t --check-prefix NEGATIVE %s
 
 // REQUIRES: objc_interop
 
@@ -10,4 +12,18 @@
   // CHECK-LABEL: sil{{.*}} @$sSo9ImplClassC19objc_implementationEABycfc : $@convention(method) (@owned ImplClass) -> @owned ImplClass {
   // CHECK:         function_ref @$ss25_unimplementedInitializer9className04initD04file4line6columns5NeverOs12StaticStringV_A2JS2utF
   // CHECK:       } // end sil function '$sSo9ImplClassC19objc_implementationEABycfc'
+}
+
+//
+// objcImpl class with an initial value expression referencing a nonpublic
+// function (rdar://114874429)
+//
+
+internal func internalFunc() -> Int { 42 }
+
+@_objcImplementation extension Rdar114874429 {
+  let prop: Int = internalFunc()
+
+  // CHECK-LABEL : sil{{.*}}@$sSo13Rdar114874429C19objc_implementationE4propSivpfi :
+  // NEGATIVE-NOT: sil{{.*}} [serialized] {{.*}}@$sSo13Rdar114874429C19objc_implementationE4propSivpfi :
 }


### PR DESCRIPTION
* Explanation: Fixes a SIL verifier failure when compiling an objcImpl class with a stored property initial value expression which references a non-public function.
* Main branch PR: #75431
* Resolves: rdar://114874429
* Risk: Low (affects only objcImpl classes, and only targets code that currently crashes the compiler)
* Reviewed by: @tshortli, @nkcsgexi 
* Testing: Added a new test case.
