### PR TITLE
[immediate] Load Foundation early enough for bridging

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -115,6 +115,8 @@ ERROR(error_immediate_mode_missing_library,none,
       (unsigned, StringRef))
 ERROR(error_immediate_mode_primary_file,none,
       "immediate mode is incompatible with -primary-file", ())
+WARNING(warning_immediate_mode_cannot_load_foundation,none,
+        "immediate mode failed to load Foundation: %0", (StringRef))
 ERROR(error_missing_frontend_action,none,
       "no frontend action was selected", ())
 ERROR(error_invalid_source_location_str,none,

--- a/include/swift/Immediate/Immediate.h
+++ b/include/swift/Immediate/Immediate.h
@@ -24,6 +24,7 @@
 
 namespace swift {
   class CompilerInstance;
+  class DiagnosticEngine;
   class IRGenOptions;
   class SILOptions;
   class SILModule;
@@ -44,6 +45,9 @@ namespace swift {
 
   int RunImmediatelyFromAST(CompilerInstance &CI);
 
+  /// On platforms that support ObjC bridging from the Foundation framework,
+  /// ensure that Foundation is loaded early enough. Otherwise does nothing.
+  void loadFoundationIfNeeded(DiagnosticEngine &Diags);
 } // end namespace swift
 
 #endif // SWIFT_IMMEDIATE_IMMEDIATE_H

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1955,6 +1955,13 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     return finishDiagProcessing(1, /*verifierEnabled*/ false);
   }
 
+  // Scripts that use the Foundation framework need it loaded early for bridging
+  // to work correctly on Darwin platforms. On other platforms this is a no-op.
+  if (Invocation.getFrontendOptions().RequestedAction ==
+      FrontendOptions::ActionType::Immediate) {
+    loadFoundationIfNeeded(Instance->getDiags());
+  }
+
   // Don't ask clients to report bugs when running a script in immediate mode.
   // When a script asserts the compiler reports the error with the same
   // stacktrace as a compiler crash. From here we can't tell which is which,

--- a/test/Interpreter/foundation-bridge-error.swift
+++ b/test/Interpreter/foundation-bridge-error.swift
@@ -1,0 +1,25 @@
+// Check that we can access localizedDescription, which crashes in the runtime
+// if Foundation is loaded after the runtime is already initialized on Darwin.
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+// FIXME: There's a separate bridging error with the just-built stdlib on CI
+// nodes.
+// REQUIRES: use_os_stdlib
+
+// RUN: %target-jit-run %s
+// RUN: DYLD_INSERT_LIBRARIES=/System/Library/Frameworks/Foundation.framework/Foundation %target-jit-run %s
+
+import Foundation
+
+print("Insert Libraries: \(ProcessInfo.processInfo.environment["DYLD_INSERT_LIBRARIES"] ?? "<nil>")")
+
+enum SomeError: LocalizedError {
+ case fail
+}
+
+let err = SomeError.fail
+let path = (#file as NSString).lastPathComponent
+let desc = err.localizedDescription


### PR DESCRIPTION
Foundation needs to be loaded early in the process for Swift's runtime to properly initialize bridging support; otherwise it may cause issues like unrecognized selectors. When scripting, load Foundation early in performFrontend before any swift code runs.

rdar://129528115

--- 

Note to reviewers: compared to https://github.com/swiftlang/swift/pull/75485, just dlopen'ing Foundation early like this is more robust against OS level issues around using dyld environment variables. It also does not have the risk of a re-exec cycle in such cases. However, it is more fragile to future changes to the compiler that involve using Swift earlier in the process, and might require tweaking if we do that before we find a more general solution here using e.g. out-of-process JIT for the scripts.