### PR TITLE
SIL: allow atomic operations in `@_noLocks` functions

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -32,8 +32,15 @@ extension BuiltinInst : OnoneSimplifyable {
            .Strideof,
            .Alignof:
         optimizeTargetTypeConst(context)
-      case .DestroyArray,
-           .CopyArray,
+      case .DestroyArray:
+        if let elementType = substitutionMap.replacementTypes[0],
+           elementType.isTrivial(in: parentFunction)
+        {
+          context.erase(instruction: self)
+          return
+        }
+        optimizeArgumentToThinMetatype(argument: 0, context)
+      case .CopyArray,
            .TakeArrayNoAlias,
            .TakeArrayFrontToBack,
            .TakeArrayBackToFront,

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -728,8 +728,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
   case SILInstructionKind::AllocStackInst:
   case SILInstructionKind::AllocVectorInst:
   case SILInstructionKind::ProjectBoxInst:
-    if (!cast<SingleValueInstruction>(inst)->getType().
-          isLoadable(*inst->getFunction())) {
+    if (cast<SingleValueInstruction>(inst)->getType().hasArchetype()) {
       impactType = cast<SingleValueInstruction>(inst)->getType();
       return RuntimeEffect::MetaData;
     }
@@ -1028,7 +1027,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
     case BuiltinValueKind::AtomicLoad:
     case BuiltinValueKind::AtomicStore:
     case BuiltinValueKind::AtomicRMW:
-      return RuntimeEffect::Locking;
+      return RuntimeEffect::NoEffect;
     case BuiltinValueKind::DestroyArray:
       return RuntimeEffect::Releasing;
     case BuiltinValueKind::CopyArray:

--- a/test/SILOptimizer/performance-annotations-atomics.swift
+++ b/test/SILOptimizer/performance-annotations-atomics.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -emit-sil %s -o /dev/null
+
+// REQUIRES: synchronization
+
+import Synchronization
+
+// Check that atomics work in no-locks mode.
+
+@_noLocks
+func testFence() {
+  atomicMemoryFence(ordering: .acquiring)
+  atomicMemoryFence(ordering: .releasing)
+  atomicMemoryFence(ordering: .acquiringAndReleasing)
+  atomicMemoryFence(ordering: .sequentiallyConsistent)
+}
+
+@_noLocks
+func testLoadStore() -> Int {
+  let x = Atomic(0)
+  x.store(27, ordering: .relaxed)
+  x.compareExchange(expected: 27, desired: 42, successOrdering: .relaxed, failureOrdering: .relaxed)
+  return x.load(ordering: .acquiring)
+}
+
+@_noLocks
+func testRMW(_ b: Bool) -> (Bool, Bool) {
+  let x = Atomic(false)
+  return x.logicalOr(true, ordering: .relaxed)
+}
+

--- a/test/SILOptimizer/simplify_builtin.sil
+++ b/test/SILOptimizer/simplify_builtin.sil
@@ -605,3 +605,12 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
   return %0 : $Builtin.RawPointer
 }
 
+// CHECK-LABEL: sil @remove_trivial_destroy_array
+// CHECK-NOT:     builtin
+// CHECK:       } // end sil function 'remove_trivial_destroy_array'
+sil @remove_trivial_destroy_array : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> Builtin.RawPointer {
+bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
+  %2 = metatype $@thin Int.Type
+  %3 = builtin "destroyArray"<Int>(%2 : $@thin Int.Type, %0 : $Builtin.RawPointer, %1 : $Builtin.Word) : $()
+  return %0 : $Builtin.RawPointer
+}


### PR DESCRIPTION
Also add an instruction simplification for `builtin "destroyArray"`: remove such builtins with trivial element types. This is need in order to use the `Atomic` struct from the Synchronization module. The implementation of `Atomic` uses `UnsafeMutablePointer` which calls this builtin.

Fixes https://github.com/swiftlang/swift/issues/74407
rdar://131726837

