### PR TITLE
[cxx-interop] Allow compiling with libc++ on Linux

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -722,7 +722,7 @@ protected:
     HasAnyUnavailableDuringLoweringValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+8,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -779,6 +779,10 @@ protected:
 
     /// Whether this module has been built with C++ interoperability enabled.
     HasCxxInteroperability : 1,
+
+    /// Whether this module uses the platform default C++ stdlib, or an
+    /// overridden C++ stdlib.
+    CXXStdlibKind : 8,
 
     /// Whether this module has been built with -allow-non-resilient-access.
     AllowNonResilientAccess : 1,

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -50,6 +50,7 @@ namespace swift {
   class ValueDecl;
   class SourceFile;
 
+  enum class CXXStdlibKind : uint8_t;
   enum class DescriptivePatternKind : uint8_t;
   enum class SelfAccessKind : uint8_t;
   enum class ReferenceOwnership : uint8_t;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -942,6 +942,10 @@ ERROR(need_cxx_interop_to_import_module,none,
 NOTE(enable_cxx_interop_docs,none,
      "visit https://www.swift.org/documentation/cxx-interop/project-build-setup to learn how to enable C++ interoperability", ())
 
+ERROR(cxx_stdlib_kind_mismatch,none,
+      "module %0 was built with %1, but current compilation uses %2",
+      (Identifier, StringRef, StringRef))
+
 ERROR(modularization_issue_decl_moved,Fatal,
       "reference to %select{top-level declaration|type}0 %1 broken by a context change; "
       "%1 was expected to be in %2, but now a candidate is found only in %3",

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -27,6 +27,7 @@
 #include "swift/AST/Type.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/BasicSourceInfo.h"
+#include "swift/Basic/CXXStdlibKind.h"
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/OptionSet.h"
@@ -703,6 +704,13 @@ public:
   }
   void setHasCxxInteroperability(bool enabled = true) {
     Bits.ModuleDecl.HasCxxInteroperability = enabled;
+  }
+
+  CXXStdlibKind getCXXStdlibKind() const {
+    return static_cast<CXXStdlibKind>(Bits.ModuleDecl.CXXStdlibKind);
+  }
+  void setCXXStdlibKind(CXXStdlibKind kind) {
+    Bits.ModuleDecl.CXXStdlibKind = static_cast<uint8_t>(kind);
   }
 
   /// \returns true if this module is a system module; note that the StdLib is

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -21,6 +21,7 @@
 #include "swift/AST/Import.h"
 #include "swift/AST/LinkLibrary.h"
 #include "swift/AST/SearchPathOptions.h"
+#include "swift/Basic/CXXStdlibKind.h"
 #include "swift/Basic/LLVM.h"
 #include "clang/CAS/CASOptions.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
@@ -135,7 +136,7 @@ void registerBackDeployLibraries(
     std::function<void(const LinkLibrary &)> RegistrationCallback);
 void registerCxxInteropLibraries(
     const llvm::Triple &Target, StringRef mainModuleName, bool hasStaticCxx,
-    bool hasStaticCxxStdlib,
+    bool hasStaticCxxStdlib, CXXStdlibKind cxxStdlibKind,
     std::function<void(const LinkLibrary &)> RegistrationCallback);
 } // namespace dependencies
 

--- a/include/swift/Basic/CXXStdlibKind.h
+++ b/include/swift/Basic/CXXStdlibKind.h
@@ -1,0 +1,48 @@
+//===--- CXXStdlibKind.h ----------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_CXX_STDLIB_KIND_H
+#define SWIFT_BASIC_CXX_STDLIB_KIND_H
+
+namespace swift {
+
+enum class CXXStdlibKind : uint8_t {
+  Unknown = 0,
+
+  /// libc++ is the default C++ stdlib on Darwin platforms. It is also supported
+  /// on Linux when explicitly requested via `-Xcc -stdlib=libc++` flag.
+  Libcxx = 1,
+
+  /// libstdc++ is the default C++ stdlib on most Linux distributions.
+  Libstdcxx = 2,
+
+  /// msvcprt is used when targeting Windows.
+  Msvcprt = 3,
+};
+
+inline std::string to_string(CXXStdlibKind kind) {
+  switch (kind) {
+  case CXXStdlibKind::Unknown:
+    return "unknown C++ stdlib";
+  case CXXStdlibKind::Libcxx:
+    return "libc++";
+  case CXXStdlibKind::Libstdcxx:
+    return "libstdc++";
+  case CXXStdlibKind::Msvcprt:
+    return "msvcprt";
+  }
+  llvm_unreachable("unhandled CXXStdlibKind");
+}
+
+} // namespace swift
+
+#endif // SWIFT_BASIC_CXX_STDLIB_KIND_H

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -19,6 +19,7 @@
 #define SWIFT_BASIC_LANGOPTIONS_H
 
 #include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Basic/CXXStdlibKind.h"
 #include "swift/Basic/Feature.h"
 #include "swift/Basic/FixedBitSet.h"
 #include "swift/Basic/FunctionBodySkipping.h"
@@ -320,6 +321,16 @@ namespace swift {
 
     void setCxxInteropFromArgs(llvm::opt::ArgList &Args,
                                swift::DiagnosticEngine &Diags);
+
+    /// The C++ standard library used for the current build. This can differ
+    /// from the default C++ stdlib on a particular platform when `-Xcc
+    /// -stdlib=xyz` was passed to the compiler.
+    CXXStdlibKind CXXStdlib = CXXStdlibKind::Unknown;
+    CXXStdlibKind PlatformDefaultCXXStdlib = CXXStdlibKind::Unknown;
+
+    bool isUsingPlatformDefaultCXXStdlib() const {
+      return CXXStdlib == PlatformDefaultCXXStdlib;
+    }
 
     bool CForeignReferenceTypes = false;
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -26,6 +26,9 @@ namespace llvm {
   class Triple;
   class FileCollectorBase;
   template<typename Fn> class function_ref;
+  namespace opt {
+    class InputArgList;
+  }
   namespace vfs {
     class FileSystem;
     class OutputBackend;
@@ -51,6 +54,9 @@ namespace clang {
   class DeclarationName;
   class CompilerInvocation;
   class TargetOptions;
+  namespace driver {
+    class Driver;
+  }
 namespace tooling {
 namespace dependencies {
   struct ModuleDeps;
@@ -74,9 +80,11 @@ class EnumDecl;
 class FuncDecl;
 class ImportDecl;
 class IRGenOptions;
+class LangOptions;
 class ModuleDecl;
 struct ModuleDependencyID;
 class NominalTypeDecl;
+class SearchPathOptions;
 class StructDecl;
 class SwiftLookupTable;
 class TypeDecl;
@@ -195,6 +203,22 @@ public:
                         const ClangImporterOptions &importerOpts,
                         llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
                         const std::vector<std::string> &CC1Args);
+
+  /// Creates a Clang Driver based on the Swift compiler options.
+  ///
+  /// \return a pair of the Clang Driver and the diagnostic engine, which needs
+  /// to be alive during the use of the Driver.
+  static std::pair<clang::driver::Driver,
+                   llvm::IntrusiveRefCntPtr<clang::DiagnosticsEngine>>
+  createClangDriver(
+      const LangOptions &LangOpts,
+      const ClangImporterOptions &ClangImporterOpts,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs = nullptr);
+
+  static llvm::opt::InputArgList
+  createClangArgs(const ClangImporterOptions &ClangImporterOpts,
+                  const SearchPathOptions &SearchPathOpts,
+                  clang::driver::Driver &clangDriver);
 
   ClangImporter(const ClangImporter &) = delete;
   ClangImporter(ClangImporter &&) = delete;

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -256,6 +256,10 @@ public:
   /// FIXME: Remove this after all the clients start sending it.
   void setDefaultInProcessPluginServerPathIfNecessary();
 
+  /// Determine which C++ stdlib should be used for this compilation, and which
+  /// C++ stdlib is the default for the specified target.
+  void computeCXXStdlibOptions();
+
   /// Computes the runtime resource path relative to the given Swift
   /// executable.
   static void computeRuntimeResourcePathFromExecutablePath(

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -14,6 +14,7 @@
 #define SWIFT_SERIALIZATION_VALIDATION_H
 
 #include "swift/AST/Identifier.h"
+#include "swift/Basic/CXXStdlibKind.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Version.h"
 #include "swift/Serialization/SerializationOptions.h"
@@ -128,6 +129,7 @@ class ExtendedValidationInfo {
   StringRef ModuleABIName;
   StringRef ModulePackageName;
   StringRef ExportAsName;
+  CXXStdlibKind CXXStdlib;
   struct {
     unsigned ArePrivateImportsEnabled : 1;
     unsigned IsSIB : 1;
@@ -241,6 +243,9 @@ public:
   void setHasCxxInteroperability(bool val) {
     Bits.HasCxxInteroperability = val;
   }
+
+  CXXStdlibKind getCXXStdlibKind() const { return CXXStdlib; }
+  void setCXXStdlibKind(CXXStdlibKind kind) { CXXStdlib = kind; }
 };
 
 struct SearchPath {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -725,6 +725,7 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   Bits.ModuleDecl.IsConcurrencyChecked = 0;
   Bits.ModuleDecl.ObjCNameLookupCachePopulated = 0;
   Bits.ModuleDecl.HasCxxInteroperability = 0;
+  Bits.ModuleDecl.CXXStdlibKind = 0;
   Bits.ModuleDecl.AllowNonResilientAccess = 0;
   Bits.ModuleDecl.SerializePackageEnabled = 0;
 }

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -540,11 +540,11 @@ void
 swift::dependencies::registerCxxInteropLibraries(
     const llvm::Triple &Target,
     StringRef mainModuleName,
-    bool hasStaticCxx, bool hasStaticCxxStdlib,
+    bool hasStaticCxx, bool hasStaticCxxStdlib, CXXStdlibKind cxxStdlibKind,
     std::function<void(const LinkLibrary&)> RegistrationCallback) {
-  if (Target.isOSDarwin())
+  if (cxxStdlibKind == CXXStdlibKind::Libcxx)
     RegistrationCallback(LinkLibrary("c++", LibraryKind::Library));
-  else if (Target.isOSLinux())
+  else if (cxxStdlibKind == CXXStdlibKind::Libstdcxx)
     RegistrationCallback(LinkLibrary("stdc++", LibraryKind::Library));
 
   // Do not try to link Cxx with itself.

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -172,6 +172,12 @@ void ModuleLoader::findOverlayFiles(SourceLoc diagLoc, ModuleDecl *module,
   using namespace llvm::sys;
   using namespace file_types;
 
+  // If an overlay for CxxStdlib was requested, only proceed if compiling with
+  // the platform-default C++ stdlib.
+  if (module->getName() == module->getASTContext().Id_CxxStdlib &&
+      !module->getASTContext().LangOpts.isUsingPlatformDefaultCXXStdlib())
+    return;
+
   // If cross import information is passed on command-line, prefer use that.
   auto &crossImports = module->getASTContext().SearchPathOpts.CrossImportInfo;
   auto overlays = crossImports.find(module->getNameStr());

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4298,8 +4298,10 @@ ModuleDecl *ClangModuleUnit::getOverlayModule() const {
     }
     // If this Clang module is a part of the C++ stdlib, and we haven't loaded
     // the overlay for it so far, it is a split libc++ module (e.g. std_vector).
-    // Load the CxxStdlib overlay explicitly.
-    if (!overlay && importer::isCxxStdModule(clangModule)) {
+    // Load the CxxStdlib overlay explicitly, if building with the
+    // platform-default C++ stdlib.
+    if (!overlay && importer::isCxxStdModule(clangModule) &&
+        Ctx.LangOpts.isUsingPlatformDefaultCXXStdlib()) {
       ImportPath::Module::Builder builder(Ctx.Id_CxxStdlib);
       overlay = owner.loadModule(SourceLoc(), std::move(builder).get());
     }

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1429,7 +1429,8 @@ static void resolveImplicitLinkLibraries(const CompilerInstance &instance,
     bool hasStaticCxxStdlib = OptionalCxxStdLibDep.has_value() &&
                               OptionalCxxStdLibDep.value()->isStaticLibrary();
     registerCxxInteropLibraries(langOpts.Target, mainModuleName, hasStaticCxx,
-                                hasStaticCxxStdlib, addLinkLibrary);
+                                hasStaticCxxStdlib, langOpts.CXXStdlib,
+                                addLinkLibrary);
   }
 
   if (!irGenOpts.UseJIT && !langOpts.hasFeature(Feature::Embedded))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/Driver/Driver.h"
 #include "swift/AST/SILOptions.h"
 #include "swift/Basic/DiagnosticOptions.h"
 #include "swift/Frontend/Frontend.h"
@@ -333,6 +334,43 @@ setBridgingHeaderFromFrontendOptions(ClangImporterOptions &ImporterOpts,
 
   ImporterOpts.BridgingHeader =
       FrontendOpts.InputsAndOutputs.getFilenameOfFirstInput();
+}
+
+void CompilerInvocation::computeCXXStdlibOptions() {
+  auto [clangDriver, clangDiagEngine] =
+      ClangImporter::createClangDriver(LangOpts, ClangImporterOpts);
+  auto clangDriverArgs = ClangImporter::createClangArgs(
+      ClangImporterOpts, SearchPathOpts, clangDriver);
+  auto &clangToolchain =
+      clangDriver.getToolChain(clangDriverArgs, LangOpts.Target);
+  auto cxxStdlibKind = clangToolchain.GetCXXStdlibType(clangDriverArgs);
+  auto cxxDefaultStdlibKind = clangToolchain.GetDefaultCXXStdlibType();
+
+  auto toCXXStdlibKind =
+      [](clang::driver::ToolChain::CXXStdlibType clangCXXStdlibType)
+      -> CXXStdlibKind {
+    switch (clangCXXStdlibType) {
+    case clang::driver::ToolChain::CST_Libcxx:
+      return CXXStdlibKind::Libcxx;
+    case clang::driver::ToolChain::CST_Libstdcxx:
+      return CXXStdlibKind::Libstdcxx;
+    }
+  };
+
+  // The MSVC driver in Clang is not aware of the C++ stdlib, and currently
+  // always assumes libstdc++, which is incorrect: the Microsoft stdlib is
+  // normally used.
+  if (LangOpts.Target.isOSWindows()) {
+    // In the future, we should support libc++ on Windows. That would require
+    // the MSVC driver to support it first
+    // (see https://reviews.llvm.org/D101479).
+    LangOpts.CXXStdlib = CXXStdlibKind::Msvcprt;
+    LangOpts.PlatformDefaultCXXStdlib = CXXStdlibKind::Msvcprt;
+  }
+  if (LangOpts.Target.isOSLinux() || LangOpts.Target.isOSDarwin()) {
+    LangOpts.CXXStdlib = toCXXStdlibKind(cxxStdlibKind);
+    LangOpts.PlatformDefaultCXXStdlib = toCXXStdlibKind(cxxDefaultStdlibKind);
+  }
 }
 
 void CompilerInvocation::setRuntimeResourcePath(StringRef Path) {
@@ -3592,6 +3630,7 @@ bool CompilerInvocation::parseArgs(
   // Now that we've parsed everything, setup some inter-option-dependent state.
   setIRGenOutputOptsFromFrontendOptions(IRGenOpts, FrontendOpts);
   setBridgingHeaderFromFrontendOptions(ClangImporterOpts, FrontendOpts);
+  computeCXXStdlibOptions();
   if (LangOpts.hasFeature(Feature::Embedded)) {
     IRGenOpts.InternalizeAtLink = true;
     IRGenOpts.DisableLegacyTypeInfo = true;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1465,6 +1465,8 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     if (Invocation.getLangOptions().EnableCXXInterop &&
         Invocation.getLangOptions().RequireCxxInteropToImportCxxInteropModule)
       MainModule->setHasCxxInteroperability();
+    if (Invocation.getLangOptions().EnableCXXInterop)
+      MainModule->setCXXStdlibKind(Invocation.getLangOptions().CXXStdlib);
     if (Invocation.getLangOptions().AllowNonResilientAccess)
       MainModule->setAllowNonResilientAccess();
     if (Invocation.getSILOptions().EnableSerializePackage)

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1646,6 +1646,7 @@ void IRGenModule::addLinkLibraries() {
                                               getSwiftModule()->getName().str(),
                                               hasStaticCxx,
                                               hasStaticCxxStdlib,
+                                              Context.LangOpts.CXXStdlib,
                                               registerLinkLibrary);
   }
 

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -642,6 +642,11 @@ public:
     return Core->Bits.HasCxxInteroperability;
   }
 
+  /// The kind of the C++ stdlib that this module was built with.
+  CXXStdlibKind getCXXStdlibKind() const {
+    return static_cast<CXXStdlibKind>(Core->Bits.CXXStdlibKind);
+  }
+
   /// Whether the module is resilient. ('-enable-library-evolution')
   ResilienceStrategy getResilienceStrategy() const {
     return ResilienceStrategy(Core->Bits.ResilienceStrategy);

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -198,6 +198,11 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::HAS_CXX_INTEROPERABILITY_ENABLED:
       extendedInfo.setHasCxxInteroperability(true);
       break;
+    case options_block::CXX_STDLIB_KIND:
+      unsigned rawKind;
+      options_block::CXXStdlibKindLayout::readRecord(scratch, rawKind);
+      extendedInfo.setCXXStdlibKind(static_cast<CXXStdlibKind>(rawKind));
+      break;
     case options_block::ALLOW_NON_RESILIENT_ACCESS:
       extendedInfo.setAllowNonResilientAccess(true);
       break;
@@ -1461,6 +1466,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
           extInfo.isAllowModuleWithCompilerErrorsEnabled();
       Bits.IsConcurrencyChecked = extInfo.isConcurrencyChecked();
       Bits.HasCxxInteroperability = extInfo.hasCxxInteroperability();
+      Bits.CXXStdlibKind = static_cast<uint8_t>(extInfo.getCXXStdlibKind());
       Bits.AllowNonResilientAccess = extInfo.allowNonResilientAccess();
       Bits.SerializePackageEnabled = extInfo.serializePackageEnabled();
       MiscVersion = info.miscVersion;

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -391,6 +391,10 @@ private:
     /// Whether this module is built with C++ interoperability enabled.
     unsigned HasCxxInteroperability : 1;
 
+    /// Whether this module uses the platform default C++ stdlib, or an
+    /// overridden C++ stdlib.
+    unsigned CXXStdlibKind : 8;
+
     /// Whether this module is built with -allow-non-resilient-access.
     unsigned AllowNonResilientAccess : 1;
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 881; // Changes to LifetimeDependence
+const uint16_t SWIFTMODULE_VERSION_MINOR = 882; // CXXStdlibKind
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -949,6 +949,7 @@ namespace options_block {
     HAS_CXX_INTEROPERABILITY_ENABLED,
     ALLOW_NON_RESILIENT_ACCESS,
     SERIALIZE_PACKAGE_ENABLED,
+    CXX_STDLIB_KIND,
   };
 
   using SDKPathLayout = BCRecordLayout<
@@ -1030,6 +1031,11 @@ namespace options_block {
 
   using HasCxxInteroperabilityEnabledLayout = BCRecordLayout<
     HAS_CXX_INTEROPERABILITY_ENABLED
+  >;
+
+  using CXXStdlibKindLayout = BCRecordLayout<
+    CXX_STDLIB_KIND,
+    BCFixed<2>
   >;
 
   using AllowNonResilientAccess = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -853,6 +853,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, MODULE_ABI_NAME);
   BLOCK_RECORD(options_block, IS_CONCURRENCY_CHECKED);
   BLOCK_RECORD(options_block, HAS_CXX_INTEROPERABILITY_ENABLED);
+  BLOCK_RECORD(options_block, CXX_STDLIB_KIND);
   BLOCK_RECORD(options_block, MODULE_PACKAGE_NAME);
   BLOCK_RECORD(options_block, MODULE_EXPORT_AS_NAME);
   BLOCK_RECORD(options_block, PLUGIN_SEARCH_OPTION);
@@ -1134,6 +1135,10 @@ void Serializer::writeHeader() {
         options_block::HasCxxInteroperabilityEnabledLayout
             CxxInteroperabilityEnabled(Out);
         CxxInteroperabilityEnabled.emit(ScratchRecord);
+
+        options_block::CXXStdlibKindLayout CXXStdlibKind(Out);
+        CXXStdlibKind.emit(ScratchRecord,
+                           static_cast<uint8_t>(M->getCXXStdlibKind()));
       }
 
       if (Options.SerializeOptionsForDebugging) {

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -954,8 +954,10 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
       M.setABIName(Ctx.getIdentifier(loadedModuleFile->getModuleABIName()));
     if (loadedModuleFile->isConcurrencyChecked())
       M.setIsConcurrencyChecked();
-    if (loadedModuleFile->hasCxxInteroperability())
+    if (loadedModuleFile->hasCxxInteroperability()) {
       M.setHasCxxInteroperability();
+      M.setCXXStdlibKind(loadedModuleFile->getCXXStdlibKind());
+    }
     if (!loadedModuleFile->getModulePackageName().empty()) {
       M.setPackageName(Ctx.getIdentifier(loadedModuleFile->getModulePackageName()));
     }
@@ -1054,6 +1056,18 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
     Ctx.Diags.diagnose(loc, diag::need_cxx_interop_to_import_module,
                        M.getName());
     Ctx.Diags.diagnose(loc, diag::enable_cxx_interop_docs);
+  }
+  // Modules built with libc++ cannot be imported into modules that are built
+  // with libstdc++, and vice versa. Make an exception for Cxx.swiftmodule since
+  // it doesn't refer to any C++ stdlib symbols, and for CxxStdlib.swiftmodule
+  // since we skipped loading the overlay for the module.
+  if (M.hasCxxInteroperability() && Ctx.LangOpts.EnableCXXInterop &&
+      M.getCXXStdlibKind() != Ctx.LangOpts.CXXStdlib &&
+      M.getName() != Ctx.Id_Cxx && M.getName() != Ctx.Id_CxxStdlib) {
+    auto loc = diagLoc.value_or(SourceLoc());
+    Ctx.Diags.diagnose(loc, diag::cxx_stdlib_kind_mismatch, M.getName(),
+                       to_string(M.getCXXStdlibKind()),
+                       to_string(Ctx.LangOpts.CXXStdlib));
   }
 
   return fileUnit;

--- a/test/Interop/Cxx/stdlib/unsupported-stdlib.swift
+++ b/test/Interop/Cxx/stdlib/unsupported-stdlib.swift
@@ -1,0 +1,6 @@
+// RUN: not %target-swift-frontend -typecheck -Xcc -stdlib=invalid -cxx-interoperability-mode=default %s 2>&1 | %FileCheck %s
+
+// Windows does not honor `-stdlib=xyz` arguments, so the error message is different on Windows.
+// XFAIL: OS=windows-msvc
+
+// CHECK: error: invalid library name in argument '-stdlib=invalid'

--- a/test/Interop/Cxx/stdlib/use-libcxx-dependency-linux.swift
+++ b/test/Interop/Cxx/stdlib/use-libcxx-dependency-linux.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Make sure we can build a Swift library with libc++ and then import it from a Swift executable.
+// RUN: %target-build-swift %t/library.swift -emit-module -emit-library -cxx-interoperability-mode=default -Xcc -stdlib=libc++ -module-name MyLibrary -emit-module-path %t/artifacts/MyLibrary.swiftmodule -I %S/Inputs
+// RUN: %target-build-swift %t/executable.swift -emit-executable -cxx-interoperability-mode=default -Xcc -stdlib=libc++ -module-name ImportsMyLibrary -I %t/artifacts -I %S/Inputs
+
+// RUN: %empty-directory(%t/artifacts)
+
+// Make sure Swift does not allow importing a library built with libc++ into an executable that uses libstdc++.
+// RUN: %target-build-swift %t/library.swift -emit-module -emit-library -cxx-interoperability-mode=default -Xcc -stdlib=libc++ -module-name MyLibrary -emit-module-path %t/artifacts/MyLibrary.swiftmodule -I %S/Inputs
+// RUN: not %target-build-swift %t/executable.swift -emit-executable -cxx-interoperability-mode=default -module-name ImportsMyLibrary -I %t/artifacts -I %S/Inputs 2>&1 | %FileCheck %s --check-prefix=CHECK-LIBCXX-DEPENDENCY
+
+// CHECK-LIBCXX-DEPENDENCY: error: module 'MyLibrary' was built with libc++, but current compilation uses libstdc++
+
+// RUN: %empty-directory(%t/artifacts)
+
+// Make sure Swift does not allow importing a library built with libstdc++ into an executable that uses libc++.
+// RUN: %target-build-swift %t/library.swift -emit-module -emit-library -cxx-interoperability-mode=default -module-name MyLibrary -emit-module-path %t/artifacts/MyLibrary.swiftmodule -I %S/Inputs
+// RUN: not %target-build-swift %t/executable.swift -emit-executable -cxx-interoperability-mode=default -Xcc -stdlib=libc++ -module-name ImportsMyLibrary -I %t/artifacts -I %S/Inputs 2>&1 | %FileCheck %s --check-prefix=CHECK-LIBSTDCXX-DEPENDENCY
+
+// CHECK-LIBSTDCXX-DEPENDENCY: error: module 'MyLibrary' was built with libstdc++, but current compilation uses libc++
+
+// REQUIRES: OS=linux-gnu
+// REQUIRES: system_wide_libcxx
+
+//--- library.swift
+import CxxStdlib
+import StdString
+public func getStdString() -> std.string { return std.string() }
+
+//--- executable.swift
+import MyLibrary
+print("")

--- a/test/Interop/Cxx/stdlib/use-libcxx-linux.swift
+++ b/test/Interop/Cxx/stdlib/use-libcxx-linux.swift
@@ -1,0 +1,53 @@
+// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=swift-5.9)
+// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=swift-6)
+// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
+// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+
+// REQUIRES: OS=linux-gnu
+// REQUIRES: system_wide_libcxx
+
+// This test ensures that the C++ stdlib functionality can be used when
+// compiling with libc++ on Linux. Since the CxxStdlib overlay currently isn't
+// available when compiling with a non-default C++ stdlib, this only tests the
+// features that don't require CxxStdlib overlay.
+
+// This test should be removed once CxxStdlib overlay supports libc++ on Linux.
+// Instead, we should run the existing use-std-*.swift tests with libc++ in
+// addition to the default config.
+
+import StdlibUnittest
+import CxxStdlib
+import StdVector
+
+var LibcxxLinuxTestSuite = TestSuite("libc++-Linux")
+
+LibcxxLinuxTestSuite.test("std::string") {
+  var s = std.string()
+  s.push_back(65)
+  s.push_back(66)
+  s.push_back(67)
+  expectEqual(3, s.size())
+
+  var sum = 0
+  for c in s { // relies on the conformance to CxxRandomAccessCollection
+    sum += Int(c)
+  }
+  expectEqual(198, sum)
+}
+
+LibcxxLinuxTestSuite.test("std::vector<std::string>") {
+  var v = VectorOfString()
+  v.push_back(std.string())
+  v.push_back(std.string())
+  expectEqual(2, v.size())
+  
+  var count = 0
+  for s in v { // relies on the conformance to CxxRandomAccessCollection
+    count += 1
+  }
+  expectEqual(2, count)
+}
+
+runAllTests()

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -44,6 +44,10 @@ else:
     config.substitutions.insert(0, ('%target-abi', 'SYSV'))
     config.substitutions.insert(0, ('%target-swift-flags', ''))
 
+if get_target_os() in ['linux-gnu']:
+    if os.path.exists('/usr/include/c++/v1') or os.path.exists('/usr/local/include/c++/v1'):
+        config.available_features.add('system_wide_libcxx')
+
 # Enable C++ interop when compiling Swift sources.
 config.substitutions.insert(0, ('%target-interop-build-swift',
                                 '%target-build-swift -Xfrontend -enable-experimental-cxx-interop '))

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4545,6 +4545,10 @@ int main(int argc, char *argv[]) {
     }
   }
 
+  if (InitInvok.getLangOptions().EnableCXXInterop) {
+    InitInvok.computeCXXStdlibOptions();
+  }
+
   if (!options::InProcessPluginServerPath.empty()) {
     InitInvok.getSearchPathOptions().InProcessPluginServerPath =
         options::InProcessPluginServerPath;

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -185,6 +185,8 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
   swift::LangOptions langOpts;
   langOpts.EnableCXXInterop = true;
   langOpts.Target = llvm::Triple("x86_64", "unknown", "linux", "gnu");
+  langOpts.CXXStdlib = CXXStdlibKind::Libstdcxx;
+  langOpts.PlatformDefaultCXXStdlib = CXXStdlibKind::Libstdcxx;
   swift::SILOptions silOpts;
   swift::TypeCheckerOptions typecheckOpts;
   INITIALIZE_LLVM();


### PR DESCRIPTION
This makes sure that Swift respects `-Xcc -stdlib=libc++` flags.

Clang already has existing logic to discover the system-wide libc++ installation on Linux. We rely on that logic here.

Importing a Swift module that was built with a different C++ stdlib is not supported and emits an error.

The Cxx module can be imported when compiling with any C++ stdlib. The synthesized conformances, e.g. to CxxRandomAccessCollection also work. However, CxxStdlib currently cannot be imported when compiling with libc++, since on Linux it refers to symbols from libstdc++ which have different mangled names in libc++.

rdar://118357548 / https://github.com/swiftlang/swift/issues/69825