### PR TITLE
[NFC] OwnedLifetimeCanonicalization: Switch an API usage.

### DIFF
--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -1168,8 +1168,8 @@ void CanonicalizeOSSALifetime::rewriteCopies(
       liveness->updateForUse(destroy, /*lifetimeEnding=*/true);
     }
     for (auto *dvi : debugValues) {
-      if (liveness->areUsesWithinBoundary(
-              {&dvi->getOperandRef()},
+      if (liveness->isWithinBoundary(
+              dvi,
               deadEndBlocksAnalysis->get(getCurrentDef()->getFunction()))) {
         continue;
       }

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -600,3 +600,15 @@ exit:
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test {{.*}} on dead_arg_debug_dead_end
+// CHECK-LABEL: sil [ossa] @dead_arg_debug_dead_end : {{.*}} {
+// CHECK:         debug_value
+// CHECK-LABEL: } // end sil function 'dead_arg_debug_dead_end'
+// CHECK-LABEL: end running test {{.*}} on dead_arg_debug_dead_end
+sil [ossa] @dead_arg_debug_dead_end : $@convention(thin) (@owned C) -> () {
+entry(%c : @owned $C):
+  debug_value %c : $C
+  specify_test "canonicalize-ossa-lifetime true false true %c"
+  unreachable
+}


### PR DESCRIPTION
Now that `isWithinBoundary` and `areUsesWithinBoundary` are "the same" (up to the fact that one takes an instruction and the other an array of operands), there's no reason to use the latter when looking at a single instruction.
