### PR TITLE
NCGenerics: begin process of removing compat hack

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -392,7 +392,7 @@ EXPERIMENTAL_FEATURE(DebugDescriptionMacro, true)
 
 EXPERIMENTAL_FEATURE(ReinitializeConsumeInMultiBlockDefer, false)
 
-EXPERIMENTAL_FEATURE(SE427NoInferenceOnExtension, false)
+EXPERIMENTAL_FEATURE(SE427NoInferenceOnExtension, true)
 
 EXPERIMENTAL_FEATURE(Extern, true)
 

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -627,6 +627,7 @@ function(_compile_swift_files
 
   list(APPEND swift_flags "-enable-experimental-feature" "NoncopyableGenerics2")
   list(APPEND swift_flags "-enable-experimental-feature" "SuppressedAssociatedTypes")
+  list(APPEND swift_flags "-enable-experimental-feature" "SE427NoInferenceOnExtension")
 
   if(SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES)
     list(APPEND swift_flags "-enable-experimental-feature" "NonescapableTypes")

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -142,3 +142,12 @@ public struct RegularTwice: ~Copyable, ~Copyable {}
 public struct Continuation<T: ~Copyable, E: Error> {
   public func resume(returning value: consuming T) where E == Never {}
 }
+
+// coverage for rdar://132453000 (Can't make a type both conditionally Copyable and conditionally Escapable)
+@frozen
+public enum Moptional<Wrapped: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {
+  case none
+  case some(Wrapped)
+}
+extension Moptional: Copyable where Wrapped: Copyable {}
+extension Moptional: Escapable where Wrapped: Escapable {}

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -1,8 +1,5 @@
 // RUN: %empty-directory(%t)
 
-// Due to SE427NoInferenceOnExtension not being in production
-// REQUIRES: asserts
-
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
 // RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:     -enable-experimental-feature NonescapableTypes \
@@ -159,6 +156,11 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC-NEXT: }
 
 // CHECK-MISC-NEXT: public struct Continuation<T, E> where E : Swift.Error, T : ~Copyable {
+
+// CHECK-MISC: @frozen public enum Moptional<Wrapped> : ~Swift.Copyable, ~Swift.Escapable where Wrapped : ~Copyable, Wrapped : ~Escapable {
+// CHECK-MISC: extension {{.*}}.Moptional : Swift.Copyable where Wrapped : Swift.Copyable {
+// CHECK-MISC: extension {{.*}}.Moptional : Swift.Escapable where Wrapped : Swift.Escapable {
+
 // CHECK-MISC-NOT:  ~
 
 // NOTE: below are extensions emitted at the end of NoncopyableGenerics_Misc.swift


### PR DESCRIPTION
The reverse-condfail workaround needs to be removed, and this is the first step to allowing the stdlib to build with conditionally escapable types.

resolves rdar://132453000