### PR TITLE
Reflection tests are incompatible with ASAN

### DIFF
--- a/test/Concurrency/Reflection/reflect_task.swift
+++ b/test/Concurrency/Reflection/reflect_task.swift
@@ -9,6 +9,7 @@
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
 
 import Swift
 import _Concurrency

--- a/validation-test/Reflection/reflect_Array.swift
+++ b/validation-test/Reflection/reflect_Array.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Bool.swift
+++ b/validation-test/Reflection/reflect_Bool.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Double.swift
+++ b/validation-test/Reflection/reflect_Double.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_254CaseNoPayloads.swift
+++ b/validation-test/Reflection/reflect_Enum_254CaseNoPayloads.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_bulky.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_bulky.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_degenerate.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_degenerate.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic2.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic2.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic3.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic3.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic4.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic4.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic5.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic5.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic6.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic6.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic8.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic8.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic_empty.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic_empty.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_large.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_large.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_value.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_value.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_value_indirect.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_value_indirect.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_NoCase.swift
+++ b/validation-test/Reflection/reflect_Enum_NoCase.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
@@ -8,6 +8,7 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/reflect_Enum_SingleCaseIntPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseIntPayload.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_SingleCaseNoPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseNoPayload.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_SingleCasePointerPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCasePointerPayload.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_SingleCaseVoidPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseVoidPayload.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_SinglePayload_generic1.swift
+++ b/validation-test/Reflection/reflect_Enum_SinglePayload_generic1.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_TwoCaseNoPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_TwoCaseNoPayload.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_TwoCaseOnePointerPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_TwoCaseOnePointerPayload.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_TwoCaseOneStructPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_TwoCaseOneStructPayload.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_TwoCaseTwoPayloads.swift
+++ b/validation-test/Reflection/reflect_Enum_TwoCaseTwoPayloads.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_value.swift
+++ b/validation-test/Reflection/reflect_Enum_value.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import Foundation
 import SwiftReflectionTest

--- a/validation-test/Reflection/reflect_Enum_values.swift
+++ b/validation-test/Reflection/reflect_Enum_values.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_values10.swift
+++ b/validation-test/Reflection/reflect_Enum_values10.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_values11.swift
+++ b/validation-test/Reflection/reflect_Enum_values11.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_values2.swift
+++ b/validation-test/Reflection/reflect_Enum_values2.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_values3.swift
+++ b/validation-test/Reflection/reflect_Enum_values3.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_values4.swift
+++ b/validation-test/Reflection/reflect_Enum_values4.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_values5.swift
+++ b/validation-test/Reflection/reflect_Enum_values5.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 public enum E: Error {

--- a/validation-test/Reflection/reflect_Enum_values6.swift
+++ b/validation-test/Reflection/reflect_Enum_values6.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_values7.swift
+++ b/validation-test/Reflection/reflect_Enum_values7.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_values8.swift
+++ b/validation-test/Reflection/reflect_Enum_values8.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_values9.swift
+++ b/validation-test/Reflection/reflect_Enum_values9.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_values_resilient.swift
+++ b/validation-test/Reflection/reflect_Enum_values_resilient.swift
@@ -11,6 +11,7 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop, OS=macosx
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Float.swift
+++ b/validation-test/Reflection/reflect_Float.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Int.swift
+++ b/validation-test/Reflection/reflect_Int.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Int16.swift
+++ b/validation-test/Reflection/reflect_Int16.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Int32.swift
+++ b/validation-test/Reflection/reflect_Int32.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Int64.swift
+++ b/validation-test/Reflection/reflect_Int64.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Int8.swift
+++ b/validation-test/Reflection/reflect_Int8.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_NSArray.swift
+++ b/validation-test/Reflection/reflect_NSArray.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/reflect_NSNumber.swift
+++ b/validation-test/Reflection/reflect_NSNumber.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/reflect_NSSet.swift
+++ b/validation-test/Reflection/reflect_NSSet.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/reflect_NSString.swift
+++ b/validation-test/Reflection/reflect_NSString.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/reflect_Optional_Any.swift
+++ b/validation-test/Reflection/reflect_Optional_Any.swift
@@ -9,6 +9,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Optional_Bool.swift
+++ b/validation-test/Reflection/reflect_Optional_Bool.swift
@@ -8,6 +8,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_UInt.swift
+++ b/validation-test/Reflection/reflect_UInt.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_UInt16.swift
+++ b/validation-test/Reflection/reflect_UInt16.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_UInt32.swift
+++ b/validation-test/Reflection/reflect_UInt32.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_UInt64.swift
+++ b/validation-test/Reflection/reflect_UInt64.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_UInt8.swift
+++ b/validation-test/Reflection/reflect_UInt8.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_deep_generic.swift
+++ b/validation-test/Reflection/reflect_deep_generic.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_empty_class.swift
+++ b/validation-test/Reflection/reflect_empty_class.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_empty_struct.swift
+++ b/validation-test/Reflection/reflect_empty_struct.swift
@@ -8,6 +8,7 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_empty_struct_compat.swift
+++ b/validation-test/Reflection/reflect_empty_struct_compat.swift
@@ -8,6 +8,7 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_existential.swift
+++ b/validation-test/Reflection/reflect_existential.swift
@@ -7,6 +7,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/reflect_nested.swift
+++ b/validation-test/Reflection/reflect_nested.swift
@@ -5,6 +5,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_nested_generic.swift
+++ b/validation-test/Reflection/reflect_nested_generic.swift
@@ -8,6 +8,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 


### PR DESCRIPTION
#75415 sped up Reflection tests by having the test harness make broader requests for blocks of memory.  This upset ASAN since those requests are (by design) not aligned with heap allocations.  #75454 attempted to work around this but failed, so let's just disable all of the relevant tests whenever ASAN is enabled.