### PR TITLE
Sema: Refactor superfluous public import tracking

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -440,9 +440,11 @@ public:
   AccessLevel
   getMaxAccessLevelUsingImport(const ModuleDecl *import) const;
 
-  /// Register the use of \p import from an API with \p accessLevel.
-  void registerAccessLevelUsingImport(AttributedImport<ImportedModule> import,
-                                      AccessLevel accessLevel);
+  /// Register the requirement that \p mod be imported with an access level
+  /// that is at least as permissive as \p accessLevel in order to satisfy
+  /// access or exportability checking constraints.
+  void registerRequiredAccessLevelForModule(ModuleDecl *mod,
+                                            AccessLevel accessLevel);
 
   enum ImportQueryKind {
     /// Return the results for testable or private imports.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2728,10 +2728,8 @@ SourceFile::getMaxAccessLevelUsingImport(
   return known->second;
 }
 
-void SourceFile::registerAccessLevelUsingImport(
-    AttributedImport<ImportedModule> import,
-    AccessLevel accessLevel) {
-  auto mod = import.module.importedModule;
+void SourceFile::registerRequiredAccessLevelForModule(ModuleDecl *mod,
+                                                      AccessLevel accessLevel) {
   auto known = ImportsUseAccessLevel.find(mod);
   if (known == ImportsUseAccessLevel.end())
     ImportsUseAccessLevel[mod] = accessLevel;
@@ -2754,7 +2752,7 @@ void SourceFile::registerAccessLevelUsingImport(
     auto otherImportModName = otherImportMod->getName();
     if (otherImportMod == declaringMod ||
         llvm::find(bystanders, otherImportModName) != bystanders.end()) {
-      registerAccessLevelUsingImport(otherImport, accessLevel);
+      registerRequiredAccessLevelForModule(otherImportMod, accessLevel);
     }
   }
 }

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -76,20 +76,15 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   }
 
   // Remember that the module defining the decl must be imported publicly.
-  recordRequiredImportAccessLevelForDecl(D, DC, AccessLevel::Public);
-
-  // Emit a remark explaining the required access level.
-  ImportAccessLevel problematicImport = D->getImportAccessFrom(DC);
-  if (problematicImport.has_value()) {
-    if (Context.LangOpts.EnableModuleApiImportRemarks) {
-      ModuleDecl *importedVia = problematicImport->module.importedModule,
-                 *sourceModule = D->getModuleContext();
-      Context.Diags.diagnose(loc, diag::module_api_import,
-                             D, importedVia, sourceModule,
-                             importedVia == sourceModule,
-                             /*isImplicit*/false);
-    }
-  }
+  recordRequiredImportAccessLevelForDecl(
+      D, DC, AccessLevel::Public,
+      [&](AttributedImport<ImportedModule> attributedImport) {
+        ModuleDecl *importedVia = attributedImport.module.importedModule,
+                   *sourceModule = D->getModuleContext();
+        Context.Diags.diagnose(loc, diag::module_api_import, D, importedVia,
+                               sourceModule, importedVia == sourceModule,
+                               /*isImplicit*/ false);
+      });
 
   // General check on access-level of the decl.
   auto declAccessScope =
@@ -140,6 +135,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
 
   Context.Diags.diagnose(D, diag::resilience_decl_declared_here, D);
 
+  ImportAccessLevel problematicImport = D->getImportAccessFrom(DC);
   if (problematicImport.has_value() &&
       problematicImport->accessLevel < D->getFormalAccess()) {
     Context.Diags.diagnose(problematicImport->importLoc,
@@ -166,19 +162,14 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
 
   // Remember that the module defining the underlying type must be imported
   // publicly.
-  recordRequiredImportAccessLevelForDecl(D, DC, AccessLevel::Public);
-
-  // Emit a remark explaining the required access level.
-  ImportAccessLevel problematicImport = D->getImportAccessFrom(DC);
-  if (problematicImport.has_value()) {
-    if (ctx.LangOpts.EnableModuleApiImportRemarks) {
-      ModuleDecl *importedVia = problematicImport->module.importedModule,
-                 *sourceModule = D->getModuleContext();
-      ctx.Diags.diagnose(loc, diag::module_api_import_aliases,
-                             D, importedVia, sourceModule,
-                             importedVia == sourceModule);
-    }
-  }
+  recordRequiredImportAccessLevelForDecl(
+      D, DC, AccessLevel::Public,
+      [&](AttributedImport<ImportedModule> attributedImport) {
+        ModuleDecl *importedVia = attributedImport.module.importedModule,
+                   *sourceModule = D->getModuleContext();
+        ctx.Diags.diagnose(loc, diag::module_api_import_aliases, D, importedVia,
+                           sourceModule, importedVia == sourceModule);
+      });
 
   auto ignoredDowngradeToWarning = DowngradeToWarning::No;
   auto originKind =
@@ -249,7 +240,19 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
   auto originKind = getDisallowedOriginKind(D, where, downgradeToWarning);
 
   // Remember that the module defining the decl must be imported publicly.
-  recordRequiredImportAccessLevelForDecl(D, DC, AccessLevel::Public);
+  recordRequiredImportAccessLevelForDecl(
+      D, DC, AccessLevel::Public,
+      [&](AttributedImport<ImportedModule> attributedImport) {
+        if (where.isExported() && reason != ExportabilityReason::General &&
+            originKind != DisallowedOriginKind::NonPublicImport) {
+          // These may be reported twice, for the Type and for the TypeRepr.
+          ModuleDecl *importedVia = attributedImport.module.importedModule,
+                     *sourceModule = D->getModuleContext();
+          ctx.Diags.diagnose(loc, diag::module_api_import, D, importedVia,
+                             sourceModule, importedVia == sourceModule,
+                             /*isImplicit*/ false);
+        }
+      });
 
   // Access levels from imports are reported with the others access levels.
   // Except for extensions and protocol conformances, we report them here.
@@ -267,21 +270,6 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
     }();
     if (!reportHere)
       return false;
-  }
-
-  // Emit a remark explaining the required access level.
-  ImportAccessLevel import = D->getImportAccessFrom(DC);
-  if (ctx.LangOpts.EnableModuleApiImportRemarks &&
-      import.has_value() && where.isExported() &&
-      reason != ExportabilityReason::General &&
-      originKind != DisallowedOriginKind::NonPublicImport) {
-    // These may be reported twice, for the Type and for the TypeRepr.
-    ModuleDecl *importedVia = import->module.importedModule,
-               *sourceModule = D->getModuleContext();
-    ctx.Diags.diagnose(loc, diag::module_api_import,
-                       D, importedVia, sourceModule,
-                       importedVia == sourceModule,
-                       /*isImplicit*/false);
   }
 
   if (originKind == DisallowedOriginKind::None)
@@ -330,6 +318,7 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
   }
 
   // If limited by an import, note which one.
+  ImportAccessLevel import = D->getImportAccessFrom(DC);
   if (originKind == DisallowedOriginKind::NonPublicImport) {
     assert(import.has_value() &&
            import->accessLevel < AccessLevel::Public &&
@@ -379,20 +368,16 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
 
   // Remember that the module defining the conformance must be imported
   // publicly.
-  recordRequiredImportAccessLevelForDecl(ext, DC, AccessLevel::Public);
-
-  // Emit a remark explaining the required access level.
-  ImportAccessLevel problematicImport = ext->getImportAccessFrom(DC);
-  if (problematicImport.has_value()) {
-    if (ctx.LangOpts.EnableModuleApiImportRemarks) {
-      ModuleDecl *importedVia = problematicImport->module.importedModule,
-                 *sourceModule = ext->getModuleContext();
-      ctx.Diags.diagnose(loc, diag::module_api_import_conformance,
-                         rootConf->getType(), rootConf->getProtocol(),
-                         importedVia, sourceModule,
-                         importedVia == sourceModule);
-    }
-  }
+  recordRequiredImportAccessLevelForDecl(
+      ext, DC, AccessLevel::Public,
+      [&](AttributedImport<ImportedModule> attributedImport) {
+        ModuleDecl *importedVia = attributedImport.module.importedModule,
+                   *sourceModule = ext->getModuleContext();
+        ctx.Diags.diagnose(loc, diag::module_api_import_conformance,
+                           rootConf->getType(), rootConf->getProtocol(),
+                           importedVia, sourceModule,
+                           importedVia == sourceModule);
+      });
 
   auto originKind = getDisallowedOriginKind(ext, where);
   if (originKind == DisallowedOriginKind::None)

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1522,6 +1522,13 @@ public:
   }
 };
 
+/// Make a note that uses of \p decl in \p dc require that the decl's defining
+/// module be imported with an access level that is at least as permissive as \p
+/// accessLevel.
+void recordRequiredImportAccessLevelForDecl(const Decl *decl,
+                                            const DeclContext *dc,
+                                            AccessLevel accessLevel);
+
 /// Report imports that are marked public but are not used in API.
 void diagnoseUnnecessaryPublicImports(SourceFile &SF);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1522,12 +1522,15 @@ public:
   }
 };
 
+using RequiredImportAccessLevelCallback =
+    std::function<void(AttributedImport<ImportedModule>)>;
+
 /// Make a note that uses of \p decl in \p dc require that the decl's defining
 /// module be imported with an access level that is at least as permissive as \p
 /// accessLevel.
-void recordRequiredImportAccessLevelForDecl(const Decl *decl,
-                                            const DeclContext *dc,
-                                            AccessLevel accessLevel);
+void recordRequiredImportAccessLevelForDecl(
+    const Decl *decl, const DeclContext *dc, AccessLevel accessLevel,
+    RequiredImportAccessLevelCallback remark);
 
 /// Report imports that are marked public but are not used in API.
 void diagnoseUnnecessaryPublicImports(SourceFile &SF);


### PR DESCRIPTION
In anticipation of reusing minimum access level information for diagnostics related to the `MemberImportVisibility` feature, refactor the way the type checker tracks the modules which must be imported publicly. Recording minimum access levels is no longer restricted to modules that are already imported in a source file since `MemberImportVisibility` diagnostics will need this information when emitting fix-its for modules that are not already imported.
    
Unblocks rdar://126637855.
