### PR TITLE
Ensure Foundation tests don't run when passing --skip-foundation-tests

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -213,6 +213,7 @@ def _apply_default_arguments(args):
         args.test_android = False
         args.test_cmark = False
         args.test_swiftpm = False
+        args.test_foundation = False
         args.test_swift_driver = False
         args.test_swiftsyntax = False
         args.test_indexstoredb = False
@@ -1312,6 +1313,8 @@ def create_argument_parser():
            help='skip testing cmark')
     option('--skip-test-swiftpm', toggle_false('test_swiftpm'),
            help='skip testing swiftpm')
+    option('--skip-test-foundation', toggle_false('test_foundation'),
+           help='skip testing Foundation')
     option('--skip-test-swift-driver', toggle_false('test_swift_driver'),
            help='skip testing Swift driver')
     option('--skip-test-swiftsyntax', toggle_false('test_swiftsyntax'),

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -738,6 +738,7 @@ EXPECTED_OPTIONS = [
                   dest='test_playgroundsupport'),
     DisableOption('--skip-test-cmark', dest='test_cmark'),
     DisableOption('--skip-test-swiftpm', dest='test_swiftpm'),
+    DisableOption('--skip-test-foundation', dest='test_foundation'),
     DisableOption('--skip-test-swift-driver', dest='test_swift_driver'),
     DisableOption('--skip-test-swiftsyntax', dest='test_swiftsyntax'),
     DisableOption('--skip-test-indexstore-db', dest='test_indexstoredb'),

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -307,6 +307,7 @@ EXPECTED_DEFAULTS = {
     'test_playgroundsupport': True,
     'test_cmark': False,
     'test_swiftpm': False,
+    'test_foundation': False,
     'test_swift_driver': False,
     'test_swiftsyntax': False,
     'test_indexstoredb': False,

--- a/utils/swift_build_support/swift_build_support/products/foundationtests.py
+++ b/utils/swift_build_support/swift_build_support/products/foundationtests.py
@@ -50,7 +50,7 @@ class FoundationTests(product.Product):
         return False
 
     def should_test(self, host_target):
-        return True
+        return self.args.test_foundation
 
     def configuration(self):
         return 'release' if self.is_release() else 'debug'

--- a/utils/swift_build_support/swift_build_support/products/swiftfoundationtests.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftfoundationtests.py
@@ -50,7 +50,7 @@ class SwiftFoundationTests(product.Product):
         return False
 
     def should_test(self, host_target):
-        return True
+        return self.args.test_foundation
 
     def configuration(self):
         return 'release' if self.is_release() else 'debug'


### PR DESCRIPTION
Now that Foundation's tests are defined as separate build script steps after SwiftPM, we need to ensure that the tests respect the `--skip-foundation-tests` argument. Instead of passing it to `build-script-impl`, we capture it as an argument and use it to provide the `should_test` value. This ensures that CI runs that don't test Foundation (because they don't build SwiftPM or otherwise) don't attempt to run Foundation tests.