### PR TITLE
SILBuilder: use the new ASSERT macro in the SILBuilder

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -183,7 +183,7 @@ public:
   SILBuilder(SILBasicBlock *BB, SILBuilderContext &C,
              const SILDebugScope *DS = nullptr)
       : TempContext(C.getModule()), C(C), F(BB->getParent()) {
-    assert(DS && "block has no debug scope");
+    ASSERT(DS && "block has no debug scope");
     setInsertionPoint(BB);
     if (DS)
       setCurrentDebugScope(DS);
@@ -197,7 +197,7 @@ public:
   void setSILConventions(SILModuleConventions silConv) { C.silConv = silConv; }
 
   SILFunction &getFunction() const {
-    assert(F && "cannot create this instruction without a function context");
+    ASSERT(F && "cannot create this instruction without a function context");
     return *F;
   }
 
@@ -286,7 +286,7 @@ public:
   SILBasicBlock *getInsertionBB() const { return BB; }
   SILBasicBlock::iterator getInsertionPoint() const { return InsertPt; }
   SILLocation getInsertionPointLoc() const {
-    assert(!insertingAtEndOfBlock());
+    ASSERT(!insertingAtEndOfBlock());
     return InsertPt->getLoc();
   }
 
@@ -294,7 +294,7 @@ public:
   /// of the current basic block.  False if we're inserting before an existing
   /// instruction.
   bool insertingAtEndOfBlock() const {
-    assert(hasValidInsertionPoint() &&
+    ASSERT(hasValidInsertionPoint() &&
            "Must have insertion point to ask about it");
     return InsertPt == BB->end();
   }
@@ -307,13 +307,13 @@ public:
   void setInsertionPoint(SILBasicBlock *BB, SILBasicBlock::iterator insertPt) {
     this->BB = BB;
     this->InsertPt = insertPt;
-    assert(insertPt == BB->end() || insertPt->getParent() == BB);
+    ASSERT(insertPt == BB->end() || insertPt->getParent() == BB);
   }
 
   /// setInsertionPoint - Set the insertion point to insert before the specified
   /// instruction.
   void setInsertionPoint(SILInstruction *I) {
-    assert(I && "can't set insertion point to a null instruction");
+    ASSERT(I && "can't set insertion point to a null instruction");
     setInsertionPoint(I->getParent(), I->getIterator());
   }
 
@@ -326,7 +326,7 @@ public:
   /// setInsertionPoint - Set the insertion point to insert at the end of the
   /// specified block.
   void setInsertionPoint(SILBasicBlock *BB) {
-    assert(BB && "can't set insertion point to a null basic block");
+    ASSERT(BB && "can't set insertion point to a null basic block");
     setInsertionPoint(BB, BB->end());
   }
 
@@ -369,7 +369,7 @@ public:
   ///
   /// Assumes that no insertion point is currently active.
   void emitBlock(SILBasicBlock *BB) {
-    assert(!hasValidInsertionPoint());
+    ASSERT(!hasValidInsertionPoint());
     setInsertionPoint(BB);
   }
 
@@ -418,7 +418,7 @@ public:
     Loc.markAsPrologue();
 #ifndef NDEBUG
     if (dyn_cast_or_null<VarDecl>(Loc.getAsASTNode<Decl>()))
-      assert((skipVarDeclAssert || Loc.isSynthesizedAST() || Var) &&
+      ASSERT((skipVarDeclAssert || Loc.isSynthesizedAST() || Var) &&
              "location is a VarDecl, but SILDebugVariable is empty");
 #else
     (void)skipVarDeclAssert;
@@ -462,7 +462,7 @@ public:
                                ArrayRef<SILValue> ElementCountOperands) {
     // AllocRefInsts expand to function calls and can therefore not be
     // counted towards the function prologue.
-    assert(!Loc.isInPrologue());
+    ASSERT(!Loc.isInPrologue());
     return insert(AllocRefInst::create(getSILDebugLocation(Loc), getFunction(),
                                        ObjectType, objc, canAllocOnStack, isBare,
                                        ElementTypes, ElementCountOperands));
@@ -475,7 +475,7 @@ public:
                                     ArrayRef<SILValue> ElementCountOperands) {
     // AllocRefDynamicInsts expand to function calls and can therefore
     // not be counted towards the function prologue.
-    assert(!Loc.isInPrologue());
+    ASSERT(!Loc.isInPrologue());
     return insert(AllocRefDynamicInst::create(
         getSILDebugLocation(Loc), *F, operand, type, objc, canAllocOnStack,
         ElementTypes, ElementCountOperands));
@@ -515,7 +515,7 @@ public:
 #if defined(NDEBUG)
     (void) skipVarDeclAssert;
 #endif
-    assert((skipVarDeclAssert ||
+    ASSERT((skipVarDeclAssert ||
             !dyn_cast_or_null<VarDecl>(Loc.getAsASTNode<Decl>()) || Var) &&
            "location is a VarDecl, but SILDebugVariable is empty");
     return insert(AllocBoxInst::create(
@@ -569,7 +569,7 @@ public:
       PartialApplyInst::OnStackKind OnStack =
           PartialApplyInst::OnStackKind::NotOnStack,
       const GenericSpecializationInformation *SpecializationInfo = nullptr) {
-    assert(OnStack == PartialApplyInst::OnStackKind::OnStack ||
+    ASSERT(OnStack == PartialApplyInst::OnStackKind::OnStack ||
            llvm::all_of(Args,
                         [](SILValue value) {
                           return value->getOwnershipKind().isCompatibleWith(
@@ -640,10 +640,10 @@ public:
   BuiltinInst *
   createBuiltinBinaryFunctionWithOverflow(SILLocation Loc, StringRef Name,
                                           ArrayRef<SILValue> Args) {
-    assert(Args.size() == 3 && "Need three arguments");
-    assert(Args[0]->getType() == Args[1]->getType() &&
+    ASSERT(Args.size() == 3 && "Need three arguments");
+    ASSERT(Args[0]->getType() == Args[1]->getType() &&
            "Binary operands must match");
-    assert(Args[2]->getType().is<BuiltinIntegerType>() &&
+    ASSERT(Args[2]->getType().is<BuiltinIntegerType>() &&
            Args[2]->getType().getASTType()->isBuiltinIntegerType(1) &&
            "Must have a third Int1 operand");
 
@@ -675,7 +675,7 @@ public:
       return createDynamicFunctionRef(Loc, f);
     else if (kind == SILInstructionKind::PreviousDynamicFunctionRefInst)
       return createPreviousDynamicFunctionRef(Loc, f);
-    assert(false && "Should not get here");
+    ASSERT(false && "Should not get here");
     return nullptr;
   }
 
@@ -762,7 +762,7 @@ public:
                                 LoadOwnershipQualifier Qualifier,
                                 bool SupportUnqualifiedSIL = false) {
     if (SupportUnqualifiedSIL && !hasOwnership()) {
-      assert(
+      ASSERT(
           Qualifier != LoadOwnershipQualifier::Copy &&
           "In unqualified SIL, a copy must be done separately form the load");
       return createLoad(Loc, LV, LoadOwnershipQualifier::Unqualified);
@@ -776,11 +776,11 @@ public:
 
   LoadInst *createLoad(SILLocation Loc, SILValue LV,
                        LoadOwnershipQualifier Qualifier) {
-    assert((Qualifier != LoadOwnershipQualifier::Unqualified) ||
+    ASSERT((Qualifier != LoadOwnershipQualifier::Unqualified) ||
            !hasOwnership() && "Unqualified inst in qualified function");
-    assert((Qualifier == LoadOwnershipQualifier::Unqualified) ||
+    ASSERT((Qualifier == LoadOwnershipQualifier::Unqualified) ||
            hasOwnership() && "Qualified inst in unqualified function");
-    assert(isLoadableOrOpaque(LV->getType()));
+    ASSERT(isLoadableOrOpaque(LV->getType()));
     return insert(new (getModule())
                       LoadInst(getSILDebugLocation(Loc), LV, Qualifier));
   }
@@ -799,7 +799,7 @@ public:
   /// non-address values.
   SILValue emitLoadValueOperation(SILLocation Loc, SILValue LV,
                                   LoadOwnershipQualifier Qualifier) {
-    assert(isLoadableOrOpaque(LV->getType()));
+    ASSERT(isLoadableOrOpaque(LV->getType()));
     const auto &lowering = getTypeLowering(LV->getType());
     return lowering.emitLoad(*this, Loc, LV, Qualifier);
   }
@@ -809,7 +809,7 @@ public:
   SILValue emitLoweredLoadValueOperation(
       SILLocation Loc, SILValue LV, LoadOwnershipQualifier Qualifier,
       Lowering::TypeLowering::TypeExpansionKind ExpansionKind) {
-    assert(isLoadableOrOpaque(LV->getType()));
+    ASSERT(isLoadableOrOpaque(LV->getType()));
     const auto &lowering = getTypeLowering(LV->getType());
     return lowering.emitLoweredLoad(*this, Loc, LV, Qualifier, ExpansionKind);
   }
@@ -820,13 +820,13 @@ public:
       SILLocation Loc, SILValue Value, SILValue Addr,
       StoreOwnershipQualifier Qual,
       Lowering::TypeLowering::TypeExpansionKind ExpansionKind) {
-    assert(isLoadableOrOpaque(Value->getType()));
+    ASSERT(isLoadableOrOpaque(Value->getType()));
     const auto &lowering = getTypeLowering(Value->getType());
     lowering.emitLoweredStore(*this, Loc, Value, Addr, Qual, ExpansionKind);
   }
 
   LoadBorrowInst *createLoadBorrow(SILLocation Loc, SILValue LV) {
-    assert(isLoadableOrOpaque(LV->getType()) &&
+    ASSERT(isLoadableOrOpaque(LV->getType()) &&
            !LV->getType().isTrivial(getFunction()));
     return insert(new (getModule())
                       LoadBorrowInst(getSILDebugLocation(Loc), LV));
@@ -837,8 +837,8 @@ public:
       HasPointerEscape_t hasPointerEscape = DoesNotHavePointerEscape,
       IsFromVarDecl_t fromVarDecl = IsNotFromVarDecl,
       BeginBorrowInst::IsFixed_t fixed = BeginBorrowInst::IsNotFixed) {
-    assert(getFunction().hasOwnership());
-    assert(!LV->getType().isAddress());
+    ASSERT(getFunction().hasOwnership());
+    ASSERT(!LV->getType().isAddress());
     return insert(new (getModule())
                       BeginBorrowInst(getSILDebugLocation(Loc), LV, isLexical,
                                       hasPointerEscape, fromVarDecl, fixed));
@@ -902,7 +902,7 @@ public:
                                   StoreOwnershipQualifier Qualifier,
                                   bool SupportUnqualifiedSIL = false) {
     if (SupportUnqualifiedSIL && !hasOwnership()) {
-      assert(
+      ASSERT(
           Qualifier != StoreOwnershipQualifier::Assign &&
           "In unqualified SIL, assigns must be represented via 2 instructions");
       return createStore(Loc, Src, DestAddr,
@@ -916,9 +916,9 @@ public:
 
   StoreInst *createStore(SILLocation Loc, SILValue Src, SILValue DestAddr,
                          StoreOwnershipQualifier Qualifier) {
-    assert((Qualifier != StoreOwnershipQualifier::Unqualified) ||
+    ASSERT((Qualifier != StoreOwnershipQualifier::Unqualified) ||
            !hasOwnership() && "Unqualified inst in qualified function");
-    assert((Qualifier == StoreOwnershipQualifier::Unqualified) ||
+    ASSERT((Qualifier == StoreOwnershipQualifier::Unqualified) ||
            hasOwnership() && "Qualified inst in unqualified function");
     return insert(new (getModule()) StoreInst(getSILDebugLocation(Loc), Src,
                                                 DestAddr, Qualifier));
@@ -928,15 +928,15 @@ public:
   /// non-address values.
   void emitStoreValueOperation(SILLocation Loc, SILValue Src, SILValue DestAddr,
                                StoreOwnershipQualifier Qualifier) {
-    assert(!Src->getType().isAddress());
+    ASSERT(!Src->getType().isAddress());
     const auto &lowering = getTypeLowering(Src->getType());
     return lowering.emitStore(*this, Loc, Src, DestAddr, Qualifier);
   }
 
   EndBorrowInst *createEndBorrow(SILLocation loc, SILValue borrowedValue) {
-    assert(!SILArgument::isTerminatorResult(borrowedValue) &&
+    ASSERT(!SILArgument::isTerminatorResult(borrowedValue) &&
                "terminator results do not have end_borrow");
-    assert(!isa<SILFunctionArgument>(borrowedValue) &&
+    ASSERT(!isa<SILFunctionArgument>(borrowedValue) &&
            "Function arguments should never have an end_borrow");
     return insert(new (getModule())
                       EndBorrowInst(getSILDebugLocation(loc), borrowedValue));
@@ -1100,7 +1100,7 @@ public:
 
   UnownedCopyValueInst *createUnownedCopyValue(SILLocation Loc,
                                                SILValue operand) {
-    assert(!getFunction().getModule().useLoweredAddresses());
+    ASSERT(!getFunction().getModule().useLoweredAddresses());
     auto type = operand->getType()
                     .getReferenceStorageType(getFunction().getASTContext(),
                                              ReferenceOwnership::Unowned)
@@ -1110,7 +1110,7 @@ public:
   }
 
   WeakCopyValueInst *createWeakCopyValue(SILLocation Loc, SILValue operand) {
-    assert(!getFunction().getModule().useLoweredAddresses());
+    ASSERT(!getFunction().getModule().useLoweredAddresses());
     auto type = operand->getType()
                     .getReferenceStorageType(getFunction().getASTContext(),
                                              ReferenceOwnership::Weak)
@@ -1194,7 +1194,7 @@ public:
   CopyAddrInst *createCopyAddr(SILLocation Loc, SILValue srcAddr,
                                SILValue destAddr, IsTake_t isTake,
                                IsInitialization_t isInitialize) {
-    assert(srcAddr->getType() == destAddr->getType());
+    ASSERT(srcAddr->getType() == destAddr->getType());
     return insert(new (getModule()) CopyAddrInst(
         getSILDebugLocation(Loc), srcAddr, destAddr, isTake, isInitialize));
   }
@@ -1202,7 +1202,7 @@ public:
   ExplicitCopyAddrInst *
   createExplicitCopyAddr(SILLocation Loc, SILValue srcAddr, SILValue destAddr,
                          IsTake_t isTake, IsInitialization_t isInitialize) {
-    assert(srcAddr->getType() == destAddr->getType());
+    ASSERT(srcAddr->getType() == destAddr->getType());
     return insert(new (getModule()) ExplicitCopyAddrInst(
         getSILDebugLocation(Loc), srcAddr, destAddr, isTake, isInitialize));
   }
@@ -1250,7 +1250,7 @@ public:
 
   UpcastInst *createUpcast(SILLocation Loc, SILValue Op, SILType Ty,
                            ValueOwnershipKind forwardingOwnershipKind) {
-    assert(Ty.isObject());
+    ASSERT(Ty.isObject());
     if (isInsertingIntoGlobal()) {
       return insert(UpcastInst::create(getSILDebugLocation(Loc), Op, Ty,
                                        getModule(), forwardingOwnershipKind));
@@ -1328,7 +1328,7 @@ public:
   UncheckedValueCastInst *
   createUncheckedValueCast(SILLocation Loc, SILValue Op, SILType Ty,
                            ValueOwnershipKind forwardingOwnershipKind) {
-    assert(hasOwnership());
+    ASSERT(hasOwnership());
     return insert(UncheckedValueCastInst::create(
         getSILDebugLocation(Loc), Op, Ty, getFunction(),
         forwardingOwnershipKind));
@@ -1422,11 +1422,11 @@ public:
   }
 
   CopyValueInst *createCopyValue(SILLocation Loc, SILValue operand) {
-    assert(getFunction().hasOwnership());
-    assert(!operand->getType().isTrivial(getFunction()) &&
+    ASSERT(getFunction().hasOwnership());
+    ASSERT(!operand->getType().isTrivial(getFunction()) &&
            "Should not be passing trivial values to this api. Use instead "
            "emitCopyValueOperation");
-    assert((getModule().getStage() == SILStage::Raw
+    ASSERT((getModule().getStage() == SILStage::Raw
             || !operand->getType().isMoveOnly())
            && "should not be copying move-only values in canonical SIL");
     return insert(new (getModule())
@@ -1435,7 +1435,7 @@ public:
 
   ExplicitCopyValueInst *createExplicitCopyValue(SILLocation Loc,
                                                  SILValue operand) {
-    assert(!operand->getType().isTrivial(getFunction()) &&
+    ASSERT(!operand->getType().isTrivial(getFunction()) &&
            "Should not be passing trivial values to this api. Use instead "
            "emitCopyValueOperation");
     return insert(new (getModule())
@@ -1445,9 +1445,9 @@ public:
   DestroyValueInst *createDestroyValue(SILLocation Loc, SILValue operand,
                                        PoisonRefs_t poisonRefs = DontPoisonRefs,
                                        IsDeadEnd_t isDeadEnd = IsntDeadEnd) {
-    assert(getFunction().hasOwnership());
-    assert(isLoadableOrOpaque(operand->getType()));
-    assert(!operand->getType().isTrivial(getFunction()) &&
+    ASSERT(getFunction().hasOwnership());
+    ASSERT(isLoadableOrOpaque(operand->getType()));
+    ASSERT(!operand->getType().isTrivial(getFunction()) &&
            "Should not be passing trivial values to this api. Use instead "
            "emitDestroyValueOperation");
     return insert(new (getModule()) DestroyValueInst(
@@ -1458,8 +1458,8 @@ public:
       SILLocation loc, SILValue operand, IsLexical_t isLexical = IsNotLexical,
       HasPointerEscape_t hasPointerEscape = DoesNotHavePointerEscape,
       IsFromVarDecl_t fromVarDecl = IsNotFromVarDecl) {
-    assert(getFunction().hasOwnership());
-    assert(fromVarDecl || !operand->getType().isTrivial(getFunction()) &&
+    ASSERT(getFunction().hasOwnership());
+    ASSERT(fromVarDecl || !operand->getType().isTrivial(getFunction()) &&
            "Should not be passing trivial values to this api. Use instead "
            "emitMoveValueOperation");
     return insert(new (getModule())
@@ -1468,8 +1468,8 @@ public:
   }
 
   DropDeinitInst *createDropDeinit(SILLocation loc, SILValue operand) {
-    assert(getFunction().hasOwnership());
-    assert(!operand->getType().isTrivial(getFunction()) &&
+    ASSERT(getFunction().hasOwnership());
+    ASSERT(!operand->getType().isTrivial(getFunction()) &&
            "Should not be passing trivial values to this api.");
     return insert(new (getModule()) DropDeinitInst(getSILDebugLocation(loc),
                                                    operand));
@@ -1508,7 +1508,7 @@ public:
   CopyableToMoveOnlyWrapperValueInst *
   createGuaranteedCopyableToMoveOnlyWrapperValue(SILLocation loc,
                                                  SILValue src) {
-    assert(!src->getType().isTrivial(*F) &&
+    ASSERT(!src->getType().isTrivial(*F) &&
            "trivial types can only use the owned version of this API");
     return insert(new (getModule()) CopyableToMoveOnlyWrapperValueInst(
         getSILDebugLocation(loc), src,
@@ -1576,23 +1576,23 @@ public:
 
   RetainValueInst *createRetainValue(SILLocation Loc, SILValue operand,
                                      Atomicity atomicity) {
-    assert(!hasOwnership());
-    assert(isLoadableOrOpaque(operand->getType()));
+    ASSERT(!hasOwnership());
+    ASSERT(isLoadableOrOpaque(operand->getType()));
     return insert(new (getModule()) RetainValueInst(getSILDebugLocation(Loc),
                                                       operand, atomicity));
   }
 
   RetainValueAddrInst *createRetainValueAddr(SILLocation Loc, SILValue operand,
                                              Atomicity atomicity) {
-    assert(!hasOwnership());
+    ASSERT(!hasOwnership());
     return insert(new (getModule()) RetainValueAddrInst(
         getSILDebugLocation(Loc), operand, atomicity));
   }
 
   ReleaseValueInst *createReleaseValue(SILLocation Loc, SILValue operand,
                                        Atomicity atomicity) {
-    assert(!hasOwnership());
-    assert(isLoadableOrOpaque(operand->getType()));
+    ASSERT(!hasOwnership());
+    ASSERT(isLoadableOrOpaque(operand->getType()));
     return insert(new (getModule()) ReleaseValueInst(getSILDebugLocation(Loc),
                                                        operand, atomicity));
   }
@@ -1600,7 +1600,7 @@ public:
   ReleaseValueAddrInst *createReleaseValueAddr(SILLocation Loc,
                                                SILValue operand,
                                                Atomicity atomicity) {
-    assert(!hasOwnership());
+    ASSERT(!hasOwnership());
     return insert(new (getModule()) ReleaseValueAddrInst(
         getSILDebugLocation(Loc), operand, atomicity));
   }
@@ -1608,8 +1608,8 @@ public:
   UnmanagedRetainValueInst *createUnmanagedRetainValue(SILLocation Loc,
                                                        SILValue operand,
                                                        Atomicity atomicity) {
-    assert(hasOwnership());
-    assert(isLoadableOrOpaque(operand->getType()));
+    ASSERT(hasOwnership());
+    ASSERT(isLoadableOrOpaque(operand->getType()));
     return insert(new (getModule()) UnmanagedRetainValueInst(
         getSILDebugLocation(Loc), operand, atomicity));
   }
@@ -1617,8 +1617,8 @@ public:
   UnmanagedReleaseValueInst *createUnmanagedReleaseValue(SILLocation Loc,
                                                          SILValue operand,
                                                          Atomicity atomicity) {
-    assert(hasOwnership());
-    assert(isLoadableOrOpaque(operand->getType()));
+    ASSERT(hasOwnership());
+    ASSERT(isLoadableOrOpaque(operand->getType()));
     return insert(new (getModule()) UnmanagedReleaseValueInst(
         getSILDebugLocation(Loc), operand, atomicity));
   }
@@ -1673,7 +1673,7 @@ public:
   StructInst *createStruct(SILLocation Loc, SILType Ty,
                            ArrayRef<SILValue> Elements,
                            ValueOwnershipKind forwardingOwnershipKind) {
-    assert(isLoadableOrOpaque(Ty));
+    ASSERT(isLoadableOrOpaque(Ty));
     return insert(StructInst::create(getSILDebugLocation(Loc), Ty, Elements,
                                      getModule(), forwardingOwnershipKind));
   }
@@ -1689,7 +1689,7 @@ public:
   TupleInst *createTuple(SILLocation Loc, SILType Ty,
                          ArrayRef<SILValue> Elements,
                          ValueOwnershipKind forwardingOwnershipKind) {
-    assert(isLoadableOrOpaque(Ty));
+    ASSERT(isLoadableOrOpaque(Ty));
     return insert(TupleInst::create(getSILDebugLocation(Loc), Ty, Elements,
                                     getModule(), forwardingOwnershipKind));
   }
@@ -1700,7 +1700,7 @@ public:
   createTupleAddrConstructor(SILLocation Loc, SILValue DestAddr,
                              ArrayRef<SILValue> Elements,
                              IsInitialization_t IsInitOfDest) {
-    assert(getFunction().getModule().useLoweredAddresses());
+    ASSERT(getFunction().getModule().useLoweredAddresses());
     return insert(TupleAddrConstructorInst::create(getSILDebugLocation(Loc),
                                                    DestAddr, Elements,
                                                    IsInitOfDest, getModule()));
@@ -1718,7 +1718,7 @@ public:
   EnumInst *createEnum(SILLocation Loc, SILValue Operand,
                        EnumElementDecl *Element, SILType Ty,
                        ValueOwnershipKind forwardingOwnershipKind) {
-    assert(isLoadableOrOpaque(Ty));
+    ASSERT(isLoadableOrOpaque(Ty));
     return insert(new (getModule())
                       EnumInst(getSILDebugLocation(Loc), Operand, Element, Ty,
                                forwardingOwnershipKind));
@@ -1726,14 +1726,14 @@ public:
 
   /// Inject a loadable value into the corresponding optional type.
   EnumInst *createOptionalSome(SILLocation Loc, SILValue operand, SILType ty) {
-    assert(isLoadableOrOpaque(ty));
+    ASSERT(isLoadableOrOpaque(ty));
     auto someDecl = getModule().getASTContext().getOptionalSomeDecl();
     return createEnum(Loc, operand, someDecl, ty);
   }
 
   /// Create the nil value of a loadable optional type.
   EnumInst *createOptionalNone(SILLocation Loc, SILType ty) {
-    assert(isLoadableOrOpaque(ty));
+    ASSERT(isLoadableOrOpaque(ty));
     auto noneDecl = getModule().getASTContext().getOptionalNoneDecl();
     return createEnum(Loc, nullptr, noneDecl, ty);
   }
@@ -1766,7 +1766,7 @@ public:
   createUncheckedEnumData(SILLocation Loc, SILValue Operand,
                           EnumElementDecl *Element, SILType Ty,
                           ValueOwnershipKind forwardingOwnershipKind) {
-    assert(isLoadableOrOpaque(Ty));
+    ASSERT(isLoadableOrOpaque(Ty));
     return insert(new (getModule()) UncheckedEnumDataInst(
         getSILDebugLocation(Loc), Operand, Element, Ty,
         forwardingOwnershipKind));
@@ -1805,7 +1805,7 @@ public:
       ArrayRef<std::pair<EnumElementDecl *, SILValue>> CaseValues,
       std::optional<ArrayRef<ProfileCounter>> CaseCounts = std::nullopt,
       ProfileCounter DefaultCount = ProfileCounter()) {
-    assert(isLoadableOrOpaque(Ty));
+    ASSERT(isLoadableOrOpaque(Ty));
     return insert(SelectEnumInst::create(
         getSILDebugLocation(Loc), Operand, Ty, DefaultValue, CaseValues,
         getModule(), CaseCounts, DefaultCount));
@@ -1847,7 +1847,7 @@ public:
                                                SILValue Operand,
                                                unsigned FieldNo,
                                                SILType ResultTy) {
-    assert(!Operand->getType().castTo<TupleType>().containsPackExpansionType()
+    ASSERT(!Operand->getType().castTo<TupleType>().containsPackExpansionType()
            && "tuples with pack expansions must be indexed with "
               "tuple_pack_element_addr");
     return insert(new (getModule()) TupleElementAddrInst(
@@ -1953,7 +1953,7 @@ public:
     //
     // emitDestructureValueOperation(SILLocation, SILValue,
     //                               SmallVectorImpl<SILValue> &);
-    assert(hasOwnership() && "Expected to be called in ownership code only.");
+    ASSERT(hasOwnership() && "Expected to be called in ownership code only.");
     SILType opTy = operand->getType();
     if (opTy.is<TupleType>())
       return createDestructureTuple(loc, operand);
@@ -2210,7 +2210,7 @@ public:
                                                SILValue packIndex,
                                                SILValue tuple,
                                                SILType elementType) {
-    assert(!getFunction().getModule().useLoweredAddresses());
+    ASSERT(!getFunction().getModule().useLoweredAddresses());
     return insert(TuplePackExtractInst::create(
         getFunction(), getSILDebugLocation(loc), packIndex, tuple, elementType,
         tuple->getOwnershipKind()));
@@ -2279,13 +2279,13 @@ public:
 
   StrongRetainInst *createStrongRetain(SILLocation Loc, SILValue Operand,
                                        Atomicity atomicity) {
-    assert(!hasOwnership());
+    ASSERT(!hasOwnership());
     return insert(new (getModule()) StrongRetainInst(getSILDebugLocation(Loc),
                                                        Operand, atomicity));
   }
   StrongReleaseInst *createStrongRelease(SILLocation Loc, SILValue Operand,
                                          Atomicity atomicity) {
-    assert(!hasOwnership());
+    ASSERT(!hasOwnership());
     return insert(new (getModule()) StrongReleaseInst(
         getSILDebugLocation(Loc), Operand, atomicity));
   }
@@ -2835,7 +2835,7 @@ public:
   /// Convenience function for calling emitCopy on the type lowering
   /// for the non-address value.
   SILValue emitCopyValueOperation(SILLocation Loc, SILValue v) {
-    assert(!v->getType().isAddress());
+    ASSERT(!v->getType().isAddress());
     auto &lowering = getTypeLowering(v->getType());
     return lowering.emitCopyValue(*this, Loc, v);
   }
@@ -2845,7 +2845,7 @@ public:
   SILValue emitLoweredCopyValueOperation(
       SILLocation Loc, SILValue v,
       Lowering::TypeLowering::TypeExpansionKind expansionKind) {
-    assert(!v->getType().isAddress());
+    ASSERT(!v->getType().isAddress());
     auto &lowering = getTypeLowering(v->getType());
     return lowering.emitLoweredCopyValue(*this, Loc, v, expansionKind);
   }
@@ -2853,7 +2853,7 @@ public:
   /// Convenience function for calling TypeLowering.emitDestroy on the type
   /// lowering for the non-address value.
   void emitDestroyValueOperation(SILLocation Loc, SILValue v) {
-    assert(!v->getType().isAddress());
+    ASSERT(!v->getType().isAddress());
     if (F->hasOwnership() && v->getOwnershipKind() == OwnershipKind::None)
       return;
     auto &lowering = getTypeLowering(v->getType());
@@ -2865,7 +2865,7 @@ public:
   void emitLoweredDestroyValueOperation(
       SILLocation Loc, SILValue v,
       Lowering::TypeLowering::TypeExpansionKind expansionKind) {
-    assert(!v->getType().isAddress());
+    ASSERT(!v->getType().isAddress());
     if (F->hasOwnership() && v->getOwnershipKind() == OwnershipKind::None)
       return;
     auto &lowering = getTypeLowering(v->getType());
@@ -2888,10 +2888,10 @@ public:
       SILLocation Loc, SILValue v, IsLexical_t isLexical = IsNotLexical,
       HasPointerEscape_t hasPointerEscape = DoesNotHavePointerEscape,
       IsFromVarDecl_t fromVarDecl = IsNotFromVarDecl) {
-    assert(!v->getType().isAddress());
+    ASSERT(!v->getType().isAddress());
     if (v->getType().isTrivial(*getInsertionBB()->getParent()))
       return v;
-    assert(v->getOwnershipKind() == OwnershipKind::Owned &&
+    ASSERT(v->getOwnershipKind() == OwnershipKind::Owned &&
            "move_value consumes its argument");
     return createMoveValue(Loc, v, isLexical, hasPointerEscape, fromVarDecl);
   }
@@ -3066,7 +3066,7 @@ private:
   }
 
   void insertImpl(SILInstruction *TheInst) {
-    assert(hasValidInsertionPoint());
+    ASSERT(hasValidInsertionPoint());
     BB->insert(InsertPt, TheInst);
     getModule().notifyAddedInstruction(TheInst);
     C.notifyInserted(TheInst);
@@ -3111,7 +3111,7 @@ private:
       case BuiltinFloatType::PPC128: Name += "PPC128"; break;
       }
     } else {
-      assert(OpdTy.getASTType() == getASTContext().TheRawPointerType);
+      ASSERT(OpdTy.getASTType() == getASTContext().TheRawPointerType);
       Name += "_RawPointer";
     }
   }
@@ -3123,11 +3123,11 @@ private:
 /// SIL instructions.
 class SILBuilderWithScope : public SILBuilder {
   void inheritScopeFrom(SILInstruction *I) {
-    assert(I->getDebugScope() && "instruction has no debug scope");
+    ASSERT(I->getDebugScope() && "instruction has no debug scope");
     SILBasicBlock::iterator II(*I);
     auto End = I->getParent()->end();
     const SILDebugScope *DS = II->getDebugScope();
-    assert(DS);
+    ASSERT(DS);
     // Skip over meta instructions, since debug_values may originate from outer
     // scopes. Don't do any of this after inlining.
     while (!DS->InlinedCallSite && II != End && II->isMetaInstruction())
@@ -3137,7 +3137,7 @@ class SILBuilderWithScope : public SILBuilder {
       if (!nextScope->InlinedCallSite)
         DS = nextScope;
     }
-    assert(DS);
+    ASSERT(DS);
     setCurrentDebugScope(DS);
   }
 
@@ -3208,7 +3208,7 @@ public:
   /// non-metainstruction in the BB.
   explicit SILBuilderWithScope(SILBasicBlock *BB) : SILBuilder(BB->begin()) {
     const SILDebugScope *DS = BB->getScopeOfFirstNonMetaInstruction();
-    assert(DS && "Instruction without debug scope associated!");
+    ASSERT(DS && "Instruction without debug scope associated!");
     setCurrentDebugScope(DS);
   }
 
@@ -3237,7 +3237,7 @@ public:
       return insertAfter(mvir->getParent(), func);
     if (auto *arg = dyn_cast<SILArgument>(value))
       return insertAfter(&*arg->getParent()->begin(), func);
-    assert(!isa<SILUndef>(value) && "This API can not use undef");
+    ASSERT(!isa<SILUndef>(value) && "This API can not use undef");
     llvm_unreachable("Unhandled case?!");
   }
 };
@@ -3319,7 +3319,7 @@ public:
   }
 
   ~DebugLocOverrideRAII() {
-    assert(Builder.getCurrentDebugLocOverride() == installedOverride &&
+    ASSERT(Builder.getCurrentDebugLocOverride() == installedOverride &&
            "Restoring debug location override to an unexpected state");
     Builder.applyDebugLocOverride(oldOverride);
   }

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -61,7 +61,7 @@ SILType SILBuilder::getPartialApplyResultType(
   if (!subs.empty())
     FTI = FTI->substGenericArgs(M, subs, context);
 
-  assert(!FTI->isPolymorphic()
+  ASSERT(!FTI->isPolymorphic()
          && "must provide substitutions for generic partial_apply");
   auto params = FTI->getParameters();
   auto newParams = params.slice(0, params.size() - argCount);
@@ -155,7 +155,7 @@ SILBuilder::createClassifyBridgeObject(SILLocation Loc, SILValue value) {
 SingleValueInstruction *
 SILBuilder::createUncheckedReinterpretCast(SILLocation Loc, SILValue Op,
                                            SILType Ty) {
-  assert(isLoadableOrOpaque(Ty));
+  ASSERT(isLoadableOrOpaque(Ty));
   if (Ty.isTrivial(getFunction()))
     return insert(UncheckedTrivialBitCastInst::create(
         getSILDebugLocation(Loc), Op, Ty, getFunction()));
@@ -189,7 +189,7 @@ SILBuilder::createUncheckedForwardingCast(SILLocation Loc, SILValue Op,
   if (!hasOwnership())
     return createUncheckedReinterpretCast(Loc, Op, Ty);
 
-  assert(isLoadableOrOpaque(Ty));
+  ASSERT(isLoadableOrOpaque(Ty));
   if (Ty.isTrivial(getFunction()))
     return insert(UncheckedTrivialBitCastInst::create(
         getSILDebugLocation(Loc), Op, Ty, getFunction()));
@@ -232,7 +232,7 @@ void SILBuilder::emitBlock(SILBasicBlock *BB, SILLocation BranchLoc) {
   }
 
   // Fall though from the currently active block into the given block.
-  assert(BB->args_empty() && "cannot fall through to bb with args");
+  ASSERT(BB->args_empty() && "cannot fall through to bb with args");
 
   // This is a fall through into BB, emit the fall through branch.
   createBranch(BranchLoc, BB);
@@ -537,7 +537,7 @@ SILValue SILBuilder::emitObjCToThickMetatype(SILLocation Loc, SILValue Op,
 ValueMetatypeInst *SILBuilder::createValueMetatype(SILLocation Loc,
                                                    SILType MetatypeTy,
                                                    SILValue Base) {
-  assert(Base->getType().isLoweringOf(
+  ASSERT(Base->getType().isLoweringOf(
              getTypeExpansionContext(), getModule(),
              MetatypeTy.castTo<MetatypeType>().getInstanceType()) &&
          "value_metatype result must be formal metatype of the lowered operand "
@@ -757,7 +757,7 @@ CheckedCastBranchInst *SILBuilder::createCheckedCastBranch(
     SILType destLoweredTy, CanType destFormalTy, SILBasicBlock *successBB,
     SILBasicBlock *failureBB, ValueOwnershipKind forwardingOwnershipKind,
     ProfileCounter target1Count, ProfileCounter target2Count) {
-  assert((!hasOwnership() || !failureBB->getNumArguments() ||
+  ASSERT((!hasOwnership() || !failureBB->getNumArguments() ||
           failureBB->getArgument(0)->getType() == op->getType()) &&
          "failureBB's argument doesn't match incoming argument type");
 
@@ -772,7 +772,7 @@ void SILBuilderWithScope::insertAfter(SILInstruction *inst,
   if (isa<TermInst>(inst)) {
     for (const SILSuccessor &succ : inst->getParent()->getSuccessors()) {
       SILBasicBlock *succBlock = succ;
-      assert(succBlock->getSinglePredecessorBlock() == inst->getParent() &&
+      ASSERT(succBlock->getSinglePredecessorBlock() == inst->getParent() &&
              "the terminator instruction must not have critical successors");
       SILBuilderWithScope builder(succBlock->begin());
       func(builder);


### PR DESCRIPTION
It's important to catch assert failures in the SILBuilder also in a release build of the compiler
