### PR TITLE
[cxx-interop] Fix crash with reverse interop in Embedded Swift

### DIFF
--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -186,9 +186,21 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
   if (!(isSwiftIntLong && !isInt64Long))
     primTypesArray = primTypesArray.drop_back(2);
 
+  // We do not have metadata for primitive types in Embedded Swift.
+  bool embedded = astContext.LangOpts.hasFeature(Feature::Embedded);
+
   for (Type type : primTypesArray) {
     auto typeInfo = *typeMapping.getKnownCxxTypeInfo(
         type->getNominalOrBoundGenericNominal());
+
+    if (!isCForwardDefinition) {
+      os << "template<>\n";
+      os << "static inline const constexpr bool isUsableInGenericContext<"
+         << typeInfo.name << "> = true;\n\n";
+    }
+
+    if (embedded)
+      continue;
 
     auto typeMetadataFunc = irgen::LinkEntity::forTypeMetadata(
         type->getCanonicalType(), irgen::TypeMetadataAddress::AddressPoint);
@@ -200,10 +212,6 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
          << ";\n";
       continue;
     }
-
-    os << "template<>\n";
-    os << "static inline const constexpr bool isUsableInGenericContext<"
-       << typeInfo.name << "> = true;\n\n";
 
     os << "template<>\nstruct TypeMetadataTrait<" << typeInfo.name << "> {\n"
        << "  static ";

--- a/test/Interop/SwiftToCxx/core/embedded-swift.swift
+++ b/test/Interop/SwiftToCxx/core/embedded-swift.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Core -target arm64-apple-macos15.0 -enable-experimental-feature Embedded -clang-header-expose-decls=all-public -emit-clang-header-path %t/core.h
+// RUN: %FileCheck %s < %t/core.h
+
+// REQUIRES: OS=macosx
+
+public func id(_ x: Int) -> Int {
+    return x
+}
+
+// CHECK-NOT: TypeMetadataTrait<bool>


### PR DESCRIPTION
Embedded Swift has a minimal runtime, some type metadata is not available. This patch works around a crash that tries to emit C++ briding to this non-existent Swift metadata. It is very likely that there will be more fallout in reverse interop, but this patch should fix the most glaring issue, crashing on an empty Embedded Swift project.

rdar://129030521