### PR TITLE
Promote _Concurrency and StringProcessing to core subset of the stdlib

### DIFF
--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -101,7 +101,7 @@ option(SWIFT_STDLIB_EMIT_API_DESCRIPTORS
 
 option(SWIFT_STDLIB_BUILD_ONLY_CORE_MODULES
        "Build only the core subset of the standard library,
-       ignoring additional libraries such as Concurrency, Distributed and StringProcessing.
+       ignoring additional libraries such as Distributed, Observation and Synchronization.
        This is an option meant for internal configurations inside Apple
        that need to build the standard libraries in chunks when constructing an SDK"
        FALSE)

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -269,6 +269,16 @@ if(SWIFT_BUILD_STDLIB)
   if(SWIFT_BUILD_CLANG_OVERLAYS)
     add_subdirectory(ClangOverlays)
   endif()
+
+  if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
+    add_subdirectory(Concurrency)
+  endif()
+
+  if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
+    add_subdirectory(RegexParser)
+    add_subdirectory(StringProcessing)
+    add_subdirectory(RegexBuilder)
+  endif()
 endif()
 
 if(SWIFT_BUILD_STDLIB AND NOT SWIFT_STDLIB_BUILD_ONLY_CORE_MODULES)
@@ -279,18 +289,8 @@ if(SWIFT_BUILD_STDLIB AND NOT SWIFT_STDLIB_BUILD_ONLY_CORE_MODULES)
     add_subdirectory(Differentiation)
   endif()
 
-  if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
-    add_subdirectory(Concurrency)
-  endif()
-
   if(SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED)
     add_subdirectory(Distributed)
-  endif()
-
-  if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
-    add_subdirectory(RegexParser)
-    add_subdirectory(StringProcessing)
-    add_subdirectory(RegexBuilder)
   endif()
 
   if(SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION)


### PR DESCRIPTION
This is needed to support Apple internal configurations.

Addresses rdar://125909114