### PR TITLE
[Sema] Avoid getCalleeLocator() with inner call that is still variable type.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2080,13 +2080,16 @@ ConstraintSystem::matchFunctionResultTypes(Type expectedResult, Type fnResult,
     auto anchor = locator.getAnchor();
     if (auto *callExpr = getAsExpr<CallExpr>(anchor)) {
       if (auto *innerCall = getAsExpr<CallExpr>(callExpr->getSemanticFn())) {
-        auto *innerCalleeLoc =
+        if (!simplifyType(getType(innerCall->getFn()))
+                 ->is<TypeVariableType>()) {
+          auto *innerCalleeLoc =
             getCalleeLocator(getConstraintLocator(innerCall));
-        if (auto innerOverload = findSelectedOverloadFor(innerCalleeLoc)) {
-          auto choice = innerOverload->choice;
-          if (choice.getFunctionRefKind() == FunctionRefKind::DoubleApply) {
-            isSecondApply = true;
-            selected.emplace(*innerOverload);
+          if (auto innerOverload = findSelectedOverloadFor(innerCalleeLoc)) {
+            auto choice = innerOverload->choice;
+            if (choice.getFunctionRefKind() == FunctionRefKind::DoubleApply) {
+              isSecondApply = true;
+              selected.emplace(*innerOverload);
+            }
           }
         }
       }

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -189,3 +189,12 @@ do {
   let _ = i16 -- i16
   // expected-error@-1 {{ambiguous use of operator '--'}}
 }
+
+struct Issue75623 {
+  func f(p: String) {}
+  func f(_: Int) -> (Int) -> Void {}
+
+  func g() {
+    f(0)(0) // was hitting assertion
+  }
+}


### PR DESCRIPTION
`getCalleeLocator()` at ConstraintSystem.cpp:681 asserts that the function type is not a type variable. (The assert got added after Swift 5.10 it looks like, which is why this is a regression.) In this particular spot, if there is an unresolved overload skip checking the inner overload choice, avoiding the call. (Later on when the type variable is bound, simplifying here happens again and succeeds.)

Resolves #75623.
