### PR TITLE
ClangImporter: support SDK for APINotes

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -749,10 +749,24 @@ void importer::getNormalInvocationArguments(
   invocationArgStrs.push_back("-fapinotes-modules");
   invocationArgStrs.push_back("-fapinotes-swift-version=" +
                               languageVersion.asAPINotesVersionString());
-  invocationArgStrs.push_back("-iapinotes-modules");
-  invocationArgStrs.push_back((llvm::Twine(searchPathOpts.RuntimeResourcePath) +
-                               llvm::sys::path::get_separator() +
-                               "apinotes").str());
+
+  // Prefer `-sdk` paths.
+  if (!searchPathOpts.getSDKPath().empty()) {
+    llvm::SmallString<261> path{searchPathOpts.getSDKPath()};
+    llvm::sys::path::append(path, "usr", "lib", "swift", "apinotes");
+
+    invocationArgStrs.push_back("-iapinotes-modules");
+    invocationArgStrs.push_back(path.str().str());
+  }
+
+  // Fallback to "legacy" `-resource-dir` paths.
+  {
+    llvm::SmallString<261> path{searchPathOpts.RuntimeResourcePath};
+    llvm::sys::path::append(path, "apinotes");
+
+    invocationArgStrs.push_back("-iapinotes-modules");
+    invocationArgStrs.push_back(path.str().str());
+  }
 }
 
 static void

--- a/test/ClangImporter/sdk-apinotes.swift
+++ b/test/ClangImporter/sdk-apinotes.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify
+
+import cfuncs
+
+let array: [UnsafePointer<CChar>?] = [nil]
+array.withUnsafeBufferPointer { nullability_note($0.baseAddress!) }

--- a/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
@@ -60,3 +60,5 @@ void opaque_pointer_param(struct not_importable *);
 
 int unsupported_parameter_type(int param1, _Complex int param2);
 _Complex int unsupported_return_type();
+
+void nullability_note(const char * _Nonnull const * _Nonnull parameter);

--- a/test/Inputs/clang-importer-sdk/usr/lib/swift/apinotes/cfuncs.apinotes
+++ b/test/Inputs/clang-importer-sdk/usr/lib/swift/apinotes/cfuncs.apinotes
@@ -1,0 +1,7 @@
+---
+Name: cfuncs
+Functions:
+- Name: nullability_note
+  Parameters:
+  - Position: 0
+    Type: "const char * _Nullable const * _Nonnull"


### PR DESCRIPTION
Honour the SDK for APINotes to augment the system libraries. This allows us to distribute APINotes with the Swift SDK and impact the system without having to map the APINotes into the filesystem.