### PR TITLE
[Cleanup] Remove last `equals` in unittests

### DIFF
--- a/unittests/AST/ASTWalkerTests.cpp
+++ b/unittests/AST/ASTWalkerTests.cpp
@@ -361,7 +361,7 @@ private:
       if (component.getCheckpoint() == checkpoint) {
         auto arg = this->walkStr.str().slice(component.getArgumentStartIndex(),
                                              component.getArgumentEndIndex());
-        if (arg.equals(argumentStr)) {
+        if (arg == argumentStr) {
           return index;
         }
       }


### PR DESCRIPTION
This was removed in upstream LLVM in preference for `==`.