### PR TITLE
[build-wrangler] Disable test that fails without an optimized_stdlib to get the build green.

### DIFF
--- a/test/IRGen/nested_generics.swift
+++ b/test/IRGen/nested_generics.swift
@@ -4,6 +4,13 @@
 
 // REQUIRES: PTRSIZE=64
 
+// This fails with an unoptimized stdlib. Disable it on that so we can get
+// builds green.
+//
+// rdar://131554269
+//
+// REQUIRES: optimized_stdlib
+
 func blah<T>(_: T.Type) {}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s15nested_generics13makeAMetadatayyF"()


### PR DESCRIPTION
rdar://131554269