### PR TITLE
[embedded] Don't build embedded stdlibs in 'standalone' builds

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2596,6 +2596,7 @@ build-swift-tools=0
 build-swift-libexec=0
 skip-early-swift-driver
 skip-early-swiftsyntax
+build-embedded-stdlib=0
 
 # Then set the paths to our native tools. If compiling against a toolchain,
 # these should all be the ./usr/bin directory.

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1137,6 +1137,10 @@ def create_argument_parser():
     option('--build-swift-stdlib-static-print', toggle_true,
            help='Build constant-folding print() support')
 
+    option('--build-embedded-stdlib', toggle_true,
+           default=True,
+           help='Build embedded stdlib')
+
     option('--build-embedded-stdlib-cross-compiling', toggle_true,
            help='Build embedded stdlib for cross-compiling targets.')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -88,6 +88,7 @@ EXPECTED_DEFAULTS = {
     'build_swift_stdlib_unittest_extra': False,
     'build_swift_stdlib_static_print': False,
     'build_swift_stdlib_unicode_data': True,
+    'build_embedded_stdlib': True,
     'build_embedded_stdlib_cross_compiling': False,
     'build_swift_clang_overlays': True,
     'build_swift_remote_mirror': True,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -598,6 +598,7 @@ EXPECTED_OPTIONS = [
     EnableOption('--build-toolchain-only'),
     EnableOption('--build-swift-private-stdlib'),
     EnableOption('--build-swift-stdlib-unicode-data'),
+    EnableOption('--build-embedded-stdlib'),
     EnableOption('--build-embedded-stdlib-cross-compiling'),
     EnableOption('--build-swift-libexec'),
     EnableOption('--build-swift-clang-overlays'),

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -85,6 +85,8 @@ class Swift(product.Product):
 
         self.cmake_options.extend(self._enable_stdlib_unicode_data)
 
+        self.cmake_options.extend(self._enable_embedded_stdlib)
+
         self.cmake_options.extend(self._enable_embedded_stdlib_cross_compiling)
 
         self.cmake_options.extend(
@@ -258,6 +260,11 @@ updated without updating swift.py?")
     def _enable_experimental_parser_validation(self):
         return [('SWIFT_ENABLE_EXPERIMENTAL_PARSER_VALIDATION:BOOL',
                  self.args.enable_experimental_parser_validation)]
+
+    @property
+    def _enable_embedded_stdlib(self):
+        return [('SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB',
+                 self.args.build_embedded_stdlib)]
 
     @property
     def _enable_embedded_stdlib_cross_compiling(self):

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -67,6 +67,7 @@ class SwiftTestCase(unittest.TestCase):
             build_early_swiftsyntax=False,
             build_swift_stdlib_static_print=False,
             build_swift_stdlib_unicode_data=True,
+            build_embedded_stdlib=True,
             build_embedded_stdlib_cross_compiling=False,
             swift_freestanding_is_darwin=False,
             build_swift_private_stdlib=True,
@@ -116,6 +117,7 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_FREESTANDING_IS_DARWIN:BOOL=FALSE',
             '-DSWIFT_STDLIB_BUILD_PRIVATE:BOOL=TRUE',
             '-DSWIFT_STDLIB_ENABLE_UNICODE_DATA=TRUE',
+            '-DSWIFT_SHOULD_BUILD_EMBEDDED_STDLIB=TRUE',
             '-DSWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING=FALSE',
             '-DSWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS:BOOL=FALSE',
             '-USWIFT_DEBUGINFO_NON_LTO_ARGS'
@@ -149,6 +151,7 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_FREESTANDING_IS_DARWIN:BOOL=FALSE',
             '-DSWIFT_STDLIB_BUILD_PRIVATE:BOOL=TRUE',
             '-DSWIFT_STDLIB_ENABLE_UNICODE_DATA=TRUE',
+            '-DSWIFT_SHOULD_BUILD_EMBEDDED_STDLIB=TRUE',
             '-DSWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING=FALSE',
             '-DSWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS:BOOL=FALSE',
             '-USWIFT_DEBUGINFO_NON_LTO_ARGS'


### PR DESCRIPTION
To fix a broken CI job: https://ci.swift.org/job/oss-swift-test-stdlib-with-toolchain-minimal/8977/console

rdar://130528949