### PR TITLE
Sema: Fix crash with SpecializeExpr around something that's not a type

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13978,6 +13978,8 @@ ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
     decl = bound->getDecl();
     for (auto argType : bound->getDirectGenericArgs()) {
       auto *typeVar = argType->getAs<TypeVariableType>();
+      if (!typeVar)
+        return SolutionKind::Error;
       auto *genericParam = typeVar->getImpl().getGenericParameter();
       openedTypes.push_back({genericParam, typeVar});
     }

--- a/test/Sema/issue-74858.swift
+++ b/test/Sema/issue-74858.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+
+typealias Alias<T> = Int
+
+func invalidSpecializeExpr(_ x: Alias<Int>.Type) {
+  let y = x<Int>.self
+  // expected-error@-1 {{type of expression is ambiguous without a type annotation}}
+  // FIXME: Bad diagnostic
+}


### PR DESCRIPTION
Unfortunately the diagnostic is terrible.

Fixes https://github.com/swiftlang/swift/issues/74858