### PR TITLE
[cxx-interop] Support nested structs

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -244,8 +244,8 @@ swift::cxx_translation::getDeclRepresentation(const ValueDecl *VD) {
         return {Unsupported, UnrepresentableGeneric};
       genericSignature = typeDecl->getGenericSignature();
     }
-    // Nested types are not yet supported.
-    if (!typeDecl->hasClangNode() &&
+    // Nested classes are not yet supported.
+    if (isa<ClassDecl>(VD) && !typeDecl->hasClangNode() &&
         isa_and_nonnull<NominalTypeDecl>(
             typeDecl->getDeclContext()->getAsDecl()))
       return {Unsupported, UnrepresentableNested};

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -20,8 +20,10 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/NestedNameSpecifier.h"
+#include "llvm/Support/Casting.h"
 
 using namespace swift;
 using namespace cxx_synthesis;
@@ -79,7 +81,6 @@ void ClangSyntaxPrinter::printModuleNamespaceQualifiersIfNeeded(
 
 bool ClangSyntaxPrinter::printNominalTypeOutsideMemberDeclTemplateSpecifiers(
     const NominalTypeDecl *typeDecl) {
-  // FIXME: Full qualifiers for nested types?
   if (!typeDecl->isGeneric())
     return true;
   printGenericSignature(
@@ -126,6 +127,26 @@ void ClangSyntaxPrinter::printClangTypeReference(const clang::Decl *typeDecl) {
   }
 }
 
+bool ClangSyntaxPrinter::printNestedTypeNamespaceQualifiers(
+    const ValueDecl *D) const {
+  bool first = true;
+  while (auto parent = dyn_cast_or_null<NominalTypeDecl>(
+             D->getDeclContext()->getAsDecl())) {
+    // C++ namespaces are imported as enums.
+    if (parent->hasClangNode() &&
+        isa<clang::NamespaceDecl>(parent->getClangNode().getAsDecl()))
+      break;
+    if (!first)
+      os << "::";
+    first = false;
+    os << "__";
+    printBaseName(parent);
+    os << "Nested";
+    D = parent;
+  }
+  return first;
+}
+
 void ClangSyntaxPrinter::printNominalTypeReference(
     const NominalTypeDecl *typeDecl, const ModuleDecl *moduleContext) {
   if (typeDecl->hasClangNode()) {
@@ -134,7 +155,8 @@ void ClangSyntaxPrinter::printNominalTypeReference(
   }
   printModuleNamespaceQualifiersIfNeeded(typeDecl->getModuleContext(),
                                          moduleContext);
-  // FIXME: Full qualifiers for nested types?
+  if (!printNestedTypeNamespaceQualifiers(typeDecl))
+    os << "::";
   ClangSyntaxPrinter(os).printBaseName(typeDecl);
   if (typeDecl->isGeneric())
     printGenericSignatureParams(
@@ -178,6 +200,18 @@ void ClangSyntaxPrinter::printNamespace(
     StringRef name, llvm::function_ref<void(raw_ostream &OS)> bodyPrinter,
     NamespaceTrivia trivia) const {
   printNamespace([&](raw_ostream &os) { os << name; }, bodyPrinter, trivia);
+}
+
+void ClangSyntaxPrinter::printParentNamespaceForNestedTypes(
+    const ValueDecl *D, llvm::function_ref<void(raw_ostream &OS)> bodyPrinter,
+    NamespaceTrivia trivia) const {
+  if (!isa_and_nonnull<NominalTypeDecl>(D->getDeclContext()->getAsDecl())) {
+    bodyPrinter(os);
+    return;
+  }
+  printNamespace(
+      [=](raw_ostream &os) { printNestedTypeNamespaceQualifiers(D); },
+      bodyPrinter, trivia);
 }
 
 void ClangSyntaxPrinter::printExternC(
@@ -383,7 +417,8 @@ void ClangSyntaxPrinter::printPrimaryCxxTypeName(
     const NominalTypeDecl *type, const ModuleDecl *moduleContext) {
   printModuleNamespaceQualifiersIfNeeded(type->getModuleContext(),
                                          moduleContext);
-  // FIXME: Print class qualifiers for nested class references.
+  if (!printNestedTypeNamespaceQualifiers(type))
+    os << "::";
   printBaseName(type);
 }
 

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -94,6 +94,9 @@ public:
   bool printNominalTypeOutsideMemberDeclInnerStaticAssert(
       const NominalTypeDecl *typeDecl);
 
+  // Returns true when no qualifiers were printed.
+  bool printNestedTypeNamespaceQualifiers(const ValueDecl *D) const;
+
   /// Print out the C++ class access qualifier for the given Swift  type
   /// declaration.
   ///
@@ -134,6 +137,13 @@ public:
   void printNamespace(StringRef name,
                       llvm::function_ref<void(raw_ostream &OS)> bodyPrinter,
                       NamespaceTrivia trivia = NamespaceTrivia::None) const;
+
+  /// Prints the C++ namespaces of the outer types for a nested type.
+  /// E.g., for struct Foo { struct Bar {...} } it will print
+  /// namespace __FooNested { ..body.. } // namespace __FooNested
+  void printParentNamespaceForNestedTypes(
+      const ValueDecl *D, llvm::function_ref<void(raw_ostream &OS)> bodyPrinter,
+      NamespaceTrivia trivia = NamespaceTrivia::None) const;
 
   /// Print an extern C block with given body.
   void

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -148,6 +148,8 @@ public:
   getObjectTypeAndOptionality(const ValueDecl *D, Type ty);
 };
 
+bool isStringNestedType(const ValueDecl *VD, StringRef Typename);
+
 } // end namespace swift
 
 #endif

--- a/lib/PrintAsClang/PrintClangClassType.cpp
+++ b/lib/PrintAsClang/PrintClangClassType.cpp
@@ -30,81 +30,83 @@ void ClangClassTypePrinter::printClassTypeDecl(
       typeDecl->getDeclaredType()->getCanonicalType());
   std::string typeMetadataFuncName = typeMetadataFunc.mangleAsString();
 
-  // Print out a forward declaration of the "hidden" _impl class.
-  printer.printNamespace(cxx_synthesis::getCxxImplNamespaceName(),
-                         [&](raw_ostream &os) {
-                           os << "class";
-                           declAndTypePrinter.printAvailability(os, typeDecl);
-                           os << ' ';
-                           printCxxImplClassName(os, typeDecl);
-                           os << ";\n";
-                           // Print out special functions, like functions that
-                           // access type metadata.
-                           printer.printCTypeMetadataTypeFunction(
-                               typeDecl, typeMetadataFuncName, {});
-                         });
+  printer.printParentNamespaceForNestedTypes(typeDecl, [&](raw_ostream &os) {
+    // Print out a forward declaration of the "hidden" _impl class.
+    printer.printNamespace(cxx_synthesis::getCxxImplNamespaceName(),
+                           [&](raw_ostream &os) {
+                             os << "class";
+                             declAndTypePrinter.printAvailability(os, typeDecl);
+                             os << ' ';
+                             printCxxImplClassName(os, typeDecl);
+                             os << ";\n";
+                             // Print out special functions, like functions that
+                             // access type metadata.
+                             printer.printCTypeMetadataTypeFunction(
+                                 typeDecl, typeMetadataFuncName, {});
+                           });
 
-  std::string baseClassName;
-  std::string baseClassQualifiedName;
+    std::string baseClassName;
+    std::string baseClassQualifiedName;
 
-  if (auto *parentClass = typeDecl->getSuperclassDecl()) {
-    llvm::raw_string_ostream baseNameOS(baseClassName);
-    ClangSyntaxPrinter(baseNameOS).printBaseName(parentClass);
-    llvm::raw_string_ostream baseQualNameOS(baseClassQualifiedName);
-    ClangSyntaxPrinter(baseQualNameOS)
-        .printModuleNamespaceQualifiersIfNeeded(parentClass->getModuleContext(),
-                                                typeDecl->getModuleContext());
-    baseQualNameOS << baseNameOS.str();
-  } else {
-    baseClassName = "RefCountedClass";
-    baseClassQualifiedName = "swift::_impl::RefCountedClass";
-  }
+    if (auto *parentClass = typeDecl->getSuperclassDecl()) {
+      llvm::raw_string_ostream baseNameOS(baseClassName);
+      ClangSyntaxPrinter(baseNameOS).printBaseName(parentClass);
+      llvm::raw_string_ostream baseQualNameOS(baseClassQualifiedName);
+      ClangSyntaxPrinter(baseQualNameOS)
+          .printModuleNamespaceQualifiersIfNeeded(
+              parentClass->getModuleContext(), typeDecl->getModuleContext());
+      baseQualNameOS << baseNameOS.str();
+    } else {
+      baseClassName = "RefCountedClass";
+      baseClassQualifiedName = "swift::_impl::RefCountedClass";
+    }
 
-  os << "class";
-  declAndTypePrinter.printAvailability(os, typeDecl);
-  ClangSyntaxPrinter(os).printSymbolUSRAttribute(typeDecl);
-  os << ' ';
-  printer.printBaseName(typeDecl);
-  if (typeDecl->isFinal())
-    os << " final";
-  os << " : public " << baseClassQualifiedName;
-  os << " {\n";
-  os << "public:\n";
+    os << "class";
+    declAndTypePrinter.printAvailability(os, typeDecl);
+    ClangSyntaxPrinter(os).printSymbolUSRAttribute(typeDecl);
+    os << ' ';
+    printer.printBaseName(typeDecl);
+    if (typeDecl->isFinal())
+      os << " final";
+    os << " : public " << baseClassQualifiedName;
+    os << " {\n";
+    os << "public:\n";
 
-  os << "  using " << baseClassName << "::" << baseClassName << ";\n";
-  os << "  using " << baseClassName << "::operator=;\n";
-  bodyPrinter();
-  os << "protected:\n";
-  os << "  ";
-  printer.printInlineForThunk();
-  printer.printBaseName(typeDecl);
-  os << "(void * _Nonnull ptr) noexcept : " << baseClassName << "(ptr) {}\n";
-  os << "private:\n";
-  os << "  friend class " << cxx_synthesis::getCxxImplNamespaceName() << "::";
-  printCxxImplClassName(os, typeDecl);
-  os << ";\n";
+    os << "  using " << baseClassName << "::" << baseClassName << ";\n";
+    os << "  using " << baseClassName << "::operator=;\n";
+    bodyPrinter();
+    os << "protected:\n";
+    os << "  ";
+    printer.printInlineForThunk();
+    printer.printBaseName(typeDecl);
+    os << "(void * _Nonnull ptr) noexcept : " << baseClassName << "(ptr) {}\n";
+    os << "private:\n";
+    os << "  friend class " << cxx_synthesis::getCxxImplNamespaceName() << "::";
+    printCxxImplClassName(os, typeDecl);
+    os << ";\n";
 
-  printer.printSwiftMangledNameForDebugger(typeDecl);
+    printer.printSwiftMangledNameForDebugger(typeDecl);
 
-  os << "};\n\n";
+    os << "};\n\n";
 
-  // Print out the "hidden" _impl class.
-  printer.printNamespace(
-      cxx_synthesis::getCxxImplNamespaceName(), [&](raw_ostream &os) {
-        os << "class";
-        declAndTypePrinter.printAvailability(os, typeDecl);
-        os << ' ';
-        printCxxImplClassName(os, typeDecl);
-        os << " {\n";
-        os << "public:\n";
-        os << "static ";
-        printer.printInlineForThunk();
-        printer.printBaseName(typeDecl);
-        os << " makeRetained(void * _Nonnull ptr) noexcept { return ";
-        printer.printBaseName(typeDecl);
-        os << "(ptr); }\n";
-        os << "};\n";
-      });
+    // Print out the "hidden" _impl class.
+    printer.printNamespace(
+        cxx_synthesis::getCxxImplNamespaceName(), [&](raw_ostream &os) {
+          os << "class";
+          declAndTypePrinter.printAvailability(os, typeDecl);
+          os << ' ';
+          printCxxImplClassName(os, typeDecl);
+          os << " {\n";
+          os << "public:\n";
+          os << "static ";
+          printer.printInlineForThunk();
+          printer.printBaseName(typeDecl);
+          os << " makeRetained(void * _Nonnull ptr) noexcept { return ";
+          printer.printBaseName(typeDecl);
+          os << "(ptr); }\n";
+          os << "};\n";
+        });
+  });
 
   ClangValueTypePrinter::printTypeGenericTraits(
       os, typeDecl, typeMetadataFuncName, /*genericRequirements=*/{},

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1057,9 +1057,11 @@ void DeclAndTypeClangFunctionPrinter::printCxxToCFunctionParameterUse(
 
     if (auto *decl = type->getNominalOrBoundGenericNominal()) {
       if ((isa<StructDecl>(decl) || isa<EnumDecl>(decl))) {
-        if (!directTypeEncoding.empty())
-          os << cxx_synthesis::getCxxImplNamespaceName()
+        if (!directTypeEncoding.empty()) {
+          ClangSyntaxPrinter(os).printBaseName(moduleContext);
+          os << "::" << cxx_synthesis::getCxxImplNamespaceName()
              << "::swift_interop_passDirect_" << directTypeEncoding << '(';
+        }
         if (decl->hasClangNode()) {
             if (!directTypeEncoding.empty())
                 os << "reinterpret_cast<const char *>(";
@@ -1298,8 +1300,11 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   auto printCallToCFunc = [&](std::optional<StringRef> additionalParam) {
     if (indirectFunctionVar)
       os << "(* " << *indirectFunctionVar << ')';
-    else
-      os << cxx_synthesis::getCxxImplNamespaceName() << "::" << swiftSymbolName;
+    else {
+      ClangSyntaxPrinter(os).printBaseName(moduleContext);
+      os << "::" << cxx_synthesis::getCxxImplNamespaceName()
+         << "::" << swiftSymbolName;
+    }
     os << '(';
 
     bool needsComma = false;
@@ -1423,7 +1428,9 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
         if (auto directResultType = signature.getDirectResultType()) {
           std::string typeEncoding =
               encodeTypeInfo(*directResultType, moduleContext, typeMapping);
-          os << cxx_synthesis::getCxxImplNamespaceName()
+
+          ClangSyntaxPrinter(os).printBaseName(moduleContext);
+          os << "::" << cxx_synthesis::getCxxImplNamespaceName()
              << "::swift_interop_returnDirect_" << typeEncoding << '('
              << resultPointerName << ", ";
           printCallToCFunc(std::nullopt);

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -16,17 +16,14 @@
 #include "OutputLanguageMode.h"
 #include "PrimitiveTypeMapping.h"
 #include "SwiftToClangInteropContext.h"
-#include "swift/AST/ASTMangler.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/ParameterList.h"
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/Type.h"
-#include "swift/AST/TypeVisitor.h"
-#include "swift/Basic/Assertions.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/IRGen/IRABIDetailsProvider.h"
 #include "swift/IRGen/Linking.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
 
@@ -34,7 +31,8 @@ using namespace swift;
 static void printCTypeName(raw_ostream &os, const NominalTypeDecl *type) {
   ClangSyntaxPrinter printer(os);
   printer.printModuleNameCPrefix(*type->getParentModule());
-  // FIXME: add nested type qualifiers to fully disambiguate the name.
+  if (!ClangSyntaxPrinter(os).printNestedTypeNamespaceQualifiers(type))
+    os << "::";
   printer.printBaseName(type);
 }
 
@@ -87,17 +85,21 @@ printCValueTypeStorageStruct(raw_ostream &os, const NominalTypeDecl *typeDecl,
 void ClangValueTypePrinter::forwardDeclType(
     raw_ostream &os, const NominalTypeDecl *typeDecl,
     DeclAndTypePrinter &declAndTypePrinter) {
-  if (typeDecl->isGeneric()) {
-    auto genericSignature =
-        typeDecl->getGenericSignature().getCanonicalSignature();
-    ClangSyntaxPrinter(os).printGenericSignature(genericSignature);
-  }
-  os << "class";
-  declAndTypePrinter.printAvailability(os, typeDecl);
-  ClangSyntaxPrinter(os).printSymbolUSRAttribute(typeDecl);
-  os << ' ';
-  ClangSyntaxPrinter(os).printBaseName(typeDecl);
-  os << ";\n";
+  ClangSyntaxPrinter(os).printParentNamespaceForNestedTypes(
+      typeDecl, [&](raw_ostream &) {
+        if (typeDecl->isGeneric()) {
+          auto genericSignature =
+              typeDecl->getGenericSignature().getCanonicalSignature();
+          ClangSyntaxPrinter(os).printGenericSignature(genericSignature);
+        }
+
+        os << "class";
+        declAndTypePrinter.printAvailability(os, typeDecl);
+        ClangSyntaxPrinter(os).printSymbolUSRAttribute(typeDecl);
+        os << ' ';
+        ClangSyntaxPrinter(os).printBaseName(typeDecl);
+        os << ";\n";
+      });
   printTypePrecedingGenericTraits(os, typeDecl, typeDecl->getModuleContext());
 }
 
@@ -211,8 +213,6 @@ void ClangValueTypePrinter::printValueTypeDecl(
   }
   bool isOpaqueLayout = !typeSizeAlign.has_value();
 
-  ClangSyntaxPrinter printer(os);
-
   auto typeMetadataFunc = irgen::LinkEntity::forTypeMetadataAccessFunction(
       typeDecl->getDeclaredType()->getCanonicalType());
   std::string typeMetadataFuncName = typeMetadataFunc.mangleAsString();
@@ -221,285 +221,291 @@ void ClangValueTypePrinter::printValueTypeDecl(
           .getTypeMetadataAccessFunctionGenericRequirementParameters(
               const_cast<NominalTypeDecl *>(typeDecl));
 
-  // Print out a forward declaration of the "hidden" _impl class.
-  printer.printNamespace(cxx_synthesis::getCxxImplNamespaceName(),
-                         [&](raw_ostream &os) {
-                           printGenericSignature(os);
-                           os << "class";
-                           declAndTypePrinter.printAvailability(os, typeDecl);
-                           os << ' ';
-                           printCxxImplClassName(os, typeDecl);
-                           os << ";\n\n";
+  ClangSyntaxPrinter printer(os);
+  printer.printParentNamespaceForNestedTypes(typeDecl, [&](raw_ostream &os) {
+    // Print out a forward declaration of the "hidden" _impl class.
+    printer.printNamespace(
+        cxx_synthesis::getCxxImplNamespaceName(), [&](raw_ostream &os) {
+          printGenericSignature(os);
+          os << "class";
+          declAndTypePrinter.printAvailability(os, typeDecl);
+          os << ' ';
+          printCxxImplClassName(os, typeDecl);
+          os << ";\n\n";
 
-                           // Print out special functions, like functions that
-                           // access type metadata.
-                           printer.printCTypeMetadataTypeFunction(
-                               typeDecl, typeMetadataFuncName,
-                               typeMetadataFuncGenericParams);
-                           // Print out global variables for resilient enum
-                           // cases
-                           if (isa<EnumDecl>(typeDecl) && isOpaqueLayout) {
-                             auto elementTagMapping =
-                                 interopContext.getIrABIDetails()
-                                     .getEnumTagMapping(
-                                         cast<EnumDecl>(typeDecl));
-                             os << "// Tags for resilient enum ";
-                             os << typeDecl->getName().str() << '\n';
-                             os << "extern \"C\" {\n";
-                             for (const auto &pair : elementTagMapping) {
-                               os << "extern unsigned "
-                                  << pair.second.globalVariableName << ";\n";
-                             }
-                             os << "}\n";
-                           }
-                         });
+          // Print out special functions, like functions that
+          // access type metadata.
+          printer.printCTypeMetadataTypeFunction(typeDecl, typeMetadataFuncName,
+                                                 typeMetadataFuncGenericParams);
+          // Print out global variables for resilient enum
+          // cases
+          if (isa<EnumDecl>(typeDecl) && isOpaqueLayout) {
+            auto elementTagMapping =
+                interopContext.getIrABIDetails().getEnumTagMapping(
+                    cast<EnumDecl>(typeDecl));
+            os << "// Tags for resilient enum ";
+            os << typeDecl->getName().str() << '\n';
+            os << "extern \"C\" {\n";
+            for (const auto &pair : elementTagMapping) {
+              os << "extern unsigned " << pair.second.globalVariableName
+                 << ";\n";
+            }
+            os << "}\n";
+          }
+        });
 
-  auto printEnumVWTableVariable = [&](StringRef metadataName = "metadata",
-                                      StringRef vwTableName = "vwTable",
-                                      StringRef enumVWTableName =
-                                          "enumVWTable") {
+    auto printEnumVWTableVariable = [&](StringRef metadataName = "metadata",
+                                        StringRef vwTableName = "vwTable",
+                                        StringRef enumVWTableName =
+                                            "enumVWTable") {
+      ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+          os, typeMetadataFuncName, typeMetadataFuncGenericParams);
+      os << "    const auto *" << enumVWTableName << " = reinterpret_cast<";
+      ClangSyntaxPrinter(os).printSwiftImplQualifier();
+      os << "EnumValueWitnessTable";
+      os << " *>(" << vwTableName << ");\n";
+    };
+
+    // Print out the C++ class itself.
+    printGenericSignature(os);
+    os << "class";
+    declAndTypePrinter.printAvailability(os, typeDecl);
+    ClangSyntaxPrinter(os).printSymbolUSRAttribute(typeDecl);
+    os << ' ';
+    ClangSyntaxPrinter(os).printBaseName(typeDecl);
+    os << " final {\n";
+    os << "public:\n";
+    if (genericSignature)
+      ClangSyntaxPrinter(os).printGenericSignatureInnerStaticAsserts(
+          genericSignature);
+
+    // Print out the destructor.
+    os << "  ";
+    printer.printInlineForThunk();
+    os << '~';
+    printer.printBaseName(typeDecl);
+    os << "() noexcept {\n";
     ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
         os, typeMetadataFuncName, typeMetadataFuncGenericParams);
-    os << "    const auto *" << enumVWTableName << " = reinterpret_cast<";
-    ClangSyntaxPrinter(os).printSwiftImplQualifier();
-    os << "EnumValueWitnessTable";
-    os << " *>(" << vwTableName << ");\n";
-  };
+    os << "    vwTable->destroy(_getOpaquePointer(), metadata._0);\n";
+    os << "  }\n";
 
-  // Print out the C++ class itself.
-  printGenericSignature(os);
-  os << "class";
-  declAndTypePrinter.printAvailability(os, typeDecl);
-  ClangSyntaxPrinter(os).printSymbolUSRAttribute(typeDecl);
-  os << ' ';
-  ClangSyntaxPrinter(os).printBaseName(typeDecl);
-  os << " final {\n";
-  os << "public:\n";
-  if (genericSignature)
-    ClangSyntaxPrinter(os).printGenericSignatureInnerStaticAsserts(
-        genericSignature);
+    // copy constructor.
+    os << "  ";
+    printer.printInlineForThunk();
+    printer.printBaseName(typeDecl);
+    os << "(const ";
+    printer.printBaseName(typeDecl);
+    os << " &other) noexcept {\n";
+    ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+        os, typeMetadataFuncName, typeMetadataFuncGenericParams);
+    if (isOpaqueLayout) {
+      os << "    _storage = ";
+      printer.printSwiftImplQualifier();
+      os << cxx_synthesis::getCxxOpaqueStorageClassName()
+         << "(vwTable->size, vwTable->getAlignment());\n";
+    }
+    os << "    vwTable->initializeWithCopy(_getOpaquePointer(), "
+          "const_cast<char "
+          "*>(other._getOpaquePointer()), metadata._0);\n";
+    os << "  }\n";
 
-  // Print out the destructor.
-  os << "  ";
-  printer.printInlineForThunk();
-  os << '~';
-  printer.printBaseName(typeDecl);
-  os << "() noexcept {\n";
-  ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
-      os, typeMetadataFuncName, typeMetadataFuncGenericParams);
-  os << "    vwTable->destroy(_getOpaquePointer(), metadata._0);\n";
-  os << "  }\n";
+    // copy assignment.
+    os << "  ";
+    printer.printInlineForThunk();
+    printer.printBaseName(typeDecl);
+    os << " &operator =(const ";
+    printer.printBaseName(typeDecl);
+    os << " &other) noexcept {\n";
+    ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+        os, typeMetadataFuncName, typeMetadataFuncGenericParams);
+    os << "    vwTable->assignWithCopy(_getOpaquePointer(), const_cast<char "
+          "*>(other._getOpaquePointer()), metadata._0);\n";
+    os << "  return *this;\n";
+    os << "  }\n";
 
-  // copy constructor.
-  os << "  ";
-  printer.printInlineForThunk();
-  printer.printBaseName(typeDecl);
-  os << "(const ";
-  printer.printBaseName(typeDecl);
-  os << " &other) noexcept {\n";
-  ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
-      os, typeMetadataFuncName, typeMetadataFuncGenericParams);
-  if (isOpaqueLayout) {
-    os << "    _storage = ";
-    printer.printSwiftImplQualifier();
-    os << cxx_synthesis::getCxxOpaqueStorageClassName()
-       << "(vwTable->size, vwTable->getAlignment());\n";
-  }
-  os << "    vwTable->initializeWithCopy(_getOpaquePointer(), const_cast<char "
-        "*>(other._getOpaquePointer()), metadata._0);\n";
-  os << "  }\n";
+    // FIXME: implement the move assignment.
+    os << "  ";
+    printer.printInlineForThunk();
+    printer.printBaseName(typeDecl);
+    os << " &operator =(";
+    printer.printBaseName(typeDecl);
+    os << " &&other) = delete;\n";
 
-  // copy assignment.
-  os << "  ";
-  printer.printInlineForThunk();
-  printer.printBaseName(typeDecl);
-  os << " &operator =(const ";
-  printer.printBaseName(typeDecl);
-  os << " &other) noexcept {\n";
-  ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
-      os, typeMetadataFuncName, typeMetadataFuncGenericParams);
-  os << "    vwTable->assignWithCopy(_getOpaquePointer(), const_cast<char "
-        "*>(other._getOpaquePointer()), metadata._0);\n";
-  os << "  return *this;\n";
-  os << "  }\n";
-
-  // FIXME: implement the move assignment.
-  os << "  ";
-  printer.printInlineForThunk();
-  printer.printBaseName(typeDecl);
-  os << " &operator =(";
-  printer.printBaseName(typeDecl);
-  os << " &&other) = delete;\n";
-
-  // FIXME: implement the move constructor.
-  os << "  [[noreturn]] ";
-  // NOTE: Do not apply attribute((used))
-  // here to ensure the linker error isn't
-  // forced, so just mark this an inline
-  // helper function instead.
-  printer.printInlineForHelperFunction();
-  printer.printBaseName(typeDecl);
-  os << "(";
-  printer.printBaseName(typeDecl);
-  StringRef moveErrorMessage = "C++ does not support moving a Swift value yet";
-  os << " &&) noexcept {\n  "
-        "swift::_impl::_fatalError_Cxx_move_of_Swift_value_type_not_supported_"
-        "yet();\n  swift::_impl::_swift_stdlib_reportFatalError(\"swift\", 5, "
-        "\""
-     << moveErrorMessage << "\", " << moveErrorMessage.size()
-     << ", 0);\n  abort();\n  }\n";
-
-  bodyPrinter();
-  if (typeDecl->isStdlibDecl())
-    addCppExtensionsToStdlibType(typeDecl, os, printer, cPrologueOS);
-
-  os << "private:\n";
-
-  // Print out private default constructor.
-  os << "  ";
-  printer.printInlineForThunk();
-  printer.printBaseName(typeDecl);
-  if (isOpaqueLayout) {
+    // FIXME: implement the move constructor.
+    os << "  [[noreturn]] ";
+    // NOTE: Do not apply attribute((used))
+    // here to ensure the linker error isn't
+    // forced, so just mark this an inline
+    // helper function instead.
+    printer.printInlineForHelperFunction();
+    printer.printBaseName(typeDecl);
     os << "(";
-    printer.printSwiftImplQualifier();
-    os << "ValueWitnessTable * _Nonnull vwTable) noexcept : "
-          "_storage(vwTable->size, "
-          "vwTable->getAlignment()) {}\n";
-  } else {
-    os << "() noexcept {}\n";
-  }
-  // Print out '_make' function which returns an unitialized instance for
-  // passing to Swift.
-  os << "  static ";
-  printer.printInlineForThunk();
-  printer.printBaseName(typeDecl);
-  os << " _make() noexcept {";
-  if (isOpaqueLayout) {
+    printer.printBaseName(typeDecl);
+    StringRef moveErrorMessage =
+        "C++ does not support moving a Swift value yet";
+    os << " &&) noexcept {\n  "
+          "swift::_impl::_fatalError_Cxx_move_of_Swift_value_type_not_"
+          "supported_"
+          "yet();\n  swift::_impl::_swift_stdlib_reportFatalError(\"swift\", "
+          "5, "
+          "\""
+       << moveErrorMessage << "\", " << moveErrorMessage.size()
+       << ", 0);\n  abort();\n  }\n";
+
+    bodyPrinter();
+    if (typeDecl->isStdlibDecl())
+      addCppExtensionsToStdlibType(typeDecl, os, printer, cPrologueOS);
+
+    os << "private:\n";
+
+    // Print out private default constructor.
+    os << "  ";
+    printer.printInlineForThunk();
+    printer.printBaseName(typeDecl);
+    if (isOpaqueLayout) {
+      os << "(";
+      printer.printSwiftImplQualifier();
+      os << "ValueWitnessTable * _Nonnull vwTable) noexcept : "
+            "_storage(vwTable->size, "
+            "vwTable->getAlignment()) {}\n";
+    } else {
+      os << "() noexcept {}\n";
+    }
+    // Print out '_make' function which returns an unitialized instance for
+    // passing to Swift.
+    os << "  static ";
+    printer.printInlineForThunk();
+    printer.printBaseName(typeDecl);
+    os << " _make() noexcept {";
+    if (isOpaqueLayout) {
+      os << "\n";
+      ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+          os, typeMetadataFuncName, typeMetadataFuncGenericParams);
+      os << "    return ";
+      printer.printBaseName(typeDecl);
+      os << "(vwTable);\n  }\n";
+    } else {
+      os << " return ";
+      printer.printBaseName(typeDecl);
+      os << "(); }\n";
+    }
+    // Print out the private accessors to the underlying Swift value storage.
+    os << "  ";
+    printer.printInlineForThunk();
+    os << "const char * _Nonnull _getOpaquePointer() const noexcept { return "
+          "_storage";
+    if (isOpaqueLayout)
+      os << ".getOpaquePointer()";
+    os << "; }\n";
+    os << "  ";
+    printer.printInlineForThunk();
+    os << "char * _Nonnull _getOpaquePointer() noexcept { return _storage";
+    if (isOpaqueLayout)
+      os << ".getOpaquePointer()";
+    os << "; }\n";
     os << "\n";
-    ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
-        os, typeMetadataFuncName, typeMetadataFuncGenericParams);
-    os << "    return ";
-    printer.printBaseName(typeDecl);
-    os << "(vwTable);\n  }\n";
-  } else {
-    os << " return ";
-    printer.printBaseName(typeDecl);
-    os << "(); }\n";
-  }
-  // Print out the private accessors to the underlying Swift value storage.
-  os << "  ";
-  printer.printInlineForThunk();
-  os << "const char * _Nonnull _getOpaquePointer() const noexcept { return "
-        "_storage";
-  if (isOpaqueLayout)
-    os << ".getOpaquePointer()";
-  os << "; }\n";
-  os << "  ";
-  printer.printInlineForThunk();
-  os << "char * _Nonnull _getOpaquePointer() noexcept { return _storage";
-  if (isOpaqueLayout)
-    os << ".getOpaquePointer()";
-  os << "; }\n";
-  os << "\n";
-  // Print out helper function for enums
-  if (isa<EnumDecl>(typeDecl)) {
+    // Print out helper function for enums
+    if (isa<EnumDecl>(typeDecl)) {
+      os << "  ";
+      printer.printInlineForThunk();
+      os << "char * _Nonnull _destructiveProjectEnumData() noexcept {\n";
+      printEnumVWTableVariable();
+      os << "    enumVWTable->destructiveProjectEnumData(_getOpaquePointer(), "
+            "metadata._0);\n";
+      os << "    return _getOpaquePointer();\n";
+      os << "  }\n";
+      os << "  ";
+      printer.printInlineForThunk();
+      os << "void _destructiveInjectEnumTag(unsigned tag) noexcept {\n";
+      printEnumVWTableVariable();
+      os << "    enumVWTable->destructiveInjectEnumTag(_getOpaquePointer(), "
+            "tag, "
+            "metadata._0);\n";
+      os << "  }\n";
+      os << "  ";
+      printer.printInlineForThunk();
+      os << "unsigned _getEnumTag() const noexcept {\n";
+      printEnumVWTableVariable();
+      os << "    return enumVWTable->getEnumTag(_getOpaquePointer(), "
+            "metadata._0);\n";
+      os << "  }\n";
+    }
+    // Print out the storage for the value type.
     os << "  ";
-    printer.printInlineForThunk();
-    os << "char * _Nonnull _destructiveProjectEnumData() noexcept {\n";
-    printEnumVWTableVariable();
-    os << "    enumVWTable->destructiveProjectEnumData(_getOpaquePointer(), "
-          "metadata._0);\n";
-    os << "    return _getOpaquePointer();\n";
-    os << "  }\n";
-    os << "  ";
-    printer.printInlineForThunk();
-    os << "void _destructiveInjectEnumTag(unsigned tag) noexcept {\n";
-    printEnumVWTableVariable();
-    os << "    enumVWTable->destructiveInjectEnumTag(_getOpaquePointer(), tag, "
-          "metadata._0);\n";
-    os << "  }\n";
-    os << "  ";
-    printer.printInlineForThunk();
-    os << "unsigned _getEnumTag() const noexcept {\n";
-    printEnumVWTableVariable();
-    os << "    return enumVWTable->getEnumTag(_getOpaquePointer(), "
-          "metadata._0);\n";
-    os << "  }\n";
-  }
-  // Print out the storage for the value type.
-  os << "  ";
-  if (isOpaqueLayout) {
-    printer.printSwiftImplQualifier();
-    os << cxx_synthesis::getCxxOpaqueStorageClassName() << " _storage;\n";
-  } else {
-    os << "alignas(" << typeSizeAlign->alignment << ") ";
-    os << "char _storage[" << typeSizeAlign->size << "];\n";
-  }
-  // Wrap up the value type.
-  os << "  friend class " << cxx_synthesis::getCxxImplNamespaceName() << "::";
-  printCxxImplClassName(os, typeDecl);
-  printGenericParamRefs(os);
-  os << ";\n";
+    if (isOpaqueLayout) {
+      printer.printSwiftImplQualifier();
+      os << cxx_synthesis::getCxxOpaqueStorageClassName() << " _storage;\n";
+    } else {
+      os << "alignas(" << typeSizeAlign->alignment << ") ";
+      os << "char _storage[" << typeSizeAlign->size << "];\n";
+    }
+    // Wrap up the value type.
+    os << "  friend class " << cxx_synthesis::getCxxImplNamespaceName() << "::";
+    printCxxImplClassName(os, typeDecl);
+    printGenericParamRefs(os);
+    os << ";\n";
 
-  printer.printSwiftMangledNameForDebugger(typeDecl);
+    printer.printSwiftMangledNameForDebugger(typeDecl);
 
-  os << "};\n";
-  os << '\n';
+    os << "};\n";
+    os << '\n';
 
-  const auto *moduleContext = typeDecl->getModuleContext();
-  // Print out the "hidden" _impl class.
-  printer.printNamespace(
-      cxx_synthesis::getCxxImplNamespaceName(), [&](raw_ostream &os) {
-        printGenericSignature(os);
-        os << "class";
-        declAndTypePrinter.printAvailability(os, typeDecl);
-        os << ' ';
-        printCxxImplClassName(os, typeDecl);
-        os << " {\n";
-        os << "public:\n";
-        if (genericSignature)
-          ClangSyntaxPrinter(os).printGenericSignatureInnerStaticAsserts(
-              genericSignature);
+    const auto *moduleContext = typeDecl->getModuleContext();
+    // Print out the "hidden" _impl class.
+    printer.printNamespace(
+        cxx_synthesis::getCxxImplNamespaceName(), [&](raw_ostream &os) {
+          printGenericSignature(os);
+          os << "class";
+          declAndTypePrinter.printAvailability(os, typeDecl);
+          os << ' ';
+          printCxxImplClassName(os, typeDecl);
+          os << " {\n";
+          os << "public:\n";
+          if (genericSignature)
+            ClangSyntaxPrinter(os).printGenericSignatureInnerStaticAsserts(
+                genericSignature);
 
-        os << "  static ";
-        ClangSyntaxPrinter(os).printInlineForThunk();
-        os << "char * _Nonnull getOpaquePointer(";
-        printCxxTypeName(os, typeDecl, moduleContext);
-        printGenericParamRefs(os);
-        os << " &object) { return object._getOpaquePointer(); }\n";
+          os << "  static ";
+          ClangSyntaxPrinter(os).printInlineForThunk();
+          os << "char * _Nonnull getOpaquePointer(";
+          printCxxTypeName(os, typeDecl, moduleContext);
+          printGenericParamRefs(os);
+          os << " &object) { return object._getOpaquePointer(); }\n";
 
-        os << "  static ";
-        ClangSyntaxPrinter(os).printInlineForThunk();
-        os << "const char * _Nonnull getOpaquePointer(const ";
-        printCxxTypeName(os, typeDecl, moduleContext);
-        printGenericParamRefs(os);
-        os << " &object) { return object._getOpaquePointer(); }\n";
+          os << "  static ";
+          ClangSyntaxPrinter(os).printInlineForThunk();
+          os << "const char * _Nonnull getOpaquePointer(const ";
+          printCxxTypeName(os, typeDecl, moduleContext);
+          printGenericParamRefs(os);
+          os << " &object) { return object._getOpaquePointer(); }\n";
 
-        os << "  template<class T>\n";
-        os << "  static ";
-        ClangSyntaxPrinter(os).printInlineForHelperFunction();
-        printCxxTypeName(os, typeDecl, moduleContext);
-        printGenericParamRefs(os);
-        os << " returnNewValue(T callable) {\n";
-        os << "    auto result = ";
-        printCxxTypeName(os, typeDecl, moduleContext);
-        printGenericParamRefs(os);
-        os << "::_make();\n";
-        os << "    callable(result._getOpaquePointer());\n";
-        os << "    return result;\n";
-        os << "  }\n";
-        // Print out helper function for initializeWithTake
-        os << "  static ";
-        ClangSyntaxPrinter(os).printInlineForThunk();
-        os << "void initializeWithTake(char * _Nonnull "
-              "destStorage, char * _Nonnull srcStorage) {\n";
-        ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
-            os, typeMetadataFuncName, typeMetadataFuncGenericParams);
-        os << "    vwTable->initializeWithTake(destStorage, srcStorage, "
-              "metadata._0);\n";
-        os << "  }\n";
-        os << "};\n";
-      });
+          os << "  template<class T>\n";
+          os << "  static ";
+          ClangSyntaxPrinter(os).printInlineForHelperFunction();
+          printCxxTypeName(os, typeDecl, moduleContext);
+          printGenericParamRefs(os);
+          os << " returnNewValue(T callable) {\n";
+          os << "    auto result = ";
+          printCxxTypeName(os, typeDecl, moduleContext);
+          printGenericParamRefs(os);
+          os << "::_make();\n";
+          os << "    callable(result._getOpaquePointer());\n";
+          os << "    return result;\n";
+          os << "  }\n";
+          // Print out helper function for initializeWithTake
+          os << "  static ";
+          ClangSyntaxPrinter(os).printInlineForThunk();
+          os << "void initializeWithTake(char * _Nonnull "
+                "destStorage, char * _Nonnull srcStorage) {\n";
+          ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+              os, typeMetadataFuncName, typeMetadataFuncGenericParams);
+          os << "    vwTable->initializeWithTake(destStorage, srcStorage, "
+                "metadata._0);\n";
+          os << "  }\n";
+          os << "};\n";
+        });
+  });
 
   if (!isOpaqueLayout)
     printCValueTypeStorageStruct(cPrologueOS, typeDecl, *typeSizeAlign);
@@ -535,8 +541,10 @@ void ClangValueTypePrinter::printValueTypeReturnType(
       printCxxTypeName(os, type, moduleContext);
     else {
       assert(typeUse == TypeUseKind::CxxImplTypeName);
-      ClangSyntaxPrinter(os).printModuleNamespaceQualifiersIfNeeded(
-          type->getModuleContext(), moduleContext);
+      ClangSyntaxPrinter(os).printBaseName(type->getModuleContext());
+      os << "::";
+      if (!ClangSyntaxPrinter(os).printNestedTypeNamespaceQualifiers(type))
+        os << "::";
       os << cxx_synthesis::getCxxImplNamespaceName() << "::";
       printCxxImplClassName(os, type);
     }
@@ -660,6 +668,8 @@ void ClangValueTypePrinter::printTypeGenericTraits(
     printer.printBaseName(typeDecl->getModuleContext());
     os << "::";
   }
+  if (!printer.printNestedTypeNamespaceQualifiers(typeDecl))
+    os << "::";
   os << cxx_synthesis::getCxxImplNamespaceName() << "::";
   ClangSyntaxPrinter(os).printSwiftTypeMetadataAccessFunctionCall(
       typeMetadataFuncName, typeMetadataFuncRequirements);
@@ -708,7 +718,10 @@ void ClangValueTypePrinter::printTypeGenericTraits(
     printer.printNominalTypeReference(NTD, moduleContext);
     os << "> { using type = ";
     printer.printBaseName(typeDecl->getModuleContext());
-    os << "::" << cxx_synthesis::getCxxImplNamespaceName() << "::";
+    os << "::";
+    if (!printer.printNestedTypeNamespaceQualifiers(typeDecl))
+      os << "::";
+    os << cxx_synthesis::getCxxImplNamespaceName() << "::";
     printCxxImplClassName(os, NTD);
     if (NTD->isGeneric())
       printer.printGenericSignatureParams(

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -196,11 +196,11 @@ public struct Strct {
 // CHECK: SWIFT_EXTERN struct swift_interop_returnStub_UseCxxTy_uint32_t_0_4 $s8UseCxxTy10retTrivialSo0E0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // retTrivial()
 
 // CHECK: ns::Immortal *_Nonnull retImmortal() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT: return _impl::$s8UseCxxTy11retImmortalSo2nsO0E0VyF();
+// CHECK-NEXT: return UseCxxTy::_impl::$s8UseCxxTy11retImmortalSo2nsO0E0VyF();
 // CHECK-NEXT: }
 
 // CHECK:  ns::ImmortalTemplate<int> *_Nonnull retImmortalTemplate() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT: return _impl::$s8UseCxxTy19retImmortalTemplateSo2nsO0028ImmortalTemplateCInt_jBAGgnbVyF();
+// CHECK-NEXT: return UseCxxTy::_impl::$s8UseCxxTy19retImmortalTemplateSo2nsO0028ImmortalTemplateCInt_jBAGgnbVyF();
 // CHECK-NEXT: }
 
 // CHECK: } // end namespace
@@ -301,7 +301,7 @@ public struct Strct {
 // CHECK: SWIFT_INLINE_THUNK Trivial retTrivial() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(Trivial)) char storage[sizeof(Trivial)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<Trivial *>(storage);
-// CHECK-NEXT: _impl::swift_interop_returnDirect_UseCxxTy_uint32_t_0_4(storage, _impl::$s8UseCxxTy10retTrivialSo0E0VyF());
+// CHECK-NEXT: UseCxxTy::_impl::swift_interop_returnDirect_UseCxxTy_uint32_t_0_4(storage, UseCxxTy::_impl::$s8UseCxxTy10retTrivialSo0E0VyF());
 // CHECK-NEXT: return *storageObjectPtr;
 // CHECK-NEXT: }
 
@@ -320,7 +320,7 @@ public struct Strct {
 // CHECK: SWIFT_INLINE_THUNK void takeSimpleScopedEnum(const SimpleScopedEnum& x) noexcept SWIFT_SYMBOL({{.*}}) {
 
 // CHECK: SWIFT_INLINE_THUNK void takeTrivial(const Trivial& x) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:   _impl::$s8UseCxxTy11takeTrivialyySo0E0VF(_impl::swift_interop_passDirect_UseCxxTy_uint32_t_0_4(reinterpret_cast<const char *>(swift::_impl::getOpaquePointer(x))));
+// CHECK-NEXT:   _impl::$s8UseCxxTy11takeTrivialyySo0E0VF(UseCxxTy::_impl::swift_interop_passDirect_UseCxxTy_uint32_t_0_4(reinterpret_cast<const char *>(swift::_impl::getOpaquePointer(x))));
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK void takeTrivialInout(Trivial& x) noexcept SWIFT_SYMBOL({{.*}}) {

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
@@ -60,10 +60,10 @@ public func retObjClassNullable() -> ObjCKlass? {
 // CHECK-NEXT: void $s9UseObjCTy04takeB14CClassNullableyySo0B6CKlassCSgF(ObjCKlass *_Nullable x) SWIFT_NOEXCEPT SWIFT_CALL;
 
 // CHECK: SWIFT_INLINE_THUNK ObjCKlass *_Nonnull retObjClass() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT: return (__bridge_transfer ObjCKlass *)(__bridge void *)_impl::$s9UseObjCTy03retB5ClassSo0B6CKlassCyF();
+// CHECK-NEXT: return (__bridge_transfer ObjCKlass *)(__bridge void *)UseObjCTy::_impl::$s9UseObjCTy03retB5ClassSo0B6CKlassCyF();
 
 // CHECK: SWIFT_INLINE_THUNK ObjCKlass *_Nullable retObjClassNullable() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT: return (__bridge_transfer ObjCKlass *)(__bridge void *)_impl::$s9UseObjCTy03retB13ClassNullableSo0B6CKlassCSgyF();
+// CHECK-NEXT: return (__bridge_transfer ObjCKlass *)(__bridge void *)UseObjCTy::_impl::$s9UseObjCTy03retB13ClassNullableSo0B6CKlassCSgyF();
 
 // CHECK: void takeObjCClass(ObjCKlass *_Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT: _impl::$s9UseObjCTy04takeB6CClassyySo0B6CKlassCF(x);

--- a/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
@@ -107,7 +107,7 @@ public final class register { }
 // CHECK: class SWIFT_SYMBOL("s:5Class8registerC") register_ final : public swift::_impl::RefCountedClass {
 
 // CHECK: SWIFT_INLINE_THUNK ClassWithIntField passThroughClassWithIntField(const ClassWithIntField& x) noexcept SWIFT_SYMBOL("s:5Class011passThroughA12WithIntFieldyAA0adeF0CADF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_ClassWithIntField::makeRetained(_impl::$s5Class011passThroughA12WithIntFieldyAA0adeF0CADF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x)));
+// CHECK-NEXT:  return _impl::_impl_ClassWithIntField::makeRetained(Class::_impl::$s5Class011passThroughA12WithIntFieldyAA0adeF0CADF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 public func returnClassWithIntField() -> ClassWithIntField {
@@ -130,7 +130,7 @@ public func takeClassWithIntFieldInout(_ x: inout ClassWithIntField) {
 }
 
 // CHECK: SWIFT_INLINE_THUNK ClassWithIntField returnClassWithIntField() noexcept SWIFT_SYMBOL("s:5Class06returnA12WithIntFieldAA0acdE0CyF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_ClassWithIntField::makeRetained(_impl::$s5Class06returnA12WithIntFieldAA0acdE0CyF());
+// CHECK-NEXT:   return _impl::_impl_ClassWithIntField::makeRetained(Class::_impl::$s5Class06returnA12WithIntFieldAA0acdE0CyF());
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK void takeClassWithIntField(const ClassWithIntField& x) noexcept SWIFT_SYMBOL("s:5Class04takeA12WithIntFieldyyAA0acdE0CF") {

--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
@@ -145,7 +145,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   }
 
 // CHECK:        swift::Int BaseClass::finalMethodInBase(swift::Int x) {
-// CHECK-NEXT:   return _impl::$s5Class04BaseA0C013finalMethodInB0yS2iF(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT:   return Class::_impl::$s5Class04BaseA0C013finalMethodInB0yS2iF(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
 // CHECK:        swift::Int BaseClass::getVirtualComputedProp() {
@@ -362,7 +362,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     }
 
 // CHECK:        BaseClass DerivedDerivedClass::virtualMethodInDerived(const BaseClass& x) {
-// CHECK-NEXT:     return _impl::_impl_BaseClass::makeRetained(_impl::$s5Class07DerivedbA0C015virtualMethodInB0yAA04BaseA0CAFF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
+// CHECK-NEXT:     return _impl::_impl_BaseClass::makeRetained(Class::_impl::$s5Class07DerivedbA0C015virtualMethodInB0yAA04BaseA0CAFF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT:     }
 
 // CHECK:        void DerivedDerivedClass::methodInDerivedDerived() {
@@ -370,9 +370,9 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     }
 
 // CHECK:          swift::Int DerivedDerivedClass::getStoredProp() {
-// CHECK-NEXT:     return _impl::$s5Class07DerivedbA0C10storedPropSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT:     return Class::_impl::$s5Class07DerivedbA0C10storedPropSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
 // CHECK:          swift::Int DerivedDerivedClass::getComputedPropInDerivedDerived() {
-// CHECK-NEXT:     return _impl::$s5Class07DerivedbA0C014computedPropInbB0Sivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT:     return Class::_impl::$s5Class07DerivedbA0C014computedPropInbB0Sivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }

--- a/test/Interop/SwiftToCxx/class/swift-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-resilient-class-virtual-method-dispatch.swift
@@ -17,11 +17,11 @@
 // CHECK-NEXT:  }
 
 // CHECK:      swift::Int BaseClass::virtualMethodIntInt(swift::Int x) {
-// CHECK-NEXT: return _impl::$s5Class04BaseA0C016virtualMethodIntE0yS2iFTj(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT: return Class::_impl::$s5Class04BaseA0C016virtualMethodIntE0yS2iFTj(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
 // CHECK:        swift::Int BaseClass::finalMethodInBase(swift::Int x) {
-// CHECK-NEXT:   return _impl::$s5Class04BaseA0C013finalMethodInB0yS2iF(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT:   return Class::_impl::$s5Class04BaseA0C013finalMethodInB0yS2iF(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
 // CHECK:         swift::Int BaseClass::getVirtualComputedProp() {
@@ -40,22 +40,22 @@
 // CHECK-NEXT:    _impl::$s5Class04BaseA0C10storedPropSivsTj(value, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
 // CHECK:           swift::Int BaseClass::operator [](swift::Int i) const
-// CHECK-NEXT:      return _impl::$s5Class04BaseA0CyS2icigTj(i, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT:      return Class::_impl::$s5Class04BaseA0CyS2icigTj(i, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
 // CHECK:        void DerivedClass::virtualMethod() {
 // CHECK-NEXT:   _impl::$s5Class04BaseA0C13virtualMethodyyFTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
 // CHECK:        swift::Int DerivedClass::virtualMethodIntInt(swift::Int x) {
-// CHECK-NEXT:   return _impl::$s5Class04BaseA0C016virtualMethodIntE0yS2iFTj(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT:   return Class::_impl::$s5Class04BaseA0C016virtualMethodIntE0yS2iFTj(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
 // CHECK:        BaseClass DerivedClass::virtualMethodInDerived(const BaseClass& x) {
-// CHECK-NEXT:   return _impl::_impl_BaseClass::makeRetained(_impl::$s5Class07DerivedA0C015virtualMethodInB0yAA04BaseA0CAFFTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
+// CHECK-NEXT:   return _impl::_impl_BaseClass::makeRetained(Class::_impl::$s5Class07DerivedA0C015virtualMethodInB0yAA04BaseA0CAFFTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT:   }
 
 // CHECK:         swift::Int DerivedClass::getVirtualComputedProp() {
-// CHECK-NEXT:   _impl::$s5Class04BaseA0C19virtualComputedPropSivgTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT:   Class::_impl::$s5Class04BaseA0C19virtualComputedPropSivgTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
 
 // CHECK:        void DerivedDerivedClass::virtualMethod() {
@@ -63,7 +63,7 @@
 // CHECK-NEXT:     }
 
 // CHECK:        BaseClass DerivedDerivedClass::virtualMethodInDerived(const BaseClass& x) {
-// CHECK-NEXT:     return _impl::_impl_BaseClass::makeRetained(_impl::$s5Class07DerivedbA0C015virtualMethodInB0yAA04BaseA0CAFF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
+// CHECK-NEXT:     return _impl::_impl_BaseClass::makeRetained(Class::_impl::$s5Class07DerivedbA0C015virtualMethodInB0yAA04BaseA0CAFF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT:     }
 
 // CHECK:        void DerivedDerivedClass::methodInDerivedDerived() {
@@ -71,7 +71,7 @@
 // CHECK-NEXT:     }
 
 // CHECK:         swift::Int DerivedDerivedClass::getStoredProp() {
-// CHECK-NEXT:     return _impl::$s5Class07DerivedbA0C10storedPropSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT:     return Class::_impl::$s5Class07DerivedbA0C10storedPropSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
 // CHECK:          swift::Int DerivedDerivedClass::getComputedPropInDerivedDerived() {
-// CHECK-NEXT:     return _impl::$s5Class07DerivedbA0C014computedPropInbB0Sivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT:     return Class::_impl::$s5Class07DerivedbA0C014computedPropInbB0Sivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
@@ -50,18 +50,18 @@ public func passThroughStructSmallDirect(_ x: SmallStructDirectPassing) -> Small
 
 // CHECK:      SWIFT_INLINE_THUNK Structs::SmallStructDirectPassing passThroughStructSmallDirect(const Structs::SmallStructDirectPassing& x) noexcept SWIFT_SYMBOL("s:11UsesStructs28passThroughStructSmallDirecty0B00feG7PassingVAEF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::_impl_SmallStructDirectPassing::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_UsesStructs_uint32_t_0_4(result, _impl::$s11UsesStructs28passThroughStructSmallDirecty0B00feG7PassingVAEF(_impl::swift_interop_passDirect_UsesStructs_uint32_t_0_4(Structs::_impl::_impl_SmallStructDirectPassing::getOpaquePointer(x))));
+// CHECK-NEXT:    UsesStructs::_impl::swift_interop_returnDirect_UsesStructs_uint32_t_0_4(result, UsesStructs::_impl::$s11UsesStructs28passThroughStructSmallDirecty0B00feG7PassingVAEF(UsesStructs::_impl::swift_interop_passDirect_UsesStructs_uint32_t_0_4(Structs::_impl::_impl_SmallStructDirectPassing::getOpaquePointer(x))));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK Structs::StructSeveralI64 UsesStructsStruct::passThroughStructSeveralI64(const Structs::StructSeveralI64& y) const {
 // CHECK-NEXT: return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::$s11UsesStructs0aB6StructV011passThroughC10SeveralI64y0B00cfG0VAGF(result, Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(y), _getOpaquePointer());
+// CHECK-NEXT:   UsesStructs::_impl::$s11UsesStructs0aB6StructV011passThroughC10SeveralI64y0B00cfG0VAGF(result, Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(y), _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK Structs::StructSeveralI64 UsesStructsStruct::getX() const {
 // CHECK-NEXT: return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::$s11UsesStructs0aB6StructV1x0B00C10SeveralI64Vvg(result, _getOpaquePointer());
+// CHECK-NEXT:   UsesStructs::_impl::$s11UsesStructs0aB6StructV1x0B00C10SeveralI64Vvg(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
@@ -53,7 +53,7 @@ public enum G<T> {
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK bool E::matchesIntValue(swift::Int value) const {
-// CHECK-NEXT: return _impl::$s5Enums1EO15matchesIntValueySbSiF(value, _impl::swift_interop_passDirect_Enums_{{.*}}(_getOpaquePointer()));
+// CHECK-NEXT: return Enums::_impl::$s5Enums1EO15matchesIntValueySbSiF(value, Enums::_impl::swift_interop_passDirect_Enums_{{.*}}(_getOpaquePointer()));
 
 // CHECK: SWIFT_INLINE_THUNK swift::Array<C> F::getB() const {
 // CHECK-NEXT:    if (!isB()) abort();

--- a/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
@@ -45,21 +45,21 @@ public func inoutLarge(_ en: inout Large, _ x: Int) {
 // CHECK: class SWIFT_SYMBOL("s:5Enums5LargeO") Large final {
 
 // CHECK:      SWIFT_INLINE_THUNK void inoutLarge(Large& en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums10inoutLargeyyAA0C0Oz_SitF") {
-// CHECK-NEXT:   _impl::$s5Enums10inoutLargeyyAA0C0Oz_SitF(_impl::_impl_Large::getOpaquePointer(en), x);
+// CHECK-NEXT:   Enums::_impl::$s5Enums10inoutLargeyyAA0C0Oz_SitF(Enums::_impl::_impl_Large::getOpaquePointer(en), x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK Large makeLarge(swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums9makeLargeyAA0C0OSiF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_Large::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::$s5Enums9makeLargeyAA0C0OSiF(result, x);
+// CHECK-NEXT:   return Enums::_impl::_impl_Large::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Enums::_impl::$s5Enums9makeLargeyAA0C0OSiF(result, x);
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK Large passThroughLarge(const Large& en) noexcept SWIFT_SYMBOL("s:5Enums16passThroughLargeyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_Large::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::$s5Enums16passThroughLargeyAA0D0OADF(result, _impl::_impl_Large::getOpaquePointer(en));
+// CHECK-NEXT:   return Enums::_impl::_impl_Large::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Enums::_impl::$s5Enums16passThroughLargeyAA0D0OADF(result, Enums::_impl::_impl_Large::getOpaquePointer(en));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK void printLarge(const Large& en) noexcept SWIFT_SYMBOL("s:5Enums10printLargeyyAA0C0OF") {
-// CHECK-NEXT:   _impl::$s5Enums10printLargeyyAA0C0OF(_impl::_impl_Large::getOpaquePointer(en));
+// CHECK-NEXT:   Enums::_impl::$s5Enums10printLargeyyAA0C0OF(Enums::_impl::_impl_Large::getOpaquePointer(en));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
@@ -109,41 +109,41 @@ public func inoutSmall(_ en: inout Small, _ x: Int) {
 // CHECK: class SWIFT_SYMBOL("s:5Enums4TinyO") Tiny final {
 
 // CHECK:      SWIFT_INLINE_THUNK void inoutSmall(Small& en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums10inoutSmallyyAA0C0Oz_SitF") {
-// CHECK-NEXT:   _impl::$s5Enums10inoutSmallyyAA0C0Oz_SitF(_impl::_impl_Small::getOpaquePointer(en), x);
+// CHECK-NEXT:  Enums::_impl::$s5Enums10inoutSmallyyAA0C0Oz_SitF(Enums::_impl::_impl_Small::getOpaquePointer(en), x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK void inoutTiny(Tiny& en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums9inoutTinyyyAA0C0Oz_SitF") {
-// CHECK-NEXT:   _impl::$s5Enums9inoutTinyyyAA0C0Oz_SitF(_impl::_impl_Tiny::getOpaquePointer(en), x);
+// CHECK-NEXT:   Enums::_impl::$s5Enums9inoutTinyyyAA0C0Oz_SitF(Enums::_impl::_impl_Tiny::getOpaquePointer(en), x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK Small makeSmall(swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums9makeSmallyAA0C0OSiF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_Small::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_[[Small]](result, _impl::$s5Enums9makeSmallyAA0C0OSiF(x));
+// CHECK-NEXT:   return Enums::_impl::_impl_Small::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Enums::_impl::swift_interop_returnDirect_Enums_[[Small]](result, Enums::_impl::$s5Enums9makeSmallyAA0C0OSiF(x));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK Tiny makeTiny(swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums8makeTinyyAA0C0OSiF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_Tiny::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_uint8_t_0_1(result, _impl::$s5Enums8makeTinyyAA0C0OSiF(x));
+// CHECK-NEXT:   return Enums::_impl::_impl_Tiny::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Enums::_impl::swift_interop_returnDirect_Enums_uint8_t_0_1(result, Enums::_impl::$s5Enums8makeTinyyAA0C0OSiF(x));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK Small passThroughSmall(const Small& en) noexcept SWIFT_SYMBOL("s:5Enums16passThroughSmallyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_Small::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_[[Small]](result, _impl::$s5Enums16passThroughSmallyAA0D0OADF(_impl::swift_interop_passDirect_Enums_[[Small]](_impl::_impl_Small::getOpaquePointer(en))));
+// CHECK-NEXT:   return Enums::_impl::_impl_Small::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Enums::_impl::swift_interop_returnDirect_Enums_[[Small]](result, Enums::_impl::$s5Enums16passThroughSmallyAA0D0OADF(Enums::_impl::swift_interop_passDirect_Enums_[[Small]](Enums::_impl::_impl_Small::getOpaquePointer(en))));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK Tiny passThroughTiny(const Tiny& en) noexcept SWIFT_SYMBOL("s:5Enums15passThroughTinyyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_Tiny::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_uint8_t_0_1(result, _impl::$s5Enums15passThroughTinyyAA0D0OADF(_impl::swift_interop_passDirect_Enums_uint8_t_0_1(_impl::_impl_Tiny::getOpaquePointer(en))));
+// CHECK-NEXT:   return Enums::_impl::_impl_Tiny::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Enums::_impl::swift_interop_returnDirect_Enums_uint8_t_0_1(result, Enums::_impl::$s5Enums15passThroughTinyyAA0D0OADF(Enums::_impl::swift_interop_passDirect_Enums_uint8_t_0_1(Enums::_impl::_impl_Tiny::getOpaquePointer(en))));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK void printSmall(const Small& en) noexcept SWIFT_SYMBOL("s:5Enums10printSmallyyAA0C0OF") {
-// CHECK-NEXT:   _impl::$s5Enums10printSmallyyAA0C0OF(_impl::swift_interop_passDirect_Enums_[[Small]](_impl::_impl_Small::getOpaquePointer(en)));
+// CHECK-NEXT:   Enums::_impl::$s5Enums10printSmallyyAA0C0OF(Enums::_impl::swift_interop_passDirect_Enums_[[Small]](Enums::_impl::_impl_Small::getOpaquePointer(en)));
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK void printTiny(const Tiny& en) noexcept SWIFT_SYMBOL("s:5Enums9printTinyyyAA0C0OF") {
-// CHECK-NEXT:   _impl::$s5Enums9printTinyyyAA0C0OF(_impl::swift_interop_passDirect_Enums_uint8_t_0_1(_impl::_impl_Tiny::getOpaquePointer(en)));
+// CHECK-NEXT:   Enums::_impl::$s5Enums9printTinyyyAA0C0OF(Enums::_impl::swift_interop_passDirect_Enums_uint8_t_0_1(Enums::_impl::_impl_Tiny::getOpaquePointer(en)));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
@@ -290,13 +290,13 @@ public struct S {
 // CHECK-NEXT:     return *this == E::foobar;
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK E E::init() {
-// CHECK-NEXT:     return _impl::_impl_E::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:       _impl::swift_interop_returnDirect_Enums[[ENUMENCODING:[a-z0-9_]+]](result, _impl::$s5Enums1EOACycfC());
+// CHECK-NEXT:     return Enums::_impl::_impl_E::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:       Enums::_impl::swift_interop_returnDirect_Enums[[ENUMENCODING:[a-z0-9_]+]](result, Enums::_impl::$s5Enums1EOACycfC());
 // CHECK-NEXT:     });
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK swift::Int E::getTen() const {
-// CHECK-NEXT:     return _impl::$s5Enums1EO3tenSivg(_impl::swift_interop_passDirect_Enums[[ENUMENCODING]](_getOpaquePointer()));
+// CHECK-NEXT:     return Enums::_impl::$s5Enums1EO3tenSivg(Enums::_impl::swift_interop_passDirect_Enums[[ENUMENCODING]](_getOpaquePointer()));
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK void E::printSelf() const {
-// CHECK-NEXT:     _impl::$s5Enums1EO9printSelfyyF(_impl::swift_interop_passDirect_Enums[[ENUMENCODING]](_getOpaquePointer()));
+// CHECK-NEXT:     Enums::_impl::$s5Enums1EO9printSelfyyF(Enums::_impl::swift_interop_passDirect_Enums[[ENUMENCODING]](_getOpaquePointer()));
 // CHECK-NEXT:   }

--- a/test/Interop/SwiftToCxx/functions/cdecl.swift
+++ b/test/Interop/SwiftToCxx/functions/cdecl.swift
@@ -14,5 +14,5 @@
 public func differentCDeclName(x: CInt, y: CInt) -> CInt { return x + y }
 
 // CHECK: SWIFT_INLINE_THUNK int differentCDeclName(int x, int y) noexcept SWIFT_SYMBOL("{{.*}}") SWIFT_WARN_UNUSED_RESULT {
-// CHECK: return _impl::cfuncPassTwo(x, y);
+// CHECK: return CdeclFunctions::_impl::cfuncPassTwo(x, y);
 // CHECK: }

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -121,7 +121,7 @@ public func throwFunctionWithPossibleReturn(_ a: Int) throws -> Int {
 // CHECK: SWIFT_INLINE_THUNK swift::ThrowingResult<swift::Int> throwFunctionWithPossibleReturn(swift::Int a) SWIFT_SYMBOL("s:9Functions31throwFunctionWithPossibleReturnyS2iKF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK: void* opaqueError = nullptr;
 // CHECK: void* _ctx = nullptr;
-// CHECK: auto returnValue = _impl::$s9Functions31throwFunctionWithPossibleReturnyS2iKF(a, _ctx, &opaqueError);
+// CHECK: auto returnValue = Functions::_impl::$s9Functions31throwFunctionWithPossibleReturnyS2iKF(a, _ctx, &opaqueError);
 // CHECK: if (opaqueError != nullptr)
 // CHECK: #ifdef __cpp_exceptions
 // CHECK: throw (swift::Error(opaqueError));
@@ -141,7 +141,7 @@ public func throwFunctionWithReturn() throws -> Int {
 // CHECK: SWIFT_INLINE_THUNK swift::ThrowingResult<swift::Int> throwFunctionWithReturn() SWIFT_SYMBOL("s:9Functions23throwFunctionWithReturnSiyKF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK: void* opaqueError = nullptr;
 // CHECK: void* _ctx = nullptr;
-// CHECK: auto returnValue = _impl::$s9Functions23throwFunctionWithReturnSiyKF(_ctx, &opaqueError);
+// CHECK: auto returnValue = Functions::_impl::$s9Functions23throwFunctionWithReturnSiyKF(_ctx, &opaqueError);
 // CHECK: #ifdef __cpp_exceptions
 // CHECK: throw (swift::Error(opaqueError));
 // CHECK: #else

--- a/test/Interop/SwiftToCxx/functions/swift-functions.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions.swift
@@ -32,7 +32,7 @@ public func passIntReturnVoid(x: CInt) { print("passIntReturnVoid \(x)") }
 public func passTwoIntReturnInt(x: CInt, y: CInt) -> CInt { return x + y }
 
 // CHECK: SWIFT_INLINE_THUNK int passTwoIntReturnInt(int x, int y) noexcept SWIFT_SYMBOL("s:9Functions016passTwoIntReturnD01x1ys5Int32VAF_AFtF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK: return _impl::$s9Functions016passTwoIntReturnD01x1ys5Int32VAF_AFtF(x, y);
+// CHECK: return Functions::_impl::$s9Functions016passTwoIntReturnD01x1ys5Int32VAF_AFtF(x, y);
 // CHECK: }
 
 public func passTwoIntReturnIntNoArgLabel(_: CInt, _: CInt) -> CInt {
@@ -41,13 +41,13 @@ public func passTwoIntReturnIntNoArgLabel(_: CInt, _: CInt) -> CInt {
 }
 
 // CHECK: SWIFT_INLINE_THUNK int passTwoIntReturnIntNoArgLabel(int _1, int _2) noexcept SWIFT_SYMBOL("s:9Functions016passTwoIntReturnD10NoArgLabelys5Int32VAD_ADtF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK: return _impl::$s9Functions016passTwoIntReturnD10NoArgLabelys5Int32VAD_ADtF(_1, _2);
+// CHECK: return Functions::_impl::$s9Functions016passTwoIntReturnD10NoArgLabelys5Int32VAD_ADtF(_1, _2);
 // CHECK: }
 
 public func passTwoIntReturnIntNoArgLabelParamName(_ x2: CInt, _ y2: CInt) -> CInt { return x2 + y2 }
 
 // CHECK: SWIFT_INLINE_THUNK int passTwoIntReturnIntNoArgLabelParamName(int x2, int y2) noexcept SWIFT_SYMBOL("s:9Functions016passTwoIntReturnD19NoArgLabelParamNameys5Int32VAD_ADtF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK:   return _impl::$s9Functions016passTwoIntReturnD19NoArgLabelParamNameys5Int32VAD_ADtF(x2, y2);
+// CHECK:   return Functions::_impl::$s9Functions016passTwoIntReturnD19NoArgLabelParamNameys5Int32VAD_ADtF(x2, y2);
 // CHECK: }
 
 public func passVoidReturnNever() -> Never {

--- a/test/Interop/SwiftToCxx/functions/swift-operators.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-operators.swift
@@ -47,7 +47,7 @@ public func -(lhs: IntBox, rhs: IntBox) -> CInt {
 }
 
 // CHECK: SWIFT_INLINE_THUNK int operator-(const IntBox& lhs, const IntBox& rhs) noexcept SWIFT_SYMBOL("s:9Operators1soiys5Int32VAA6IntBoxV_AFtF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Operators1soiys5Int32VAA6IntBoxV_AFtF(_impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(lhs)), _impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(rhs)));
+// CHECK-NEXT:   return Operators::_impl::$s9Operators1soiys5Int32VAA6IntBoxV_AFtF(Operators::_impl::swift_interop_passDirect_Operators_uint32_t_0_4(Operators::_impl::_impl_IntBox::getOpaquePointer(lhs)), Operators::_impl::swift_interop_passDirect_Operators_uint32_t_0_4(Operators::_impl::_impl_IntBox::getOpaquePointer(rhs)));
 // CHECK-NEXT: }
 
 public func ==(lhs: IntBox, rhs: IntBox) -> Bool {
@@ -55,5 +55,6 @@ public func ==(lhs: IntBox, rhs: IntBox) -> Bool {
 }
 
 // CHECK: SWIFT_INLINE_THUNK bool operator==(const IntBox& lhs, const IntBox& rhs) noexcept SWIFT_SYMBOL("s:9Operators2eeoiySbAA6IntBoxV_ADtF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Operators2eeoiySbAA6IntBoxV_ADtF(_impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(lhs)), _impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(rhs)));
+// CHECK-NEXT:   return Operators::_impl::$s9Operators2eeoiySbAA6IntBoxV_ADtF(Operators::_impl::swift_interop_passDirect_Operators_uint32_t_0_4(Operators::_impl::_impl_IntBox::getOpaquePointer(lhs)), Operators::_impl::swift_interop_passDirect_Operators_uint32_t_0_4(Operators::_impl::_impl_IntBox::getOpaquePointer(rhs)));
 // CHECK-NEXT: }
+

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
@@ -5,159 +5,159 @@
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
 
 // CHECK:      SWIFT_INLINE_THUNK bool passThroughBool(bool x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions15passThroughBoolyS2bF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions15passThroughBoolyS2bF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK bool passThroughCBool(bool x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions16passThroughCBoolyS2bF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions16passThroughCBoolyS2bF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK char passThroughCChar(char x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions16passThroughCCharys4Int8VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions16passThroughCCharys4Int8VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK char16_t passThroughCChar16(char16_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions18passThroughCChar16ys6UInt16VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions18passThroughCChar16ys6UInt16VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK char32_t passThroughCChar32(char32_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions18passThroughCChar32ys7UnicodeO6ScalarVAFF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions18passThroughCChar32ys7UnicodeO6ScalarVAFF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK double passThroughCDouble(double x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions18passThroughCDoubleyS2dF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions18passThroughCDoubleyS2dF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK float passThroughCFloat(float x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT: return _impl::$s9Functions17passThroughCFloatyS2fF(x);
+// CHECK-NEXT: return Functions::_impl::$s9Functions17passThroughCFloatyS2fF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK int passThroughCInt(int x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions15passThroughCIntys5Int32VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions15passThroughCIntys5Int32VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK long long passThroughCLongLong(long long x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions20passThroughCLongLongys5Int64VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions20passThroughCLongLongys5Int64VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK short passThroughCShort(short x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions17passThroughCShortys5Int16VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions17passThroughCShortys5Int16VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK signed char passThroughCSignedChar(signed char x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions22passThroughCSignedCharys4Int8VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions22passThroughCSignedCharys4Int8VADF(x);
 // CHECK-NEXT: }
 
 
 // CHECK:      SWIFT_INLINE_THUNK unsigned int passThroughCUnsignedInt(unsigned int x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions23passThroughCUnsignedIntys6UInt32VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions23passThroughCUnsignedIntys6UInt32VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK unsigned long long passThroughCUnsignedLongLong(unsigned long long x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions024passThroughCUnsignedLongE0ys6UInt64VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions024passThroughCUnsignedLongE0ys6UInt64VADF(x);
 // CHECK-NEXT: }
 
 
 // CHECK:      SWIFT_INLINE_THUNK unsigned short passThroughCUnsignedShort(unsigned short x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions25passThroughCUnsignedShortys6UInt16VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions25passThroughCUnsignedShortys6UInt16VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK unsigned char passThroughCUnsignedSignedChar(unsigned char x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions30passThroughCUnsignedSignedCharys5UInt8VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions30passThroughCUnsignedSignedCharys5UInt8VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK wchar_t passThroughCWideChar(wchar_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-SYSV:   return _impl::$s9Functions20passThroughCWideCharys7UnicodeO6ScalarVAFF(x);
-// CHECK-WIN:   return _impl::$s9Functions20passThroughCWideCharys6UInt16VADF(x);
+// CHECK-SYSV:   return Functions::_impl::$s9Functions20passThroughCWideCharys7UnicodeO6ScalarVAFF(x);
+// CHECK-WIN:   return Functions::_impl::$s9Functions20passThroughCWideCharys6UInt16VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK double passThroughDouble(double x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions17passThroughDoubleyS2dF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions17passThroughDoubleyS2dF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK float passThroughFloat(float x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions16passThroughFloatyS2fF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions16passThroughFloatyS2fF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK float passThroughFloat32(float x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions18passThroughFloat32yS2fF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions18passThroughFloat32yS2fF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK double passThroughFloat64(double x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions18passThroughFloat64yS2dF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions18passThroughFloat64yS2dF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK swift::Int passThroughInt(swift::Int x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions14passThroughIntyS2iF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions14passThroughIntyS2iF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK int16_t passThroughInt16(int16_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions16passThroughInt16ys0D0VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions16passThroughInt16ys0D0VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK int32_t passThroughInt32(int32_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions16passThroughInt32ys0D0VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions16passThroughInt32ys0D0VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK int64_t passThroughInt64(int64_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions16passThroughInt64ys0D0VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions16passThroughInt64ys0D0VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK int8_t passThroughInt8(int8_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions15passThroughInt8ys0D0VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions15passThroughInt8ys0D0VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK void * _Nonnull passThroughOpaquePointer(void * _Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions24passThroughOpaquePointerys0dE0VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions24passThroughOpaquePointerys0dE0VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK swift::UInt passThroughUInt(swift::UInt x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions15passThroughUIntyS2uF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions15passThroughUIntyS2uF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK uint16_t passThroughUInt16(uint16_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions17passThroughUInt16ys0D0VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions17passThroughUInt16ys0D0VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK uint32_t passThroughUInt32(uint32_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions17passThroughUInt32ys0D0VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions17passThroughUInt32ys0D0VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK uint64_t passThroughUInt64(uint64_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions17passThroughUInt64ys0D0VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions17passThroughUInt64ys0D0VADF(x);
 // CHECK-NEXT: }
 
 
 // CHECK:      SWIFT_INLINE_THUNK uint8_t passThroughUInt8(uint8_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions16passThroughUInt8ys0D0VADF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions16passThroughUInt8ys0D0VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK int32_t * _Nullable passThroughUnsafeGenericMutableOptionalPointer(int32_t * _Nullable x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions46passThroughUnsafeGenericMutableOptionalPointerySpys5Int32VGSgAFF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions46passThroughUnsafeGenericMutableOptionalPointerySpys5Int32VGSgAFF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK int32_t * _Nonnull passThroughUnsafeGenericMutablePointer(int32_t * _Nonnull x) noexcept  SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions38passThroughUnsafeGenericMutablePointerySpys5Int32VGAEF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions38passThroughUnsafeGenericMutablePointerySpys5Int32VGAEF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK int32_t const * _Nullable passThroughUnsafeGenericOptionalPointer(int32_t const * _Nullable x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions39passThroughUnsafeGenericOptionalPointerySPys5Int32VGSgAFF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions39passThroughUnsafeGenericOptionalPointerySPys5Int32VGSgAFF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK int32_t const * _Nonnull passThroughUnsafeGenericPointer(int32_t const * _Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions31passThroughUnsafeGenericPointerySPys5Int32VGAEF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions31passThroughUnsafeGenericPointerySPys5Int32VGAEF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK void * _Nonnull passThroughUnsafeMutableRawPointer(void * _Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions34passThroughUnsafeMutableRawPointeryS2vF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions34passThroughUnsafeMutableRawPointeryS2vF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK void const * _Nonnull passThroughUnsafeRawPointer(void const * _Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions27passThroughUnsafeRawPointeryS2VF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions27passThroughUnsafeRawPointeryS2VF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK void * _Nullable roundTwoPassThroughUnsafeMutableRawPointer(void * _Nullable x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions42roundTwoPassThroughUnsafeMutableRawPointerySvSgACF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions42roundTwoPassThroughUnsafeMutableRawPointerySvSgACF(x);
 // CHECK-NEXT: }
 
 public func passThroughCBool(_ x: CBool) -> CBool { return x }

--- a/test/Interop/SwiftToCxx/functions/swift-simd-vector-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-simd-vector-functions-cxx-bridging.swift
@@ -5,23 +5,23 @@
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
 // CHECK:      SWIFT_INLINE_THUNK swift_double2 passThroughdouble2(swift_double2 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions18passThroughdouble2y4simd7double2VAEF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions18passThroughdouble2y4simd7double2VAEF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK swift_float3 passThroughfloat3(swift_float3 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions17passThroughfloat3y4simd6float3VAEF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions17passThroughfloat3y4simd6float3VAEF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK swift_float4 passThroughfloat4(swift_float4 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions17passThroughfloat4y4simd6float4VAEF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions17passThroughfloat4y4simd6float4VAEF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK swift_int3 passThroughint3(swift_int3 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions15passThroughint3y4simd4int3VAEF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions15passThroughint3y4simd4int3VAEF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK swift_uint4 passThroughuint4(swift_uint4 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions16passThroughuint4y4simd5uint4VAEF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions16passThroughuint4y4simd5uint4VAEF(x);
 // CHECK-NEXT: }
 
 import simd

--- a/test/Interop/SwiftToCxx/functions/swift-transparent-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-transparent-functions-cxx-bridging.swift
@@ -7,7 +7,7 @@
 // CHECK: SWIFT_EXTERN ptrdiff_t $s9Functions24transparentPrimitiveFuncyS2iF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // transparentPrimitiveFunc(_:)
 
 // CHECK:      SWIFT_INLINE_THUNK swift::Int transparentPrimitiveFunc(swift::Int x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::$s9Functions24transparentPrimitiveFuncyS2iF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions24transparentPrimitiveFuncyS2iF(x);
 // CHECK-NEXT: }
 
 @_transparent

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -175,7 +175,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 
 
 // CHECK: SWIFT_INLINE_THUNK void inoutConcreteOpt(GenericOpt<uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics16inoutConcreteOptyyAA07GenericD0Oys6UInt16VGzF") {
-// CHECK-NEXT:   _impl::$s8Generics16inoutConcreteOptyyAA07GenericD0Oys6UInt16VGzF(_impl::_impl_GenericOpt<uint16_t>::getOpaquePointer(x));
+// CHECK-NEXT:   Generics::_impl::$s8Generics16inoutConcreteOptyyAA07GenericD0Oys6UInt16VGzF(Generics::_impl::_impl_GenericOpt<uint16_t>::getOpaquePointer(x));
 // CHECK-NEXT: }
 
 
@@ -187,13 +187,13 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT:   _impl::$s8Generics15inoutGenericOptyyAA0cD0OyxGz_xtlF(_impl::_impl_GenericOpt<T_0_0>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT:   Generics::_impl::$s8Generics15inoutGenericOptyyAA0cD0OyxGz_xtlF(Generics::_impl::_impl_GenericOpt<T_0_0>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK GenericOpt<uint16_t> makeConcreteOpt(uint16_t x) noexcept SWIFT_SYMBOL("s:8Generics15makeConcreteOptyAA07GenericD0Oys6UInt16VGAFF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_GenericOpt<uint16_t>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Generics_uint32_t_0_4(result, _impl::$s8Generics15makeConcreteOptyAA07GenericD0Oys6UInt16VGAFF(x));
+// CHECK-NEXT:   return Generics::_impl::_impl_GenericOpt<uint16_t>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Generics::_impl::swift_interop_returnDirect_Generics_uint32_t_0_4(result, Generics::_impl::$s8Generics15makeConcreteOptyAA07GenericD0Oys6UInt16VGAFF(x));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
@@ -206,14 +206,14 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT:   return _impl::_impl_GenericOpt<T_0_0>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::$s8Generics14makeGenericOptyAA0cD0OyxGxlF(result, swift::_impl::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT:   return Generics::_impl::_impl_GenericOpt<T_0_0>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Generics::_impl::$s8Generics14makeGenericOptyAA0cD0OyxGxlF(result, swift::_impl::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK void takeConcreteOpt(const GenericOpt<uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics15takeConcreteOptyyAA07GenericD0Oys6UInt16VGF") {
-// CHECK-NEXT:   _impl::$s8Generics15takeConcreteOptyyAA07GenericD0Oys6UInt16VGF(_impl::swift_interop_passDirect_Generics_uint32_t_0_4(_impl::_impl_GenericOpt<uint16_t>::getOpaquePointer(x)));
+// CHECK-NEXT:   Generics::_impl::$s8Generics15takeConcreteOptyyAA07GenericD0Oys6UInt16VGF(Generics::_impl::swift_interop_passDirect_Generics_uint32_t_0_4(Generics::_impl::_impl_GenericOpt<uint16_t>::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
@@ -225,7 +225,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT:   _impl::$s8Generics14takeGenericOptyyAA0cD0OyxGlF(_impl::_impl_GenericOpt<T_0_0>::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT:   Generics::_impl::$s8Generics14takeGenericOptyyAA0cD0OyxGlF(Generics::_impl::_impl_GenericOpt<T_0_0>::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK  bool GenericCustomType<T_0_0>::isFailure() const {
@@ -312,7 +312,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT: _impl::$s8Generics10GenericOptO6methodyyF(swift::TypeMetadataTrait<GenericOpt<T_0_0>>::getTypeMetadata(), _getOpaquePointer());
+// CHECK-NEXT: Generics::_impl::$s8Generics10GenericOptO6methodyyF(swift::TypeMetadataTrait<GenericOpt<T_0_0>>::getTypeMetadata(), _getOpaquePointer());
 // CHECK-NEXT: }
 
 // CHECK: template<class T_0_0>
@@ -339,5 +339,5 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT: return _impl::$s8Generics10GenericOptO12computedPropSivg(swift::TypeMetadataTrait<GenericOpt<T_0_0>>::getTypeMetadata(), _getOpaquePointer());
+// CHECK-NEXT: return Generics::_impl::$s8Generics10GenericOptO12computedPropSivg(swift::TypeMetadataTrait<GenericOpt<T_0_0>>::getTypeMetadata(), _getOpaquePointer());
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
@@ -215,22 +215,22 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT:   if constexpr (std::is_base_of<::swift::_impl::RefCountedClass, T_0_0>::value) {
 // CHECK-NEXT:   void *returnValue;
-// CHECK-NEXT:   _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT:   _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), Functions::_impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:   return ::swift::_impl::implClassFor<T_0_0>::type::makeRetained(returnValue);
 // CHECK-NEXT:   } else if constexpr (::swift::_impl::isValueType<T_0_0>) {
 // CHECK-NEXT:   return ::swift::_impl::implClassFor<T_0_0>::type::returnNewValue([&](void * _Nonnull returnValue) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(returnValue, swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(returnValue, swift::_impl::getOpaquePointer(x), Functions::_impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:   });
 // CHECK-NEXT:   } else if constexpr (::swift::_impl::isSwiftBridgedCxxRecord<T_0_0>) {
 // CHECK-NEXT:    alignas(alignof(T_0_0)) char storage[sizeof(T_0_0)];
 // CHECK-NEXT:    auto * _Nonnull storageObjectPtr = reinterpret_cast<T_0_0 *>(storage);
-// CHECK-NEXT:    _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(storage, swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata())
+// CHECK-NEXT:    _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(storage, swift::_impl::getOpaquePointer(x), Functions::_impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata())
 // CHECK-NEXT:    T_0_0 result(static_cast<T_0_0 &&>(*storageObjectPtr));
 // CHECK-NEXT:    storageObjectPtr->~T_0_0();
 // CHECK-NEXT:    return result;
 // CHECK-NEXT:   } else {
 // CHECK-NEXT:   T_0_0 returnValue;
-// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), Functions::_impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:   return returnValue;
 // CHECK-NEXT:   }
 // CHECK-NEXT:   #pragma clang diagnostic pop

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -300,7 +300,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: } // namespace swift
 
 // CHECK: SWIFT_INLINE_THUNK void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept SWIFT_SYMBOL("s:8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF") {
-// CHECK-NEXT:   _impl::$s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(x, _impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(y));
+// CHECK-NEXT:   Generics::_impl::$s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(x, Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(y));
 // CHECK-NEXT: }
 
 // CHECK: template<class T_0_0, class T_0_1>
@@ -312,7 +312,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT:   _impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
+// CHECK-NEXT:   Generics::_impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT: }
 
 // CHECK: template<class T_0_0, class T_0_1>
@@ -324,14 +324,14 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT:   return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(result, swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
+// CHECK-NEXT:   return Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Generics::_impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(result, swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& x, uint16_t y) noexcept SWIFT_SYMBOL("s:8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Generics_uint32_t_0_4(result, _impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(_impl::swift_interop_passDirect_Generics_uint32_t_0_4(_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)), y));
+// CHECK-NEXT:  return Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Generics::_impl::swift_interop_returnDirect_Generics_uint32_t_0_4(result, Generics::_impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(Generics::_impl::swift_interop_passDirect_Generics_uint32_t_0_4(Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)), y));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
@@ -344,13 +344,13 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT:   return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(result, _impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
+// CHECK-NEXT:   return Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Generics::_impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(result, Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK void takeConcretePair(const GenericPair<uint16_t, uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF") {
-// CHECK-NEXT:   _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(_impl::swift_interop_passDirect_Generics_uint32_t_0_4(_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)));
+// CHECK-NEXT:   _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(Generics::_impl::swift_interop_passDirect_Generics_uint32_t_0_4(Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 // CHECK: template<class T_0_0, class T_0_1>
@@ -362,7 +362,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT:  _impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
+// CHECK-NEXT:  Generics::_impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT:}
 
 // CHECK: template<class T_0_0, class T_0_1>
@@ -421,8 +421,8 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: alignas(alignof(T_0_1)) char copyBuffer_consumedParamCopy_y[sizeof(T_0_1)];
 // CHECK-NEXT: auto &consumedParamCopy_y = *(new(copyBuffer_consumedParamCopy_y) T_0_1(y));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<T_0_1> storageGuard_consumedParamCopy_y(consumedParamCopy_y);
-// CHECK-NEXT: return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::$s8Generics11GenericPairVyACyxq_Gx_Siq_tcfC(result, swift::_impl::getOpaquePointer(consumedParamCopy_x), i, swift::_impl::getOpaquePointer(consumedParamCopy_y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
+// CHECK-NEXT: return Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   Generics::_impl::$s8Generics11GenericPairVyACyxq_Gx_Siq_tcfC(result, swift::_impl::getOpaquePointer(consumedParamCopy_x), i, swift::_impl::getOpaquePointer(consumedParamCopy_y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: template<class T_0_0, class T_0_1>
@@ -445,7 +445,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT: _impl::$s8Generics11GenericPairV14mutatingMethodyyACyq_xGF(_impl::_impl_GenericPair<T_0_1, T_0_0>::getOpaquePointer(other), swift::TypeMetadataTrait<GenericPair<T_0_0, T_0_1>>::getTypeMetadata(), _getOpaquePointer());
+// CHECK-NEXT: _impl::$s8Generics11GenericPairV14mutatingMethodyyACyq_xGF(Generics::_impl::_impl_GenericPair<T_0_1, T_0_0>::getOpaquePointer(other), swift::TypeMetadataTrait<GenericPair<T_0_0, T_0_1>>::getTypeMetadata(), _getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: #ifdef __cpp_concepts
@@ -490,7 +490,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT: return _impl::$s8Generics11GenericPairV12computedPropSivg(swift::TypeMetadataTrait<GenericPair<T_0_0, T_0_1>>::getTypeMetadata(), _getOpaquePointer());
+// CHECK-NEXT: return Generics::_impl::$s8Generics11GenericPairV12computedPropSivg(swift::TypeMetadataTrait<GenericPair<T_0_0, T_0_1>>::getTypeMetadata(), _getOpaquePointer());
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK T_0_0 GenericPair<T_0_0, T_0_1>::getComputedVar()

--- a/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
@@ -98,7 +98,7 @@
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept SWIFT_SYMBOL("s:8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF") {
-// CHECK-NEXT: _impl::$s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(x, _impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(y));
+// CHECK-NEXT: Generics::_impl::$s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(x, Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(y));
 // CHECK-NEXT: }
 
 
@@ -107,35 +107,35 @@
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT: _impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
+// CHECK-NEXT: Generics::_impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK GenericPair<uint16_t, uint16_t> makeConcretePair(uint16_t x, uint16_t y) noexcept SWIFT_SYMBOL("s:8Generics16makeConcretePairyAA07GenericD0Vys6UInt16VAFGAF_AFtF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics16makeConcretePairyAA07GenericD0Vys6UInt16VAFGAF_AFtF(x, y));
+// CHECK-NEXT:  return Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, Generics::_impl::$s8Generics16makeConcretePairyAA07GenericD0Vys6UInt16VAFGAF_AFtF(x, y));
 
 // CHECK: SWIFT_INLINE_THUNK GenericPair<T_0_0, T_0_1> makeGenericPair(const T_0_0& x, const T_0_1& y) noexcept SWIFT_SYMBOL("s:8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT:  return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
+// CHECK-NEXT:  return Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, Generics::_impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
 
 // CHECK: SWIFT_INLINE_THUNK GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& x, uint16_t y) noexcept SWIFT_SYMBOL("s:8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)), y));
+// CHECK-NEXT:  return Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    Generics::_impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, Generics::_impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)), y));
 
 // CHECK: SWIFT_INLINE_THUNK GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& x, const T_0_1& y) noexcept SWIFT_SYMBOL("s:8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT:  return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x)), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
+// CHECK-NEXT:  return Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    Generics::_impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, Generics::_impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x)), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
 
 // CHECK: SWIFT_INLINE_THUNK void takeConcretePair(const GenericPair<uint16_t, uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF") {
-// CHECK-NEXT: _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)));
+// CHECK-NEXT: _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](Generics::_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 // CHECK:  SWIFT_INLINE_THUNK void takeGenericPair(const GenericPair<T_0_0, T_0_1>& x) noexcept SWIFT_SYMBOL("s:8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF") {
@@ -143,7 +143,7 @@
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK-NEXT: _impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x)), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
+// CHECK-NEXT: _impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x)), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK T_0_1 GenericPair<T_0_0, T_0_1>::getY() const {
@@ -151,7 +151,7 @@
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
-// CHECK: _impl::$s8Generics11GenericPairV1yq_vg(reinterpret_cast<void *>(&returnValue), _impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
+// CHECK: _impl::$s8Generics11GenericPairV1yq_vg(reinterpret_cast<void *>(&returnValue), Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 
 // CHECK: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::setY(const T_0_1& newValue) {
 // CHECK-NEXT: #ifndef __cpp_concepts
@@ -175,8 +175,8 @@
 // CHECK-NEXT: alignas(alignof(T_0_1)) char copyBuffer_consumedParamCopy_y[sizeof(T_0_1)];
 // CHECK-NEXT: auto &consumedParamCopy_y = *(new(copyBuffer_consumedParamCopy_y) T_0_1(y));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<T_0_1> storageGuard_consumedParamCopy_y(consumedParamCopy_y);
-// CHECK-NEXT: return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT: _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics11GenericPairVyACyxq_Gx_Siq_tcfC(swift::_impl::getOpaquePointer(consumedParamCopy_x), i, swift::_impl::getOpaquePointer(consumedParamCopy_y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
+// CHECK-NEXT: return Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT: _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, Generics::_impl::$s8Generics11GenericPairVyACyxq_Gx_Siq_tcfC(swift::_impl::getOpaquePointer(consumedParamCopy_x), i, swift::_impl::getOpaquePointer(consumedParamCopy_y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
 
 // CHECK: SWIFT_INLINE_THUNK T_1_0 GenericPair<T_0_0, T_0_1>::genericMethod(const T_1_0& x, const T_0_1& y) const {
-// CHECK: _impl::$s8Generics11GenericPairV13genericMethodyqd__qd___q_tlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), _impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata(), swift::TypeMetadataTrait<T_1_0>::getTypeMetadata());
+// CHECK: _impl::$s8Generics11GenericPairV13genericMethodyqd__qd___q_tlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata(), swift::TypeMetadataTrait<T_1_0>::getTypeMetadata());

--- a/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
@@ -143,50 +143,50 @@ public struct WrapOverloadedInits {
 // CHECK-NOT: WrapOverloadedInits init(
 
 // CHECK: BaseClass BaseClass::init(swift::Int x, swift::Int y) {
-// CHECK-NEXT: return _impl::_impl_BaseClass::makeRetained(_impl::$s4Init9BaseClassCyACSi_SitcfC(x, y, swift::TypeMetadataTrait<BaseClass>::getTypeMetadata()));
+// CHECK-NEXT: return _impl::_impl_BaseClass::makeRetained(Init::_impl::$s4Init9BaseClassCyACSi_SitcfC(x, y, swift::TypeMetadataTrait<BaseClass>::getTypeMetadata()));
 
 // CHECK: DerivedClass DerivedClass::init(swift::Int x, swift::Int y) {
-// CHECK-NEXT: _impl::_impl_DerivedClass::makeRetained(_impl::$s4Init12DerivedClassCyACSi_SitcfC(x, y, swift::TypeMetadataTrait<DerivedClass>::getTypeMetadata()));
+// CHECK-NEXT: _impl::_impl_DerivedClass::makeRetained(Init::_impl::$s4Init12DerivedClassCyACSi_SitcfC(x, y, swift::TypeMetadataTrait<DerivedClass>::getTypeMetadata()));
 
 // CHECK: DerivedClassTwo DerivedClassTwo::init(swift::Int x, swift::Int y) {
-// CHECK-NEXT: return _impl::_impl_DerivedClassTwo::makeRetained(_impl::$s4Init15DerivedClassTwoCyACSi_SitcfC(x, y, swift::TypeMetadataTrait<DerivedClassTwo>::getTypeMetadata()));
+// CHECK-NEXT: return _impl::_impl_DerivedClassTwo::makeRetained(Init::_impl::$s4Init15DerivedClassTwoCyACSi_SitcfC(x, y, swift::TypeMetadataTrait<DerivedClassTwo>::getTypeMetadata()));
 
 // CHECK: FinalClass FinalClass::init(const FirstSmallStruct& prop) {
-// CHECK-NEXT: return _impl::_impl_FinalClass::makeRetained(_impl::$s4Init10FinalClassCyAcA16FirstSmallStructVcfC(_impl::swift_interop_passDirect_Init_uint32_t_0_4(_impl::_impl_FirstSmallStruct::getOpaquePointer(prop)), swift::TypeMetadataTrait<FinalClass>::getTypeMetadata()));
+// CHECK-NEXT: return _impl::_impl_FinalClass::makeRetained(Init::_impl::$s4Init10FinalClassCyAcA16FirstSmallStructVcfC(Init::_impl::swift_interop_passDirect_Init_uint32_t_0_4(Init::_impl::_impl_FirstSmallStruct::getOpaquePointer(prop)), swift::TypeMetadataTrait<FinalClass>::getTypeMetadata()));
 
 
 // CHECK:      SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const {
-// CHECK-NEXT: return _impl::$s4Init16FirstSmallStructV1xs6UInt32Vvg(_impl::swift_interop_passDirect_Init_uint32_t_0_4(_getOpaquePointer()));
+// CHECK-NEXT: return Init::_impl::$s4Init16FirstSmallStructV1xs6UInt32Vvg(Init::_impl::swift_interop_passDirect_Init_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct FirstSmallStruct::init() {
-// CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_uint32_t_0_4(result, _impl::$s4Init16FirstSmallStructVACycfC());
+// CHECK-NEXT: return Init::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_uint32_t_0_4(result, Init::_impl::$s4Init16FirstSmallStructVACycfC());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct FirstSmallStruct::init(swift::Int x) {
-// CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_uint32_t_0_4(result, _impl::$s4Init16FirstSmallStructVyACSicfC(x));
+// CHECK-NEXT: return Init::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_uint32_t_0_4(result, Init::_impl::$s4Init16FirstSmallStructVyACSicfC(x));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK LargeStruct LargeStruct::init() {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT: return Init::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s4Init11LargeStructVACycfC(result);
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::init(swift::Int x, const FirstSmallStruct& y) {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::$s4Init11LargeStructV1x1yACSi_AA010FirstSmallC0VtcfC(result, x, _impl::swift_interop_passDirect_Init_uint32_t_0_4(_impl::_impl_FirstSmallStruct::getOpaquePointer(y)));
+// CHECK-NEXT: return Init::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   _impl::$s4Init11LargeStructV1x1yACSi_AA010FirstSmallC0VtcfC(result, x, Init::_impl::swift_interop_passDirect_Init_uint32_t_0_4(Init::_impl::_impl_FirstSmallStruct::getOpaquePointer(y)));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK StructWithRefCountStoredProp StructWithRefCountStoredProp::init() {
-// CHECK-NEXT: return _impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_[[PTRENC]](result, _impl::$s4Init28StructWithRefCountStoredPropVACycfC());
+// CHECK-NEXT: return Init::_impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_[[PTRENC]](result, Init::_impl::$s4Init28StructWithRefCountStoredPropVACycfC());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK StructWithRefCountStoredProp StructWithRefCountStoredProp::init(swift::Int x) {
-// CHECK-NEXT: return _impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_[[PTRENC]](result, _impl::$s4Init28StructWithRefCountStoredPropV1xACSi_tcfC(x));
+// CHECK-NEXT: return Init::_impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_[[PTRENC]](result, Init::_impl::$s4Init28StructWithRefCountStoredPropV1xACSi_tcfC(x));
 // CHECK-NEXT: });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
@@ -160,28 +160,28 @@ public func createPassStructInClassMethod() -> PassStructInClassMethod {
 // CHECK-NEXT: _impl::$s7Methods09ClassWithA0C4dumpyyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK ClassWithMethods ClassWithMethods::sameRet() {
-// CHECK-NEXT: return _impl::_impl_ClassWithMethods::makeRetained(_impl::$s7Methods09ClassWithA0C7sameRetACyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
+// CHECK-NEXT: return _impl::_impl_ClassWithMethods::makeRetained(Methods::_impl::$s7Methods09ClassWithA0C7sameRetACyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void ClassWithMethods::mutate() {
 // CHECK-NEXT: _impl::$s7Methods09ClassWithA0C6mutateyyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK ClassWithMethods ClassWithMethods::deepCopy(swift::Int x) {
-// CHECK-NEXT: return _impl::_impl_ClassWithMethods::makeRetained(_impl::$s7Methods09ClassWithA0C8deepCopyyACSiF(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
+// CHECK-NEXT: return _impl::_impl_ClassWithMethods::makeRetained(Methods::_impl::$s7Methods09ClassWithA0C8deepCopyyACSiF(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct ClassWithMethods::staticFinalClassMethod(swift::Int x) {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT: return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s7Methods09ClassWithA0C011staticFinalB6Method1xAA11LargeStructVSi_tFZ(result, x, swift::TypeMetadataTrait<ClassWithMethods>::getTypeMetadata());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int ClassWithNonFinalMethods::classClassMethod(swift::Int x) {
-// CHECK-NEXT: return _impl::$s7Methods017ClassWithNonFinalA0C05classB6Method1xS2i_tFZ(x, swift::TypeMetadataTrait<ClassWithNonFinalMethods>::getTypeMetadata());
+// CHECK-NEXT: return Methods::_impl::$s7Methods017ClassWithNonFinalA0C05classB6Method1xS2i_tFZ(x, swift::TypeMetadataTrait<ClassWithNonFinalMethods>::getTypeMetadata());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void ClassWithNonFinalMethods::staticClassMethod() {
 // CHECK-NEXT: _impl::$s7Methods017ClassWithNonFinalA0C06staticB6MethodyyFZ(swift::TypeMetadataTrait<ClassWithNonFinalMethods>::getTypeMetadata());
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK LargeStruct LargeStruct::doubled() const {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT: return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s7Methods11LargeStructV7doubledACyF(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
@@ -189,13 +189,13 @@ public func createPassStructInClassMethod() -> PassStructInClassMethod {
 // CHECK-NEXT: _impl::$s7Methods11LargeStructV4dumpyyF(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::scaled(swift::Int x, swift::Int y) const {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT: return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s7Methods11LargeStructV6scaledyACSi_SitF(result, x, y, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::added(const LargeStruct& x) const {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::$s7Methods11LargeStructV5addedyA2CF(result, _impl::_impl_LargeStruct::getOpaquePointer(x), _getOpaquePointer());
+// CHECK-NEXT: return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   _impl::$s7Methods11LargeStructV5addedyA2CF(result, Methods::_impl::_impl_LargeStruct::getOpaquePointer(x), _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void LargeStruct::staticMethod() {
@@ -203,10 +203,10 @@ public func createPassStructInClassMethod() -> PassStructInClassMethod {
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK LargeStruct PassStructInClassMethod::retStruct(swift::Int x) {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT: return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s7Methods23PassStructInClassMethodC03retC0yAA05LargeC0VSiF(result, x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void PassStructInClassMethod::updateStruct(swift::Int x, const LargeStruct& y) {
-// CHECK-NEXT: _impl::$s7Methods23PassStructInClassMethodC06updateC0yySi_AA05LargeC0VtF(x, _impl::_impl_LargeStruct::getOpaquePointer(y), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT: _impl::$s7Methods23PassStructInClassMethodC06updateC0yySi_AA05LargeC0VtF(x, Methods::_impl::_impl_LargeStruct::getOpaquePointer(y), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
@@ -82,25 +82,25 @@ public func createSmallStruct(x: Float) -> SmallStruct {
 }
 
 // CHECK:        SWIFT_INLINE_THUNK void LargeStruct::dump() const {
-// CHECK-NEXT:   _impl::$s7Methods11LargeStructV4dumpyyF(_getOpaquePointer());
+// CHECK-NEXT:   Methods::_impl::$s7Methods11LargeStructV4dumpyyF(_getOpaquePointer());
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStruct::double_() {
-// CHECK-NEXT:   _impl::$s7Methods11LargeStructV6doubleyyF(_getOpaquePointer());
+// CHECK-NEXT:   Methods::_impl::$s7Methods11LargeStructV6doubleyyF(_getOpaquePointer());
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK LargeStruct LargeStruct::scale(swift::Int x, swift::Int y) {
-// CHECK-NEXT:   return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::$s7Methods11LargeStructV5scaleyACSi_SitF(result, x, y, _getOpaquePointer());
+// CHECK-NEXT:   return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Methods::_impl::$s7Methods11LargeStructV5scaleyACSi_SitF(result, x, y, _getOpaquePointer());
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
 
 // CHECK:        SWIFT_INLINE_THUNK void SmallStruct::dump() const {
-// CHECK-NEXT:   _impl::$s7Methods11SmallStructV4dumpyyF(_impl::swift_interop_passDirect_Methods_float_0_4(_getOpaquePointer()));
+// CHECK-NEXT:   Methods::_impl::$s7Methods11SmallStructV4dumpyyF(Methods::_impl::swift_interop_passDirect_Methods_float_0_4(_getOpaquePointer()));
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK SmallStruct SmallStruct::scale(float y) {
-// CHECK-NEXT:   return _impl::_impl_SmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Methods_float_0_4(result, _impl::$s7Methods11SmallStructV5scaleyACSfF(y, _getOpaquePointer()));
+// CHECK-NEXT:   return Methods::_impl::_impl_SmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Methods::_impl::swift_interop_returnDirect_Methods_float_0_4(result, Methods::_impl::$s7Methods11SmallStructV5scaleyACSfF(y, _getOpaquePointer()));
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK void SmallStruct::invert() {
-// CHECK-NEXT:   _impl::$s7Methods11SmallStructV6invertyyF(_getOpaquePointer());
+// CHECK-NEXT:   Methods::_impl::$s7Methods11SmallStructV6invertyyF(_getOpaquePointer());
 // CHECK-NEXT:   }

--- a/test/Interop/SwiftToCxx/module/module-to-namespace.swift
+++ b/test/Interop/SwiftToCxx/module/module-to-namespace.swift
@@ -12,4 +12,5 @@
 // CHECK-LABEL: namespace Test SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE({{.*}}) {
 // CHECK:       } // namespace Test
 // CHECK-EMPTY:
+// CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: #undef SWIFT_SYMBOL

--- a/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
@@ -140,13 +140,13 @@ public struct TheGenericContainerInitNonTriv {
 // CHECK-NEXT: alignas(alignof(LargeStructNonTrivial)) char copyBuffer_consumedParamCopy_2[sizeof(LargeStructNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_2 = *(new(copyBuffer_consumedParamCopy_2) LargeStructNonTrivial(_2));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<LargeStructNonTrivial> storageGuard_consumedParamCopy_2(consumedParamCopy_2);
-// CHECK-NON_EVO-NEXT: _impl::$s4Init0A9FromSmallV04takeC5LargeyyAA0C16StructNonTrivialVn_AA0efgH0VntF(_impl::swift_interop_passDirect_Init_{{.*}}(_impl::_impl_SmallStructNonTrivial::getOpaquePointer(consumedParamCopy_1)), _impl::_impl_LargeStructNonTrivial::getOpaquePointer(consumedParamCopy_2), _impl::swift_interop_passDirect_Init_{{.*}}(_getOpaquePointer()));
+// CHECK-NON_EVO-NEXT: Init::_impl::$s4Init0A9FromSmallV04takeC5LargeyyAA0C16StructNonTrivialVn_AA0efgH0VntF(Init::_impl::swift_interop_passDirect_Init_{{.*}}(Init::_impl::_impl_SmallStructNonTrivial::getOpaquePointer(consumedParamCopy_1)), Init::_impl::_impl_LargeStructNonTrivial::getOpaquePointer(consumedParamCopy_2), Init::_impl::swift_interop_passDirect_Init_{{.*}}(_getOpaquePointer()));
 
 // CHECK: SWIFT_INLINE_THUNK void LargeStructNonTrivial::takeMe() const {
 // CHECK-NEXT: alignas(alignof(LargeStructNonTrivial)) char copyBuffer_consumedParamCopy_this[sizeof(LargeStructNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_this = *(new(copyBuffer_consumedParamCopy_this) LargeStructNonTrivial(*this));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<LargeStructNonTrivial> storageGuard_consumedParamCopy_this(consumedParamCopy_this);
-// CHECK-NEXT: _impl::$s4Init21LargeStructNonTrivialV6takeMeyyF(_impl::_impl_LargeStructNonTrivial::getOpaquePointer(consumedParamCopy_this));
+// CHECK-NEXT: Init::_impl::$s4Init21LargeStructNonTrivialV6takeMeyyF(Init::_impl::_impl_LargeStructNonTrivial::getOpaquePointer(consumedParamCopy_this));
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK TheGenericContainer<T_0_0> TheGenericContainer<T_0_0>::init(const T_0_0& x) {
@@ -166,7 +166,7 @@ public struct TheGenericContainerInitNonTriv {
 // CHECK-NEXT: alignas(alignof(TheGenericContainer<T_0_0>)) char copyBuffer_consumedParamCopy_this[sizeof(TheGenericContainer<T_0_0>)];
 // CHECK-NEXT: auto &consumedParamCopy_this = *(new(copyBuffer_consumedParamCopy_this) TheGenericContainer<T_0_0>(*this));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<TheGenericContainer<T_0_0>> storageGuard_consumedParamCopy_this(consumedParamCopy_this);
-// CHECK-NEXT: _impl::$s4Init19TheGenericContainerV04takecD0yyF(swift::TypeMetadataTrait<TheGenericContainer<T_0_0>>::getTypeMetadata(), _impl::_impl_TheGenericContainer<T_0_0>::getOpaquePointer(consumedParamCopy_this));
+// CHECK-NEXT: _impl::$s4Init19TheGenericContainerV04takecD0yyF(swift::TypeMetadataTrait<TheGenericContainer<T_0_0>>::getTypeMetadata(), Init::_impl::_impl_TheGenericContainer<T_0_0>::getOpaquePointer(consumedParamCopy_this));
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK TheGenericContainerInitNonTriv TheGenericContainerInitNonTriv::init(const TheGenericContainer<AKlass>& x) {

--- a/test/Interop/SwiftToCxx/properties/bool-is-has-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/bool-is-has-in-cxx.swift
@@ -33,26 +33,26 @@ public struct IsHasProperties {
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getIsOption() const SWIFT_SYMBOL({{.*}});
 
 // CHECK: SWIFT_INLINE_THUNK bool IsHasProperties::isEmpty() const {
-// CHECK-NEXT: return _impl::$s10Properties05IsHasA0V7isEmptySbvg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V7isEmptySbvg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::hasFlavor() const {
-// CHECK-NEXT: return _impl::$s10Properties05IsHasA0V9hasFlavorSbvg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V9hasFlavorSbvg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::isSolid() const {
-// CHECK-NEXT: return _impl::$s10Properties05IsHasA0V7isSolidSbvg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V7isSolidSbvg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void IsHasProperties::setIsSolid(bool value) {
-// CHECK-NEXT: _impl::$s10Properties05IsHasA0V7isSolidSbvs(value, _getOpaquePointer());
+// CHECK-NEXT: Properties::_impl::$s10Properties05IsHasA0V7isSolidSbvs(value, _getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::getFlag() const {
-// CHECK-NEXT: return _impl::$s10Properties05IsHasA0V4flagSbvg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V4flagSbvg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void IsHasProperties::setFlag(bool value) {
-// CHECK-NEXT: _impl::$s10Properties05IsHasA0V4flagSbvs(value, _getOpaquePointer());
+// CHECK-NEXT: Properties::_impl::$s10Properties05IsHasA0V4flagSbvs(value, _getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::getHas() const {
-// CHECK-NEXT: return _impl::$s10Properties05IsHasA0V3hasSbvg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V3hasSbvg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int IsHasProperties::getIsOption() const {
-// CHECK-NEXT: return _impl::$s10Properties05IsHasA0V8isOptionSivg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V8isOptionSivg(_getOpaquePointer());
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
@@ -135,71 +135,71 @@ public func createStructWithRefCountStoredProp() -> StructWithRefCountStoredProp
 }
 
 // CHECK: SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const {
-// CHECK-NEXT: return _impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
+// CHECK-NEXT: return Properties::_impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK swift::Int LargeStruct::getX1() const {
-// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x1Sivg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x1Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX2() const {
-// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x2Sivg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x2Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX3() const {
-// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x3Sivg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x3Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX4() const {
-// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x4Sivg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x4Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX5() const {
-// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x5Sivg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x5Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX6() const {
-// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x6Sivg(_getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x6Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::getAnotherLargeStruct() const {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::$s10Properties11LargeStructV07anotherbC0ACvg(result, _getOpaquePointer());
+// CHECK-NEXT: return Properties::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   Properties::_impl::$s10Properties11LargeStructV07anotherbC0ACvg(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct LargeStruct::getFirstSmallStruct() const {
-// CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, _impl::$s10Properties11LargeStructV010firstSmallC0AA05FirsteC0Vvg(_getOpaquePointer()));
+// CHECK-NEXT: return Properties::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   Properties::_impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, Properties::_impl::$s10Properties11LargeStructV010firstSmallC0AA05FirsteC0Vvg(_getOpaquePointer()));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getStaticX() {
-// CHECK-NEXT: return _impl::$s10Properties11LargeStructV7staticXSivgZ();
+// CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV7staticXSivgZ();
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct LargeStruct::getStaticSmallStruct() {
-// CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, _impl::$s10Properties11LargeStructV011staticSmallC0AA05FirsteC0VvgZ());
+// CHECK-NEXT: return Properties::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   Properties::_impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, Properties::_impl::$s10Properties11LargeStructV011staticSmallC0AA05FirsteC0VvgZ());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK int32_t PropertiesInClass::getStoredInt() {
-// CHECK-NEXT: return _impl::$s10Properties0A7InClassC9storedInts5Int32Vvg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT: return Properties::_impl::$s10Properties0A7InClassC9storedInts5Int32Vvg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int PropertiesInClass::getComputedInt() {
-// CHECK-NEXT: return _impl::$s10Properties0A7InClassC11computedIntSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT: return Properties::_impl::$s10Properties0A7InClassC11computedIntSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct PropertiesInClass::getSmallStruct() {
-// CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, _impl::$s10Properties0A7InClassC11smallStructAA010FirstSmallE0Vvg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
+// CHECK-NEXT: return Properties::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   Properties::_impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, Properties::_impl::$s10Properties0A7InClassC11smallStructAA010FirstSmallE0Vvg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK uint32_t SmallStructWithGetters::getStoredInt() const {
-// CHECK-NEXT: return _impl::$s10Properties22SmallStructWithGettersV9storedInts6UInt32Vvg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
+// CHECK-NEXT: return Properties::_impl::$s10Properties22SmallStructWithGettersV9storedInts6UInt32Vvg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int SmallStructWithGetters::getComputedInt() const {
-// CHECK-NEXT: return _impl::$s10Properties22SmallStructWithGettersV11computedIntSivg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
+// CHECK-NEXT: return Properties::_impl::$s10Properties22SmallStructWithGettersV11computedIntSivg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct SmallStructWithGetters::getLargeStruct() const {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::$s10Properties22SmallStructWithGettersV05largeC0AA05LargeC0Vvg(result, _impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
+// CHECK-NEXT: return Properties::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   Properties::_impl::$s10Properties22SmallStructWithGettersV05largeC0AA05LargeC0Vvg(result, Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK SmallStructWithGetters SmallStructWithGetters::getSmallStruct() const {
-// CHECK-NEXT: return _impl::_impl_SmallStructWithGetters::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, _impl::$s10Properties22SmallStructWithGettersV05smallC0ACvg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer())));
+// CHECK-NEXT: return Properties::_impl::_impl_SmallStructWithGetters::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   Properties::_impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, Properties::_impl::$s10Properties22SmallStructWithGettersV05smallC0ACvg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer())));
 // CHECK-NEXT: });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
@@ -130,73 +130,73 @@ public func createFirstSmallStruct(_ x: UInt32) -> FirstSmallStruct {
 }
 
 // CHECK: SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const {
-// CHECK-NEXT: return _impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
+// CHECK-NEXT: return Properties::_impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void FirstSmallStruct::setX(uint32_t value) {
 // CHECK-NEXT: _impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvs(value, _getOpaquePointer());
 // CHECK-NEXT: }
 
 // CHECK:        SWIFT_INLINE_THUNK swift::Int LargeStruct::getX1() const {
-// CHECK-NEXT:   return _impl::$s10Properties11LargeStructV2x1Sivg(_getOpaquePointer());
+// CHECK-NEXT:   return Properties::_impl::$s10Properties11LargeStructV2x1Sivg(_getOpaquePointer());
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStruct::setX1(swift::Int value) {
 // CHECK-NEXT:   _impl::$s10Properties11LargeStructV2x1Sivs(value, _getOpaquePointer());
 // CHECK-NEXT:   }
 
 // CHECK:      SWIFT_INLINE_THUNK swift::Int LargeStruct::getStaticX() {
-// CHECK-NEXT: return _impl::$s10Properties11LargeStructV7staticXSivgZ();
+// CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV7staticXSivgZ();
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void LargeStruct::setStaticX(swift::Int newValue) {
 // CHECK-NEXT: _impl::$s10Properties11LargeStructV7staticXSivsZ(newValue);
 // CHECK-NEXT: }
 
 // CHECK:        SWIFT_INLINE_THUNK LargeStruct LargeStructWithProps::getStoredLargeStruct() const {
-// CHECK-NEXT:    return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    return Properties::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:     _impl::$s10Properties20LargeStructWithPropsV06storedbC0AA0bC0Vvg(result, _getOpaquePointer());
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStructWithProps::setStoredLargeStruct(const LargeStruct& value) {
-// CHECK-NEXT:   _impl::$s10Properties20LargeStructWithPropsV06storedbC0AA0bC0Vvs(_impl::_impl_LargeStruct::getOpaquePointer(value), _getOpaquePointer());
+// CHECK-NEXT:   _impl::$s10Properties20LargeStructWithPropsV06storedbC0AA0bC0Vvs(Properties::_impl::_impl_LargeStruct::getOpaquePointer(value), _getOpaquePointer());
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK FirstSmallStruct LargeStructWithProps::getStoredSmallStruct() const {
-// CHECK-NEXT:   return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, _impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvg(_getOpaquePointer()));
+// CHECK-NEXT:   return Properties::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, Properties::_impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvg(_getOpaquePointer()));
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStructWithProps::setStoredSmallStruct(const FirstSmallStruct& value) {
-// CHECK-NEXT:   _impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvs(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_impl::_impl_FirstSmallStruct::getOpaquePointer(value)), _getOpaquePointer());
+// CHECK-NEXT:   _impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvs(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(Properties::_impl::_impl_FirstSmallStruct::getOpaquePointer(value)), _getOpaquePointer());
 // CHECK-NEXT:   }
 
 // CHECK: SWIFT_INLINE_THUNK int32_t PropertiesInClass::getStoredInt() {
-// CHECK-NEXT: return _impl::$s10Properties0A7InClassC9storedInts5Int32Vvg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT: return Properties::_impl::$s10Properties0A7InClassC9storedInts5Int32Vvg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void PropertiesInClass::setStoredInt(int32_t value) {
 // CHECK-NEXT: _impl::$s10Properties0A7InClassC9storedInts5Int32Vvs(value, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int PropertiesInClass::getComputedInt() {
-// CHECK-NEXT: return _impl::$s10Properties0A7InClassC11computedIntSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT: return Properties::_impl::$s10Properties0A7InClassC11computedIntSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void PropertiesInClass::setComputedInt(swift::Int newValue) {
 // CHECK-NEXT: _impl::$s10Properties0A7InClassC11computedIntSivs(newValue, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 
 // CHECK:        SWIFT_INLINE_THUNK uint32_t SmallStructWithProps::getStoredInt() const {
-// CHECK-NEXT:  return _impl::$s10Properties20SmallStructWithPropsV9storedInts6UInt32Vvg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
+// CHECK-NEXT:  return Properties::_impl::$s10Properties20SmallStructWithPropsV9storedInts6UInt32Vvg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT:  }
 // CHECK-NEXT:  SWIFT_INLINE_THUNK void SmallStructWithProps::setStoredInt(uint32_t value) {
 // CHECK-NEXT:  _impl::$s10Properties20SmallStructWithPropsV9storedInts6UInt32Vvs(value, _getOpaquePointer());
 // CHECK-NEXT:  }
 // CHECK-NEXT:  SWIFT_INLINE_THUNK swift::Int SmallStructWithProps::getComputedInt() const {
-// CHECK-NEXT:  return _impl::$s10Properties20SmallStructWithPropsV11computedIntSivg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
+// CHECK-NEXT:  return Properties::_impl::$s10Properties20SmallStructWithPropsV11computedIntSivg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT:  }
 // CHECK-NEXT:  SWIFT_INLINE_THUNK void SmallStructWithProps::setComputedInt(swift::Int newValue) {
 // CHECK-NEXT:  _impl::$s10Properties20SmallStructWithPropsV11computedIntSivs(newValue, _getOpaquePointer());
 // CHECK-NEXT:  }
 // CHECK-NEXT:  SWIFT_INLINE_THUNK LargeStructWithProps SmallStructWithProps::getLargeStructWithProps() const {
-// CHECK-NEXT:  return _impl::_impl_LargeStructWithProps::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::$s10Properties20SmallStructWithPropsV05largecdE0AA05LargecdE0Vvg(result, _impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
+// CHECK-NEXT:  return Properties::_impl::_impl_LargeStructWithProps::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    _impl::$s10Properties20SmallStructWithPropsV05largecdE0AA05LargecdE0Vvg(result, Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT:  });
 // CHECK-NEXT:  }
 // CHECK-NEXT:  SWIFT_INLINE_THUNK void SmallStructWithProps::setLargeStructWithProps(const LargeStructWithProps& newValue) {
-// CHECK-NEXT:  _impl::$s10Properties20SmallStructWithPropsV05largecdE0AA05LargecdE0Vvs(_impl::_impl_LargeStructWithProps::getOpaquePointer(newValue), _getOpaquePointer());
+// CHECK-NEXT:  _impl::$s10Properties20SmallStructWithPropsV05largecdE0AA05LargecdE0Vvs(Properties::_impl::_impl_LargeStructWithProps::getOpaquePointer(newValue), _getOpaquePointer());
 // CHECK-NEXT:  }

--- a/test/Interop/SwiftToCxx/stdlib/optional/optional-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/optional/optional-in-cxx.swift
@@ -48,21 +48,21 @@ public func resetOpt<T>(_ val: inout Optional<T>) {
 
 
 // CHECK: SWIFT_INLINE_THUNK swift::Optional<int> createCIntOpt(int val) noexcept SWIFT_SYMBOL("s:11UseOptional13createCIntOptys5Int32VSgADF") SWIFT_WARN_UNUSED_RESULT {
- // CHECK-NEXT: return swift::_impl::_impl_Optional<int>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_UseOptional_[[CINTENC:[a-z0-9_]+]](result, _impl::$s11UseOptional13createCIntOptys5Int32VSgADF(val));
+// CHECK-NEXT: return swift::_impl::_impl_Optional<int>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   UseOptional::_impl::swift_interop_returnDirect_UseOptional_[[CINTENC:[a-z0-9_]+]](result, UseOptional::_impl::$s11UseOptional13createCIntOptys5Int32VSgADF(val));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK swift::Optional<Klass> createKlassOpt(int16_t val) noexcept SWIFT_SYMBOL("s:11UseOptional14createKlassOptyAA0D0CSgs5Int16VF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return swift::_impl::_impl_Optional<Klass>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT: _impl::swift_interop_returnDirect_UseOptional_[[CLASSENC:[a-z0-9_]+]](result, _impl::$s11UseOptional14createKlassOptyAA0D0CSgs5Int16VF(val));
+// CHECK-NEXT: UseOptional::_impl::swift_interop_returnDirect_UseOptional_[[CLASSENC:[a-z0-9_]+]](result, UseOptional::_impl::$s11UseOptional14createKlassOptyAA0D0CSgs5Int16VF(val));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK swift::Optional<SmallStruct> createSmallStructOpt(int16_t val) noexcept SWIFT_SYMBOL("s:11UseOptional20createSmallStructOptyAA0dE0VSgs5Int16VF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return swift::_impl::_impl_Optional<SmallStruct>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_UseOptional_uint32_t_0_4(result, _impl::$s11UseOptional20createSmallStructOptyAA0dE0VSgs5Int16VF(val));
+// CHECK-NEXT:     UseOptional::_impl::swift_interop_returnDirect_UseOptional_uint32_t_0_4(result, UseOptional::_impl::$s11UseOptional20createSmallStructOptyAA0dE0VSgs5Int16VF(val));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
@@ -80,15 +80,15 @@ public func resetOpt<T>(_ val: inout Optional<T>) {
 
 
 // CHECK: SWIFT_INLINE_THUNK void takeCIntOpt(const swift::Optional<int>& val) noexcept SWIFT_SYMBOL("s:11UseOptional11takeCIntOptyys5Int32VSgF") {
-// CHECK-NEXT:  _impl::$s11UseOptional11takeCIntOptyys5Int32VSgF(_impl::swift_interop_passDirect_UseOptional_[[CINTENC]](swift::_impl::_impl_Optional<int>::getOpaquePointer(val)));
+// CHECK-NEXT:  UseOptional::_impl::$s11UseOptional11takeCIntOptyys5Int32VSgF(UseOptional::_impl::swift_interop_passDirect_UseOptional_[[CINTENC]](swift::_impl::_impl_Optional<int>::getOpaquePointer(val)));
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK void takeKlassOpt(const swift::Optional<Klass>& val) noexcept SWIFT_SYMBOL("s:11UseOptional12takeKlassOptyyAA0D0CSgF") {
-// CHECK-NEXT:   _impl::$s11UseOptional12takeKlassOptyyAA0D0CSgF(_impl::swift_interop_passDirect_UseOptional_[[CLASSENC]](swift::_impl::_impl_Optional<Klass>::getOpaquePointer(val)));
+// CHECK-NEXT:   UseOptional::_impl::$s11UseOptional12takeKlassOptyyAA0D0CSgF(UseOptional::_impl::swift_interop_passDirect_UseOptional_[[CLASSENC]](swift::_impl::_impl_Optional<Klass>::getOpaquePointer(val)));
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK void takeSmallStructOpt(const swift::Optional<SmallStruct>& val) noexcept SWIFT_SYMBOL("s:11UseOptional18takeSmallStructOptyyAA0dE0VSgF") {
-// CHECK-NEXT:  _impl::$s11UseOptional18takeSmallStructOptyyAA0dE0VSgF(_impl::swift_interop_passDirect_UseOptional_uint32_t_0_4(swift::_impl::_impl_Optional<SmallStruct>::getOpaquePointer(val)));
+// CHECK-NEXT:  UseOptional::_impl::$s11UseOptional18takeSmallStructOptyyAA0dE0VSgF(UseOptional::_impl::swift_interop_passDirect_UseOptional_uint32_t_0_4(swift::_impl::_impl_Optional<SmallStruct>::getOpaquePointer(val)));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
@@ -32,24 +32,24 @@ public func inoutStructSeveralI64(_ s: inout StructSeveralI64) {
 }
 
 // CHECK:      SWIFT_INLINE_THUNK void inoutStructSeveralI64(StructSeveralI64& s) noexcept SWIFT_SYMBOL("s:7Structs21inoutStructSeveralI64yyAA0cdE0VzF") {
-// CHECK-NEXT:   _impl::$s7Structs21inoutStructSeveralI64yyAA0cdE0VzF(_impl::_impl_StructSeveralI64::getOpaquePointer(s));
+// CHECK-NEXT:   Structs::_impl::$s7Structs21inoutStructSeveralI64yyAA0cdE0VzF(Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(s));
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK StructSeveralI64 passThroughStructSeveralI64(int64_t i, const StructSeveralI64& x, float j) noexcept SWIFT_SYMBOL("s:7Structs27passThroughStructSeveralI641i_1jAA0deF0Vs5Int64V_AFSftF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::$s7Structs27passThroughStructSeveralI641i_1jAA0deF0Vs5Int64V_AFSftF(result, i, _impl::_impl_StructSeveralI64::getOpaquePointer(x), j);
+// CHECK-NEXT:  return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    Structs::_impl::$s7Structs27passThroughStructSeveralI641i_1jAA0deF0Vs5Int64V_AFSftF(result, i, Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(x), j);
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK void printStructSeveralI64(const StructSeveralI64& x) noexcept SWIFT_SYMBOL("s:7Structs21printStructSeveralI64yyAA0cdE0VF") {
-// CHECK-NEXT:  _impl::$s7Structs21printStructSeveralI64yyAA0cdE0VF(_impl::_impl_StructSeveralI64::getOpaquePointer(x));
+// CHECK-NEXT:  Structs::_impl::$s7Structs21printStructSeveralI64yyAA0cdE0VF(Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(x));
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK StructSeveralI64 returnNewStructSeveralI64(int64_t i) noexcept SWIFT_SYMBOL("s:7Structs25returnNewStructSeveralI641iAA0deF0Vs5Int64V_tF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::$s7Structs25returnNewStructSeveralI641iAA0deF0Vs5Int64V_tF(result, i);
+// CHECK-NEXT:  return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    Structs::_impl::$s7Structs25returnNewStructSeveralI641iAA0deF0Vs5Int64V_tF(result, i);
 // CHECK-NEXT:  });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx-execution.cpp
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/nested-structs-in-cxx.swift -enable-library-evolution -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+
+// RUN: %target-interop-build-clangxx -std=c++17 -c %s -I %t -o %t/swift-structs-execution.o
+
+// RUN: %target-interop-build-swift %S/nested-structs-in-cxx.swift -enable-library-evolution -o %t/swift-structs-execution -Xlinker %t/swift-structs-execution.o -module-name Structs -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-structs-execution
+// RUN: %target-run %t/swift-structs-execution
+
+// REQUIRES: executable_test
+
+#include "structs.h"
+
+int main() {
+  using namespace Structs;
+  auto x = makeRecordConfig();
+  RecordConfig::File::Gate y = x.getGate();
+  RecordConfig::AudioFormat z = x.getFile().getFormat();
+
+  auto xx = makeAudioFileType();
+  AudioFileType::SubType yy = xx.getCAF();
+}

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+// RN: %FileCheck %s < %t/structs.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++17)
+
+public enum AudioFileType {
+    public enum WaveType {
+        case THIS
+        case THAT
+    }
+
+    public struct SubType {
+        public var id: Int
+    }
+
+    case CAF(SubType), WAVE(WaveType)
+}
+
+public struct RecordConfig {
+    public enum AudioFormat {
+        case PCM, ALAC, AAC
+    }
+
+    public struct Directory {
+        public var path: String?
+    }
+
+    public struct File {
+        public var type: AudioFileType = .CAF(AudioFileType.SubType(id: 42))
+        public var format: AudioFormat = .ALAC
+
+        public struct Gate {
+            public var prop: Double = -80.0
+        }
+    }
+
+    public class Serializer {
+        public init(_ x: Int) { self.id = x }
+        public var id: Int
+    }
+
+    public var directory = Directory()
+    public var file = File()
+    public var gate = File.Gate()
+}
+
+public class AuxConfig {
+    public struct AuxDirectory {
+        public var path: String?
+    }
+
+    public var directory = AuxDirectory()
+}
+
+public func makeRecordConfig() -> RecordConfig {
+    return RecordConfig()
+}
+
+public func makeAudioFileType() -> AudioFileType {
+    return AudioFileType.CAF(AudioFileType.SubType(id: 42))
+}

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
@@ -221,50 +221,50 @@ public func mutateSmall(_ x: inout FirstSmallStruct) {
 }
 
 // CHECK:      SWIFT_INLINE_THUNK LargeStruct createLargeStruct(swift::Int x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::$s7Structs17createLargeStructyAA0cD0VSiF(result, x);
+// CHECK-NEXT:   return Structs::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Structs::_impl::$s7Structs17createLargeStructyAA0cD0VSiF(result, x);
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK StructWithRefCountStoredProp createStructWithRefCountStoredProp() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:     _impl::$s7Structs34createStructWithRefCountStoredPropAA0cdefgH0VyF(result);
+// CHECK-NEXT:   return Structs::_impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:     Structs::_impl::$s7Structs34createStructWithRefCountStoredPropAA0cdefgH0VyF(result);
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK void mutateSmall(FirstSmallStruct& x) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:   _impl::$s7Structs11mutateSmallyyAA05FirstC6StructVzF(_impl::_impl_FirstSmallStruct::getOpaquePointer(x));
+// CHECK-NEXT:   Structs::_impl::$s7Structs11mutateSmallyyAA05FirstC6StructVzF(Structs::_impl::_impl_FirstSmallStruct::getOpaquePointer(x));
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK void printSmallAndLarge(const FirstSmallStruct& x, const LargeStruct& y) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:   _impl::$s7Structs18printSmallAndLargeyyAA05FirstC6StructV_AA0eG0VtF(_impl::_impl_FirstSmallStruct::getOpaquePointer(x), _impl::_impl_LargeStruct::getOpaquePointer(y));
+// CHECK-NEXT:   Structs::_impl::$s7Structs18printSmallAndLargeyyAA05FirstC6StructV_AA0eG0VtF(Structs::_impl::_impl_FirstSmallStruct::getOpaquePointer(x), Structs::_impl::_impl_LargeStruct::getOpaquePointer(y));
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const {
-// CHECK-NEXT:   return _impl::$s7Structs16FirstSmallStructV1xs6UInt32Vvg(_getOpaquePointer());
+// CHECK-NEXT:   return Structs::_impl::$s7Structs16FirstSmallStructV1xs6UInt32Vvg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK:      SWIFT_INLINE_THUNK void FirstSmallStruct::setX(uint32_t value) {
-// CHECK-NEXT:   _impl::$s7Structs16FirstSmallStructV1xs6UInt32Vvs(value, _getOpaquePointer());
+// CHECK-NEXT:   Structs::_impl::$s7Structs16FirstSmallStructV1xs6UInt32Vvs(value, _getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void FirstSmallStruct::dump() const {
-// CHECK-NEXT:   _impl::$s7Structs16FirstSmallStructV4dumpyyF(_getOpaquePointer());
+// CHECK-NEXT:   Structs::_impl::$s7Structs16FirstSmallStructV4dumpyyF(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void FirstSmallStruct::mutate() {
-// CHECK-NEXT:   _impl::$s7Structs16FirstSmallStructV6mutateyyF(_getOpaquePointer());
+// CHECK-NEXT:   Structs::_impl::$s7Structs16FirstSmallStructV6mutateyyF(_getOpaquePointer());
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK swift::Int LargeStruct::getX1() const {
-// CHECK-NEXT: return _impl::$s7Structs11LargeStructV2x1Sivg(_getOpaquePointer());
+// CHECK-NEXT: return Structs::_impl::$s7Structs11LargeStructV2x1Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct LargeStruct::getFirstSmallStruct() const {
-// CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:   _impl::$s7Structs11LargeStructV010firstSmallC0AA05FirsteC0Vvg(result, _getOpaquePointer());
+// CHECK-NEXT: return Structs::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:   Structs::_impl::$s7Structs11LargeStructV010firstSmallC0AA05FirsteC0Vvg(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK void LargeStruct::dump() const {
-// CHECK-NEXT: _impl::$s7Structs11LargeStructV4dumpyyF(_getOpaquePointer());
+// CHECK-NEXT: Structs::_impl::$s7Structs11LargeStructV4dumpyyF(_getOpaquePointer());
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK void StructWithRefCountStoredProp::dump() const {
-// CHECK-NEXT:   _impl::$s7Structs28StructWithRefCountStoredPropV4dumpyyF(_getOpaquePointer());
+// CHECK-NEXT:   Structs::_impl::$s7Structs28StructWithRefCountStoredPropV4dumpyyF(_getOpaquePointer());
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
@@ -121,94 +121,94 @@ public func inoutStructDoubleAndFloat(_ s: inout StructDoubleAndFloat) {
 }
 
 // CHECK: SWIFT_INLINE_THUNK double getStructDoubleAndFloat_x(const StructDoubleAndFloat& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::$s7Structs25getStructDoubleAndFloat_xySdAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_double_0_8_float_8_12(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
+// CHECK-NEXT:  return Structs::_impl::$s7Structs25getStructDoubleAndFloat_xySdAA0cdeF0VF(Structs::_impl::swift_interop_passDirect_Structs_double_0_8_float_8_12(Structs::_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK float getStructDoubleAndFloat_y(const StructDoubleAndFloat& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::$s7Structs25getStructDoubleAndFloat_yySfAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_double_0_8_float_8_12(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
+// CHECK-NEXT:  return Structs::_impl::$s7Structs25getStructDoubleAndFloat_yySfAA0cdeF0VF(Structs::_impl::swift_interop_passDirect_Structs_double_0_8_float_8_12(Structs::_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK uint8_t getStructU16AndPointer_x(const StructU16AndPointer& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::$s7Structs24getStructU16AndPointer_xys5UInt8VAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_[[StructU16AndPointer:[0-9a-z_]+]](_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
+// CHECK-NEXT:  return Structs::_impl::$s7Structs24getStructU16AndPointer_xys5UInt8VAA0cdeF0VF(Structs::_impl::swift_interop_passDirect_Structs_[[StructU16AndPointer:[0-9a-z_]+]](Structs::_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK void * _Nonnull getStructU16AndPointer_y(const StructU16AndPointer& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::$s7Structs24getStructU16AndPointer_yySvAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_[[StructU16AndPointer]](_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
+// CHECK-NEXT:  return Structs::_impl::$s7Structs24getStructU16AndPointer_yySvAA0cdeF0VF(Structs::_impl::swift_interop_passDirect_Structs_[[StructU16AndPointer]](Structs::_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK:      SWIFT_INLINE_THUNK void inoutStructDoubleAndFloat(StructDoubleAndFloat& s) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:   _impl::$s7Structs25inoutStructDoubleAndFloatyyAA0cdeF0VzF(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(s));
+// CHECK-NEXT:   Structs::_impl::$s7Structs25inoutStructDoubleAndFloatyyAA0cdeF0VzF(Structs::_impl::_impl_StructDoubleAndFloat::getOpaquePointer(s));
 // CHECK-NEXT: }
 
 
 // CHECK:      SWIFT_INLINE_THUNK void inoutStructOneI16AndOneStruct(StructOneI16AndOneStruct& s, const StructTwoI32& s2) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:   _impl::$s7Structs020inoutStructOneI16AnddC0yyAA0cdefdC0Vz_AA0C6TwoI32VtF(_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(s), _impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(s2)));
+// CHECK-NEXT:   Structs::_impl::$s7Structs020inoutStructOneI16AnddC0yyAA0cdefdC0Vz_AA0C6TwoI32VtF(Structs::_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(s), Structs::_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](Structs::_impl::_impl_StructTwoI32::getOpaquePointer(s2)));
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK StructOneI64 passThroughStructOneI64(const StructOneI64& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_StructOneI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_uint64_t_0_8(result, _impl::$s7Structs23passThroughStructOneI64yAA0deF0VADF(_impl::swift_interop_passDirect_Structs_uint64_t_0_8(_impl::_impl_StructOneI64::getOpaquePointer(x))));
+// CHECK-NEXT:  return Structs::_impl::_impl_StructOneI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    Structs::_impl::swift_interop_returnDirect_Structs_uint64_t_0_8(result, Structs::_impl::$s7Structs23passThroughStructOneI64yAA0deF0VADF(Structs::_impl::swift_interop_passDirect_Structs_uint64_t_0_8(Structs::_impl::_impl_StructOneI64::getOpaquePointer(x))));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK StructTwoI32 passThroughStructTwoI32(int32_t i, const StructTwoI32& x, int32_t j) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_StructTwoI32::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructTwoI32]](result, _impl::$s7Structs23passThroughStructTwoI32yAA0deF0Vs5Int32V_AdFtF(i, _impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(x)), j));
+// CHECK-NEXT:  return Structs::_impl::_impl_StructTwoI32::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    Structs::_impl::swift_interop_returnDirect_Structs_[[StructTwoI32]](result, Structs::_impl::$s7Structs23passThroughStructTwoI32yAA0deF0Vs5Int32V_AdFtF(i, Structs::_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](Structs::_impl::_impl_StructTwoI32::getOpaquePointer(x)), j));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK void printStructOneI64(const StructOneI64& x) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:   _impl::$s7Structs17printStructOneI64yyAA0cdE0VF(_impl::swift_interop_passDirect_Structs_uint64_t_0_8(_impl::_impl_StructOneI64::getOpaquePointer(x)));
+// CHECK-NEXT:   Structs::_impl::$s7Structs17printStructOneI64yyAA0cdE0VF(Structs::_impl::swift_interop_passDirect_Structs_uint64_t_0_8(Structs::_impl::_impl_StructOneI64::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK void printStructStructTwoI32_and_OneI16AndOneStruct(const StructTwoI32& y, const StructOneI16AndOneStruct& x) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:  _impl::$s7Structs011printStructc20TwoI32_and_OneI16AndgC0yyAA0cdE0V_AA0cghigC0VtF(_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(y)), _impl::swift_interop_passDirect_Structs_[[StructOneI16AndOneStruct:[0-9a-z_]+]](_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(x)));
+// CHECK-NEXT:  Structs::_impl::$s7Structs011printStructc20TwoI32_and_OneI16AndgC0yyAA0cdE0V_AA0cghigC0VtF(Structs::_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](Structs::_impl::_impl_StructTwoI32::getOpaquePointer(y)), Structs::_impl::swift_interop_passDirect_Structs_[[StructOneI16AndOneStruct:[0-9a-z_]+]](Structs::_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK void printStructTwoI32(const StructTwoI32& x) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:  _impl::$s7Structs17printStructTwoI32yyAA0cdE0VF(_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(x)));
+// CHECK-NEXT:  Structs::_impl::$s7Structs17printStructTwoI32yyAA0cdE0VF(Structs::_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](Structs::_impl::_impl_StructTwoI32::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK StructDoubleAndFloat returnNewStructDoubleAndFloat(float y, double x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_StructDoubleAndFloat::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_double_0_8_float_8_12(result, _impl::$s7Structs29returnNewStructDoubleAndFloatyAA0defG0VSf_SdtF(y, x));
+// CHECK-NEXT:  return Structs::_impl::_impl_StructDoubleAndFloat::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    Structs::_impl::swift_interop_returnDirect_Structs_double_0_8_float_8_12(result, Structs::_impl::$s7Structs29returnNewStructDoubleAndFloatyAA0defG0VSf_SdtF(y, x));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK StructOneI16AndOneStruct returnNewStructOneI16AndOneStruct() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_StructOneI16AndOneStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructOneI16AndOneStruct]](result, _impl::$s7Structs024returnNewStructOneI16AndeD0AA0defgeD0VyF());
+// CHECK-NEXT:  return Structs::_impl::_impl_StructOneI16AndOneStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    Structs::_impl::swift_interop_returnDirect_Structs_[[StructOneI16AndOneStruct]](result, Structs::_impl::$s7Structs024returnNewStructOneI16AndeD0AA0defgeD0VyF());
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK StructOneI64 returnNewStructOneI64() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_StructOneI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_uint64_t_0_8(result, _impl::$s7Structs21returnNewStructOneI64AA0deF0VyF());
+// CHECK-NEXT:  return Structs::_impl::_impl_StructOneI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    Structs::_impl::swift_interop_returnDirect_Structs_uint64_t_0_8(result, Structs::_impl::$s7Structs21returnNewStructOneI64AA0deF0VyF());
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK StructTwoI32 returnNewStructTwoI32(int32_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_StructTwoI32::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructTwoI32]](result, _impl::$s7Structs21returnNewStructTwoI32yAA0deF0Vs5Int32VF(x));
+// CHECK-NEXT:  return Structs::_impl::_impl_StructTwoI32::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    Structs::_impl::swift_interop_returnDirect_Structs_[[StructTwoI32]](result, Structs::_impl::$s7Structs21returnNewStructTwoI32yAA0deF0Vs5Int32VF(x));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: SWIFT_INLINE_THUNK StructU16AndPointer returnNewStructU16AndPointer(void * _Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_StructU16AndPointer::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructU16AndPointer]](result, _impl::$s7Structs28returnNewStructU16AndPointeryAA0defG0VSvF(x));
+// CHECK-NEXT:  return Structs::_impl::_impl_StructU16AndPointer::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
+// CHECK-NEXT:    Structs::_impl::swift_interop_returnDirect_Structs_[[StructU16AndPointer]](result, Structs::_impl::$s7Structs28returnNewStructU16AndPointeryAA0defG0VSvF(x));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-decls-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-decls-in-cxx.swift
@@ -65,6 +65,6 @@ public distributed actor DistributedActorClass {
     @_expose(Cxx) // ok
     nonisolated public var prop2: Int { 42 }
 
-    @_expose(Cxx) // expected-error {{nested struct 'NestedStruct' can not yet be represented in C++}}
+    @_expose(Cxx) // ok
     public struct NestedStruct {}
 }


### PR DESCRIPTION
It is really involved to change how methods and classes are emitted into the header so this patch introduces the impression of nested structs through using statements and still emits the structs themselves as top level structs. It emits them in their own namespace to avoid name collisions. This patch also had to change some names to be fully qualified to avoid some name lookup errors in case of nested structs. Moreover, nesting level of 3 and above requires C++17 because it relies on nested namespaces. Only nested structs are supported, not nested classes.

Since this patch is already started to grow quite big, I decided to put it out for reviews and plan to address some of the shortcomings in a follow-up PR.

rdar://118793469