### PR TITLE
Revert one line from #75586

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -3319,7 +3319,7 @@ public:
   }
 
   ~DebugLocOverrideRAII() {
-    ASSERT(Builder.getCurrentDebugLocOverride() == installedOverride &&
+    assert(Builder.getCurrentDebugLocOverride() == installedOverride &&
            "Restoring debug location override to an unexpected state");
     Builder.applyDebugLocOverride(oldOverride);
   }


### PR DESCRIPTION
`installedOverride` is declared behind an `#ifndef NDEBUG` so this fails to build in release builds.

rdar://132930970