### PR TITLE
[Cleanup] Remove more `StringRef::equals`

### DIFF
--- a/lib/Parse/ParseVersion.cpp
+++ b/lib/Parse/ParseVersion.cpp
@@ -94,7 +94,7 @@ std::optional<Version> VersionParser::parseCompilerVersionString(
 
     // The second version component isn't used for comparison.
     if (i == 1) {
-      if (!SplitComponent.equals("*")) {
+      if (SplitComponent != "*") {
         if (Diags) {
           // Majors 600-1300 were used for Swift 1.0-5.5 (based on clang
           // versions), but then we reset the numbering based on Swift versions,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2442,7 +2442,7 @@ static bool allowSymbolLinkageMarkers(ASTContext &ctx, Decl *D) {
 
   if (macroDecl->getParentModule()->isStdlibModule() &&
       macroDecl->getName().getBaseIdentifier()
-          .str().equals("_DebugDescriptionProperty"))
+          .str() == "_DebugDescriptionProperty")
     return true;
 
   return false;
@@ -7366,11 +7366,11 @@ void AttributeChecker::visitUnsafeInheritExecutorAttr(
   if (!fn->isAsyncContext()) {
     diagnose(attr->getLocation(), diag::inherits_executor_without_async);
   } else if (fn->getBaseName().isSpecial() ||
-             !fn->getParentModule()->getName().str().equals("_Concurrency") ||
+             fn->getParentModule()->getName().str() != "_Concurrency" ||
              !fn->getBaseIdentifier().str()
                 .starts_with("_unsafeInheritExecutor_")) {
     bool inConcurrencyModule = D->getDeclContext()->getParentModule()->getName()
-        .str().equals("_Concurrency");
+        .str() == "_Concurrency";
     auto diag = fn->diagnose(diag::unsafe_inherits_executor_deprecated);
     diag.warnUntilSwiftVersion(6);
     diag.limitBehaviorIf(inConcurrencyModule, DiagnosticBehavior::Warning);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2096,7 +2096,7 @@ void swift::replaceUnsafeInheritExecutorWithDefaultedIsolationParam(
 
 /// Whether this declaration context is in the _Concurrency module.
 static bool inConcurrencyModule(const DeclContext *dc) {
-  return dc->getParentModule()->getName().str().equals("_Concurrency");
+  return dc->getParentModule()->getName().str() == "_Concurrency";
 }
 
 void swift::introduceUnsafeInheritExecutorReplacements(


### PR DESCRIPTION
`StringRef::equals` has been removed upstream.