### PR TITLE
Harden new distributed_actor_protocol_call_resilient_lib test for lib search paths

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_protocol_call_resilient_lib.swift
+++ b/test/Distributed/Runtime/distributed_actor_protocol_call_resilient_lib.swift
@@ -52,7 +52,11 @@
 // RUN:     -o %t/a.out
 
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-run %t/a.out                                                   \
+// RUN:     %t/%target-library-name(FakeDistributedActorSystems)               \
+// RUN:     %t/%target-library-name(ResilientLib)                              \
+// RUN:     %t/%target-library-name(ResilientActorLib)                         \
+// RUN:     | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_protocol_call_resilient_lib.swift
+++ b/test/Distributed/Runtime/distributed_actor_protocol_call_resilient_lib.swift
@@ -51,11 +51,17 @@
 // RUN:     -enable-library-evolution                                          \
 // RUN:     -o %t/a.out
 
+// Sign the main binary and all libraries
 // RUN: %target-codesign %t/a.out
+// RUN: %target-codesign %t/%target-library-name(FakeDistributedActorSystems)
+// RUN: %target-codesign %t/%target-library-name(ResilientActorLib)
+// RUN: %target-codesign %t/%target-library-name(ResilientLib)
+
+// Run and verify output
 // RUN: %target-run %t/a.out                                                   \
 // RUN:     %t/%target-library-name(FakeDistributedActorSystems)               \
-// RUN:     %t/%target-library-name(ResilientLib)                              \
 // RUN:     %t/%target-library-name(ResilientActorLib)                         \
+// RUN:     %t/%target-library-name(ResilientLib)                              \
 // RUN:     | %FileCheck %s
 
 // REQUIRES: executable_test


### PR DESCRIPTION
This hardens the test for envs where the libs are not found without explicitly linking.

Thanks @xedin for the hint how to solve this.

resolves rdar://132714652