### PR TITLE
[DependencyScanner] Use mutex to protect all accesses to contextCacheMap

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -998,7 +998,7 @@ class SwiftDependencyScanningService {
   std::vector<std::string> AllContextHashes;
 
   /// Shared state mutual-exclusivity lock
-  llvm::sys::SmartMutex<true> ScanningServiceGlobalLock;
+  mutable llvm::sys::SmartMutex<true> ScanningServiceGlobalLock;
 
   /// Retrieve the dependencies map that corresponds to the given dependency
   /// kind.

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -736,6 +736,7 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
 
 SwiftDependencyScanningService::ContextSpecificGlobalCacheState *
 SwiftDependencyScanningService::getCacheForScanningContextHash(StringRef scanningContextHash) const {
+  llvm::sys::SmartScopedLock<true> Lock(ScanningServiceGlobalLock);
   auto contextSpecificCache = ContextSpecificCacheMap.find(scanningContextHash);
   assert(contextSpecificCache != ContextSpecificCacheMap.end() &&
          "Global Module Dependencies Cache not configured with context-specific "
@@ -756,7 +757,6 @@ SwiftDependencyScanningService::getDependenciesMap(
 ModuleNameToDependencyMap &
 SwiftDependencyScanningService::getDependenciesMap(
     ModuleDependencyKind kind, StringRef scanContextHash) {
-  llvm::sys::SmartScopedLock<true> Lock(ScanningServiceGlobalLock);
   auto contextSpecificCache = getCacheForScanningContextHash(scanContextHash);
   auto it = contextSpecificCache->ModuleDependenciesMap.find(kind);
   assert(it != contextSpecificCache->ModuleDependenciesMap.end() &&


### PR DESCRIPTION
Rather than only protecting the insertion and non-const access to `ContextSpecificCacheMap` in ScanningService, extend the mutex protection to all accesses. Even a 'const' lookup in the cache map is not thread safe because the `StringMap` could be in the process of being rehashed.

rdar://127205953