### PR TITLE
[6.0][immediate] Load Foundation early enough for bridging

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -120,6 +120,8 @@ ERROR(error_immediate_mode_missing_library,none,
       (unsigned, StringRef))
 ERROR(error_immediate_mode_primary_file,none,
       "immediate mode is incompatible with -primary-file", ())
+WARNING(warning_immediate_mode_cannot_load_foundation,none,
+        "immediate mode failed to load Foundation: %0", (StringRef))
 ERROR(error_missing_frontend_action,none,
       "no frontend action was selected", ())
 ERROR(error_unsupported_frontend_action, none,

--- a/include/swift/Immediate/Immediate.h
+++ b/include/swift/Immediate/Immediate.h
@@ -24,6 +24,7 @@
 
 namespace swift {
   class CompilerInstance;
+  class DiagnosticEngine;
   class IRGenOptions;
   class SILOptions;
   class SILModule;
@@ -44,6 +45,9 @@ namespace swift {
 
   int RunImmediatelyFromAST(CompilerInstance &CI);
 
+  /// On platforms that support ObjC bridging from the Foundation framework,
+  /// ensure that Foundation is loaded early enough. Otherwise does nothing.
+  void loadFoundationIfNeeded(DiagnosticEngine &Diags);
 } // end namespace swift
 
 #endif // SWIFT_IMMEDIATE_IMMEDIATE_H

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1942,6 +1942,13 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     return finishDiagProcessing(1, /*verifierEnabled*/ false);
   }
 
+  // Scripts that use the Foundation framework need it loaded early for bridging
+  // to work correctly on Darwin platforms. On other platforms this is a no-op.
+  if (Invocation.getFrontendOptions().RequestedAction ==
+      FrontendOptions::ActionType::Immediate) {
+    loadFoundationIfNeeded(Instance->getDiags());
+  }
+
   // Don't ask clients to report bugs when running a script in immediate mode.
   // When a script asserts the compiler reports the error with the same
   // stacktrace as a compiler crash. From here we can't tell which is which,

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -431,3 +431,30 @@ int swift::RunImmediatelyFromAST(CompilerInstance &CI) {
 
   return *Result;
 }
+
+void swift::loadFoundationIfNeeded(DiagnosticEngine &Diags) {
+#if defined(__APPLE__)
+  const char *FoundationPath =
+      "/System/Library/Frameworks/Foundation.framework/Foundation";
+  void *handle = dlopen(FoundationPath, RTLD_NOLOAD);
+  if (handle) {
+    // Foundation is already loaded. Use dlclose to release the ref-count that
+    // was incremented by dlopen and return.
+    dlclose(handle);
+    return;
+  } else {
+    // Foundation is not yet loaded. Load it now and leak the handle.
+    // FIXME: it is fragile to load here, as there is no guarantee the swift
+    // runtime has not initialized already. As the compiler adds more swift code
+    // we may need to move this or find another solution.
+    handle = dlopen(FoundationPath, RTLD_LAZY | RTLD_GLOBAL);
+    if (!handle)
+      Diags.diagnose(SourceLoc(),
+                     diag::warning_immediate_mode_cannot_load_foundation,
+                     dlerror());
+  }
+
+#else
+  // Nothing to do.
+#endif
+}

--- a/test/Interpreter/foundation-bridge-error.swift
+++ b/test/Interpreter/foundation-bridge-error.swift
@@ -1,0 +1,25 @@
+// Check that we can access localizedDescription, which crashes in the runtime
+// if Foundation is loaded after the runtime is already initialized on Darwin.
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+// FIXME: There's a separate bridging error with the just-built stdlib on CI
+// nodes.
+// REQUIRES: use_os_stdlib
+
+// RUN: %target-jit-run %s
+// RUN: DYLD_INSERT_LIBRARIES=/System/Library/Frameworks/Foundation.framework/Foundation %target-jit-run %s
+
+import Foundation
+
+print("Insert Libraries: \(ProcessInfo.processInfo.environment["DYLD_INSERT_LIBRARIES"] ?? "<nil>")")
+
+enum SomeError: LocalizedError {
+ case fail
+}
+
+let err = SomeError.fail
+let path = (#file as NSString).lastPathComponent
+let desc = err.localizedDescription


### PR DESCRIPTION
  - **Explanation**: Some bridged Foundation types require Foundation to be loaded in the process before we ever reach certain code paths.  Swift scripts using such types were crashing, because they were loading Foundation too late. This change unconditionally loads Foundation early in the frontend process when in scripting mode to workaround this issue.
  - **Scope**: Only affects running swift scripts, and only on Darwin. For scripts that import Foundation the only difference is we `dlopen` it earlier.  For scripts that don't use Foundation they will now `dlopen` Foundation, because it's too early in the process to detect whether it's needed. The risk to such scripts is mitigated because failure to load Foundation is only a warning not an error.
  - **Issues**: rdar://129528115
  - **Original PRs**: https://github.com/swiftlang/swift/pull/75594
  - **Risk**: The risk of regression from this change is low and scope is limited. The primary risk for this change is that we could make future changes to the compiler that introduce swift bridging calls earlier in the process and cause this bug to return.  That should be caught by CI running tests with `--param use_os_stdlib`, but that isn't in PR test configs so it may not be caught immediately.  We have multiple options to fix this bug more thoroughly for the future though either in the runtime/Foundation or in the immediate mode JIT, but they are all much more involved changes.
  - **Testing**: Tested manually on macOS 15 beta and macOS 13.6. On 13.6, also checked multiple configurations (arm64, arm64 with SIP disabled, x86_64).  There's a lit test included that will run with `--param use_os_stdlib`.
  - **Reviewers**: @mikeash 