### PR TITLE
[6.0][IRGen] Properly compute bit mask for extra tag bits in CVW

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1696,7 +1696,7 @@ namespace {
             projectedBits = IGF.Builder.CreateElementBitCast(projectedBits, IGM.Int8Ty);
           }
           extraTag = IGF.Builder.CreateLoad(projectedBits);
-          auto maskBits = llvm::PowerOf2Ceil(NumExtraTagValues) - 1;
+          auto maskBits = (1 << ExtraTagBitCount) - 1;
           auto mask = llvm::ConstantInt::get(extraTag->getType(), maskBits);
           extraTag = IGF.Builder.CreateAnd(extraTag, mask);
         } else {

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -629,6 +629,38 @@ public enum TwoPayloadOuter {
     case y(TwoPayloadInner)
 }
 
+public enum OneExtraTagValue {
+    public enum E0 {
+        case a(Bool)
+        case b(Bool)
+    }
+
+    public enum E1 {
+        case a(E0)
+        case b(Bool)
+    }
+    public enum E2 {
+        case a(E1)
+        case b(Bool)
+    }
+    public enum E3 {
+        case a(E2)
+        case b(Bool)
+    }
+
+    public enum E4 {
+        case a(E3)
+        case b(Bool)
+    }
+
+    case x0(E4, Int8, Int16, Int32)
+    case x1(E4, Int8, Int16, Int32)
+    case x2(E4, Int8, Int16, Int32)
+    case x3(E4, Int8, Int16, Int32)
+    case y(SimpleClass)
+    case z
+}
+
 @inline(never)
 public func consume<T>(_ x: T.Type) {
     withExtendedLifetime(x) {}

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -1319,6 +1319,35 @@ func testNestedTwoPayload() {
 
 testNestedTwoPayload()
 
+func testMultiPayloadOneExtraTagValue() {
+    let ptr = UnsafeMutablePointer<OneExtraTagValue>.allocate(capacity: 1)
+
+    do {
+        let x = OneExtraTagValue.y(SimpleClass(x: 23))
+        testInit(ptr, to: x)
+    }
+
+    do {
+        let y = OneExtraTagValue.y(SimpleClass(x: 1))
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testMultiPayloadOneExtraTagValue()
+
 #if os(macOS)
 func testObjc() {
     let ptr = UnsafeMutablePointer<ObjcWrapper>.allocate(capacity: 1)


### PR DESCRIPTION
- **Explanation**: PowerOf2Ceil is not the correct function to use, because we end up with an empty mask if there is only one value stored in the extra tag bits
- **Scope**: Compact value witnesses
- **Issues**: rdar://132501359
- **Original PRs**: https://github.com/swiftlang/swift/pull/75514
- **Risk**: Low. Only affects CVW
- **Testing**: Added unit test that reproduced the issue before the fix and passes after.
- **Reviewers**: @mikeash 