### PR TITLE
Match parameter names in documentation to declaration

### DIFF
--- a/stdlib/public/Concurrency/AsyncSequence.swift
+++ b/stdlib/public/Concurrency/AsyncSequence.swift
@@ -147,8 +147,9 @@ extension AsyncSequence {
   /// elements of an entire sequence. For example, you can use this method on a
   /// sequence of numbers to find their sum or product.
   ///
-  /// The `nextPartialResult` closure executes sequentially with an accumulating
-  /// value initialized to `initialResult` and each element of the sequence.
+  /// The `updateAccumulatingResult` closure executes sequentially with an
+  /// accumulating value initialized to `initialResult` and each element of the
+  /// sequence.
   ///
   /// Prefer this method over `reduce(_:_:)` for efficiency when the result is
   /// a copy-on-write type, for example an `Array` or `Dictionary`.
@@ -157,10 +158,10 @@ extension AsyncSequence {
   ///   - initialResult: The value to use as the initial accumulating value.
   ///     The `nextPartialResult` closure receives `initialResult` the first
   ///     time the closure executes.
-  ///   - nextPartialResult: A closure that combines an accumulating value and
-  ///     an element of the asynchronous sequence into a new accumulating value,
-  ///     for use in the next call of the `nextPartialResult` closure or
-  ///     returned to the caller.
+  ///   - updateAccumulatingResult: A closure that combines an accumulating
+  ///     value and an element of the asynchronous sequence into a new
+  ///     accumulating value, for use in the next call of the
+  ///     `nextPartialResult` closure or returned to the caller.
   /// - Returns: The final accumulated value. If the sequence has no elements,
   ///   the result is `initialResult`.
   @inlinable

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -250,7 +250,7 @@ public struct AsyncStream<Element> {
   ///
   /// - Parameters:
   ///    - elementType: The type of element the `AsyncStream` produces.
-  ///    - bufferingPolicy: A `Continuation.BufferingPolicy` value to
+  ///    - limit: A `Continuation.BufferingPolicy` value to
   ///       set the stream's buffering behavior. By default, the stream buffers an
   ///       unlimited number of elements. You can also set the policy to buffer a
   ///       specified number of oldest or newest elements.

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -832,7 +832,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// Instead, the corresponding call to `ThrowingTaskGroup.next()` rethrows that error.
   ///
   /// - Parameters:
-  ///   - overridingPriority: The priority of the operation task.
+  ///   - priority: The priority of the operation task.
   ///     Omit this parameter or pass `.unspecified`
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.
@@ -863,7 +863,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// Instead, the corresponding call to `ThrowingTaskGroup.next()` rethrows that error.
   ///
   /// - Parameters:
-  ///   - overridingPriority: The priority of the operation task.
+  ///   - priority: The priority of the operation task.
   ///     Omit this parameter or pass `.unspecified`
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -59,7 +59,8 @@ public struct ObjectIdentifier: Sendable {
 
   /// Creates an instance that uniquely identifies the given metatype.
   ///
-  /// - x: A metatype.
+  /// - Parameters:
+  ///   - x: A metatype.
   @inlinable // trivial-implementation
   public init(_ x: Any.Type) {
     self._value = unsafeBitCast(x, to: Builtin.RawPointer.self)

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -59,7 +59,7 @@ public struct ObjectIdentifier: Sendable {
 
   /// Creates an instance that uniquely identifies the given metatype.
   ///
-  /// - Parameter: A metatype.
+  /// - x: A metatype.
   @inlinable // trivial-implementation
   public init(_ x: Any.Type) {
     self._value = unsafeBitCast(x, to: Builtin.RawPointer.self)

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -183,7 +183,7 @@ extension String: RangeReplaceableCollection {
   /// string.
   ///
   /// - Parameters:
-  ///   - bounds: The range of text to replace. The bounds of the range must be
+  ///   - subrange: The range of text to replace. The bounds of the range must be
   ///     valid indices of the string.
   ///   - newElements: The new characters to add to the string.
   ///

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -540,7 +540,7 @@ extension String.UTF16View.Index {
   ///     // Prints "Café"
   ///
   /// - Parameters:
-  ///   - sourcePosition: A position in at least one of the views of the string
+  ///   - idx: A position in at least one of the views of the string
   ///     shared by `target`.
   ///   - target: The `UTF16View` in which to find the new position.
   public init?(

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -354,7 +354,7 @@ extension String.UTF8View.Index {
   ///     // Prints "nil"
   ///
   /// - Parameters:
-  ///   - sourcePosition: A position in a `String` or one of its views.
+  ///   - idx: A position in a `String` or one of its views.
   ///   - target: The `UTF8View` in which to find the new position.
   public init?(_ idx: String.Index, within target: String.UTF8View) {
     // Note: This method used to be inlinable until Swift 5.7.


### PR DESCRIPTION
Fixes part of rdar://123853415

Fixes: rdar://132944086
