### PR TITLE
AST: Resume printing `convenience` on actor initializers

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4280,13 +4280,15 @@ void PrintAST::visitConstructorDecl(ConstructorDecl *decl) {
     // Protocol extension initializers are modeled as convenience initializers,
     // but they're not written that way in source. Check if we're actually
     // printing onto a class.
-    ClassDecl *classDecl = CurrentType
-                               ? CurrentType->getClassOrBoundGenericClass()
-                               : decl->getDeclContext()->getSelfClassDecl();
-    if (classDecl) {
-      // Convenience intializers are also unmarked on actors.
-      if (!classDecl->isActor())
-        Printer.printKeyword("convenience", Options, " ");
+    bool isClassContext;
+    if (CurrentType) {
+      isClassContext = CurrentType->getClassOrBoundGenericClass() != nullptr;
+    } else {
+      const DeclContext *dc = decl->getDeclContext();
+      isClassContext = dc->getSelfClassDecl() != nullptr;
+    }
+    if (isClassContext) {
+      Printer.printKeyword("convenience", Options, " ");
     } else {
       assert(decl->getDeclContext()->getExtendedProtocolDecl() &&
              "unexpected convenience initializer");

--- a/test/ModuleInterface/actor_init.swift
+++ b/test/ModuleInterface/actor_init.swift
@@ -12,11 +12,29 @@
 // CHECK-LABEL: public actor TestActor {
 @available(SwiftStdlib 5.5, *)
 public actor TestActor {
-  // FIXME: The convenience keyword should be omitted (rdar://130926278)
-  // CHECK: public convenience init(convenience: Swift.Int)
-  public init(convenience: Int) {
-    self.init()
+  private var x: Int
+
+  // CHECK: public convenience init(convenience x: Swift.Int)
+  public init(convenience x: Int) {
+    self.init(designated: x)
   }
+
   // CHECK: public init()
-  public init() {}
+  public init() {
+    self.x = 0
+  }
+
+  // CHECK: public init(designated x: Swift.Int)
+  public init(designated x: Int) {
+    self.x = x
+  }
+}
+
+// CHECK-LABEL: extension Library.TestActor {
+@available(SwiftStdlib 5.5, *)
+extension TestActor {
+  // CHECK: public convenience init(convenienceInExtension x: Swift.Int)
+  public init(convenienceInExtension x: Int) {
+    self.init(designated: x)
+  }
 }

--- a/test/ModuleInterface/actor_init.swift
+++ b/test/ModuleInterface/actor_init.swift
@@ -12,7 +12,8 @@
 // CHECK-LABEL: public actor TestActor {
 @available(SwiftStdlib 5.5, *)
 public actor TestActor {
-  // CHECK: public init(convenience: Swift.Int)
+  // FIXME: The convenience keyword should be omitted (rdar://130926278)
+  // CHECK: public convenience init(convenience: Swift.Int)
   public init(convenience: Int) {
     self.init()
   }


### PR DESCRIPTION
The type checker does not expect initializers in extensions to omit the `convenience` keyword so https://github.com/swiftlang/swift/pull/75180 caused a regression where initializers declared in actor extensions yield broken swiftinterfaces.

It's not clear to me that we gain anything concrete from omitting the `convenience` keyword in swiftinterfaces so this PR reverts https://github.com/swiftlang/swift/pull/75180 and adds more test cases.

Resolves rdar://133012963.