### PR TITLE
[6.0] [test] Disable `coverage_inlined_counters_exec.swift` on `device_run`

### DIFF
--- a/test/Profiler/coverage_inlined_counters_exec.swift
+++ b/test/Profiler/coverage_inlined_counters_exec.swift
@@ -21,6 +21,9 @@
 // REQUIRES: profile_runtime
 // REQUIRES: executable_test
 
+// FIXME: Currently fails on device_run (rdar://132715280)
+// UNSUPPORTED: device_run
+
 //--- a.swift
 @_transparent
 public func foo() {}


### PR DESCRIPTION
rdar://132715280