### PR TITLE
tests: disable IRGen/nested_generics.swift for arm64e

### DIFF
--- a/test/IRGen/nested_generics.swift
+++ b/test/IRGen/nested_generics.swift
@@ -10,6 +10,7 @@
 // rdar://131554269
 //
 // REQUIRES: optimized_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 func blah<T>(_: T.Type) {}
 


### PR DESCRIPTION
The check lines don't consider ptrauth

rdar://131554269
