### PR TITLE
Consume: warn about no-op consumes to be fixed

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7749,6 +7749,8 @@ ERROR(consume_expression_needed_for_cast,none,
       "implicit conversion to %0 is consuming", (Type))
 NOTE(add_consume_to_silence,none,
      "add 'consume' to make consumption explicit", ())
+WARNING(consume_of_bitwisecopyable_noop,none,
+      "'consume' applied to bitwise-copyable type %0 has no effect", (Type))
 ERROR(consume_expression_not_passed_lvalue,none,
       "'consume' can only be applied to a local binding ('let', 'var', or parameter)", ())
 ERROR(consume_expression_partial_copyable,none,

--- a/test/Parse/move_expr.swift
+++ b/test/Parse/move_expr.swift
@@ -2,7 +2,7 @@
 
 var global: Int = 5
 func testGlobal() {
-    let _ = consume global
+    let _ = consume global // expected-warning {{'consume' applied to bitwise-copyable type 'Int' has no effect}}
 }
 
 func testLet() {

--- a/test/SILOptimizer/consume_operator_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_loadable_vars.swift
@@ -725,7 +725,14 @@ func consumeInitdArray() {
 func isNegative(_ c: consuming Int) -> Bool { return c < 0 }
 func consumeInt() {
     var g = 0 // expected-warning{{variable 'g' was never mutated; consider changing to 'let' constant}}
-    isNegative(consume g) // expected-warning{{result of call to 'isNegative' is unused}}
+              // expected-error@-1 {{'g' used after consume}}
+
+    _ = isNegative(consume g) // expected-note {{consumed here}}
+                              // expected-warning@-1 {{'consume' applied to bitwise-copyable type 'Int' has no effect}}
+
+    _ = isNegative(consume g) // expected-note {{used here}}
+                              // expected-error@-1 {{'consume' applied to value that the compiler does not support. This is a compiler bug. Please file a bug with a small example of the bug}}
+                              // expected-warning@-2 {{'consume' applied to bitwise-copyable type 'Int' has no effect}}
 }
 
 //////////////////////

--- a/test/Sema/consume_operator_noop_warning.swift
+++ b/test/Sema/consume_operator_noop_warning.swift
@@ -1,0 +1,60 @@
+// RUN: %target-swift-emit-sil %s -verify -sil-verify-all
+
+struct Point {
+  let x: Float
+  let y: Float
+}
+
+struct ConditionallyBC<T> {
+  var t: T
+}
+extension ConditionallyBC: BitwiseCopyable where T: BitwiseCopyable {}
+
+func test<T, BCG: BitwiseCopyable>(_ t: T, // expected-error {{'t' is borrowed and cannot be consumed}}
+                                   _ bcg: BCG, // expected-error {{'bcg' is borrowed and cannot be consumed}}
+                                   _ cbcg_generic: ConditionallyBC<BCG>, // expected-error {{'cbcg_generic' is borrowed and cannot be consumed}}
+                                   _ maybeBCG: BCG?, // expected-error {{'maybeBCG' is borrowed and cannot be consumed}}
+                                   _ maybeT: T?, // expected-error {{'maybeT' is borrowed and cannot be consumed}}
+                                   _ anyBC: any BitwiseCopyable, // expected-error {{'anyBC' is borrowed and cannot be consumed}}
+                                   _ x: Int,
+                                   _ point: Point,
+                                   _ cbcg_concrete: ConditionallyBC<Int>,
+                                   _ maybeFloat: Float?) {
+  _ = consume t  // expected-note {{consumed here}}
+  _ = consume bcg // expected-note {{consumed here}}
+  _ = consume cbcg_generic // expected-note {{consumed here}}
+  _ = consume maybeBCG // expected-note {{consumed here}}
+  _ = consume maybeT // expected-note {{consumed here}}
+  _ = consume anyBC // expected-note {{consumed here}}
+
+  _ = consume x // expected-warning {{'consume' applied to bitwise-copyable type 'Int' has no effect}}{{7-15=}}
+  _ = consume point // expected-warning {{'consume' applied to bitwise-copyable type 'Point' has no effect}}{{7-15=}}
+  _ = consume  cbcg_concrete // expected-warning {{'consume' applied to bitwise-copyable type 'ConditionallyBC<Int>' has no effect}}{{7-16=}}
+   _ = consume maybeFloat // expected-warning {{'consume' applied to bitwise-copyable type 'Float?' has no effect}}{{8-16=}}
+}
+
+func proofOfUseAfterConsume() -> Int {
+  let someInt = 10
+  let y = consume someInt // expected-warning {{'consume' applied to bitwise-copyable type 'Int' has no effect}}
+  print(y)
+  return someInt  // undiagnosed use-after-consume
+}
+
+func moreProofs(_ share: __shared Int,
+                _ own: __owned Int,
+                _ snd: sending Int, // expected-error {{'snd' used after consume}}
+                _ ino: inout Int, // expected-error {{'ino' used after consume}}
+                _ brw: borrowing Int, // expected-error {{'brw' is borrowed and cannot be consumed}}
+                _ csm: consuming Int // expected-error {{'csm' consumed more than once}}
+               ) {
+  _ = consume share // expected-warning {{'consume' applied to bitwise-copyable type 'Int' has no effect}}
+  _ = consume own // expected-warning {{'consume' applied to bitwise-copyable type 'Int' has no effect}}
+  let _ = (share, own)
+
+   _ = consume ino // expected-note {{consumed}}
+   _ = consume brw // expected-note {{consumed}}
+   _ = consume csm // expected-note {{consumed}}
+   _ = consume csm // expected-note {{consumed}}
+   _ = consume snd // expected-note {{consumed}}
+   _ = snd // expected-note {{used}}
+} // expected-note {{used here}}

--- a/test/Sema/move_expr.swift
+++ b/test/Sema/move_expr.swift
@@ -6,7 +6,7 @@ class Klass {
 
 var global: Int = 5
 func testGlobal() {
-    let _ = consume global
+    let _ = consume global // expected-warning {{'consume' applied to bitwise-copyable type 'Int' has no effect}}
 }
 
 func testLet() {
@@ -23,14 +23,14 @@ func testVar() {
 func testExprFailureLet() {
     let t = 5
     // Next line is parsed as move(t) + t
-    let _ = consume t + t
+    let _ = consume t + t // expected-warning {{'consume' applied to bitwise-copyable type 'Int' has no effect}}
 }
 
 func testExprFailureVar() {
     var t = 5
     t = 5
     // Next line is parsed as move(t) + t
-    let _ = consume t + t
+    let _ = consume t + t // expected-warning {{'consume' applied to bitwise-copyable type 'Int' has no effect}}
 }
 
 func letAddressOnly<T>(_ v: T) {


### PR DESCRIPTION
As of now, SE-366 is not correctly implemented with respect to concrete, bitwise-copyable types like `Int`. Writing `consume someInt` doesn't actually consume the variable binding as it should, meaning code that should be flagged as having a use-after-consume is being silently permitted:

```swift
let someInt = 10
let y = consume someInt
print(someInt) // no error!
```

This has been a problem since Swift 5.9. Eventually we plan to fix this issue, which means code previously doing the above would become an error. To help people get ready for the fix, start warning people that these consumes are actually no-ops and suggest removing them until the intended behavior is actually enforced in the future.

resolves rdar://127081103
