### PR TITLE
[Tests] NFC: Don't attempt to run inlinable init accessor tests on de…

### DIFF
--- a/test/Interpreter/inlinable_init_accessors.swift
+++ b/test/Interpreter/inlinable_init_accessors.swift
@@ -21,6 +21,8 @@
 
 // REQUIRES: executable_test
 
+// UNSUPPORTED: remote_run || device_run
+
 //--- Library.swift
 @frozen
 public struct Inlinable {


### PR DESCRIPTION
…vice or remotely

This test is using dylibs, which don't play way with remote/device CI.

Resolves: rdar://132715122

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
