### PR TITLE
[android] fix path and cmake local build target tracking for posix_fi…

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -418,29 +418,6 @@ GetPlatformAuxiliaryFile(StringRef Platform, StringRef File,
   return "";
 }
 
-SmallVector<std::pair<std::string, std::string>, 2>
-GetAndroidFileMappings(
-    ASTContext &Context, const std::string &sysroot,
-    const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &VFS) {
-  const llvm::Triple &Triple = Context.LangOpts.Target;
-  const SearchPathOptions &SearchPathOpts = Context.SearchPathOpts;
-  SmallVector<std::pair<std::string, std::string>, 2> Mappings;
-  std::string AuxiliaryFile;
-
-  if (!Triple.isAndroid()) return Mappings;
-
-  llvm::SmallString<261> NDKInjection{sysroot};
-  llvm::sys::path::append(NDKInjection, "posix_filesystem.apinotes");
-
-  AuxiliaryFile =
-      GetPlatformAuxiliaryFile("android", "posix_filesystem.apinotes",
-                               SearchPathOpts);
-  if (!AuxiliaryFile.empty())
-    Mappings.emplace_back(std::string(NDKInjection), AuxiliaryFile);
-
-  return Mappings;
-}
-
 SmallVector<std::pair<std::string, std::string>, 2> GetWindowsFileMappings(
     ASTContext &Context,
     const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &driverVFS,
@@ -612,9 +589,5 @@ ClangInvocationFileMapping swift::getClangInvocationFileMapping(
 
   result.redirectedFiles.append(GetWindowsFileMappings(
       ctx, vfs, result.requiresBuiltinHeadersInSystemModules));
-
-  result.redirectedFiles.append(GetAndroidFileMappings(ctx, sysroot.str().str(),
-                                                       vfs));
-
   return result;
 }

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -474,10 +474,23 @@ if("ANDROID" IN_LIST SWIFT_SDKS)
     endif()
   endforeach()
 
+  set(android_posix_filesystem_apinotes_source "posix_filesystem.apinotes")
+  set(apinotes_subdir "${SWIFTLIB_DIR}/apinotes")
+  add_custom_command_target(
+    copy_android_posix_filesystem_apinotes_resource
+    COMMAND
+      "${CMAKE_COMMAND}" "-E" "make_directory" ${apinotes_subdir}
+    COMMAND
+      "${CMAKE_COMMAND}" "-E" "copy_if_different"
+        "${CMAKE_CURRENT_SOURCE_DIR}/${android_posix_filesystem_apinotes_source}" ${apinotes_subdir}
+    OUTPUT ${apinotes_subdir}/${android_posix_filesystem_apinotes_source}
+    COMMENT "Copying Android posix_filesystem API notes to resource directories")
+  add_dependencies(sdk-overlay ${copy_android_posix_filesystem_apinotes_resource})
+  list(APPEND android_modulemap_target_list ${copy_android_posix_filesystem_apinotes_resource})
   swift_install_in_component(FILES
-      posix_filesystem.apinotes
-    DESTINATION "share"
-    COMPONENT sdk-overlay)
+                              "${android_posix_filesystem_apinotes_source}"
+                             DESTINATION "lib/swift/apinotes"
+                             COMPONENT sdk-overlay)
 endif()
 add_custom_target(android_modulemap DEPENDS ${android_modulemap_target_list})
 set_property(TARGET android_modulemap PROPERTY FOLDER "Miscellaneous")


### PR DESCRIPTION
…lesystem.apinotes

This apinote file needs to be accessible in the locally built Android SDK as it's being built with build.ps1, so that swift-foundation can be built with that file present. This change ensures that the file is copied over into the local build directory for that Android SDK, in addition to being included in the installed component

This change also places the component into lib/swift/apinotes, as that's where the clang importer already looks for API notes
