### PR TITLE
stdlib: Add runtime support for zippered availability checks

### DIFF
--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -109,11 +109,6 @@ public func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(
   _ variantMinor: Builtin.Word,
   _ variantPatch: Builtin.Word
   ) -> Builtin.Int1 {
-  return _stdlib_isOSVersionAtLeast(major, minor, patch)
-
-  // FIXME: Enable when __isPlatformOrVariantPlatformVersionAtLeast() support
-  // is added to compiler-rt.
-#if false
   if Int(major) == 9999 {
     return true._value
   }
@@ -136,7 +131,6 @@ public func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(
           variantMajor32._value, variantMinor32._value, variantPatch32._value))
 
   return (result32 != (0 as UInt32))._value
-#endif
 }
 #endif
 

--- a/test/SIL/availability_query_maccatalyst_zippered_inlined.swift
+++ b/test/SIL/availability_query_maccatalyst_zippered_inlined.swift
@@ -9,7 +9,7 @@
 // RUN: rm %t/Library.swiftmodule
 // RUN: %target-swift-frontend -emit-sil %t/main.swift -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -I %t | %FileCheck %t/main.swift
 
-// REQUIRES: maccatalyst_support
+// REQUIRES: OS=macosx || OS=maccatalyst
 
 //--- Library.swift
 


### PR DESCRIPTION
Now that `__isPlatformOrVariantPlatformVersionAtLeast()` is available in upstream LLVM (https://github.com/llvm/llvm-project/pull/100605), the implementation of the zippered variant of the OS version check utility can use the `targetOSVersionOrVariantOSVersionAtLeast` builtin safely.

Resolves rdar://103960437.