### PR TITLE
[CSApply] Allow marker existential to superclass conversions

### DIFF
--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -302,3 +302,33 @@ do {
     }
   }
 }
+
+// rdar://132700409 - coercion PartialKeyPath & Sendable -> PartialKeyPath crashes in CSApply
+do {
+  struct Test {
+    enum KeyPath {
+      static var member: PartialKeyPath<Test> {
+        fatalError()
+      }
+    }
+  }
+
+  struct KeyPathComparator<Compared> {
+    @preconcurrency public let keyPath: any PartialKeyPath<Compared> & Sendable
+
+    func testDirect() {
+      switch keyPath { // Ok
+      case Test.KeyPath.member: break // Ok
+      default: break
+      }
+    }
+
+    func testErasure() {
+      let kp: PartialKeyPath<Compared> = keyPath
+      switch kp { // Ok
+      case Test.KeyPath.member: break // Ok
+      default: break
+      }
+    }
+  }
+}


### PR DESCRIPTION
If existential is a protocol composition type where all of the protocols are `@_marker`, narrowly allow coercion to its superclass bound (if it matches). Both types have the same representation which makes it okay.

This is only a problem in Swift 5 mode without strict concurrency checks. In this mode `@preconcurrency` stripping happens outside of the solver which means that no conversion restrictions are recorded for members that got `& Sendable` stripped from their types.

For example:

```swift
struct S {
  @preconcurrency static let member: KeyPath<String, Int> & Sendable
}

func test() {
  _ = S.member
}
```

Since `member` is `@preconcurrency` its type would get concurrency annotations stripped, which includes `& Sendable` which means that the solver uses `KeyPath<String, Int>` type for the reference and not the original `KeyPath<String, Int> & Sendable`, this is a problem for `ExprRewritter::adjustTypeForDeclReference` because conversion between existential and its superclass bound requires a constraint restriction which won't be available in this case.

Resolves: rdar://132700409

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
