### PR TITLE
[6.0][region-isolation] Fix handling of coroutine apply results.

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -120,15 +120,26 @@ public:
 /// matching.
 class SILIsolationInfo {
 public:
-  /// The lattice is:
+  /// This forms a lattice of semantics. The lattice progresses from left ->
+  /// right below:
   ///
   /// Unknown -> Disconnected -> TransferringParameter -> Task -> Actor.
   ///
-  /// Unknown means no information. We error when merging on it.
   enum Kind : uint8_t {
+    /// Unknown means no information. We error when merging on it.
     Unknown,
+
+    /// An entity with disconnected isolation can be freely transferred into
+    /// another isolation domain. These are associated with "use after transfer"
+    /// diagnostics.
     Disconnected,
+
+    /// An entity that is in the same region as a task-isolated value. Cannot be
+    /// sent into another isolation domain.
     Task,
+
+    /// An entity that is in the same region as an actor-isolated value. Cannot
+    /// be sent into another isolation domain.
     Actor,
   };
 

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -99,6 +99,8 @@ actor MyActor {
   var klass: NonSendableKlass { get set }
 }
 
+sil @beginApplyMultipleResultCallee : $@yield_once @convention(thin) () -> (@yields @guaranteed NonSendableKlass, @yields @guaranteed NonSendableKlass)
+
 /////////////////
 // MARK: Tests //
 /////////////////
@@ -393,6 +395,22 @@ bb0:
 
   destroy_addr %0 : $*NonSendableKlass
   dealloc_stack %0 : $*NonSendableKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// Make sure that we do not crash on this.
+//
+// We used to crash on this since we would want to assign the region of an
+// operand to the results... but we do not have one and have multiple
+// results. This doesn't normally happen with most applies since applies do not
+// have multiple results, so in such a case, we would just assign fresh and not
+// try to do the assignment for the rest of the values.
+sil [ossa] @handleNoOperandToAssignToResults : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @beginApplyMultipleResultCallee : $@yield_once @convention(thin) () -> (@yields @guaranteed NonSendableKlass, @yields @guaranteed NonSendableKlass)
+  (%1, %2, %3) = begin_apply %0() : $@yield_once @convention(thin) () -> (@yields @guaranteed NonSendableKlass, @yields @guaranteed NonSendableKlass)
+  end_apply %3 as $()
   %9999 = tuple ()
   return %9999 : $()
 }

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -410,7 +410,7 @@ sil [ossa] @handleNoOperandToAssignToResults : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @beginApplyMultipleResultCallee : $@yield_once @convention(thin) () -> (@yields @guaranteed NonSendableKlass, @yields @guaranteed NonSendableKlass)
   (%1, %2, %3) = begin_apply %0() : $@yield_once @convention(thin) () -> (@yields @guaranteed NonSendableKlass, @yields @guaranteed NonSendableKlass)
-  end_apply %3 as $()
+  end_apply %3
   %9999 = tuple ()
   return %9999 : $()
 }


### PR DESCRIPTION
Explanation: [region-isolation] Fix handling of coroutine apply results.

In this part of the code, we are attempting to merge all of the operands into
the same region and then assigning all non-Sendable results of the function to
that same region. The problem that was occuring here was a thinko due to the
control flow of the code here not separating nicely the case of whether or not
we had operands or not. Previously this did not matter, since we just used the
first result in such a case... but since we changed to assign to the first
operand element in some cases, it matters now. To fix this, I split the confused
logic into two different easy to follow control paths... one if we have operands
and one where we do not have an operand. In the case where we have a first
operand, we merge our elements into its region. If we do not have any operands,
then we just perform one large region assign fresh.

This was not exposed by code that used non-coroutines since in SIL only
coroutines today have multiple results.

Without this change, in such a cases, we will crash.

Radars:

- rdar://132767643

Original PRs:

- https://github.com/swiftlang/swift/pull/75590

Risk: Low. What this change, we only change the behavior specifically for apply like things that have multiple results. Today the only instruction with this property begin_apply, so that is the only case that we could break by accepting this change (that is we could only break the case that is already broken). 