### PR TITLE
Revert "AST: Make absence of discriminator into a fatal error"

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1934,12 +1934,7 @@ unsigned AbstractClosureExpr::getDiscriminator() const {
         Bits.AbstractClosureExpr.Discriminator = discriminator;
   }
 
-  if (getRawDiscriminator() == InvalidDiscriminator) {
-    llvm::errs() << "Closure does not have an assigned discriminator:\n";
-    dump(llvm::errs());
-    abort();
-  }
-
+  assert(getRawDiscriminator() != InvalidDiscriminator);
   return getRawDiscriminator();
 }
 


### PR DESCRIPTION
  - **Explanation**: This assertion-turned-fatal-error tripped up some existing code that we haven't been able to reproduce locally. 
  - **Scope**: This issue only seems to impact some applications of freestanding macros that accept closures.
  - **Issues**: rdar://130229431
  - **Original PRs**: N/A; we're keeping this change on `main`.
  - **Risk**: No additional risk compared to what's in the compiler today.
  - **Testing**: N/A
  - **Reviewers**: @slavapestov