### PR TITLE
Serialization: Bubble up more errors from readParameterList 

### DIFF
--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -502,7 +502,7 @@ private:
   /// Recursively reads a pattern from \c DeclTypeCursor.
   llvm::Expected<Pattern *> readPattern(DeclContext *owningDC);
 
-  ParameterList *readParameterList();
+  llvm::Expected<ParameterList *> readParameterList();
   
   /// Reads a generic param list from \c DeclTypeCursor.
   ///


### PR DESCRIPTION
At this point, deserializing any decls can trigger errors. Make sure we recover from errors in more deserialization paths known to fail.

rdar://131002388