### PR TITLE
Several ClangImporter rebranch fixes

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -274,8 +274,11 @@ private:
   /// Prints an encoded string, escaped properly for C.
   void printEncodedString(raw_ostream &os, StringRef str,
                           bool includeQuotes = true) {
-    // NB: We don't use raw_ostream::write_escaped() because it does hex escapes
-    // for non-ASCII chars.
+    // Per "P2361 Unevaluated string literals", we should generally print
+    // either raw Unicode characters or letter-based escape sequences for
+    // string literals in e.g. availability attributes. In particular, we
+    // must not use hex escapes. When we don't have an escape for a particular
+    // control character, we'll print its hex value in "{U+NNNN}" format.
 
     llvm::SmallString<128> Buf;
     StringRef decodedStr = Lexer::getEncodedStringSegment(str, Buf);
@@ -283,23 +286,42 @@ private:
     if (includeQuotes) os << '"';
     for (unsigned char c : decodedStr) {
       switch (c) {
+        // Note: We aren't bothering to escape single quote or question mark
+        // even though we could.
+      case '"':
+        os << '\\' << '"';
+        break;
       case '\\':
         os << '\\' << '\\';
         break;
-      case '\t':
-        os << '\\' << 't';
+      case '\a':
+        os << '\\' << 'a';
+        break;
+      case '\b':
+        os << '\\' << 'b';
+        break;
+      case '\f':
+        os << '\\' << 'f';
         break;
       case '\n':
         os << '\\' << 'n';
         break;
-      case '"':
-        os << '\\' << '"';
+      case '\r':
+        os << '\\' << 'r';
         break;
+      case '\t':
+        os << '\\' << 't';
+        break;
+      case '\v':
+        os << '\\' << 'v';
+        break;
+
       default:
         if (c < 0x20 || c == 0x7F) {
-          os << '\\' << 'x';
+          os << "{U+00";
           os << llvm::hexdigit((c >> 4) & 0xF);
           os << llvm::hexdigit((c >> 0) & 0xF);
+          os << "}";
         } else {
           os << c;
         }

--- a/test/ClangImporter/CoreGraphics_test.swift
+++ b/test/ClangImporter/CoreGraphics_test.swift
@@ -11,7 +11,7 @@ func blackHole<T>(_ value: T) -> Void
 
 // CHECK: [[SWITCHTABLE:@.*]] = private unnamed_addr constant [8 x i64] [i64 0, i64 12, i64 23, i64 34, i64 45, i64 55, i64 67, i64 71]
 
-// CHECK-LABEL: define swiftcc i64 {{.*}}testEnums{{.*}} {
+// CHECK-LABEL: define swiftcc{{.*}} i64 {{.*}}testEnums{{.*}} {
 public func testEnums(_ model: CGColorSpaceModel) -> Int {
   switch model {
      case .unknown : return 0

--- a/test/ClangImporter/Inputs/const_and_pure.h
+++ b/test/ClangImporter/Inputs/const_and_pure.h
@@ -1,7 +1,7 @@
 
-__attribute__((const)) void const_function();
+__attribute__((const)) int const_function();
 
-__attribute__((pure)) void pure_function();
+__attribute__((pure)) int pure_function();
 
-void normal_function();
+int normal_function();
 

--- a/test/ClangImporter/const_and_pure.swift
+++ b/test/ClangImporter/const_and_pure.swift
@@ -1,15 +1,15 @@
 // RUN: %target-swift-frontend -emit-sil %s -enable-objc-interop -import-objc-header %S/Inputs/const_and_pure.h | %FileCheck %s
 
 func testit() {
-	const_function()
+	_ = const_function()
 
-	pure_function()
+  _ = pure_function()
 
-	normal_function()
+  _ = normal_function()
 }
 
-// CHECK: sil [readnone] [clang const_function] @const_function : $@convention(c) () -> ()
-// CHECK: sil [readonly] [clang pure_function] @pure_function : $@convention(c) () -> ()
-// CHECK: sil [clang normal_function] @normal_function : $@convention(c) () -> ()
+// CHECK: sil [readnone] [clang const_function] @const_function : $@convention(c) () -> Int32
+// CHECK: sil [readonly] [clang pure_function] @pure_function : $@convention(c) () -> Int32
+// CHECK: sil [clang normal_function] @normal_function : $@convention(c) () -> Int32
 
 

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -16,7 +16,7 @@
 // CHECK-NEXT: - (void)alwaysDeprecatedTwo SWIFT_DEPRECATED_MSG("it's old");
 // CHECK-NEXT: - (void)alwaysDeprecatedThree SWIFT_DEPRECATED_MSG("", "qux");
 // CHECK-NEXT: - (void)alwaysDeprecatedFour SWIFT_DEPRECATED_MSG("use something else", "quux");
-// CHECK-NEXT: - (void)escapeMessage SWIFT_DEPRECATED_MSG("one\ntwo\tthree\x0Dfour\\ \"five\"");
+// CHECK-NEXT: - (void)escapeMessage SWIFT_DEPRECATED_MSG("one\ntwo\tthree\rfour\\ \"five\"{U+0000}six");
 // CHECK-NEXT: - (void)unicodeMessage SWIFT_DEPRECATED_MSG("über");
 // CHECK-NEXT: - (void)singlePlatShorthand SWIFT_AVAILABILITY(macos,introduced=10.10);
 // CHECK-NEXT: - (void)multiPlatShorthand
@@ -275,7 +275,7 @@
     @available(*, deprecated, message: "use something else", renamed: "quux")
     @objc func alwaysDeprecatedFour() {}
 
-    @available(*, deprecated, message: "one\ntwo\tthree\rfour\\ \"five\"")
+    @available(*, deprecated, message: "one\ntwo\tthree\rfour\\ \"five\"\0six")
     @objc func escapeMessage() {}
     @available(*, deprecated, message: "über")
     @objc func unicodeMessage() {}


### PR DESCRIPTION
This PR fixes three small rebranch bugs:

* The header supporting `ClangImporter/const_and_pure.swift` declared `const` and `pure` functions with a `void` result type. This never made much sense, but clang used to tolerate it. Now it doesn't, so we need to use more realistic result types.
* The header generated by `PrintAsObjC/availability.swift` was no longer valid in clang because the rules about escape sequences in clang availability attributes have changed. Update PrintAsClang to follow the new rules and change the test to expect the new behavior.
* A check line in `ClangImporter/CoreGraphics_test.swift` was not tolerant of a new attribute appearing in the emitted IR. Modify the check line to be less picky.

Fixes rdar://127262497&127262449&127263671.