### PR TITLE
Adding more comment for Reflection tests that does not support ASAN

### DIFF
--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -6,6 +6,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 /*
    This file pokes at the swift_reflection_projectExistential API

--- a/validation-test/Reflection/existentials_objc.swift
+++ b/validation-test/Reflection/existentials_objc.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/existentials_objc.swift
+++ b/validation-test/Reflection/existentials_objc.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import Foundation
 

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -10,6 +10,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 /*
    This file pokes at the swift_reflection_infoForInstance() API

--- a/validation-test/Reflection/functions_objc.swift
+++ b/validation-test/Reflection/functions_objc.swift
@@ -8,6 +8,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/functions_objc.swift
+++ b/validation-test/Reflection/functions_objc.swift
@@ -7,6 +7,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import Foundation
 import simd

--- a/validation-test/Reflection/inherits_ObjCClasses.swift
+++ b/validation-test/Reflection/inherits_ObjCClasses.swift
@@ -9,6 +9,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/inherits_ObjCClasses.swift
+++ b/validation-test/Reflection/inherits_ObjCClasses.swift
@@ -10,6 +10,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import simd
 import ObjCClasses

--- a/validation-test/Reflection/inherits_Swift.swift
+++ b/validation-test/Reflection/inherits_Swift.swift
@@ -8,6 +8,7 @@
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Enum_value.swift
+++ b/validation-test/Reflection/reflect_Enum_value.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values.swift
+++ b/validation-test/Reflection/reflect_Enum_values.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values10.swift
+++ b/validation-test/Reflection/reflect_Enum_values10.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values11.swift
+++ b/validation-test/Reflection/reflect_Enum_values11.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values2.swift
+++ b/validation-test/Reflection/reflect_Enum_values2.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values3.swift
+++ b/validation-test/Reflection/reflect_Enum_values3.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values4.swift
+++ b/validation-test/Reflection/reflect_Enum_values4.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values5.swift
+++ b/validation-test/Reflection/reflect_Enum_values5.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values6.swift
+++ b/validation-test/Reflection/reflect_Enum_values6.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values7.swift
+++ b/validation-test/Reflection/reflect_Enum_values7.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values8.swift
+++ b/validation-test/Reflection/reflect_Enum_values8.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values9.swift
+++ b/validation-test/Reflection/reflect_Enum_values9.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_Enum_values_resilient.swift
+++ b/validation-test/Reflection/reflect_Enum_values_resilient.swift
@@ -10,6 +10,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop, OS=macosx
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_NSArray.swift
+++ b/validation-test/Reflection/reflect_NSArray.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_NSNumber.swift
+++ b/validation-test/Reflection/reflect_NSNumber.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_NSSet.swift
+++ b/validation-test/Reflection/reflect_NSSet.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_NSString.swift
+++ b/validation-test/Reflection/reflect_NSString.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
 


### PR DESCRIPTION
### Summary:

As reference the PR https://github.com/swiftlang/swift/pull/75509 (Reflection tests are incompatible with ASAN), Adding more comment on some files in Reflection tests

### Modifications:

+ validation-test/Reflection/existentials.swift
+ validation-test/Reflection/existentials_objc.swift
+ validation-test/Reflection/functions.swift
+ validation-test/Reflection/functions_objc.swift
+ validation-test/Reflection/inherits_NSObject.swift
+ validation-test/Reflection/inherits_ObjCClasses.swift
+ validation-test/Reflection/inherits_Swift.swift

### Result:

Adding more "UNSUPPORTED: asan"
