### PR TITLE
Fix the release/6.0 windows arm64 CI

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -866,7 +866,7 @@ function Build-CMakeProject {
     }
 
     if ($UseBuiltCompilers.Contains("Swift")) {
-      $env:Path = "$($HostArch.SDKInstallRoot)\usr\bin;$($HostArch.BinaryCache)\cmark-gfm-0.29.0.gfm.13\src;$($HostArch.ToolchainInstallRoot)\usr\bin;${env:Path}"
+      $env:Path = "$($BuildArch.SDKInstallRoot)\usr\bin;$($BuildArch.BinaryCache)\cmark-gfm-0.29.0.gfm.13\src;$($BuildArch.ToolchainInstallRoot)\usr\bin;${env:Path}"
     } elseif ($UsePinnedCompilers.Contains("Swift")) {
       $env:Path = "$(Get-PinnedToolchainRuntime);${env:Path}"
     }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1718,7 +1718,7 @@ function Build-Driver($Arch) {
     -Bin (Get-HostProjectBinaryCache Driver) `
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
-    -UseBuiltCompilers Swift `
+    -UseBuiltCompilers C,CXX,Swift `
     -SwiftSDK ([IO.Path]::Combine((Get-InstallDir $HostArch), "Platforms", "Windows.platform", "Developer", "SDKs", "Windows.sdk")) `
     -BuildTargets default `
     -Defines @{
@@ -1730,6 +1730,11 @@ function Build-Driver($Arch) {
       ArgumentParser_DIR = (Get-HostProjectCMakeModules ArgumentParser);
       SQLite3_INCLUDE_DIR = "$LibraryRoot\sqlite-3.43.2\usr\include";
       SQLite3_LIBRARY = "$LibraryRoot\sqlite-3.43.2\usr\lib\SQLite3.lib";
+      SWIFT_DRIVER_BUILD_TOOLS = "YES";
+      LLVM_DIR = "$(Get-HostProjectBinaryCache Compilers)\lib\cmake\llvm";
+      Clang_DIR = "$(Get-HostProjectBinaryCache Compilers)\lib\cmake\clang";
+      Swift_DIR = "$(Get-HostProjectBinaryCache Compilers)\tools\swift\lib\cmake\swift";
+      CMAKE_CXX_FLAGS = "-Xclang -fno-split-cold-code";
     }
 }
 


### PR DESCRIPTION
  - **Explanation**:
  The release/6.0 windows arm64 toolchain CI is currently broken https://ci-external.swift.org/job/swift-6.0-windows-toolchain-arm64/ due to missing cherrypicks. This PR adds those cherrypicks to (attempt to) fix it.
  - **Scope**:
  The change is limited in windows build (`utils/build.ps1`) and the release/6.0 branch. It could in theory affect the other windows x64 release/6.0 CI.
  - **Issues**:
  https://github.com/swiftlang/swift/issues/75385
  - **Original PRs**:
https://github.com/swiftlang/swift/pull/72376
https://github.com/swiftlang/swift/pull/74212
  - **Risk**:
The release is currently not buildable. So, probably not a lot.
  - **Testing**:
A local build after reproducing the build error locally.
  - **Reviewers**:
@compnerd 