### PR TITLE
[RemoteMirror] Handle UnsafeContinuation

### DIFF
--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -428,6 +428,7 @@ private:
   const TypeInfo *getThickFunctionTypeInfo();
   const TypeInfo *getAnyMetatypeTypeInfo();
   const TypeInfo *getDefaultActorStorageTypeInfo();
+  const TypeInfo *getRawUnsafeContinuationTypeInfo();
   const TypeInfo *getEmptyTypeInfo();
 
   template <typename TypeInfoTy, typename... Args>

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -1603,7 +1603,7 @@ const TypeInfo *TypeConverter::getDefaultActorStorageTypeInfo() {
 }
 
 const TypeInfo *TypeConverter::getRawUnsafeContinuationTypeInfo() {
-  // FIXME:  This is a bad approximation
+  // An UnsafeContinuation is (essentially) a strong pointer to heap data
   return getReferenceTypeInfo(ReferenceKind::Strong,
 				 ReferenceCounting::Native);
 }

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -1602,6 +1602,12 @@ const TypeInfo *TypeConverter::getDefaultActorStorageTypeInfo() {
   return DefaultActorStorageTI;
 }
 
+const TypeInfo *TypeConverter::getRawUnsafeContinuationTypeInfo() {
+  // FIXME:  This is a bad approximation
+  return getReferenceTypeInfo(ReferenceKind::Strong,
+				 ReferenceCounting::Native);
+}
+
 const TypeInfo *TypeConverter::getEmptyTypeInfo() {
   if (EmptyTI != nullptr)
     return EmptyTI;
@@ -2208,6 +2214,8 @@ public:
                                      ReferenceCounting::Unknown);
     } else if (B->getMangledName() == "BD") {
       return TC.getDefaultActorStorageTypeInfo();
+    } else if (B->getMangledName() == "Bc") {
+      return TC.getRawUnsafeContinuationTypeInfo();
     }
 
     /// Otherwise, get the fixed layout information from reflection

--- a/validation-test/Reflection/reflect_UnsafeContinuation.swift
+++ b/validation-test/Reflection/reflect_UnsafeContinuation.swift
@@ -8,6 +8,7 @@
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: ASAN
+// UNSUPPORTED: back_deployment_runtime
 
 import SwiftReflectionTest
 
@@ -22,7 +23,7 @@ struct MyError: Error {
 @available(SwiftStdlib 5.1, *)
 class MyClass {
     let cont: UnsafeContinuation<MyValue, any Error>
-    
+
     init(cont: UnsafeContinuation<MyValue, any Error>) {
         self.cont = cont
     }

--- a/validation-test/Reflection/reflect_UnsafeContinuation.swift
+++ b/validation-test/Reflection/reflect_UnsafeContinuation.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UnsafeContinuation
+// RUN: %target-codesign %t/reflect_UnsafeContinuation
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_UnsafeContinuation | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: ASAN
+
+import SwiftReflectionTest
+
+struct MyValue {
+    let u: UInt
+}
+
+struct MyError: Error {
+    let i: Int
+}
+
+@available(SwiftStdlib 5.1, *)
+class MyClass {
+    let cont: UnsafeContinuation<MyValue, any Error>
+    
+    init(cont: UnsafeContinuation<MyValue, any Error>) {
+        self.cont = cont
+    }
+}
+
+if #available(SwiftStdlib 5.1, *) {
+  _ = try await withUnsafeThrowingContinuation { unsafeContinuation in
+    let myClass = MyClass(cont: unsafeContinuation)
+    reflect(object: myClass)
+    unsafeContinuation.resume(returning: MyValue(u: 1))
+  }
+}
+
+// CHECK: Reflecting an object.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (class reflect_UnsafeContinuation.MyClass)
+
+// CHECK-64: Type info:
+// CHECK-64-NEXT: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:   (field name=cont offset=16
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:       (field name=context offset=0
+// CHECK-64-NEXT:         (reference kind=strong refcounting=native)))))
+
+// TODO: 32-bit layout
+
+doneReflecting()
+
+// CHECK-64: Done.
+
+// CHECK-32: Done.


### PR DESCRIPTION
UnsafeContinuations can be stored in variables or properties, so it's important for RemoteMirror to be able to at least minimally recognize them.

This just treats an UnsafeContinuation as a refcounted pointer. Which might be "good enough" for now.

Resolves rdar://110351406