### PR TITLE
[6.0] Run moveonly checker + TSAN tests in a separate file.

### DIFF
--- a/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
-// RUN: %target-swift-emit-sil -sanitize=thread -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
 
 // This test validates that we properly emit errors if we partially invalidate
 // through a type with a deinit.

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil %s -O -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses
-// RUN: %target-swift-emit-sil -sanitize=thread %s -O -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_addresschecker_tsan.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_tsan.swift
@@ -1,5 +1,6 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s -Xllvm -sil-print-final-ossa-module | %FileCheck %s
-// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -sanitize=thread -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s -Xllvm -sil-print-final-ossa-module | %FileCheck %s
+// RUN: %target-swift-emit-sil -sanitize=thread -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// REQUIRES: OS=macOS
 
 // This file contains tests that used to crash due to verifier errors. It must
 // be separate from moveonly_addresschecker_diagnostics since when we fail on
@@ -33,16 +34,5 @@ func testAssertLikeUseDifferentBits() {
             assert(index >= currentPosition)
             currentPosition = index
         }
-    }
-}
-
-// issue #75312
-struct S
-{
-    @usableFromInline
-    init(utf8:consuming [UInt8])
-    {
-        utf8.withUnsafeBufferPointer { _ in }
-        fatalError()
     }
 }


### PR DESCRIPTION
Explanation: Fixes a test failure in 6.0 CI.
Scope: Test fix, no change in compiler or runtime behavior
Issue: rdar://129286269
Original PR: https://github.com/apple/swift/pull/74270
Risk: Low. Test fix, no change in compiler or runtime behavior
Testing: Swift CI
Reviewed by: @eeckstein 
