### PR TITLE
[Concurrency] Warning and fixig to remove unsafe from nonisolated(unsafe) func

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5738,6 +5738,10 @@ WARNING(nonisolated_unsafe_sendable_actor_constant,none,
      "'nonisolated(unsafe)' is unnecessary for a constant actor-isolated "
      "property with 'Sendable' type %0, consider removing it",
      (Type))
+WARNING(nonisolated_unsafe_uneffective_on_funcs,none,
+     "'nonisolated(unsafe)' has no effect on %0 %1, "
+     "consider using 'nonisolated'",
+     (DescriptiveDeclKind, const ValueDecl*))
 ERROR(nonisolated_non_sendable,none,
       "'nonisolated' can not be applied to variable with non-'Sendable' "
       "type %0",

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7217,6 +7217,17 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
   }
 
   if (auto VD = dyn_cast<ValueDecl>(D)) {
+    //'nonisolated(unsafe)' is meaningless for computed properties, functions etc.
+    auto var = dyn_cast<VarDecl>(VD);
+    if (attr->isUnsafe() &&
+        (!var || !var->hasStorage())) {
+      auto &ctx = VD->getASTContext();
+      ctx.Diags.diagnose(attr->getStartLoc(),
+                         diag::nonisolated_unsafe_uneffective_on_funcs,
+                         VD->getDescriptiveKind(), VD)
+          .fixItReplace(attr->getStartLoc(), "nonisolated");
+    }
+
     (void)getActorIsolation(VD);
   }
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -187,6 +187,9 @@ extension MyActor {
     set { }
   }
 
+  // expected-warning@+1{{'nonisolated(unsafe)' has no effect on instance method 'nonisolatedUnsafe(otherActor:)', consider using 'nonisolated'}}{{3-14=nonisolated}}
+  nonisolated(unsafe) func nonisolatedUnsafe(otherActor: MyActor) -> Int { }
+
   nonisolated func actorIndependentFunc(otherActor: MyActor) -> Int {
     _ = immutable
     _ = mutable // expected-error{{actor-isolated property 'mutable' can not be referenced from a nonisolated}}

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -507,6 +507,7 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
   case second
 
   nonisolated(unsafe) var nonIsolatedUnsafeVarObject: NonSendableKlass { NonSendableKlass() }
+  // expected-warning@-1{{'nonisolated(unsafe)' has no effect on property 'nonIsolatedUnsafeVarObject', consider using 'nonisolated'}}
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
@@ -605,6 +606,7 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
   nonisolated(unsafe) let nonIsolatedUnsafeLetObject = NonSendableKlass()
   nonisolated(unsafe) var nonIsolatedUnsafeVarObject = NonSendableKlass()
   nonisolated(unsafe) var nonIsolatedUnsafeVarComputedObject: NonSendableKlass { NonSendableKlass() }
+  // expected-warning@-1{{'nonisolated(unsafe)' has no effect on property 'nonIsolatedUnsafeVarComputedObject', consider using 'nonisolated'}}
 
   var t: T? = nil
 
@@ -646,6 +648,7 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
   case second
 
   nonisolated(unsafe) var nonIsolatedUnsafeVarObject: NonSendableKlass { NonSendableKlass() }
+  // expected-warning@-1{{'nonisolated(unsafe)' has no effect on property 'nonIsolatedUnsafeVarObject', consider using 'nonisolated'}}
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
@@ -668,6 +671,7 @@ struct NonIsolatedUnsafeFieldNonSendableStruct {
   nonisolated(unsafe) let nonIsolatedUnsafeLetObject = NonSendableKlass()
   nonisolated(unsafe) var nonIsolatedUnsafeVarObject = NonSendableKlass()
   nonisolated(unsafe) var nonIsolatedUnsafeVarComputedObject: NonSendableKlass { NonSendableKlass() }
+  // expected-warning@-1{{'nonisolated(unsafe)' has no effect on property 'nonIsolatedUnsafeVarComputedObject', consider using 'nonisolated'}}
 
   let letObject = NonSendableKlass()
   var varObject = NonSendableKlass()


### PR DESCRIPTION

It doesn't mean anything to do "unsafe" on a func

rdar://130406646
resolves #74571

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
