### PR TITLE
[ASTGen] Update for new FixIt.Change API in Swift-Syntax

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -75,6 +75,12 @@ fileprivate func emitDiagnosticParts(
       replaceEndLoc = bridgedSourceLoc(at: oldToken.endPosition)
       newText = newTrivia.description
 
+    case .replaceChild(let replacingChildData):
+      let replacementRange = replacingChildData.replacementRange
+      replaceStartLoc = bridgedSourceLoc(at: replacementRange.lowerBound)
+      replaceEndLoc = bridgedSourceLoc(at: replacementRange.upperBound)
+      newText = replacingChildData.newChild.description
+      
 #if RESILIENT_SWIFT_SYNTAX
     @unknown default:
       fatalError()
@@ -221,6 +227,18 @@ extension SourceManager {
         )
         newText = newTrivia.description
 
+      case .replaceChild(let replacingChildData):
+        let replacementRange = replacingChildData.replacementRange
+        replaceStartLoc = bridgedSourceLoc(
+          for: replacingChildData.parent,
+          at: replacementRange.lowerBound
+        )
+        replaceEndLoc = bridgedSourceLoc(
+          for: replacingChildData.parent,
+          at: replacementRange.upperBound
+        )
+        newText = replacingChildData.newChild.description
+        
 #if RESILIENT_SWIFT_SYNTAX
       @unknown default:
         fatalError()


### PR DESCRIPTION
[https://github.com/swiftlang/swift-syntax/pull/2758](https://github.com/swiftlang/swift-syntax/pull/2758) is introducing an API-breaking change to Swift Syntax, necessitating a concerted update to ASTGen.
