### PR TITLE
utils: attempt to enable sccache on Windows

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -75,11 +75,14 @@ if not "%WINDOWS_SDKS%"=="" set "WindowsSDKArchitecturesArg=-WindowsSDKArchitect
 
 call :CloneRepositories || (exit /b 1)
 
+set SCCACHE_DIRECT=true
+
 :: We only have write access to BuildRoot, so use that as the image root.
 powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -SourceCache %SourceRoot% ^
   -BinaryCache %BuildRoot% ^
   -ImageRoot %BuildRoot% ^
+  -EnableCaching ^
   %SkipPackagingArg% ^
   %WindowsSDKArchitecturesArg% ^
   %TestArg% ^


### PR DESCRIPTION
This requires additional environment variables to be configured (for sccache to locate the bucket) and requires that sccache is installed and available in `Path`.