### PR TITLE
[6.0] Disallow consuming `self` in a noncopyable `deinit` again.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -876,6 +876,8 @@ ERROR(sil_movechecking_discard_missing_consume_self, none,
       "must consume 'self' before exiting method that discards self", ())
 ERROR(sil_movechecking_reinit_after_discard, none,
       "cannot reinitialize 'self' after 'discard self'", ())
+ERROR(sil_movechecking_consume_during_deinit, none,
+      "'self' cannot be consumed during 'deinit'", ())
 
 NOTE(sil_movechecking_discard_self_here, none,
      "discarded self here", ())

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -246,6 +246,7 @@ EXPERIMENTAL_FEATURE(OldOwnershipOperatorSpellings, true)
 EXPERIMENTAL_FEATURE(MoveOnlyEnumDeinits, true)
 EXPERIMENTAL_FEATURE(MoveOnlyTuples, true)
 EXPERIMENTAL_FEATURE(MoveOnlyPartialReinitialization, true)
+EXPERIMENTAL_FEATURE(ConsumeSelfInDeinit, true)
 
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(LayoutPrespecialization, true)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -695,6 +695,7 @@ UNINTERESTING_FEATURE(BorrowingSwitch)
 
 UNINTERESTING_FEATURE(ClosureIsolation)
 UNINTERESTING_FEATURE(Extern)
+UNINTERESTING_FEATURE(ConsumeSelfInDeinit)
 
 static bool usesFeatureConformanceSuppression(Decl *decl) {
   auto *nominal = dyn_cast<NominalTypeDecl>(decl);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1816,7 +1816,21 @@ shouldEmitPartialMutationError(UseState &useState, PartialMutation::Kind kind,
   LLVM_DEBUG(llvm::dbgs() << "    Iter Type: " << iterType << '\n'
                           << "    Target Type: " << targetType << '\n');
 
+  // Allowing full object consumption in a deinit is still not allowed.
   if (iterType == targetType && !isa<DropDeinitInst>(user)) {
+    // Don't allow whole-value consumption of `self` from a `deinit`.
+    if (!fn->getModule().getASTContext().LangOpts
+            .hasFeature(Feature::ConsumeSelfInDeinit)
+        && kind == PartialMutation::Kind::Consume
+        && useState.sawDropDeinit
+        // TODO: Revisit this when we introduce deinits on enums.
+        && !targetType.getEnumOrBoundGenericEnum()) {
+      LLVM_DEBUG(llvm::dbgs() << "    IterType is TargetType in deinit! "
+                                 "Not allowed yet");
+      
+      return {PartialMutationError::consumeDuringDeinit(iterType)};
+    }
+
     LLVM_DEBUG(llvm::dbgs() << "    IterType is TargetType! Exiting early "
                                "without emitting error!\n");
     return {};

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -889,5 +889,11 @@ void DiagnosticEmitter::emitCannotPartiallyMutateError(
     registerDiagnosticEmitted(address);
     return;
   }
+  case PartialMutationError::Kind::ConsumeDuringDeinit: {
+    astContext.Diags.diagnose(user->getLoc().getSourceLoc(),
+                              diag::sil_movechecking_consume_during_deinit);
+    return;
   }
+  }
+  llvm_unreachable("unhandled case");
 }

--- a/test/SILOptimizer/deinit_total_consumption.swift
+++ b/test/SILOptimizer/deinit_total_consumption.swift
@@ -1,0 +1,104 @@
+// RUN: %target-swift-frontend -DEMPTY -emit-sil -verify %s
+// RUN: %target-swift-frontend -DTRIVIAL -emit-sil -verify %s
+// RUN: %target-swift-frontend -DLOADABLE -emit-sil -verify %s
+// RUN: %target-swift-frontend -DADDRESS_ONLY -emit-sil -verify %s
+
+// Don't allow whole-value consumption or mutation of a value in its own
+// `deinit`, but allow consumption of its individual fields.
+
+struct T1: ~Copyable {
+#if EMPTY
+#elseif TRIVIAL
+    var _x: Int
+#elseif LOADABLE
+    var _x: AnyObject
+#elseif ADDRESS_ONLY
+    var _x: Any
+#else
+    #error("pick one")
+#endif
+    deinit {
+        self.foo() // expected-error{{'self' cannot be consumed during 'deinit'}}
+    }
+
+    consuming func foo() {}
+}
+
+struct T2: ~Copyable {
+#if EMPTY
+#elseif TRIVIAL
+    var _x: Int
+#elseif LOADABLE
+    var _x: AnyObject
+#elseif ADDRESS_ONLY
+    var _x: Any
+#else
+    #error("pick one")
+#endif
+
+    deinit {
+        let myself = self // expected-error{{'self' cannot be consumed during 'deinit'}}
+        _ = myself
+    }
+}
+
+func consume<T: ~Copyable>(_: consuming T) {}
+
+struct NC<T: ~Copyable>: ~Copyable {
+    var x: T
+}
+
+struct T3: ~Copyable {
+#if EMPTY
+    var _x: NC<()>
+#elseif TRIVIAL
+    var _x: NC<Int>
+#elseif LOADABLE
+    var _x: NC<AnyObject>
+#elseif ADDRESS_ONLY
+    var _x: NC<Any>
+#else
+    #error("pick one")
+#endif
+
+    // consuming the single field of a one-field type is OK
+    deinit {
+        consume(_x)
+    }
+}
+
+struct T4: ~Copyable {
+#if EMPTY
+#elseif TRIVIAL
+    var _x: Int
+#elseif LOADABLE
+    var _x: AnyObject
+#elseif ADDRESS_ONLY
+    var _x: Any
+#else
+    #error("pick one")
+#endif
+
+    // the implicit cleanup of the value is OK
+    deinit {
+    }
+}
+
+struct T5: ~Copyable {
+#if EMPTY
+    var _x: NC<()>
+#elseif TRIVIAL
+    var _x: NC<Int>
+#elseif LOADABLE
+    var _x: NC<AnyObject>
+#elseif ADDRESS_ONLY
+    var _x: NC<Any>
+#else
+    #error("pick one")
+#endif
+
+    // the implicit cleanup of the value is OK
+    deinit {
+    }
+}
+

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyEnumDeinits %s
+// RUN: %target-swift-frontend -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyEnumDeinits -enable-experimental-feature ConsumeSelfInDeinit %s
 
 class Klass {}
 

--- a/test/SILOptimizer/moveonly_discard.swift
+++ b/test/SILOptimizer/moveonly_discard.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyEnumDeinits %s
+// RUN: %target-swift-frontend -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyEnumDeinits -enable-experimental-feature ConsumeSelfInDeinit %s
 
 
 func posix_close(_ t: Int) {}


### PR DESCRIPTION
Explanation: Disables the ability to pass `self` as a consuming parameter out of a `deinit`. Changes to allow partial consumption accidentally also allow this case, which we have not yet fully designed the semantics for.
Scope: Disables an unwanted language feature.
Issue: rdar://132761460
Original PR: https://github.com/swiftlang/swift/pull/75560
Risk: Low. Disables functionality that was accidentally added.
Testing: Swift CI
Reviewer: @kavon 