### PR TITLE
[6.0] Sema: Update inheritance availability checking exception

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2254,7 +2254,8 @@ public:
     // declaration slipped in when the compiler wasn't able to diagnose it and
     // can't be changed.
     if (nominal->getName().is("AnyColorBox") &&
-        nominal->getModuleContext()->getName().is("SwiftUI"))
+        (nominal->getModuleContext()->getName().is("SwiftUI") ||
+         nominal->getModuleContext()->getName().is("SwiftUICore")))
       flags |= DeclAvailabilityFlag::
           AllowPotentiallyUnavailableAtOrBelowDeploymentTarget;
 


### PR DESCRIPTION
- **Explanation:** The changes from https://github.com/swiftlang/swift/pull/62327 need to be updated for compatibility with the SDKs accompanying Xcode 16.
- **Scope:** Prevents the open source Swift toolchain from being able to compile code against the SDKs accompanying Xcode 16.
- **Issue/Radar:**  rdar://132438383, https://github.com/swiftlang/swift/issues/75175
- **Original PR:** https://github.com/swiftlang/swift/pull/75455
- **Risk:** Low. This change relaxes a type checker rule to accept more code instead of diagnosing.
- **Testing:** Verified building a test project with the Xcode 16 SDKs locally.
- **Reviewer:** @hborla @nkcsgexi 