### PR TITLE
[ClangImporter] Deprecate versioned `__swift__` macro in imported (Obj)C(++) code.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -3319,7 +3319,7 @@ public:
   }
 
   ~DebugLocOverrideRAII() {
-    ASSERT(Builder.getCurrentDebugLocOverride() == installedOverride &&
+    assert(Builder.getCurrentDebugLocOverride() == installedOverride &&
            "Restoring debug location override to an unexpected state");
     Builder.applyDebugLocOverride(oldOverride);
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -509,7 +509,7 @@ void importer::getNormalInvocationArguments(
       // Enable block support.
       "-fblocks",
 
-      languageVersion.preprocessorDefinition("__swift__", {10000, 100, 1}),
+      "-D__swift__",
 
       "-fretain-comments-from-system-headers",
 

--- a/test/ClangImporter/Inputs/custom-modules/PredefinedMacros.h
+++ b/test/ClangImporter/Inputs/custom-modules/PredefinedMacros.h
@@ -1,9 +1,5 @@
 #if !defined(__swift__)
 # error "__swift__ not defined"
-#elif __swift__ < 30000
-# error "Why are you using such an old version of Swift?"
-#elif __swift__ >= 810000
-# error "Is Swift 81 out already? If so, please update this test."
 #else
-void swift3ReadyToGo();
+void swiftReadyToGo();
 #endif

--- a/test/ClangImporter/predefined_macros.swift
+++ b/test/ClangImporter/predefined_macros.swift
@@ -2,4 +2,4 @@
 
 import PredefinedMacros
 
-swift3ReadyToGo()
+swiftReadyToGo()

--- a/test/SourceKit/InterfaceGen/Inputs/header2.h
+++ b/test/SourceKit/InterfaceGen/Inputs/header2.h
@@ -9,6 +9,6 @@ typedef struct {
 
 } NUPixelSize;
 
-#if __swift__ >= 50000
-void show_only_for_swift_4(void);
+#if __swift__
+void show_only_for_swift(void);
 #endif

--- a/test/SourceKit/InterfaceGen/gen_header.swift
+++ b/test/SourceKit/InterfaceGen/gen_header.swift
@@ -9,18 +9,9 @@
 // RUN: %diff -u %s.header2.response %t.header2.response
 
 // RUN: echo '#include "header2.h"' > %t.m
-// RUN: %sourcekitd-test -req=interface-gen -header %S/Inputs/header2.h -swift-version=4 -- -fsyntax-only %t.m -I %S/Inputs > %t.header2.response
-// RUN: %diff -u %s.header2.response %t.header2.response
-
-// RUN: echo '#include "header2.h"' > %t.m
 // RUN: %sourcekitd-test -req=interface-gen -header %S/Inputs/header2.h -swift-version=5 -pass-version-as-string -- -fsyntax-only %t.m -I %S/Inputs > %t.header2.swift4.response
-// RUN: %FileCheck -input-file %t.header2.swift4.response %s -check-prefix=SWIFT4
-// SWIFT4: public func show_only_for_swift_4()
-
-// RUN: echo '#include "header2.h"' > %t.m
-// RUN: %sourcekitd-test -req=interface-gen -header %S/Inputs/header2.h -swift-version=5 -pass-version-as-string -- -fsyntax-only %t.m -I %S/Inputs > %t.header2.swift4.response
-// RUN: %FileCheck -input-file %t.header2.swift4.response %s -check-prefix=SWIFT4-STR
-// SWIFT4-STR: public func show_only_for_swift_4()
+// RUN: %FileCheck -input-file %t.header2.swift4.response %s -check-prefix=SWIFT
+// SWIFT: public func show_only_for_swift()
 
 // RUN: echo '#include "header3.h"' > %t.m
 // RUN: %sourcekitd-test -req=interface-gen -header %S/Inputs/header3.h -swift-version=5 -- -fsyntax-only %t.m -I %S/Inputs > %t.header3.response

--- a/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
@@ -12,6 +12,7 @@ public struct NUPixelSize {
      */
     public var height: Int
 }
+public func show_only_for_swift()
 
 [
   {
@@ -118,6 +119,21 @@ public struct NUPixelSize {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 226,
     key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 232,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 239,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 244,
+    key.length: 19
   }
 ]
 [
@@ -256,6 +272,22 @@ public struct NUPixelSize {
             key.attribute: source.decl.attribute.public
           }
         ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "show_only_for_swift()",
+    key.offset: 239,
+    key.length: 26,
+    key.nameoffset: 244,
+    key.namelength: 21,
+    key.attributes: [
+      {
+        key.offset: 232,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
       }
     ]
   }


### PR DESCRIPTION
Leaving behind an un-versioned `__swift__` macro.
Originally added in https://github.com/swiftlang/swift/pull/4510 (rdar://26921435) following a discussion in https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20160822/002754.html, the versioned macro was used to allow clients primarily to ready their existing ObjectiveC code for Swift 2 -> Swift 3 transition.

Now that neither one of those versions is a supported language mode and we have versioned APINotes support, and we do not currently know of clients that rely on the version carried by this macro, we would like to deprecate it, leaving behind the un-versioned `-D__swift__`.

The reason for the deprecation is that it is likely that in a build with multiple targets which have very similar configuration aside from Swift language version, they would not be able to share module dependencies due to the mismatch in the macro value.
