### PR TITLE
[6.0] Update test/SILGen/keypaths_objc_optional.swift for SDK availability change.

### DIFF
--- a/test/SILGen/keypaths_objc_optional.swift
+++ b/test/SILGen/keypaths_objc_optional.swift
@@ -66,4 +66,4 @@ func testKeyPathAccessorsForOptionalStorageComponents() {
   _ = \ObjCProtocol.flag
 }
 
-// CHECK-macosx-x86_64: sil [transparent] [serialized] @$s10ObjectiveC22_convertObjCBoolToBoolySbAA0cD0VF : $@convention(thin) (ObjCBool) -> Bool
+// CHECK-macosx-x86_64: sil [transparent] [serialized] {{.*}}@$s10ObjectiveC22_convertObjCBoolToBoolySbAA0cD0VF : $@convention(thin) (ObjCBool) -> Bool


### PR DESCRIPTION
Explanation: Test fix for CI
Scope: Test fix, no change to compiler or runtime
Issue: rdar://129894685, rdar://132710874
Original PR: https://github.com/swiftlang/swift/pull/74497
Risk: Low. Test fix, no change to compiler or runtime
Testing: Swift CI
Reviewer: @eeckstein 
