### PR TITLE
[Distributed] Map into context computed property result type for SerReq checking

### DIFF
--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -420,7 +420,10 @@ static bool checkDistributedTargetResultType(
   if (auto func = dyn_cast<FuncDecl>(valueDecl)) {
     resultType = func->mapTypeIntoContext(func->getResultInterfaceType());
   } else if (auto var = dyn_cast<VarDecl>(valueDecl)) {
-    resultType = var->getInterfaceType();
+    // Distributed computed properties are always getters,
+    // so get the get accessor for mapping the type into context:
+    auto getter = var->getAccessor(swift::AccessorKind::Get);
+    resultType = getter->mapTypeIntoContext(var->getInterfaceType());
   } else {
     llvm_unreachable("Unsupported distributed target");
   }

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -96,6 +96,18 @@ extension ProtocolWithChecksSeqReqDA {
   }
 }
 
+protocol Recipient: DistributedActor where ActorSystem == FakeActorSystem {
+  associatedtype Info: Sendable & Codable // is Codable, should be ok
+  distributed var info: Info { get async }
+  distributed func getInfo() -> Info
+}
+
+distributed actor RecipientImpl: Recipient {
+  typealias Info = String
+  distributed var info: Info { "info" }
+  distributed func getInfo() -> Info { "info" }
+}
+
 // FIXME(distributed): remove the -verify-ignore-unknown
 // <unknown>:0: error: unexpected error produced: instance method 'recordReturnType' requires that 'NotCodable' conform to 'Decodable'
 // <unknown>:0: error: unexpected error produced: instance method 'recordReturnType' requires that 'NotCodable' conform to 'Encodable'


### PR DESCRIPTION
We were doing the right thing for functions but didn't for computed properties, and thus the type checking serialization req would fail for computed properties.

resolves https://github.com/swiftlang/swift/issues/75466 
resolves rdar://132467762 