### PR TITLE
[SourceKit] Run interface generation request on a deep stack

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -921,7 +921,7 @@ static void
 handleRequestEditorOpenInterface(const RequestDict &Req,
                                  SourceKitCancellationToken CancellationToken,
                                  ResponseReceiver Rec) {
-  {
+  handleSemanticRequest(Req, Rec, [Req, Rec]() {
     SmallVector<const char *, 8> Args;
     if (getCompilerArgumentsForRequestOrEmitError(Req, Args, Rec))
       return;
@@ -938,7 +938,7 @@ handleRequestEditorOpenInterface(const RequestDict &Req,
     std::optional<StringRef> InterestedUSR = Req.getString(KeyInterestedUSR);
     return Rec(editorOpenInterface(*Name, *ModuleName, GroupName, Args,
                                    SynthesizedExtension, InterestedUSR));
-  }
+  });
 }
 
 static void handleRequestEditorOpenHeaderInterface(


### PR DESCRIPTION
Building the generated interface for WinSDK can overflow the stack. Treat it as a semantic request to run it on a large stack.

Fixes swiftlang/sourcekit-lsp#1115
rdar://123944504
