### PR TITLE
Address 128-bit integer comparison type inference issue

### DIFF
--- a/stdlib/public/core/Int128.swift
+++ b/stdlib/public/core/Int128.swift
@@ -499,3 +499,30 @@ extension Int128: FixedWidthInteger, SignedInteger {
     Self(Builtin.mul_Int128(lhs._value, rhs._value))
   }
 }
+
+// MARK: - Integer comparison type inference
+@available(SwiftStdlib 6.0, *)
+extension Int128 {
+  // IMPORTANT: The following four apparently unnecessary overloads of
+  // comparison operations are necessary for literal comparands to be
+  // inferred as the desired type.
+  @_transparent @_alwaysEmitIntoClient
+  public static func != (lhs: Self, rhs: Self) -> Bool {
+    return !(lhs == rhs)
+  }
+
+  @_transparent @_alwaysEmitIntoClient
+  public static func <= (lhs: Self, rhs: Self) -> Bool {
+    return !(rhs < lhs)
+  }
+
+  @_transparent @_alwaysEmitIntoClient
+  public static func >= (lhs: Self, rhs: Self) -> Bool {
+    return !(lhs < rhs)
+  }
+
+  @_transparent @_alwaysEmitIntoClient
+  public static func > (lhs: Self, rhs: Self) -> Bool {
+    return rhs < lhs
+  }
+}

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -552,3 +552,30 @@ extension UInt128: FixedWidthInteger, UnsignedInteger {
     return Self(_low: _high.byteSwapped, _high: _low.byteSwapped)
   }
 }
+
+// MARK: - Integer comparison type inference
+@available(SwiftStdlib 6.0, *)
+extension UInt128 {
+  // IMPORTANT: The following four apparently unnecessary overloads of
+  // comparison operations are necessary for literal comparands to be
+  // inferred as the desired type.
+  @_transparent @_alwaysEmitIntoClient
+  public static func != (lhs: Self, rhs: Self) -> Bool {
+    return !(lhs == rhs)
+  }
+
+  @_transparent @_alwaysEmitIntoClient
+  public static func <= (lhs: Self, rhs: Self) -> Bool {
+    return !(rhs < lhs)
+  }
+
+  @_transparent @_alwaysEmitIntoClient
+  public static func >= (lhs: Self, rhs: Self) -> Bool {
+    return !(lhs < rhs)
+  }
+
+  @_transparent @_alwaysEmitIntoClient
+  public static func > (lhs: Self, rhs: Self) -> Bool {
+    return rhs < lhs
+  }
+}

--- a/test/stdlib/integer_comparison_typeinference.swift
+++ b/test/stdlib/integer_comparison_typeinference.swift
@@ -14,4 +14,22 @@ ComparisonTypeInferenceTests.test("Int8") {
   expectTrue( 1 << 7 <= Int8.max)
 }
 
+ComparisonTypeInferenceTests.test("Int128") {
+  if #available(SwiftStdlib 6.0, *) {
+    expectTrue(Int128.max != 9_999_999_999_999_999_999_999_999_999_999_999)
+    expectTrue(Int128.max > 9_999_999_999_999_999_999_999_999_999_999_999)
+    expectTrue(Int128.max >= 9_999_999_999_999_999_999_999_999_999_999_999)
+    expectFalse(Int128.max <= 9_999_999_999_999_999_999_999_999_999_999_999)
+  }
+}
+
+ComparisonTypeInferenceTests.test("UInt128") {
+  if #available(SwiftStdlib 6.0, *) {
+    expectTrue(UInt128.max != 9_999_999_999_999_999_999_999_999_999_999_999)
+    expectTrue(UInt128.max > 9_999_999_999_999_999_999_999_999_999_999_999)
+    expectTrue(UInt128.max >= 9_999_999_999_999_999_999_999_999_999_999_999)
+    expectFalse(UInt128.max <= 9_999_999_999_999_999_999_999_999_999_999_999)
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
This PR is basically just like #70043, but for our shiny new 128-bit types:

Generic comparison operators will default literal operands to type `Int`, which means that for `!=` `<=` `>` and `>=` comparison with large literals that can't be represented as an `Int` will result in a compiler error:

```swift
func f(_ x: UInt128) -> Bool {
  x <= 9_999_999_999_999_999_999_999_999_999_999_999
  // Error: integer literal '9999999999999999999999999999999999' overflows when stored into 'Int'
}
```

(For `<` and `==`, the `Comparable` protocol requirements win overload resolution and, since they are homogeneous comparison operators, give the desired behavior.)

So we carry over the same fix as before. If we do this fast enough and cherry pick into Swift 6.0, these might not need to be `@_alwaysEmitIntoClient`.

Resolves #74931.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
