### PR TITLE
[cxx-interop] Copy SwiftBridging modulemap into the build directory

### DIFF
--- a/lib/ClangImporter/SwiftBridging/CMakeLists.txt
+++ b/lib/ClangImporter/SwiftBridging/CMakeLists.txt
@@ -2,12 +2,22 @@
 # install it into the compiler toolchain.
 
 add_custom_command(
+    OUTPUT "${SWIFT_INCLUDE_DIR}/module.modulemap"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/module.modulemap"
+    COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${CMAKE_CURRENT_SOURCE_DIR}/module.modulemap" "${SWIFT_INCLUDE_DIR}")
+add_custom_command(
     OUTPUT "${SWIFT_INCLUDE_DIR}/swift/bridging"
     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/swift/bridging"
     COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${CMAKE_CURRENT_SOURCE_DIR}/swift/bridging" "${SWIFT_INCLUDE_DIR}/swift")
+add_custom_command(
+    OUTPUT "${SWIFT_INCLUDE_DIR}/swift/bridging.modulemap"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/swift/bridging.modulemap"
+    COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${CMAKE_CURRENT_SOURCE_DIR}/swift/bridging.modulemap" "${SWIFT_INCLUDE_DIR}/swift")
 
 add_custom_target("copy_cxxInterop_support_header"
+    DEPENDS "${SWIFT_INCLUDE_DIR}/module.modulemap"
     DEPENDS "${SWIFT_INCLUDE_DIR}/swift/bridging"
+    DEPENDS "${SWIFT_INCLUDE_DIR}/swift/bridging.modulemap"
     COMMENT "Copying C++ interop support header to ${SWIFT_INCLUDE_DIR}/swift")
 
 swift_install_in_component(FILES


### PR DESCRIPTION
The modulemap file is already copied to the installation directory, and shipped with the toolchain. This change makes sure it is also copied over to the build directory, which simplifies testing of the just-built compiler.