### PR TITLE
utils: try to downscope builds for the runtime

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1549,6 +1549,8 @@ function Build-Runtime([Platform]$Platform, $Arch) {
     $PlatformDefines += @{
       LLVM_ENABLE_LIBCXX = "YES";
       SWIFT_USE_LINKER = "lld";
+      SWIFT_INCLUDE_TESTS = "NO";
+      SWIFT_INCLUDE_TEST_BINARIES = "NO";
     }
   }
 


### PR DESCRIPTION
This tweaks the build configuration for the runtime to downscope what we actually build to what we require. This should have a negligible improvement to the build times.