### PR TITLE
[6.0][CSApply] Allow marker existential to superclass conversions

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7763,6 +7763,20 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     llvm_unreachable("BuiltinTupleType should not show up here");
   }
 
+  // Allow existential-to-supertype conversion if all protocol
+  // bounds are marker protocols. Normally this requires a
+  // conversion restriction but there are situations related
+  // to `@preconcurrency` where the `& Sendable` would be stripped
+  // transparently to the solver.
+  if (auto *existential = fromType->getAs<ExistentialType>()) {
+    if (auto *PCT = existential->getConstraintType()
+                        ->getAs<ProtocolCompositionType>()) {
+      if (PCT->withoutMarkerProtocols()->isEqual(toType)) {
+        return coerceSuperclass(expr, toType);
+      }
+    }
+  }
+
   // Unresolved types come up in diagnostics for lvalue and inout types.
   if (fromType->hasUnresolvedType() || toType->hasUnresolvedType())
     return cs.cacheType(new (ctx) UnresolvedTypeConversionExpr(expr, toType));

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -302,3 +302,33 @@ do {
     }
   }
 }
+
+// rdar://132700409 - coercion PartialKeyPath & Sendable -> PartialKeyPath crashes in CSApply
+do {
+  struct Test {
+    enum KeyPath {
+      static var member: PartialKeyPath<Test> {
+        fatalError()
+      }
+    }
+  }
+
+  struct KeyPathComparator<Compared> {
+    @preconcurrency public let keyPath: any PartialKeyPath<Compared> & Sendable
+
+    func testDirect() {
+      switch keyPath { // Ok
+      case Test.KeyPath.member: break // Ok
+      default: break
+      }
+    }
+
+    func testErasure() {
+      let kp: PartialKeyPath<Compared> = keyPath
+      switch kp { // Ok
+      case Test.KeyPath.member: break // Ok
+      default: break
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Explanation:

  Fixes a compiler crash caused by adding `@preconcurrency` and annotating a property with `& Sendable`.

  If existential is a protocol composition type where all of the protocols are `@_marker`, narrowly allow coercion to its superclass bound (if it matches). Both types have the same representation which makes it okay.

  This is only a problem in Swift 5 mode without strict concurrency checks. In this mode `@preconcurrency` stripping happens outside of the solver which means that no conversion restrictions are recorded for members that got `& Sendable` stripped from their types.

  For example:

  ```swift
  struct S {
    @preconcurrency static let member: KeyPath<String, Int> & Sendable
  }

  func test() {
    _ = S.member
  }
  ```

  Since `member` is `@preconcurrency` its type would get concurrency annotations stripped, which includes `& Sendable` which means that the solver uses `KeyPath<String, Int>` type for the reference and not the original `KeyPath<String, Int> & Sendable`, this is a problem for `ExprRewritter::adjustTypeForDeclReference` because conversion between existential and its superclass bound requires a constraint restriction which won't be available in this case.

- Main Branch PR: https://github.com/swiftlang/swift/pull/75628

- Resolves: rdar://132700409

- Risk: Low (This is a very narrow change that affects only non-strict concurrency mode and properties that are both marked as `@preconcurrency` and use `& Sendable` type, if we don't take this it would mean adding @preconcurrency + Sendable on some properties has source compatibility impact with no workaround but to use `-strict-concurrency=complete`).

- Reviewed By: @hborla  

- Testing: Added new tests to the concurrency test suite.

(cherry picked from commit 38aa71de91e31c9d0ed16d93db76c09b25c1ae8d)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
