### PR TITLE
[region-isolation] Use a hard to use API correctly.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -1982,7 +1982,8 @@ void AssignIsolatedIntoSendingResultDiagnosticEmitter::emit() {
     // string a path component for that class_method.
     if (info.srcOperand->get()->getType() != info.outSendingResult->getType()) {
       if (auto fas = FullApplySite::isa(info.srcOperand->getUser())) {
-        if (fas.getSelfArgument() == info.srcOperand->get() &&
+        if (fas.hasSelfArgument() &&
+            fas.getSelfArgument() == info.srcOperand->get() &&
             fas.getNumIndirectSILResults() == 1) {
           // First check if our function argument is exactly our out parameter.
           bool canEmit =

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1849,3 +1849,18 @@ func testBooleanCapture(_ x: inout NonSendableKlass) {
     print(z)
   }
 }
+
+public class Context {
+  let value: Int
+
+  init(value: Int) {
+    self.value = value
+  }
+}
+
+extension MyActor {
+  public func withContext<T>(_ block: sending (NonSendableKlass) throws -> T) async throws -> sending T {
+    return try block(klass) // expected-tns-warning {{returning 'self'-isolated 'self.klass' as a 'sending' result risks causing data races}}
+    // expected-tns-note @-1 {{returning 'self'-isolated 'self.klass' risks causing data races since the caller assumes that 'self.klass' can be safely sent to other isolation domains}}
+  }
+}


### PR DESCRIPTION
Specifically, this API has some hard edges where instead of just returning an invalid value to signal that we do not have self, we assert or return something bogus. This commit just fixes our usage of that API to be correct.

rdar://132545626
