### PR TITLE
tests: fix the SILOptimizer/performance-annotations-atomics.swift test

### DIFF
--- a/test/SILOptimizer/performance-annotations-atomics.swift
+++ b/test/SILOptimizer/performance-annotations-atomics.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -emit-sil %s -o /dev/null
 
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: synchronization
 
 import Synchronization


### PR DESCRIPTION
Require that the stdlib is optimized and not built with assertions

rdar://133069361
