### PR TITLE
Un-deprecate Task.startOnMainActor

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -255,8 +255,6 @@ extension Task where Failure == Error {
     @_spi(MainActorUtilities)
     @MainActor
     @available(SwiftStdlib 5.9, *)
-    @available(*, deprecated, message: "Use Task.init with a main actor isolated closure instead")
-    @available(swift, obsoleted: 6.0, message: "Use Task.init with a main actor isolated closure instead")
     @discardableResult
     public static func startOnMainActor(
         priority: TaskPriority? = nil,
@@ -280,8 +278,6 @@ extension Task where Failure == Never {
     @_spi(MainActorUtilities)
     @MainActor
     @available(SwiftStdlib 5.9, *)
-    @available(*, deprecated, message: "Use Task.init with a main actor isolated closure instead")
-    @available(swift, obsoleted: 6.0, message: "Use Task.init with a main actor isolated closure instead")
     @discardableResult
     public static func startOnMainActor(
         priority: TaskPriority? = nil,


### PR DESCRIPTION
This was deprecated in #74239 with a message to replace with

```swift
Task { @MainActor in ... }
```

But that doesn't have equivalent semantics. `startOnMainActor` executes the closure synchronously up to the first suspension point, which is necessary for working with APIs like XPC connections and UIKit drag-and-drop. `Task { @MainActor in }` enqueues a job that gets kicked off on the next run loop tick.

Let's un-deprecate this SPI until we can replace it with something with equivalent semantics/guarantees.

Resolves rdar://132595273