### PR TITLE
[Test] Replaced hyphens with underscores in SIL unit test names.

### DIFF
--- a/include/swift/SIL/Test.h
+++ b/include/swift/SIL/Test.h
@@ -148,7 +148,7 @@ public:
   /// To create a new test, just write
   ///
   ///     namespace swift::test {
-  ///     static FunctionTest myTest("my-test", [](
+  ///     static FunctionTest myTest("my_new_test", [](
   ///       SILFunction &function, Arguments &arguments, FunctionTest &test){
   ///         // test code
   ///       });

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -126,7 +126,7 @@ void SILInstruction::moveBefore(SILInstruction *Later) {
 }
 
 namespace swift::test {
-FunctionTest MoveBeforeTest("instruction-move-before",
+FunctionTest MoveBeforeTest("instruction_move_before",
                             [](auto &function, auto &arguments, auto &test) {
                               auto *inst = arguments.takeInstruction();
                               auto *other = arguments.takeInstruction();

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1310,7 +1310,7 @@ namespace swift::test {
 // - SILValue: value
 // Dumps:
 // - message
-static FunctionTest IsSILTrivial("is-sil-trivial", [](auto &function,
+static FunctionTest IsSILTrivial("is_sil_trivial", [](auto &function,
                                                       auto &arguments,
                                                       auto &test) {
   SILValue value = arguments.takeValue();

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -162,7 +162,7 @@ namespace swift::test {
 // Dumps:
 // - value
 // - whether it's lexical
-static FunctionTest IsLexicalTest("is-lexical", [](auto &function,
+static FunctionTest IsLexicalTest("is_lexical", [](auto &function,
                                                    auto &arguments,
                                                    auto &test) {
   auto value = arguments.takeValue();

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -725,7 +725,7 @@ namespace swift::test {
 // - SILValue: value
 // Dumps:
 // - message
-static FunctionTest GetOwnershipKind("get-ownership-kind", [](auto &function,
+static FunctionTest GetOwnershipKind("get_ownership_kind", [](auto &function,
                                                               auto &arguments,
                                                               auto &test) {
   SILValue value = arguments.takeValue();

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -1212,7 +1212,7 @@ namespace swift::test {
 // locations. In that case, the def nodes may be stores and the uses may be
 // destroy_addrs.
 static FunctionTest FieldSensitiveMultiDefUseLiveRangeTest(
-    "fieldsensitive-multidefuse-liverange",
+    "fieldsensitive_multidefuse_liverange",
     [](auto &function, auto &arguments, auto &test) {
       SmallVector<SILBasicBlock *, 8> discoveredBlocks;
       auto value = arguments.takeValue();

--- a/lib/SIL/Utils/OwnershipLiveness.cpp
+++ b/lib/SIL/Utils/OwnershipLiveness.cpp
@@ -381,7 +381,7 @@ namespace swift::test {
 // - function
 // - the computed pruned liveness
 // - the liveness boundary
-static FunctionTest LinearLivenessTest("linear-liveness", [](auto &function,
+static FunctionTest LinearLivenessTest("linear_liveness", [](auto &function,
                                                              auto &arguments,
                                                              auto &test) {
   SILValue value = arguments.takeValue();

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -2169,7 +2169,7 @@ namespace swift::test {
 // - function
 // - the borrow introducers
 static FunctionTest FindBorrowIntroducers(
-    "find-borrow-introducers", [](auto &function, auto &arguments, auto &test) {
+    "find_borrow_introducers", [](auto &function, auto &arguments, auto &test) {
       function.print(llvm::outs());
       llvm::outs() << "Introducers:\n";
       visitBorrowIntroducers(arguments.takeValue(), [](SILValue def) {

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -2288,7 +2288,7 @@ namespace swift::test {
 // - function
 // - the adjacent phis
 static FunctionTest VisitInnerAdjacentPhisTest(
-    "visit-inner-adjacent-phis",
+    "visit_inner_adjacent_phis",
     [](auto &function, auto &arguments, auto &test) {
       function.print(llvm::outs());
       visitInnerAdjacentPhis(cast<SILPhiArgument>(arguments.takeValue()),

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -103,7 +103,7 @@ namespace swift::test {
 // - the value
 // - whether it has a pointer escape
 static FunctionTest OwnershipUtilsHasPointerEscape(
-    "has-pointer-escape", [](auto &function, auto &arguments, auto &test) {
+    "has_pointer_escape", [](auto &function, auto &arguments, auto &test) {
       auto value = arguments.takeValue();
       auto has = findPointerEscape(value);
       value->print(llvm::outs());

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -2144,7 +2144,7 @@ namespace swift::test {
 // - function
 // - the enclosing defs
 static FunctionTest FindEnclosingDefsTest(
-    "find-enclosing-defs", [](auto &function, auto &arguments, auto &test) {
+    "find_enclosing_defs", [](auto &function, auto &arguments, auto &test) {
       function.print(llvm::outs());
       llvm::outs() << "Enclosing Defs:\n";
       visitEnclosingDefs(arguments.takeValue(), [](SILValue def) {

--- a/lib/SIL/Utils/ScopedAddressUtils.cpp
+++ b/lib/SIL/Utils/ScopedAddressUtils.cpp
@@ -113,7 +113,7 @@ namespace swift::test {
 // Dumps:
 // - the liveness result and boundary
 static FunctionTest ScopedAddressLivenessTest(
-    "scoped-address-liveness", [](auto &function, auto &arguments, auto &test) {
+    "scoped_address_liveness", [](auto &function, auto &arguments, auto &test) {
       auto value = arguments.takeValue();
       assert(!arguments.hasUntaken());
       llvm::outs() << "Scoped address analysis: " << value;

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -94,7 +94,7 @@ namespace swift::test {
 // Dumps:
 // - instruction
 // - whether it's a deinit barrier
-static FunctionTest IsDeinitBarrierTest("is-deinit-barrier", [](auto &function,
+static FunctionTest IsDeinitBarrierTest("is_deinit_barrier", [](auto &function,
                                                                 auto &arguments,
                                                                 auto &test) {
   auto *instruction = arguments.takeInstruction();

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2911,7 +2911,7 @@ namespace swift::test {
 /// Dumps:
 /// - nothing
 static FunctionTest SimplifyCFGCanonicalizeSwitchEnum(
-    "simplify-cfg-canonicalize-switch-enum",
+    "simplify_cfg_canonicalize_switch_enum",
     [](auto &function, auto &arguments, auto &test) {
       auto *passToRun = cast<SILFunctionTransform>(createSimplifyCFG());
       passToRun->injectPassManager(test.getPassManager());

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2215,7 +2215,7 @@ namespace swift::test {
 /// Dumps:
 /// - nothing
 static FunctionTest SimplifyCFGSimplifySwitchEnumBlock(
-    "simplify-cfg-simplify-switch-enum-block",
+    "simplify_cfg_simplify_switch_enum_block",
     [](auto &function, auto &arguments, auto &test) {
       auto *passToRun = cast<SILFunctionTransform>(createSimplifyCFG());
       passToRun->injectPassManager(test.getPassManager());

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1829,7 +1829,7 @@ namespace swift::test {
 /// Dumps:
 /// - nothing
 static FunctionTest SimplifyCFGSimplifySwitchEnumUnreachableBlocks(
-    "simplify-cfg-simplify-switch-enum-unreachable-blocks",
+    "simplify_cfg_simplify_switch_enum_unreachable_blocks",
     [](auto &function, auto &arguments, auto &test) {
       auto *passToRun = cast<SILFunctionTransform>(createSimplifyCFG());
       passToRun->injectPassManager(test.getPassManager());

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1079,7 +1079,7 @@ namespace swift::test {
 /// Dumps:
 /// - nothing
 static FunctionTest SimplifyCFGTryJumpThreading(
-    "simplify-cfg-try-jump-threading",
+    "simplify_cfg_try_jump_threading",
     [](auto &function, auto &arguments, auto &test) {
       auto *passToRun = cast<SILFunctionTransform>(createSimplifyCFG());
       passToRun->injectPassManager(test.getPassManager());

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2139,7 +2139,7 @@ namespace swift::test {
 /// Dumps:
 /// - nothing
 static FunctionTest SimplifyCFGSwitchEnumOnObjcClassOptional(
-    "simplify-cfg-simplify-switch-enum-on-objc-class-optional",
+    "simplify_cfg_simplify_switch_enum_on_objc_class_optional",
     [](auto &function, auto &arguments, auto &test) {
       auto *passToRun = cast<SILFunctionTransform>(createSimplifyCFG());
       passToRun->injectPassManager(test.getPassManager());

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2665,7 +2665,7 @@ namespace swift::test {
 /// Dumps:
 /// - nothing
 static FunctionTest SimplifyCFGSimplifyTermWithIdenticalDestBlocks(
-    "simplify-cfg-simplify-term-with-identical-dest-blocks",
+    "simplify_cfg_simplify_term_with_identical_dest_blocks",
     [](auto &function, auto &arguments, auto &test) {
       auto *passToRun = cast<SILFunctionTransform>(createSimplifyCFG());
       passToRun->injectPassManager(test.getPassManager());

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -3793,7 +3793,7 @@ namespace swift::test {
 /// Dumps:
 /// - nothing
 static FunctionTest SimplifyCFGSimplifyArgument(
-    "simplify-cfg-simplify-argument",
+    "simplify_cfg_simplify_argument",
     [](auto &function, auto &arguments, auto &test) {
       auto *passToRun = cast<SILFunctionTransform>(createSimplifyCFG());
       passToRun->injectPassManager(test.getPassManager());

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -3680,7 +3680,7 @@ namespace swift::test {
 /// Dumps:
 /// - nothing
 static FunctionTest SimplifyCFGSimplifyBlockArgs(
-    "simplify-cfg-simplify-block-args",
+    "simplify_cfg_simplify_block_args",
     [](auto &function, auto &arguments, auto &test) {
       auto *passToRun = cast<SILFunctionTransform>(createSimplifyCFG());
       passToRun->injectPassManager(test.getPassManager());

--- a/lib/SILOptimizer/UtilityPasses/TestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/TestRunner.cpp
@@ -114,7 +114,7 @@ void TestRunner::run() {
 // Arguments: NONE
 // Dumps:
 // - the function
-static FunctionTest DumpFunctionTest("dump-function",
+static FunctionTest DumpFunctionTest("dump_function",
                                      [](auto &function, auto &, auto &) {
                                        function.print(llvm::outs());
                                      });

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -860,7 +860,7 @@ namespace swift::test {
 // Dumps:
 // - function after value canonicalization
 static FunctionTest CanonicalizeBorrowScopeTest(
-    "canonicalize-borrow-scope",
+    "canonicalize_borrow_scope",
     [](auto &function, auto &arguments, auto &test) {
       auto value = arguments.takeValue();
       auto borrowedValue = BorrowedValue(value);

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -1357,7 +1357,7 @@ namespace swift::test {
 // Dumps:
 // - function after value canonicalization
 static FunctionTest CanonicalizeOSSALifetimeTest(
-    "canonicalize-ossa-lifetime",
+    "canonicalize_ossa_lifetime",
     [](auto &function, auto &arguments, auto &test) {
       auto *accessBlockAnalysis =
           test.template getAnalysis<NonLocalAccessBlockAnalysis>();

--- a/lib/SILOptimizer/Utils/InstructionDeleter.cpp
+++ b/lib/SILOptimizer/Utils/InstructionDeleter.cpp
@@ -335,7 +335,7 @@ namespace swift::test {
 // Dumps:
 // - the function
 static FunctionTest DeleterDeleteIfDeadTest(
-    "deleter-delete-if-dead", [](auto &function, auto &arguments, auto &test) {
+    "deleter_delete_if_dead", [](auto &function, auto &arguments, auto &test) {
       auto *inst = arguments.takeInstruction();
       InstructionDeleter deleter;
       llvm::outs() << "Deleting-if-dead " << *inst;

--- a/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
+++ b/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
@@ -812,7 +812,7 @@ namespace swift::test {
 // Dumps:
 // - the function
 static FunctionTest LexicalDestroyFoldingTest(
-    "lexical-destroy-folding", [](auto &function, auto &arguments, auto &test) {
+    "lexical_destroy_folding", [](auto &function, auto &arguments, auto &test) {
       auto *dominanceAnalysis = test.template getAnalysis<DominanceAnalysis>();
       DominanceInfo *domTree = dominanceAnalysis->get(&function);
       auto value = arguments.takeValue();

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1273,7 +1273,7 @@ namespace swift::test {
 // Dumps:
 // - The inferred isolation.
 static FunctionTest
-    IsolationInfoInferrence("sil-isolation-info-inference",
+    IsolationInfoInferrence("sil_isolation_info_inference",
                             [](auto &function, auto &arguments, auto &test) {
                               auto value = arguments.takeValue();
 

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -801,7 +801,7 @@ namespace swift::test {
 // - The inferred name
 // - The inferred value.
 static FunctionTest VariableNameInferrerTests(
-    "variable-name-inference", [](auto &function, auto &arguments, auto &test) {
+    "variable_name_inference", [](auto &function, auto &arguments, auto &test) {
       auto value = arguments.takeValue();
       SmallString<64> finalString;
       VariableNameInferrer::Options options;

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -44,26 +44,26 @@ sil @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<M
 // For now we always infer an actor as having unknown isolation since we only
 // talk about isolation of an actor (or other Sendable types).
 //
-// CHECK: begin running test 1 of 1 on actor_self_isolation_unknown: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on actor_self_isolation_unknown: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = argument of bb0 : $MyActor
 // CHECK-NEXT: Isolation: unknown
-// CHECK-NEXT: end running test 1 of 1 on actor_self_isolation_unknown: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on actor_self_isolation_unknown: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @actor_self_isolation_unknown : $@convention(thin) (@guaranteed MyActor) -> () {
 bb0(%0 : @guaranteed $MyActor):
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
   debug_value [trace] %0 : $MyActor
   %9999 = tuple ()
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on actor_field_isolation: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on actor_field_isolation: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %2 = ref_element_addr %0 : $MyActor
 // CHECK-NEXT: Isolation: 'argument'-isolated
-// CHECK-NEXT: end running test 1 of 1 on actor_field_isolation: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on actor_field_isolation: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @actor_field_isolation : $@convention(thin) (@guaranteed MyActor) -> () {
 bb0(%0 : @guaranteed $MyActor):
   debug_value %0 : $MyActor, let, name "argument"
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
   %1 = ref_element_addr %0 : $MyActor, #MyActor.ns
   debug_value [trace] %1 : $*NonSendableKlass
   %9999 = tuple ()
@@ -74,13 +74,13 @@ bb0(%0 : @guaranteed $MyActor):
 // MARK: Temporary Alloc Stack //
 /////////////////////////////////
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_infer_from_indirect_arg_same_block: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_infer_from_indirect_arg_same_block: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_infer_from_indirect_arg_same_block: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_infer_from_indirect_arg_same_block: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_infer_from_indirect_arg_same_block : $@convention(thin) () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
   %0 = alloc_stack $NonSendableKlass
   %f = function_ref @constructNonSendableKlassIndirect : $@convention(thin) () -> @out NonSendableKlass
   apply %f(%0) : $@convention(thin) () -> @out NonSendableKlass
@@ -91,13 +91,13 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_infer_from_indirect_arg_with_isolation_same_block: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_infer_from_indirect_arg_with_isolation_same_block: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: global actor '<null>'-isolated
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_infer_from_indirect_arg_with_isolation_same_block: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_infer_from_indirect_arg_with_isolation_same_block: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_infer_from_indirect_arg_with_isolation_same_block : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
   %0 = alloc_stack $NonSendableKlass
   %f = function_ref @constructNonSendableKlassIndirectAsync : $@convention(thin) @async () -> @out NonSendableKlass
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%0) : $@convention(thin) @async () -> @out NonSendableKlass
@@ -108,13 +108,13 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_infer_failure_write_before_in_same_block: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_infer_failure_write_before_in_same_block: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_infer_failure_write_before_in_same_block: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_infer_failure_write_before_in_same_block: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_infer_failure_write_before_in_same_block : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -133,13 +133,13 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_infer_failure_ignore_later_same_block_init: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_infer_failure_ignore_later_same_block_init: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: global actor '<null>'-isolated
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_infer_failure_ignore_later_same_block_init: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_infer_failure_ignore_later_same_block_init: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_infer_failure_ignore_later_same_block_init : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -155,13 +155,13 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_infer_failure_ignore_later_same_block_init_2: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_infer_failure_ignore_later_same_block_init_2: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: actor-isolated
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_infer_failure_ignore_later_same_block_init_2: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_infer_failure_ignore_later_same_block_init_2: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_infer_failure_ignore_later_same_block_init_2 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -177,13 +177,13 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_simple: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_simple: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: actor-isolated
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_simple: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_simple: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_simple : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -208,13 +208,13 @@ bb3:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_disrupting_write : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -242,13 +242,13 @@ bb3:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write_2: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write_2: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write_2: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write_2: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_disrupting_write_2 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -276,13 +276,13 @@ bb3:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write_3: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write_3: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write_3: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_disrupting_write_3: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_disrupting_write_3 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -312,13 +312,13 @@ bb3:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_matching_inits: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_matching_inits: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_matching_inits: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_matching_inits: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_matching_inits : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -344,13 +344,13 @@ bb3:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_matching_inits_2: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_matching_inits_2: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_matching_inits_2: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_matching_inits_2: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_matching_inits_2 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -379,13 +379,13 @@ bb3:
 // If we see multiple initializations, just leave it as disconnected. This is
 // more conservative.
 //
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_conflicting_inits: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_conflicting_inits: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_conflicting_inits: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_conflicting_inits: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_conflicting_inits : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -411,13 +411,13 @@ bb3:
 
 // If we see multiple initializations along any path... we need to be disconnected.
 //
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_conflicting_inits_2: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_conflicting_inits_2: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_conflicting_inits_2: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_conflicting_inits_2: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_conflicting_inits_2 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -443,13 +443,13 @@ bb3:
 
 // More complex CFG work with a loop.
 //
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: global actor '<null>'-isolated
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_larger_cfg : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -483,13 +483,13 @@ bb7:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_2: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_2: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: global actor '<null>'-isolated
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_2: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_2: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_larger_cfg_2 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -523,13 +523,13 @@ bb7:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_3: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_3: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: global actor '<null>'-isolated
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_3: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_3: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_larger_cfg_3 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -565,13 +565,13 @@ bb7:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_4: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_4: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_4: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_4: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_larger_cfg_4 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -610,13 +610,13 @@ bb7:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_5: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_5: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: global actor '<null>'-isolated
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_5: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_5: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_larger_cfg_5 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -658,13 +658,13 @@ bb7:
   return %9999 : $()
 }
 
-// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_6: sil-isolation-info-inference with: @trace[0]
+// CHECK: begin running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_6: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %0 = alloc_stack $NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_6: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on temp_alloc_stack_different_block_larger_cfg_6: sil_isolation_info_inference with: @trace[0]
 sil @temp_alloc_stack_different_block_larger_cfg_6 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
 
   %0 = alloc_stack $NonSendableKlass
   debug_value [trace] %0 : $*NonSendableKlass
@@ -704,13 +704,13 @@ bb7:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on lookthrough_test: sil-isolation-info-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on lookthrough_test: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %7 = apply %6(%5) : $@convention(thin) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
 // CHECK-NEXT: Isolation: 'argument'-isolated
-// CHECK-NEXT: end running test 1 of 1 on lookthrough_test: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on lookthrough_test: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @lookthrough_test : $@convention(thin) (@owned MyActor) -> @owned NonSendableKlass {
 bb0(%0 : @owned $MyActor):
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
   debug_value %0 : $MyActor, let, name "argument"
   %1 = end_init_let_ref %0 : $MyActor
   %1a = copy_value %1 : $MyActor
@@ -725,13 +725,13 @@ bb0(%0 : @owned $MyActor):
   return %3 : $NonSendableKlass
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on isolated_variable_test_1: sil-isolation-info-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on isolated_variable_test_1: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   %2 = apply %1(%0) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
 // CHECK-NEXT: Isolation: disconnected
-// CHECK-NEXT: end running test 1 of 1 on isolated_variable_test_1: sil-isolation-info-inference with: @trace[0]
+// CHECK-NEXT: end running test 1 of 1 on isolated_variable_test_1: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @isolated_variable_test_1 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "sil-isolation-info-inference @trace[0]"
+  specify_test "sil_isolation_info_inference @trace[0]"
   %0 = enum $Optional<MyActor>, #Optional.none
   %1 = function_ref @useOptionalActor : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass
   %2 = apply %1(%0) : $@convention(thin) (@sil_isolated @guaranteed Optional<MyActor>) -> @owned NonSendableKlass

--- a/test/SIL/moveonly_ownership.sil
+++ b/test/SIL/moveonly_ownership.sil
@@ -34,25 +34,25 @@ struct NC : ~Copyable {
 // CHECK:   %2 = struct $MO_DEINIT (%1 : $FakeInt)
 // CHECK:  is not trivial
 // CHECK: end running test 1 of 4 on motest1: is-sil-trivial with: @instruction[2]
-// CHECK: begin running test 2 of 4 on motest1: get-ownership-kind with: @instruction[2]
+// CHECK: begin running test 2 of 4 on motest1: get_ownership_kind with: @instruction[2]
 // CHECK:   %2 = struct $MO_DEINIT (%1 : $FakeInt)
 // CHECK: OwnershipKind: owned
-// CHECK: end running test 2 of 4 on motest1: get-ownership-kind with: @instruction[2]
+// CHECK: end running test 2 of 4 on motest1: get_ownership_kind with: @instruction[2]
 // CHECK: begin running test 3 of 4 on motest1: is-sil-trivial with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $MO_DEINIT
 // CHECK:  is not trivial
 // CHECK: end running test 3 of 4 on motest1: is-sil-trivial with: @instruction[4]
-// CHECK: begin running test 4 of 4 on motest1: get-ownership-kind with: @instruction[4]
+// CHECK: begin running test 4 of 4 on motest1: get_ownership_kind with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $MO_DEINIT
 // CHECK: OwnershipKind: owned
-// CHECK: end running test 4 of 4 on motest1: get-ownership-kind with: @instruction[4]
+// CHECK: end running test 4 of 4 on motest1: get_ownership_kind with: @instruction[4]
 sil hidden [ossa] @motest1 : $@convention(thin) () -> () {
 [global: read,write,copy,destroy,allocate,deinit_barrier]
 bb0:
   specify_test "is-sil-trivial @instruction[2]"
-  specify_test "get-ownership-kind @instruction[2]"
+  specify_test "get_ownership_kind @instruction[2]"
   specify_test "is-sil-trivial @instruction[4]"
-  specify_test "get-ownership-kind @instruction[4]"
+  specify_test "get_ownership_kind @instruction[4]"
   %0 = integer_literal $Builtin.Int32, 38
   %1 = struct $FakeInt (%0 : $Builtin.Int32)
   %2 = struct $MO_DEINIT (%1 : $FakeInt)
@@ -67,25 +67,25 @@ bb0:
 // CHECK:   %2 = struct $MO (%1 : $FakeInt)
 // CHECK:  is not trivial
 // CHECK: end running test 1 of 4 on motest2: is-sil-trivial with: @instruction[2]
-// CHECK: begin running test 2 of 4 on motest2: get-ownership-kind with: @instruction[2]
+// CHECK: begin running test 2 of 4 on motest2: get_ownership_kind with: @instruction[2]
 // CHECK:   %2 = struct $MO (%1 : $FakeInt)
 // CHECK: OwnershipKind: owned
-// CHECK: end running test 2 of 4 on motest2: get-ownership-kind with: @instruction[2]
+// CHECK: end running test 2 of 4 on motest2: get_ownership_kind with: @instruction[2]
 // CHECK: begin running test 3 of 4 on motest2: is-sil-trivial with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $MO
 // CHECK:  is not trivial
 // CHECK: end running test 3 of 4 on motest2: is-sil-trivial with: @instruction[4]
-// CHECK: begin running test 4 of 4 on motest2: get-ownership-kind with: @instruction[4]
+// CHECK: begin running test 4 of 4 on motest2: get_ownership_kind with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $MO
 // CHECK: OwnershipKind: owned
-// CHECK: end running test 4 of 4 on motest2: get-ownership-kind with: @instruction[4]
+// CHECK: end running test 4 of 4 on motest2: get_ownership_kind with: @instruction[4]
 sil hidden [ossa] @motest2 : $@convention(thin) () -> () {
 [global: read,write,copy,destroy,allocate,deinit_barrier]
 bb0:
   specify_test "is-sil-trivial @instruction[2]"
-  specify_test "get-ownership-kind @instruction[2]"
+  specify_test "get_ownership_kind @instruction[2]"
   specify_test "is-sil-trivial @instruction[4]"
-  specify_test "get-ownership-kind @instruction[4]"
+  specify_test "get_ownership_kind @instruction[4]"
   %0 = integer_literal $Builtin.Int32, 38
   %1 = struct $FakeInt (%0 : $Builtin.Int32)
   %2 = struct $MO (%1 : $FakeInt)
@@ -100,26 +100,26 @@ bb0:
 // CHECK:   %2 = struct $NC_DEINIT (%1 : $FakeInt)
 // CHECK:  is not trivial
 // CHECK: end running test 1 of 4 on nctest1: is-sil-trivial with: @instruction[2]
-// CHECK: begin running test 2 of 4 on nctest1: get-ownership-kind with: @instruction[2]
+// CHECK: begin running test 2 of 4 on nctest1: get_ownership_kind with: @instruction[2]
 // CHECK:   %2 = struct $NC_DEINIT (%1 : $FakeInt)
 // CHECK: OwnershipKind: owned
-// CHECK: end running test 2 of 4 on nctest1: get-ownership-kind with: @instruction[2]
+// CHECK: end running test 2 of 4 on nctest1: get_ownership_kind with: @instruction[2]
 // CHECK: begin running test 3 of 4 on nctest1: is-sil-trivial with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $NC_DEINIT
 // CHECK:  is not trivial
 // CHECK: end running test 3 of 4 on nctest1: is-sil-trivial with: @instruction[4]
-// CHECK: begin running test 4 of 4 on nctest1: get-ownership-kind with: @instruction[4]
+// CHECK: begin running test 4 of 4 on nctest1: get_ownership_kind with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $NC_DEINIT
 // CHECK: OwnershipKind: owned
-// CHECK: end running test 4 of 4 on nctest1: get-ownership-kind with: @instruction[4]
+// CHECK: end running test 4 of 4 on nctest1: get_ownership_kind with: @instruction[4]
 
 sil hidden [ossa] @nctest1 : $@convention(thin) () -> () {
 [global: read,write,copy,destroy,allocate,deinit_barrier]
 bb0:
   specify_test "is-sil-trivial @instruction[2]"
-  specify_test "get-ownership-kind @instruction[2]"
+  specify_test "get_ownership_kind @instruction[2]"
   specify_test "is-sil-trivial @instruction[4]"
-  specify_test "get-ownership-kind @instruction[4]"
+  specify_test "get_ownership_kind @instruction[4]"
   %0 = integer_literal $Builtin.Int32, 38
   %1 = struct $FakeInt (%0 : $Builtin.Int32)
   %2 = struct $NC_DEINIT (%1 : $FakeInt)
@@ -134,25 +134,25 @@ bb0:
 // CHECK:   %2 = struct $NC (%1 : $FakeInt)
 // CHECK:  is not trivial
 // CHECK: end running test 1 of 4 on nctest2: is-sil-trivial with: @instruction[2]
-// CHECK: begin running test 2 of 4 on nctest2: get-ownership-kind with: @instruction[2]
+// CHECK: begin running test 2 of 4 on nctest2: get_ownership_kind with: @instruction[2]
 // CHECK:   %2 = struct $NC (%1 : $FakeInt)
 // CHECK: OwnershipKind: owned
-// CHECK: end running test 2 of 4 on nctest2: get-ownership-kind with: @instruction[2]
+// CHECK: end running test 2 of 4 on nctest2: get_ownership_kind with: @instruction[2]
 // CHECK: begin running test 3 of 4 on nctest2: is-sil-trivial with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $NC
 // CHECK:  is not trivial
 // CHECK: end running test 3 of 4 on nctest2: is-sil-trivial with: @instruction[4]
-// CHECK: begin running test 4 of 4 on nctest2: get-ownership-kind with: @instruction[4]
+// CHECK: begin running test 4 of 4 on nctest2: get_ownership_kind with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $NC
 // CHECK: OwnershipKind: owned
-// CHECK: end running test 4 of 4 on nctest2: get-ownership-kind with: @instruction[4]
+// CHECK: end running test 4 of 4 on nctest2: get_ownership_kind with: @instruction[4]
 sil hidden [ossa] @nctest2 : $@convention(thin) () -> () {
 [global: read,write,copy,destroy,allocate,deinit_barrier]
 bb0:
   specify_test "is-sil-trivial @instruction[2]"
-  specify_test "get-ownership-kind @instruction[2]"
+  specify_test "get_ownership_kind @instruction[2]"
   specify_test "is-sil-trivial @instruction[4]"
-  specify_test "get-ownership-kind @instruction[4]"
+  specify_test "get_ownership_kind @instruction[4]"
   %0 = integer_literal $Builtin.Int32, 38
   %1 = struct $FakeInt (%0 : $Builtin.Int32)
   %2 = struct $NC (%1 : $FakeInt)

--- a/test/SIL/moveonly_ownership.sil
+++ b/test/SIL/moveonly_ownership.sil
@@ -30,18 +30,18 @@ struct NC : ~Copyable {
   @_hasStorage var value: FakeInt { get set }
 }
 
-// CHECK: begin running test 1 of 4 on motest1: is-sil-trivial with: @instruction[2]
+// CHECK: begin running test 1 of 4 on motest1: is_sil_trivial with: @instruction[2]
 // CHECK:   %2 = struct $MO_DEINIT (%1 : $FakeInt)
 // CHECK:  is not trivial
-// CHECK: end running test 1 of 4 on motest1: is-sil-trivial with: @instruction[2]
+// CHECK: end running test 1 of 4 on motest1: is_sil_trivial with: @instruction[2]
 // CHECK: begin running test 2 of 4 on motest1: get_ownership_kind with: @instruction[2]
 // CHECK:   %2 = struct $MO_DEINIT (%1 : $FakeInt)
 // CHECK: OwnershipKind: owned
 // CHECK: end running test 2 of 4 on motest1: get_ownership_kind with: @instruction[2]
-// CHECK: begin running test 3 of 4 on motest1: is-sil-trivial with: @instruction[4]
+// CHECK: begin running test 3 of 4 on motest1: is_sil_trivial with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $MO_DEINIT
 // CHECK:  is not trivial
-// CHECK: end running test 3 of 4 on motest1: is-sil-trivial with: @instruction[4]
+// CHECK: end running test 3 of 4 on motest1: is_sil_trivial with: @instruction[4]
 // CHECK: begin running test 4 of 4 on motest1: get_ownership_kind with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $MO_DEINIT
 // CHECK: OwnershipKind: owned
@@ -49,9 +49,9 @@ struct NC : ~Copyable {
 sil hidden [ossa] @motest1 : $@convention(thin) () -> () {
 [global: read,write,copy,destroy,allocate,deinit_barrier]
 bb0:
-  specify_test "is-sil-trivial @instruction[2]"
+  specify_test "is_sil_trivial @instruction[2]"
   specify_test "get_ownership_kind @instruction[2]"
-  specify_test "is-sil-trivial @instruction[4]"
+  specify_test "is_sil_trivial @instruction[4]"
   specify_test "get_ownership_kind @instruction[4]"
   %0 = integer_literal $Builtin.Int32, 38
   %1 = struct $FakeInt (%0 : $Builtin.Int32)
@@ -63,18 +63,18 @@ bb0:
   return %6 : $()
 }
 
-// CHECK: begin running test 1 of 4 on motest2: is-sil-trivial with: @instruction[2]
+// CHECK: begin running test 1 of 4 on motest2: is_sil_trivial with: @instruction[2]
 // CHECK:   %2 = struct $MO (%1 : $FakeInt)
 // CHECK:  is not trivial
-// CHECK: end running test 1 of 4 on motest2: is-sil-trivial with: @instruction[2]
+// CHECK: end running test 1 of 4 on motest2: is_sil_trivial with: @instruction[2]
 // CHECK: begin running test 2 of 4 on motest2: get_ownership_kind with: @instruction[2]
 // CHECK:   %2 = struct $MO (%1 : $FakeInt)
 // CHECK: OwnershipKind: owned
 // CHECK: end running test 2 of 4 on motest2: get_ownership_kind with: @instruction[2]
-// CHECK: begin running test 3 of 4 on motest2: is-sil-trivial with: @instruction[4]
+// CHECK: begin running test 3 of 4 on motest2: is_sil_trivial with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $MO
 // CHECK:  is not trivial
-// CHECK: end running test 3 of 4 on motest2: is-sil-trivial with: @instruction[4]
+// CHECK: end running test 3 of 4 on motest2: is_sil_trivial with: @instruction[4]
 // CHECK: begin running test 4 of 4 on motest2: get_ownership_kind with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $MO
 // CHECK: OwnershipKind: owned
@@ -82,9 +82,9 @@ bb0:
 sil hidden [ossa] @motest2 : $@convention(thin) () -> () {
 [global: read,write,copy,destroy,allocate,deinit_barrier]
 bb0:
-  specify_test "is-sil-trivial @instruction[2]"
+  specify_test "is_sil_trivial @instruction[2]"
   specify_test "get_ownership_kind @instruction[2]"
-  specify_test "is-sil-trivial @instruction[4]"
+  specify_test "is_sil_trivial @instruction[4]"
   specify_test "get_ownership_kind @instruction[4]"
   %0 = integer_literal $Builtin.Int32, 38
   %1 = struct $FakeInt (%0 : $Builtin.Int32)
@@ -96,18 +96,18 @@ bb0:
   return %6 : $()
 }
 
-// CHECK: begin running test 1 of 4 on nctest1: is-sil-trivial with: @instruction[2]
+// CHECK: begin running test 1 of 4 on nctest1: is_sil_trivial with: @instruction[2]
 // CHECK:   %2 = struct $NC_DEINIT (%1 : $FakeInt)
 // CHECK:  is not trivial
-// CHECK: end running test 1 of 4 on nctest1: is-sil-trivial with: @instruction[2]
+// CHECK: end running test 1 of 4 on nctest1: is_sil_trivial with: @instruction[2]
 // CHECK: begin running test 2 of 4 on nctest1: get_ownership_kind with: @instruction[2]
 // CHECK:   %2 = struct $NC_DEINIT (%1 : $FakeInt)
 // CHECK: OwnershipKind: owned
 // CHECK: end running test 2 of 4 on nctest1: get_ownership_kind with: @instruction[2]
-// CHECK: begin running test 3 of 4 on nctest1: is-sil-trivial with: @instruction[4]
+// CHECK: begin running test 3 of 4 on nctest1: is_sil_trivial with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $NC_DEINIT
 // CHECK:  is not trivial
-// CHECK: end running test 3 of 4 on nctest1: is-sil-trivial with: @instruction[4]
+// CHECK: end running test 3 of 4 on nctest1: is_sil_trivial with: @instruction[4]
 // CHECK: begin running test 4 of 4 on nctest1: get_ownership_kind with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $NC_DEINIT
 // CHECK: OwnershipKind: owned
@@ -116,9 +116,9 @@ bb0:
 sil hidden [ossa] @nctest1 : $@convention(thin) () -> () {
 [global: read,write,copy,destroy,allocate,deinit_barrier]
 bb0:
-  specify_test "is-sil-trivial @instruction[2]"
+  specify_test "is_sil_trivial @instruction[2]"
   specify_test "get_ownership_kind @instruction[2]"
-  specify_test "is-sil-trivial @instruction[4]"
+  specify_test "is_sil_trivial @instruction[4]"
   specify_test "get_ownership_kind @instruction[4]"
   %0 = integer_literal $Builtin.Int32, 38
   %1 = struct $FakeInt (%0 : $Builtin.Int32)
@@ -130,18 +130,18 @@ bb0:
   return %6 : $()
 }
 
-// CHECK: begin running test 1 of 4 on nctest2: is-sil-trivial with: @instruction[2]
+// CHECK: begin running test 1 of 4 on nctest2: is_sil_trivial with: @instruction[2]
 // CHECK:   %2 = struct $NC (%1 : $FakeInt)
 // CHECK:  is not trivial
-// CHECK: end running test 1 of 4 on nctest2: is-sil-trivial with: @instruction[2]
+// CHECK: end running test 1 of 4 on nctest2: is_sil_trivial with: @instruction[2]
 // CHECK: begin running test 2 of 4 on nctest2: get_ownership_kind with: @instruction[2]
 // CHECK:   %2 = struct $NC (%1 : $FakeInt)
 // CHECK: OwnershipKind: owned
 // CHECK: end running test 2 of 4 on nctest2: get_ownership_kind with: @instruction[2]
-// CHECK: begin running test 3 of 4 on nctest2: is-sil-trivial with: @instruction[4]
+// CHECK: begin running test 3 of 4 on nctest2: is_sil_trivial with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $NC
 // CHECK:  is not trivial
-// CHECK: end running test 3 of 4 on nctest2: is-sil-trivial with: @instruction[4]
+// CHECK: end running test 3 of 4 on nctest2: is_sil_trivial with: @instruction[4]
 // CHECK: begin running test 4 of 4 on nctest2: get_ownership_kind with: @instruction[4]
 // CHECK:   %4 = move_value [lexical] %2 : $NC
 // CHECK: OwnershipKind: owned
@@ -149,9 +149,9 @@ bb0:
 sil hidden [ossa] @nctest2 : $@convention(thin) () -> () {
 [global: read,write,copy,destroy,allocate,deinit_barrier]
 bb0:
-  specify_test "is-sil-trivial @instruction[2]"
+  specify_test "is_sil_trivial @instruction[2]"
   specify_test "get_ownership_kind @instruction[2]"
-  specify_test "is-sil-trivial @instruction[4]"
+  specify_test "is_sil_trivial @instruction[4]"
   specify_test "get_ownership_kind @instruction[4]"
   %0 = integer_literal $Builtin.Int32, 38
   %1 = struct $FakeInt (%0 : $Builtin.Int32)

--- a/test/SILOptimizer/address_lowering_preprocessed.sil
+++ b/test/SILOptimizer/address_lowering_preprocessed.sil
@@ -27,7 +27,7 @@ bb0(%t : @owned $T, %box : $*Box<T>):
   // The destroy_value appears first in the textual SIL in order to be first in
   // the use list.  Before running AddressLowering, it's sunk to after the
   // end_access.
-  specify_test "instruction-move-before @instruction @instruction[+5]"
+  specify_test "instruction_move_before @instruction @instruction[+5]"
   destroy_value %t : $T
   %copy = copy_value %t : $T
   %field_addr = struct_element_addr %box : $*Box<T>, #Box._value

--- a/test/SILOptimizer/borrow_introducer_unit.sil
+++ b/test/SILOptimizer/borrow_introducer_unit.sil
@@ -30,11 +30,11 @@ sil @coro : $@yield_once @convention(thin) () -> @yields @guaranteed C
 
 // The introducer of an introducer is always itself.
 
-// CHECK-LABEL: introducer_identity: find-borrow-introducers with: %0
+// CHECK-LABEL: introducer_identity: find_borrow_introducers with: %0
 // CHECK: } // end sil function 'introducer_identity'
 // CHECK: Introducers:
 // CHECK-NEXT: %0 = argument of bb0 : $C
-// CHECK-NEXT: introducer_identity: find-borrow-introducers with: %0
+// CHECK-NEXT: introducer_identity: find_borrow_introducers with: %0
 
 // CHECK-LABEL: introducer_identity: borrow_introducers with: %0
 // CHECK: } // end sil function 'introducer_identity'
@@ -42,11 +42,11 @@ sil @coro : $@yield_once @convention(thin) () -> @yields @guaranteed C
 // CHECK-NEXT: %0 = argument of bb0 : $C
 // CHECK-NEXT: introducer_identity: borrow_introducers with: %0
 
-// CHECK-LABEL: introducer_identity: find-borrow-introducers with: %borrow1
+// CHECK-LABEL: introducer_identity: find_borrow_introducers with: %borrow1
 // CHECK: } // end sil function 'introducer_identity'
 // CHECK: Introducers:
 // CHECK-NEXT: begin_borrow %0 : $C
-// CHECK-NEXT: introducer_identity: find-borrow-introducers with: %borrow1
+// CHECK-NEXT: introducer_identity: find_borrow_introducers with: %borrow1
 
 // CHECK-LABEL: introducer_identity: borrow_introducers with: %borrow1
 // CHECK: } // end sil function 'introducer_identity'
@@ -54,11 +54,11 @@ sil @coro : $@yield_once @convention(thin) () -> @yields @guaranteed C
 // CHECK-NEXT: begin_borrow %0 : $C
 // CHECK-NEXT: introducer_identity: borrow_introducers with: %borrow1
 
-// CHECK-LABEL: introducer_identity: find-borrow-introducers with: %borrow2
+// CHECK-LABEL: introducer_identity: find_borrow_introducers with: %borrow2
 // CHECK: } // end sil function 'introducer_identity'
 // CHECK: Introducers:
 // CHECK-NEXT: load_borrow %1 : $*C
-// CHECK-NEXT: introducer_identity: find-borrow-introducers with: %borrow2
+// CHECK-NEXT: introducer_identity: find_borrow_introducers with: %borrow2
 
 // CHECK-LABEL: introducer_identity: borrow_introducers with: %borrow2
 // CHECK: } // end sil function 'introducer_identity'
@@ -66,11 +66,11 @@ sil @coro : $@yield_once @convention(thin) () -> @yields @guaranteed C
 // CHECK-NEXT: load_borrow %1 : $*C
 // CHECK-NEXT: introducer_identity: borrow_introducers with: %borrow2
 
-// CHECK-LABEL: introducer_identity: find-borrow-introducers with: %reborrow
+// CHECK-LABEL: introducer_identity: find_borrow_introducers with: %reborrow
 // CHECK: } // end sil function 'introducer_identity'
 // CHECK: Introducers:
 // CHECK-NEXT: argument of bb1 : $C
-// CHECK-NEXT: introducer_identity: find-borrow-introducers with: %reborrow
+// CHECK-NEXT: introducer_identity: find_borrow_introducers with: %reborrow
 
 // CHECK-LABEL: introducer_identity: borrow_introducers with: %reborrow
 // CHECK: } // end sil function 'introducer_identity'
@@ -79,21 +79,21 @@ sil @coro : $@yield_once @convention(thin) () -> @yields @guaranteed C
 // CHECK-NEXT: introducer_identity: borrow_introducers with: %reborrow
 sil [ossa] @introducer_identity : $@convention(thin) (@guaranteed C, @in C) -> () {
 entry(%0 : @guaranteed $C, %1 : $*C):
-  specify_test "find-borrow-introducers %0"
+  specify_test "find_borrow_introducers %0"
   specify_test "borrow_introducers %0"
   %borrow1 = begin_borrow %0 : $C
-  specify_test "find-borrow-introducers %borrow1"
+  specify_test "find_borrow_introducers %borrow1"
   specify_test "borrow_introducers %borrow1"
 
   %borrow2 = load_borrow %1 : $*C
-  specify_test "find-borrow-introducers %borrow2"
+  specify_test "find_borrow_introducers %borrow2"
   specify_test "borrow_introducers %borrow2"
   end_borrow %borrow2 : $C
 
   br exit(%borrow1 : $C)
 
 exit(%reborrow : @guaranteed $C):
-  specify_test "find-borrow-introducers %reborrow"
+  specify_test "find_borrow_introducers %reborrow"
   specify_test "borrow_introducers %reborrow"
   end_borrow %reborrow : $C
   destroy_addr %1 : $*C
@@ -104,10 +104,10 @@ exit(%reborrow : @guaranteed $C):
 // There is no introducer if the guaranteed value is produced from a
 // trivial value.
 
-// CHECK-LABEL: introducer_trivial: find-borrow-introducers with: %phi
+// CHECK-LABEL: introducer_trivial: find_borrow_introducers with: %phi
 // CHECK: } // end sil function 'introducer_trivial'
 // CHECK: Introducers:
-// CHECK-NEXT: introducer_trivial: find-borrow-introducers with: %phi
+// CHECK-NEXT: introducer_trivial: find_borrow_introducers with: %phi
 
 // CHECK-LABEL: introducer_trivial: borrow_introducers with: %phi
 // CHECK: } // end sil function 'introducer_trivial'
@@ -120,7 +120,7 @@ entry:
   br none(%trivial : $FakeOptional<C>)
 
 none(%phi : @guaranteed $FakeOptional<C>):
-  specify_test "find-borrow-introducers %phi"
+  specify_test "find_borrow_introducers %phi"
   specify_test "borrow_introducers %phi"
   %retval = tuple ()
   return %retval : $()
@@ -131,11 +131,11 @@ none(%phi : @guaranteed $FakeOptional<C>):
 // TODO: When we have a reborrow flag, an unreachable phi can be
 // either a reborrow or forwarded, as long as it has no end_borrow.
 
-// CHECK-LABEL: introducer_unreachable: find-borrow-introducers with: %phiCycle
+// CHECK-LABEL: introducer_unreachable: find_borrow_introducers with: %phiCycle
 // CHECK: } // end sil function 'introducer_unreachable'
 // CHECK: Introducers:
 // CHECK-NEXT: argument of bb1 : $C
-// CHECK-NEXT: introducer_unreachable: find-borrow-introducers with: %phiCycle
+// CHECK-NEXT: introducer_unreachable: find_borrow_introducers with: %phiCycle
 
 // CHECK-LABEL: introducer_unreachable: borrow_introducers with: %phiCycle
 // CHECK: } // end sil function 'introducer_unreachable'
@@ -147,7 +147,7 @@ entry:
   br exit
 
 unreachable_loop(%phiCycle : @guaranteed $C):
-  specify_test "find-borrow-introducers %phiCycle"
+  specify_test "find_borrow_introducers %phiCycle"
   specify_test "borrow_introducers %phiCycle"
   br unreachable_loop(%phiCycle : $C)
 
@@ -159,11 +159,11 @@ exit:
 // All data flow paths through phis and aggregates originate from the
 // same function argument.
 
-// CHECK-LABEL: introducer_single: find-borrow-introducers with: %aggregate2
+// CHECK-LABEL: introducer_single: find_borrow_introducers with: %aggregate2
 // CHECK: } // end sil function 'introducer_single'
 // CHECK: Introducers:
 // CHECK-NEXT: %0 = argument of bb0 : $C
-// CHECK-NEXT: introducer_single: find-borrow-introducers with: %aggregate2
+// CHECK-NEXT: introducer_single: find_borrow_introducers with: %aggregate2
 
 // CHECK-LABEL: introducer_single: borrow_introducers with: %aggregate2
 // CHECK: } // end sil function 'introducer_single'
@@ -185,7 +185,7 @@ bb1(%payload : @guaranteed $D):
   %first = struct_extract %aggregate : $PairC, #PairC.first
   %second = struct_extract %aggregate : $PairC, #PairC.second
   %aggregate2 = struct $PairC(%first : $C, %second : $C)
-  specify_test "find-borrow-introducers %aggregate2"
+  specify_test "find_borrow_introducers %aggregate2"
   specify_test "borrow_introducers %aggregate2"
   br exit
 
@@ -205,13 +205,13 @@ exit:
 // %reborrow. Therefore, %reborrow is an introducer from separate phi
 // paths, but should only appear in the introducer list once.
 //
-// CHECK-LABEL: introducer_revisit_reborrow: find-borrow-introducers with: %aggregate2
+// CHECK-LABEL: introducer_revisit_reborrow: find_borrow_introducers with: %aggregate2
 // CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C
 // CHECK: } // end sil function 'introducer_revisit_reborrow'
 // CHECK: Introducers:
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
 // CHECK-NEXT: %0 = argument of bb0 : $C
-// CHECK-NEXT: introducer_revisit_reborrow: find-borrow-introducers with: %aggregate2
+// CHECK-NEXT: introducer_revisit_reborrow: find_borrow_introducers with: %aggregate2
 
 // CHECK-LABEL: introducer_revisit_reborrow: borrow_introducers with: %aggregate2
 // CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C
@@ -229,7 +229,7 @@ entry(%0 : @guaranteed $C):
 bb2(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
   %first = struct_extract %phi : $PairC, #PairC.first
   %aggregate2 = struct $PairC(%reborrow : $C, %first : $C)
-  specify_test "find-borrow-introducers %aggregate2"
+  specify_test "find_borrow_introducers %aggregate2"
   specify_test "borrow_introducers %aggregate2"
   br exit
 
@@ -242,7 +242,7 @@ exit:
 // %phi originates from %0, %borrow1, & %borrow2. %borrow1 is, however,
 // reborrowed in bb2.
 
-// CHECK-LABEL: introducer_multiple_borrow: find-borrow-introducers with: %aggregate2
+// CHECK-LABEL: introducer_multiple_borrow: find_borrow_introducers with: %aggregate2
 // CHECK: begin_borrow %0 : $C  
 // CHECK: [[BORROW2:%.*]] = begin_borrow %0 : $C
 // CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C
@@ -251,7 +251,7 @@ exit:
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
 // CHECK-NEXT: %0 = argument of bb0 : $C
 // CHECK-NEXT: [[BORROW2]] = begin_borrow %0 : $C
-// CHECK-NEXT: introducer_multiple_borrow: find-borrow-introducers with: %aggregate2
+// CHECK-NEXT: introducer_multiple_borrow: find_borrow_introducers with: %aggregate2
 
 // CHECK-LABEL: introducer_multiple_borrow: borrow_introducers with: %aggregate2
 // CHECK: begin_borrow %0 : $C  
@@ -273,7 +273,7 @@ entry(%0 : @guaranteed $C):
 bb2(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
   %first = struct_extract %phi : $PairC, #PairC.first
   %aggregate2 = struct $PairC(%reborrow : $C, %first : $C)
-  specify_test "find-borrow-introducers %aggregate2"
+  specify_test "find_borrow_introducers %aggregate2"
   specify_test "borrow_introducers %aggregate2"
   br exit
 
@@ -284,10 +284,10 @@ exit:
   return %retval : $()
 }
 
-// CHECK-LABEL: introducer_dependence: find-borrow-introducers with: %dependent
+// CHECK-LABEL: introducer_dependence: find_borrow_introducers with: %dependent
 // CHECK: Introducers:
 // CHECK: %0 = argument of bb0 : $C
-// CHECK-LABEL: introducer_dependence: find-borrow-introducers with: %dependent
+// CHECK-LABEL: introducer_dependence: find_borrow_introducers with: %dependent
 
 // CHECK-LABEL: introducer_dependence: borrow_introducers with: %dependent
 // CHECK: Borrow introducers for: %{{.*}} = mark_dependence %0 : $C on %1 : $Builtin.NativeObject
@@ -295,17 +295,17 @@ exit:
 // CHECK-NEXT: introducer_dependence: borrow_introducers with: %dependent
 sil [ossa] @introducer_dependence : $@convention(thin) (@guaranteed C, @guaranteed Builtin.NativeObject) -> () {
 entry(%0 : @guaranteed $C, %1 : @guaranteed $Builtin.NativeObject):
-  specify_test "find-borrow-introducers %dependent"
+  specify_test "find_borrow_introducers %dependent"
   specify_test "borrow_introducers %dependent"
   %dependent = mark_dependence %0 : $C on %1 : $Builtin.NativeObject
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: introducer_bridge: find-borrow-introducers with: %bridge
+// CHECK-LABEL: introducer_bridge: find_borrow_introducers with: %bridge
 // CHECK: Introducers:
 // CHECK: %0 = argument of bb0 : $C
-// CHECK-LABEL: introducer_bridge: find-borrow-introducers with: %bridge
+// CHECK-LABEL: introducer_bridge: find_borrow_introducers with: %bridge
 
 // CHECK-LABEL: introducer_bridge: borrow_introducers with: %bridge
 // CHECK: Borrow introducers for: %{{.*}} = ref_to_bridge_object %0 : $C, %1 : $Builtin.Word
@@ -313,7 +313,7 @@ entry(%0 : @guaranteed $C, %1 : @guaranteed $Builtin.NativeObject):
 // CHECK-NEXT: introducer_bridge: borrow_introducers with: %bridge
 sil [ossa] @introducer_bridge : $@convention(thin) (@guaranteed C, Builtin.Word) -> () {
 entry(%0 : @guaranteed $C, %1 : $Builtin.Word):
-  specify_test "find-borrow-introducers %bridge"
+  specify_test "find_borrow_introducers %bridge"
   specify_test "borrow_introducers %bridge"
   %bridge = ref_to_bridge_object %0 : $C, %1 : $Builtin.Word
   %retval = tuple ()

--- a/test/SILOptimizer/canonicalize_borrow_scope_unit.sil
+++ b/test/SILOptimizer/canonicalize_borrow_scope_unit.sil
@@ -19,17 +19,17 @@ struct Unmanaged<Instance> where Instance : AnyObject {
   unowned(unsafe) var _value: @sil_unmanaged Instance
 }
 
-// CHECK-LABEL: begin {{.*}} on copy_and_move_argument: canonicalize-borrow-scope
+// CHECK-LABEL: begin {{.*}} on copy_and_move_argument: canonicalize_borrow_scope
 // CHECK-LABEL: sil [ossa] @copy_and_move_argument : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
 // CHECK:         [[UNMANAGED:%[^,]+]] = ref_to_unmanaged [[INSTANCE]]
 // CHECK:         [[RETVAL:%[^,]+]] = struct $Unmanaged<Instance> ([[UNMANAGED]] : $@sil_unmanaged Instance) 
 // CHECK:         return [[RETVAL]]
 // CHECK-LABEL: } // end sil function 'copy_and_move_argument'
-// CHECK-LABEL: end {{.*}} on copy_and_move_argument: canonicalize-borrow-scope
+// CHECK-LABEL: end {{.*}} on copy_and_move_argument: canonicalize_borrow_scope
 sil [ossa] @copy_and_move_argument : $@convention(thin) <Instance where Instance : AnyObject> (@guaranteed Instance) -> Unmanaged<Instance> {
 bb0(%instance : @guaranteed $Instance):
-  specify_test "canonicalize-borrow-scope @argument"
+  specify_test "canonicalize_borrow_scope @argument"
   %copy_1 = copy_value %instance : $Instance
   %copy_2 = copy_value %copy_1 : $Instance
   %move = move_value %copy_2 : $Instance
@@ -44,17 +44,17 @@ bb0(%instance : @guaranteed $Instance):
   return %retval : $Unmanaged<Instance>
 }
 
-// CHECK-LABEL: begin {{.*}} on copy_and_move_lexical_argument: canonicalize-borrow-scope
+// CHECK-LABEL: begin {{.*}} on copy_and_move_lexical_argument: canonicalize_borrow_scope
 // CHECK-LABEL: sil [ossa] @copy_and_move_lexical_argument : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
 // CHECK:         [[UNMANAGED:%[^,]+]] = ref_to_unmanaged [[INSTANCE]]
 // CHECK:         [[RETVAL:%[^,]+]] = struct $Unmanaged<Instance> ([[UNMANAGED]] : $@sil_unmanaged Instance) 
 // CHECK:         return [[RETVAL]]
 // CHECK-LABEL: } // end sil function 'copy_and_move_lexical_argument'
-// CHECK-LABEL: end {{.*}} on copy_and_move_lexical_argument: canonicalize-borrow-scope
+// CHECK-LABEL: end {{.*}} on copy_and_move_lexical_argument: canonicalize_borrow_scope
 sil [ossa] @copy_and_move_lexical_argument : $@convention(thin) <Instance where Instance : AnyObject> (@guaranteed Instance) -> Unmanaged<Instance> {
 bb0(%instance : @guaranteed $Instance):
-  specify_test "canonicalize-borrow-scope @argument"
+  specify_test "canonicalize_borrow_scope @argument"
   %copy_1 = copy_value %instance : $Instance
   %copy_2 = copy_value %copy_1 : $Instance
   %move = move_value [lexical] %copy_2 : $Instance
@@ -69,7 +69,7 @@ bb0(%instance : @guaranteed $Instance):
   return %retval : $Unmanaged<Instance>
 }
 
-// CHECK-LABEL: begin running test {{.*}} on dont_rewrite_inner_forwarding_user: canonicalize-borrow-scope
+// CHECK-LABEL: begin running test {{.*}} on dont_rewrite_inner_forwarding_user: canonicalize_borrow_scope
 // CHECK-LABEL: sil [ossa] @dont_rewrite_inner_forwarding_user : {{.*}} {
 // CHECK:         [[GET_C:%[^,]+]] = function_ref @getD
 // CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
@@ -84,12 +84,12 @@ bb0(%instance : @guaranteed $Instance):
 // CHECK:         destroy_value [[C]]
 // CHECK:         return [[OUTER_UPCAST]]
 // CHECK-LABEL: } // end sil function 'dont_rewrite_inner_forwarding_user'
-// CHECK-LABEL: end running test {{.*}} on dont_rewrite_inner_forwarding_user: canonicalize-borrow-scope
+// CHECK-LABEL: end running test {{.*}} on dont_rewrite_inner_forwarding_user: canonicalize_borrow_scope
 sil [ossa] @dont_rewrite_inner_forwarding_user : $@convention(thin) () -> (@owned C) {
     %getD = function_ref @getD : $@convention(thin) () -> (@owned D)
     %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
     %d = apply %getD() : $@convention(thin) () -> (@owned D)
-    specify_test "canonicalize-borrow-scope @instruction"
+    specify_test "canonicalize_borrow_scope @instruction"
     %b = begin_borrow %d : $D
     %c2 = copy_value %b : $D
     %u2 = upcast %c2 : $D to $C
@@ -101,7 +101,7 @@ sil [ossa] @dont_rewrite_inner_forwarding_user : $@convention(thin) () -> (@owne
     return %u2 : $C
 }
 
-// CHECK-LABEL: begin running test {{.*}} on dont_hoist_inner_destructure: canonicalize-borrow-scope
+// CHECK-LABEL: begin running test {{.*}} on dont_hoist_inner_destructure: canonicalize_borrow_scope
 // CHECK-LABEL: sil [ossa] @dont_hoist_inner_destructure : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[S:%[^,]+]] :
 // CHECK:         [[OUTER_COPY:%[^,]+]] = copy_value [[S]]
@@ -123,10 +123,10 @@ sil [ossa] @dont_rewrite_inner_forwarding_user : $@convention(thin) () -> (@owne
 // CHECK:         br [[EXIT]]                                          
 // CHECK:       [[EXIT]]:                                              
 // CHECK-LABEL: } // end sil function 'dont_hoist_inner_destructure'
-// CHECK-LABEL: end running test {{.*}} on dont_hoist_inner_destructure: canonicalize-borrow-scope
+// CHECK-LABEL: end running test {{.*}} on dont_hoist_inner_destructure: canonicalize_borrow_scope
 sil [ossa] @dont_hoist_inner_destructure : $@convention(thin) (@owned S) -> () {
 entry(%s : @owned $S):
-  specify_test "canonicalize-borrow-scope @instruction"
+  specify_test "canonicalize_borrow_scope @instruction"
   %s_borrow = begin_borrow %s : $S
   %s_copy = copy_value %s_borrow : $S
   cond_br undef, left, right

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -13,11 +13,11 @@ struct S {}
 struct MoS: ~Copyable {}
 struct MoE: ~Copyable {}
 
-// CHECK-LABEL: begin running test 1 of 1 on fn: canonicalize-ossa-lifetime with: true, true, true, @trace
-// CHECK-LABEL: end running test 1 of 1 on fn: canonicalize-ossa-lifetime with: true, true, true, @trace
+// CHECK-LABEL: begin running test 1 of 1 on fn: canonicalize_ossa_lifetime with: true, true, true, @trace
+// CHECK-LABEL: end running test 1 of 1 on fn: canonicalize_ossa_lifetime with: true, true, true, @trace
 sil [ossa] @fn : $@convention(thin) () -> () {
 entry:
-    specify_test "canonicalize-ossa-lifetime true true true @trace"
+    specify_test "canonicalize_ossa_lifetime true true true @trace"
     %getC = function_ref @getC : $@convention(thin) () -> @owned C
     %c = apply %getC() : $@convention(thin) () -> @owned C
     debug_value [trace] %c : $C
@@ -31,7 +31,7 @@ entry:
 
 // When access scopes are respected, the lifetime which previously extended
 // beyond the access scope still extends beyond it.
-// CHECK-LABEL: begin running test 1 of 2 on retract_value_lifetime_into_access_scope_when_access_scopes_not_respected: canonicalize-ossa-lifetime with: true, false, true, @trace
+// CHECK-LABEL: begin running test 1 of 2 on retract_value_lifetime_into_access_scope_when_access_scopes_not_respected: canonicalize_ossa_lifetime with: true, false, true, @trace
 // CHECK-LABEL: sil [ossa] @retract_value_lifetime_into_access_scope_when_access_scopes_not_respected {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] :
 // CHECK:         [[INSTANCE:%[^,]+]] = apply
@@ -41,11 +41,11 @@ entry:
 // CHECK:         end_access [[ACCESS]]
 // CHECK:         destroy_value [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'retract_value_lifetime_into_access_scope_when_access_scopes_not_respected'
-// CHECK-LABEL: end running test 1 of 2 on retract_value_lifetime_into_access_scope_when_access_scopes_not_respected: canonicalize-ossa-lifetime with: true, false, true, @trace
+// CHECK-LABEL: end running test 1 of 2 on retract_value_lifetime_into_access_scope_when_access_scopes_not_respected: canonicalize_ossa_lifetime with: true, false, true, @trace
 
 // When access scopes are not respected, the lifetime which previously extended
 // beyond the access scope is retracted into the scope.
-// CHECK-LABEL: begin running test 2 of 2 on retract_value_lifetime_into_access_scope_when_access_scopes_not_respected: canonicalize-ossa-lifetime with: true, false, false, @trace
+// CHECK-LABEL: begin running test 2 of 2 on retract_value_lifetime_into_access_scope_when_access_scopes_not_respected: canonicalize_ossa_lifetime with: true, false, false, @trace
 // CHECK-LABEL: sil [ossa] @retract_value_lifetime_into_access_scope_when_access_scopes_not_respected {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] :
 // CHECK:         [[INSTANCE:%[^,]+]] = apply
@@ -53,15 +53,15 @@ entry:
 // CHECK:         store [[INSTANCE]] to [init] [[ACCESS]]
 // CHECK:         end_access [[ACCESS]]
 // CHECK-LABEL: } // end sil function 'retract_value_lifetime_into_access_scope_when_access_scopes_not_respected'
-// CHECK-LABEL: end running test 2 of 2 on retract_value_lifetime_into_access_scope_when_access_scopes_not_respected: canonicalize-ossa-lifetime with: true, false, false, @trace
+// CHECK-LABEL: end running test 2 of 2 on retract_value_lifetime_into_access_scope_when_access_scopes_not_respected: canonicalize_ossa_lifetime with: true, false, false, @trace
 sil [ossa] @retract_value_lifetime_into_access_scope_when_access_scopes_not_respected : $@convention(thin) () -> @out C {
 bb0(%addr : $*C):
   %instance = apply undef() : $@convention(thin) () -> @owned C
   debug_value [trace] %instance : $C
                                                    // respect access scopes
                                                    // VVVV
-  specify_test "canonicalize-ossa-lifetime true false true @trace"
-  specify_test "canonicalize-ossa-lifetime true false false @trace"
+  specify_test "canonicalize_ossa_lifetime true false true @trace"
+  specify_test "canonicalize_ossa_lifetime true false false @trace"
                                                    // ^^^^^
                                                    // respect access scopes
   %copy = copy_value %instance : $C
@@ -74,17 +74,17 @@ bb0(%addr : $*C):
 }
 
 
-// CHECK-LABEL: begin running test 1 of 1 on reuse_destroy_after_barrier_phi: canonicalize-ossa-lifetime with: true, false, true, @trace
+// CHECK-LABEL: begin running test 1 of 1 on reuse_destroy_after_barrier_phi: canonicalize_ossa_lifetime with: true, false, true, @trace
 // CHECK-LABEL: sil [ossa] @reuse_destroy_after_barrier_phi : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
 // CHECK:       {{bb[0-9]+}}({{%[^,]+}}
 // CHECK:         destroy_value [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'reuse_destroy_after_barrier_phi'
-// CHECK-LABEL: end running test 1 of 1 on reuse_destroy_after_barrier_phi: canonicalize-ossa-lifetime with: true, false, true, @trace
+// CHECK-LABEL: end running test 1 of 1 on reuse_destroy_after_barrier_phi: canonicalize_ossa_lifetime with: true, false, true, @trace
 sil [ossa] @reuse_destroy_after_barrier_phi : $@convention(thin) (@owned C) -> @owned C {
 entry(%instance : @owned $C):
   debug_value [trace] %instance : $C
-  specify_test "canonicalize-ossa-lifetime true false true @trace"
+  specify_test "canonicalize_ossa_lifetime true false true @trace"
   %get = function_ref @getOwned : $@convention(thin) () -> @owned C
   cond_br undef, through, loop
 
@@ -101,16 +101,16 @@ exit(%out : @owned $C):
   return %out : $C
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on store_arg_to_out_addr: canonicalize-ossa-lifetime with: true, false, true, @trace
+// CHECK-LABEL: begin running test 1 of 1 on store_arg_to_out_addr: canonicalize_ossa_lifetime with: true, false, true, @trace
 // CHECK-LABEL: sil [ossa] @store_arg_to_out_addr : $@convention(thin) (@owned C) -> @out C {
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] : $*C, [[INSTANCE:%[^,]+]] :
 // CHECK:       store [[INSTANCE]] to [init] [[ADDR]]
 // CHECK-LABEL: } // end sil function 'store_arg_to_out_addr'
-// CHECK-LABEL: end running test 1 of 1 on store_arg_to_out_addr: canonicalize-ossa-lifetime with: true, false, true, @trace
+// CHECK-LABEL: end running test 1 of 1 on store_arg_to_out_addr: canonicalize_ossa_lifetime with: true, false, true, @trace
 sil [ossa] @store_arg_to_out_addr : $@convention(thin) (@owned C) -> @out C {
 bb0(%0 : $*C, %instance : @owned $C):
   debug_value [trace] %instance : $C
-  specify_test "canonicalize-ossa-lifetime true false true @trace"
+  specify_test "canonicalize_ossa_lifetime true false true @trace"
   %copy = copy_value %instance : $C
   store %copy to [init] %0 : $*C
   destroy_value %instance : $C
@@ -118,7 +118,7 @@ bb0(%0 : $*C, %instance : @owned $C):
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on store_arg_to_out_addr_with_barrier: canonicalize-ossa-lifetime with: true, false, true, @trace
+// CHECK-LABEL: begin running test 1 of 1 on store_arg_to_out_addr_with_barrier: canonicalize_ossa_lifetime with: true, false, true, @trace
 // CHECK-LABEL: sil [ossa] @store_arg_to_out_addr_with_barrier : $@convention(thin) (@owned C) -> @out C {
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] : $*C, [[INSTANCE:%[^,]+]] :
 // CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
@@ -127,12 +127,12 @@ bb0(%0 : $*C, %instance : @owned $C):
 // CHECK:         apply [[BARRIER]]()
 // CHECK:         destroy_value [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'store_arg_to_out_addr_with_barrier'
-// CHECK-LABEL: end running test 1 of 1 on store_arg_to_out_addr_with_barrier: canonicalize-ossa-lifetime with: true, false, true, @trace
+// CHECK-LABEL: end running test 1 of 1 on store_arg_to_out_addr_with_barrier: canonicalize_ossa_lifetime with: true, false, true, @trace
 sil [ossa] @store_arg_to_out_addr_with_barrier : $@convention(thin) (@owned C) -> @out C {
 bb0(%0 : $*C, %instance : @owned $C):
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   debug_value [trace] %instance : $C
-  specify_test "canonicalize-ossa-lifetime true false true @trace"
+  specify_test "canonicalize_ossa_lifetime true false true @trace"
   %copy = copy_value %instance : $C
   store %copy to [init] %0 : $*C
   apply %barrier() : $@convention(thin) () -> ()
@@ -153,7 +153,7 @@ right2(%c2p : @owned $C):
 
 exit(%phi : @owned $C, %typhi : $S):
   debug_value [trace] %phi : $C
-  specify_test "canonicalize-ossa-lifetime true false true @trace"
+  specify_test "canonicalize_ossa_lifetime true false true @trace"
   destroy_value %phi : $C
   %retval = tuple ()
   return %retval : $()
@@ -168,16 +168,16 @@ bb0:
 
 // Even though the apply of %empty is not a deinit barrier, verify that the
 // destroy is not hoisted, because MoS is move-only.
-// CHECK-LABEL: begin running test {{.*}} on dont_move_destroy_value_of_moveonly_struct: canonicalize-ossa-lifetime with: true, false, true, @argument
+// CHECK-LABEL: begin running test {{.*}} on dont_move_destroy_value_of_moveonly_struct: canonicalize_ossa_lifetime with: true, false, true, @argument
 // CHECK-LABEL: sil [ossa] @dont_move_destroy_value_of_moveonly_struct : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
 // CHECK:         apply
 // CHECK:         destroy_value [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'dont_move_destroy_value_of_moveonly_struct'
-// CHECK-LABEL: end running test {{.*}} on dont_move_destroy_value_of_moveonly_struct: canonicalize-ossa-lifetime with: true, false, true, @argument
+// CHECK-LABEL: end running test {{.*}} on dont_move_destroy_value_of_moveonly_struct: canonicalize_ossa_lifetime with: true, false, true, @argument
 sil [ossa] @dont_move_destroy_value_of_moveonly_struct : $@convention(thin) (@owned MoS) -> () {
 entry(%instance : @owned $MoS):
-  specify_test "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize_ossa_lifetime true false true @argument"
   %empty = function_ref @empty : $@convention(thin) () -> ()
   apply %empty() : $@convention(thin) () -> ()
   destroy_value %instance : $MoS
@@ -185,16 +185,16 @@ entry(%instance : @owned $MoS):
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test {{.*}} on dont_move_destroy_value_of_moveonly_enum: canonicalize-ossa-lifetime with: true, false, true, @argument
+// CHECK-LABEL: begin running test {{.*}} on dont_move_destroy_value_of_moveonly_enum: canonicalize_ossa_lifetime with: true, false, true, @argument
 // CHECK-LABEL: sil [ossa] @dont_move_destroy_value_of_moveonly_enum : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
 // CHECK:         apply
 // CHECK:         destroy_value [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'dont_move_destroy_value_of_moveonly_enum'
-// CHECK-LABEL: end running test {{.*}} on dont_move_destroy_value_of_moveonly_enum: canonicalize-ossa-lifetime with: true, false, true, @argument
+// CHECK-LABEL: end running test {{.*}} on dont_move_destroy_value_of_moveonly_enum: canonicalize_ossa_lifetime with: true, false, true, @argument
 sil [ossa] @dont_move_destroy_value_of_moveonly_enum : $@convention(thin) (@owned MoE) -> () {
 entry(%instance : @owned $MoE):
-  specify_test "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize_ossa_lifetime true false true @argument"
   %empty = function_ref @empty : $@convention(thin) () -> ()
   apply %empty() : $@convention(thin) () -> ()
   destroy_value %instance : $MoE
@@ -216,7 +216,7 @@ entry(%instance : @owned $MoE):
 // CHECK-LABEL: end running test 1 of 1 on respect_boundary_edges_when_extending_to_deinit_barriers
 sil [ossa] @respect_boundary_edges_when_extending_to_deinit_barriers : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):
-  specify_test "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize_ossa_lifetime true false true @argument"
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   apply %barrier() : $@convention(thin) () -> ()
   cond_br undef, die, destroy
@@ -244,7 +244,7 @@ destroy:
 // CHECK-LABEL: end running test {{.*}} on respect_boundary_edges_when_extending_to_deinit_barriers_2
 sil [ossa] @respect_boundary_edges_when_extending_to_deinit_barriers_2 : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):
-  specify_test "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize_ossa_lifetime true false true @argument"
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   apply %barrier() : $@convention(thin) () -> ()
   cond_br undef, die, destroy
@@ -277,7 +277,7 @@ destroy:
 // CHECK-LABEL: end running test {{.*}} on respect_boundary_edges_when_extending_to_deinit_barriers_3
 sil [ossa] @respect_boundary_edges_when_extending_to_deinit_barriers_3 : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):
-  specify_test "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize_ossa_lifetime true false true @argument"
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   apply %barrier() : $@convention(thin) () -> ()
   cond_br undef, die, destroy
@@ -309,7 +309,7 @@ destroy:
 // CHECK-LABEL: end running test 1 of 1 on respect_preexisting_destroy_values_when_extending_to_deinit_barriers
 sil [ossa] @respect_preexisting_destroy_values_when_extending_to_deinit_barriers : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):
-  specify_test "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize_ossa_lifetime true false true @argument"
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   cond_br undef, die, destroy
 
@@ -331,7 +331,7 @@ destroy:
 // CHECK-LABEL: end running test {{.*}} on preserve_dead_end_1
 sil [ossa] @preserve_dead_end_1 : $@convention(thin) () -> () {
 entry:
-  specify_test "canonicalize-ossa-lifetime true false true %c"
+  specify_test "canonicalize_ossa_lifetime true false true %c"
 
   %get = function_ref @getOwned : $@convention(thin) () -> @owned C
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
@@ -349,7 +349,7 @@ entry:
 // CHECK-LABEL: end running test {{.*}} on preserve_dead_end_2
 sil [ossa] @preserve_dead_end_2 : $@convention(thin) () -> () {
 entry:
-  specify_test "canonicalize-ossa-lifetime true false true %c"
+  specify_test "canonicalize_ossa_lifetime true false true %c"
 
   %get = function_ref @getOwned : $@convention(thin) () -> @owned C
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
@@ -372,7 +372,7 @@ entry:
 // CHECK-LABEL: end running test {{.*}} on preserve_dead_end_3
 sil [ossa] @preserve_dead_end_3 : $@convention(thin) () -> () {
 entry:
-  specify_test "canonicalize-ossa-lifetime true false true %c"
+  specify_test "canonicalize_ossa_lifetime true false true %c"
 
   %get = function_ref @getOwned : $@convention(thin) () -> @owned C
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
@@ -397,7 +397,7 @@ die:
 // CHECK-LABEL: end running test {{.*}} on preserve_dead_end_4
 sil [ossa] @preserve_dead_end_4 : $@convention(thin) () -> () {
 entry:
-  specify_test "canonicalize-ossa-lifetime true false true %c"
+  specify_test "canonicalize_ossa_lifetime true false true %c"
 
   %get = function_ref @getOwned : $@convention(thin) () -> @owned C
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
@@ -427,7 +427,7 @@ die:
 // CHECK-LABEL: end running test {{.*}} on preserve_dead_end_5
 sil [ossa] @preserve_dead_end_5 : $@convention(thin) () -> () {
 entry:
-  specify_test "canonicalize-ossa-lifetime true false true %c"
+  specify_test "canonicalize_ossa_lifetime true false true %c"
 
   %get = function_ref @getOwned : $@convention(thin) () -> @owned C
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
@@ -450,7 +450,7 @@ entry:
 // CHECK-LABEL: end running test {{.*}} on preserve_dead_end_6
 sil [ossa] @preserve_dead_end_6 : $@convention(thin) () -> () {
 entry:
-  specify_test "canonicalize-ossa-lifetime true false true %c"
+  specify_test "canonicalize_ossa_lifetime true false true %c"
 
   %get = function_ref @getOwned : $@convention(thin) () -> @owned C
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
@@ -479,7 +479,7 @@ die2:
 // CHECK-LABEL: end running test {{.*}} on preserve_dead_end_7
 sil [ossa] @preserve_dead_end_7 : $@convention(thin) () -> () {
 entry:
-  specify_test "canonicalize-ossa-lifetime true false true %c"
+  specify_test "canonicalize_ossa_lifetime true false true %c"
 
   %get = function_ref @getOwned : $@convention(thin) () -> @owned C
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
@@ -502,7 +502,7 @@ die2:
 }
 
 // (1) When no end is specified, the lifetime ends after the barrier.
-// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_1: canonicalize-ossa-lifetime
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_1: canonicalize_ossa_lifetime
 // CHECK-LABEL: sil [ossa] @lexical_end_at_end_1 : {{.*}} {
 // CHECK:       bb0([[C1:%[^,]+]] :
 // CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
@@ -513,9 +513,9 @@ die2:
 // CHECK:         apply [[BARRIER]]()
 // CHECK:         destroy_value [[C1]]
 // CHECK-LABEL: } // end sil function 'lexical_end_at_end_1'
-// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_1: canonicalize-ossa-lifetime
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_1: canonicalize_ossa_lifetime
 // (2) When the move_value is specified as a lexical-lifetime-end, the lifetime doesn't extend to the destroy.
-// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_1: canonicalize-ossa-lifetime
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_1: canonicalize_ossa_lifetime
 // CHECK-LABEL: sil [ossa] @lexical_end_at_end_1 : {{.*}} {
 // CHECK:       bb0([[C1:%[^,]+]] :
 // CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
@@ -524,11 +524,11 @@ die2:
 // CHECK:         apply [[TAKE_C]]([[M]])
 // CHECK:         apply [[BARRIER]]()
 // CHECK-LABEL: } // end sil function 'lexical_end_at_end_1'
-// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_1: canonicalize-ossa-lifetime
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_1: canonicalize_ossa_lifetime
 sil [ossa] @lexical_end_at_end_1 : $@convention(thin) (@owned C) -> () {
 entry(%c1 : @owned $C):
-  specify_test "canonicalize-ossa-lifetime true false true @argument"
-  specify_test "canonicalize-ossa-lifetime true false true @argument %m"
+  specify_test "canonicalize_ossa_lifetime true false true @argument"
+  specify_test "canonicalize_ossa_lifetime true false true @argument %m"
   %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   %c2 = copy_value %c1 : $C
@@ -541,7 +541,7 @@ entry(%c1 : @owned $C):
 }
 
 // (1) When no end is specified, the lifetime ends after the barrier.
-// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_2: canonicalize-ossa-lifetime
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_2: canonicalize_ossa_lifetime
 // CHECK-LABEL: sil [ossa] @lexical_end_at_end_2 : {{.*}} {
 // CHECK:       bb0([[C1:%[^,]+]] :
 // CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
@@ -559,11 +559,11 @@ entry(%c1 : @owned $C):
 // CHECK:         apply [[BARRIER]]()
 // CHECK:         destroy_value [[C1]]
 // CHECK-LABEL: } // end sil function 'lexical_end_at_end_2'
-// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_2: canonicalize-ossa-lifetime
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_2: canonicalize_ossa_lifetime
 // (2) When the move_value is specified as a lexical-lifetime-end, the lifetime
 //     doesn't extend to the destroy.  But it DOES extend beyond barriers in
 //     blocks where unaffected by the move_value.
-// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_2: canonicalize-ossa-lifetime
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_2: canonicalize_ossa_lifetime
 // CHECK-LABEL: sil [ossa] @lexical_end_at_end_2 : {{.*}} {
 // CHECK:       bb0([[C1:%[^,]+]] : @owned $C):
 // CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
@@ -580,11 +580,11 @@ entry(%c1 : @owned $C):
 // CHECK:       [[EXIT]]:                                              
 // CHECK:         apply [[BARRIER]]()
 // CHECK-LABEL: } // end sil function 'lexical_end_at_end_2'
-// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_2: canonicalize-ossa-lifetime
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_2: canonicalize_ossa_lifetime
 sil [ossa] @lexical_end_at_end_2 : $@convention(thin) (@owned C) -> () {
 entry(%c1 : @owned $C):
-  specify_test "canonicalize-ossa-lifetime true false true @argument"
-  specify_test "canonicalize-ossa-lifetime true false true @argument %m"
+  specify_test "canonicalize_ossa_lifetime true false true @argument"
+  specify_test "canonicalize_ossa_lifetime true false true @argument %m"
   %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   cond_br undef, left, right
@@ -604,7 +604,7 @@ exit:
 }
 
 // Check barriers on branching unconsumed paths are respected.
-// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_3: canonicalize-ossa-lifetime
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_3: canonicalize_ossa_lifetime
 // CHECK-LABEL: sil [ossa] @lexical_end_at_end_3 : {{.*}} {
 // CHECK:       bb0([[C1:%[^,]+]] :
 // CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
@@ -631,8 +631,8 @@ exit:
 // CHECK:         apply [[BARRIER]]()
 // CHECK:         destroy_value [[C1]]
 // CHECK-LABEL: } // end sil function 'lexical_end_at_end_3'
-// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_3: canonicalize-ossa-lifetime
-// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_3: canonicalize-ossa-lifetime
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_3: canonicalize_ossa_lifetime
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_3: canonicalize_ossa_lifetime
 // CHECK-LABEL: sil [ossa] @lexical_end_at_end_3 : {{.*}} {
 // CHECK:       bb0([[C1:%[^,]+]] :
 // CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
@@ -658,11 +658,11 @@ exit:
 // CHECK:       bb6:
 // CHECK:         apply [[BARRIER]]()
 // CHECK-LABEL: } // end sil function 'lexical_end_at_end_3'
-// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_3: canonicalize-ossa-lifetime
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_3: canonicalize_ossa_lifetime
 sil [ossa] @lexical_end_at_end_3 : $@convention(thin) (@owned C) -> () {
 entry(%c1 : @owned $C):
-  specify_test "canonicalize-ossa-lifetime true false true @argument"
-  specify_test "canonicalize-ossa-lifetime true false true @argument %m"
+  specify_test "canonicalize_ossa_lifetime true false true @argument"
+  specify_test "canonicalize_ossa_lifetime true false true @argument %m"
   %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   cond_br undef, left, right_top
@@ -690,7 +690,7 @@ exit:
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_4: canonicalize-ossa-lifetime
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_4: canonicalize_ossa_lifetime
 // CHECK-LABEL: sil [ossa] @lexical_end_at_end_4 : {{.*}} {
 // CHECK:       bb0([[C1:%[^,]+]] :
 // CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
@@ -718,8 +718,8 @@ exit:
 // CHECK:         apply [[BARRIER]]()
 // CHECK:         destroy_value [[C1]]
 // CHECK-LABEL: } // end sil function 'lexical_end_at_end_4'
-// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_4: canonicalize-ossa-lifetime
-// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_4: canonicalize-ossa-lifetime
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_4: canonicalize_ossa_lifetime
+// CHECK-LABEL: begin running test {{.*}} on lexical_end_at_end_4: canonicalize_ossa_lifetime
 // CHECK-LABEL: sil [ossa] @lexical_end_at_end_4 : {{.*}} {
 // CHECK:       bb0([[C1:%[^,]+]] :
 // CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC : $@convention(thin) (@owned C) -> ()
@@ -745,11 +745,11 @@ exit:
 // CHECK:       [[EXIT]]:
 // CHECK:         apply [[BARRIER]]()
 // CHECK-LABEL: } // end sil function 'lexical_end_at_end_4'
-// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_4: canonicalize-ossa-lifetime
+// CHECK-LABEL: end running test {{.*}} on lexical_end_at_end_4: canonicalize_ossa_lifetime
 sil [ossa] @lexical_end_at_end_4 : $@convention(thin) (@owned C) -> () {
 entry(%c1 : @owned $C):
-  specify_test "canonicalize-ossa-lifetime true false true @argument"
-  specify_test "canonicalize-ossa-lifetime true false true @argument %m %m2"
+  specify_test "canonicalize_ossa_lifetime true false true @argument"
+  specify_test "canonicalize_ossa_lifetime true false true @argument %m %m2"
   %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   cond_br undef, left, right_top
@@ -786,6 +786,6 @@ exit:
 sil [ossa] @dead_arg_debug_dead_end : $@convention(thin) (@owned C) -> () {
 entry(%c : @owned $C):
   debug_value %c : $C
-  specify_test "canonicalize-ossa-lifetime true false true %c"
+  specify_test "canonicalize_ossa_lifetime true false true %c"
   unreachable
 }

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -45,46 +45,46 @@ sil [ossa] @empty_fn_caller_caller : $@convention(thin) () -> () {
 // CHECK:       [[UNKNOWN:%[^,]+]] = function_ref @unknown
 // CHECK:       [[UNKNOWN_CALLER:%[^,]+]] = function_ref @unknown_caller
 // CHECK-LABEL: end running test 1 of {{[0-9]+}} on call_functions: dump-function
-// CHECK-LABEL: begin running test 2 of {{[0-9]+}} on call_functions: is-deinit-barrier
+// CHECK-LABEL: begin running test 2 of {{[0-9]+}} on call_functions: is_deinit_barrier
 // CHECK:   apply [[EMPTY_FN]]
 // CHECK:   false
-// CHECK-LABEL: end running test 2 of {{[0-9]+}} on call_functions: is-deinit-barrier
-// CHECK-LABEL: begin running test 3 of {{[0-9]+}} on call_functions: is-deinit-barrier
+// CHECK-LABEL: end running test 2 of {{[0-9]+}} on call_functions: is_deinit_barrier
+// CHECK-LABEL: begin running test 3 of {{[0-9]+}} on call_functions: is_deinit_barrier
 // CHECK:   apply [[EMPTY_FN_CALLER]]
 // CHECK:   false
-// CHECK-LABEL: end running test 3 of {{[0-9]+}} on call_functions: is-deinit-barrier
-// CHECK-LABEL: begin running test 4 of {{[0-9]+}} on call_functions: is-deinit-barrier
+// CHECK-LABEL: end running test 3 of {{[0-9]+}} on call_functions: is_deinit_barrier
+// CHECK-LABEL: begin running test 4 of {{[0-9]+}} on call_functions: is_deinit_barrier
 // CHECK:   apply [[EMPTY_FN_CALLER_CALLER]]
 // CHECK:   false
-// CHECK-LABEL: end running test 4 of {{[0-9]+}} on call_functions: is-deinit-barrier
-// CHECK-LABEL: begin running test 5 of {{[0-9]+}} on call_functions: is-deinit-barrier
+// CHECK-LABEL: end running test 4 of {{[0-9]+}} on call_functions: is_deinit_barrier
+// CHECK-LABEL: begin running test 5 of {{[0-9]+}} on call_functions: is_deinit_barrier
 // CHECK:   apply [[UNKNOWN]]
 // CHECK:   true
-// CHECK-LABEL: end running test 5 of {{[0-9]+}} on call_functions: is-deinit-barrier
-// CHECK-LABEL: begin running test 6 of {{[0-9]+}} on call_functions: is-deinit-barrier
+// CHECK-LABEL: end running test 5 of {{[0-9]+}} on call_functions: is_deinit_barrier
+// CHECK-LABEL: begin running test 6 of {{[0-9]+}} on call_functions: is_deinit_barrier
 // CHECK:   apply [[UNKNOWN_CALLER]]
 // CHECK:   true
-// CHECK-LABEL: end running test 6 of {{[0-9]+}} on call_functions: is-deinit-barrier
+// CHECK-LABEL: end running test 6 of {{[0-9]+}} on call_functions: is_deinit_barrier
 sil [ossa] @call_functions : $@convention(thin) () -> () {
 entry:
   specify_test "dump-function"
-  specify_test "is-deinit-barrier @instruction[1]"
+  specify_test "is_deinit_barrier @instruction[1]"
   %empty_fn = function_ref @empty_fn : $@convention(thin) () -> ()
   apply %empty_fn() : $@convention(thin) () -> ()
 
-  specify_test "is-deinit-barrier @instruction[3]"
+  specify_test "is_deinit_barrier @instruction[3]"
   %empty_fn_caller = function_ref @empty_fn_caller : $@convention(thin) () -> ()
   apply %empty_fn_caller() : $@convention(thin) () -> ()
 
-  specify_test "is-deinit-barrier @instruction[5]"
+  specify_test "is_deinit_barrier @instruction[5]"
   %empty_fn_caller_caller = function_ref @empty_fn_caller_caller : $@convention(thin) () -> ()
   apply %empty_fn_caller_caller() : $@convention(thin) () -> ()
 
-  specify_test "is-deinit-barrier @instruction[7]"
+  specify_test "is_deinit_barrier @instruction[7]"
   %unknown = function_ref @unknown : $@convention(thin) () -> ()
   apply %unknown() : $@convention(thin) () -> ()
 
-  specify_test "is-deinit-barrier @instruction[9]"
+  specify_test "is_deinit_barrier @instruction[9]"
   %unknown_caller = function_ref @unknown_caller : $@convention(thin) () -> ()
   apply %unknown_caller() : $@convention(thin) () -> ()
 
@@ -97,58 +97,58 @@ actor A {}
 sil @getA : $() -> (@owned A)
 sil @borrowA : $@yield_once @convention(thin) () -> @yields @guaranteed A
 
-// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_hop_to_executor: is-deinit-barrier
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_hop_to_executor: is_deinit_barrier
 // CHECK:  hop_to_executor
 // CHECK:  true
-// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_hop_to_executor: is-deinit-barrier
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_hop_to_executor: is_deinit_barrier
 sil [ossa] @test_hop_to_executor : $@convention(thin) () -> () {
   %borrowA = function_ref @borrowA : $@yield_once @convention(thin) () -> @yields @guaranteed A
   (%a, %token) = begin_apply %borrowA() : $@yield_once @convention(thin) () -> @yields @guaranteed A
-  specify_test "is-deinit-barrier @instruction"
+  specify_test "is_deinit_barrier @instruction"
   hop_to_executor %a : $A
   end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_instructions_1: is_deinit_barrier
 // CHECK:  debug_step
 // CHECK:  false
-// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
-// CHECK-LABEL: begin running test 2 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_instructions_1: is_deinit_barrier
+// CHECK-LABEL: begin running test 2 of {{[0-9]+}} on test_instructions_1: is_deinit_barrier
 // CHECK:  load [trivial] {{%[^,]+}} : $*Builtin.Int32
 // CHECK:  true
-// CHECK-LABEL: end running test 2 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
-// CHECK-LABEL: begin running test 3 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
+// CHECK-LABEL: end running test 2 of {{[0-9]+}} on test_instructions_1: is_deinit_barrier
+// CHECK-LABEL: begin running test 3 of {{[0-9]+}} on test_instructions_1: is_deinit_barrier
 // CHECK:  load [trivial] {{%[^,]+}} : $*Builtin.Int32
 // CHECK:  true
-// CHECK-LABEL: end running test 3 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
+// CHECK-LABEL: end running test 3 of {{[0-9]+}} on test_instructions_1: is_deinit_barrier
 sil [ossa] @test_instructions_1 : $@convention(thin) () -> () {
 entry:
-  specify_test "is-deinit-barrier @instruction"
+  specify_test "is_deinit_barrier @instruction"
   debug_step
 
   %my_errno = global_addr @my_errno : $*Builtin.Int32
-  specify_test "is-deinit-barrier @instruction"
+  specify_test "is_deinit_barrier @instruction"
   %my_errno_value = load [trivial] %my_errno : $*Int32
 
   %global_var = global_addr @global_var : $*Builtin.Int32
-  specify_test "is-deinit-barrier @instruction"
+  specify_test "is_deinit_barrier @instruction"
   %global_var_value = load [trivial] %global_var : $*Int32
 
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test {{.*}} on rdar120656227: is-deinit-barrier
+// CHECK-LABEL: begin running test {{.*}} on rdar120656227: is_deinit_barrier
 // CHECK:       builtin "int_memmove_RawPointer_RawPointer_Int64"
 // CHECK:       true
-// CHECK-LABEL: end running test {{.*}} on rdar120656227: is-deinit-barrier
+// CHECK-LABEL: end running test {{.*}} on rdar120656227: is_deinit_barrier
 sil [ossa] @rdar120656227 : $@convention(thin) (Builtin.RawPointer, Builtin.RawPointer) -> () {
 bb0(%42 : $Builtin.RawPointer, %9 : $Builtin.RawPointer):
   %14 = integer_literal $Builtin.Int64, 27
   %28 = integer_literal $Builtin.Int1, 1
-  specify_test "is-deinit-barrier @instruction"
+  specify_test "is_deinit_barrier @instruction"
   %43 = builtin "int_memmove_RawPointer_RawPointer_Int64"(%42 : $Builtin.RawPointer, %9 : $Builtin.RawPointer, %14 : $Builtin.Int64, %28 : $Builtin.Int1) : $()
   %68 = tuple ()
   return %68 : $()

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -38,13 +38,13 @@ sil [ossa] @empty_fn_caller_caller : $@convention(thin) () -> () {
 }
 
 
-// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on call_functions: dump-function
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on call_functions: dump_function
 // CHECK:       [[EMPTY_FN:%[^,]+]] = function_ref @empty_fn
 // CHECK:       [[EMPTY_FN_CALLER:%[^,]+]] = function_ref @empty_fn_caller
 // CHECK:       [[EMPTY_FN_CALLER_CALLER:%[^,]+]] = function_ref @empty_fn_caller_caller
 // CHECK:       [[UNKNOWN:%[^,]+]] = function_ref @unknown
 // CHECK:       [[UNKNOWN_CALLER:%[^,]+]] = function_ref @unknown_caller
-// CHECK-LABEL: end running test 1 of {{[0-9]+}} on call_functions: dump-function
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on call_functions: dump_function
 // CHECK-LABEL: begin running test 2 of {{[0-9]+}} on call_functions: is_deinit_barrier
 // CHECK:   apply [[EMPTY_FN]]
 // CHECK:   false
@@ -67,7 +67,7 @@ sil [ossa] @empty_fn_caller_caller : $@convention(thin) () -> () {
 // CHECK-LABEL: end running test 6 of {{[0-9]+}} on call_functions: is_deinit_barrier
 sil [ossa] @call_functions : $@convention(thin) () -> () {
 entry:
-  specify_test "dump-function"
+  specify_test "dump_function"
   specify_test "is_deinit_barrier @instruction[1]"
   %empty_fn = function_ref @empty_fn : $@convention(thin) () -> ()
   apply %empty_fn() : $@convention(thin) () -> ()

--- a/test/SILOptimizer/enclosing_def_unit.sil
+++ b/test/SILOptimizer/enclosing_def_unit.sil
@@ -28,20 +28,20 @@ class D : C {}
 
 // These introducers have no enclosing def.
 
-// CHECK-LABEL: enclosing_def_empty: find-enclosing-defs with: %0
+// CHECK-LABEL: enclosing_def_empty: find_enclosing_defs with: %0
 // CHECK: } // end sil function 'enclosing_def_empty'
 // CHECK: Enclosing Defs:
-// CHECK-NEXT: enclosing_def_empty: find-enclosing-defs with: %0
+// CHECK-NEXT: enclosing_def_empty: find_enclosing_defs with: %0
 
 // CHECK-LABEL: enclosing_def_empty: enclosing_values with: %0
 // CHECK: } // end sil function 'enclosing_def_empty'
 // CHECK: Enclosing values for:  %0 = argument of bb0 : $C
 // CHECK-NEXT: enclosing_def_empty: enclosing_values with: %0
 
-// CHECK-LABEL: enclosing_def_empty: find-enclosing-defs with: %borrow1
+// CHECK-LABEL: enclosing_def_empty: find_enclosing_defs with: %borrow1
 // CHECK: } // end sil function 'enclosing_def_empty'
 // CHECK: Enclosing Defs:
-// CHECK-NEXT: enclosing_def_empty: find-enclosing-defs with: %borrow1
+// CHECK-NEXT: enclosing_def_empty: find_enclosing_defs with: %borrow1
 
 // CHECK-LABEL: enclosing_def_empty: enclosing_values with: %borrow1
 // CHECK: } // end sil function 'enclosing_def_empty'
@@ -49,10 +49,10 @@ class D : C {}
 // CHECK-NEXT: enclosing_def_empty: enclosing_values with: %borrow1
 sil [ossa] @enclosing_def_empty : $@convention(thin) (@guaranteed C, @in C) -> () {
 entry(%0 : @guaranteed $C, %1 : $*C):
-  specify_test "find-enclosing-defs %0"
+  specify_test "find_enclosing_defs %0"
   specify_test "enclosing_values %0"
   %borrow1 = load_borrow %1 : $*C
-  specify_test "find-enclosing-defs %borrow1"
+  specify_test "find_enclosing_defs %borrow1"
   specify_test "enclosing_values %borrow1"
   end_borrow %borrow1 : $C
   destroy_addr %1 : $*C
@@ -63,10 +63,10 @@ entry(%0 : @guaranteed $C, %1 : $*C):
 // There is no introducer if the guaranteed value is produced from a
 // trivial value.
 
-// CHECK-LABEL: enclosing_def_trivial: find-enclosing-defs with: %phi
+// CHECK-LABEL: enclosing_def_trivial: find_enclosing_defs with: %phi
 // CHECK: } // end sil function 'enclosing_def_trivial'
 // CHECK: Enclosing Defs:
-// CHECK-NEXT: enclosing_def_trivial: find-enclosing-defs with: %phi
+// CHECK-NEXT: enclosing_def_trivial: find_enclosing_defs with: %phi
 
 // CHECK-LABEL: enclosing_def_trivial: enclosing_values with: %phi
 // CHECK: } // end sil function 'enclosing_def_trivial'
@@ -78,7 +78,7 @@ entry:
   br none(%trivial : $FakeOptional<C>)
 
 none(%phi : @guaranteed $FakeOptional<C>):
-  specify_test "find-enclosing-defs %phi"
+  specify_test "find_enclosing_defs %phi"
   specify_test "enclosing_values %phi"
   %retval = tuple ()
   return %retval : $()
@@ -87,10 +87,10 @@ none(%phi : @guaranteed $FakeOptional<C>):
 // There is an introducer but no enclosing def if the guaranteed value
 // is produced from a an unreachable loop.
 
-// CHECK-LABEL: enclosing_def_unreachable: find-enclosing-defs with: %phiCycle
+// CHECK-LABEL: enclosing_def_unreachable: find_enclosing_defs with: %phiCycle
 // CHECK: } // end sil function 'enclosing_def_unreachable'
 // CHECK: Enclosing Defs:
-// CHECK-NEXT: enclosing_def_unreachable: find-enclosing-defs with: %phiCycle
+// CHECK-NEXT: enclosing_def_unreachable: find_enclosing_defs with: %phiCycle
 
 // CHECK-LABEL: enclosing_def_unreachable: enclosing_values with: %phiCycle
 // CHECK: } // end sil function 'enclosing_def_unreachable'
@@ -101,7 +101,7 @@ entry:
   br exit
 
 unreachable_loop(%phiCycle : @guaranteed $C):
-  specify_test "find-enclosing-defs %phiCycle"
+  specify_test "find_enclosing_defs %phiCycle"
   specify_test "enclosing_values %phiCycle"
   br unreachable_loop(%phiCycle : $C)
 
@@ -113,11 +113,11 @@ exit:
 // All data flow paths through phis and aggregates originate from the
 // same borrow scope. This is the same as finding the introducer.
 
-// CHECK-LABEL: enclosing_def_single_introducer: find-enclosing-defs with: %aggregate2
+// CHECK-LABEL: enclosing_def_single_introducer: find_enclosing_defs with: %aggregate2
 // CHECK: sil [ossa] @enclosing_def_single_introducer
 // CHECK: Enclosing Defs:
 // CHECK:   begin_borrow %0 : $C
-// CHECK-NEXT: enclosing_def_single_introducer: find-enclosing-defs with: %aggregate2
+// CHECK-NEXT: enclosing_def_single_introducer: find_enclosing_defs with: %aggregate2
 
 // CHECK-LABEL: enclosing_def_single_introducer: enclosing_values with: %aggregate2
 // CHECK: sil [ossa] @enclosing_def_single_introducer
@@ -140,7 +140,7 @@ bb1(%payload : @guaranteed $D):
   %first = struct_extract %aggregate : $PairC, #PairC.first
   %second = struct_extract %aggregate : $PairC, #PairC.second
   %aggregate2 = struct $PairC(%first : $C, %second : $C)
-  specify_test "find-enclosing-defs %aggregate2"
+  specify_test "find_enclosing_defs %aggregate2"
   specify_test "enclosing_values %aggregate2"
   br exit
 
@@ -155,11 +155,11 @@ exit:
 
 // All reborrows original from the same dominating borrow scope.
 
-// CHECK: enclosing_def_single_outer: find-enclosing-defs with: %reborrow3
+// CHECK: enclosing_def_single_outer: find_enclosing_defs with: %reborrow3
 // CHECK: } // end sil function 'enclosing_def_single_outer'
 // CHECK: Enclosing Defs:
 // CHECK-NEXT: %0 = argument of bb0 : $C
-// CHECK-NEXT: enclosing_def_single_outer: find-enclosing-defs with: %reborrow3
+// CHECK-NEXT: enclosing_def_single_outer: find_enclosing_defs with: %reborrow3
 
 // CHECK: enclosing_def_single_outer: enclosing_values with: %reborrow3
 // CHECK: } // end sil function 'enclosing_def_single_outer'
@@ -176,7 +176,7 @@ bb2(%reborrow2 : @guaranteed $C):
   br bb3(%reborrow2 : $C)
 
 bb3(%reborrow3 : @guaranteed $C):
-  specify_test "find-enclosing-defs %reborrow3"
+  specify_test "find_enclosing_defs %reborrow3"
   specify_test "enclosing_values %reborrow3"
   end_borrow %reborrow3 : $C
   %retval = tuple ()
@@ -185,13 +185,13 @@ bb3(%reborrow3 : @guaranteed $C):
 
 // Find the outer enclosingreborrow.
 
-// CHECK-LABEL: enclosing_def_reborrow: find-enclosing-defs with: %reborrow_inner3
+// CHECK-LABEL: enclosing_def_reborrow: find_enclosing_defs with: %reborrow_inner3
 // CHECK: sil [ossa] @enclosing_def_reborrow : $@convention(thin) (@guaranteed C) -> () {
 // CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C, %{{.*}} : @reborrow @guaranteed $C):
 // CHECK: } // end sil function 'enclosing_def_reborrow'
 // CHECK: Enclosing Defs:
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
-// CHECK-NEXT: enclosing_def_reborrow: find-enclosing-defs with: %reborrow_inner3
+// CHECK-NEXT: enclosing_def_reborrow: find_enclosing_defs with: %reborrow_inner3
 
 // CHECK-LABEL: enclosing_def_reborrow: enclosing_values with: %reborrow_inner3
 // CHECK: sil [ossa] @enclosing_def_reborrow : $@convention(thin) (@guaranteed C) -> () {
@@ -210,7 +210,7 @@ bb2(%reborrow_outer : @guaranteed $C, %reborrow_inner : @guaranteed $C):
   br bb3(%reborrow_inner : $C)
 
 bb3(%reborrow_inner3 : @guaranteed $C):
-  specify_test "find-enclosing-defs %reborrow_inner3"
+  specify_test "find_enclosing_defs %reborrow_inner3"
   specify_test "enclosing_values %reborrow_inner3"
   end_borrow %reborrow_inner3 : $C
   end_borrow %reborrow_outer : $C
@@ -220,13 +220,13 @@ bb3(%reborrow_inner3 : @guaranteed $C):
 
 // The enclosing def of a forwarding phi cycle is the reborrow phi cycle.
 
-// CHECK-LABEL: enclosing_def_cycle: find-enclosing-defs with: %forward
+// CHECK-LABEL: enclosing_def_cycle: find_enclosing_defs with: %forward
 // CHECK: sil [ossa] @enclosing_def_cycle : $@convention(thin) (@guaranteed C) -> () {
 // CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C,
 // CHECK: } // end sil function 'enclosing_def_cycle'
 // CHECK: Enclosing Defs:
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
-// CHECK-NEXT: enclosing_def_cycle: find-enclosing-defs with: %forward
+// CHECK-NEXT: enclosing_def_cycle: find_enclosing_defs with: %forward
 
 // CHECK-LABEL: enclosing_def_cycle: enclosing_values with: %forward
 // CHECK: sil [ossa] @enclosing_def_cycle : $@convention(thin) (@guaranteed C) -> () {
@@ -243,7 +243,7 @@ entry(%0 : @guaranteed $C):
   br bb2(%borrow : $C, %first1 : $C)
 
 bb2(%reborrow_outer : @guaranteed $C, %forward : @guaranteed $C):
-  specify_test "find-enclosing-defs %forward"
+  specify_test "find_enclosing_defs %forward"
   specify_test "enclosing_values %forward"
   %aggregate2 = struct $PairC(%reborrow_outer : $C, %forward : $C)
   %first2 = struct_extract %aggregate2 : $PairC, #PairC.first

--- a/test/SILOptimizer/field_sensitive_liverange_unit.sil
+++ b/test/SILOptimizer/field_sensitive_liverange_unit.sil
@@ -9,7 +9,7 @@ sil @getC : $@convention(thin) () -> (@owned C)
 //
 // This live range is not dominated by the original borrow.
 //
-// CHECK-LABEL: testReborrow: fieldsensitive-multidefuse-liverange
+// CHECK-LABEL: testReborrow: fieldsensitive_multidefuse_liverange
 // CHECK: FieldSensitive MultiDef lifetime analysis:
 // CHECK:   def in range [0, 1) value:   [[B:%.*]] = load_borrow %0 : $*C
 // CHECK:   def in range [0, 1) value:   [[RB:%.*]] = borrowed {{.*}} from
@@ -23,7 +23,7 @@ sil @getC : $@convention(thin) () -> (@owned C)
 sil [ossa] @testReborrow : $@convention(thin) () -> () {
 bb0:
   specify_test """
-                     fieldsensitive-multidefuse-liverange
+                     fieldsensitive_multidefuse_liverange
                      @instruction
                      defs: 
                      @trace[0] 0 1
@@ -75,7 +75,7 @@ bb4:
 sil [ossa] @testMultiDefUseAddressReinit : $@convention(thin) (@owned C) -> () {
 bb0(%0: @owned $C):
   specify_test """
-                     fieldsensitive-multidefuse-liverange
+                     fieldsensitive_multidefuse_liverange
                      @instruction
                      defs: 
                      @instruction[+2] 0 1
@@ -110,7 +110,7 @@ bb3:
 // boundary. Once as a last use, and once as a dead def.
 // This is a particularly problematic corner case.
 //
-// CHECK-LABEL: testDeadSelfKill: fieldsensitive-multidefuse-liverange
+// CHECK-LABEL: testDeadSelfKill: fieldsensitive_multidefuse_liverange
 // CHECK: FieldSensitive MultiDef lifetime analysis:
 // CHECK: def in range [0, 1) instruction: store {{%[^,]+}} to [init] [[STACK:%[^,]+]] :
 // CHECK: def in range [0, 1) instruction: store {{%[^,]+}} to [assign] [[STACK]]
@@ -123,7 +123,7 @@ bb0:
 
 bb1(%1 : @owned $C, %2 : @owned $C):
   specify_test """
-                     fieldsensitive-multidefuse-liverange
+                     fieldsensitive_multidefuse_liverange
                      @instruction
                      defs: 
                      @instruction[+1] 0 1
@@ -144,7 +144,7 @@ bb3:
 // A dead-end block with a def can still be a boundary edge. This can
 // only happen in OSSA with incomplete lifetimes.
 //
-// CHECK-LABEL: testMultiDefDeadDefBoundaryEdge: fieldsensitive-multidefuse-liverange
+// CHECK-LABEL: testMultiDefDeadDefBoundaryEdge: fieldsensitive_multidefuse_liverange
 // CHECK: FieldSensitive MultiDef lifetime analysis:
 // CHECK:   def in range [0, 1) instruction: store {{%[^,]+}} to [init] [[STACK:%[^,]+]] :
 // CHECK:   def in range [0, 1) instruction: store {{%[^,]+}} to [assign] [[STACK]]
@@ -164,7 +164,7 @@ bb0:
   %c = apply %getC() : $@convention(thin) () -> (@owned C)
   store %c to [init] %stack : $*C
   specify_test """
-                     fieldsensitive-multidefuse-liverange
+                     fieldsensitive_multidefuse_liverange
                      @instruction[-3]
                      defs: 
                      @instruction[-1] 0 1

--- a/test/SILOptimizer/instruction_deleter.sil
+++ b/test/SILOptimizer/instruction_deleter.sil
@@ -27,7 +27,7 @@ sil [ossa] @dontDeleteDeadMoveOnlyValue : $() -> () {
   %get = function_ref @getMOS : $@convention(thin) () -> (@owned MOS)
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   %mos = apply %get() : $@convention(thin) () -> (@owned MOS)
-  specify_test "deleter-delete-if-dead @instruction"
+  specify_test "deleter_delete_if_dead @instruction"
   %mov = move_value %mos : $MOS
   apply %barrier() : $@convention(thin) () -> ()
   destroy_value %mov : $MOS
@@ -50,7 +50,7 @@ sil [ossa] @doDeleteLoadTake : $() -> () {
   %stack = alloc_stack $C
   %get = function_ref @get : $@convention(thin) <T> () -> (@out T)
   apply %get<C>(%stack) : $@convention(thin) <T> () -> (@out T)
-  specify_test "deleter-delete-if-dead @instruction"
+  specify_test "deleter_delete_if_dead @instruction"
   %c = load [take] %stack : $*C
   destroy_value %c : $C
   dealloc_stack %stack : $*C

--- a/test/SILOptimizer/lexical_destroy_folding_unit.sil
+++ b/test/SILOptimizer/lexical_destroy_folding_unit.sil
@@ -24,7 +24,7 @@ sil [ossa] @callee_owned : $@convention(thin) (@owned C) -> ()
 // CHECK-LABEL: } // end sil function 'nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use'
 sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):
-  specify_test "lexical-destroy-folding @trace[0]"
+  specify_test "lexical_destroy_folding @trace[0]"
   %copy_2 = copy_value %instance : $C
   %lifetime = begin_borrow [lexical] %instance : $C
   debug_value [trace] %lifetime : $C

--- a/test/SILOptimizer/lexical_unit.sil
+++ b/test/SILOptimizer/lexical_unit.sil
@@ -8,10 +8,10 @@ class C {}
 
 sil [ossa] @getC : $@convention(thin) () -> (@owned C)
 
-// CHECK-LABEL: begin running test 1 of 1 on phi_direct_no_lexical: is-lexical
+// CHECK-LABEL: begin running test 1 of 1 on phi_direct_no_lexical: is_lexical
 // CHECK: argument of bb3
 // CHECK: false
-// CHECK-LABEL: end running test 1 of 1 on phi_direct_no_lexical: is-lexical
+// CHECK-LABEL: end running test 1 of 1 on phi_direct_no_lexical: is_lexical
 sil [ossa] @phi_direct_no_lexical : $() -> () {
 entry:
   %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
@@ -23,16 +23,16 @@ right:
   %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
   br exit(%c2 : $C)
 exit(%cm : @owned $C):
-  specify_test "is-lexical @block.argument"
+  specify_test "is_lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on phi_direct_first_lexical: is-lexical
+// CHECK-LABEL: begin running test 1 of 1 on phi_direct_first_lexical: is_lexical
 // CHECK: argument of bb3
 // CHECK: true
-// CHECK-LABEL: end running test 1 of 1 on phi_direct_first_lexical: is-lexical
+// CHECK-LABEL: end running test 1 of 1 on phi_direct_first_lexical: is_lexical
 sil [ossa] @phi_direct_first_lexical : $() -> () {
 entry:
   %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
@@ -45,16 +45,16 @@ right:
   %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
   br exit(%c2 : $C)
 exit(%cm : @owned $C):
-  specify_test "is-lexical @block.argument"
+  specify_test "is_lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on phi_direct_second_lexical: is-lexical
+// CHECK-LABEL: begin running test 1 of 1 on phi_direct_second_lexical: is_lexical
 // CHECK: argument of bb3
 // CHECK: true
-// CHECK-LABEL: end running test 1 of 1 on phi_direct_second_lexical: is-lexical
+// CHECK-LABEL: end running test 1 of 1 on phi_direct_second_lexical: is_lexical
 sil [ossa] @phi_direct_second_lexical : $() -> () {
 entry:
   %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
@@ -67,16 +67,16 @@ right:
   %m2 = move_value [lexical] %c2 : $C
   br exit(%m2 : $C)
 exit(%cm : @owned $C):
-  specify_test "is-lexical @block.argument"
+  specify_test "is_lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on phi_direct_both_lexical: is-lexical
+// CHECK-LABEL: begin running test 1 of 1 on phi_direct_both_lexical: is_lexical
 // CHECK: argument of bb3
 // CHECK: true
-// CHECK-LABEL: end running test 1 of 1 on phi_direct_both_lexical: is-lexical
+// CHECK-LABEL: end running test 1 of 1 on phi_direct_both_lexical: is_lexical
 sil [ossa] @phi_direct_both_lexical : $() -> () {
 entry:
   %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
@@ -90,16 +90,16 @@ right:
   %m2 = move_value [lexical] %c2 : $C
   br exit(%m2 : $C)
 exit(%cm : @owned $C):
-  specify_test "is-lexical @block.argument"
+  specify_test "is_lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0000_lexical: is-lexical
+// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0000_lexical: is_lexical
 // CHECK: argument of bb9
 // CHECK: false
-// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0000_lexical: is-lexical
+// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0000_lexical: is_lexical
 sil [ossa] @phi_indirect_0000_lexical : $() -> () {
 entry:
   %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
@@ -128,16 +128,16 @@ rb(%cr : @owned $C):
   br exit(%cr : $C)
 
 exit(%cm : @owned $C):
-  specify_test "is-lexical @block.argument"
+  specify_test "is_lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_1000_lexical: is-lexical
+// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_1000_lexical: is_lexical
 // CHECK: argument of bb9
 // CHECK: true
-// CHECK-LABEL: end running test 1 of 1 on phi_indirect_1000_lexical: is-lexical
+// CHECK-LABEL: end running test 1 of 1 on phi_indirect_1000_lexical: is_lexical
 sil [ossa] @phi_indirect_1000_lexical : $() -> () {
 entry:
   %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
@@ -167,16 +167,16 @@ rb(%cr : @owned $C):
   br exit(%cr : $C)
 
 exit(%cm : @owned $C):
-  specify_test "is-lexical @block.argument"
+  specify_test "is_lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0100_lexical: is-lexical
+// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0100_lexical: is_lexical
 // CHECK: argument of bb9
 // CHECK: true
-// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0100_lexical: is-lexical
+// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0100_lexical: is_lexical
 sil [ossa] @phi_indirect_0100_lexical : $() -> () {
 entry:
   %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
@@ -206,16 +206,16 @@ rb(%cr : @owned $C):
   br exit(%cr : $C)
 
 exit(%cm : @owned $C):
-  specify_test "is-lexical @block.argument"
+  specify_test "is_lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0010_lexical: is-lexical
+// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0010_lexical: is_lexical
 // CHECK: argument of bb9
 // CHECK: true
-// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0010_lexical: is-lexical
+// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0010_lexical: is_lexical
 sil [ossa] @phi_indirect_0010_lexical : $() -> () {
 entry:
   %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
@@ -245,16 +245,16 @@ rb(%cr : @owned $C):
   br exit(%cr : $C)
 
 exit(%cm : @owned $C):
-  specify_test "is-lexical @block.argument"
+  specify_test "is_lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0001_lexical: is-lexical
+// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0001_lexical: is_lexical
 // CHECK: argument of bb9
 // CHECK: true
-// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0001_lexical: is-lexical
+// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0001_lexical: is_lexical
 sil [ossa] @phi_indirect_0001_lexical : $() -> () {
 entry:
   %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
@@ -284,7 +284,7 @@ rb(%cr : @owned $C):
   br exit(%cr : $C)
 
 exit(%cm : @owned $C):
-  specify_test "is-lexical @block.argument"
+  specify_test "is_lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()

--- a/test/SILOptimizer/liveness_incomplete_unit.sil
+++ b/test/SILOptimizer/liveness_incomplete_unit.sil
@@ -106,7 +106,7 @@ sil @genericReturn : $@convention(thin) <τ_0_0> (@guaranteed C) -> @out τ_0_0
 // incomplete. Since the store_borrow produces an address, the load
 // borrow is considered a ScopedAddressUse, and all of its uses,
 // including the Apply will contribute to the store_borrow liveness.
-// CHECK-LABEL: testInnerUnreachable: scoped-address-liveness
+// CHECK-LABEL: testInnerUnreachable: scoped_address_liveness
 // CHECK: Scoped address analysis: [[SB:%.*]] = store_borrow %0
 // CHECK: bb0: LiveWithin
 // CHECK-NEXT: regular user: %{{.*}} = apply
@@ -115,7 +115,7 @@ sil shared [ossa] @testInnerUnreachable : $@convention(thin) (@guaranteed C, @th
 bb0(%0 : @guaranteed $C, %1 : $@thick Never.Type):
   %2 = alloc_stack $C
   %3 = store_borrow %0 to %2 : $*C
-  specify_test "scoped-address-liveness @trace[0]"
+  specify_test "scoped_address_liveness @trace[0]"
   debug_value [trace] %3 : $*C
   %5 = load_borrow %3 : $*C
   %6 = function_ref @genericReturn : $@convention(thin) <τ_0_0> (@guaranteed C) -> @out τ_0_0

--- a/test/SILOptimizer/ownership-utils-unit.sil
+++ b/test/SILOptimizer/ownership-utils-unit.sil
@@ -38,11 +38,11 @@ right:
   %rinstance = apply %getOwned() : $@convention(thin) () -> (@owned C)
   br exit(%rinstance : $C)
 exit(%instance : @owned $C):
-// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_escape_of_phi_transitive_incoming_value: has-pointer-escape
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_escape_of_phi_transitive_incoming_value: has_pointer_escape
 // CHECK:       %14 = argument of bb6 : $C
 // CHECK:       true
-// CHECK-LABEL: end running test {{[0-9]+}} of {{[0-9]+}} on test_escape_of_phi_transitive_incoming_value: has-pointer-escape with
-  specify_test "has-pointer-escape @block.argument"
+// CHECK-LABEL: end running test {{[0-9]+}} of {{[0-9]+}} on test_escape_of_phi_transitive_incoming_value: has_pointer_escape with
+  specify_test "has_pointer_escape @block.argument"
   destroy_value %instance : $C
   %retval = tuple ()
   return %retval : $()
@@ -54,7 +54,7 @@ entry:
   br loop_entry(%instance_1 : $FakeOptional<C>)
 
 loop_entry(%18 : @owned $FakeOptional<C>):
-  specify_test "has-pointer-escape @block.argument"
+  specify_test "has_pointer_escape @block.argument"
   br loop_body
 
 loop_body:

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -37,7 +37,7 @@ sil @getC : $@convention(thin) () -> @owned C
 // LinearLiveness
 // =============================================================================
 
-// CHECK-LABEL: testLinearRefElementEscape: linear-liveness with: %borrow
+// CHECK-LABEL: testLinearRefElementEscape: linear_liveness with: %borrow
 // CHECK-LABEL: Linear liveness:
 // CHECK: lifetime-ending user:
 // CHECK-SAME: end_borrow
@@ -56,7 +56,7 @@ sil @getC : $@convention(thin) () -> @owned C
 sil [ossa] @testLinearRefElementEscape : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %borrow = begin_borrow %0 : $C
-  specify_test "linear-liveness %borrow"
+  specify_test "linear_liveness %borrow"
   specify_test "linear_liveness_swift %borrow"
   cond_br undef, bb1, bb2
 
@@ -78,7 +78,7 @@ bb3(%phi : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: testLinearBitwiseEscape: linear-liveness with: %borrow
+// CHECK-LABEL: testLinearBitwiseEscape: linear_liveness with: %borrow
 // CHECK: Linear liveness:
 // CHECK: lifetime-ending user:
 // CHECK-SAME: end_borrow
@@ -97,7 +97,7 @@ bb3(%phi : @guaranteed $D):
 sil [ossa] @testLinearBitwiseEscape : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %borrow = begin_borrow %0 : $C
-  specify_test "linear-liveness %borrow"
+  specify_test "linear_liveness %borrow"
   specify_test "linear_liveness_swift %borrow"
   cond_br undef, bb1, bb2
 
@@ -115,7 +115,7 @@ bb3(%phi : @unowned $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: testLinearInnerReborrow: linear-liveness with: @argument[0]
+// CHECK-LABEL: testLinearInnerReborrow: linear_liveness with: @argument[0]
 // CHECK: Linear liveness:
 // CHECK: lifetime-ending user:
 // CHECK-SAME: destroy_value %0
@@ -133,7 +133,7 @@ bb3(%phi : @unowned $D):
 // CHECK-NEXT: testLinearInnerReborrow
 sil [ossa] @testLinearInnerReborrow : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
-  specify_test "linear-liveness @argument[0]"
+  specify_test "linear_liveness @argument[0]"
   specify_test "linear_liveness_swift @argument[0]"
   cond_br undef, bb1, bb2
 
@@ -152,7 +152,7 @@ bb3(%phi : @guaranteed $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: testLinearAdjacentReborrow: linear-liveness with: %borrow
+// CHECK-LABEL: testLinearAdjacentReborrow: linear_liveness with: %borrow
 // CHECK: lifetime-ending user:
 // CHECK-SAME: br bb3
 // CHECK-NEXT: lifetime-ending user: br bb3
@@ -172,7 +172,7 @@ bb3(%phi : @guaranteed $C):
 // CHECK-NEXT: testLinearAdjacentReborrow
 sil [ossa] @testLinearAdjacentReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  specify_test "linear-liveness %borrow"
+  specify_test "linear_liveness %borrow"
   specify_test "linear_liveness_swift %borrow"
   %borrow = begin_borrow %0 : $C
   cond_br undef, bb1, bb2
@@ -192,7 +192,7 @@ bb3(%outer : @guaranteed $C, %inner : @guaranteed $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test {{.*}} on testLoopConditional_incomplete_linear: linear-liveness
+// CHECK-LABEL: begin running test {{.*}} on testLoopConditional_incomplete_linear: linear_liveness
 // CHECK-LABEL: sil [ossa] @testLoopConditional_incomplete_linear : {{.*}} {
 // CHECK:       [[ENTRY:bb[0-9]+]]([[C:%[^,]+]] :
 // CHECK:         cond_br undef, [[HEADER:bb[0-9]+]], [[EXIT:bb[0-9]+]]
@@ -211,7 +211,7 @@ bb3(%outer : @guaranteed $C, %inner : @guaranteed $C):
 // CHECK:       lifetime-ending user:   destroy_value [[C]]
 // CHECK:       last user:   destroy_value [[C]]
 // CHECK:       boundary edge: [[HEADER]]
-// CHECK-LABEL: end running test {{.*}} on testLoopConditional_incomplete_linear: linear-liveness
+// CHECK-LABEL: end running test {{.*}} on testLoopConditional_incomplete_linear: linear_liveness
 // CHECK-LABEL: begin running test {{.*}} on testLoopConditional_incomplete_linear: linear_liveness_swift
 // CHECK:       Linear liveness: [[C]]
 // CHECK:       Live blocks:
@@ -225,7 +225,7 @@ bb3(%outer : @guaranteed $C, %inner : @guaranteed $C):
 // CHECK-LABEL: end running test {{.*}} on testLoopConditional_incomplete_linear: linear_liveness_swift
 sil [ossa] @testLoopConditional_incomplete_linear : $@convention(thin) (@owned C) -> () {
 entry(%c : @owned $C):
-  specify_test "linear-liveness %c"
+  specify_test "linear_liveness %c"
   specify_test "linear_liveness_swift %c"
   cond_br undef, header, exit
 
@@ -243,7 +243,7 @@ exit:
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test {{.*}} on testLoopConditional_complete_linear: linear-liveness
+// CHECK-LABEL: begin running test {{.*}} on testLoopConditional_complete_linear: linear_liveness
 // CHECK-LABEL: sil [ossa] @testLoopConditional_complete_linear : {{.*}} {
 // CHECK:       [[ENTRY:bb[0-9]+]]([[C:%[^,]+]] :
 // CHECK:         cond_br undef, [[HEADER:bb[0-9]+]], [[EXIT:bb[0-9]+]]
@@ -265,7 +265,7 @@ exit:
 // CHECK:       lifetime-ending user:   destroy_value [[C]]
 // CHECK:       regular user:   extend_lifetime [[C]]
 // CHECK:       last user:   destroy_value [[C]]
-// CHECK-LABEL: end running test {{.*}} on testLoopConditional_complete_linear: linear-liveness
+// CHECK-LABEL: end running test {{.*}} on testLoopConditional_complete_linear: linear_liveness
 // CHECK-LABEL: begin running test {{.*}} on testLoopConditional_complete_linear: linear_liveness_swift
 // CHECK:       Linear liveness: [[C]]
 // CHECK:       Live blocks:
@@ -276,7 +276,7 @@ exit:
 // CHECK-LABEL: end running test {{.*}} on testLoopConditional_complete_linear: linear_liveness_swift
 sil [ossa] @testLoopConditional_complete_linear : $@convention(thin) (@owned C) -> () {
 entry(%c : @owned $C):
-  specify_test "linear-liveness %c"
+  specify_test "linear_liveness %c"
   specify_test "linear_liveness_swift %c"
   cond_br undef, header, exit
 

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -299,7 +299,7 @@ exit:
 // visitInnerAdjacentPhis
 // =============================================================================
 
-// CHECK-LABEL: pay_the_phi: visit-inner-adjacent-phis with: %owned
+// CHECK-LABEL: pay_the_phi: visit_inner_adjacent_phis with: %owned
 // CHECK: sil [ossa] @pay_the_phi : {{.*}} {
 // CHECK:   [[C:%[^,]+]] = apply
 // CHECK:   [[BORROW1:%[^,]+]] = begin_borrow %1
@@ -310,7 +310,7 @@ exit:
 //
 // CHECK:[[GUARANTEED1]] = argument of [[EXIT]]
 // CHECK:[[GUARANTEED2]] = argument of [[EXIT]]
-// CHECK-LABEL: pay_the_phi: visit-inner-adjacent-phis with: %owned
+// CHECK-LABEL: pay_the_phi: visit_inner_adjacent_phis with: %owned
 sil [ossa] @pay_the_phi : $@convention(thin) () -> () {
 entry:
   %getC = function_ref @getC : $@convention(thin) () -> @owned C
@@ -321,7 +321,7 @@ entry:
   br exit(%c : $C, %borrow1 : $C, %borrow2 : $C, %borrow3 : $C)
 
 exit(%owned : @owned $C, %guaranteed_1 : @guaranteed $C, %guaranteed_2 : @guaranteed $C, %guaranteed_3 : @guaranteed $C):
-  specify_test "visit-inner-adjacent-phis %owned"
+  specify_test "visit_inner_adjacent_phis %owned"
   end_borrow %guaranteed_3 : $C
   end_borrow %guaranteed_2 : $C
   end_borrow %guaranteed_1 : $C
@@ -330,11 +330,11 @@ exit(%owned : @owned $C, %guaranteed_1 : @guaranteed $C, %guaranteed_2 : @guaran
   return %retval : $()
 }
 
-// CHECK-LABEL: pay_the_phi_forward: visit-inner-adjacent-phis with: %reborrow
+// CHECK-LABEL: pay_the_phi_forward: visit_inner_adjacent_phis with: %reborrow
 // CHECK: bb1(%{{.*}} : @reborrow @guaranteed $C, [[INNER:%.*]] : @guaranteed $D):    // Preds: bb0
 // CHECK: } // end sil function 'pay_the_phi_forward'
 // CHECK: [[INNER]] = argument of bb1 : $D
-// CHECK: pay_the_phi_forward: visit-inner-adjacent-phis with: %reborrow
+// CHECK: pay_the_phi_forward: visit_inner_adjacent_phis with: %reborrow
 sil [ossa] @pay_the_phi_forward : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %borrow0 = begin_borrow %0 : $C
@@ -342,7 +342,7 @@ bb0(%0 : @guaranteed $C):
   br exit(%borrow0 : $C, %d0 : $D)
 
 exit(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
-  specify_test "visit-inner-adjacent-phis %reborrow"
+  specify_test "visit_inner_adjacent_phis %reborrow"
   %f = ref_element_addr %phi : $D, #D.object
   %o = load [copy] %f : $*C
   destroy_value %o : $C

--- a/test/SILOptimizer/pruned_liveness_boundary.sil
+++ b/test/SILOptimizer/pruned_liveness_boundary.sil
@@ -1,15 +1,15 @@
 // RUN: %target-sil-opt -test-runner %s 2>&1 | %FileCheck %s
 
-// CHECK: begin running test 1 of {{[^,]+}} on last_uses_merge_points: dump-function
+// CHECK: begin running test 1 of {{[^,]+}} on last_uses_merge_points: dump_function
 // CHECK: [[REGISTER_3:%[^,]+]] = tuple ()
 // CHECK: return [[REGISTER_3]]
-// CHECK: end running test 1 of {{[^,]+}} on last_uses_merge_points: dump-function
+// CHECK: end running test 1 of {{[^,]+}} on last_uses_merge_points: dump_function
 // CHECK: begin running test 2 of {{[^,]+}} on last_uses_merge_points: pruned_liveness_boundary_with_list_of_last_users_insertion_points
 // CHECK: [[REGISTER_3]] = tuple ()
 // CHECK: end running test 2 of {{[^,]+}} on last_uses_merge_points: pruned_liveness_boundary_with_list_of_last_users_insertion_points
 sil [ossa] @last_uses_merge_points : $@convention(thin) () -> () {
 entry:
-  specify_test "dump-function"
+  specify_test "dump_function"
   specify_test "pruned_liveness_boundary_with_list_of_last_users_insertion_points @block[1].instruction[0] @block[2].instruction[0]"
   cond_br undef, left, right
 left:

--- a/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
@@ -22,7 +22,7 @@ sil @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
 // CHECK-LABEL: } // end sil function 'test_simplify_args1'
 sil [ossa] @test_simplify_args1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-block-args"
+  specify_test "simplify_cfg_simplify_block_args"
   %1 = begin_borrow %0 : $Klass
   br bb1(%1 : $Klass)
 
@@ -41,7 +41,7 @@ bb2(%5 : @guaranteed $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_args2'
 sil [ossa] @test_simplify_args2 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-block-args"
+  specify_test "simplify_cfg_simplify_block_args"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -65,7 +65,7 @@ bb3(%4 : @guaranteed $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_args3'
 sil [ossa] @test_simplify_args3 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-block-args"
+  specify_test "simplify_cfg_simplify_block_args"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -87,7 +87,7 @@ bb3(%4 : @owned $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_args4'
 sil [ossa] @test_simplify_args4 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-block-args"
+  specify_test "simplify_cfg_simplify_block_args"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -109,7 +109,7 @@ bb3(%4 : @owned $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_args5'
 sil [ossa] @test_simplify_args5 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-block-args"
+  specify_test "simplify_cfg_simplify_block_args"
   %2 = begin_borrow %0 : $Klass
   cond_br undef, bb1, bb2
 
@@ -132,7 +132,7 @@ bb3(%4 : @guaranteed $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_args6'
 sil [ossa] @test_simplify_args6 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-block-args"
+  specify_test "simplify_cfg_simplify_block_args"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb1(%1 : $FakeOptional<Klass>)
 
@@ -156,7 +156,7 @@ bb4:
 // CHECK-LABEL: } // end sil function 'test_simplify_args7'
 sil [ossa] @test_simplify_args7 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-block-args"
+  specify_test "simplify_cfg_simplify_block_args"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb1(%1 : $FakeOptional<Klass>)
 

--- a/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
@@ -180,7 +180,7 @@ bb4:
 // CHECK-LABEL: } // end sil function 'test_simplify_args8'
 sil [ossa] @test_simplify_args8 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  specify_test "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify_cfg_simplify_argument @block[1] 0"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb1(%1 : $FakeOptional<Klass>)
 
@@ -200,7 +200,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_args9'
 sil [ossa] @test_simplify_args9 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify_cfg_simplify_argument @block[1] 0"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb1(%1 : $FakeOptional<Klass>)
 
@@ -223,7 +223,7 @@ bb3:
 // CHECK: return
 sil [ossa] @test_dont_remove_mandatory_dead_args : $@convention(thin) (@guaranteed AnyKlass) -> () {
 bb0(%0 : @guaranteed $AnyKlass):
-  specify_test "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify_cfg_simplify_argument @block[1] 0"
   checked_cast_br AnyKlass in %0 : $AnyKlass to Klass, bb1, bb2
 
 bb1(%1 : @guaranteed $Klass):
@@ -244,7 +244,7 @@ bb3(%4 : $Builtin.Int32):
 // CHECK-LABEL: } // end sil function 'test_simplify_enum_arg_owned'
 sil [ossa] @test_simplify_enum_arg_owned : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify_cfg_simplify_argument @block[1] 0"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   %c = copy_value %1 : $FakeOptional<Klass>
   br bb1(%1 : $FakeOptional<Klass>)
@@ -270,7 +270,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_enum_arg_guaranteed1'
 sil [ossa] @test_simplify_enum_arg_guaranteed1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify_cfg_simplify_argument @block[1] 0"
   %b = begin_borrow %0 : $Klass
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %b : $Klass
   %c = copy_value %1 : $FakeOptional<Klass>
@@ -293,7 +293,7 @@ bb2:
 // CHECK: bb1([[ARG:%.*]] : @guaranteed $NonTrivialStruct)
 sil [ossa] @test_simplify_enum_arg_guaranteed2 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify_cfg_simplify_argument @block[1] 0"
   %b = begin_borrow %0 : $Klass
   %1 = struct $NonTrivialStruct(%b : $Klass) 
   %c = copy_value %1 : $NonTrivialStruct

--- a/test/SILOptimizer/simplify_cfg_ossa_jump_threading.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_jump_threading.sil
@@ -23,7 +23,7 @@ sil @get_klass : $@convention(thin) () -> @owned Klass
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_jump_threading1'
 sil [ossa] @test_simplify_switch_enum_jump_threading1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-try-jump-threading @instruction[1]"
+  specify_test "simplify_cfg_try_jump_threading @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb1(%1 : $FakeOptional<Klass>)
 
@@ -51,12 +51,12 @@ bb0(%0 : @owned $Klass):
   cond_br undef, bb1, bb2
 
 bb1:
-  specify_test "simplify-cfg-try-jump-threading @instruction[2]"
+  specify_test "simplify_cfg_try_jump_threading @instruction[2]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb3(%1 : $FakeOptional<Klass>)
 
 bb2:
-  specify_test "simplify-cfg-try-jump-threading @instruction[5]"
+  specify_test "simplify_cfg_try_jump_threading @instruction[5]"
   destroy_value %0 : $Klass
   %2 = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt
   br bb3(%2 : $FakeOptional<Klass>)
@@ -87,7 +87,7 @@ bb0(%0 : @owned $Klass):
   cond_br undef, bb1, bb2
 
 bb1:
-  specify_test "simplify-cfg-try-jump-threading @instruction[4]"
+  specify_test "simplify_cfg_try_jump_threading @instruction[4]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb3(%1 : $FakeOptional<Klass>)
 
@@ -111,7 +111,7 @@ bb4:
 // CHECK-LABEL: } // end sil function 'test_jump_thread_ref_ele_loop'
 sil [ossa] @test_jump_thread_ref_ele_loop : $@convention(thin) () -> () {
 bb0:
-  specify_test "simplify-cfg-try-jump-threading @instruction[3]"
+  specify_test "simplify_cfg_try_jump_threading @instruction[3]"
   %f = function_ref @get_klass : $@convention(thin) () -> @owned Klass
   cond_br undef, bb1, bb2
 
@@ -153,7 +153,7 @@ bb0(%0 : @owned $AnyKlass, %1 : @owned $AnyKlass):
   cond_br undef, bb1, bb2
 
 bb1:
-  specify_test "simplify-cfg-try-jump-threading @instruction[2]"
+  specify_test "simplify_cfg_try_jump_threading @instruction[2]"
   %2 = copy_value %0 : $AnyKlass
   br bb6(%2 : $AnyKlass)
 
@@ -204,7 +204,7 @@ bb0(%0 : @owned $Klass, %1 : $*Klass):
   cond_br undef, bb1, bb2
 
 bb1:
-  specify_test "simplify-cfg-try-jump-threading @instruction[4]"
+  specify_test "simplify_cfg_try_jump_threading @instruction[4]"
   %2 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb3(%2 : $FakeOptional<Klass>)
 
@@ -247,7 +247,7 @@ bb0(%0 : @owned $Klass, %1 : $Builtin.RawPointer):
   cond_br undef, bb1, bb2
 
 bb1:
-  specify_test "simplify-cfg-try-jump-threading @instruction[2]"
+  specify_test "simplify_cfg_try_jump_threading @instruction[2]"
   %s = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb3(%s : $FakeOptional<Klass>)
 

--- a/test/SILOptimizer/simplify_cfg_ossa_simplify_branch.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_simplify_branch.sil
@@ -58,7 +58,7 @@ enum E1<T> {
 // CHECK-LABEL: } // end sil function 'test_simplify_term_with_identical_dest_blocks1'
 sil [ossa] @test_simplify_term_with_identical_dest_blocks1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-term-with-identical-dest-blocks @block[0]"
+  specify_test "simplify_cfg_simplify_term_with_identical_dest_blocks @block[0]"
   %1 = begin_borrow %0 : $Klass
   br bb1(%1 : $Klass)
 
@@ -79,7 +79,7 @@ bb2(%5 : @guaranteed $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_term_with_identical_dest_blocks2'
 sil [ossa] @test_simplify_term_with_identical_dest_blocks2 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-term-with-identical-dest-blocks @block[0]"
+  specify_test "simplify_cfg_simplify_term_with_identical_dest_blocks @block[0]"
   br bb1(%0 : $Klass)
 
 bb1(%3 : @owned $Klass):

--- a/test/SILOptimizer/simplify_cfg_ossa_switch_enum.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_switch_enum.sil
@@ -231,7 +231,7 @@ bb6:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable1'
 sil [ossa] @test_simplify_switch_enum_unreachable1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
+  specify_test "simplify_cfg_simplify_switch_enum_unreachable_blocks @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -252,7 +252,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable2'
 sil [ossa] @test_simplify_switch_enum_unreachable2 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
+  specify_test "simplify_cfg_simplify_switch_enum_unreachable_blocks @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -275,7 +275,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable3'
 sil [ossa] @test_simplify_switch_enum_unreachable3 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
+  specify_test "simplify_cfg_simplify_switch_enum_unreachable_blocks @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -296,7 +296,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable4'
 sil [ossa] @test_simplify_switch_enum_unreachable4 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
+  specify_test "simplify_cfg_simplify_switch_enum_unreachable_blocks @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -316,7 +316,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable5'
 sil [ossa] @test_simplify_switch_enum_unreachable5 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[2]"
+  specify_test "simplify_cfg_simplify_switch_enum_unreachable_blocks @instruction[2]"
   %b = begin_borrow %0 : $Klass
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %b : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
@@ -339,7 +339,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable6'
 sil [ossa] @test_simplify_switch_enum_unreachable6 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
+  specify_test "simplify_cfg_simplify_switch_enum_unreachable_blocks @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -359,7 +359,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable7'
 sil [ossa] @test_simplify_switch_enum_unreachable7 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[2]"
+  specify_test "simplify_cfg_simplify_switch_enum_unreachable_blocks @instruction[2]"
   %b = begin_borrow %0 : $Klass
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %b : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2

--- a/test/SILOptimizer/simplify_cfg_ossa_switch_enum.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_switch_enum.sil
@@ -87,7 +87,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum1'
 sil [ossa] @test_simplify_switch_enum1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[1]"
+  specify_test "simplify_cfg_simplify_switch_enum_block @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -108,7 +108,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum2'
 sil [ossa] @test_simplify_switch_enum2 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[1]"
+  specify_test "simplify_cfg_simplify_switch_enum_block @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -128,7 +128,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum3'
 sil [ossa] @test_simplify_switch_enum3 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[2]"
+  specify_test "simplify_cfg_simplify_switch_enum_block @instruction[2]"
   %b = begin_borrow %0 : $Klass
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %b : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
@@ -153,7 +153,7 @@ sil @use_optional : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum4'
 sil [ossa] @test_simplify_switch_enum4 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[3]"
+  specify_test "simplify_cfg_simplify_switch_enum_block @instruction[3]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   %f = function_ref @use_optional : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
   %c = apply %f(%1) : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
@@ -175,7 +175,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum5'
 sil [ossa] @test_simplify_switch_enum5 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[4]"
+  specify_test "simplify_cfg_simplify_switch_enum_block @instruction[4]"
   %b = begin_borrow %0 : $Klass
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %b : $Klass
   %f = function_ref @use_optional : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
@@ -211,7 +211,7 @@ bb2:
   br bb3(%4 : $FakeOptional<Klass>)
 
 bb3(%6 :@owned  $FakeOptional<Klass>):
-  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[5]"
+  specify_test "simplify_cfg_simplify_switch_enum_block @instruction[5]"
   switch_enum %6 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb4, case #FakeOptional.none!enumelt: bb5
 
 bb4(%8 : @owned $Klass):

--- a/test/SILOptimizer/simplify_cfg_ossa_switch_enum.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_switch_enum.sil
@@ -25,7 +25,7 @@ enum E2 {
 // CHECK-LABEL: } // end sil function 'test_canonicalize_switch_enum1'
 sil [ossa] @test_canonicalize_switch_enum1 : $@convention(thin) (@owned FakeOptional<Klass>) -> () {
 bb0(%0 : @owned $FakeOptional<Klass>):
-  specify_test "simplify-cfg-canonicalize-switch-enum"
+  specify_test "simplify_cfg_canonicalize_switch_enum"
   switch_enum %0 : $FakeOptional<Klass>, case #FakeOptional.none!enumelt: bb1, default bb2
 
 bb1:
@@ -45,7 +45,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_canonicalize_switch_enum2'
 sil [ossa] @test_canonicalize_switch_enum2 : $@convention(thin) (@owned E1) -> () {
 bb0(%0 : @owned $E1):
-  specify_test "simplify-cfg-canonicalize-switch-enum"
+  specify_test "simplify_cfg_canonicalize_switch_enum"
   switch_enum %0 : $E1, case #E1.A!enumelt: bb1, default bb2
 
 bb1(%2 : @owned $Klass):
@@ -66,7 +66,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_canonicalize_switch_enum3'
 sil [ossa] @test_canonicalize_switch_enum3 : $@convention(thin) (@owned E2) -> () {
 bb0(%0 : @owned $E2):
-  specify_test "simplify-cfg-canonicalize-switch-enum"
+  specify_test "simplify_cfg_canonicalize_switch_enum"
   switch_enum %0 : $E2, case #E2.A!enumelt: bb1, default bb2
 
 bb1(%2 : @owned $Klass):

--- a/test/SILOptimizer/simplify_switch_enum_objc_ossa.sil
+++ b/test/SILOptimizer/simplify_switch_enum_objc_ossa.sil
@@ -13,7 +13,7 @@ class Test : NSObject {
 // CHECK-LABEL: } // end sil function 'test_switch_enum_objc_call1'
 sil [ossa] @test_switch_enum_objc_call1 : $@convention(thin) (@guaranteed Optional<Test>) -> () {
 bb0(%0 : @guaranteed $Optional<Test>):
-  specify_test "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
+  specify_test "simplify_cfg_simplify_switch_enum_on_objc_class_optional @instruction[1]"
   %3 = copy_value %0 : $Optional<Test>
   switch_enum %3 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
 
@@ -39,7 +39,7 @@ sil @some_sideeffect : $@convention(thin) () -> ()
 // CHECK-LABEL: } // end sil function 'test_switch_enum_objc_call2'
 sil [ossa] @test_switch_enum_objc_call2 : $@convention(thin) (@guaranteed Optional<Test>) -> () {
 bb0(%0 : @guaranteed $Optional<Test>):
-  specify_test "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
+  specify_test "simplify_cfg_simplify_switch_enum_on_objc_class_optional @instruction[1]"
   %3 = copy_value %0 : $Optional<Test>
   switch_enum %3 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
 
@@ -65,7 +65,7 @@ bb6:
 // CHECK-LABEL: } // end sil function 'test_switch_enum_objc_call3'
 sil [ossa] @test_switch_enum_objc_call3 : $@convention(thin) (@guaranteed Optional<Test>) -> () {
 bb0(%0 : @guaranteed $Optional<Test>):
-  specify_test "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
+  specify_test "simplify_cfg_simplify_switch_enum_on_objc_class_optional @instruction[1]"
   %3 = copy_value %0 : $Optional<Test>
   switch_enum %3 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
 
@@ -91,7 +91,7 @@ bb6:
 // CHECK-LABEL: } // end sil function 'test_switch_enum_objc_call4'
 sil [ossa] @test_switch_enum_objc_call4 : $@convention(thin) (@guaranteed Optional<Test>) -> () {
 bb0(%0 : @guaranteed $Optional<Test>):
-  specify_test "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
+  specify_test "simplify_cfg_simplify_switch_enum_on_objc_class_optional @instruction[1]"
   %3 = copy_value %0 : $Optional<Test>
   switch_enum %3 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
 
@@ -117,7 +117,7 @@ bb6:
 // CHECK-LABEL: } // end sil function 'test_switch_enum_objc_call5'
 sil [ossa] @test_switch_enum_objc_call5 : $@convention(thin) (@guaranteed Optional<Test>) -> () {
 bb0(%0 : @guaranteed $Optional<Test>):
-  specify_test "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[0]"
+  specify_test "simplify_cfg_simplify_switch_enum_on_objc_class_optional @instruction[0]"
   switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
 
 bb1(%8 : @guaranteed $Test):

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -51,14 +51,14 @@ case third(FakeOptional<T>)
 //                                MARK: Tests
 //===----------------------------------------------------------------------===//
 
-// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on simple_test_case: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on simple_test_case: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
 // CHECK: Name: 'MyName'
 // CHECK: Root:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
-// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on simple_test_case: variable-name-inference with: @trace[0]
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on simple_test_case: variable_name_inference with: @trace[0]
 sil [ossa] @simple_test_case : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %1 = apply %0() : $@convention(thin) () -> @owned Klass
   debug_value [trace] %1 : $Klass
@@ -68,14 +68,14 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_copy_addr: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_copy_addr: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %4 = alloc_stack $Klass
 // CHECK: Name: 'MyName'
 // CHECK: Root:   %2 = alloc_stack $Klass, var, name "MyName"
-// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_copy_addr: variable-name-inference with: @trace[0]
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_copy_addr: variable_name_inference with: @trace[0]
 sil [ossa] @temporary_init_with_copy_addr : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %1 = apply %0() : $@convention(thin) () -> @owned Klass
   %2 = alloc_stack $Klass, name "MyName"
@@ -95,14 +95,14 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_store: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_store: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %3 = alloc_stack $Klass
 // CHECK: Name: 'MyName'
 // CHECK: Root:   %1 = apply %0()
-// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_store: variable-name-inference with: @trace[0]
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_store: variable_name_inference with: @trace[0]
 sil [ossa] @temporary_init_with_store : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %1 = apply %0() : $@convention(thin) () -> @owned Klass
   debug_value %1 : $Klass, name "MyName", let
@@ -119,13 +119,13 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test {{.*}} of {{.*}} on look_through_accessors_get: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test {{.*}} of {{.*}} on look_through_accessors_get: variable_name_inference with: @trace[0]
 // CHECK: Name: 'myName.computedKlass'
 // CHECK: Root: %2 = move_value [lexical] [var_decl]
-// CHECK: end running test {{.*}} of {{.*}} on look_through_accessors_get: variable-name-inference with: @trace[0]
+// CHECK: end running test {{.*}} of {{.*}} on look_through_accessors_get: variable_name_inference with: @trace[0]
 sil [ossa] @look_through_accessors_get : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = function_ref @getContainsKlass : $@convention(thin) () -> @owned ContainsKlass
   %1 = apply %0() : $@convention(thin) () -> @owned ContainsKlass
   %3 = move_value [lexical] [var_decl] %1 : $ContainsKlass
@@ -143,13 +143,13 @@ bb0:
 
 sil [thunk] @test_reabstraction_thunk : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out ()
 
-// CHECK-LABEL: begin running test {{.*}} of {{.*}} on handle_function_conversion_reabstraction_thunks: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test {{.*}} of {{.*}} on handle_function_conversion_reabstraction_thunks: variable_name_inference with: @trace[0]
 // CHECK: Name: 'namedClosure'
 // CHECK: Root: %0 = alloc_stack [lexical] $@callee_guaranteed () -> (), var, name "namedClosure"
-// CHECK: end running test {{.*}} of {{.*}} on handle_function_conversion_reabstraction_thunks: variable-name-inference with: @trace[0]
+// CHECK: end running test {{.*}} of {{.*}} on handle_function_conversion_reabstraction_thunks: variable_name_inference with: @trace[0]
 sil [ossa] @handle_function_conversion_reabstraction_thunks : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %namedStack = alloc_stack [lexical] $@callee_guaranteed () -> (), var, name "namedClosure"
   %f = function_ref @sideEffect : $@convention(thin) () -> ()
   %pa = partial_apply [callee_guaranteed] %f() : $@convention(thin) () -> ()
@@ -175,13 +175,13 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test {{.*}} of {{.*}} on mark_uninitialized_test: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test {{.*}} of {{.*}} on mark_uninitialized_test: variable_name_inference with: @trace[0]
 // CHECK: Name: 'self'
 // CHECK: Root: %0 = alloc_stack $Klass, var, name "self"
-// CHECK: end running test {{.*}} of {{.*}} on mark_uninitialized_test: variable-name-inference with: @trace[0]
+// CHECK: end running test {{.*}} of {{.*}} on mark_uninitialized_test: variable_name_inference with: @trace[0]
 sil [ossa] @mark_uninitialized_test : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %1 = alloc_stack $Klass, var, name "self"
   %2 = mark_uninitialized [rootself] %1 : $*Klass
   debug_value [trace] %2 : $*Klass
@@ -190,13 +190,13 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test {{.*}} of {{.*}} on copyable_to_moveonlywrapper_addr_test: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test {{.*}} of {{.*}} on copyable_to_moveonlywrapper_addr_test: variable_name_inference with: @trace[0]
 // CHECK: Name: 'self'
 // CHECK: Root: %0 = alloc_stack $Klass, var, name "self"
-// CHECK: end running test {{.*}} of {{.*}} on copyable_to_moveonlywrapper_addr_test: variable-name-inference with: @trace[0]
+// CHECK: end running test {{.*}} of {{.*}} on copyable_to_moveonlywrapper_addr_test: variable_name_inference with: @trace[0]
 sil [ossa] @copyable_to_moveonlywrapper_addr_test : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = alloc_stack $Klass, var, name "self"
   %1 = copyable_to_moveonlywrapper_addr %0 : $*Klass
   %2 = moveonlywrapper_to_copyable_addr %1 : $*@moveOnly Klass
@@ -206,14 +206,14 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on test_tuple_destructure: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on test_tuple_destructure: variable_name_inference with: @trace[0]
 // CHECK: Input Value: (**%8**, %9) = destructure_tuple %7 : $(Klass, Klass)
 // CHECK: Name: 'y.0'
 // CHECK: Root:   %5 = tuple (%1 : $Klass, %2 : $Klass)
-// CHECK: end running test 1 of 1 on test_tuple_destructure: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on test_tuple_destructure: variable_name_inference with: @trace[0]
 sil [ossa] @test_tuple_destructure : $@convention(thin) (@owned Klass, @guaranteed Klass, @guaranteed Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %3 = alloc_stack [lexical] $Klass, var, name "x"
   store %0 to [init] %3 : $*Klass
   %5 = tuple (%1 : $Klass, %2 : $Klass)
@@ -231,14 +231,14 @@ bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
   return %18 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on test_tuple_extract: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on test_tuple_extract: variable_name_inference with: @trace[0]
 // CHECK: Input Value: %9 = tuple_extract %8 : $(Klass, Klass), 0
 // CHECK: Name: 'y.0'
 // CHECK: Root:   %5 = tuple (%1 : $Klass, %2 : $Klass)
-// CHECK: end running test 1 of 1 on test_tuple_extract: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on test_tuple_extract: variable_name_inference with: @trace[0]
 sil [ossa] @test_tuple_extract : $@convention(thin) (@owned Klass, @guaranteed Klass, @guaranteed Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %3 = alloc_stack [lexical] $Klass, var, name "x"
   store %0 to [init] %3 : $*Klass
   %5 = tuple (%1 : $Klass, %2 : $Klass)
@@ -255,14 +255,14 @@ bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
   return %18 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on test_struct_destructure: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on test_struct_destructure: variable_name_inference with: @trace[0]
 // CHECK: Input Value: (%8, **%9**) = destructure_struct %7 : $KlassPair
 // CHECK: Name: 'y.rhs'
 // CHECK: Root:   %5 = struct $KlassPair (%1 : $Klass, %2 : $Klass)
-// CHECK: end running test 1 of 1 on test_struct_destructure: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on test_struct_destructure: variable_name_inference with: @trace[0]
 sil [ossa] @test_struct_destructure : $@convention(thin) (@owned Klass, @guaranteed Klass, @guaranteed Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %3 = alloc_stack [lexical] $Klass, var, name "x"
   store %0 to [init] %3 : $*Klass
   %5 = struct $KlassPair (%1 : $Klass, %2 : $Klass)
@@ -280,14 +280,14 @@ bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
   return %18 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on test_struct_extract: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on test_struct_extract: variable_name_inference with: @trace[0]
 // CHECK: Input Value: %9 = struct_extract %8 : $KlassPair, #KlassPair.rhs
 // CHECK: Name: 'y.rhs'
 // CHECK: Root: %5 = struct $KlassPair (%1 : $Klass, %2 : $Klass)
-// CHECK: end running test 1 of 1 on test_struct_extract: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on test_struct_extract: variable_name_inference with: @trace[0]
 sil [ossa] @test_struct_extract : $@convention(thin) (@owned Klass, @guaranteed Klass, @guaranteed Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %3 = alloc_stack [lexical] $Klass, var, name "x"
   store %0 to [init] %3 : $*Klass
   %5 = struct $KlassPair (%1 : $Klass, %2 : $Klass)
@@ -304,17 +304,17 @@ bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
   return %18 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on test_klass_tuple_struct_lookthrough: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on test_klass_tuple_struct_lookthrough: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %28 = load [copy] %27 : $*Klass
 // CHECK: Name: 'arg2.ns2.1.rhs'
 // CHECK: Root: %1 = argument of bb0 : $KlassWithKlassPair
-// CHECK: end running test 1 of 1 on test_klass_tuple_struct_lookthrough: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on test_klass_tuple_struct_lookthrough: variable_name_inference with: @trace[0]
 sil [ossa] @test_klass_tuple_struct_lookthrough : $@convention(thin) @async (@owned Klass, @guaranteed KlassWithKlassPair) -> () {
 bb0(%0 : @owned $Klass, %1 : @guaranteed $KlassWithKlassPair):
   debug_value %0 : $Klass, let, name "arg1", argno 1
   debug_value %1 : $KlassWithKlassPair, let, name "arg2", argno 2
 
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %2 = alloc_stack [lexical] $Klass, var, name "x"
   store %0 to [init] %2 : $*Klass
   %7 = alloc_stack $KlassPair
@@ -351,17 +351,17 @@ bb0(%0 : @owned $Klass, %1 : @guaranteed $KlassWithKlassPair):
   return %37 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on test_klass_tuple_struct_lookthrough_with_copyaddr: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on test_klass_tuple_struct_lookthrough_with_copyaddr: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %33 = load [copy] %32 : $*Klass
 // CHECK: Name: 'arg2.ns2.1.rhs'
 // CHECK: Root: %1 = argument of bb0 : $KlassWithKlassPair
-// CHECK: end running test 1 of 1 on test_klass_tuple_struct_lookthrough_with_copyaddr: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on test_klass_tuple_struct_lookthrough_with_copyaddr: variable_name_inference with: @trace[0]
 sil [ossa] @test_klass_tuple_struct_lookthrough_with_copyaddr : $@convention(thin) @async (@owned Klass, @guaranteed KlassWithKlassPair) -> () {
 bb0(%0 : @owned $Klass, %1 : @guaranteed $KlassWithKlassPair):
   debug_value %0 : $Klass, let, name "arg1", argno 1
   debug_value %1 : $KlassWithKlassPair, let, name "arg2", argno 2
 
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %2 = alloc_stack [lexical] $Klass, var, name "x"
   store %0 to [init] %2 : $*Klass
   %7 = alloc_stack $KlassPair
@@ -407,14 +407,14 @@ bb0(%0 : @owned $Klass, %1 : @guaranteed $KlassWithKlassPair):
   return %37 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_structextract: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_structextract: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %3 = copy_value %2 : $Klass
 // CHECK: Name: 'self.lhs'
 // CHECK: Root: %0 = argument of bb0 : $KlassPair
-// CHECK: end running test 1 of 1 on function_argument_inference_through_structextract: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on function_argument_inference_through_structextract: variable_name_inference with: @trace[0]
 sil [ossa] @function_argument_inference_through_structextract : $@convention(thin) (@guaranteed KlassPair) -> @owned Klass {
 bb0(%0 : @guaranteed $KlassPair):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   debug_value %0 : $KlassPair, let, name "self", argno 1
   %2 = struct_extract %0 : $KlassPair, #KlassPair.lhs
   %3 = copy_value %2 : $Klass
@@ -422,14 +422,14 @@ bb0(%0 : @guaranteed $KlassPair):
   return %3 : $Klass
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_uncheckedenumdata: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_uncheckedenumdata: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %3 = copy_value %2 : $Klass
 // CHECK: Name: 'self.some'
 // CHECK: Root: %0 = argument of bb0 : $FakeOptional<Klass>
-// CHECK: end running test 1 of 1 on function_argument_inference_through_uncheckedenumdata: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on function_argument_inference_through_uncheckedenumdata: variable_name_inference with: @trace[0]
 sil [ossa] @function_argument_inference_through_uncheckedenumdata : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> @owned Klass {
 bb0(%0 : @guaranteed $FakeOptional<Klass>):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   debug_value %0 : $FakeOptional<Klass>, let, name "self", argno 1
   %2 = unchecked_enum_data %0 : $FakeOptional<Klass>, #FakeOptional.some!enumelt
   %3 = copy_value %2 : $Klass
@@ -437,14 +437,14 @@ bb0(%0 : @guaranteed $FakeOptional<Klass>):
   return %3 : $Klass
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %3 = load [take] %2 : $*Klass
 // CHECK: Name: 'self.some'
 // CHECK: Root: %0 = argument of bb0 : $*FakeOptional<Klass>
-// CHECK: end running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr: variable_name_inference with: @trace[0]
 sil [ossa] @function_argument_inference_through_uncheckedtakeenumdataaddr : $@convention(thin) (@in FakeOptional<Klass>) -> @owned Klass {
 bb0(%0 : $*FakeOptional<Klass>):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   debug_value %0 : $*FakeOptional<Klass>, let, name "self", argno 1
   %2 = unchecked_take_enum_data_addr %0 : $*FakeOptional<Klass>, #FakeOptional.some!enumelt
   %3 = load [take] %2 : $*Klass
@@ -452,14 +452,14 @@ bb0(%0 : $*FakeOptional<Klass>):
   return %3 : $Klass
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr_2: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr_2: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %2 = unchecked_take_enum_data_addr %0
 // CHECK: Name: 'self.some'
 // CHECK: Root: %0 = argument of bb0 : $*FakeOptional<Klass>
-// CHECK: end running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr_2: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr_2: variable_name_inference with: @trace[0]
 sil [ossa] @function_argument_inference_through_uncheckedtakeenumdataaddr_2 : $@convention(thin) (@in FakeOptional<Klass>) -> @owned Klass {
 bb0(%0 : $*FakeOptional<Klass>):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   debug_value %0 : $*FakeOptional<Klass>, let, name "self", argno 1
   %2 = unchecked_take_enum_data_addr %0 : $*FakeOptional<Klass>, #FakeOptional.some!enumelt
   debug_value [trace] %2 : $*Klass
@@ -473,14 +473,14 @@ bb0(%0 : $*FakeOptional<Klass>):
 //
 // TODO: If we need to do better, we can perhaps emit all of them.
 
-// CHECK-LABEL: begin running test 1 of 1 on handle_diamond: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on handle_diamond: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %9 = argument of bb3
 // CHECK: Name: 'myname.some'
 // CHECK: Root: %0 = argument of bb0
-// CHECK: end running test 1 of 1 on handle_diamond: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on handle_diamond: variable_name_inference with: @trace[0]
 sil [ossa] @handle_diamond : $@convention(method) (@guaranteed FirstSecondEnum<Klass>) -> @sil_sending @owned FakeOptional<Klass> {
 bb0(%0 : @guaranteed $FirstSecondEnum<Klass>):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   debug_value %0 : $FirstSecondEnum<Klass>, var, name "myname"
   switch_enum %0 : $FirstSecondEnum<Klass>, case #FirstSecondEnum.first!enumelt: bb1, case #FirstSecondEnum.second!enumelt: bb2
 
@@ -504,14 +504,14 @@ bb3(%4 : @owned $FakeOptional<Klass>):
 //
 // TODO: If we need to do better, we can perhaps emit all of them.
 
-// CHECK-LABEL: begin running test 1 of 1 on handle_loop: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on handle_loop: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %16 = argument of bb5
 // CHECK: Name: 'myname.some.third'
 // CHECK: Root: %0 = argument of bb0
-// CHECK: end running test 1 of 1 on handle_loop: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on handle_loop: variable_name_inference with: @trace[0]
 sil [ossa] @handle_loop : $@convention(method) (@guaranteed FirstSecondThirdEnum<Klass>) -> @sil_sending @owned FirstSecondThirdEnum<Klass> {
 bb0(%0 : @guaranteed $FirstSecondThirdEnum<Klass>):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   debug_value %0 : $FirstSecondThirdEnum<Klass>, var, name "myname"
   %0a = copy_value %0 : $FirstSecondThirdEnum<Klass>
   br bb1(%0a : $FirstSecondThirdEnum<Klass>)
@@ -552,14 +552,14 @@ bb8:
 
 // Make sure that we properly scope by switching edge order.
 //
-// CHECK-LABEL: begin running test 1 of 1 on handle_loop_other_order: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on handle_loop_other_order: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %16 = argument of bb5
 // CHECK: Name: 'myname.some.third'
 // CHECK: Root: %0 = argument of bb0
-// CHECK: end running test 1 of 1 on handle_loop_other_order: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on handle_loop_other_order: variable_name_inference with: @trace[0]
 sil [ossa] @handle_loop_other_order : $@convention(method) (@guaranteed FirstSecondThirdEnum<Klass>) -> @sil_sending @owned FirstSecondThirdEnum<Klass> {
 bb0(%0 : @guaranteed $FirstSecondThirdEnum<Klass>):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   debug_value %0 : $FirstSecondThirdEnum<Klass>, var, name "myname"
   %0a = copy_value %0 : $FirstSecondThirdEnum<Klass>
   br bb1(%0a : $FirstSecondThirdEnum<Klass>)
@@ -600,14 +600,14 @@ bb8:
 
 // Test that we can properly handle code generation from a borrowing loadable parameter
 //
-// CHECK-LABEL: begin running test 1 of 1 on loadable_borrowing_test: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on loadable_borrowing_test: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %8 = store_borrow %6 to %7 : $*Klass            // user: %9
 // CHECK: Name: 'x'
 // CHECK: Root: %3 = mark_unresolved_non_copyable_value [no_consume_or_assign] %2
-// CHECK: end running test 1 of 1 on loadable_borrowing_test: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on loadable_borrowing_test: variable_name_inference with: @trace[0]
 sil hidden [ossa] @loadable_borrowing_test : $@convention(thin) @async (@guaranteed Klass) -> () {
 bb0(%0 : @noImplicitCopy @guaranteed $Klass):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %1 = copyable_to_moveonlywrapper [guaranteed] %0 : $Klass
   %2 = copy_value %1 : $@moveOnly Klass
   %3 = mark_unresolved_non_copyable_value [no_consume_or_assign] %2 : $@moveOnly Klass
@@ -625,14 +625,14 @@ bb0(%0 : @noImplicitCopy @guaranteed $Klass):
   return %25 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on store_borrow_tuple_test: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on store_borrow_tuple_test: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %25 = store_borrow %23 to %24 : $*Klass
 // CHECK: Name: 'z'
 // CHECK: Root: %20 = move_value [lexical] [var_decl] %19 : $Klass
-// CHECK: end running test 1 of 1 on store_borrow_tuple_test: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on store_borrow_tuple_test: variable_name_inference with: @trace[0]
 sil hidden [ossa] @store_borrow_tuple_test : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %2 = integer_literal $Builtin.IntLiteral, 0
   %7 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %8 = apply %7() : $@convention(thin) () -> @owned Klass
@@ -680,14 +680,14 @@ bb0:
   return %54 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on store_borrow_tuple_test_2: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on store_borrow_tuple_test_2: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %11 = alloc_stack $(Builtin.IntLiteral, Klass)
 // CHECK: Name: 'test'
 // CHECK: Root:   %4 = move_value [lexical] [var_decl] %3 : $(Builtin.IntLiteral, Klass)
-// CHECK: end running test 1 of 1 on store_borrow_tuple_test_2: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on store_borrow_tuple_test_2: variable_name_inference with: @trace[0]
 sil hidden [ossa] @store_borrow_tuple_test_2 : $@convention(thin) @async () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %2 = integer_literal $Builtin.IntLiteral, 0
   %7 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %8 = apply %7() : $@convention(thin) () -> @owned Klass
@@ -735,14 +735,14 @@ bb0:
   return %54 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_temporary: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_temporary: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %2 = alloc_stack $Any
 // CHECK: Name: 'my arg'
 // CHECK: Root: %0 = argument of bb0
-// CHECK: end running test 1 of 1 on init_existential_addr_temporary: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on init_existential_addr_temporary: variable_name_inference with: @trace[0]
 sil [ossa] @init_existential_addr_temporary : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   debug_value %0 : $Klass, var, name "my arg"
   %1 = alloc_stack $Any
   %2 = init_existential_addr %1 : $*Any, $Klass
@@ -754,14 +754,14 @@ bb0(%0 : @owned $Klass):
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_temporary_copy_addr: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_temporary_copy_addr: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %2 = alloc_stack $Any
 // CHECK: Name: 'my arg'
 // CHECK: Root: %0 = argument of bb0
-// CHECK: end running test 1 of 1 on init_existential_addr_temporary_copy_addr: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on init_existential_addr_temporary_copy_addr: variable_name_inference with: @trace[0]
 sil [ossa] @init_existential_addr_temporary_copy_addr : $@convention(thin) (@in Klass) -> () {
 bb0(%0 : $*Klass):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   debug_value %0 : $*Klass, var, name "my arg"
   %1 = alloc_stack $Any
   %2 = init_existential_addr %1 : $*Any, $Klass
@@ -773,14 +773,14 @@ bb0(%0 : $*Klass):
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on move_value_var_decl: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on move_value_var_decl: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %2 = move_value [var_decl] %1 : $Klass
 // CHECK: Name: 'MyName'
 // CHECK: Root:   %2 = move_value [var_decl] %1 : $Klass
-// CHECK: end running test 1 of 1 on move_value_var_decl: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on move_value_var_decl: variable_name_inference with: @trace[0]
 sil [ossa] @move_value_var_decl : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %1 = apply %0() : $@convention(thin) () -> @owned Klass
   %2 = move_value [var_decl] %1 : $Klass
@@ -791,14 +791,14 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on move_value_var_decl_2: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on move_value_var_decl_2: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
 // CHECK: Name: 'MyName'
 // CHECK: Root:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
-// CHECK: end running test 1 of 1 on move_value_var_decl_2: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on move_value_var_decl_2: variable_name_inference with: @trace[0]
 sil [ossa] @move_value_var_decl_2 : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %1 = apply %0() : $@convention(thin) () -> @owned Klass
   debug_value [trace] %1 : $Klass
@@ -809,14 +809,14 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on move_value_var_decl_3: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on move_value_var_decl_3: variable_name_inference with: @trace[0]
 // CHECK-LABEL: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
 // CHECK-LABEL: Name: 'unknown'
 // CHECK-LABEL: Root: 'unknown'
-// CHECK-LABEL: end running test 1 of 1 on move_value_var_decl_3: variable-name-inference with: @trace[0]
+// CHECK-LABEL: end running test 1 of 1 on move_value_var_decl_3: variable_name_inference with: @trace[0]
 sil [ossa] @move_value_var_decl_3 : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %1 = apply %0() : $@convention(thin) () -> @owned Klass
   debug_value [trace] %1 : $Klass
@@ -827,14 +827,14 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on begin_borrow_var_decl: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on begin_borrow_var_decl: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %2 = begin_borrow [var_decl] %1 : $Klass
 // CHECK: Name: 'MyName'
 // CHECK: Root:   %2 = begin_borrow [var_decl] %1 : $Klass
-// CHECK: end running test 1 of 1 on begin_borrow_var_decl: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on begin_borrow_var_decl: variable_name_inference with: @trace[0]
 sil [ossa] @begin_borrow_var_decl : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %1 = apply %0() : $@convention(thin) () -> @owned Klass
   %2 = begin_borrow [var_decl] %1 : $Klass
@@ -846,14 +846,14 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on begin_borrow_var_decl_2: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on begin_borrow_var_decl_2: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
 // CHECK: Name: 'MyName'
 // CHECK: Root:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
-// CHECK: end running test 1 of 1 on begin_borrow_var_decl_2: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on begin_borrow_var_decl_2: variable_name_inference with: @trace[0]
 sil [ossa] @begin_borrow_var_decl_2 : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %1 = apply %0() : $@convention(thin) () -> @owned Klass
   debug_value [trace] %1 : $Klass
@@ -865,14 +865,14 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on begin_borrow_var_decl_3: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on begin_borrow_var_decl_3: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
 // CHECK: Name: 'unknown'
 // CHECK: Root: 'unknown'
-// CHECK: end running test 1 of 1 on begin_borrow_var_decl_3: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on begin_borrow_var_decl_3: variable_name_inference with: @trace[0]
 sil [ossa] @begin_borrow_var_decl_3 : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %1 = apply %0() : $@convention(thin) () -> @owned Klass
   debug_value [trace] %1 : $Klass
@@ -884,28 +884,28 @@ bb0:
   return %9999 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on infer_through_end_init_let_ref: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on infer_through_end_init_let_ref: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %2 = end_init_let_ref %0 : $Klass
 // CHECK: Name: 'self'
 // CHECK: Root: %0 = argument of bb0 : $Klass
-// CHECK: end running test 1 of 1 on infer_through_end_init_let_ref: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on infer_through_end_init_let_ref: variable_name_inference with: @trace[0]
 sil [ossa] @infer_through_end_init_let_ref : $@convention(thin) (@owned Klass) -> @owned Klass {
 bb0(%0 : @owned $Klass):
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   debug_value %0 : $Klass, let, name "self", argno 2
   %1 = end_init_let_ref %0 : $Klass
   debug_value [trace] %1 : $Klass
   return %1 : $Klass
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on infer_for_closure: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on infer_for_closure: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %5 = convert_escape_to_noescape [not_guaranteed] %4 : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK: Name: 'closure1'
 // CHECK: Root:   %2 = move_value [lexical] [var_decl] %1 : $@callee_guaranteed () -> ()
-// CHECK: end running test 1 of 1 on infer_for_closure: variable-name-inference with: @trace[0]
+// CHECK: end running test 1 of 1 on infer_for_closure: variable_name_inference with: @trace[0]
 sil [ossa] @infer_for_closure : $@convention(thin) () -> () {
 bb0:
-  specify_test "variable-name-inference @trace[0]"
+  specify_test "variable_name_inference @trace[0]"
   %0 = function_ref @sideEffect : $@convention(thin) () -> ()
   %1 = partial_apply [callee_guaranteed] %0() : $@convention(thin) () -> ()
   %2 = move_value [lexical] [var_decl] %1 : $@callee_guaranteed () -> ()


### PR DESCRIPTION
Use underscores rather than hyphens so that text editors understand the name as a single word.
