### PR TITLE
[Caching] Use `swift-frontend` as executable name in replays

### DIFF
--- a/lib/Frontend/DiagnosticHelper.cpp
+++ b/lib/Frontend/DiagnosticHelper.cpp
@@ -347,6 +347,9 @@ static DetailedTaskDescription constructDetailedTaskDescription(
     ArrayRef<const char *> Args, bool isEmitModuleOnly = false) {
   // Command line and arguments
   std::string Executable = Invocation.getFrontendOptions().MainExecutablePath;
+  // If main executable path is never set, use `swift-frontend` as placeholder.
+  if (Executable.empty())
+    Executable = "swift-frontend";
   SmallVector<std::string, 16> Arguments;
   std::string CommandLine;
   SmallVector<CommandInput, 4> Inputs;

--- a/test/CAS/swift-scan-diagnostics-batch.swift
+++ b/test/CAS/swift-scan-diagnostics-batch.swift
@@ -50,8 +50,6 @@
 
 // PARSEABLE-COUNT-1:   "kind": "began",
 // PARSEABLE-COUNT-1:   "kind": "finished",
-// PRASEABLE-NOT: "kind": "began",
-// PRASEABLE-NOT: "kind": "finished",
 
 // NO-OUTPUT-NOT: "kind": "began",
 

--- a/test/CAS/swift-scan-diagnostics.swift
+++ b/test/CAS/swift-scan-diagnostics.swift
@@ -54,6 +54,7 @@
 // PARSEABLE-NEXT: {
 // PARSEABLE-NEXT:   "kind": "began",
 // PARSEABLE-NEXT:   "name": "compile",
+// PARSEABLE-NEXT:   "command": "swift-frontend
 
 // PARSEABLE:   "kind": "finished",
 // PARSEABLE-NEXT:   "name": "compile",

--- a/tools/libSwiftScan/SwiftCaching.cpp
+++ b/tools/libSwiftScan/SwiftCaching.cpp
@@ -981,8 +981,11 @@ static llvm::Error replayCompilation(SwiftScanReplayInstance &Instance,
     DH.initDiagConsumers(Invocation);
     DH.beginMessage(Invocation, Instance.Args);
 
-    if (auto E = CDP->replayCachedDiagnostics(DiagnosticsOutput->getData()))
+    if (auto E = CDP->replayCachedDiagnostics(DiagnosticsOutput->getData())) {
+      DH.endMessage(/*ReturnCode=*/1);
+      Inst.getDiags().finishProcessing();
       return E;
+    }
 
     if (Remarks)
       Inst.getDiags().diagnose(SourceLoc(), diag::replay_output,

--- a/tools/libSwiftScan/SwiftCaching.cpp
+++ b/tools/libSwiftScan/SwiftCaching.cpp
@@ -276,16 +276,8 @@ computeCacheKey(llvm::cas::ObjectStore &CAS, llvm::ArrayRef<const char *> Args,
   swift::CompilerInvocation Invocation;
   swift::SourceManager SourceMgr;
   swift::DiagnosticEngine Diags(SourceMgr);
-  llvm::SmallString<128> workingDirectory;
-  llvm::sys::fs::current_path(workingDirectory);
-  llvm::SmallVector<std::unique_ptr<llvm::MemoryBuffer>, 4>
-      configurationFileBuffers;
 
-  std::string MainExecutablePath = llvm::sys::fs::getMainExecutable(
-      "swift-frontend", (void *)swiftscan_cache_replay_compilation);
-
-  if (Invocation.parseArgs(Args, Diags, &configurationFileBuffers,
-                           workingDirectory, MainExecutablePath))
+  if (Invocation.parseArgs(Args, Diags, nullptr, {}))
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "Argument parsing failed");
 
@@ -826,11 +818,7 @@ swiftscan_cache_replay_instance_create(int argc, const char **argv,
   swift::DiagnosticEngine DE(SrcMgr);
   DE.addConsumer(Diags);
 
-  std::string MainExecutablePath = llvm::sys::fs::getMainExecutable(
-      "swift-frontend", (void *)swiftscan_cache_replay_compilation);
-
-  if (Instance->Invocation.parseArgs(Args, DE, nullptr, {},
-                                     MainExecutablePath)) {
+  if (Instance->Invocation.parseArgs(Args, DE, nullptr, {})) {
     delete Instance;
     *error = swift::c_string_utils::create_clone(err_msg.c_str());
     return nullptr;


### PR DESCRIPTION
Don't try to figure out the executable names during replay from
libSwiftScan.dylib. The actual executable path for the process actually
doesn't matter in this case to reconstruct the invocation and might
actually be misleading.

Just use `swift-frontend` as a placeheader executable name for
in-process cache replay.

rdar://132758308