### PR TITLE
[cxx-interop] Disable c++ execution header with libstdcxx versions >= 11

### DIFF
--- a/stdlib/public/Cxx/libstdcxx/libstdcxx.h
+++ b/stdlib/public/Cxx/libstdcxx/libstdcxx.h
@@ -1,9 +1,9 @@
-#include "version"
+#include "cstddef"
 
 // C++17 and newer:
 
 // <execution> includes tbb headers, which might not be installed.
 // Only include <execution> if tbb is installed.
-#if __has_include("execution") && __has_include(<tbb/blocked_range.h>) && (_GLIBCXX_RELEASE < 11)
+#if __has_include("execution") && __has_include(<tbb/blocked_range.h>) && (!defined(_GLIBCXX_RELEASE) || (_GLIBCXX_RELEASE < 11))
 #include "execution"
 #endif

--- a/stdlib/public/Cxx/libstdcxx/libstdcxx.h
+++ b/stdlib/public/Cxx/libstdcxx/libstdcxx.h
@@ -1,7 +1,9 @@
+#include "version"
+
 // C++17 and newer:
 
 // <execution> includes tbb headers, which might not be installed.
 // Only include <execution> if tbb is installed.
-#if __has_include("execution") && __has_include(<tbb/blocked_range.h>)
+#if __has_include("execution") && __has_include(<tbb/blocked_range.h>) && (_GLIBCXX_RELEASE < 11)
 #include "execution"
 #endif


### PR DESCRIPTION
Workaround for https://github.com/swiftlang/swift/issues/75661

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
