### PR TITLE
[Concurrency] Remove redundant `Sendable` conformances in the standard library.

### DIFF
--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -63,9 +63,6 @@ internal final class __EmptyArrayStorage
   }
 }
 
-@available(*, unavailable)
-extension __EmptyArrayStorage: Sendable {}
-
 #if $Embedded
 // In embedded Swift, the stdlib is a .swiftmodule only without any .o/.a files,
 // to allow consuming it by clients with different LLVM codegen setting (-mcpu
@@ -119,9 +116,6 @@ internal final class __StaticArrayStorage
     fatalError("__StaticArrayStorage.staticElementType must not be called")
   }
 }
-
-@available(*, unavailable)
-extension __StaticArrayStorage: Sendable {}
 
 /// The empty array prototype.  We use the same object for all empty
 /// `[Native]Array<Element>`s.
@@ -311,9 +305,6 @@ internal final class _ContiguousArrayStorage<
     return UnsafeMutablePointer(Builtin.projectTailElems(self, Element.self))
   }
 }
-
-@available(*, unavailable)
-extension _ContiguousArrayStorage: Sendable {}
 
 @_alwaysEmitIntoClient
 @inline(__always)
@@ -976,9 +967,6 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
     return true
   }
 }
-
-@available(*, unavailable)
-extension _ContiguousArrayBuffer: Sendable {}
 
 /// Append the elements of `rhs` to `lhs`.
 @inlinable

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -421,9 +421,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   }
 }
 
-@available(*, unavailable)
-extension _SwiftDeferredNSDictionary: Sendable {}
-
 // NOTE: older runtimes called this struct _CocoaDictionary. The two
 // must coexist without conflicting ObjC class names from the nested
 // classes, so it was renamed. The old names must not be used in the new

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -110,9 +110,6 @@ internal class __RawDictionaryStorage: __SwiftNativeNSDictionary {
   }
 }
 
-@available(*, unavailable)
-extension __RawDictionaryStorage: Sendable {}
-
 /// The storage class for the singleton empty set.
 /// The single instance of this class is created by the runtime.
 // NOTE: older runtimes called this class _EmptyDictionarySingleton.
@@ -138,9 +135,6 @@ internal class __EmptyDictionarySingleton: __RawDictionaryStorage {
   }
 #endif
 }
-
-@available(*, unavailable)
-extension __EmptyDictionarySingleton: Sendable {}
 
 #if _runtime(_ObjC)
 extension __EmptyDictionarySingleton: _NSDictionaryCore {
@@ -511,6 +505,3 @@ extension _DictionaryStorage {
     return storage
   }
 }
-
-extension _DictionaryStorage: @unchecked Sendable
-  where Key: Sendable, Value: Sendable {}

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -166,9 +166,6 @@ internal final class _IteratorBox<Base: IteratorProtocol>
   internal var _base: Base
 }
 
-@available(*, unavailable)
-extension _IteratorBox: Sendable {}
-
 //===--- Sequence ---------------------------------------------------------===//
 //===----------------------------------------------------------------------===//
 
@@ -402,9 +399,6 @@ internal class _AnyCollectionBox<Element>: _AnySequenceBox<Element> {
   ) -> _AnyCollectionBox<Element> { _abstract() }
 }
 
-@available(*, unavailable)
-extension _AnyCollectionBox: Sendable {}
-
 @_fixed_layout
 @usableFromInline
 internal class _AnyBidirectionalCollectionBox<Element>
@@ -468,9 +462,6 @@ internal class _AnyBidirectionalCollectionBox<Element>
   internal func _formIndex(before i: _AnyIndexBox) { _abstract() }
 }
 
-@available(*, unavailable)
-extension _AnyBidirectionalCollectionBox: Sendable {}
-
 @_fixed_layout
 @usableFromInline
 internal class _AnyRandomAccessCollectionBox<Element>
@@ -527,9 +518,6 @@ internal class _AnyRandomAccessCollectionBox<Element>
     end end: _AnyIndexBox
   ) -> _AnyRandomAccessCollectionBox<Element> { _abstract() }
 }
-
-@available(*, unavailable)
-extension _AnyRandomAccessCollectionBox: Sendable {}
 
 @_fixed_layout
 @usableFromInline
@@ -622,9 +610,6 @@ internal final class _SequenceBox<S: Sequence>: _AnySequenceBox<S.Element> {
   @usableFromInline
   internal var _base: S
 }
-
-@available(*, unavailable)
-extension _SequenceBox: Sendable {}
 
 @_fixed_layout
 @usableFromInline
@@ -819,9 +804,6 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
   @usableFromInline
   internal var _base: S
 }
-
-@available(*, unavailable)
-extension _CollectionBox: Sendable {}
 
 @_fixed_layout
 @usableFromInline
@@ -1036,9 +1018,6 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
   internal var _base: S
 }
 
-@available(*, unavailable)
-extension _BidirectionalCollectionBox: Sendable {}
-
 @_fixed_layout
 @usableFromInline
 internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
@@ -1250,9 +1229,6 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
   @usableFromInline
   internal var _base: S
 }
-
-@available(*, unavailable)
-extension _RandomAccessCollectionBox: Sendable {}
 
 @usableFromInline
 @frozen

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -105,9 +105,6 @@ internal class __RawSetStorage: __SwiftNativeNSSet {
   }
 }
 
-@available(*, unavailable)
-extension __RawSetStorage: Sendable {}
-
 /// The storage class for the singleton empty set.
 /// The single instance of this class is created by the runtime.
 // NOTE: older runtimes called this class _EmptySetSingleton. The two
@@ -129,9 +126,6 @@ internal class __EmptySetSingleton: __RawSetStorage {
   }
 #endif
 }
-
-@available(*, unavailable)
-extension __EmptySetSingleton: Sendable {}
 
 #if $Embedded
 // In embedded Swift, the stdlib is a .swiftmodule only without any .o/.a files,
@@ -315,9 +309,6 @@ final internal class _SetStorage<Element: Hashable>
   }
 #endif
 }
-
-@available(*, unavailable)
-extension _SetStorage: Sendable {}
 
 extension _SetStorage {
   @usableFromInline

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -61,9 +61,6 @@ internal class __SwiftNativeNSArrayWithContiguousStorage
   }
 }
 
-@available(*, unavailable)
-extension __SwiftNativeNSArrayWithContiguousStorage: Sendable {}
-
 private let NSNotFound: Int = .max
 
 // Implement the APIs required by NSArray 
@@ -325,9 +322,6 @@ extension __SwiftNativeNSArrayWithContiguousStorage {
   }
 }
 
-@available(*, unavailable)
-extension _SwiftNSMutableArray: Sendable {}
-
 /// An `NSArray` whose contiguous storage is created and filled, upon
 /// first access, by bridging the elements of a Swift `Array`.
 ///
@@ -434,9 +428,6 @@ extension _SwiftNSMutableArray: Sendable {}
     return _nativeStorage.countAndCapacity.count
   }
 }
-
-@available(*, unavailable)
-extension __SwiftDeferredNSArray: Sendable {}
 
 /// A `__SwiftDeferredNSArray` which is used for static read-only Swift Arrays.
 ///
@@ -593,6 +584,3 @@ internal class __ContiguousArrayStorageBase
       self !== _emptyArrayStorage, "Deallocating empty array storage?!")
   }
 }
-
-@available(*, unavailable)
-extension __ContiguousArrayStorageBase: Sendable {}


### PR DESCRIPTION
These conformances are all redundant because the `Sendable` conformance is inherited from a superclass. This resolves a slew of concurrency warnings about redundant `Sendable` conformances which were introduced by https://github.com/swiftlang/swift/pull/75135.