### PR TITLE
[Sema] Fold SequenceExpr in pre-checking pre-walk

### DIFF
--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -418,12 +418,8 @@ static Expr *foldSequence(DeclContext *DC,
     }
     
     // Pull out the next binary operator.
-    Op op2{S[0], TypeChecker::lookupPrecedenceGroupForInfixOperator(
-                     DC, S[0], /*diagnose=*/true)};
-
-    // If the second operator's precedence is lower than the
-    // precedence bound, break out of the loop.
-    if (!precedenceBound.shouldConsider(op2.precedence)) break;
+    Op op2 = getNextOperator();
+    if (!op2) break;
 
     // If we're missing precedence info for either operator, treat them
     // as non-associative.

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -631,6 +631,15 @@ swift::DefaultTypeRequest::evaluate(Evaluator &evaluator,
 }
 
 Expr *TypeChecker::foldSequence(SequenceExpr *expr, DeclContext *dc) {
+  // First resolve any unresolved decl references in operator positions.
+  for (auto i : indices(expr->getElements())) {
+    if (i % 2 == 0)
+      continue;
+    auto *elt = expr->getElement(i);
+    if (auto *UDRE = dyn_cast<UnresolvedDeclRefExpr>(elt))
+      elt = TypeChecker::resolveDeclRefExpr(UDRE, dc);
+    expr->setElement(i, elt);
+  }
   ArrayRef<Expr*> Elts = expr->getElements();
   assert(Elts.size() > 1 && "inadequate number of elements in sequence");
   assert((Elts.size() & 1) == 1 && "even number of elements in sequence");

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1810,3 +1810,14 @@ func test_extraneous_argument_with_inout() {
   var x: Int = 0
   test(42, &x) // expected-error {{extra argument in call}}
 }
+
+// https://github.com/swiftlang/swift/issues/75527
+struct Issue75527 {
+  func foo(x: Int) {}
+
+  func bar() {
+    typealias Magic<T> = T
+    let fn = Issue75527.foo(self) as Magic
+    fn(0) // Make sure the argument label does not escape here.
+  }
+}

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -52,7 +52,6 @@ do {
   _=/0/
   // expected-error@-1 {{'_' can only appear in a pattern or on the left side of an assignment}}
   // expected-error@-2 {{cannot find operator '=/' in scope}}
-  // expected-error@-3 {{'/' is not a postfix unary operator}}
 }
 
 // No closing '/' so a prefix operator.

--- a/test/expr/primary/super/unsupported.swift
+++ b/test/expr/primary/super/unsupported.swift
@@ -42,8 +42,7 @@ class Derived: Base {
     // expected-error@+1 {{'super' may be used only to access a superclass member, subscript, or initializer}}
     let _ = self[super]
 
-    // FIXME: Duplicate diagnostic because expression is re-pre-checked after folding initial sequence expression.
-    // expected-error@+1 2 {{'super' may be used only to access a superclass member, subscript, or initializer}}
+    // expected-error@+1 {{'super' may be used only to access a superclass member, subscript, or initializer}}
     _ = (0, super)
 
     func nested() {


### PR DESCRIPTION
Doing it in the post-walk meant we ended up walking the children twice, which led to duplicate diagnostics and incorrect inference of the level of application for function references. Move it to the pre-walk, ensuring that we resolve any operator references before folding.

Resolves #75527