### PR TITLE
[6.0][🍒] Avoid recursing into non swift modules when collecting exported imports

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1540,6 +1540,8 @@ collectExportedImports(const ModuleDecl *topLevelModule,
   stack.push_back(topLevelModule);
   while (!stack.empty()) {
     const ModuleDecl *module = stack.pop_back_val();
+    if (module->isNonSwiftModule())
+      continue;
 
     for (const FileUnit *file : module->getFiles()) {
       if (const SourceFile *source = dyn_cast<SourceFile>(file)) {

--- a/test/SymbolGraph/ClangImporter/ObjcProperty.swift
+++ b/test/SymbolGraph/ClangImporter/ObjcProperty.swift
@@ -1,17 +1,23 @@
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t1)
 // RUN: cp -r %S/Inputs/ObjcProperty/ObjcProperty.framework %t
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t/ObjcProperty.framework/Modules/ObjcProperty.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name ObjcProperty -disable-objc-attr-requires-foundation-module %s
-// RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -module-name ObjcProperty -F %t -output-dir %t -pretty-print -v
-// RUN: %FileCheck %s --input-file %t/ObjcProperty.symbols.json
-// RUN: %FileCheck %s --input-file %t/ObjcProperty.symbols.json --check-prefix XLANG
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t/ObjcProperty.framework/Modules/ObjcProperty.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name ObjcProperty -disable-objc-attr-requires-foundation-module %s -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -module-name ObjcProperty -F %t -output-dir %t1 -pretty-print -v
+// RUN: %validate-json %t/ObjcProperty.symbols.json %t/ObjcProperty.formatted.symbols.json
+// RUN: %FileCheck %s --input-file %t/ObjcProperty.formatted.symbols.json
+// RUN: %FileCheck %s --input-file %t/ObjcProperty.formatted.symbols.json --check-prefix XLANG
+// RUN: %FileCheck %s --input-file %t1/ObjcProperty.symbols.json
+// RUN: %FileCheck %s --input-file %t1/ObjcProperty.symbols.json --check-prefix XLANG
 
 // REQUIRES: objc_interop
-
-import Foundation
 
 public enum SwiftEnum {}
 
 public class SwiftClass : Foo {}
+
+// ensure we don't accidentaly pull in exported objc modules
+
+// CHECK-NOT: "precise": "c:objc(cs)NSString"
 
 // ensure that synthesized inherited objc symbols do not appear in the symbol graph
 


### PR DESCRIPTION
Avoid recursing into non swift modules when collecting exported imports

Original PR: https://github.com/swiftlang/swift/pull/75619

rdar://132593532