### PR TITLE
[6.0][build-wrangler] Disable a test when we are not compiling with an optimized stdlib to get the build green.

### DIFF
--- a/test/Concurrency/async_sequence_existential.swift
+++ b/test/Concurrency/async_sequence_existential.swift
@@ -4,6 +4,11 @@
 
 // REQUIRES: concurrency
 
+// Fails with an unoptimized stdlib currently.
+// rdar://128858036
+//
+// REQUIRES: optimized_stdlib
+
 extension Error {
   func printMe() { }
 }


### PR DESCRIPTION
rdar://128858036

----

Build Wrangler Notes: I think it is reasonable to just disable this test when we have a non-optimized stdlib since we are still going to get testing from the optimized stdlib and will get this [build](https://ci.swift.org/job/oss-swift-6.0_tools-RA_stdlib-DA_test-device-non_executable/) back to green.