### PR TITLE
AST: Fix MemberImportVisibility handling of `@_exported` imports

### DIFF
--- a/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
@@ -31,3 +31,17 @@ extension Y {
 public enum EnumInA {
   case caseInA
 }
+
+open class BaseClassInA {
+  open func methodInA() {}
+}
+
+public protocol ProtocolInA {
+  func defaultedRequirementInA()
+  func defaultedRequirementInB()
+  func defaultedRequirementInC()
+}
+
+extension ProtocolInA {
+  public func defaultedRequirementInA() { }
+}

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
@@ -27,3 +27,11 @@ public enum EnumInB {
 package enum EnumInB_package {
   case caseInB
 }
+
+open class DerivedClassInB: BaseClassInA {
+  open func methodInB() {}
+}
+
+extension ProtocolInA {
+  public func defaultedRequirementInB() { }
+}

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
@@ -21,3 +21,11 @@ extension Y {
 public enum EnumInC {
   case caseInC
 }
+
+open class DerivedClassInC: DerivedClassInB {
+  open func methodInC() {}
+}
+
+extension ProtocolInA {
+  public func defaultedRequirementInC() { }
+}

--- a/test/NameLookup/members_transitive.swift
+++ b/test/NameLookup/members_transitive.swift
@@ -67,3 +67,11 @@ func testTopLevelTypes() {
   _ = EnumInB_package.self // expected-error{{cannot find 'EnumInB_package' in scope}}
   _ = EnumInC.self
 }
+
+class DerivedFromClassInC: DerivedClassInC {
+  override func methodInA() {}
+  override func methodInB() {} // expected-member-visibility-error{{method does not override any method from its superclass}}
+  override func methodInC() {}
+}
+
+struct ConformsToProtocolInA: ProtocolInA {} // expected-member-visibility-error{{type 'ConformsToProtocolInA' does not conform to protocol 'ProtocolInA'}}

--- a/test/NameLookup/members_transitive_multifile.swift
+++ b/test/NameLookup/members_transitive_multifile.swift
@@ -9,13 +9,18 @@
 
 //--- main.swift
 
-// expected-member-visibility-note@+3 {{add import of module 'members_A'}}{{1-1=@_implementationOnly import members_A\n}}
-// expected-member-visibility-note@+2 {{add import of module 'members_B'}}{{1-1=@_exported import members_B\n}}
+// expected-member-visibility-note@+2 {{add import of module 'members_A'}}{{1-1=@_implementationOnly import members_A\n}}
 // expected-member-visibility-note@+1 {{add import of module 'members_C'}}{{1-1=@_weakLinked @_spiOnly import members_C\n}}
-func testMembersWithContextualBase() {
+func testMembersWithInferredContextualBase() {
   takesEnumInA(.caseInA) // expected-member-visibility-error{{enum case 'caseInA' is not available due to missing import of defining module 'members_A'}}
-  takesEnumInB(.caseInB) // expected-member-visibility-error{{enum case 'caseInB' is not available due to missing import of defining module 'members_B'}}
+  takesEnumInB(.caseInB)
   takesEnumInC(.caseInC) // expected-member-visibility-error{{enum case 'caseInC' is not available due to missing import of defining module 'members_C'}}
+}
+
+func testQualifiedMembers() {
+  takesEnumInA(EnumInA.caseInA) // expected-error{{cannot find 'EnumInA' in scope; did you mean 'EnumInB'?}}
+  takesEnumInB(EnumInB.caseInB)
+  takesEnumInC(EnumInC.caseInC) // expected-error{{cannot find 'EnumInC' in scope; did you mean 'EnumInB'?}}
 }
 
 //--- A.swift

--- a/test/NameLookup/members_transitive_underlying_clang.swift
+++ b/test/NameLookup/members_transitive_underlying_clang.swift
@@ -2,14 +2,13 @@
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -typecheck -primary-file %t/Primary.swift %t/Other.swift -I %S/Inputs/MemberImportVisibility -module-name Underlying -verify -swift-version 5
 // RUN: %target-swift-frontend -typecheck -primary-file %t/Primary.swift %t/Other.swift -I %S/Inputs/MemberImportVisibility -module-name Underlying -verify -swift-version 6
-// RUN: %target-swift-frontend -typecheck -primary-file %t/Primary.swift %t/Other.swift -I %S/Inputs/MemberImportVisibility -module-name Underlying -verify -swift-version 5 -enable-experimental-feature MemberImportVisibility -verify-additional-prefix member-visibility-
+// RUN: %target-swift-frontend -typecheck -primary-file %t/Primary.swift %t/Other.swift -I %S/Inputs/MemberImportVisibility -module-name Underlying -verify -swift-version 5 -enable-experimental-feature MemberImportVisibility
 
 //--- Other.swift
 @_exported import Underlying
 
 //--- Primary.swift
 
-// expected-member-visibility-note@+1 {{add import of module 'Underlying'}}{{1-1=@_exported import Underlying\n}}
 func test(_ s: UnderlyingStruct) {
-  _ = s.a // expected-member-visibility-error {{property 'a' is not available due to missing import of defining module 'Underlying'}}
+  _ = s.a
 }


### PR DESCRIPTION
In existing Swift, an `@_exported import` in any source file makes the declarations from the imported module visible in all source files. It's unclear whether this is an explicit decision or is simply and unintended consequence of effectively adding an implicit import to each source file for the module being compiled.

Although it's not clear whether this behavior is desirable, the behavior of member lookup when the `MemberImportVisibility` feature is enabled should align with it in order to avoid causing unnecessary churn in required imports.

Resolves rdar://132525152.
