### PR TITLE
Expose a ImportPrivateDependencies LangOpt for LLDB (NFC).

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -267,6 +267,10 @@ namespace swift {
     /// Enable features useful for running in the debugger.
     bool DebuggerSupport = false;
 
+    /// Used only by the debugger. When set, the module loader will try to
+    /// import non-public transitive dependencies.
+    bool ImportNonPublicDependencies = false;
+
     /// Enable the MemoryBufferSerializedModuleImporter.
     /// Only used by lldb-moduleimport-test.
     bool EnableMemoryBufferImporter = false;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -308,11 +308,9 @@ ModuleFile::getTransitiveLoadingBehavior(const Dependency &dependency,
   // as a partial module.
   auto isPartialModule = mod->isMainModule();
 
-  return Core->getTransitiveLoadingBehavior(dependency.Core,
-                                            ctx.LangOpts.DebuggerSupport,
-                                            isPartialModule,
-                                            ctx.LangOpts.PackageName,
-                                            forTestable);
+  return Core->getTransitiveLoadingBehavior(
+      dependency.Core, ctx.LangOpts.ImportNonPublicDependencies,
+      isPartialModule, ctx.LangOpts.PackageName, forTestable);
 }
 
 bool ModuleFile::mayHaveDiagnosticsPointingAtBuffer() const {

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1789,7 +1789,7 @@ std::string ModuleFileSharedCore::resolveModuleDefiningFilePath(const StringRef 
 ModuleLoadingBehavior
 ModuleFileSharedCore::getTransitiveLoadingBehavior(
                                           const Dependency &dependency,
-                                          bool debuggerMode,
+                                          bool importNonPublicDependencies,
                                           bool isPartialModule,
                                           StringRef packageName,
                                           bool forTestable) const {
@@ -1805,7 +1805,7 @@ ModuleFileSharedCore::getTransitiveLoadingBehavior(
   if (dependency.isImplementationOnly()) {
     // Implementation-only dependencies are not usually loaded from
     // transitive imports.
-    if (debuggerMode || forTestable) {
+    if (importNonPublicDependencies || forTestable) {
       // In the debugger, try to load the module if possible.
       // Same in the case of a testable import, try to load the dependency
       // but don't fail if it's missing as this could be source breaking.
@@ -1823,7 +1823,7 @@ ModuleFileSharedCore::getTransitiveLoadingBehavior(
     // on testable imports.
     if (forTestable || !moduleIsResilient) {
       return ModuleLoadingBehavior::Required;
-    } else if (debuggerMode) {
+    } else if (importNonPublicDependencies) {
       return ModuleLoadingBehavior::Optional;
     } else {
       return ModuleLoadingBehavior::Ignored;
@@ -1837,7 +1837,7 @@ ModuleFileSharedCore::getTransitiveLoadingBehavior(
         forTestable ||
         !moduleIsResilient) {
       return ModuleLoadingBehavior::Required;
-    } else if (debuggerMode) {
+    } else if (importNonPublicDependencies) {
       return ModuleLoadingBehavior::Optional;
     } else {
       return ModuleLoadingBehavior::Ignored;

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -624,8 +624,8 @@ public:
 
   /// How should \p dependency be loaded for a transitive import via \c this?
   ///
-  /// If \p debuggerMode, more transitive dependencies should try to be loaded
-  /// as they can be useful in debugging.
+  /// If \p importNonPublicDependencies, more transitive dependencies
+  /// should try to be loaded as they can be useful in debugging.
   ///
   /// If \p isPartialModule, transitive dependencies should be loaded as we're
   /// in merge-module mode.
@@ -637,12 +637,9 @@ public:
   /// import. Reports non-public dependencies as required for a testable
   /// client so it can access internal details, which in turn can reference
   /// those non-public dependencies.
-  ModuleLoadingBehavior
-  getTransitiveLoadingBehavior(const Dependency &dependency,
-                               bool debuggerMode,
-                               bool isPartialModule,
-                               StringRef packageName,
-                               bool forTestable) const;
+  ModuleLoadingBehavior getTransitiveLoadingBehavior(
+      const Dependency &dependency, bool importNonPublicDependencies,
+      bool isPartialModule, StringRef packageName, bool forTestable) const;
 };
 
 template <typename T, typename RawData>

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -411,7 +411,7 @@ SerializedModuleLoaderBase::getImportsOfModule(
     ModuleLoadingBehavior dependencyTransitiveBehavior =
         loadedModuleFile.getTransitiveLoadingBehavior(
             dependency,
-            /*debuggerMode*/ false,
+            /*importPrivateDependencies*/ false,
             /*isPartialModule*/ false, packageName, isTestableImport);
     if (dependencyTransitiveBehavior > transitiveBehavior)
       continue;


### PR DESCRIPTION
This patch allows controlling the automatic import of private dependencies separately from the DebuggerSupport option, which currently also triggers this behavior. With explicit modules + precise compiler invocations LLDB is moving towards no longer needing this behavior.

rdar://133088201

Risk: This patch has no effect on the compiler itself and is only needed by the compiler that's embedded into LLDB.
Resolves: rdar://132360374
Testing: In LLDB.

Needed for https://github.com/swiftlang/llvm-project/pull/9039.