### PR TITLE
ModuleInterface: Don't warn on name conflict when the alias workaround is enabled

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -163,7 +163,8 @@ static void
 diagnoseDeclShadowsModule(ModuleInterfaceOptions const &Opts,
                           TypeDecl *shadowingDecl, ModuleDecl *shadowedModule,
                           ModuleDecl *brokenModule) {
-  if (Opts.PreserveTypesAsWritten || shadowingDecl == shadowedModule)
+  if (Opts.PreserveTypesAsWritten || Opts.AliasModuleNames ||
+      shadowingDecl == shadowedModule)
     return;
 
   shadowingDecl->diagnose(

--- a/test/ModuleInterface/module_shadowing.swift
+++ b/test/ModuleInterface/module_shadowing.swift
@@ -15,6 +15,10 @@
 // RUN: %empty-directory(%t/subtest-2)
 // RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-2/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -module-interface-preserve-types-as-written -swift-version 5 -verify
 
+// alias-module-names-in-module-interface also disables this warning.
+// RUN: %empty-directory(%t/subtest-2)
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-2/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -alias-module-names-in-module-interface -swift-version 5 -verify
+
 // Build this module in a different configuration where it will shadow itself.
 // RUN: %empty-directory(%t/subtest-3)
 // RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-3/ShadowyHorror.swiftinterface %s -enable-library-evolution -module-name ShadowyHorror -DSELF_SHADOW -swift-version 5 2>&1 | %FileCheck --check-prefix SELF --implicit-check-not TestModule %s


### PR DESCRIPTION
This warning is designed to be an early report of name conflicts in swiftinterfaces caused by a type having the same name as a module. Make sure we silence this warning when the workaround `-alias-module-names-in-module-interface` is enabled. This is what we already do for `-module-interface-preserve-types-as-written`.

rdar://132990400