### PR TITLE
NFC: Update stale references to `next(_:)`

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -325,7 +325,7 @@ struct ASTContext::Implementation {
   /// The declaration of 'AsyncIteratorProtocol.next()'.
   FuncDecl *AsyncIteratorNext = nullptr;
 
-  /// The declaration of 'AsyncIteratorProtocol.next(_:)' that takes
+  /// The declaration of 'AsyncIteratorProtocol.next(isolation:)' that takes
   /// an actor isolation.
   FuncDecl *AsyncIteratorNextIsolated = nullptr;
 

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1396,7 +1396,7 @@ public:
             isRethrowLikeTypedThrows(fnRef.getFunction())) {
           // If we are in a rethrowing context and the function we're referring
           // to is a rethrow-like function using typed throws or we are
-          // calling the next() or next(_:) of an async iterator,
+          // calling the next() or next(isolation:) of an async iterator,
           // then look at all of the closure arguments.
           LLVM_FALLTHROUGH;
         } else {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3284,7 +3284,7 @@ FuncDecl *TypeChecker::getForEachIteratorNextFunction(
   if (!isAsync)
     return ctx.getIteratorNext();
 
-  // If AsyncIteratorProtocol.next(_:) isn't available at all,
+  // If AsyncIteratorProtocol.next(isolation:) isn't available at all,
   // we're stuck using AsyncIteratorProtocol.next().
   auto nextElement = ctx.getAsyncIteratorNextIsolated();
   if (!nextElement)
@@ -3295,11 +3295,11 @@ FuncDecl *TypeChecker::getForEachIteratorNextFunction(
   if (enclosingUnsafeInheritsExecutor(dc))
     return ctx.getAsyncIteratorNext();
 
-  // If availability checking is disabled, use next(_:).
+  // If availability checking is disabled, use next(isolation:).
   if (ctx.LangOpts.DisableAvailabilityChecking || loc.isInvalid())
     return nextElement;
 
-  // We can only call next(_:) if we are in an availability context
+  // We can only call next(isolation:) if we are in an availability context
   // that supports typed throws.
   auto availability = overApproximateAvailabilityAtLocation(loc, dc);
   if (availability.isContainedIn(ctx.getTypedThrowsAvailability()))

--- a/test/Concurrency/async_for_each_back_deploy.swift
+++ b/test/Concurrency/async_for_each_back_deploy.swift
@@ -3,7 +3,7 @@
 
 @available(SwiftStdlib 5.1, *)
 func f<S: AsyncSequence>(s: S) async throws {
-  // CHECK-NOT: next(_:)
+  // CHECK-NOT: next(isolation:)
   // CHECK: next()
   for try await x in s { }
 }


### PR DESCRIPTION
In the accepted proposal for SE-0421, `next(_:)` became `next(isolation:)`. Some of the references to that method in the codebase need to be updated accordingly.
