### PR TITLE
Sema: Fix crash with property override and almost-valid superclass

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -857,19 +857,6 @@ namespace {
 
       return cachedDeclType;
     }
-
-    /// Adjust the interface of the given declaration, which is found in
-    /// a supertype of the given type.
-    Type getSuperMemberDeclType(ValueDecl *baseDecl) const {
-      auto selfType = decl->getDeclContext()->getSelfInterfaceType();
-      if (selfType->getClassOrBoundGenericClass()) {
-        selfType = selfType->getSuperclass();
-        assert(selfType && "No superclass type?");
-      }
-
-      return selfType->adjustSuperclassMemberDeclType(
-               baseDecl, decl, baseDecl->getInterfaceType());
-    }
   };
 }
 
@@ -1283,7 +1270,9 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
     }
   } else if (auto property = dyn_cast<VarDecl>(decl)) {
     auto propertyTy = property->getInterfaceType();
-    auto parentPropertyTy = getSuperMemberDeclType(baseDecl);
+    auto selfType = decl->getDeclContext()->getSelfInterfaceType();
+    auto parentPropertyTy = selfType->adjustSuperclassMemberDeclType(
+             baseDecl, decl, baseDecl->getInterfaceType());
 
     CanType parentPropertyCanTy =
       parentPropertyTy->getReducedType(

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -236,7 +236,10 @@ class IUOTestSubclassOkay : IUOTestBaseClass {
   override func oneC(_ x: AnyObject) {}
 }
 
-class GenericBase<T> {}
+class GenericBase<T> { // expected-note{{generic type 'GenericBase' declared here}}
+  var values: Int { 0 } // expected-note{{attempt to override property here}}
+}
+
 class ConcreteDerived: GenericBase<Int> {}
 
 class OverriddenWithConcreteDerived<T> {
@@ -424,3 +427,7 @@ class OverrideTypoSubclass: OverrideTypoBaseClass {
   override func foo(_ x: Itn) {} // expected-error {{cannot find type 'Itn' in scope}}
 }
 
+// https://github.com/swiftlang/swift/issues/74651
+class InvalidSubclass: GenericBase { // expected-error {{reference to generic type 'GenericBase' requires arguments in <...>}}
+  var values: Float { 0 } // expected-error {{property 'values' with type 'Float' cannot override a property with type 'Int'}}
+}


### PR DESCRIPTION
It's possible that getSuperclassDecl() returns something but getSuperclass() does not, for example if you reference a generic superclass with missing or invalid generic arguments. We would crash in that case when going down this particular code path.

However, the call to getSuperclass() and the entire function it appeared in was actually unnecessary.

Fixes https://github.com/swiftlang/swift/issues/74651
Fixes rdar://problem/130394943