### PR TITLE
[Macros] Add the correct RPATH flags to the in-process plugin server host library

### DIFF
--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -25,6 +25,7 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
     set_property(TARGET SwiftInProcPluginServer
       APPEND PROPERTY INSTALL_RPATH
         "$ORIGIN")
+    _set_pure_swift_link_flags(SwiftInProcPluginServer "../../")
   endif()
 
   # FXIME: Importing package-cmo enabled '.swiftmodule' causes compiler crash :(

--- a/tools/swift-plugin-server/Sources/SwiftInProcPluginServer/InProcPluginServer.swift
+++ b/tools/swift-plugin-server/Sources/SwiftInProcPluginServer/InProcPluginServer.swift
@@ -17,6 +17,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Bionic)
+import Bionic
 #elseif canImport(Musl)
 import Musl
 #elseif canImport(ucrt)


### PR DESCRIPTION
like the in-process plugin server

Also, make sure the in-process plugin server builds for Android.

@rintaro, I noticed this library leaks the builder runpath in the latest trunk toolchain for linux:
```
> readelf -d swift-DEVELOPMENT-SNAPSHOT-2024-07-29-a-ubi9/usr/lib/swift/host/libSwiftInProcPluginServer.so | ag runpath
 0x000000000000001d (RUNPATH)            Library runpath: [/opt/swift/5.8.1/usr/lib/swift/linux:$ORIGIN]
```
This pull fixed that when I built it natively on Android, along with the `Bionic` import.

I will submit [an integration test for this new builder path](https://github.com/swiftlang/swift-integration-tests/blob/main/test-snapshot-binaries/test-rpath-linux.py#L44) once this is in.