### PR TITLE
[stdlib] fix some inconsistent declarations

### DIFF
--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -77,7 +77,7 @@ extension String {
   }
 
   @_alwaysEmitIntoClient
-  private init(_checkingCString bytes: UnsafeBufferPointer<UInt8>) {
+  internal init(_checkingCString bytes: UnsafeBufferPointer<UInt8>) {
     guard let length = bytes.firstIndex(of: 0) else {
       _preconditionFailure(
         "input of String.init(cString:) must be null-terminated"

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -433,8 +433,9 @@ extension String {
   >(_ input: C) -> (result: String, repairsMade: Bool) {
     _internalInvariant(C.Element.self == UInt8.self)
     return Array(input).withUnsafeBufferPointer {
-      let raw = UnsafeRawBufferPointer($0)
-      return String._fromUTF8Repairing(raw.bindMemory(to: UInt8.self))
+      UnsafeRawBufferPointer($0).withMemoryRebound(to: UInt8.self) {
+        String._fromUTF8Repairing($0)
+      }
     }
   }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -428,7 +428,7 @@ extension String {
   // check in String(decoding:as:).
   @_alwaysEmitIntoClient
   @inline(never) // slow-path
-  private static func _fromNonContiguousUnsafeBitcastUTF8Repairing<
+  internal static func _fromNonContiguousUnsafeBitcastUTF8Repairing<
     C: Collection
   >(_ input: C) -> (result: String, repairsMade: Bool) {
     _internalInvariant(C.Element.self == UInt8.self)


### PR DESCRIPTION
`private` function declarations should never be allowed to carry the `@_alwaysEmitIntoClient` attribute. This has been allowed by mistake for a while, but newer compilers should make this an error. The strange consequence of this combination of keywords was that these `private` symbols were emitted into the swiftinterface file.

Also: opportunistically changed a `bindMemory()` usage to use temporary rebinding instead.

Addresses rdar://132941798
