### PR TITLE
SE-0441: Add language-mode option with alias to swift-version

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -286,6 +286,13 @@ def swift_version : Separate<["-"], "swift-version">,
   HelpText<"Interpret input according to a specific Swift language version number">,
   MetaVarName<"<vers>">;
 
+def language_mode : Separate<["-"], "language-mode">,
+  Flags<[FrontendOption, ModuleInterfaceOption, SwiftSymbolGraphExtractOption,
+         SwiftAPIDigesterOption]>,
+  HelpText<"Interpret input according to a specific Swift language mode">,
+  MetaVarName<"<mode>">,
+  Alias<swift_version>;
+
 def package_description_version: Separate<["-"], "package-description-version">,
   Flags<[FrontendOption, HelpHidden, ModuleInterfaceOption]>,
   HelpText<"The version number to be applied on the input for the PackageDescription availability kind">,

--- a/test/Driver/swift-version.swift
+++ b/test/Driver/swift-version.swift
@@ -12,6 +12,9 @@
 // RUN: not %target-swiftc_driver -swift-version 4 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_4 %s
 // RUN: not %target-swiftc_driver -swift-version 5 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_5 %s
 
+// RUN: not %target-swiftc_driver -language-mode 4 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_4 %s
+// RUN: not %target-swiftc_driver -language-mode 5 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_5 %s
+
 // BAD: invalid value
 // BAD: note: valid arguments to '-swift-version' are '4', '4.2', '5'
 


### PR DESCRIPTION
As part of the implementation of SE-0441, this PR adds a compiler option `language-mode' with an alias to the existing `swift-version` option.

