### PR TITLE
[Sema/SourceKit] Emit same diagnostics for missing protocol requirements on the command line and in SourceKit

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2944,9 +2944,8 @@ NOTE(inherited_protocol_does_not_conform,none,
      "type %0 does not conform to inherited protocol %1", (Type, Type))
 NOTE(no_witnesses,none,
      "protocol requires "
-     "%select{initializer %1|function %1|property %1|subscript}0 with type %2"
-     "%select{|; add a stub for conformance}3",
-     (RequirementKind, const ValueDecl *, WitnessType, bool))
+     "%select{initializer %1|function %1|property %1|subscript}0 with type %2",
+     (RequirementKind, const ValueDecl *, WitnessType))
 NOTE(missing_witnesses_general,none, "add stubs for conformance",
      ())
 NOTE(ambiguous_witnesses,none,
@@ -2960,11 +2959,10 @@ NOTE(ambiguous_witnesses_wrong_name,none,
      "subscript operators}0 with type %2",
      (RequirementKind, const ValueDecl *, WitnessType))
 NOTE(no_witnesses_type,none,
-     "protocol requires nested type %0; add nested type %0 for conformance",
+     "protocol requires nested type %0",
      (const AssociatedTypeDecl *))
 NOTE(no_witnesses_type_tuple,none,
-     "protocol requires nested type %0; add type alias %0 with underlying type %1 "
-     "for conformance",
+     "protocol requires nested type %0",
      (const AssociatedTypeDecl *, Type))
 NOTE(default_associated_type_unsatisfied_conformance,none,
      "default type %0 for associated type %1 (from protocol %2) "

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3474,11 +3474,6 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
     conformanceDiag.fixItInsert(nameEndLoc, ": " + protoString);
   }
 
-  // Emit fix-its to insert requirement stubs if we're in editor mode.
-  if (!getASTContext().LangOpts.DiagnosticsEditorMode) {
-    return true;
-  }
-
   {
     llvm::SmallString<128> Text;
     llvm::raw_svector_ostream SS(Text);

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -2116,7 +2116,7 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
     ConformanceDecl->diagnose(diag::type_does_not_conform,
                               Nominal->getDeclaredType(), getProtocolType());
     requirement->diagnose(diag::no_witnesses, diag::RequirementKind::Func,
-                          requirement, getProtocolType(), /*AddFixIt=*/false);
+                          requirement, getProtocolType());
 
     return nullptr;
   }
@@ -2146,8 +2146,9 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
   if (!canSynthesize(*this, requirement, delayedNotes)) {
     ConformanceDecl->diagnose(diag::type_does_not_conform,
                               Nominal->getDeclaredType(), getProtocolType());
-    requirement->diagnose(diag::no_witnesses, diag::RequirementKind::Constructor,
-                          requirement, getProtocolType(), /*AddFixIt=*/false);
+    requirement->diagnose(diag::no_witnesses,
+                          diag::RequirementKind::Constructor, requirement,
+                          getProtocolType());
 
     return nullptr;
   }

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -638,8 +638,8 @@ ValueDecl *DerivedConformance::deriveDifferentiable(ValueDecl *requirement) {
   ConformanceDecl->diagnose(diag::type_does_not_conform,
                             Nominal->getDeclaredType(), getProtocolType());
   requirement->diagnose(diag::no_witnesses,
-                        getProtocolRequirementKind(requirement),
-                        requirement, getProtocolType(), /*AddFixIt=*/false);
+                        getProtocolRequirementKind(requirement), requirement,
+                        getProtocolType());
 
   // If derivation is possible, cancel the diagnostic and perform derivation.
   if (canDeriveDifferentiable(Nominal, getConformanceContext(), requirement)) {

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -599,20 +599,18 @@ bool DerivedConformance::checkAndDiagnoseDisallowedContext(
                               getProtocolType());
     Nominal->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
 
-    // In editor mode, try to insert a stub.
-    if (Context.LangOpts.DiagnosticsEditorMode) {
-      auto Extension = cast<ExtensionDecl>(getConformanceContext());
-      auto FixitLocation = Extension->getBraces().Start;
-      llvm::SmallString<128> Text;
-      {
-        llvm::raw_svector_ostream SS(Text);
-        swift::printRequirementStub(synthesizing, Nominal,
-                                    Nominal->getDeclaredType(),
-                                    Extension->getStartLoc(), SS);
-        if (!Text.empty()) {
-          ConformanceDecl->diagnose(diag::missing_witnesses_general)
-            .fixItInsertAfter(FixitLocation, Text.str());
-        }
+    // Try to insert a stub.
+    auto Extension = cast<ExtensionDecl>(getConformanceContext());
+    auto FixitLocation = Extension->getBraces().Start;
+    llvm::SmallString<128> Text;
+    {
+      llvm::raw_svector_ostream SS(Text);
+      swift::printRequirementStub(synthesizing, Nominal,
+                                  Nominal->getDeclaredType(),
+                                  Extension->getStartLoc(), SS);
+      if (!Text.empty()) {
+        ConformanceDecl->diagnose(diag::missing_witnesses_general)
+          .fixItInsertAfter(FixitLocation, Text.str());
       }
     }
     return true;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1644,11 +1644,10 @@ void swift::tryDiagnoseExecutorConformance(ASTContext &C,
 
     if (missingRequirement) {
       nominal->diagnose(diag::type_does_not_conform, nominalTy, proto->getDeclaredInterfaceType());
-      missingRequirement->diagnose(diag::no_witnesses,
-                                   getProtocolRequirementKind(missingRequirement),
-                                   missingRequirement,
-                                   missingRequirement->getParameters()->get(0)->getInterfaceType(),
-                                   /*AddFixIt=*/true);
+      missingRequirement->diagnose(
+          diag::no_witnesses, getProtocolRequirementKind(missingRequirement),
+          missingRequirement,
+          missingRequirement->getParameters()->get(0)->getInterfaceType());
       return;
     }
   }

--- a/test/AssociatedTypeInference/associated_type_inference.swift
+++ b/test/AssociatedTypeInference/associated_type_inference.swift
@@ -129,11 +129,11 @@ struct XProp0b : PropertyP0 { // expected-error{{type 'XProp0b' does not conform
 // Inference from subscripts
 protocol SubscriptP0 {
   associatedtype Index
-  // expected-note@-1 2 {{protocol requires nested type 'Index'; add nested type 'Index' for conformance}}
+  // expected-note@-1 2 {{protocol requires nested type 'Index'}}
 
   associatedtype Element : PSimple
   // expected-note@-1 {{unable to infer associated type 'Element' for protocol 'SubscriptP0'}}
-  // expected-note@-2 2 {{protocol requires nested type 'Element'; add nested type 'Element' for conformance}}
+  // expected-note@-2 2 {{protocol requires nested type 'Element'}}
 
   subscript (i: Index) -> Element { get }
 }
@@ -148,21 +148,23 @@ struct XSubP0b : SubscriptP0 {
 }
 
 struct XSubP0c : SubscriptP0 {
-// expected-error@-1 {{type 'XSubP0c' does not conform to protocol 'SubscriptP0'}}
+// expected-error@-1 {{type 'XSubP0c' does not conform to protocol 'SubscriptP0'}} 
+// expected-note@-2 {{add stubs for conformance}}
   subscript (i: Index) -> Element { get { } }
 }
 
 struct XSubP0d : SubscriptP0 {
-// expected-error@-1 {{type 'XSubP0d' does not conform to protocol 'SubscriptP0'}}
+// expected-error@-1 {{type 'XSubP0d' does not conform to protocol 'SubscriptP0'}} 
+// expected-note@-2 {{add stubs for conformance}}
   subscript (i: XSubP0d.Index) -> XSubP0d.Element { get { } }
 }
 
 // Inference from properties and subscripts
 protocol CollectionLikeP0 {
   associatedtype Index
-  // expected-note@-1 {{protocol requires nested type 'Index'; add nested type 'Index' for conformance}}
+  // expected-note@-1 {{protocol requires nested type 'Index'}}
   associatedtype Element
-  // expected-note@-1 {{protocol requires nested type 'Element'; add nested type 'Element' for conformance}}
+  // expected-note@-1 {{protocol requires nested type 'Element'}}
 
   var startIndex: Index { get }
   var endIndex: Index { get }
@@ -183,6 +185,7 @@ struct XCollectionLikeP0a<T> : CollectionLikeP0 {
 
 struct XCollectionLikeP0b : CollectionLikeP0 {
 // expected-error@-1 {{type 'XCollectionLikeP0b' does not conform to protocol 'CollectionLikeP0'}}
+// expected-note@-2 {{add stubs for conformance}}
   var startIndex: XCollectionLikeP0b.Index
   // There was an error @-1 ("'startIndex' used within its own type"),
   // but it disappeared and doesn't seem like much of a loss.
@@ -195,7 +198,7 @@ public protocol Thenable {
     func then(_ success: (_: T) -> T) -> Self
 }
 
-public class CorePromise<U> : Thenable { // expected-error{{type 'CorePromise<U>' does not conform to protocol 'Thenable'}}
+public class CorePromise<U> : Thenable { // expected-error{{type 'CorePromise<U>' does not conform to protocol 'Thenable'}} expected-note {{add stubs for conformance}}
     public func then(_ success: @escaping (_ t: U, _: CorePromise<U>) -> U) -> Self {
         return self.then() { (t: U) -> U in // expected-error{{contextual closure type '(U, CorePromise<U>) -> U' expects 2 arguments, but 1 was used in closure body}}
             return success(t: t, self)
@@ -358,7 +361,7 @@ struct X12 : P12 {
 // the associated type
 protocol Cookie {
   associatedtype Dough
-  // expected-note@-1 {{protocol requires nested type 'Dough'; add nested type 'Dough' for conformance}}
+  // expected-note@-1 {{protocol requires nested type 'Dough'}}
 
   init(t: Dough)
 }
@@ -369,6 +372,7 @@ extension Cookie {
 
 struct Thumbprint : Cookie {}
 // expected-error@-1 {{type 'Thumbprint' does not conform to protocol 'Cookie'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 // Looking through typealiases
 protocol Vector {
@@ -385,11 +389,11 @@ struct Int8Vector : Vector {
 // https://github.com/apple/swift/issues/47063
 
 protocol P13 {
-  associatedtype Arg // expected-note{{protocol requires nested type 'Arg'; add nested type 'Arg' for conformance}}
+  associatedtype Arg // expected-note{{protocol requires nested type 'Arg'}}
   func foo(arg: Arg)
 }
 
-struct S13 : P13 { // expected-error{{type 'S13' does not conform to protocol 'P13'}}
+struct S13 : P13 { // expected-error{{type 'S13' does not conform to protocol 'P13'}} expected-note {{add stubs for conformance}}
   func foo(arg: inout Int) {}
 }
 
@@ -432,7 +436,7 @@ protocol P15f {
 }
 
 protocol P15g: P15c, P15f {
-  associatedtype A // expected-note{{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A // expected-note{{protocol requires nested type 'A'}}
 }
 
 
@@ -443,7 +447,7 @@ struct X15d : P15d { }
 
 // Ambiguity.
 // FIXME: Better diagnostic here?
-struct X15g : P15g { } // expected-error{{type 'X15g' does not conform to protocol 'P15g'}}
+struct X15g : P15g { } // expected-error{{type 'X15g' does not conform to protocol 'P15g'}} expected-note {{add stubs for conformance}}
 
 // Associated type defaults in overidden associated types that require
 // substitution.
@@ -503,10 +507,10 @@ struct Foo: RefinesAssocWithDefault {
 }
 
 protocol P20 {
-  associatedtype T // expected-note{{protocol requires nested type 'T'; add nested type 'T' for conformance}}
+  associatedtype T // expected-note{{protocol requires nested type 'T'}}
   typealias TT = T?
 }
-struct S19 : P20 {  // expected-error{{type 'S19' does not conform to protocol 'P20'}}
+struct S19 : P20 {  // expected-error{{type 'S19' does not conform to protocol 'P20'}} expected-note {{add stubs for conformance}}
   typealias TT = Int?
 }
 
@@ -538,12 +542,12 @@ protocol P32 {
   var bar: B { get }
 }
 protocol P33 {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
 
   var baz: A { get }
 }
 protocol P34 {
-  associatedtype A  // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A  // expected-note {{protocol requires nested type 'A'}}
 
   func boo() -> A
 }
@@ -555,11 +559,11 @@ extension S31 where T == Int {
 extension S31 where T: Equatable {
   var bar: Bool { true }
 }
-extension S31: P33 where T == Never {} // expected-error {{type 'S31<T>' does not conform to protocol 'P33'}}
+extension S31: P33 where T == Never {} // expected-error {{type 'S31<T>' does not conform to protocol 'P33'}} expected-note {{add stubs for conformance}}
 extension S31 where T == String {
   var baz: Bool { true }
 }
-extension S31: P34 {} // expected-error {{type 'S31<T>' does not conform to protocol 'P34'}}
+extension S31: P34 {} // expected-error {{type 'S31<T>' does not conform to protocol 'P34'}} expected-note {{add stubs for conformance}}
 extension S31 where T: P32 {
   func boo() -> Void {}
 }
@@ -572,7 +576,8 @@ protocol P35a {
   associatedtype B // expected-note {{protocol requires nested type 'B'}}
 }
 protocol P35b: P35a where B == A {}
-// expected-error@+1 {{type 'S35' does not conform to protocol 'P35a'}}
+// expected-error@+2 {{type 'S35' does not conform to protocol 'P35a'}}
+// expected-note@+1 {{add stubs for conformance}}
 struct S35: P35b {}
 
 // Circular reference through a value witness.
@@ -584,8 +589,9 @@ protocol P36a {
 protocol P36b: P36a {
   associatedtype B = (Self) -> A // expected-note {{protocol requires nested type 'B'}}
 }
-// expected-error@+2 {{type 'S36' does not conform to protocol 'P36a'}}
-// expected-error@+1 {{type 'S36' does not conform to protocol 'P36b'}}
+// expected-error@+3 {{type 'S36' does not conform to protocol 'P36a'}}
+// expected-error@+2 {{type 'S36' does not conform to protocol 'P36b'}}
+// expected-note@+1 {{add stubs for conformance}}
 struct S36: P36b {
   func foo(arg: Array<B>) {}
 }
@@ -626,13 +632,14 @@ protocol P40a {
   func foo(arg: A)
 }
 protocol P40b: P40a {
-  associatedtype C = (A, B.A, D.D, E) -> Self // expected-note {{protocol requires nested type 'C'; add nested type 'C' for conformance}}
-  associatedtype D: P40b // expected-note {{protocol requires nested type 'D'; add nested type 'D' for conformance}}
-  associatedtype E: Equatable // expected-note {{protocol requires nested type 'E'; add nested type 'E' for conformance}}
+  associatedtype C = (A, B.A, D.D, E) -> Self // expected-note {{protocol requires nested type 'C'}}
+  associatedtype D: P40b // expected-note {{protocol requires nested type 'D'}}
+  associatedtype E: Equatable // expected-note {{protocol requires nested type 'E'}}
 }
 protocol P40c: P40b where D == S40<Never> {}
 struct S40<E: Equatable>: P40c {
   // expected-error@-1 {{type 'S40<E>' does not conform to protocol 'P40b'}}
+  // expected-note@-2 {{add stubs for conformance}}
   func foo(arg: Never) {}
 
   typealias B = Self
@@ -710,5 +717,6 @@ protocol FIXME_P1a {
   associatedtype B: FIXME_P1a // expected-note {{protocol requires nested type 'B'}}
 }
 protocol FIXME_P1b: FIXME_P1a where B == FIXME_S1<A> {}
-// expected-error@+1 {{type 'FIXME_S1<T>' does not conform to protocol 'FIXME_P1a'}}
+// expected-error@+2 {{type 'FIXME_S1<T>' does not conform to protocol 'FIXME_P1a'}}
+// expected-note@+1 {{add stubs for conformance}}
 struct FIXME_S1<T: Equatable>: FIXME_P1b {}

--- a/test/AssociatedTypeInference/associated_type_inference_fixed_type_experimental_inference.swift
+++ b/test/AssociatedTypeInference/associated_type_inference_fixed_type_experimental_inference.swift
@@ -57,7 +57,7 @@ protocol P6 where A == Never { // expected-error {{no type for 'Self.A' can sati
   // expected-note@+1 {{protocol requires nested type 'A}}
   associatedtype A: P6
 }
-struct S6: P6 {} // expected-error {{type 'S6' does not conform to protocol 'P6'}}
+struct S6: P6 {} // expected-error {{type 'S6' does not conform to protocol 'P6'}} expected-note {{add stubs for conformance}}
 
 protocol P7a where A == Never {
   associatedtype A
@@ -67,7 +67,7 @@ protocol P7b: P7a where A == Bool {}
 struct S7: P7b {}
 
 protocol P8a where A == Never {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
 }
 protocol P8b where A == Bool {
   associatedtype A
@@ -79,6 +79,7 @@ do {
   struct Conformer: P8a, P8b {}
   // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P8a'}}
   // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P8b'}}
+  // expected-note@-3 {{add stubs for conformance}}
 }
 
 protocol P9a where A == Never {
@@ -190,12 +191,12 @@ do {
 }
 
 protocol P17a where A == Never {
-  associatedtype A = B // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
-  associatedtype B // expected-note {{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+  associatedtype A = B // expected-note {{protocol requires nested type 'A'}}
+  associatedtype B // expected-note {{protocol requires nested type 'B'}}
 }
 protocol P17b {
-  associatedtype A = B // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
-  associatedtype B // expected-note {{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+  associatedtype A = B // expected-note {{protocol requires nested type 'A'}}
+  associatedtype B // expected-note {{protocol requires nested type 'B'}}
 }
 protocol P17c where A == Never {
   associatedtype A
@@ -209,12 +210,12 @@ do {
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer1 to P17a: {
   // CHECK-NEXT: B => (unresolved){{$}}
   // CHECK-NEXT: }
-  struct Conformer1: P17a {} // expected-error {{type 'Conformer1' does not conform to protocol 'P17a'}}
+  struct Conformer1: P17a {} // expected-error {{type 'Conformer1' does not conform to protocol 'P17a'}} expected-note {{add stubs for conformance}}
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer2<A> to P17b: {
   // CHECK-NEXT: A => A (preferred), [[EQUIV_CLASS:0x[0-9a-f]+]]
   // CHECK-NEXT: B => (unresolved)
   // CHECK-NEXT: }
-  struct Conformer2<A>: P17b {} // expected-error {{type 'Conformer2<A>' does not conform to protocol 'P17b'}}
+  struct Conformer2<A>: P17b {} // expected-error {{type 'Conformer2<A>' does not conform to protocol 'P17b'}} expected-note {{add stubs for conformance}}
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer3 to P17c: {
   // CHECK-NEXT: B => Self.A (preferred), [[EQUIV_CLASS:0x[0-9a-f]+]]
   // CHECK-NEXT: }
@@ -300,8 +301,8 @@ do {
 }
 
 protocol P23 {
-  associatedtype A: P23 = B.A // expected-note 2 {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
-  associatedtype B: P23 = A.B // expected-note 2 {{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+  associatedtype A: P23 = B.A // expected-note 2 {{protocol requires nested type 'A'}}
+  associatedtype B: P23 = A.B // expected-note 2 {{protocol requires nested type 'B'}}
 }
 do {
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P23: {
@@ -317,20 +318,20 @@ do {
 }
 
 protocol P24 where A == B.A {
-  associatedtype A: P24 // expected-note 2 {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
-  associatedtype B: P24 = A.B // expected-note 2 {{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+  associatedtype A: P24 // expected-note 2 {{protocol requires nested type 'A'}}
+  associatedtype B: P24 = A.B // expected-note 2 {{protocol requires nested type 'B'}}
 }
 do {
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P24: {
   // CHECK-NEXT: A => Self.B.A (preferred),
   // CHECK-NEXT: B => Self.A.B (preferred),
   // CHECK-NEXT: }
-  struct Conformer: P24 {} // expected-error {{type 'Conformer' does not conform to protocol 'P24'}}
+  struct Conformer: P24 {} // expected-error {{type 'Conformer' does not conform to protocol 'P24'}} expected-note {{add stubs for conformance}}
   // CHECK-LABEL: Abstract type witness system for conformance of ConformerGeneric<T> to P24: {
   // CHECK-NEXT: A => Self.B.A (preferred),
   // CHECK-NEXT: B => Self.A.B (preferred),
   // CHECK-NEXT: }
-  struct ConformerGeneric<T>: P24 {} // expected-error {{type 'ConformerGeneric<T>' does not conform to protocol 'P24'}}
+  struct ConformerGeneric<T>: P24 {} // expected-error {{type 'ConformerGeneric<T>' does not conform to protocol 'P24'}} expected-note {{add stubs for conformance}}
 }
 
 protocol P25a_1 where A == Int, B == C.Element {
@@ -407,7 +408,7 @@ do {
 }
 
 protocol P28a where A == Int {
-  associatedtype A // expected-note 2 {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A // expected-note 2 {{protocol requires nested type 'A'}}
 }
 protocol P28b where A == Bool {
   associatedtype A
@@ -428,6 +429,7 @@ do {
   struct Conformer1: Q28a {}
   // expected-error@-1 {{type 'Conformer1' does not conform to protocol 'P28a'}}
   // expected-error@-2 {{type 'Conformer1' does not conform to protocol 'P28b'}}
+  // expected-note@-3 {{add stubs for conformance}}
 
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer2 to P28a: {
   // CHECK-NEXT: A => (ambiguous),
@@ -436,6 +438,7 @@ do {
   // expected-error@-1 {{type 'Conformer2' does not conform to protocol 'P28a'}}
   // expected-error@-2 {{type 'Conformer2' does not conform to protocol 'P28b'}}
   // expected-error@-3 {{type 'Conformer2' does not conform to protocol 'P28c'}}
+  // expected-note@-4 {{add stubs for conformance}}
 }
 
 protocol P29a where A == Int {
@@ -446,8 +449,8 @@ protocol P29b where B == Never {
   associatedtype B
 }
 protocol P29c where A == B {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
-  associatedtype B // expected-note {{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
+  associatedtype B // expected-note {{protocol requires nested type 'B'}}
 }
 protocol Q29a: P29a, P29b, P29c {}
 // expected-error@-1 {{no type for 'Self.A' can satisfy both 'Self.A == Never' and 'Self.A == Int'}}
@@ -469,6 +472,7 @@ do {
   // expected-error@-1 {{type 'Conformer2' does not conform to protocol 'P29a'}}
   // expected-error@-2 {{type 'Conformer2' does not conform to protocol 'P29b'}}
   // expected-error@-3 {{type 'Conformer2' does not conform to protocol 'P29c'}}
+  // expected-note@-4 {{add stubs for conformance}}
 }
 
 protocol P30a where A == Int {
@@ -478,8 +482,8 @@ protocol P30b where A == Never {
   associatedtype A
 }
 protocol P30c where A == B {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
-  associatedtype B // expected-note {{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
+  associatedtype B // expected-note {{protocol requires nested type 'B'}}
 }
 protocol Q30: P30c, P30a, P30b {}
 // expected-error@-1 {{no type for 'Self.A' can satisfy both 'Self.A == Never' and 'Self.A == Int'}}
@@ -492,6 +496,7 @@ do {
   // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P30a'}}
   // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P30b'}}
   // expected-error@-3 {{type 'Conformer' does not conform to protocol 'P30c'}}
+  // expected-note@-4 {{add stubs for conformance}}
 }
 
 protocol P31a where B == Int {
@@ -501,8 +506,8 @@ protocol P31b where B == Never {
   associatedtype B
 }
 protocol P31c where B == A {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
-  associatedtype B // expected-note {{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
+  associatedtype B // expected-note {{protocol requires nested type 'B'}}
 }
 protocol Q31: P31c, P31a, P31b {}
 // expected-error@-1 {{no type for 'Self.A' can satisfy both 'Self.A == Never' and 'Self.A == Int'}}
@@ -514,6 +519,7 @@ do {
   // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P31a'}}
   // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P31b'}}
   // expected-error@-3 {{type 'Conformer' does not conform to protocol 'P31c'}}
+  // expected-note@-4 {{add stubs for conformance}}
 }
 
 protocol P32a where A == Int {
@@ -529,8 +535,8 @@ protocol P32d where B == Never {
   associatedtype B
 }
 protocol P32e where A == B {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
-  associatedtype B // expected-note {{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
+  associatedtype B // expected-note {{protocol requires nested type 'B'}}
 }
 protocol Q32: P32e, P32a, P32b, P32c, P32d {}
 // expected-error@-1 {{no type for 'Self.A' can satisfy both 'Self.A == Never' and 'Self.A == ()'}}
@@ -550,6 +556,7 @@ do {
   // expected-error@-3 {{type 'Conformer' does not conform to protocol 'P32c'}}
   // expected-error@-4 {{type 'Conformer' does not conform to protocol 'P32d'}}
   // expected-error@-5 {{type 'Conformer' does not conform to protocol 'P32e'}}
+ // expected-note@-6 {{add stubs for conformance}}
 }
 
 protocol P33a where A == Int {
@@ -572,7 +579,7 @@ protocol P34b {
 protocol Q34a: P34a, P34b {}
 protocol Q34b: P34b, P34a {}
 protocol Q34c: P34a, P34b {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
 }
 do {
   // FIXME: should really be ambiguous (source-breaking)?
@@ -590,7 +597,7 @@ do {
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer3 to Q34c: {
   // CHECK-NEXT: A => (unresolved){{$}}
   // CHECK-NEXT: }
-  struct Conformer3: Q34c {} // expected-error {{type 'Conformer3' does not conform to protocol 'Q34c'}}
+  struct Conformer3: Q34c {} // expected-error {{type 'Conformer3' does not conform to protocol 'Q34c'}} expected-note {{add stubs for conformance}}
 }
 
 protocol P35 {
@@ -711,15 +718,15 @@ do {
 }
 
 protocol P41 {
-  associatedtype A where A == B.A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
-  associatedtype B: P41 = Self // expected-note {{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+  associatedtype A where A == B.A // expected-note {{protocol requires nested type 'A'}}
+  associatedtype B: P41 = Self // expected-note {{protocol requires nested type 'B'}}
 }
 do {
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P41: {
   // CHECK-NEXT: A => Self.B.A (preferred),
   // CHECK-NEXT: B => Self (preferred),
   // CHECK-NEXT: }
-  struct Conformer: P41 {} // expected-error{{type 'Conformer' does not conform to protocol 'P41'}}
+  struct Conformer: P41 {} // expected-error{{type 'Conformer' does not conform to protocol 'P41'}} expected-note {{add stubs for conformance}}
 }
 
 protocol P42a {
@@ -835,8 +842,8 @@ do {
   }
 }
 
-protocol P48a { associatedtype A = Int } // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
-protocol P48b { associatedtype B } // expected-note {{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+protocol P48a { associatedtype A = Int } // expected-note {{protocol requires nested type 'A'}}
+protocol P48b { associatedtype B } // expected-note {{protocol requires nested type 'B'}}
 protocol P48c: P48a, P48b where A == B {}
 do {
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P48a: {
@@ -853,4 +860,5 @@ do {
   struct Conformer: P48c {}
   // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P48a'}}
   // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P48b'}}
+  // expected-note@-3 {{add stubs for conformance}}
 }

--- a/test/AssociatedTypeInference/associated_type_inference_generic_class.swift
+++ b/test/AssociatedTypeInference/associated_type_inference_generic_class.swift
@@ -3,8 +3,8 @@
 class C<T> {}
 
 protocol P {
-  associatedtype A: C<B> // expected-note 2{{protocol requires nested type 'A'; add nested type 'A' for conformance}}
-  associatedtype B // expected-note 2{{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+  associatedtype A: C<B> // expected-note 2{{protocol requires nested type 'A'}}
+  associatedtype B // expected-note 2{{protocol requires nested type 'B'}}
 
   func f() -> A
   func g() -> B
@@ -66,12 +66,12 @@ struct S42: P {
   func g() -> Int { fatalError() }
 }
 
-struct SBad1: P { // expected-error {{type 'SBad1' does not conform to protocol 'P'}}
+struct SBad1: P { // expected-error {{type 'SBad1' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
   func f() -> D { fatalError() }
   func g() -> String { fatalError() }
 }
 
-struct SBad2: P { // expected-error {{type 'SBad2' does not conform to protocol 'P'}}
+struct SBad2: P { // expected-error {{type 'SBad2' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
   func f() -> C<Int> { fatalError() }
   func g() -> String { fatalError() }
 }

--- a/test/AssociatedTypeInference/associated_type_tuple.swift
+++ b/test/AssociatedTypeInference/associated_type_tuple.swift
@@ -5,10 +5,10 @@
 typealias Tuple<each T> = (repeat each T)
 
 protocol P1 {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; add type alias 'A' with underlying type '(repeat (each T).A)' for conformance}}
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
 }
 
-extension Tuple: P1 where repeat each T: P1 {} // expected-error {{type '(repeat each T)' does not conform to protocol 'P1'}}
+extension Tuple: P1 where repeat each T: P1 {} // expected-error {{type '(repeat each T)' does not conform to protocol 'P1'}} expected-note {{add stubs for conformance}}
 
 protocol P2 {
   associatedtype B = Int

--- a/test/AssociatedTypeInference/missing_conformance.swift
+++ b/test/AssociatedTypeInference/missing_conformance.swift
@@ -4,8 +4,8 @@
 // in various ways.
 
 protocol LikeSetAlgebra {
-    func onion(_ other: Self) -> Self // expected-note {{protocol requires function 'onion' with type '(X) -> X'; add a stub for conformance}}
-    func indifference(_ other: Self) -> Self // expected-note {{protocol requires function 'indifference' with type '(X) -> X'; add a stub for conformance}}
+    func onion(_ other: Self) -> Self // expected-note {{protocol requires function 'onion' with type '(X) -> X'}}
+    func indifference(_ other: Self) -> Self // expected-note {{protocol requires function 'indifference' with type '(X) -> X'}}
 
 }
 protocol LikeOptionSet : LikeSetAlgebra, RawRepresentable {}
@@ -17,6 +17,7 @@ extension LikeOptionSet where RawValue : FixedWidthInteger {
 struct X : LikeOptionSet {}
 // expected-error@-1 {{type 'X' does not conform to protocol 'LikeSetAlgebra'}}
 // expected-error@-2 {{type 'X' does not conform to protocol 'RawRepresentable'}}
+// expected-note@-3 {{add stubs for conformance}}
 
 protocol IterProtocol {}
 protocol LikeSequence {
@@ -31,8 +32,8 @@ struct Y : LikeSequence {} // expected-error {{type 'Y' does not conform to prot
 
 protocol P1 {
     associatedtype Result
-    func get() -> Result // expected-note {{protocol requires function 'get()' with type '() -> Result'; add a stub for conformance}}
-    func got() // expected-note {{protocol requires function 'got()' with type '() -> ()'; add a stub for conformance}}
+    func get() -> Result // expected-note {{protocol requires function 'get()' with type '() -> Result'}}
+    func got() // expected-note {{protocol requires function 'got()' with type '() -> ()'}}
 }
 protocol P2 {
     static var singularThing: Self { get }
@@ -45,20 +46,20 @@ extension P1 where Self : P3 {
     func got() {} // expected-note {{candidate would match if 'Z<T1, T2, T3, Result, T4>' conformed to 'P3'}}
 }
 
-struct Z<T1, T2, T3, Result, T4> : P1 {} // expected-error {{type 'Z<T1, T2, T3, Result, T4>' does not conform to protocol 'P1'}}
+struct Z<T1, T2, T3, Result, T4> : P1 {} // expected-error {{type 'Z<T1, T2, T3, Result, T4>' does not conform to protocol 'P1'}} expected-note {{add stubs for conformance}}
 
 protocol P4 {
-    func this() // expected-note 2 {{protocol requires function 'this()' with type '() -> ()'; add a stub for conformance}}
+    func this() // expected-note 2 {{protocol requires function 'this()' with type '() -> ()'}}
 }
 protocol P5 {}
 extension P4 where Self : P5 {
     func this() {} // expected-note {{candidate would match if 'W' conformed to 'P5'}}
     //// expected-note@-1 {{candidate would match if 'S<T>.SS' conformed to 'P5'}}
 }
-struct W : P4 {} // expected-error {{type 'W' does not conform to protocol 'P4'}}
+struct W : P4 {} // expected-error {{type 'W' does not conform to protocol 'P4'}} expected-note {{add stubs for conformance}}
 
 struct S<T> {
-    struct SS : P4 {} // expected-error {{type 'S<T>.SS' does not conform to protocol 'P4'}}
+    struct SS : P4 {} // expected-error {{type 'S<T>.SS' does not conform to protocol 'P4'}} expected-note {{add stubs for conformance}}
 }
 
 class C {}
@@ -82,22 +83,22 @@ struct B : P8 { // expected-error {{type 'B' does not conform to protocol 'P8'}}
 }
 
 protocol P9 {
-    func foo() // expected-note {{protocol requires function 'foo()' with type '() -> ()'; add a stub for conformance}}
+    func foo() // expected-note {{protocol requires function 'foo()' with type '() -> ()'}}
 }
 class C2 {}
 extension P9 where Self : C2 {
     func foo() {} // expected-note {{candidate would match if 'C3' subclassed 'C2'}}
 }
-class C3 : P9 {} // expected-error {{type 'C3' does not conform to protocol 'P9'}}
+class C3 : P9 {} // expected-error {{type 'C3' does not conform to protocol 'P9'}} expected-note {{add stubs for conformance}}
 
 protocol P10 {
     associatedtype A
-    func bar() // expected-note {{protocol requires function 'bar()' with type '() -> ()'; add a stub for conformance}}
+    func bar() // expected-note {{protocol requires function 'bar()' with type '() -> ()'}}
 }
 extension P10 where A == Int {
     func bar() {} // expected-note {{candidate would match if 'A' was the same type as 'Int'}}
 }
-struct S2<A> : P10 {} // expected-error {{type 'S2<A>' does not conform to protocol 'P10'}}
+struct S2<A> : P10 {} // expected-error {{type 'S2<A>' does not conform to protocol 'P10'}} expected-note {{add stubs for conformance}}
 
 protocol P11 {}
 protocol P12 {
@@ -145,9 +146,10 @@ struct CountSteps1<T> : Collection {
 }
 
 extension CountSteps1 // expected-error {{type 'CountSteps1<T>' does not conform to protocol 'RandomAccessCollection'}}
-  // expected-error@-1 {{conditional conformance of type 'CountSteps1<T>' to protocol 'RandomAccessCollection' does not imply conformance to inherited protocol 'BidirectionalCollection'}}
-  // expected-note@-2 {{did you mean to explicitly state the conformance like 'extension CountSteps1: BidirectionalCollection where ...'?}}
-  // expected-error@-3 {{type 'CountSteps1<T>' does not conform to protocol 'BidirectionalCollection'}}
+  // expected-note@-1 {{add stubs for conformance}}
+  // expected-error@-2 {{conditional conformance of type 'CountSteps1<T>' to protocol 'RandomAccessCollection' does not imply conformance to inherited protocol 'BidirectionalCollection'}}
+  // expected-note@-3 {{did you mean to explicitly state the conformance like 'extension CountSteps1: BidirectionalCollection where ...'?}}
+  // expected-error@-4 {{type 'CountSteps1<T>' does not conform to protocol 'BidirectionalCollection'}}
   : RandomAccessCollection
      where T : Equatable
 {

--- a/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
@@ -607,7 +607,9 @@ class WrappedProperties: Differentiable {
 // Test derived conformances in disallowed contexts.
 
 extension OtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring class 'OtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
+// expected-error@-1 {{extension outside of file declaring class 'OtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 extension GenericOtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring generic class 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
+// expected-error@-1 {{extension outside of file declaring generic class 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
+// expected-note@-2 {{add stubs for conformance}}

--- a/test/AutoDiff/Sema/DerivedConformances/derived_differentiable_diagnostics.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/derived_differentiable_diagnostics.swift
@@ -3,7 +3,7 @@
 import _Differentiation
 
 protocol TangentVectorP: Differentiable {
-  // expected-note @+1 {{protocol requires property 'requirement' with type 'Int'; add a stub for conformance}}
+  // expected-note @+1 {{protocol requires property 'requirement' with type 'Int'}}
   var requirement: Int { get }
 }
 
@@ -13,3 +13,4 @@ struct StructWithTangentVectorConstrained: TangentVectorConstrained {
   var x: Float
 }
 // expected-error @-1 {{type 'StructWithTangentVectorConstrained.TangentVector' does not conform to protocol 'TangentVectorP'}}
+// expected-note @-2 {{add stubs for conformance}}

--- a/test/AutoDiff/Sema/DerivedConformances/struct_additive_arithmetic.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_additive_arithmetic.swift
@@ -117,8 +117,10 @@ extension OtherFileNonconforming: AdditiveArithmetic {}
 // expected-error @-1 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of 'zero' for protocol 'AdditiveArithmetic'}}
 // expected-error @-2 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of '+' for protocol 'AdditiveArithmetic'}}
 // expected-error @-3 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of '-' for protocol 'AdditiveArithmetic'}}
+// expected-note @-4 3{{add stubs for conformance}}
 
 extension GenericOtherFileNonconforming: AdditiveArithmetic {}
 // expected-error @-1 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of 'zero' for protocol 'AdditiveArithmetic'}}
 // expected-error @-2 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of '+' for protocol 'AdditiveArithmetic'}}
 // expected-error @-3 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of '-' for protocol 'AdditiveArithmetic'}}
+// expected-note @-4 3{{add stubs for conformance}}

--- a/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
@@ -424,7 +424,9 @@ struct WrappedProperties: Differentiable {
 // Verify that cross-file derived conformances are disallowed.
 
 extension OtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
+// expected-error@-1 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 extension GenericOtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
+// expected-error@-1 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
+// expected-note@-2 {{add stubs for conformance}}

--- a/test/AutoDiff/Sema/ImplicitDifferentiableAttributeCrossFile/main.swift
+++ b/test/AutoDiff/Sema/ImplicitDifferentiableAttributeCrossFile/main.swift
@@ -26,7 +26,8 @@
 import _Differentiation
 
 // Error: conformance is in different file than witnesses.
-// expected-error @+1 {{type 'ConformingStruct' does not conform to protocol 'Protocol1'}}
+// expected-error@+2 {{type 'ConformingStruct' does not conform to protocol 'Protocol1'}}
+// expected-note@+1 {{add stubs for conformance}}
 extension ConformingStruct: Protocol1 {}
 
 // No error: conformance is in same file as witnesses.

--- a/test/AutoDiff/Sema/ImplicitDifferentiableAttributeCrossFile/protocol_default_implementation_witness.swift
+++ b/test/AutoDiff/Sema/ImplicitDifferentiableAttributeCrossFile/protocol_default_implementation_witness.swift
@@ -9,5 +9,6 @@
 
 import _Differentiation
 
-// expected-error @+1 {{type 'ConformingStruct' does not conform to protocol 'P1'}}
+// expected-error @+2 {{type 'ConformingStruct' does not conform to protocol 'P1'}} 
+// expected-note @+1 {{add stubs for conformance}}
 struct ConformingStruct: P2 {}

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -218,11 +218,11 @@ protocol ProtocolRequirements: Differentiable {
   @differentiable(reverse, wrt: x)
   init(x: Float, y: Int)
 
-  // expected-note @+2 {{protocol requires function 'amb(x:y:)' with type '(Float, Float) -> Float';}}
+  // expected-note @+2 {{protocol requires function 'amb(x:y:)' with type '(Float, Float) -> Float'}}
   @differentiable(reverse)
   func amb(x: Float, y: Float) -> Float
 
-  // expected-note @+2 {{protocol requires function 'amb(x:y:)' with type '(Float, Int) -> Float';}}
+  // expected-note @+2 {{protocol requires function 'amb(x:y:)' with type '(Float, Int) -> Float'}}
   @differentiable(reverse, wrt: x)
   func amb(x: Float, y: Int) -> Float
 
@@ -281,6 +281,7 @@ struct InternalDiffAttrConformance: ProtocolRequirements {
 
 // Test missing `@differentiable` attribute for public protocol witnesses. Errors expected.
 
+// expected-note @+2 {{add stubs for conformance}}
 // expected-error @+1 {{does not conform to protocol 'ProtocolRequirements'}}
 public struct PublicDiffAttrConformance: ProtocolRequirements {
   public typealias TangentVector = DummyTangentVector
@@ -391,6 +392,7 @@ struct TF_521<T: FloatingPoint> {
     self.imaginary = imaginary
   }
 }
+// expected-note @+2 {{add stubs for conformance}}
 // expected-error @+1 {{type 'TF_521<T>' does not conform to protocol 'Differentiable'}}
 extension TF_521: Differentiable where T: Differentiable {
   // expected-note @+1 {{possibly intended match 'TF_521<T>.TangentVector' (aka 'TF_521<T>') does not conform to 'AdditiveArithmetic'}}
@@ -557,10 +559,11 @@ public protocol DoubleDifferentiableDistribution: DifferentiableDistribution
 
 public protocol HasRequirement {
   @differentiable(reverse)
-  // expected-note @+1 {{protocol requires function 'requirement' with type '<T> (T, T) -> T'; add a stub for conformance}}
+  // expected-note @+1 {{protocol requires function 'requirement' with type '<T> (T, T) -> T'}}
   func requirement<T: Differentiable>(_ x: T, _ y: T) -> T
 }
 
+// expected-note @+2 {{add stubs for conformance}}
 // expected-error @+1 {{type 'AttemptsToSatisfyRequirement' does not conform to protocol 'HasRequirement'}}
 public struct AttemptsToSatisfyRequirement: HasRequirement {
   // This `@differentiable` attribute does not satisfy the requirement because

--- a/test/ClangImporter/objc_async_conformance.swift
+++ b/test/ClangImporter/objc_async_conformance.swift
@@ -121,17 +121,20 @@ class ImplementsDictionaryLoader1: DictionaryLoader {
   func loadDictionary(completionHandler: @escaping ([String: NSNumber]?) -> Void) {}
 }
 
-// expected-error@+1 {{type 'ImplementsDictionaryLoader2' does not conform to protocol 'DictionaryLoader'}}
+// expected-error@+2 {{type 'ImplementsDictionaryLoader2' does not conform to protocol 'DictionaryLoader'}}
+// expected-note@+1 {{add stubs for conformance}}
 class ImplementsDictionaryLoader2: DictionaryLoader {
   func loadDictionary(completionHandler: @escaping ([String: Any]?) -> Void) {} // expected-note {{candidate has non-matching type '(@escaping ([String : Any]?) -> Void) -> ()'}}
 }
 
-// expected-error@+1 {{type 'ImplementsDictionaryLoader3' does not conform to protocol 'DictionaryLoader'}}
+// expected-error@+2 {{type 'ImplementsDictionaryLoader3' does not conform to protocol 'DictionaryLoader'}}
+// expected-note@+1 {{add stubs for conformance}}
 class ImplementsDictionaryLoader3: DictionaryLoader {
   func loadDictionary(completionHandler: @escaping ([String: NSNumber?]?) -> Void) {} // expected-note {{candidate has non-matching type '(@escaping ([String : NSNumber?]?) -> Void) -> ()'}}
 }
 
-// expected-error@+1 {{type 'ImplementsDictionaryLoader4' does not conform to protocol 'DictionaryLoader'}}
+// expected-error@+2 {{type 'ImplementsDictionaryLoader4' does not conform to protocol 'DictionaryLoader'}}
+// expected-note@+1 {{add stubs for conformance}}
 class ImplementsDictionaryLoader4: DictionaryLoader {
   func loadDictionary(completionHandler: @escaping ([String: Int]?) -> Void) {} // expected-note {{candidate has non-matching type '(@escaping ([String : Int]?) -> Void) -> ()'}}
 }

--- a/test/ClangImporter/objc_bridging_custom.swift
+++ b/test/ClangImporter/objc_bridging_custom.swift
@@ -108,7 +108,7 @@ protocol TestProto {
   var propGeneric: ManufacturerInfo<NSString>? { get } // expected-note {{protocol requires}}
 }
 
-@objcMembers class TestProtoImpl : NSObject, TestProto { // expected-error {{type 'TestProtoImpl' does not conform to protocol 'TestProto'}}
+@objcMembers class TestProtoImpl : NSObject, TestProto { // expected-error {{type 'TestProtoImpl' does not conform to protocol 'TestProto'}} expected-note {{add stubs for conformance}}
   // expected-note@+1 {{candidate has non-matching type '(APPRefrigerator, APPRefrigerator?) -> APPRefrigerator'}} {{16-31=Refrigerator}} {{36-52=Refrigerator?}} {{57-72=Refrigerator}}
   func test(a: APPRefrigerator, b: APPRefrigerator?) -> APPRefrigerator {
     return a

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -315,7 +315,7 @@ func ivars(_ hive: Hive) {
   hive.queen.description() // expected-error{{value of type 'Hive' has no member 'queen'}}
 }
 
-class NSObjectable : NSObjectProtocol { // expected-error {{cannot declare conformance to 'NSObjectProtocol' in Swift; 'NSObjectable' should inherit 'NSObject' instead}}
+class NSObjectable : NSObjectProtocol { // expected-error {{cannot declare conformance to 'NSObjectProtocol' in Swift; 'NSObjectable' should inherit 'NSObject' instead}} expected-note {{add stubs for conformance}}
   @objc var description : String { return "" }
   @objc(conformsToProtocol:) func conforms(to _: Protocol) -> Bool { return false }
   @objc(isKindOfClass:) func isKind(of aClass: AnyClass) -> Bool { return false }
@@ -380,13 +380,13 @@ class ProtocolAdopter2 : FooProto {
     set { /* do nothing! */ }
   }
 }
-class ProtocolAdopterBad1 : FooProto { // expected-error {{type 'ProtocolAdopterBad1' does not conform to protocol 'FooProto'}}
+class ProtocolAdopterBad1 : FooProto { // expected-error {{type 'ProtocolAdopterBad1' does not conform to protocol 'FooProto'}} expected-note {{add stubs for conformance}}
   @objc var bar: Int = 0 // expected-note {{candidate has non-matching type 'Int'}}
 }
-class ProtocolAdopterBad2 : FooProto { // expected-error {{type 'ProtocolAdopterBad2' does not conform to protocol 'FooProto'}}
+class ProtocolAdopterBad2 : FooProto { // expected-error {{type 'ProtocolAdopterBad2' does not conform to protocol 'FooProto'}} expected-note {{add stubs for conformance}}
   let bar: CInt = 0 // expected-note {{candidate is not settable, but protocol requires it}}
 }
-class ProtocolAdopterBad3 : FooProto { // expected-error {{type 'ProtocolAdopterBad3' does not conform to protocol 'FooProto'}}
+class ProtocolAdopterBad3 : FooProto { // expected-error {{type 'ProtocolAdopterBad3' does not conform to protocol 'FooProto'}} expected-note {{add stubs for conformance}}
   var bar: CInt { // expected-note {{candidate is not settable, but protocol requires it}}
     return 42
   }

--- a/test/ClangImporter/subclass_existentials.swift
+++ b/test/ClangImporter/subclass_existentials.swift
@@ -23,6 +23,7 @@ class SwiftLaundryService : NSLaundry {
 
 class OldSwiftLaundryService : NSLaundry { 
 // expected-error@-1 {{type 'OldSwiftLaundryService' does not conform to protocol 'NSLaundry'}}
+// expected-note@-2 {{add stubs for conformance}}
 
   var g: Coat? = nil
 

--- a/test/Compatibility/accessibility.swift
+++ b/test/Compatibility/accessibility.swift
@@ -662,7 +662,7 @@ fileprivate struct EquatablishOuter2 {
 }
 
 fileprivate struct EquatablishOuterProblem {
-  internal struct Inner : Equatablish { // expected-error {{type 'EquatablishOuterProblem.Inner' does not conform to protocol 'Equatablish'}}
+  internal struct Inner : Equatablish { // expected-error {{type 'EquatablishOuterProblem.Inner' does not conform to protocol 'Equatablish'}} expected-note {{add stubs for conformance}}
     private static func ==(lhs: Inner, rhs: Inner) {}
   }
 }

--- a/test/Compatibility/special_func_name.swift
+++ b/test/Compatibility/special_func_name.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4
 
 protocol P1 {
-  static func `init`(_: Int) // expected-note {{protocol requires function 'init' with type '(Int) -> ()'; add a stub for conformance}}
+  static func `init`(_: Int) // expected-note {{protocol requires function 'init' with type '(Int) -> ()'}}
   // expected-note@-1 {{did you mean 'init'?}}
 }
 
@@ -9,15 +9,15 @@ struct S11 : P1 {
   static func `init`(_: Int) {}
 }
 
-struct S12 : P1 { // expected-error {{type 'S12' does not conform to protocol 'P1'}}
+struct S12 : P1 { // expected-error {{type 'S12' does not conform to protocol 'P1'}} expected-note {{add stubs for conformance}}
   init(_: Int) {}
 }
 
 protocol P2 {
-  init(_: Int) // expected-note {{protocol requires initializer 'init(_:)' with type 'Int'; add a stub for conformance}}
+  init(_: Int) // expected-note {{protocol requires initializer 'init(_:)' with type 'Int'}}
 }
 
-struct S21 : P2 { // expected-error {{type 'S21' does not conform to protocol 'P2'}}
+struct S21 : P2 { // expected-error {{type 'S21' does not conform to protocol 'P2'}} expected-note {{add stubs for conformance}}
   static func `init`(_: Int) {}
 }
 

--- a/test/Concurrency/actor_derived_conformances.swift
+++ b/test/Concurrency/actor_derived_conformances.swift
@@ -11,13 +11,16 @@ actor A1: Comparable {}
 // expected-error@-2 {{type 'A1' does not conform to protocol 'Equatable'}}
 // expected-note@-3 {{automatic synthesis of 'Comparable' is not supported for actor declarations}}
 // expected-note@-4 {{automatic synthesis of 'Equatable' is not supported for actor declarations}}
+// expected-note@-5 {{add stubs for conformance}}
 
 actor A2: Equatable {}
 // expected-error@-1 {{type 'A2' does not conform to protocol 'Equatable'}}
 // expected-note@-2 {{automatic synthesis of 'Equatable' is not supported for actor declarations}}
+// expected-note@-3 {{add stubs for conformance}}
 
 actor A3: Hashable {}
 // expected-error@-1 {{type 'A3' does not conform to protocol 'Hashable'}}
 // expected-error@-2 {{type 'A3' does not conform to protocol 'Equatable'}}
 // expected-note@-3 {{automatic synthesis of 'Hashable' is not supported for actor declarations}}
 // expected-note@-4 {{automatic synthesis of 'Equatable' is not supported for actor declarations}}
+// expected-note@-5 {{add stubs for conformance}}

--- a/test/Concurrency/async_conformance.swift
+++ b/test/Concurrency/async_conformance.swift
@@ -11,17 +11,17 @@ import Foundation
 
 // async objc requirement, sync witness
 @objc protocol Tracker {
-    func track(event: String) async // expected-note {{protocol requires function 'track(event:)' with type '(String) async -> ()'; add a stub for conformance}}
+    func track(event: String) async // expected-note {{protocol requires function 'track(event:)' with type '(String) async -> ()'}}
 }
-class Dog: NSObject, Tracker { // expected-error {{type 'Dog' does not conform to protocol 'Tracker'}}
+class Dog: NSObject, Tracker { // expected-error {{type 'Dog' does not conform to protocol 'Tracker'}} expected-note {{add stubs for conformance}}
     func track(event: String) {} // expected-note {{candidate is not 'async', but @objc protocol requirement is}}
 }
 
 // sync objc requirement, async witness
 @objc protocol Runner {
-    func run(event: String) // expected-note {{protocol requires function 'run(event:)' with type '(String) -> ()'; add a stub for conformance}}
+    func run(event: String) // expected-note {{protocol requires function 'run(event:)' with type '(String) -> ()'}}
 }
-class Athlete: NSObject, Runner { // expected-error {{type 'Athlete' does not conform to protocol 'Runner'}}
+class Athlete: NSObject, Runner { // expected-error {{type 'Athlete' does not conform to protocol 'Runner'}} expected-note {{add stubs for conformance}}
     func run(event: String) async {} // expected-note {{candidate is 'async', but @objc protocol requirement is not}}
 }
 
@@ -38,9 +38,9 @@ class Foodie: Snacker {
 
 // sync swift protocol, async witness
 protocol Backer {
-    func back(stonk: String) // expected-note {{protocol requires function 'back(stonk:)' with type '(String) -> ()'; add a stub for conformance}}
+    func back(stonk: String) // expected-note {{protocol requires function 'back(stonk:)' with type '(String) -> ()'}}
 }
 
-class Investor: Backer {  // expected-error {{type 'Investor' does not conform to protocol 'Backer'}}
+class Investor: Backer {  // expected-error {{type 'Investor' does not conform to protocol 'Backer'}} expected-note {{add stubs for conformance}}
     func back(stonk: String) async {}  // expected-note {{candidate is 'async', but protocol requirement is not}}
 }

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -158,9 +158,9 @@ struct Location {
 }
 
 protocol DefaultConstructable {
-  init() // expected-note {{protocol requires initializer 'init()' with type '()'; add a stub for conformance}} {{+2:43-43=\n    init() {\n        <#code#>\n    \}\n}}
+  init() // expected-note {{protocol requires initializer 'init()' with type '()'}} 
 }
-extension Location: DefaultConstructable {} // expected-error {{type 'Location' does not conform to protocol 'DefaultConstructable'}}
+extension Location: DefaultConstructable {} // expected-error {{type 'Location' does not conform to protocol 'DefaultConstructable'}} expected-note {{add stubs for conformance}} {{43-43=\n    init() {\n        <#code#>\n    \}\n}}
 
 extension Location: AsyncDefaultConstructable {}
 

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift5_strict.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift5_strict.swift
@@ -116,6 +116,7 @@ func test_sendable_attr_in_type_context(test: Test) {
 
 class TestConformanceWithStripping : InnerSendableTypes {
   // expected-error@-1 {{type 'TestConformanceWithStripping' does not conform to protocol 'InnerSendableTypes'}}
+  // expected-note@-2 {{add stubs for conformance}}
 
   func testComposition(_: MyValue) {
     // expected-note@-1 {{candidate has non-matching type '(MyValue) -> ()'}}

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
@@ -115,6 +115,7 @@ func test_sendable_attr_in_type_context(test: Test) {
 
 class TestConformanceWithStripping : InnerSendableTypes {
   // expected-error@-1 {{type 'TestConformanceWithStripping' does not conform to protocol 'InnerSendableTypes'}}
+  // expected-note@-2 {{add stubs for conformance}}
 
   func testComposition(_: MyValue) {
     // expected-note@-1 {{candidate has non-matching type '(MyValue) -> ()'}}

--- a/test/Concurrency/transfernonsendable_functionsubtyping.swift
+++ b/test/Concurrency/transfernonsendable_functionsubtyping.swift
@@ -85,7 +85,10 @@ struct MatchSuccess : ProtocolWithSendingReqs, ProtocolWithMixedReqs {
   func nonSendingParamAndSendingResult(_ x: NonSendableKlass) -> sending NonSendableKlass { fatalError() }
 }
 
-struct FailToMatch : ProtocolWithSendingReqs, ProtocolWithMixedReqs { // expected-error 2{{}}
+struct FailToMatch : ProtocolWithSendingReqs, ProtocolWithMixedReqs {
+  // expected-error@-1 {{type 'FailToMatch' does not conform to protocol 'ProtocolWithSendingReqs'}} 
+  // expected-error@-2 {{type 'FailToMatch' does not conform to protocol 'ProtocolWithMixedReqs'}} 
+  // expected-note@-3 {{add stubs for conformance}}
   func sendingResult() -> NonSendableKlass { fatalError() }
   // expected-note @-1 {{candidate has non-matching type '() -> NonSendableKlass'}}
   func nonSendingParam(_ x: sending NonSendableKlass) -> () { fatalError() }
@@ -94,17 +97,17 @@ struct FailToMatch : ProtocolWithSendingReqs, ProtocolWithMixedReqs { // expecte
   // expected-note @-1 {{candidate has non-matching type '(sending NonSendableKlass) -> NonSendableKlass'}}
 }
 
-struct FailToMatch2 : ProtocolWithMixedReqs { // expected-error {{}}
+struct FailToMatch2 : ProtocolWithMixedReqs { // expected-error {{type 'FailToMatch2' does not conform to protocol 'ProtocolWithMixedReqs'}} expected-note {{add stubs for conformance}}
   func nonSendingParamAndSendingResult(_ x: sending NonSendableKlass) -> NonSendableKlass { fatalError() }
   // expected-note @-1 {{candidate has non-matching type '(sending NonSendableKlass) -> NonSendableKlass'}}
 }
 
-struct FailToMatch3 : ProtocolWithMixedReqs { // expected-error {{}}
+struct FailToMatch3 : ProtocolWithMixedReqs { // expected-error {{type 'FailToMatch3' does not conform to protocol 'ProtocolWithMixedReqs'}} expected-note {{add stubs for conformance}} 
   func nonSendingParamAndSendingResult(_ x: NonSendableKlass) -> NonSendableKlass { fatalError() }
   // expected-note @-1 {{candidate has non-matching type '(NonSendableKlass) -> NonSendableKlass'}}
 }
 
-struct FailToMatch4 : ProtocolWithMixedReqs { // expected-error {{}}
+struct FailToMatch4 : ProtocolWithMixedReqs { // expected-error {{type 'FailToMatch4' does not conform to protocol 'ProtocolWithMixedReqs'}} expected-note {{add stubs for conformance}}
   func nonSendingParamAndSendingResult(_ x: sending NonSendableKlass) -> sending NonSendableKlass { fatalError() }
   // expected-note @-1 {{candidate has non-matching type '(sending NonSendableKlass) -> sending NonSendableKlass'}}
 }

--- a/test/Constraints/associated_types.swift
+++ b/test/Constraints/associated_types.swift
@@ -62,8 +62,8 @@ protocol XReqt {}
 protocol YReqt {}
 
 protocol SameTypedDefaultWithReqts {
-    associatedtype X: XReqt // expected-note{{protocol requires nested type 'X'; add nested type 'X' for conformance}}
-    associatedtype Y: YReqt // expected-note{{protocol requires nested type 'Y'; add nested type 'Y' for conformance}}
+    associatedtype X: XReqt // expected-note{{protocol requires nested type 'X'}}
+    associatedtype Y: YReqt // expected-note{{protocol requires nested type 'Y'}}
     static var x: X { get }
     static var y: Y { get }
 }
@@ -80,13 +80,14 @@ struct UsesSameTypedDefaultWithReqts: SameTypedDefaultWithReqts {
     static var y: XYType { return XYType() }
 }
 
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1{{does not conform}}
 struct UsesSameTypedDefaultWithoutSatisfyingReqts: SameTypedDefaultWithReqts {
     static var y: YType { return YType() }
 }
 
 protocol SameTypedDefaultBaseWithReqts {
-    associatedtype X: XReqt // expected-note{{protocol requires nested type 'X'; add nested type 'X' for conformance}}
+    associatedtype X: XReqt // expected-note{{protocol requires nested type 'X'}}
     static var x: X { get }
 }
 protocol SameTypedDefaultDerivedWithReqts: SameTypedDefaultBaseWithReqts {
@@ -104,6 +105,7 @@ struct UsesSameTypedDefaultDerivedWithReqts: SameTypedDefaultDerivedWithReqts {
     static var y: XYType { return XYType() }
 }
 
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1{{does not conform}}
 struct UsesSameTypedDefaultDerivedWithoutSatisfyingReqts: SameTypedDefaultDerivedWithReqts {
     static var y: YType { return YType() }

--- a/test/Constraints/generic_protocol_witness.swift
+++ b/test/Constraints/generic_protocol_witness.swift
@@ -37,7 +37,7 @@ class LooseConstraints : NeedsGenericMethods {
 }
 func •<T>(_ x: LooseConstraints, y: T) {} // expected-note {{candidate has non-matching type '<T> (LooseConstraints, T) -> ()'}}
 
-class TooTightConstraints : NeedsGenericMethods { // expected-error{{type 'TooTightConstraints' does not conform to protocol 'NeedsGenericMethods'}}
+class TooTightConstraints : NeedsGenericMethods { // expected-error{{type 'TooTightConstraints' does not conform to protocol 'NeedsGenericMethods'}} expected-note {{add stubs for conformance}}
   func oneArgNoConstraints<U : Runcible>(x: U) {} // expected-note{{candidate has non-matching type '<U> (x: U) -> ()'}}
   func oneArgWithConstraint<U : Fungible>(x: U) {} // expected-note{{candidate has non-matching type '<U> (x: U) -> ()'}}
   func oneArgWithConstraints<U : Runcible & Fungible & Ansible>(x: U) {} // expected-note{{candidate has non-matching type '<U> (x: U) -> ()'}}

--- a/test/Constraints/invalid_stdlib_2.swift
+++ b/test/Constraints/invalid_stdlib_2.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-class Dictionary<K, V> : ExpressibleByDictionaryLiteral { // expected-error {{type 'Dictionary<K, V>' does not conform to protocol 'ExpressibleByDictionaryLiteral'}} 
+class Dictionary<K, V> : ExpressibleByDictionaryLiteral { // expected-error {{type 'Dictionary<K, V>' does not conform to protocol 'ExpressibleByDictionaryLiteral'}}  expected-note {{add stubs for conformance}}
   typealias Key = K
   typealias Value = V
   init(dictionaryLiteral xs: (K)...){} // expected-note {{candidate has non-matching type '(dictionaryLiteral: (K)...)'}}

--- a/test/Constraints/issue-52995.swift
+++ b/test/Constraints/issue-52995.swift
@@ -3,14 +3,14 @@
 // https://github.com/apple/swift/issues/52995
 
 protocol Nested {
-    associatedtype U // expected-note {{protocol requires nested type 'U'; add nested type 'U' for conformance}}
+    associatedtype U // expected-note {{protocol requires nested type 'U'}}
 }
 
 class A<M> {
     func f<T : Nested>(_ t: T, _ keyPath: WritableKeyPath<M, T.U>) {}
 }
 
-class B<Y> : Nested { // expected-error {{type 'B<Y>' does not conform to protocol 'Nested'}}
+class B<Y> : Nested { // expected-error {{type 'B<Y>' does not conform to protocol 'Nested'}} expected-note {{add stubs for conformance}}
     var i: Y?
 }
 

--- a/test/Constraints/issue-54820.swift
+++ b/test/Constraints/issue-54820.swift
@@ -5,11 +5,11 @@
 protocol Protocol {
   associatedtype Index: Comparable
   subscript(bounds: Range<Index>) -> Int { get }
-  // expected-note@+1 {{protocol requires subscript with type '(Wrapper<Base>.Index) -> Int' (aka '(Base.Index) -> Int'); add a stub for conformance}}
+  // expected-note@+1 {{protocol requires subscript with type '(Wrapper<Base>.Index) -> Int' (aka '(Base.Index) -> Int')}}
   subscript(position: Index) -> Int { get } 
 }
 
-struct Wrapper<Base: Protocol>: Protocol { // expected-error {{type 'Wrapper<Base>' does not conform to protocol 'Protocol'}}
+struct Wrapper<Base: Protocol>: Protocol { // expected-error {{type 'Wrapper<Base>' does not conform to protocol 'Protocol'}} expected-note {{add stubs for conformance}}
   typealias Index = Base.Index
   subscript(bounds: Range<Index>) -> Int { // expected-note {{candidate has non-matching type '<Base> (Range<Wrapper<Base>.Index>) -> Int' (aka '<Base> (Range<Base.Index>) -> Int')}}
     get { 1 }

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -2,7 +2,7 @@
 // RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol Fooable {
-  associatedtype Foo // expected-note{{protocol requires nested type 'Foo'; add nested type 'Foo' for conformance}}
+  associatedtype Foo // expected-note{{protocol requires nested type 'Foo'}}
 
   var foo: Foo { get }
 }
@@ -169,7 +169,7 @@ rdar19137463(1)
 
 struct Brunch<U : Fooable> where U.Foo == X {}
 
-struct BadFooable : Fooable { // expected-error{{type 'BadFooable' does not conform to protocol 'Fooable'}}
+struct BadFooable : Fooable { // expected-error{{type 'BadFooable' does not conform to protocol 'Fooable'}} expected-note {{add stubs for conformance}}
   typealias Foo = DoesNotExist // expected-error{{cannot find type 'DoesNotExist' in scope}}
   var foo: Foo { while true {} }
 }

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
@@ -26,16 +26,16 @@ distributed actor Caplin {
   typealias ActorSystem = FakeActorSystem
 }
 
-@Resolvable // expected-note 3{{in expansion of macro 'Resolvable' on protocol 'Fail' here}}
+@Resolvable // expected-note 4{{in expansion of macro 'Resolvable' on protocol 'Fail' here}}
 protocol Fail: DistributedActor {
   distributed func method() -> String
 }
 
-@Resolvable // expected-note{{in expansion of macro 'Resolvable' on protocol 'SomeRoot' here}}
+@Resolvable // expected-note2{{in expansion of macro 'Resolvable' on protocol 'SomeRoot' here}}
 public protocol SomeRoot: DistributedActor, Sendable
   where ActorSystem: DistributedActorSystem<any Codable> {
 
-  associatedtype AssociatedSomething: Sendable // expected-note{{protocol requires nested type 'AssociatedSomething'; add nested type 'AssociatedSomething' for conformance}}
+  associatedtype AssociatedSomething: Sendable // expected-note{{protocol requires nested type 'AssociatedSomething'}}
   static var staticValue: String { get }
   var value: String { get }
 }

--- a/test/Distributed/actor_protocols.swift
+++ b/test/Distributed/actor_protocols.swift
@@ -45,6 +45,7 @@ actor A2: DistributedActor {
 // FIXME(distributed): error reporting is a bit whacky here; needs cleanup
 // expected-error@-2{{actor type 'A2' cannot conform to the 'DistributedActor' protocol. Isolation rules of these actor types are not interchangeable.}}
 // expected-error@-3{{actor type 'A2' cannot conform to the 'DistributedActor' protocol. Isolation rules of these actor types are not interchangeable.}}
+// expected-note@-4 {{add stubs for conformance}}
   nonisolated var id: ID {
     fatalError()
   }
@@ -63,6 +64,7 @@ actor A2: DistributedActor {
 
 final class DA2: DistributedActor {
 // expected-error@-1{{non-distributed actor type 'DA2' cannot conform to the 'DistributedActor' protocol}}
+// expected-note@-2 {{add stubs for conformance}}
   nonisolated var id: ID {
     fatalError()
   }
@@ -84,6 +86,7 @@ final class DA2: DistributedActor {
 struct S2: DistributedActor {
   // expected-error@-1{{non-class type 'S2' cannot conform to class protocol 'DistributedActor'}}
   // expected-error@-2{{type 'S2' does not conform to protocol 'Identifiable'}}
+  // expected-note@-3 {{add stubs for conformance}}
 }
 
 // ==== -----------------------------------------------------------------------

--- a/test/Distributed/distributed_actor_derived_conformances.swift
+++ b/test/Distributed/distributed_actor_derived_conformances.swift
@@ -12,3 +12,4 @@ typealias DefaultDistributedActorSystem = FakeActorSystem
 distributed actor DA: Comparable {}
 // expected-error@-1 {{type 'DA' does not conform to protocol 'Comparable'}}
 // expected-note@-2 {{automatic synthesis of 'Comparable' is not supported for distributed actor declarations}}
+// expected-note@-3 {{add stubs for conformance}}

--- a/test/Distributed/distributed_actor_system_missing.swift
+++ b/test/Distributed/distributed_actor_system_missing.swift
@@ -9,7 +9,7 @@ import Distributed
 distributed actor DA {
   // expected-error@-1{{distributed actor 'DA' does not declare ActorSystem it can be used with}}
   // expected-error@-2 {{type 'DA' does not conform to protocol 'DistributedActor'}}
-
+  // expected-note@-3 {{add stubs for conformance}}
   // expected-note@-4{{you can provide a module-wide default actor system by declaring:}}
 
   // Note to add the typealias is diagnosed on the protocol:
@@ -23,6 +23,7 @@ distributed actor DA {
 distributed actor Server { // expected-error 2 {{distributed actor 'Server' does not declare ActorSystem it can be used with}}
   // expected-error@-1 {{type 'Server' does not conform to protocol 'DistributedActor'}}
   // expected-note@-2{{you can provide a module-wide default actor system by declaring:}}
+  // expected-note@-3 {{add stubs for conformance}}
   typealias ActorSystem = DoesNotExistDataSystem
   // expected-error@-1{{cannot find type 'DoesNotExistDataSystem' in scope}}
   typealias SerializationRequirement = any Codable

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_fixits.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_fixits.swift
@@ -6,12 +6,14 @@
 
 import Distributed
 
-struct MissingRemoteCall: DistributedActorSystem { // expected-error {{type 'MissingRemoteCall' does not conform to protocol 'DistributedActorSystem'}}
+struct MissingRemoteCall: DistributedActorSystem { 
   // expected-error@-1{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
   // expected-note@-2{{add stubs for conformance}}{{51-51=\nfunc remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
-
-  // expected-error@-4{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{add stubs for conformance}}{{51-51=\nfunc remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
+  // expected-error@-3{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-4{{add stubs for conformance}}{{51-51=\nfunc remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
+  // expected-error@-5 {{type 'MissingRemoteCall' does not conform to protocol 'DistributedActorSystem'}}
+  // expected-note@-6{{add stubs for conformance}} {{51-51=\n    func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout FakeInvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act : DistributedActor, Err : Error, ActorAddress == Act.ID {\n        <#code#>\n    \}\n\n    func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout FakeInvocationEncoder, throwing: Err.Type) async throws where Act : DistributedActor, Err : Error, ActorAddress == Act.ID {\n        <#code#>\n    \}\n}}
+  
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -41,12 +43,14 @@ struct MissingRemoteCall: DistributedActorSystem { // expected-error {{type 'Mis
   }
 }
 
-public struct PublicMissingRemoteCall: DistributedActorSystem { // expected-error {{type 'PublicMissingRemoteCall' does not conform to protocol 'DistributedActorSystem'}}
+public struct PublicMissingRemoteCall: DistributedActorSystem { 
   // expected-error@-1{{struct 'PublicMissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
   // expected-note@-2{{add stubs for conformance}}{{64-64=\npublic func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
-
-  // expected-error@-4{{struct 'PublicMissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{add stubs for conformance}}{{64-64=\npublic func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
+  // expected-error@-3{{struct 'PublicMissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-4{{add stubs for conformance}}{{64-64=\npublic func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
+  // expected-error@-5{{type 'PublicMissingRemoteCall' does not conform to protocol 'DistributedActorSystem'}}
+  // expected-note@-6{{add stubs for conformance}}{{64-64=\n    public func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout FakeInvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act : DistributedActor, Err : Error, ActorAddress == Act.ID {\n        <#code#>\n    \}\n\n    public func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout FakeInvocationEncoder, throwing: Err.Type) async throws where Act : DistributedActor, Err : Error, ActorAddress == Act.ID {\n        <#code#>\n    \}\n}}
+  
 
 
   public typealias ActorID = ActorAddress

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
@@ -6,12 +6,13 @@
 
 import Distributed
 
-struct MissingRemoteCall: DistributedActorSystem { // expected-error {{type 'MissingRemoteCall' does not conform to protocol 'DistributedActorSystem'}}
-  // expected-error@-1{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
+struct MissingRemoteCall: DistributedActorSystem { 
+  // expected-error@-1 {{type 'MissingRemoteCall' does not conform to protocol 'DistributedActorSystem'}}
   // expected-note@-2{{add stubs for conformance}}
-
-  // expected-error@-4{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{add stubs for conformance}}
+  // expected-error@-3{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-4{{add stubs for conformance}}
+  // expected-error@-5{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-6{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -41,12 +42,13 @@ struct MissingRemoteCall: DistributedActorSystem { // expected-error {{type 'Mis
   }
 }
 
-struct RemoteCallMutating: DistributedActorSystem { // expected-error {{type 'RemoteCallMutating' does not conform to protocol 'DistributedActorSystem'}}
-  // expected-error@-1{{struct 'RemoteCallMutating' is missing witness for protocol requirement 'remoteCall'}}
+struct RemoteCallMutating: DistributedActorSystem { 
+  // expected-error@-1 {{type 'RemoteCallMutating' does not conform to protocol 'DistributedActorSystem'}}
   // expected-note@-2{{add stubs for conformance}}
-
-  // expected-error@-4{{struct 'RemoteCallMutating' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{add stubs for conformance}}
+  // expected-error@-3{{struct 'RemoteCallMutating' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-4{{add stubs for conformance}}
+  // expected-error@-5{{struct 'RemoteCallMutating' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-6{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -104,12 +106,13 @@ struct RemoteCallMutating: DistributedActorSystem { // expected-error {{type 'Re
   }
 }
 
-struct MissingRemoteCall_missingInout_on_encoder: DistributedActorSystem { // expected-error {{type 'MissingRemoteCall_missingInout_on_encoder' does not conform to protocol 'DistributedActorSystem'}}
-  // expected-error@-1{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCall'}}
+struct MissingRemoteCall_missingInout_on_encoder: DistributedActorSystem { 
+  // expected-error@-1 {{type 'MissingRemoteCall_missingInout_on_encoder' does not conform to protocol 'DistributedActorSystem'}}
   // expected-note@-2{{add stubs for conformance}}
-
-  // expected-error@-4{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{add stubs for conformance}}
+  // expected-error@-3{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-4{{add stubs for conformance}}
+  // expected-error@-5{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-6{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -169,6 +172,7 @@ struct MissingRemoteCall_missingInout_on_encoder: DistributedActorSystem { // ex
 
 struct MissingRemoteCall_missing_makeInvocationEncoder: DistributedActorSystem {
   // expected-error@-1{{type 'MissingRemoteCall_missing_makeInvocationEncoder' does not conform to protocol 'DistributedActorSystem'}}
+  // expected-note@-2{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -223,12 +227,13 @@ struct MissingRemoteCall_missing_makeInvocationEncoder: DistributedActorSystem {
   // func makeInvocationEncoder() -> InvocationEncoder {} // MISSING
 }
 
-struct Error_wrongReturn: DistributedActorSystem { // expected-error {{type 'Error_wrongReturn' does not conform to protocol 'DistributedActorSystem'}}
-  // expected-error@-1{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{add stubs for conformance}}
-
-  // expected-error@-4{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{add stubs for conformance}}
+struct Error_wrongReturn: DistributedActorSystem { 
+  // expected-error@-1{{type 'Error_wrongReturn' does not conform to protocol 'DistributedActorSystem'}}
+  //expected-note@-2{{add stubs for conformance}}
+  // expected-error@-3{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-4{{add stubs for conformance}}
+  // expected-error@-5{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-6{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -301,12 +306,13 @@ struct Error_wrongReturn: DistributedActorSystem { // expected-error {{type 'Err
   }
 }
 
-struct BadRemoteCall_param: DistributedActorSystem { // expected-error {{type 'BadRemoteCall_param' does not conform to protocol 'DistributedActorSystem'}}
-  // expected-error@-1{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCall'}}
+struct BadRemoteCall_param: DistributedActorSystem { 
+  // expected-error@-1{{type 'BadRemoteCall_param' does not conform to protocol 'DistributedActorSystem'}}
   // expected-note@-2{{add stubs for conformance}}
-
-  // expected-error@-4{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{add stubs for conformance}}
+  // expected-error@-3{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-4{{add stubs for conformance}}
+  // expected-error@-5{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-6{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -415,9 +421,11 @@ public struct BadRemoteCall_notPublic: DistributedActorSystem {
   }
 }
 
-public struct BadRemoteCall_badResultConformance: DistributedActorSystem { // expected-error {{type 'BadRemoteCall_badResultConformance' does not conform to protocol 'DistributedActorSystem'}}
-  // expected-error@-1{{struct 'BadRemoteCall_badResultConformance' is missing witness for protocol requirement 'remoteCall'}}
+public struct BadRemoteCall_badResultConformance: DistributedActorSystem { 
+  // expected-error@-1{{type 'BadRemoteCall_badResultConformance' does not conform to protocol 'DistributedActorSystem'}}
   // expected-note@-2{{add stubs for conformance}}
+  // expected-error@-3{{struct 'BadRemoteCall_badResultConformance' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-4{{add stubs for conformance}}
 
   public typealias ActorID = ActorAddress
   public typealias InvocationDecoder = PublicFakeInvocationDecoder
@@ -523,9 +531,11 @@ struct BadRemoteCall_largeSerializationRequirement: DistributedActorSystem {
   }
 }
 
-struct BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition: DistributedActorSystem { // expected-error {{type 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' does not conform to protocol 'DistributedActorSystem'}}
-  // expected-error@-1{{struct 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' is missing witness for protocol requirement 'remoteCall'}}
+struct BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition: DistributedActorSystem { 
+  // expected-error@-1{{type 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' does not conform to protocol 'DistributedActorSystem'}}
   // expected-note@-2{{add stubs for conformance}}
+  // expected-error@-3{{struct 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-4{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = LargeSerializationReqFakeInvocationDecoder
@@ -680,9 +690,11 @@ public struct PublicFakeInvocationEncoder: DistributedTargetInvocationEncoder {
   public mutating func doneRecording() throws {}
 }
 
-struct FakeInvocationEncoder_missing_recordArgument: DistributedTargetInvocationEncoder { // expected-error {{type 'FakeInvocationEncoder_missing_recordArgument' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
-  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument' is missing witness for protocol requirement 'recordArgument'}}
+struct FakeInvocationEncoder_missing_recordArgument: DistributedTargetInvocationEncoder { 
+  //expected-error@-1{{type 'FakeInvocationEncoder_missing_recordArgument' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
   //expected-note@-2{{add stubs for conformance}}
+  //expected-error@-3{{struct 'FakeInvocationEncoder_missing_recordArgument' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-4{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -692,9 +704,11 @@ struct FakeInvocationEncoder_missing_recordArgument: DistributedTargetInvocation
   mutating func doneRecording() throws {}
 }
 
-struct FakeInvocationEncoder_missing_recordArgument2: DistributedTargetInvocationEncoder { // expected-error {{type 'FakeInvocationEncoder_missing_recordArgument2' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
-  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument2' is missing witness for protocol requirement 'recordArgument'}}
+struct FakeInvocationEncoder_missing_recordArgument2: DistributedTargetInvocationEncoder { 
+  //expected-error@-1{{type 'FakeInvocationEncoder_missing_recordArgument2' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
   //expected-note@-2{{add stubs for conformance}}
+  //expected-error@-3{{struct 'FakeInvocationEncoder_missing_recordArgument2' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-4{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -705,9 +719,11 @@ struct FakeInvocationEncoder_missing_recordArgument2: DistributedTargetInvocatio
   mutating func doneRecording() throws {}
 }
 
-struct FakeInvocationEncoder_missing_recordReturnType: DistributedTargetInvocationEncoder { // expected-error {{type 'FakeInvocationEncoder_missing_recordReturnType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
-  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordReturnType' is missing witness for protocol requirement 'recordReturnType'}}
+struct FakeInvocationEncoder_missing_recordReturnType: DistributedTargetInvocationEncoder { 
+  //expected-error@-1{{type 'FakeInvocationEncoder_missing_recordReturnType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
   //expected-note@-2{{add stubs for conformance}}
+  //expected-error@-3{{struct 'FakeInvocationEncoder_missing_recordReturnType' is missing witness for protocol requirement 'recordReturnType'}}
+  //expected-note@-4{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -719,6 +735,7 @@ struct FakeInvocationEncoder_missing_recordReturnType: DistributedTargetInvocati
 
 struct FakeInvocationEncoder_missing_recordErrorType: DistributedTargetInvocationEncoder {
   //expected-error@-1{{type 'FakeInvocationEncoder_missing_recordErrorType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
+  //expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -728,9 +745,11 @@ struct FakeInvocationEncoder_missing_recordErrorType: DistributedTargetInvocatio
   mutating func doneRecording() throws {}
 }
 
-struct FakeInvocationEncoder_recordArgument_wrongType: DistributedTargetInvocationEncoder { // expected-error {{type 'FakeInvocationEncoder_recordArgument_wrongType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
-  //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_wrongType' is missing witness for protocol requirement 'recordArgument'}}
+struct FakeInvocationEncoder_recordArgument_wrongType: DistributedTargetInvocationEncoder { 
+  //expected-error@-1{{type 'FakeInvocationEncoder_recordArgument_wrongType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
   //expected-note@-2{{add stubs for conformance}}
+  //expected-error@-3{{struct 'FakeInvocationEncoder_recordArgument_wrongType' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-4{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -742,9 +761,11 @@ struct FakeInvocationEncoder_recordArgument_wrongType: DistributedTargetInvocati
   mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
   mutating func doneRecording() throws {}
 }
-struct FakeInvocationEncoder_recordArgument_missingMutating: DistributedTargetInvocationEncoder { // expected-error {{type 'FakeInvocationEncoder_recordArgument_missingMutating' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
-  //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_missingMutating' is missing witness for protocol requirement 'recordArgument'}}
+struct FakeInvocationEncoder_recordArgument_missingMutating: DistributedTargetInvocationEncoder { 
+  //expected-error@-1{{type 'FakeInvocationEncoder_recordArgument_missingMutating' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
   //expected-note@-2{{add stubs for conformance}}
+  //expected-error@-3{{struct 'FakeInvocationEncoder_recordArgument_missingMutating' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-4{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -755,9 +776,11 @@ struct FakeInvocationEncoder_recordArgument_missingMutating: DistributedTargetIn
   mutating func doneRecording() throws {}
 }
 
-struct FakeInvocationEncoder_recordResultType_wrongType: DistributedTargetInvocationEncoder { // expected-error {{type 'FakeInvocationEncoder_recordResultType_wrongType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
-  //expected-error@-1{{struct 'FakeInvocationEncoder_recordResultType_wrongType' is missing witness for protocol requirement 'recordReturnType'}}
+struct FakeInvocationEncoder_recordResultType_wrongType: DistributedTargetInvocationEncoder { 
+  //expected-error@-1 {{type 'FakeInvocationEncoder_recordResultType_wrongType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
   //expected-note@-2{{add stubs for conformance}}
+  //expected-error@-3{{struct 'FakeInvocationEncoder_recordResultType_wrongType' is missing witness for protocol requirement 'recordReturnType'}}
+  //expected-note@-4{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -772,6 +795,7 @@ struct FakeInvocationEncoder_recordResultType_wrongType: DistributedTargetInvoca
 
 struct FakeInvocationEncoder_recordErrorType_wrongType: DistributedTargetInvocationEncoder {
   //expected-error@-1{{type 'FakeInvocationEncoder_recordErrorType_wrongType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
+  //expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -835,9 +859,11 @@ public final class PublicFakeInvocationDecoder_badNotPublic: DistributedTargetIn
   // expected-note@-2{{mark the instance method as 'public' to satisfy the requirement}}
 }
 
-final class PublicFakeInvocationDecoder_badBadProtoRequirement: DistributedTargetInvocationDecoder { // expected-error {{type 'PublicFakeInvocationDecoder_badBadProtoRequirement' does not conform to protocol 'DistributedTargetInvocationDecoder'}}
-  // expected-error@-1{{class 'PublicFakeInvocationDecoder_badBadProtoRequirement' is missing witness for protocol requirement 'decodeNextArgument'}}
+final class PublicFakeInvocationDecoder_badBadProtoRequirement: DistributedTargetInvocationDecoder { 
+  // expected-error@-1{{type 'PublicFakeInvocationDecoder_badBadProtoRequirement' does not conform to protocol 'DistributedTargetInvocationDecoder'}}
   // expected-note@-2{{add stubs for conformance}}
+  // expected-error@-3{{class 'PublicFakeInvocationDecoder_badBadProtoRequirement' is missing witness for protocol requirement 'decodeNextArgument'}}
+  // expected-note@-4{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
@@ -888,9 +914,11 @@ struct LargeSerializationReqFakeInvocationResultHandler: DistributedTargetInvoca
   }
 }
 
-struct BadResultHandler_missingOnReturn: DistributedTargetInvocationResultHandler { // expected-error {{type 'BadResultHandler_missingOnReturn' does not conform to protocol 'DistributedTargetInvocationResultHandler'}}
-  // expected-error@-1{{struct 'BadResultHandler_missingOnReturn' is missing witness for protocol requirement 'onReturn'}}
+struct BadResultHandler_missingOnReturn: DistributedTargetInvocationResultHandler { 
+  // expected-error@-1{{type 'BadResultHandler_missingOnReturn' does not conform to protocol 'DistributedTargetInvocationResultHandler'}}
   // expected-note@-2{{add stubs for conformance}}{{84-84=\nfunc onReturn<Success: SerializationRequirement>(value: Success) async throws {\n    <#code#>\n\}\n}}
+  // expected-error@-3{{struct 'BadResultHandler_missingOnReturn' is missing witness for protocol requirement 'onReturn'}}
+  // expected-note@-4{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   // func onReturn<Res: SerializationRequirement>(value: Res) async throws {} // MISSING
@@ -908,9 +936,11 @@ struct BadResultHandler_missingRequirement: DistributedTargetInvocationResultHan
   func onThrow<Err: Error>(error: Err) async throws {}
 }
 
-struct BadResultHandler_mutatingButShouldNotBe: DistributedTargetInvocationResultHandler { // expected-error {{type 'BadResultHandler_mutatingButShouldNotBe' does not conform to protocol 'DistributedTargetInvocationResultHandler'}}
-  // expected-error@-1{{struct 'BadResultHandler_mutatingButShouldNotBe' is missing witness for protocol requirement 'onReturn'}}
+struct BadResultHandler_mutatingButShouldNotBe: DistributedTargetInvocationResultHandler { 
+  // expected-error@-1 {{type 'BadResultHandler_mutatingButShouldNotBe' does not conform to protocol 'DistributedTargetInvocationResultHandler'}}
   // expected-note@-2{{add stubs for conformance}}
+  // expected-error@-3{{struct 'BadResultHandler_mutatingButShouldNotBe' is missing witness for protocol requirement 'onReturn'}}
+  // expected-note@-4{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   // expected-note@+1 {{candidate is marked 'mutating' but protocol does not allow it}}

--- a/test/Distributed/distributed_actor_system_missing_system_type.swift
+++ b/test/Distributed/distributed_actor_system_missing_system_type.swift
@@ -13,6 +13,7 @@ distributed actor MyActor {
   // expected-error@-1{{distributed actor 'MyActor' does not declare ActorSystem it can be used with}}
   // expected-note@-2{{you can provide a module-wide default actor system by declaring:}}
   // expected-error@-3{{type 'MyActor' does not conform to protocol 'DistributedActor'}}
+  // expected-note@-4 {{add stubs for conformance}}
 
   distributed var foo: String {
     return "xyz"
@@ -23,6 +24,7 @@ distributed actor BadSystemActor {
   // expected-error@-1{{distributed actor 'BadSystemActor' does not declare ActorSystem it can be used with}}
   // expected-note@-2{{you can provide a module-wide default actor system by declaring:}}
   // expected-error@-3{{type 'BadSystemActor' does not conform to protocol 'DistributedActor'}}
+  // expected-note@-4 {{add stubs for conformance}}
 
   // This system does not exist: but we should not crash, but just diagnose about it:
   typealias ActorSystem = ClusterSystem // expected-error{{cannot find type 'ClusterSystem' in scope}}

--- a/test/Distributed/distributed_actor_system_missing_type_no_crash.swift
+++ b/test/Distributed/distributed_actor_system_missing_type_no_crash.swift
@@ -12,6 +12,7 @@ distributed actor Fish {
   // expected-error@-2{{distributed actor 'Fish' does not declare ActorSystem it can be used with}}
   // expected-error@-3{{type 'Fish' does not conform to protocol 'DistributedActor'}}
   // expected-note@-4{{you can provide a module-wide default actor system by declaring:\ntypealias DefaultDistributedActorSystem = <#ConcreteActorSystem#>}}
+  // expected-note@-5 {{add stubs for conformance}}
 
   distributed func tell(_ text: String, by: Fish) {
     // What would the fish say, if it could talk?

--- a/test/Distributed/distributed_incomplete_system_no_crash.swift
+++ b/test/Distributed/distributed_incomplete_system_no_crash.swift
@@ -12,6 +12,7 @@ public final class CompletelyHollowActorSystem: DistributedActorSystem {
   // expected-error@-3{{class 'CompletelyHollowActorSystem' is missing witness for protocol requirement 'remoteCall'}}
   // expected-note@-4{{add stubs for conformance}}
   // expected-error@-5{{class 'CompletelyHollowActorSystem' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-6{{add stubs for conformance}}  
 
   public typealias ActorID = String
   public typealias InvocationEncoder = Encoder
@@ -36,16 +37,18 @@ public final class CompletelyHollowActorSystem: DistributedActorSystem {
 
   public struct ResultHandler: DistributedTargetInvocationResultHandler {
     // expected-error@-1{{type 'CompletelyHollowActorSystem.ResultHandler' does not conform to protocol 'DistributedTargetInvocationResultHandler'}}
-    // expected-error@-2{{struct 'ResultHandler' is missing witness for protocol requirement 'onReturn'}}
-    // expected-note@-3{{add stubs for conformance}}
+    // expected-note@-2{{add stubs for conformance}}  
+    // expected-error@-3{{struct 'ResultHandler' is missing witness for protocol requirement 'onReturn'}}
+    // expected-note@-4{{add stubs for conformance}}
   }
 
 }
 
 public final class CompletelyHollowActorSystem_NotEvenTypes: DistributedActorSystem {
   // expected-error@-1{{type 'CompletelyHollowActorSystem_NotEvenTypes' does not conform to protocol 'DistributedActorSystem'}}
-  // expected-error@-2{{class 'CompletelyHollowActorSystem_NotEvenTypes' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-error@-3{{class 'CompletelyHollowActorSystem_NotEvenTypes' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-4{{add stubs for conformance}}
-  // expected-note@-5{{add stubs for conformance}}
+  // expected-note@-2{{add stubs for conformance}}
+  // expected-error@-3{{class 'CompletelyHollowActorSystem_NotEvenTypes' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-4{{add stubs for conformance}}  
+  // expected-error@-5{{class 'CompletelyHollowActorSystem_NotEvenTypes' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-6{{add stubs for conformance}}
 }

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -53,6 +53,7 @@ distributed actor ProtocolWithChecksSeqReqDA_MissingSystem: ProtocolWithChecksSe
   // expected-error@-4{{distributed actor 'ProtocolWithChecksSeqReqDA_MissingSystem' does not declare ActorSystem it can be used with}}
   //
   // expected-error@-6{{type 'ProtocolWithChecksSeqReqDA_MissingSystem' does not conform to protocol 'DistributedActor'}}
+  // expected-note@-7 {{add stubs for conformance}}
 
   // Entire conformance is doomed, so we didn't proceed to checking the functions; that's fine
   distributed func testAT() async throws -> NotCodable { .init() }

--- a/test/Distributed/distributed_serializationRequirement_must_be_protocol.swift
+++ b/test/Distributed/distributed_serializationRequirement_must_be_protocol.swift
@@ -20,6 +20,7 @@ final class System: DistributedActorSystem {
   // expected-error@-4{{class 'System' is missing witness for protocol requirement 'remoteCall'}}
   // expected-note@-5{{add stubs for conformance}}
   // expected-error@-6{{class 'System' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-7{{add stubs for conformance}}
   typealias ActorID = String
   typealias InvocationEncoder = ClassInvocationEncoder
   typealias InvocationDecoder = ClassInvocationDecoder
@@ -82,10 +83,11 @@ final class System: DistributedActorSystem {
 }
 
 struct ClassInvocationEncoder: DistributedTargetInvocationEncoder { // expected-error {{type 'ClassInvocationEncoder' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
-  // expected-error@-1{{struct 'ClassInvocationEncoder' is missing witness for protocol requirement 'recordArgument'}}
-  // expected-note@-2{{add stubs for conformance}}
-  // expected-error@-3{{struct 'ClassInvocationEncoder' is missing witness for protocol requirement 'recordReturnType'}}
-  // expected-note@-4{{add stubs for conformance}}
+  // expected-note@-1{{add stubs for conformance}}
+  // expected-error@-2{{struct 'ClassInvocationEncoder' is missing witness for protocol requirement 'recordArgument'}}
+  // expected-note@-3{{add stubs for conformance}}
+  // expected-error@-4{{struct 'ClassInvocationEncoder' is missing witness for protocol requirement 'recordReturnType'}}
+  // expected-note@-5{{add stubs for conformance}}
   typealias SerializationRequirement = SomeClazz
 
   public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -99,8 +101,9 @@ struct ClassInvocationEncoder: DistributedTargetInvocationEncoder { // expected-
 }
 
 final class ClassInvocationDecoder: DistributedTargetInvocationDecoder { // expected-error {{type 'ClassInvocationDecoder' does not conform to protocol 'DistributedTargetInvocationDecoder'}}
-  // expected-error@-1{{class 'ClassInvocationDecoder' is missing witness for protocol requirement 'decodeNextArgument'}}
-  // expected-note@-2{{add stubs for conformance}}
+  // expected-note@-1{{add stubs for conformance}}
+  // expected-error@-2{{class 'ClassInvocationDecoder' is missing witness for protocol requirement 'decodeNextArgument'}}
+  // expected-note@-3{{add stubs for conformance}}
   typealias SerializationRequirement = SomeClazz
 
   public func decodeGenericSubstitutions() throws -> [Any.Type] {

--- a/test/Generics/associated_type_where_clause.swift
+++ b/test/Generics/associated_type_where_clause.swift
@@ -22,7 +22,7 @@ struct ConcreteConforms2: Conforms { typealias T = Int }
 struct ConcreteConformsNonFoo2: Conforms { typealias T = Float }
 
 protocol NestedConforms {
-    associatedtype U where U: Conforms, U.T: Foo2 // expected-note{{protocol requires nested type 'U'; add nested type 'U' for conformance}}
+    associatedtype U where U: Conforms, U.T: Foo2 // expected-note{{protocol requires nested type 'U'}}
 
     func foo(_: U)
 }
@@ -45,6 +45,7 @@ struct BadConcreteNestedConforms: NestedConforms {
 }
 struct BadConcreteNestedConformsInfer: NestedConforms {
     // expected-error@-1 {{type 'BadConcreteNestedConformsInfer' does not conform to protocol 'NestedConforms'}}
+    // expected-note@-2{{add stubs for conformance}}
     func foo(_: ConcreteConformsNonFoo2) {}
 }
 
@@ -62,7 +63,7 @@ func needsNestedConformsDefault<X: NestedConformsDefault>(_: X.Type) {
 }
 
 protocol NestedSameType {
-    associatedtype U: Conforms where U.T == Int // expected-note{{protocol requires nested type 'U'; add nested type 'U' for conformance}}
+    associatedtype U: Conforms where U.T == Int // expected-note{{protocol requires nested type 'U'}}
 
     func foo(_: U)
 }
@@ -80,6 +81,7 @@ struct BadConcreteNestedSameType: NestedSameType {
 }
 struct BadConcreteNestedSameTypeInfer: NestedSameType {
     // expected-error@-1 {{type 'BadConcreteNestedSameTypeInfer' does not conform to protocol 'NestedSameType'}}
+    // expected-note@-2{{add stubs for conformance}}
     func foo(_: ConcreteConformsNonFoo2) {}
 }
 

--- a/test/Generics/constrained_type_witnesses.swift
+++ b/test/Generics/constrained_type_witnesses.swift
@@ -2,7 +2,7 @@
 
 protocol P {
   associatedtype A
-  // expected-note@-1 5{{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  // expected-note@-1 5{{protocol requires nested type 'A'}}
 }
 
 struct S1<T> {}
@@ -14,13 +14,16 @@ extension S1 where T : P {
 // This is rejected because S1.A is not a suitable witness for P.A.
 extension S1 : P {}
 // expected-error@-1 {{type 'S1<T>' does not conform to protocol 'P'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 struct S2<T> {}
 
 extension S2 where T : P {
   typealias A = Never
 }
-extension S2 : P {} // expected-error {{type 'S2<T>' does not conform to protocol 'P'}}
+extension S2 : P {} 
+// expected-error@-1 {{type 'S2<T>' does not conform to protocol 'P'}} 
+// expected-note@-2 {{add stubs for conformance}}
 
 // Here we have a suitable witness
 struct S3<T> {}
@@ -39,12 +42,15 @@ struct S4<T> {
 
 extension S4 : P {}
 // expected-error@-1 {{type 'S4<T>' does not conform to protocol 'P'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 struct S5<T> {
   typealias A = Never where T : P
 }
 
-extension S5 : P {} // expected-error {{type 'S5<T>' does not conform to protocol 'P'}}
+extension S5 : P {} 
+// expected-error@-1 {{type 'S5<T>' does not conform to protocol 'P'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 struct S6<T> {
   typealias A = Int where T == Int
@@ -67,5 +73,6 @@ struct S7 : Q, P {
 
 struct S8 : Q, P {
 // expected-error@-1 {{type 'S8' does not conform to protocol 'P'}}
+// expected-note@-2 {{add stubs for conformance}}
   typealias B = String
 }

--- a/test/Generics/inheritance.swift
+++ b/test/Generics/inheritance.swift
@@ -56,11 +56,11 @@ func testGenericInherit() {
 
 
 struct SS<T> : T { } // expected-error{{inheritance from non-protocol type 'T'}}
-enum SE<T> : T { case X } // expected-error{{raw type 'T' is not expressible by a string, integer, or floating-point literal}} // expected-error {{SE<T>' declares raw type 'T', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error{{RawRepresentable conformance cannot be synthesized because raw type 'T' is not Equatable}} 
+enum SE<T> : T { case X } // expected-error{{raw type 'T' is not expressible by a string, integer, or floating-point literal}} // expected-error {{SE<T>' declares raw type 'T', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error{{RawRepresentable conformance cannot be synthesized because raw type 'T' is not Equatable}} expected-note {{add stubs for conformance}}
 
 // Also need Equatable for init?(RawValue)
 enum SE2<T : ExpressibleByIntegerLiteral> 
-  : T // expected-error {{'SE2<T>' declares raw type 'T', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error{{RawRepresentable conformance cannot be synthesized because raw type 'T' is not Equatable}}
+  : T // expected-error {{'SE2<T>' declares raw type 'T', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error{{RawRepresentable conformance cannot be synthesized because raw type 'T' is not Equatable}} expected-note@-1 {{add stubs for conformance}}
 { case X }
 
 // ... but not if init?(RawValue) and `rawValue` are directly implemented some other way.

--- a/test/Generics/inverse_copyable_requirement.swift
+++ b/test/Generics/inverse_copyable_requirement.swift
@@ -259,14 +259,14 @@ func copyableExistentials(_ a: Any, _ e1: Error, _ e2: any Error, _ ah: AnyHasha
 // ensure that associated types can't be witnessed by move-only types
 
 protocol HasType<Ty> {
-  associatedtype Ty // expected-note 3{{protocol requires nested type 'Ty'; add nested type 'Ty' for conformance}}
+  associatedtype Ty // expected-note 3{{protocol requires nested type 'Ty'}}
 }
 
-class SomeGuy: HasType { // expected-error {{type 'SomeGuy' does not conform to protocol 'HasType'}}
+class SomeGuy: HasType { // expected-error {{type 'SomeGuy' does not conform to protocol 'HasType'}} expected-note {{add stubs for conformance}}
   typealias Ty = MO // expected-note {{possibly intended match 'SomeGuy.Ty' (aka 'MO') does not conform to 'Copyable'}}
 }
 
-struct AnotherGuy: HasType { // expected-error {{type 'AnotherGuy' does not conform to protocol 'HasType'}}
+struct AnotherGuy: HasType { // expected-error {{type 'AnotherGuy' does not conform to protocol 'HasType'}} expected-note {{add stubs for conformance}}
   struct Ty: ~Copyable {} // expected-note {{possibly intended match 'AnotherGuy.Ty' does not conform to 'Copyable'}}
 }
 
@@ -274,7 +274,7 @@ protocol Gives: HasType {
   func give() -> Ty
 }
 
-struct GenerousGuy: Gives { // expected-error {{type 'GenerousGuy' does not conform to protocol 'HasType'}}
+struct GenerousGuy: Gives { // expected-error {{type 'GenerousGuy' does not conform to protocol 'HasType'}} expected-note {{add stubs for conformance}}
   typealias Ty = MO // expected-note {{possibly intended match 'GenerousGuy.Ty' (aka 'MO') does not conform to 'Copyable'}}
   func give() -> Ty {}
 }

--- a/test/Generics/issue-69318.swift
+++ b/test/Generics/issue-69318.swift
@@ -8,7 +8,7 @@ public protocol View {
 
 public protocol ViewGraphNodeChildren {
     associatedtype ParentView: View where ParentView.NodeChildren == Self
-    // expected-note@-1 {{protocol requires nested type 'ParentView'; add nested type 'ParentView' for conformance}}
+    // expected-note@-1 {{protocol requires nested type 'ParentView'}}
 }
 
 public protocol ChildlessView: View where NodeChildren == EmptyViewGraphNodeChildren<Self> {}
@@ -17,3 +17,4 @@ public protocol ChildlessView: View where NodeChildren == EmptyViewGraphNodeChil
 public struct EmptyViewGraphNodeChildren<ParentView: ChildlessView>: ViewGraphNodeChildren {}
 // expected-note@-1 3{{through reference here}}
 // expected-error@-2 {{type 'EmptyViewGraphNodeChildren<ParentView>' does not conform to protocol 'ViewGraphNodeChildren'}}
+// expected-note@-3 {{add stubs for conformance}}

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -117,19 +117,19 @@ enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} //
 // NO-TYREPR: {{^}}enum EnumWithInheritance2 : <<error type>>, <<error type>> {{{$}}
 // TYREPR: {{^}}enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
 
-enum EnumWithInheritance3 : FooClass { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} 
+enum EnumWithInheritance3 : FooClass { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} expected-note {{add stubs for conformance}}
 // expected-error@-1{{'EnumWithInheritance3' declares raw type 'FooClass', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2{{RawRepresentable conformance cannot be synthesized because raw type 'FooClass' is not Equatable}}
 // NO-TYREPR: {{^}}enum EnumWithInheritance3 : <<error type>> {{{$}}
 // TYREPR: {{^}}enum EnumWithInheritance3 : FooClass {{{$}}
 
-enum EnumWithInheritance4 : FooClass, FooProtocol { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} 
+enum EnumWithInheritance4 : FooClass, FooProtocol { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} expected-note {{add stubs for conformance}}
 // expected-error@-1{{'EnumWithInheritance4' declares raw type 'FooClass', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2{{RawRepresentable conformance cannot be synthesized because raw type 'FooClass' is not Equatable}}
 // NO-TYREPR: {{^}}enum EnumWithInheritance4 : <<error type>>, FooProtocol {{{$}}
 // TYREPR: {{^}}enum EnumWithInheritance4 : FooClass, FooProtocol {{{$}}
 
-enum EnumWithInheritance5 : FooClass, BarClass { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} expected-error {{multiple enum raw types 'FooClass' and 'BarClass'}} 
+enum EnumWithInheritance5 : FooClass, BarClass { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} expected-error {{multiple enum raw types 'FooClass' and 'BarClass'}} expected-note {{add stubs for conformance}}
 // expected-error@-1{{'EnumWithInheritance5' declares raw type 'FooClass', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2{{RawRepresentable conformance cannot be synthesized because raw type 'FooClass' is not Equatable}}
 // NO-TYREPR: {{^}}enum EnumWithInheritance5 : <<error type>>, <<error type>> {{{$}}

--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -17,7 +17,7 @@ extension ConformsToProtocol : HasReturn42 {}
 extension HasVirtualMethod : HasReturn42 {}
 #endif
 
-extension DoesNotConformToProtocol : HasReturn42 {} // expected-error {{'DoesNotConformToProtocol' does not conform to protocol}}
+extension DoesNotConformToProtocol : HasReturn42 {} // expected-error {{'DoesNotConformToProtocol' does not conform to protocol}} expected-note {{add stubs for conformance}}
 
 
 protocol HasReturnNullable {

--- a/test/NameLookup/accessibility.swift
+++ b/test/NameLookup/accessibility.swift
@@ -104,10 +104,10 @@ protocol MethodProto {
 
 extension OriginallyEmpty : MethodProto {}
 #if !ACCESS_DISABLED
-extension HiddenMethod : MethodProto {} // expected-error {{type 'HiddenMethod' does not conform to protocol 'MethodProto'}}
+extension HiddenMethod : MethodProto {} // expected-error {{type 'HiddenMethod' does not conform to protocol 'MethodProto'}} expected-note {{add stubs for conformance}}
 // TESTABLE-NOT: :[[@LINE-1]]:{{[^:]+}}:
 
-extension Foo : MethodProto {} // expected-error {{type 'Foo' does not conform to protocol 'MethodProto'}}
+extension Foo : MethodProto {} // expected-error {{type 'Foo' does not conform to protocol 'MethodProto'}} expected-note {{add stubs for conformance}}
 #endif
 
 
@@ -117,10 +117,10 @@ protocol TypeProto {
 
 extension OriginallyEmpty {}
 #if !ACCESS_DISABLED
-extension HiddenType : TypeProto {} // expected-error {{type 'HiddenType' does not conform to protocol 'TypeProto'}}
+extension HiddenType : TypeProto {} // expected-error {{type 'HiddenType' does not conform to protocol 'TypeProto'}} expected-note {{add stubs for conformance}}
 // TESTABLE-NOT: :[[@LINE-1]]:{{[^:]+}}:
 
-extension Foo : TypeProto {} // expected-error {{type 'Foo' does not conform to protocol 'TypeProto'}}
+extension Foo : TypeProto {} // expected-error {{type 'Foo' does not conform to protocol 'TypeProto'}} expected-note {{add stubs for conformance}}
 #endif
 
 
@@ -157,8 +157,8 @@ public protocol Fooable {
 }
 
 #if !ACCESS_DISABLED
-internal struct FooImpl: Fooable, HasDefaultImplementation {} // expected-error {{type 'FooImpl' does not conform to protocol 'Fooable'}}
-public struct PublicFooImpl: Fooable, HasDefaultImplementation {} // expected-error {{type 'PublicFooImpl' does not conform to protocol 'Fooable'}}
+internal struct FooImpl: Fooable, HasDefaultImplementation {} // expected-error {{type 'FooImpl' does not conform to protocol 'Fooable'}} expected-note {{add stubs for conformance}}
+public struct PublicFooImpl: Fooable, HasDefaultImplementation {} // expected-error {{type 'PublicFooImpl' does not conform to protocol 'Fooable'}} expected-note {{add stubs for conformance}}
 // TESTABLE-NOT: method 'foo()'
 
 internal class TestableSub: InternalBase {} // expected-error {{cannot find type 'InternalBase' in scope}}

--- a/test/NameLookup/members_transitive.swift
+++ b/test/NameLookup/members_transitive.swift
@@ -74,4 +74,4 @@ class DerivedFromClassInC: DerivedClassInC {
   override func methodInC() {}
 }
 
-struct ConformsToProtocolInA: ProtocolInA {} // expected-member-visibility-error{{type 'ConformsToProtocolInA' does not conform to protocol 'ProtocolInA'}}
+struct ConformsToProtocolInA: ProtocolInA {} // expected-member-visibility-error{{type 'ConformsToProtocolInA' does not conform to protocol 'ProtocolInA'}} expected-member-visibility-note {{add stubs for conformance}}

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -122,7 +122,7 @@ enum Recovery6 {
   case Tusk, // expected-error {{expected identifier after comma in enum 'case' declaration}}
 } 
 
-enum RawTypeEmpty : Int {} // expected-error {{an enum with no cases cannot declare a raw type}}
+enum RawTypeEmpty : Int {} // expected-error {{an enum with no cases cannot declare a raw type}} expected-note {{add stubs for conformance}}
 // expected-error@-1{{'RawTypeEmpty' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
 
 enum Raw : Int {
@@ -138,7 +138,7 @@ enum RawTypeNotFirst : RawTypeNotFirstProtocol, Int { // expected-error {{raw ty
   case E
 }
 
-enum ExpressibleByRawTypeNotLiteral : Array<Int> { // expected-error {{raw type 'Array<Int>' is not expressible by a string, integer, or floating-point literal}}
+enum ExpressibleByRawTypeNotLiteral : Array<Int> { // expected-error {{raw type 'Array<Int>' is not expressible by a string, integer, or floating-point literal}} expected-note {{add stubs for conformance}}
   // expected-error@-1{{'ExpressibleByRawTypeNotLiteral' declares raw type 'Array<Int>', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case Ladd, Elliott, Sixteenth, Harrison
 }
@@ -162,7 +162,7 @@ enum RawTypeCircularityB : RawTypeCircularityA, ExpressibleByIntegerLiteral { //
 struct ExpressibleByFloatLiteralOnly : ExpressibleByFloatLiteral {
     init(floatLiteral: Double) {}
 }
-enum ExpressibleByRawTypeNotIntegerLiteral : ExpressibleByFloatLiteralOnly { // expected-error {{'ExpressibleByRawTypeNotIntegerLiteral' declares raw type 'ExpressibleByFloatLiteralOnly', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error {{RawRepresentable conformance cannot be synthesized because raw type 'ExpressibleByFloatLiteralOnly' is not Equatable}}
+enum ExpressibleByRawTypeNotIntegerLiteral : ExpressibleByFloatLiteralOnly { // expected-error {{'ExpressibleByRawTypeNotIntegerLiteral' declares raw type 'ExpressibleByFloatLiteralOnly', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error {{RawRepresentable conformance cannot be synthesized because raw type 'ExpressibleByFloatLiteralOnly' is not Equatable}} expected-note {{add stubs for conformance}}
   case Everett // expected-error {{enum cases require explicit raw values when the raw type is not expressible by integer or string literal}}
   case Flanders
 }
@@ -176,13 +176,13 @@ enum RawTypeWithNegativeValues : Int {
   case AutoIncAcrossZero = -1, Zero, One
 }
 
-enum RawTypeWithUnicodeScalarValues : UnicodeScalar { // expected-error {{'RawTypeWithUnicodeScalarValues' declares raw type 'UnicodeScalar' (aka 'Unicode.Scalar'), but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum RawTypeWithUnicodeScalarValues : UnicodeScalar { // expected-error {{'RawTypeWithUnicodeScalarValues' declares raw type 'UnicodeScalar' (aka 'Unicode.Scalar'), but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case Kearney = "K"
   case Lovejoy // expected-error {{enum cases require explicit raw values when the raw type is not expressible by integer or string literal}}
   case Marshall = "M"
 }
 
-enum RawTypeWithCharacterValues : Character { // expected-error {{'RawTypeWithCharacterValues' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum RawTypeWithCharacterValues : Character { // expected-error {{'RawTypeWithCharacterValues' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case First = "い"
   case Second // expected-error {{enum cases require explicit raw values when the raw type is not expressible by integer or string literal}}
   case Third = "は"
@@ -195,7 +195,7 @@ enum RawTypeWithCharacterValues_Correct : Character {
   case Fourth = "\u{1F3F4}\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}" // ok
 }
 
-enum RawTypeWithCharacterValues_Error1 : Character { // expected-error {{'RawTypeWithCharacterValues_Error1' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum RawTypeWithCharacterValues_Error1 : Character { // expected-error {{'RawTypeWithCharacterValues_Error1' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case First = "abc" // expected-error {{cannot convert value of type 'String' to raw type 'Character'}}
 }
 
@@ -240,12 +240,12 @@ enum NonliteralRawValue : Int {
   case Yeon = 100 + 20 + 3 // expected-error {{raw value for enum case must be a literal}}
 }
 
-enum RawTypeWithPayload : Int { // expected-error {{'RawTypeWithPayload' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{declared raw type 'Int' here}} expected-note {{declared raw type 'Int' here}}
+enum RawTypeWithPayload : Int { // expected-error {{'RawTypeWithPayload' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{declared raw type 'Int' here}} expected-note {{declared raw type 'Int' here}} expected-note {{add stubs for conformance}}
   case Powell(Int) // expected-error {{enum with raw type cannot have cases with arguments}}
   case Terwilliger(Int) = 17 // expected-error {{enum with raw type cannot have cases with arguments}}
 }
 
-enum RawTypeMismatch : Int { // expected-error {{'RawTypeMismatch' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum RawTypeMismatch : Int { // expected-error {{'RawTypeMismatch' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case Barbur = "foo" // expected-error {{}}
 }
 
@@ -265,12 +265,12 @@ enum DuplicateMembers3 {
   case Foo(Int) // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
-enum DuplicateMembers4 : Int { // expected-error {{'DuplicateMembers4' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum DuplicateMembers4 : Int { // expected-error {{'DuplicateMembers4' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case Foo = 1 // expected-note {{'Foo' previously declared here}}
   case Foo = 2 // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
-enum DuplicateMembers5 : Int { // expected-error {{'DuplicateMembers5' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum DuplicateMembers5 : Int { // expected-error {{'DuplicateMembers5' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case Foo = 1 // expected-note {{'Foo' previously declared here}}
   case Foo = 1 + 1 // expected-error {{invalid redeclaration of 'Foo'}} expected-error {{raw value for enum case must be a literal}}
 }
@@ -281,19 +281,19 @@ enum DuplicateMembers6 {
   case Foo // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
-enum DuplicateMembers7 : String { // expected-error {{'DuplicateMembers7' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum DuplicateMembers7 : String { // expected-error {{'DuplicateMembers7' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case Foo // expected-note {{'Foo' previously declared here}}
   case Foo = "Bar" // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
-enum DuplicateMembers8 : String { // expected-error {{'DuplicateMembers8' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum DuplicateMembers8 : String { // expected-error {{'DuplicateMembers8' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case Foo // expected-note {{'Foo' previously declared here}}
   // expected-note@-1 {{raw value previously used here}}
   case Foo // expected-error {{invalid redeclaration of 'Foo'}}
   // expected-error@-1 {{raw value for enum case is not unique}}
 }
 
-enum DuplicateMembers9 : String { // expected-error {{'DuplicateMembers9' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum DuplicateMembers9 : String { // expected-error {{'DuplicateMembers9' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case Foo = "Foo" // expected-note {{'Foo' previously declared here}}
   // expected-note@-1 {{raw value previously used here}}
   case Foo = "Foo"// expected-error {{invalid redeclaration of 'Foo'}}
@@ -352,7 +352,7 @@ enum ManyLiteralA : ManyLiteralable {
   case B = 0 // expected-error {{raw value for enum case is not unique}}
 }
 
-enum ManyLiteralB : ManyLiteralable { // expected-error {{'ManyLiteralB' declares raw type 'ManyLiteralable', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum ManyLiteralB : ManyLiteralable { // expected-error {{'ManyLiteralB' declares raw type 'ManyLiteralable', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case A = "abc"
   case B // expected-error {{enum case must declare a raw value when the preceding raw value is not an integer}}
 }
@@ -362,7 +362,7 @@ enum ManyLiteralC : ManyLiteralable {
   case B = "0"
 }
 
-enum foo : String { // expected-error {{'foo' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum foo : String { // expected-error {{'foo' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case bar = nil // expected-error {{cannot convert 'nil' to raw type 'String'}}
 }
 
@@ -517,6 +517,7 @@ enum E_53662_PatternMatching {
 
 enum CasesWithMissingElement: Int {
   // expected-error@-1 {{'CasesWithMissingElement' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  // expected-note@-2 {{add stubs for conformance}}
 
   case a = "hello", // expected-error{{expected identifier after comma in enum 'case' declaration}}
   // expected-error@-1 {{cannot convert value of type 'String' to raw type 'Int'}}

--- a/test/Parse/enum_floating_point_raw_value.swift
+++ b/test/Parse/enum_floating_point_raw_value.swift
@@ -3,12 +3,11 @@
 // FIXME: this test only passes on platforms which have Float80.
 // <rdar://problem/19508460> Floating point enum raw values are not portable
 
-// REQUIRES: CPU=i386 || CPU=x86_64
 
 // Windows does not support FP80
 // XFAIL: OS=windows-msvc
 
-enum RawTypeWithFloatValues : Float { // expected-error {{'RawTypeWithFloatValues' declares raw type 'Float', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum RawTypeWithFloatValues : Float { // expected-error {{'RawTypeWithFloatValues' declares raw type 'Float', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case Northrup = 1.5
   case Overton // expected-error {{enum case must declare a raw value when the preceding raw value is not an integer}}
   case Pettygrove = 2.25

--- a/test/Parse/objc_enum.swift
+++ b/test/Parse/objc_enum.swift
@@ -30,7 +30,7 @@ class Bar {
 }
 
 // <rdar://problem/23681566> @objc enums with payloads rejected with no source location info
-@objc enum r23681566 : Int32 {  // expected-error {{'r23681566' declares raw type 'Int32', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{declared raw type 'Int32' here}}
+@objc enum r23681566 : Int32 {  // expected-error {{'r23681566' declares raw type 'Int32', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{declared raw type 'Int32' here}} expected-note {{add stubs for conformance}}
   case Foo(progress: Int)     // expected-error {{enum with raw type cannot have cases with arguments}}
 }
 

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -759,7 +759,7 @@ let ￼tryx  = 123        // expected-error {{invalid character in source file}}
 
 
 // <rdar://problem/21369926> Malformed Swift Enums crash playground service
-enum Rank: Int {  // expected-error {{'Rank' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum Rank: Int {  // expected-error {{'Rank' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case Ace = 1
   case Two = 2.1  // expected-error {{cannot convert value of type 'Double' to raw type 'Int'}}
 }

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -1211,7 +1211,7 @@ fileprivate struct EquatablishOuterPkg2 {
 }
 
 fileprivate struct EquatablishOuterProblem {
-  internal struct Inner : Equatablish { // expected-error {{type 'EquatablishOuterProblem.Inner' does not conform to protocol 'Equatablish'}}
+  internal struct Inner : Equatablish { // expected-error {{type 'EquatablishOuterProblem.Inner' does not conform to protocol 'Equatablish'}} expected-note {{add stubs for conformance}}
     private static func ==(lhs: Inner, rhs: Inner) {}
   }
 }
@@ -1324,7 +1324,7 @@ fileprivate struct EquatablishPackageOuter2 {
 }
 
 fileprivate struct EquatablishPackageOuterProblem {
-  internal struct Inner : EquatablishPackage { // expected-error {{type 'EquatablishPackageOuterProblem.Inner' does not conform to protocol 'EquatablishPackage'}}
+  internal struct Inner : EquatablishPackage { // expected-error {{type 'EquatablishPackageOuterProblem.Inner' does not conform to protocol 'EquatablishPackage'}} expected-note {{add stubs for conformance}}
     private static func ==(lhs: Inner, rhs: Inner) {}
   }
 }

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -114,7 +114,7 @@ class Sub : Container {
 
 protocol VeryImportantProto {
   associatedtype Assoc
-  var value: Int { get set } // expected-note {{protocol requires property 'value' with type 'Int'; add a stub for conformance}}
+  var value: Int { get set } // expected-note {{protocol requires property 'value' with type 'Int'}}
 }
 
 private struct VIPPrivateType : VeryImportantProto {
@@ -138,7 +138,9 @@ private struct VIPPrivateSetProp : VeryImportantProto {
 private class VIPPrivateSetBase {
   private var value: Int = 0
 }
-private class VIPPrivateSetSub : VIPPrivateSetBase, VeryImportantProto { // expected-error {{type 'VIPPrivateSetSub' does not conform to protocol 'VeryImportantProto'}}
+private class VIPPrivateSetSub : VIPPrivateSetBase, VeryImportantProto { 
+  // expected-error@-1 {{type 'VIPPrivateSetSub' does not conform to protocol 'VeryImportantProto'}}
+  // expected-note@-2 {{add stubs for conformance}}
   typealias Assoc = Int
 }
 
@@ -193,11 +195,13 @@ extension Container {
   fileprivate typealias PrivateAlias = VeryPrivateStruct // expected-error {{type alias cannot be declared fileprivate because its underlying type uses a private type}} {{none}}
   fileprivate subscript(_: VeryPrivateStruct) -> Void { return () } // expected-error {{subscript cannot be declared fileprivate because its index uses a private type}} {{none}}
   fileprivate func privateMethod(_: VeryPrivateStruct) -> Void {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}} {{none}}
-  fileprivate enum PrivateRawValue: VeryPrivateStruct {} // expected-error {{enum cannot be declared fileprivate because its raw type uses a private type}} {{none}}
-  // expected-error@-1 {{raw type 'Container.VeryPrivateStruct' is not expressible by a string, integer, or floating-point literal}}
-  // expected-error@-2 {{'Container.PrivateRawValue' declares raw type 'Container.VeryPrivateStruct', but does not conform to RawRepresentable and conformance could not be synthesized}}
-  // expected-error@-3 {{RawRepresentable conformance cannot be synthesized because raw type 'Container.VeryPrivateStruct' is not Equatable}}
-  // expected-error@-4 {{an enum with no cases cannot declare a raw type}}
+  fileprivate enum PrivateRawValue: VeryPrivateStruct {} 
+  // expected-error@-1 {{enum cannot be declared fileprivate because its raw type uses a private type}} {{none}} 
+  // expected-error@-2 {{raw type 'Container.VeryPrivateStruct' is not expressible by a string, integer, or floating-point literal}}
+  // expected-error@-3 {{'Container.PrivateRawValue' declares raw type 'Container.VeryPrivateStruct', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  // expected-error@-4 {{RawRepresentable conformance cannot be synthesized because raw type 'Container.VeryPrivateStruct' is not Equatable}}
+  // expected-note@-5 {{add stubs for conformance}}
+  // expected-error@-6 {{an enum with no cases cannot declare a raw type}}
   fileprivate enum PrivatePayload {
     case A(VeryPrivateStruct) // expected-error {{enum case in an internal enum uses a private type}} {{none}}
   }

--- a/test/Sema/call_as_function_protocol.swift
+++ b/test/Sema/call_as_function_protocol.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 protocol P0 {
-  // expected-note @+1 {{protocol requires function 'callAsFunction()' with type '() -> Missing'; add a stub for conformance}}
+  // expected-note @+1 {{protocol requires function 'callAsFunction()' with type '() -> Missing'}}
   func callAsFunction() -> Self
 }
 func testProtocol(_ x: P0) {
@@ -28,6 +28,7 @@ extension P2 {
   }
 }
 
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error @+1 {{type 'Missing' does not conform to protocol 'P0'}}
 struct Missing : P0 {}
 struct S0 : P0 {

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -71,11 +71,11 @@ struct SomeStruct<A> {
 
 // <rdar://problem/27680407> Infinite recursion when using fully-qualified associatedtype name that has not been defined with typealias
 protocol rdar27680407Proto {
-  associatedtype T // expected-note {{protocol requires nested type 'T'; add nested type 'T' for conformance}}
+  associatedtype T // expected-note {{protocol requires nested type 'T'}}
 
   init(value: T)
 }
 
-struct rdar27680407Struct : rdar27680407Proto { // expected-error {{type 'rdar27680407Struct' does not conform to protocol 'rdar27680407Proto'}}
+struct rdar27680407Struct : rdar27680407Proto { // expected-error {{type 'rdar27680407Struct' does not conform to protocol 'rdar27680407Proto'}} expected-note {{add stubs for conformance}}
   init(value: rdar27680407Struct.T) {}
 }

--- a/test/Sema/classes_equatable_hashable.swift
+++ b/test/Sema/classes_equatable_hashable.swift
@@ -1,8 +1,13 @@
 // RUN: %target-swift-frontend -typecheck -verify -primary-file %s
 
 class Foo: Equatable {} 
-// expected-error@-1 {{type 'Foo' does not conform to protocol 'Equatable'}} expected-note@-1 {{automatic synthesis of 'Equatable' is not supported for class declarations}}
+// expected-error@-1 {{type 'Foo' does not conform to protocol 'Equatable'}} 
+// expected-note@-2 {{automatic synthesis of 'Equatable' is not supported for class declarations}}
+// expected-note@-3 {{add stubs for conformance}}
 
 class Bar: Hashable {} 
-// expected-error@-1 {{type 'Bar' does not conform to protocol 'Hashable'}} expected-note@-1 {{automatic synthesis of 'Hashable' is not supported for class declarations}}
-// expected-error@-2 {{type 'Bar' does not conform to protocol 'Equatable'}} expected-note@-2 {{automatic synthesis of 'Equatable' is not supported for class declarations}}
+// expected-error@-1 {{type 'Bar' does not conform to protocol 'Hashable'}} 
+// expected-note@-2 {{automatic synthesis of 'Hashable' is not supported for class declarations}}
+// expected-error@-3 {{type 'Bar' does not conform to protocol 'Equatable'}} 
+// expected-note@-4 {{automatic synthesis of 'Equatable' is not supported for class declarations}}
+// expected-note@-5 {{add stubs for conformance}}

--- a/test/Sema/const_pass_as_arguments.swift
+++ b/test/Sema/const_pass_as_arguments.swift
@@ -42,10 +42,10 @@ func main_member(_ u: Utils, _ i: Int, _ d: Double, _ s: String) {
 }
 
 protocol ConstFan {
-	static _const var v: String { get }  // expected-note {{protocol requires property 'v' with type 'String'; add a stub for conformance}}
+	static _const var v: String { get }  // expected-note {{protocol requires property 'v' with type 'String'}}
 }
 
-class ConstFanClass1: ConstFan { // expected-error {{type 'ConstFanClass1' does not conform to protocol 'ConstFan'}}
+class ConstFanClass1: ConstFan { // expected-error {{type 'ConstFanClass1' does not conform to protocol 'ConstFan'}} expected-note {{add stubs for conformance}}
 	static let v: String = "" // expected-note {{candidate operates as non-const, not const as required}}
 }
 

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -145,7 +145,7 @@ func enumWithHashablePayload() {
 
 // Enums with non-hashable payloads don't derive conformance.
 struct NotHashable {}
-enum EnumWithNonHashablePayload: Hashable { // expected-error 2 {{does not conform}}
+enum EnumWithNonHashablePayload: Hashable { // expected-error 2 {{does not conform}} expected-note {{add stubs for conformance}}
   case A(NotHashable) //expected-note {{associated value type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'EnumWithNonHashablePayload' to 'Hashable'}}
   // expected-note@-1 {{associated value type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'EnumWithNonHashablePayload' to 'Equatable'}}
 }
@@ -229,8 +229,8 @@ enum Complex2 {
   case B
 }
 extension Complex2 : Hashable {}
-extension Complex2 : CaseIterable {}  // expected-error {{type 'Complex2' does not conform to protocol 'CaseIterable'}}
-extension FromOtherFile: CaseIterable {} // expected-error {{extension outside of file declaring enum 'FromOtherFile' prevents automatic synthesis of 'allCases' for protocol 'CaseIterable'}}
+extension Complex2 : CaseIterable {}  // expected-error {{type 'Complex2' does not conform to protocol 'CaseIterable'}} expected-note {{add stubs for conformance}}
+extension FromOtherFile: CaseIterable {} // expected-error {{extension outside of file declaring enum 'FromOtherFile' prevents automatic synthesis of 'allCases' for protocol 'CaseIterable'}} expected-note {{add stubs for conformance}}
 extension CaseIterableAcrossFiles: CaseIterable {
   public static var allCases: [CaseIterableAcrossFiles] {
     return [ .A ]
@@ -242,8 +242,8 @@ enum NotExplicitlyHashableAndCannotDerive {
   case A(NotHashable) //expected-note {{associated value type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Hashable'}}
   // expected-note@-1 {{associated value type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Equatable'}}
 }
-extension NotExplicitlyHashableAndCannotDerive : Hashable {} // expected-error 2 {{does not conform}}
-extension NotExplicitlyHashableAndCannotDerive : CaseIterable {} // expected-error {{does not conform}}
+extension NotExplicitlyHashableAndCannotDerive : Hashable {} // expected-error 2 {{does not conform}} expected-note {{add stubs for conformance}}
+extension NotExplicitlyHashableAndCannotDerive : CaseIterable {} // expected-error {{does not conform}} expected-note {{add stubs for conformance}}
 
 // Verify that conformance (albeit manually implemented) can still be added to
 // a type in a different file.
@@ -254,8 +254,8 @@ extension OtherFileNonconforming: Hashable {
   func hash(into hasher: inout Hasher) {}
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
-extension YetOtherFileNonconforming: Equatable {} // expected-error {{extension outside of file declaring enum 'YetOtherFileNonconforming' prevents automatic synthesis of '==' for protocol 'Equatable'}}
-extension YetOtherFileNonconforming: CaseIterable {} // expected-error {{does not conform}}
+extension YetOtherFileNonconforming: Equatable {} // expected-error {{extension outside of file declaring enum 'YetOtherFileNonconforming' prevents automatic synthesis of '==' for protocol 'Equatable'}} expected-note {{add stubs for conformance}}
+extension YetOtherFileNonconforming: CaseIterable {} // expected-error {{does not conform}} expected-note {{add stubs for conformance}}
 
 // Verify that an indirect enum doesn't emit any errors as long as its "leaves"
 // are conformant.
@@ -293,7 +293,7 @@ case only([Int])
 
 struct NotEquatable { }
 
-enum ArrayOfNotEquatables : Equatable { // expected-error{{type 'ArrayOfNotEquatables' does not conform to protocol 'Equatable'}}
+enum ArrayOfNotEquatables : Equatable { // expected-error{{type 'ArrayOfNotEquatables' does not conform to protocol 'Equatable'}} expected-note {{add stubs for conformance}}
 case only([NotEquatable]) //expected-note {{associated value type '[NotEquatable]' does not conform to protocol 'Equatable', preventing synthesized conformance of 'ArrayOfNotEquatables' to 'Equatable'}}
 }
 
@@ -309,8 +309,9 @@ enum BadGenericDeriveExtension<T> {
     case A(T) //expected-note {{associated value type 'T' does not conform to protocol 'Hashable', preventing synthesized conformance of 'BadGenericDeriveExtension<T>' to 'Hashable'}}
   //expected-note@-1 {{associated value type 'T' does not conform to protocol 'Equatable', preventing synthesized conformance of 'BadGenericDeriveExtension<T>' to 'Equatable'}}
 }
-extension BadGenericDeriveExtension: Equatable {} //
+extension BadGenericDeriveExtension: Equatable {}
 // expected-error@-1 {{type 'BadGenericDeriveExtension<T>' does not conform to protocol 'Equatable'}}
+// expected-note@-2 {{add stubs for conformance}}
 extension BadGenericDeriveExtension: Hashable where T: Equatable {}
 // expected-error@-1 {{type 'BadGenericDeriveExtension' does not conform to protocol 'Hashable'}}
 
@@ -325,7 +326,8 @@ extension UnusedGenericDeriveExtension: Hashable {}
 // Cross-file synthesis is disallowed for conditional cases just as it is for
 // non-conditional ones.
 extension GenericOtherFileNonconforming: Equatable where T: Equatable {}
-// expected-error@-1{{extension outside of file declaring generic enum 'GenericOtherFileNonconforming' prevents automatic synthesis of '==' for protocol 'Equatable'}}
+// expected-error@-1{{extension outside of file declaring generic enum 'GenericOtherFileNonconforming' prevents automatic synthesis of '==' for protocol 'Equatable'}} 
+// expected-note@-2 {{add stubs for conformance}}
 
 // rdar://problem/41852654
 

--- a/test/Sema/enum_equatable_conditional.swift
+++ b/test/Sema/enum_equatable_conditional.swift
@@ -2,11 +2,11 @@
 
 struct NotEquatable { }
 
-enum WithArrayOfNotEquatables : Equatable { // expected-error{{type 'WithArrayOfNotEquatables' does not conform to protocol 'Equatable'}}
+enum WithArrayOfNotEquatables : Equatable { // expected-error{{type 'WithArrayOfNotEquatables' does not conform to protocol 'Equatable'}} expected-note {{add stubs for conformance}}
   case only([NotEquatable]) // expected-note{{associated value type '[NotEquatable]' does not conform to protocol 'Equatable', preventing synthesized conformance of 'WithArrayOfNotEquatables' to 'Equatable'}}
 }
 
-enum WithArrayOfNotEquatables2<T> : Equatable { // expected-error{{type 'WithArrayOfNotEquatables2<T>' does not conform to protocol 'Equatable'}}
+enum WithArrayOfNotEquatables2<T> : Equatable { // expected-error{{type 'WithArrayOfNotEquatables2<T>' does not conform to protocol 'Equatable'}} expected-note {{add stubs for conformance}}
   case only([T]) // expected-note{{associated value type '[T]' does not conform to protocol 'Equatable', preventing synthesized conformance of 'WithArrayOfNotEquatables2<T>' to 'Equatable'}}
 }
 

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -71,7 +71,7 @@ var colorRaw: Color.RawValue = 7.5
 
 // Mismatched case types
 
-enum BadPlain : UInt { // expected-error {{'BadPlain' declares raw type 'UInt', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum BadPlain : UInt { // expected-error {{'BadPlain' declares raw type 'UInt', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
     case a = "hello"   // expected-error {{cannot convert value of type 'String' to raw type 'UInt'}}
 }
 
@@ -87,6 +87,7 @@ class Outer {
   enum E : Array<Int> {
   // expected-error@-1 {{raw type 'Array<Int>' is not expressible by a string, integer, or floating-point literal}}
   // expected-error@-2 {{'Outer.E' declares raw type 'Array<Int>', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  // expected-note@-3 {{add stubs for conformance}}
     case a
   }
 }
@@ -231,6 +232,7 @@ enum ArrayOfNewEquatable : Array<NotEquatable> { }
 // expected-error@-2{{'ArrayOfNewEquatable' declares raw type 'Array<NotEquatable>', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-3{{RawRepresentable conformance cannot be synthesized because raw type 'Array<NotEquatable>' is not Equatable}}
 // expected-error@-4{{an enum with no cases cannot declare a raw type}}
+// expected-note@-5 {{add stubs for conformance}}
 
 // rdar://58127114
 struct NotEquatableInteger : ExpressibleByIntegerLiteral {
@@ -242,6 +244,7 @@ struct NotEquatableInteger : ExpressibleByIntegerLiteral {
 enum NotEquatableRawType1 : NotEquatableInteger {
 // expected-error@-1 {{'NotEquatableRawType1' declares raw type 'NotEquatableInteger', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'NotEquatableInteger' is not Equatable}}
+// expected-note@-3 {{add stubs for conformance}}
   case a = 123
 }
 
@@ -249,6 +252,7 @@ enum NotEquatableRawType1 : NotEquatableInteger {
 enum NotEquatableRawType2 : NotEquatableInteger {
 // expected-error@-1 {{'NotEquatableRawType2' declares raw type 'NotEquatableInteger', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'NotEquatableInteger' is not Equatable}}
+// expected-note@-3 {{add stubs for conformance}}
   typealias RawValue = NotEquatableInteger
 
   case a = 123
@@ -262,6 +266,7 @@ struct NotEquatableString : ExpressibleByStringLiteral {
 enum NotEquatableRawType3: NotEquatableString {
 // expected-error@-1 {{RawRepresentable conformance cannot be synthesized because raw type 'NotEquatableString' is not Equatable}}
 // expected-error@-2 {{'NotEquatableRawType3' declares raw type 'NotEquatableString', but does not conform to RawRepresentable and conformance could not be synthesized}}
+// expected-note@-3 {{add stubs for conformance}}
   case a
   typealias RawValue = NotEquatableString
   init?(rawValue: Int) { self = .a }
@@ -275,12 +280,14 @@ enum MismatchedRawValues {
     // expected-error@-1 {{raw type 'Any?' is not expressible}}
     // expected-error@-2 {{'MismatchedRawValues.ExistentialBound' declares raw type 'Any?'}}
     // expected-error@-3 {{RawRepresentable conformance cannot be synthesized }}
+    // expected-note@-4 {{add stubs for conformance}}
     case test = nil
   }
 
   public enum StringViaStaticString: StaticString {
     // expected-error@-1 {{'MismatchedRawValues.StringViaStaticString' declares raw type 'StaticString', but does not conform to RawRepresentable}}
     // expected-error@-2 {{RawRepresentable conformance cannot be synthesized because}}
+    // expected-note@-3 {{add stubs for conformance}}
     public typealias RawValue = String
 
     case TRUE = "TRUE"
@@ -289,6 +296,7 @@ enum MismatchedRawValues {
 
   public enum IntViaString: String {
     // expected-error@-1 {{'MismatchedRawValues.IntViaString' declares raw type 'String', but does not conform to RawRepresentable}}
+    // expected-note@-2 {{add stubs for conformance}}
     public typealias RawValue = Int
 
     case TRUE = "TRUE"
@@ -297,6 +305,7 @@ enum MismatchedRawValues {
 
   public enum ViaNested: String {
     // expected-error@-1 {{'MismatchedRawValues.ViaNested' declares raw type 'String', but does not conform to RawRepresentable}}
+    // expected-note@-2 {{add stubs for conformance}}
     struct RawValue: Equatable {
       let x: String
     }
@@ -306,7 +315,8 @@ enum MismatchedRawValues {
   }
 
   public enum ViaGenericBound<RawValue: Equatable>: String {
-    // expected-error@-1 {{'MismatchedRawValues.ViaGenericBound<RawValue>' declares raw type 'String'}}
+    // expected-error@-1 {{'MismatchedRawValues.ViaGenericBound<RawValue>' declares raw type 'String', but does not conform to RawRepresentable}}
+    // expected-note@-2 {{add stubs for conformance}}
     typealias RawValue = RawValue
     case TRUE = "TRUE"
     case FALSE = "FALSE"

--- a/test/Sema/generic-subscript.swift
+++ b/test/Sema/generic-subscript.swift
@@ -1,12 +1,12 @@
 // RUN: %target-typecheck-verify-swift
 
 protocol P {
-  subscript<Value>(x: Value) -> Int { // expected-note {{protocol requires subscript with type '<Value> (Value) -> Int'; add a stub for conformance}}
+  subscript<Value>(x: Value) -> Int { // expected-note {{protocol requires subscript with type '<Value> (Value) -> Int'}}
     get
   }
 }
 
-struct S : P { // expected-error {{type 'S' does not conform to protocol 'P'}}
+struct S : P { // expected-error {{type 'S' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
   subscript<Value>(x: Int) -> Value { // expected-note {{candidate has non-matching type '<Value> (Int) -> Value'}}
   }  // expected-error {{missing return in subscript expected to return 'Value'}}
 }

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -283,7 +283,7 @@ struct TestStruct2 : MutatingTestProto {
   __consuming func consuming_nonmutating_func() {}
 }
 
-struct TestStruct3 : MutatingTestProto {   // expected-error {{type 'TestStruct3' does not conform to protocol 'MutatingTestProto'}}
+struct TestStruct3 : MutatingTestProto {   // expected-error {{type 'TestStruct3' does not conform to protocol 'MutatingTestProto'}} expected-note {{add stubs for conformance}}
   func mutatingfunc() {}
 
   // This is not ok, "nonmutatingfunc" doesn't allow mutating functions.
@@ -312,7 +312,7 @@ struct TestStruct5 : MutatingTestProto {
 protocol NonMutatingSubscriptable {
   subscript(i: Int) -> Int {get nonmutating set} // expected-note {{protocol requires subscript with type '(Int) -> Int'}}
 }
-struct MutatingSubscriptor : NonMutatingSubscriptable {  // expected-error {{type 'MutatingSubscriptor' does not conform to protocol 'NonMutatingSubscriptable'}}
+struct MutatingSubscriptor : NonMutatingSubscriptable {  // expected-error {{type 'MutatingSubscriptor' does not conform to protocol 'NonMutatingSubscriptable'}} expected-note {{add stubs for conformance}}
   subscript(i: Int) -> Int {
     get { return 42 }
     mutating set {}   // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}
@@ -322,7 +322,7 @@ struct MutatingSubscriptor : NonMutatingSubscriptable {  // expected-error {{typ
 protocol NonMutatingGet {
   var a: Int { get } // expected-note {{protocol requires property 'a' with type 'Int'}}
 }
-struct MutatingGet : NonMutatingGet { // expected-error {{type 'MutatingGet' does not conform to protocol 'NonMutatingGet'}}
+struct MutatingGet : NonMutatingGet { // expected-error {{type 'MutatingGet' does not conform to protocol 'NonMutatingGet'}} expected-note {{add stubs for conformance}}
   var a: Int { mutating get { return 0 } } // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}
 }
 
@@ -353,7 +353,7 @@ protocol OpaqueRefinement : class, OpaqueBase {
   var x: Int { get set } // expected-note {{protocol requires property 'x' with type 'Int'}}
 }
 
-class SetterMutatingConflict : OpaqueRefinement {} // expected-error {{type 'SetterMutatingConflict' does not conform to protocol 'OpaqueRefinement'}}
+class SetterMutatingConflict : OpaqueRefinement {} // expected-error {{type 'SetterMutatingConflict' does not conform to protocol 'OpaqueRefinement'}} expected-note {{add stubs for conformance}}
 
 struct DuplicateMutating {
   mutating mutating func f() {} // expected-error {{duplicate modifier}} expected-note {{modifier already specified here}}

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -125,12 +125,14 @@ func tryToCastIt(_ fd: borrowing FileDescriptor) {
 }
 
 protocol GiveSendable<T> {
-  associatedtype T: Sendable // expected-note {{protocol requires nested type 'T'; add nested type 'T' for conformance}}
+  associatedtype T: Sendable // expected-note {{protocol requires nested type 'T'}}
   func give() -> T
 }
 
 // make sure witnessing associatedtypes is still prevented, even though we meet the explicit constraint.
-class Bad: GiveSendable { // expected-error {{type 'Bad' does not conform to protocol 'GiveSendable'}}
+class Bad: GiveSendable { 
+  // expected-error@-1 {{type 'Bad' does not conform to protocol 'GiveSendable'}} 
+  // expected-note@-2 {{add stubs for conformance}}
   typealias T = FileDescriptor // expected-note {{possibly intended match 'Bad.T' (aka 'FileDescriptor') does not conform to 'Copyable'}}
   func give() -> FileDescriptor { return FileDescriptor(id: -1) }
 }

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -122,7 +122,7 @@ func structWithoutExplicitConformance() {
 
 // Structs with non-hashable/equatable stored properties don't derive conformance.
 struct NotHashable {}
-struct StructWithNonHashablePayload: Hashable { // expected-error 2 {{does not conform}}
+struct StructWithNonHashablePayload: Hashable { // expected-error 2 {{does not conform}} expected-note {{add stubs for conformance}}
   let a: NotHashable // expected-note {{stored property type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'StructWithNonHashablePayload' to 'Hashable'}}
   // expected-note@-1 {{stored property type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'StructWithNonHashablePayload' to 'Equatable'}}
 }
@@ -184,7 +184,7 @@ struct NotExplicitlyHashableAndCannotDerive {
   let v: NotHashable // expected-note {{stored property type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Hashable'}}
   // expected-note@-1 {{stored property type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Equatable'}}
 }
-extension NotExplicitlyHashableAndCannotDerive : Hashable {}  // expected-error 2 {{does not conform}}
+extension NotExplicitlyHashableAndCannotDerive : Hashable {}  // expected-error 2 {{does not conform}} expected-note {{add stubs for conformance}}
 
 // A struct with no stored properties trivially derives conformance.
 struct NoStoredProperties: Hashable {}
@@ -198,7 +198,7 @@ extension OtherFileNonconforming: Hashable {
   func hash(into hasher: inout Hasher) {}
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
-extension YetOtherFileNonconforming: Equatable {} // expected-error {{extension outside of file declaring struct 'YetOtherFileNonconforming' prevents automatic synthesis of '==' for protocol 'Equatable'}}
+extension YetOtherFileNonconforming: Equatable {} // expected-error {{extension outside of file declaring struct 'YetOtherFileNonconforming' prevents automatic synthesis of '==' for protocol 'Equatable'}} expected-note {{add stubs for conformance}}
 
 // Verify that we can add Hashable conformance in an extension by only
 // implementing hash(into:)
@@ -242,6 +242,7 @@ struct BadGenericDeriveExtension<T> {
 }
 extension BadGenericDeriveExtension: Equatable {}
 // expected-error@-1 {{type 'BadGenericDeriveExtension<T>' does not conform to protocol 'Equatable'}}
+// expected-note@-2 {{add stubs for conformance}}
 extension BadGenericDeriveExtension: Hashable where T: Equatable {}
 // expected-error@-1 {{type 'BadGenericDeriveExtension' does not conform to protocol 'Hashable'}}
 
@@ -256,6 +257,7 @@ extension UnusedGenericDeriveExtension: Hashable {}
 // Cross-file synthesis is still disallowed for conditional cases
 extension GenericOtherFileNonconforming: Equatable where T: Equatable {}
 // expected-error@-1{{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of '==' for protocol 'Equatable'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 // rdar://problem/41852654
 

--- a/test/Serialization/Recovery/types-4-to-5.swift
+++ b/test/Serialization/Recovery/types-4-to-5.swift
@@ -17,7 +17,7 @@ func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
 class Sub: Base {} // okay
-class Impl: Proto {} // expected-error {{type 'Impl' does not conform to protocol 'Proto'}}
+class Impl: Proto {} // expected-error {{type 'Impl' does not conform to protocol 'Proto'}} expected-note {{add stubs for conformance}}
 
 #else // TEST
 

--- a/test/SourceKit/Sema/sema_protocol_stubs.swift
+++ b/test/SourceKit/Sema/sema_protocol_stubs.swift
@@ -9,4 +9,3 @@ class C1: P1, P2 {}
 // RUN: %sourcekitd-test -req=sema %s -- %s | %FileCheck %s
 // CHECK: key.description: "type 'C1' does not conform to protocol 'P1'"
 // CHECK: key.description: "type 'C1' does not conform to protocol 'P2'"
-// CHECK: key.description: "add stubs for conformance"

--- a/test/TypeCoercion/integer_literals.swift
+++ b/test/TypeCoercion/integer_literals.swift
@@ -44,7 +44,7 @@ struct meters : ExpressibleByIntegerLiteral {
   }
 }
 
-struct supermeters : ExpressibleByIntegerLiteral { // expected-error{{type 'supermeters' does not conform to protocol 'ExpressibleByIntegerLiteral'}}
+struct supermeters : ExpressibleByIntegerLiteral { // expected-error{{type 'supermeters' does not conform to protocol 'ExpressibleByIntegerLiteral'}} expected-note {{add stubs for conformance}}
   var value : meters
 
   typealias IntegerLiteralType = meters // expected-note{{possibly intended match 'supermeters.IntegerLiteralType' (aka 'meters') does not conform to '_ExpressibleByBuiltinIntegerLiteral'}}

--- a/test/attr/attr_implements_bad_types.swift
+++ b/test/attr/attr_implements_bad_types.swift
@@ -1,10 +1,10 @@
 // RUN: %target-typecheck-verify-swift
 
 protocol NeedsF0 {
-  func f0() // expected-note {{protocol requires function 'f0()' with type '() -> ()'; add a stub for conformance}}
+  func f0() // expected-note {{protocol requires function 'f0()' with type '() -> ()'}}
 }
 
-struct S0 : NeedsF0 {  // expected-error {{type 'S0' does not conform to protocol 'NeedsF0'}}
+struct S0 : NeedsF0 {  // expected-error {{type 'S0' does not conform to protocol 'NeedsF0'}} expected-note {{add stubs for conformance}}
   @_implements(NeedsF0, f0())
   func g0() -> Bool {  // expected-note {{candidate has non-matching type '() -> Bool'}}
     return true

--- a/test/attr/attr_nonobjc.swift
+++ b/test/attr/attr_nonobjc.swift
@@ -81,7 +81,7 @@ class NSManagedAndNonObjCNotAllowed {
 
 @nonobjc func nonObjCTopLevelFuncNotAllowed() { } // expected-error {{only class members and extensions of classes can be declared @nonobjc}} {{1-10=}}
 
-@objc class NonObjCPropertyObjCProtocolNotAllowed : ObjCProtocol { // expected-error {{does not conform to protocol}}
+@objc class NonObjCPropertyObjCProtocolNotAllowed : ObjCProtocol { // expected-error {{does not conform to protocol}} expected-note {{add stubs for conformance}}
   @nonobjc func protocolMethod() { } // expected-note {{candidate is explicitly '@nonobjc'}}
 
   func nonObjCProtocolMethodNotAllowed() { }

--- a/test/attr/attr_rethrows_protocol.swift
+++ b/test/attr/attr_rethrows_protocol.swift
@@ -157,14 +157,15 @@ takesEmpty(EmptyWitness())
 // Note: the SimpleThrowsClosure protocol is not @rethrows
 protocol SimpleThrowsClosure {
   func doIt(_: () throws -> ()) rethrows
-  // expected-note@-1 {{protocol requires function 'doIt' with type '(() throws -> ()) throws -> ()'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'doIt' with type '(() throws -> ()) throws -> ()'}}
 
   func doIt2<T : Empty>(_: T) rethrows
-  // expected-note@-1 {{protocol requires function 'doIt2' with type '<T> (T) throws -> ()'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'doIt2' with type '<T> (T) throws -> ()'}}
 }
 
 struct ConformsToSimpleThrowsClosure<T : RethrowingProtocol> : SimpleThrowsClosure {
-// expected-error@-1 {{type 'ConformsToSimpleThrowsClosure<T>' does not conform to protocol 'SimpleThrowsClosure'}}
+  // expected-error@-1 {{type 'ConformsToSimpleThrowsClosure<T>' does not conform to protocol 'SimpleThrowsClosure'}}
+  // expected-note@-2 {{add stubs for conformance}}
   let t: T
 
   // This cannot witness SimpleThrowsClosure.doIt(), because the

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -20,11 +20,11 @@ struct GenericGlobalActor<T> {
 
 // Ill-formed global actors.
 @globalActor
-final class GA2 { // expected-error{{type 'GA2' does not conform to protocol 'GlobalActor'}}
+final class GA2 { // expected-error{{type 'GA2' does not conform to protocol 'GlobalActor'}} expected-note {{add stubs for conformance}}
 }
 
 @globalActor
-struct GA3 { // expected-error{{type 'GA3' does not conform to protocol 'GlobalActor'}}
+struct GA3 { // expected-error{{type 'GA3' does not conform to protocol 'GlobalActor'}} expected-note {{add stubs for conformance}}
   let shared = SomeActor()
 }
 
@@ -41,7 +41,7 @@ open class GA5 { // expected-error{{non-final class 'GA5' cannot be a global act
 }
 
 @globalActor
-struct GA6<T> { // expected-error{{type 'GA6<T>' does not conform to protocol 'GlobalActor'}}
+struct GA6<T> { // expected-error{{type 'GA6<T>' does not conform to protocol 'GlobalActor'}} expected-note {{add stubs for conformance}}
 }
 
 extension GA6 where T: Equatable {

--- a/test/decl/circularity.swift
+++ b/test/decl/circularity.swift
@@ -60,7 +60,7 @@ extension SIMD3 where SIMD3.Scalar == Float {
 // Test case with circular overrides
 protocol P {
     associatedtype A
-    // expected-note@-1 {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+    // expected-note@-1 {{protocol requires nested type 'A'}}
     func run(a: A)
 }
 
@@ -85,6 +85,7 @@ class C3: G1<A>, P {
     // expected-error@-1 {{type 'C3' does not conform to protocol 'P'}}
     // expected-error@-2 {{cannot find type 'A' in scope}}
     // expected-note@-3 2{{through reference here}}
+    // expected-note@-4 {{add stubs for conformance}}
     override func run(a: A) {}
     // expected-error@-1 {{circular reference}}
     // expected-note@-2 2 {{through reference here}}

--- a/test/decl/enum/bool_raw_value.swift
+++ b/test/decl/enum/bool_raw_value.swift
@@ -9,7 +9,8 @@ enum IsDefinitelyRecursive : Bool, Equatable, Hashable {
   case recursive=false
 }
 
-// expected-error@+1{{'IsRecursive' declares raw type 'Bool', but does not conform to RawRepresentable and conformance could not be synthesized}}
+// expected-error@+2 {{'IsRecursive' declares raw type 'Bool', but does not conform to RawRepresentable and conformance could not be synthesized}}
+// expected-note@+1 {{add stubs for conformance}}
 enum IsRecursive : Bool, Equatable, Hashable {
   case recursive=false
   case nonrecursive // expected-error{{enum case must declare a raw value when the preceding raw value is not an integer}}
@@ -20,7 +21,8 @@ enum IsRecursiveBad1Integral : Bool, Equatable, Hashable {
   case nonrecursive
 }
 
-// expected-error @+1{{'IsRecursiveBad2' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
+// expected-error@+2 {{'IsRecursiveBad2' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
+// expected-note@+1 {{add stubs for conformance}}
 enum IsRecursiveBad2 : Int, Equatable, Hashable {
   case recursive = false // expected-error{{cannot convert value of type 'Bool' to raw type 'Int'}}
 }

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -605,7 +605,7 @@ extension PConforms9 {
   subscript (i: Self.Assoc) -> Self.Assoc { return Assoc() }
 }
 
-struct SConforms9a : PConforms9 { // expected-error{{type 'SConforms9a' does not conform to protocol 'PConforms9'}}
+struct SConforms9a : PConforms9 { // expected-error{{type 'SConforms9a' does not conform to protocol 'PConforms9'}} expected-note {{add stubs for conformance}}
 }
 
 struct SConforms9b : PConforms9 {
@@ -988,7 +988,7 @@ protocol BadProto5 {
   associatedtype T3 // expected-note{{protocol requires nested type 'T3'}}
 }
 
-class BadClass5 : BadProto5 {} // expected-error{{type 'BadClass5' does not conform to protocol 'BadProto5'}}
+class BadClass5 : BadProto5 {} // expected-error{{type 'BadClass5' does not conform to protocol 'BadProto5'}} expected-note {{add stubs for conformance}}
 
 typealias A = BadProto1
 typealias B = BadProto1

--- a/test/decl/ext/protocol_as_witness.swift
+++ b/test/decl/ext/protocol_as_witness.swift
@@ -11,7 +11,7 @@ extension P1 where Self : Q1 {
   func f() {} // expected-note{{candidate would match if 'X1' conformed to 'Q1'}}
 }
 
-struct X1 : P1 {} // expected-error{{type 'X1' does not conform to protocol 'P1'}}
+struct X1 : P1 {} // expected-error{{type 'X1' does not conform to protocol 'P1'}} expected-note {{add stubs for conformance}}
 
 // rdar://problem/21153652
 protocol P2 {
@@ -35,4 +35,4 @@ extension P3 where Self : Equatable {
   func f() {} // expected-note{{candidate would match if 'X3' conformed to 'Equatable'}}
 }
 
-struct X3 : P3 {} // expected-error{{type 'X3' does not conform to protocol 'P3'}}
+struct X3 : P3 {} // expected-error{{type 'X3' does not conform to protocol 'P3'}} expected-note {{add stubs for conformance}}

--- a/test/decl/func/async.swift
+++ b/test/decl/func/async.swift
@@ -25,10 +25,10 @@ class Sub: Super {
 
 // Witness checking
 protocol P1 {
-  func g() // expected-note{{protocol requires function 'g()' with type '() -> ()'; add a stub for conformance}}
+  func g() // expected-note{{protocol requires function 'g()' with type '() -> ()'}}
 }
 
-struct ConformsToP1: P1 { // expected-error{{type 'ConformsToP1' does not conform to protocol 'P1'}}
+struct ConformsToP1: P1 { // expected-error{{type 'ConformsToP1' does not conform to protocol 'P1'}} expected-note {{add stubs for conformance}}
   func g() async { }  // expected-note{{candidate is 'async', but protocol requirement is not}}
 }
 

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -22,7 +22,7 @@ protocol P {
   func rhf(_ f: () throws -> ()) rethrows // expected-note {{protocol requires}}
 }
 
-struct T0 : P { // expected-error {{type 'T0' does not conform to protocol 'P'}}
+struct T0 : P { // expected-error {{type 'T0' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
   func tf() throws {}
   func nf() throws {} // expected-note {{candidate throws, but protocol does not allow it}}
 
@@ -40,7 +40,7 @@ struct T1 : P {
   func rhf(_ f: () throws -> ()) {}
 }
 
-struct T2 : P { // expected-error {{type 'T2' does not conform to protocol 'P'}}
+struct T2 : P { // expected-error {{type 'T2' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
   func tf() {}
   func nf() {}
 

--- a/test/decl/func/special_func_name.swift
+++ b/test/decl/func/special_func_name.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5
 
 protocol P1 {
-  static func `init`(_: Int) // expected-note {{protocol requires function 'init' with type '(Int) -> ()'; add a stub for conformance}}
+  static func `init`(_: Int) // expected-note {{protocol requires function 'init' with type '(Int) -> ()'}}
   // expected-note@-1 {{did you mean 'init'?}}
 }
 
@@ -9,15 +9,15 @@ struct S11 : P1 {
   static func `init`(_: Int) {}
 }
 
-struct S12 : P1 { // expected-error {{type 'S12' does not conform to protocol 'P1'}}
+struct S12 : P1 { // expected-error {{type 'S12' does not conform to protocol 'P1'}} expected-note {{add stubs for conformance}}
   init(_: Int) {}
 }
 
 protocol P2 {
-  init(_: Int) // expected-note {{protocol requires initializer 'init(_:)' with type 'Int'; add a stub for conformance}}
+  init(_: Int) // expected-note {{protocol requires initializer 'init(_:)' with type 'Int'}}
 }
 
-struct S21 : P2 { // expected-error {{type 'S21' does not conform to protocol 'P2'}}
+struct S21 : P2 { // expected-error {{type 'S21' does not conform to protocol 'P2'}} expected-note {{add stubs for conformance}}
   static func `init`(_: Int) {}
 }
 

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -275,9 +275,9 @@ extension OtherGenericClass {
 // A nested protocol does not satisfy an associated type requirement.
 
 protocol HasAssoc {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
 }
-struct ConformsToHasAssoc: HasAssoc { // expected-error {{type 'ConformsToHasAssoc' does not conform to protocol 'HasAssoc'}}
+struct ConformsToHasAssoc: HasAssoc { // expected-error {{type 'ConformsToHasAssoc' does not conform to protocol 'HasAssoc'}} expected-note {{add stubs for conformance}} 
   protocol A {}
 }
 

--- a/test/decl/protocol/associated_type_overrides_conformances.swift
+++ b/test/decl/protocol/associated_type_overrides_conformances.swift
@@ -5,12 +5,12 @@ func assertTypeWitnessForP2_A<T: P2, U>(in: T.Type, is: U.Type) where T.A == U {
 
 protocol P1 {
   associatedtype A
-  // expected-note@-1 2 {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  // expected-note@-1 2 {{protocol requires nested type 'A'}}
   // expected-note@-2 2 {{multiple matching types named 'A'}}
 }
 protocol P2: P1 {
   associatedtype A
-  // expected-note@-1 2 {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  // expected-note@-1 2 {{protocol requires nested type 'A'}}
   // expected-note@-2 2 {{multiple matching types named 'A'}}
 }
 
@@ -31,7 +31,7 @@ struct S2<T> {}
 extension S2: P1 where T == Never {
   typealias A = Int
 }
-extension S2: P2 {} // expected-error {{type 'S2<T>' does not conform to protocol 'P2'}}
+extension S2: P2 {} // expected-error {{type 'S2<T>' does not conform to protocol 'P2'}} expected-note {{add stubs for conformance}}
 
 struct S3<T> {}
 extension S3: P1 where T == Never {}
@@ -59,7 +59,7 @@ extension S5: P1 {
 extension S5: P2 where T == Never {}
 
 struct S6<T> {}
-extension S6: P1 {} // expected-error {{type 'S6<T>' does not conform to protocol 'P1'}}
+extension S6: P1 {} // expected-error {{type 'S6<T>' does not conform to protocol 'P1'}} expected-note {{add stubs for conformance}}
 extension S6: P2 where T == Never {
   typealias A = Bool
 }
@@ -83,7 +83,7 @@ struct S9<T> {}
 extension S9: P2 where T == Never {
   typealias A = Bool
 }
-extension S9: P1 {} // expected-error {{type 'S9<T>' does not conform to protocol 'P1'}}
+extension S9: P1 {} // expected-error {{type 'S9<T>' does not conform to protocol 'P1'}} expected-note {{add stubs for conformance}}
 
 // Conformance to P2 checked first and less restrictive.
 struct S10<T> {}
@@ -99,7 +99,7 @@ extension S10: P1 where T == Never { // expected-error {{type 'S10<T>' does not 
 }
 
 struct S11<T> {}
-extension S11: P2 {} // expected-error {{type 'S11<T>' does not conform to protocol 'P2'}}
+extension S11: P2 {} // expected-error {{type 'S11<T>' does not conform to protocol 'P2'}} expected-note {{add stubs for conformance}}
 extension S11: P1 where T == Never {
   typealias A = Int
 }

--- a/test/decl/protocol/conforms/access_corner_case.swift
+++ b/test/decl/protocol/conforms/access_corner_case.swift
@@ -22,7 +22,7 @@ fileprivate protocol R : Q {
 private protocol S : R {
   func privateRequirement()
   func privateRequirementCannotWork()
-  // expected-note@-1 {{protocol requires function 'privateRequirementCannotWork()' with type '() -> ()'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'privateRequirementCannotWork()' with type '() -> ()'}}
 }
 
 extension S {
@@ -37,6 +37,7 @@ extension S {
 
 public struct T : S {}
 // expected-error@-1 {{type 'T' does not conform to protocol 'S'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 protocol Qpkg : Pkg {
   func internalRequirement()
@@ -48,7 +49,7 @@ fileprivate protocol Rpkg : Qpkg {
 private protocol Spkg : Rpkg {
   func privateRequirement()
   func privateRequirementCannotWork()
-  // expected-note@-1 {{protocol requires function 'privateRequirementCannotWork()' with type '() -> ()'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'privateRequirementCannotWork()' with type '() -> ()'}}
 }
 
 extension Spkg {
@@ -64,6 +65,7 @@ extension Spkg {
 
 public struct Tpkg : Spkg {}
 // expected-error@-1 {{type 'Tpkg' does not conform to protocol 'Spkg'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 // This is also OK
 @usableFromInline

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -3,11 +3,11 @@
 class C { }
 
 protocol P {
-  associatedtype AssocP : C // expected-note{{protocol requires nested type 'AssocP'; add nested type 'AssocP' for conformance}}
-  associatedtype AssocA : AnyObject // expected-note{{protocol requires nested type 'AssocA'; add nested type 'AssocA' for conformance}}
+  associatedtype AssocP : C // expected-note{{protocol requires nested type 'AssocP'}}
+  associatedtype AssocA : AnyObject // expected-note{{protocol requires nested type 'AssocA'}}
 }
 
-struct X : P { // expected-error{{type 'X' does not conform to protocol 'P'}}
+struct X : P { // expected-error{{type 'X' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
   typealias AssocP = Int // expected-note{{possibly intended match 'X.AssocP' (aka 'Int') does not inherit from 'C'}}
   typealias AssocA = Int // expected-note{{possibly intended match 'X.AssocA' (aka 'Int') does not conform to 'AnyObject'}}
 }
@@ -78,9 +78,9 @@ struct X1d : P1 {
 }
 
 protocol P2 {
-  func f(_: (Int) -> Int) // expected-note{{expected sendability to match requirement here}} expected-note 2{{protocol requires function 'f' with type '((Int) -> Int) -> ()'; add a stub for conformance}}
+  func f(_: (Int) -> Int) // expected-note{{expected sendability to match requirement here}} expected-note 2{{protocol requires function 'f' with type '((Int) -> Int) -> ()'}}
   func g(_: @escaping (Int) -> Int) // expected-note 2 {{expected sendability to match requirement here}}
-  func h(_: @Sendable (Int) -> Int) // expected-note 2 {{protocol requires function 'h' with type '(@Sendable (Int) -> Int) -> ()'; add a stub for conformance}}
+  func h(_: @Sendable (Int) -> Int) // expected-note 2 {{protocol requires function 'h' with type '(@Sendable (Int) -> Int) -> ()'}}
   func i(_: @escaping @Sendable (Int) -> Int)
 }
 
@@ -91,7 +91,7 @@ struct X2a : P2 {
   func i(_: (Int) -> Int) { }
 }
 
-struct X2b : P2 { // expected-error{{type 'X2b' does not conform to protocol 'P2'}}
+struct X2b : P2 { // expected-error{{type 'X2b' does not conform to protocol 'P2'}} expected-note {{add stubs for conformance}}
   func f(_: @escaping (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping (Int) -> Int) -> ()'}}
   func g(_: @escaping (Int) -> Int) { }
   func h(_: @escaping (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping (Int) -> Int) -> ()'}}
@@ -105,7 +105,7 @@ struct X2c : P2 {
   func i(_: @Sendable (Int) -> Int) { }
 }
 
-struct X2d : P2 { // expected-error{{type 'X2d' does not conform to protocol 'P2'}}
+struct X2d : P2 { // expected-error{{type 'X2d' does not conform to protocol 'P2'}} expected-note {{add stubs for conformance}}
   func f(_: @escaping @Sendable (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping @Sendable (Int) -> Int) -> ()'}}
   func g(_: @escaping @Sendable (Int) -> Int) { } // expected-warning{{sendability of function types in instance method 'g' does not match requirement in protocol 'P2'}}
   func h(_: @escaping @Sendable (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping @Sendable (Int) -> Int) -> ()'}}

--- a/test/decl/protocol/conforms/circular_validation.swift
+++ b/test/decl/protocol/conforms/circular_validation.swift
@@ -4,10 +4,10 @@
 // not crash.
 
 protocol P {
-  var x: Int { get set } // expected-note {{protocol requires property 'x' with type 'Int'; add a stub for conformance}}
+  var x: Int { get set } // expected-note {{protocol requires property 'x' with type 'Int'}}
 }
 
-struct S : P { // expected-error {{type 'S' does not conform to protocol 'P'}}
+struct S : P { // expected-error {{type 'S' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}} 
   static var x = 0 // expected-note {{candidate operates on a type, not an instance as required}}
   var x = S.x // expected-note {{candidate references itself}}
 }

--- a/test/decl/protocol/conforms/failure.swift
+++ b/test/decl/protocol/conforms/failure.swift
@@ -9,7 +9,7 @@ extension P1 {
   func bar() {} // okay
 }
 
-struct P1Conformer : P1 {} // expected-error {{does not conform}}
+struct P1Conformer : P1 {} // expected-error {{does not conform}} expected-note {{add stubs for conformance}} 
 
 
 protocol P2 {
@@ -22,7 +22,7 @@ extension P2 where Self : P2Helper {
   func bar() {} // expected-note {{candidate}}
 }
 
-struct P2Conformer : P2 {} // expected-error {{does not conform}}
+struct P2Conformer : P2 {} // expected-error {{does not conform}} expected-note {{add stubs for conformance}} 
 
 
 protocol P3 {
@@ -36,7 +36,7 @@ extension P3 {
   func bar() {} // okay
 }
 
-struct P3Conformer : P3 { // expected-error {{does not conform}}
+struct P3Conformer : P3 { // expected-error {{does not conform}} expected-note {{add stubs for conformance}} 
   func baz() -> Int { return 0 }
 }
 
@@ -53,7 +53,7 @@ extension P4 where Self : P4Helper {
   func bar() {} // expected-note {{candidate}}
 }
 
-struct P4Conformer : P4 { // expected-error {{does not conform}}
+struct P4Conformer : P4 { // expected-error {{does not conform}} expected-note {{add stubs for conformance}} 
   func baz() -> Int { return 0 }
 }
 
@@ -69,13 +69,13 @@ extension P5 {
   func bar() -> Foo { return foo() } // okay
 }
 
-struct P5Conformer : P5 { // expected-error {{does not conform}}
+struct P5Conformer : P5 { // expected-error {{does not conform}} expected-note {{add stubs for conformance}} 
   func baz() -> Int { return 0 }
 }
 
 
 protocol P6Base {
-  associatedtype Foo // expected-note{{protocol requires nested type 'Foo'; add nested type 'Foo' for conformance}}
+  associatedtype Foo // expected-note{{protocol requires nested type 'Foo'}}
   func foo()
   func bar() -> Foo
 }
@@ -88,11 +88,12 @@ extension P6 {
   func bar() -> Bar? { return nil }
 }
 
-struct P6Conformer : P6 { // expected-error 2 {{does not conform}}
+struct P6Conformer : P6 { // expected-error 2 {{does not conform}} expected-note {{add stubs for conformance}} 
   func foo() {}
 }
 
 // rdar://problem/23033862
+// expected-note@+3 {{add stubs for conformance}} 
 // expected-error@+2{{type 'A' does not conform to protocol 'OptionSet'}}
 // expected-error@+1{{type 'A' does not conform to protocol 'RawRepresentable'}}
 struct A: OptionSet {
@@ -103,29 +104,30 @@ struct A: OptionSet {
 // Type witness cannot have its own generic parameters
 // FIXME: Crappy diagnostic
 protocol PA {
-  associatedtype A // expected-note 3 {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A // expected-note 3 {{protocol requires nested type 'A'}}
 }
 
-struct BadCase1 : PA { // expected-error {{type 'BadCase1' does not conform to protocol 'PA'}}
+struct BadCase1 : PA { // expected-error {{type 'BadCase1' does not conform to protocol 'PA'}} expected-note {{add stubs for conformance}} 
   struct A<T> {}
 }
 
-struct BadCase2 : PA { // expected-error {{type 'BadCase2' does not conform to protocol 'PA'}}
+struct BadCase2 : PA { // expected-error {{type 'BadCase2' does not conform to protocol 'PA'}} expected-note {{add stubs for conformance}} 
   typealias A<T> = T
 }
 
 // Variation on the above
 struct G<T> {}
 
-struct BadCase3 : PA { // expected-error {{type 'BadCase3' does not conform to protocol 'PA'}}
+struct BadCase3 : PA { // expected-error {{type 'BadCase3' does not conform to protocol 'PA'}} expected-note {{add stubs for conformance}} 
   typealias A = G
 }
 
 // rdar://problem/32215763
 extension UInt32: @retroactive ExpressibleByStringLiteral {}
-// expected-error@-1 {{type 'UInt32' does not conform to protocol 'ExpressibleByStringLiteral'}}
+// expected-error@-1 {{type 'UInt32' does not conform to protocol 'ExpressibleByStringLiteral'}} 
 // expected-error@-2 {{type 'UInt32' does not conform to protocol 'ExpressibleByExtendedGraphemeClusterLiteral'}}
 // expected-error@-3 {{type 'UInt32' does not conform to protocol 'ExpressibleByUnicodeScalarLiteral'}}
+// expected-note@-4 {{add stubs for conformance}} 
 
 // After successfully type-checking this (due to the presumption of
 // the type actually conforming), do not crash when failing to find
@@ -135,36 +137,37 @@ let diagnose: UInt32 = "reta"
 // Test that we attempt to resolve a value witness unless mapping its interface
 // type into the conformance context produces an invalid type.
 protocol P7 {
-  associatedtype A: Sequence // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A: Sequence // expected-note {{protocol requires nested type 'A'}}
 
   subscript(subscript1 _: A) -> Never { get }
   subscript<T>(subscript2 _: T) -> Never where T: Sequence, T.Element == A { get }
-  // expected-note@-1 {{protocol requires subscript with type '<T> (subscript2: T) -> Never'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires subscript with type '<T> (subscript2: T) -> Never'}}
 
   func method1(_: A)
   func method2() -> A.Element
   func method3<T>(_: T) where T: Sequence, T.Element == A
-  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'; add a stub for conformance}}
-  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'}}
+  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'}}
 }
 do {
-  struct Conformer: P7 {} // expected-error {{type 'Conformer' does not conform to protocol 'P7'}}
+  struct Conformer: P7 {} // expected-error {{type 'Conformer' does not conform to protocol 'P7'}} expected-note {{add stubs for conformance}} 
 }
 
 protocol P8 {
   associatedtype A: Sequence where A.Element == Never
 
-  func method1(_: A) // expected-note {{protocol requires function 'method1' with type '(Conformer.A) -> ()' (aka '(Array<Bool>) -> ()'); add a stub for conformance}}
-  func method2() -> A.Element // expected-note {{protocol requires function 'method2()' with type '() -> Bool'; add a stub for conformance}}
+  func method1(_: A) // expected-note {{protocol requires function 'method1' with type '(Conformer.A) -> ()' (aka '(Array<Bool>) -> ()')}}
+  func method2() -> A.Element // expected-note {{protocol requires function 'method2()' with type '() -> Bool'}}
   func method3<T>(_: T) where T: Sequence, T.Element == A
-  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'; add a stub for conformance}}
-  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'}}
+  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'}}
 }
 do {
   struct Conformer: P8 {
     // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P8'}}
     // expected-error@-2 {{'P8' requires the types 'Bool' and 'Never' be equivalent}}
     // expected-note@-3 {{requirement specified as 'Self.A.Element' == 'Never' [with Self = Conformer]}}
+    // expected-note@-4 {{add stubs for conformance}} 
     typealias A = Array<Bool>
   }
 }
@@ -175,18 +178,19 @@ protocol P9a {
 protocol P9b: P9a where A: Sequence {
   subscript(subscript1 _: A.Element) -> Never { get }
   subscript<T>(subscript2 _: T) -> Never where T: Sequence, T.Element == A.Element { get }
-  // expected-note@-1 {{protocol requires subscript with type '<T> (subscript2: T) -> Never'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires subscript with type '<T> (subscript2: T) -> Never'}}
 
-  func method1(_: A) // expected-note {{protocol requires function 'method1' with type '(Conformer.A) -> ()' (aka '(Bool) -> ()'); add a stub for conformance}}
+  func method1(_: A) // expected-note {{protocol requires function 'method1' with type '(Conformer.A) -> ()' (aka '(Bool) -> ()')}}
   func method2() -> A.Element
   func method3<T>(_: T) where T: Sequence, T.Element == A
-  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'; add a stub for conformance}}
-  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'}}
+  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'}}
 }
 do {
   struct Conformer: P9b {
     // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P9b'}}
     // expected-error@-2 {{type 'Conformer.A' (aka 'Bool') does not conform to protocol 'Sequence'}}
+    // expected-note@-3 {{add stubs for conformance}} 
     typealias A = Bool
   }
 }
@@ -195,17 +199,18 @@ protocol P10a {
   associatedtype A
 }
 protocol P10b: P10a where A: Sequence, A.Element == Never {
-  func method1(_: A) // expected-note {{protocol requires function 'method1' with type '(Conformer.A) -> ()' (aka '(Array<Bool>) -> ()'); add a stub for conformance}}
-  func method2() -> A.Element // expected-note {{protocol requires function 'method2()' with type '() -> Bool'; add a stub for conformance}}
+  func method1(_: A) // expected-note {{protocol requires function 'method1' with type '(Conformer.A) -> ()' (aka '(Array<Bool>) -> ()')}}
+  func method2() -> A.Element // expected-note {{protocol requires function 'method2()' with type '() -> Bool'}}
   func method3<T>(_: T) where T: Sequence, T.Element == A
-  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'; add a stub for conformance}}
-  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'}}
+  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'}}
 }
 do {
   struct Conformer: P10b {
     // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P10b'}}
     // expected-error@-2 {{'P10b' requires the types 'Bool' and 'Never' be equivalent}}
     // expected-note@-3 {{requirement specified as 'Self.A.Element' == 'Never' [with Self = Conformer]}}
+    // expected-note@-4 {{add stubs for conformance}} 
     typealias A = Array<Bool>
   }
 }
@@ -214,7 +219,7 @@ protocol P11 {
   associatedtype A: Equatable
   // FIXME: Should not resolve witness for 'method', but Type::subst doesn't care
   // about conditional requirements when querying type witnesses.
-  // expected-note@+1 {{protocol requires function 'method()' with type '() -> Conformer.A' (aka '() -> Array<any P11>'); add a stub for conformance}}
+  // expected-note@+1 {{protocol requires function 'method()' with type '() -> Conformer.A' (aka '() -> Array<any P11>')}}
   func method() -> A
 }
 do {
@@ -224,12 +229,13 @@ do {
     // expected-error@-3 {{'P11' requires that 'any P11' conform to 'Equatable'}}
     // expected-note@-4 {{requirement specified as 'any P11' : 'Equatable'}}
     // expected-note@-5 {{requirement from conditional conformance of 'Conformer.A' (aka 'Array<any P11>') to 'Equatable'}}
+    // expected-note@-6 {{add stubs for conformance}} 
     typealias A = Array<any P11>
   }
 }
 
 protocol P12 {
-  associatedtype A: Sequence where A.Element == Never // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A: Sequence where A.Element == Never // expected-note {{protocol requires nested type 'A'}}
   // FIXME: Should not resolve witness for 'prop', but getInterfaceType() returns
   // '(Self) -> Never' instead of '(Self) -> Self.A.Element', and the invalid
   // type parameter is never found (see 'hasInvalidTypeInConformanceContext').
@@ -239,11 +245,11 @@ protocol P12 {
   // Instead, patterns should be refactored to use interface types, at least if
   // they appear in type contexts.
   //
-  // expected-note@+1 {{protocol requires property 'prop' with type '(Conformer) -> Never'; add a stub for conformance}}
+  // expected-note@+1 {{protocol requires property 'prop' with type '(Conformer) -> Never'}}
   var prop: (Self) -> A.Element { get }
 }
 do {
-  struct Conformer: P12 { // expected-error {{type 'Conformer' does not conform to protocol 'P12'}}
+  struct Conformer: P12 { // expected-error {{type 'Conformer' does not conform to protocol 'P12'}} expected-note {{add stubs for conformance}} 
     typealias A = Bool // expected-note {{possibly intended match 'Conformer.A' (aka 'Bool') does not conform to 'Sequence'}}
   }
 }

--- a/test/decl/protocol/conforms/fixit_stub.swift
+++ b/test/decl/protocol/conforms/fixit_stub.swift
@@ -1,198 +1,196 @@
 // RUN: %target-typecheck-verify-swift
 
 protocol Protocol1 {
-  func foo(arg1: Int, arg2: String) -> String // expected-note{{protocol requires function 'foo(arg1:arg2:)' with type '(Int, String) -> String'; add a stub for conformance}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  func bar() throws -> String // expected-note{{protocol requires function 'bar()' with type '() throws -> String'; add a stub for conformance}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  func generic<T>(t: T) // expected-note{{protocol requires function 'generic(t:)' with type '<T> (t: T) -> ()'; add a stub for conformance}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; add a stub for conformance}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  var baz: Int { get } // expected-note{{protocol requires property 'baz' with type 'Int'; add a stub for conformance}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  var baz2: Int { get set } // expected-note{{protocol requires property 'baz2' with type 'Int'; add a stub for conformance}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  subscript(arg: Int) -> String { get } //expected-note{{rotocol requires subscript with type '(Int) -> String'; add a stub for conformance}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'; add a stub for conformance}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  func foo(arg1: Int, arg2: String) -> String // expected-note{{protocol requires function 'foo(arg1:arg2:)' with type '(Int, String) -> String'}}
+  func bar() throws -> String // expected-note{{protocol requires function 'bar()' with type '() throws -> String'}}
+  func generic<T>(t: T) // expected-note{{protocol requires function 'generic(t:)' with type '<T> (t: T) -> ()'}}
+  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'}}
+  var baz: Int { get } // expected-note{{protocol requires property 'baz' with type 'Int'}}
+  var baz2: Int { get set } // expected-note{{protocol requires property 'baz2' with type 'Int'}}
+  subscript(arg: Int) -> String { get } //expected-note{{rotocol requires subscript with type '(Int) -> String'}}
+  subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'}}
 }
 
-class Adopter: Protocol1 { // expected-error{{type 'Adopter' does not conform to protocol 'Protocol1'}}
+class Adopter: Protocol1 { // expected-error{{type 'Adopter' does not conform to protocol 'Protocol1'}} expected-note {{add stubs for conformance}} {{27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
 }
-
 
 
 protocol Protocol2 {
-  func foo(arg1: Int, arg2: String) -> String // expected-note{{protocol requires function 'foo(arg1:arg2:)' with type '(Int, String) -> String'; add a stub for conformance}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  func bar() throws -> String // expected-note{{protocol requires function 'bar()' with type '() throws -> String'; add a stub for conformance}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  func foo(arg1: Int, arg2: String) -> String // expected-note{{protocol requires function 'foo(arg1:arg2:)' with type '(Int, String) -> String'}}
+  func bar() throws -> String // expected-note{{protocol requires function 'bar()' with type '() throws -> String'}}
   init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'}} {{none}}
-  var baz: Int { get } // expected-note{{protocol requires property 'baz' with type 'Int'; add a stub for conformance}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  var baz2: Int { get set } // expected-note{{protocol requires property 'baz2' with type 'Int'; add a stub for conformance}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  subscript(arg: Int) -> String { get } //expected-note{{rotocol requires subscript with type '(Int) -> String'; add a stub for conformance}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'; add a stub for conformance}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  var baz: Int { get } // expected-note{{protocol requires property 'baz' with type 'Int'}}
+  var baz2: Int { get set } // expected-note{{protocol requires property 'baz2' with type 'Int'}}
+  subscript(arg: Int) -> String { get } //expected-note{{rotocol requires subscript with type '(Int) -> String'}}
+  subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'}}
 }
 
 class Adopter2 {}
 
-extension Adopter2: Protocol2 { // expected-error{{ype 'Adopter2' does not conform to protocol 'Protocol2'}}
+extension Adopter2: Protocol2 { // expected-error {{ype 'Adopter2' does not conform to protocol 'Protocol2'}} expected-note {{add stubs for conformance}} {{32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
 }
 
 
 
 protocol ProtocolWithAssocType {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{+2:41-41=\n    typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}}
 }
-struct Adopter3: ProtocolWithAssocType { //expected-error{{type 'Adopter3' does not conform to protocol 'ProtocolWithAssocType'}}
+struct Adopter3: ProtocolWithAssocType { //expected-error{{type 'Adopter3' does not conform to protocol 'ProtocolWithAssocType'}} expected-note {{add stubs for conformance}} {{41-41=\n    typealias AssocType = <#type#>\n}}
 }
 
 
 
 protocol ProtocolWithAssocType2 {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'; add nested type 'AssocType' for conformance}} {{+4:45-45=\n    typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}}
 }
 struct Adopter4 {
 }
-extension Adopter4: ProtocolWithAssocType2 { //expected-error{{type 'Adopter4' does not conform to protocol 'ProtocolWithAssocType2'}}
+extension Adopter4: ProtocolWithAssocType2 { //expected-error {{type 'Adopter4' does not conform to protocol 'ProtocolWithAssocType2'}} expected-note {{add stubs for conformance}} {{45-45=\n    typealias AssocType = <#type#>\n}}
 }
 
 
 
 protocol ProtocolWithSelfRequirement {
-  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Adopter5'; add a stub for conformance}} {{+3:47-47=\n    func foo() -> Adopter5 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter5, rhs: Adopter5) -> Adopter5 {\n        <#code#>\n    \}\n}}
-  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter5, Adopter5) -> Adopter5'; add a stub for conformance}} {{+2:47-47=\n    func foo() -> Adopter5 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter5, rhs: Adopter5) -> Adopter5 {\n        <#code#>\n    \}\n}}
+  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Adopter5'}}
+  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter5, Adopter5) -> Adopter5'}}
 }
-struct Adopter5: ProtocolWithSelfRequirement { //expected-error{{type 'Adopter5' does not conform to protocol 'ProtocolWithSelfRequirement'}}
+struct Adopter5: ProtocolWithSelfRequirement { //expected-error{{type 'Adopter5' does not conform to protocol 'ProtocolWithSelfRequirement'}} expected-note {{add stubs for conformance}} {{47-47=\n    func foo() -> Adopter5 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter5, rhs: Adopter5) -> Adopter5 {\n        <#code#>\n    \}\n}}
 }
 
 
 
 protocol ProtocolWithSelfRequirement2 {
-  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Adopter6'; add a stub for conformance}} {{+4:51-51=\n    func foo() -> Adopter6 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter6, rhs: Adopter6) -> Adopter6 {\n        <#code#>\n    \}\n}}
-  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter6, Adopter6) -> Adopter6'; add a stub for conformance}} {{+3:51-51=\n    func foo() -> Adopter6 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter6, rhs: Adopter6) -> Adopter6 {\n        <#code#>\n    \}\n}}
+  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Adopter6'}}
+  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter6, Adopter6) -> Adopter6'}}
 }
 struct Adopter6 {}
-extension Adopter6: ProtocolWithSelfRequirement2 { //expected-error{{type 'Adopter6' does not conform to protocol 'ProtocolWithSelfRequirement2'}}
+extension Adopter6: ProtocolWithSelfRequirement2 { //expected-error{{type 'Adopter6' does not conform to protocol 'ProtocolWithSelfRequirement2'}} expected-note {{add stubs for conformance}} {{51-51=\n    func foo() -> Adopter6 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter6, rhs: Adopter6) -> Adopter6 {\n        <#code#>\n    \}\n}}
 }
 
 
 protocol ProtocolWithSelfRequirement3 {
-  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Self'; add a stub for conformance}} {{+3:47-47=\n    func foo() -> Self {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter7, rhs: Adopter7) -> Self {\n        <#code#>\n    \}\n}}
-  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter7, Adopter7) -> Self'; add a stub for conformance}} {{+2:47-47=\n    func foo() -> Self {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter7, rhs: Adopter7) -> Self {\n        <#code#>\n    \}\n}}
+  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Self'}} 
+  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter7, Adopter7) -> Self'}}
 }
-class Adopter7: ProtocolWithSelfRequirement3 { //expected-error{{type 'Adopter7' does not conform to protocol 'ProtocolWithSelfRequirement3'}}
+class Adopter7: ProtocolWithSelfRequirement3 { //expected-error{{type 'Adopter7' does not conform to protocol 'ProtocolWithSelfRequirement3'}} expected-note {{add stubs for conformance}} {{47-47=\n    func foo() -> Self {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter7, rhs: Adopter7) -> Self {\n        <#code#>\n    \}\n}}
 }
 
 
 public protocol ProtocolWithPublicAccess1 {
-  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; add a stub for conformance}} {{+5:71-71=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'}} 
 }
 public protocol ProtocolWithPublicAccess2 {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{+2:71-71=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}}
 }
 class Adopter8: ProtocolWithPublicAccess1, ProtocolWithPublicAccess2 {
-  // expected-error@-1{{type 'Adopter8' does not conform to protocol 'ProtocolWithPublicAccess1'}}
-  // expected-error@-2{{type 'Adopter8' does not conform to protocol 'ProtocolWithPublicAccess2'}}
+  // expected-error@-1{{type 'Adopter8' does not conform to protocol 'ProtocolWithPublicAccess1'}} expected-note@-1 {{add stubs for conformance}} {{71-71=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  // expected-error@-2{{type 'Adopter8' does not conform to protocol 'ProtocolWithPublicAccess2'}} 
 }
 
 public protocol ProtocolWithPublicAccess3 {
-  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; add a stub for conformance}} {{+5:78-78=\n    public func foo() {\n        <#code#>\n    \}\n\n    public typealias AssocType = <#type#>\n}}
+  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'}} 
 }
 public protocol ProtocolWithPublicAccess4 {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{+2:78-78=\n    public func foo() {\n        <#code#>\n    \}\n\n    public typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}}
 }
 public class Adopter9: ProtocolWithPublicAccess3, ProtocolWithPublicAccess4 {
-  // expected-error@-1{{type 'Adopter9' does not conform to protocol 'ProtocolWithPublicAccess3'}}
+  // expected-error@-1{{type 'Adopter9' does not conform to protocol 'ProtocolWithPublicAccess3'}} expected-note@-1 {{add stubs for conformance}} {{78-78=\n    public func foo() {\n        <#code#>\n    \}\n\n    public typealias AssocType = <#type#>\n}}
   // expected-error@-2{{type 'Adopter9' does not conform to protocol 'ProtocolWithPublicAccess4'}}
 }
 
 private protocol ProtocolWithPrivateAccess1 {
-  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; add a stub for conformance}} {{+5:74-74=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'}} 
 }
 private protocol ProtocolWithPrivateAccess2 {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{+2:74-74=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}}
 }
 class Adopter10: ProtocolWithPrivateAccess1, ProtocolWithPrivateAccess2 {
-  // expected-error@-1{{type 'Adopter10' does not conform to protocol 'ProtocolWithPrivateAccess1'}}
+  // expected-error@-1{{type 'Adopter10' does not conform to protocol 'ProtocolWithPrivateAccess1'}} expected-note@-1 {{add stubs for conformance}} {{74-74=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
   // expected-error@-2{{type 'Adopter10' does not conform to protocol 'ProtocolWithPrivateAccess2'}}
 }
 
 private protocol ProtocolWithPrivateAccess3 {
-  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; add a stub for conformance}} {{+5:81-81=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'}}
 }
 private protocol ProtocolWithPrivateAccess4 {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{+2:81-81=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}}
 }
 public class Adopter11: ProtocolWithPrivateAccess3, ProtocolWithPrivateAccess4 {
-  // expected-error@-1{{type 'Adopter11' does not conform to protocol 'ProtocolWithPrivateAccess3'}}
+  // expected-error@-1{{type 'Adopter11' does not conform to protocol 'ProtocolWithPrivateAccess3'}} expected-note@-1 {{add stubs for conformance}} {{81-81=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
   // expected-error@-2{{type 'Adopter11' does not conform to protocol 'ProtocolWithPrivateAccess4'}}
 }
 
 protocol ProtocolRequiresInit1 {
-  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; add a stub for conformance}} {{+2:48-48=\n    init(arg: Int) {\n        <#code#>\n    \}\n}}
+  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'}}
 }
-final class Adopter12 : ProtocolRequiresInit1 {} //expected-error {{type 'Adopter12' does not conform to protocol 'ProtocolRequiresInit1'}}
+final class Adopter12 : ProtocolRequiresInit1 {} //expected-error {{type 'Adopter12' does not conform to protocol 'ProtocolRequiresInit1'}} expected-note {{add stubs for conformance}} {{48-48=\n    init(arg: Int) {\n        <#code#>\n    \}\n}}
 
 protocol ProtocolRequiresInit2 {
-  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; add a stub for conformance}} {{+3:46-46=\n    convenience init(arg: Int) {\n        <#code#>\n    \}\n}}
+  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'}}
 }
 final class Adopter13 {}
-extension Adopter13 : ProtocolRequiresInit2 {} //expected-error {{type 'Adopter13' does not conform to protocol 'ProtocolRequiresInit2'}}
+extension Adopter13 : ProtocolRequiresInit2 {} //expected-error {{type 'Adopter13' does not conform to protocol 'ProtocolRequiresInit2'}} expected-note {{add stubs for conformance}} {{46-46=\n    convenience init(arg: Int) {\n        <#code#>\n    \}\n}}
 
 protocol ProtocolRequiresInit3 {
-  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; add a stub for conformance}} {{+3:46-46=\n    init(arg: Int) {\n        <#code#>\n    \}\n}}
+  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'}}
 }
 struct Adopter14 {}
-extension Adopter14 : ProtocolRequiresInit3 {} //expected-error {{type 'Adopter14' does not conform to protocol 'ProtocolRequiresInit3'}}
+extension Adopter14 : ProtocolRequiresInit3 {} //expected-error {{type 'Adopter14' does not conform to protocol 'ProtocolRequiresInit3'}} expected-note {{add stubs for conformance}} {{46-46=\n    init(arg: Int) {\n        <#code#>\n    \}\n}}
 
 protocol ProtocolChain1 {
-  func foo1() // expected-note {{protocol requires function 'foo1()' with type '() -> ()'; add a stub for conformance}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  func foo2() // expected-note {{protocol requires function 'foo2()' with type '() -> ()'; add a stub for conformance}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  func foo3() // expected-note {{protocol requires function 'foo3()' with type '() -> ()'; add a stub for conformance}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  var foo4 : Int {get set } // expected-note {{protocol requires property 'foo4' with type 'Int'; add a stub for conformance}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
+  func foo1() // expected-note {{protocol requires function 'foo1()' with type '() -> ()'}}
+  func foo2() // expected-note {{protocol requires function 'foo2()' with type '() -> ()'}}
+  func foo3() // expected-note {{protocol requires function 'foo3()' with type '() -> ()'}}
+  var foo4 : Int {get set } // expected-note {{protocol requires property 'foo4' with type 'Int'}}
 }
 protocol ProtocolChain2 : ProtocolChain1 {
-  func bar1() // expected-note {{protocol requires function 'bar1()' with type '() -> ()'; add a stub for conformance}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  func bar2() // expected-note {{protocol requires function 'bar2()' with type '() -> ()'; add a stub for conformance}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  func bar3() // expected-note {{protocol requires function 'bar3()' with type '() -> ()'; add a stub for conformance}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  var bar4 : Int {get set } // expected-note {{protocol requires property 'bar4' with type 'Int'; add a stub for conformance}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
+  func bar1() // expected-note {{protocol requires function 'bar1()' with type '() -> ()'}}
+  func bar2() // expected-note {{protocol requires function 'bar2()' with type '() -> ()'}}
+  func bar3() // expected-note {{protocol requires function 'bar3()' with type '() -> ()'}}
+  var bar4 : Int {get set } // expected-note {{protocol requires property 'bar4' with type 'Int'}}
 }
 
-class Adopter15 : ProtocolChain2 {} //expected-error {{type 'Adopter15' does not conform to protocol 'ProtocolChain2'}} expected-error {{type 'Adopter15' does not conform to protocol 'ProtocolChain1'}}
+class Adopter15 : ProtocolChain2 {} //expected-error {{type 'Adopter15' does not conform to protocol 'ProtocolChain2'}} expected-error {{type 'Adopter15' does not conform to protocol 'ProtocolChain1'}} expected-note {{add stubs for conformance}} {{35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
 
 protocol ProtocolParallel1 {
-  associatedtype Foo1 // expected-note {{protocol requires nested type 'Foo1'; add nested type 'Foo1' for conformance}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n\n    func Bar4() {\n        <#code#>\n    \}\n}}
-  associatedtype Foo2 // expected-note {{protocol requires nested type 'Foo2'; add nested type 'Foo2' for conformance}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n\n    func Bar4() {\n        <#code#>\n    \}\n}}
-  associatedtype Foo3 // expected-note {{protocol requires nested type 'Foo3'; add nested type 'Foo3' for conformance}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n\n    func Bar4() {\n        <#code#>\n    \}\n}}
-  // FIXME: Why do we add stubs for all missing requirements when the note implies a single one?
-  func Foo4() // expected-note {{protocol requires function 'Foo4()' with type '() -> ()'; add a stub for conformance}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n\n    func Bar4() {\n        <#code#>\n    \}\n}}
+  associatedtype Foo1 // expected-note {{protocol requires nested type 'Foo1'}}
+  associatedtype Foo2 // expected-note {{protocol requires nested type 'Foo2'}}
+  associatedtype Foo3 // expected-note {{protocol requires nested type 'Foo3'}}
+  func Foo4() // expected-note {{protocol requires function 'Foo4()' with type '() -> ()'}}
 }
 
 protocol ProtocolParallel2 {
-  associatedtype Bar1 // expected-note {{protocol requires nested type 'Bar1'; add nested type 'Bar1' for conformance}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n\n    func Bar4() {\n        <#code#>\n    \}\n}}
-  associatedtype Bar2 // expected-note {{protocol requires nested type 'Bar2'; add nested type 'Bar2' for conformance}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n\n    func Bar4() {\n        <#code#>\n    \}\n}}
-  associatedtype Bar3 // expected-note {{protocol requires nested type 'Bar3'; add nested type 'Bar3' for conformance}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n\n    func Bar4() {\n        <#code#>\n    \}\n}}
-  func Bar4() // expected-note {{protocol requires function 'Bar4()' with type '() -> ()'; add a stub for conformance}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n\n    func Bar4() {\n        <#code#>\n    \}\n}}
+  associatedtype Bar1 // expected-note {{protocol requires nested type 'Bar1'}}
+  associatedtype Bar2 // expected-note {{protocol requires nested type 'Bar2'}}
+  associatedtype Bar3 // expected-note {{protocol requires nested type 'Bar3'}}
+  func Bar4() // expected-note {{protocol requires function 'Bar4()' with type '() -> ()'}}
 }
 
-class Adopter16 : ProtocolParallel1, ProtocolParallel2 {} // expected-error {{type 'Adopter16' does not conform to protocol 'ProtocolParallel1'}} expected-error {{type 'Adopter16' does not conform to protocol 'ProtocolParallel2'}}
+class Adopter16 : ProtocolParallel1, ProtocolParallel2 {} // expected-error {{type 'Adopter16' does not conform to protocol 'ProtocolParallel1'}} expected-error {{type 'Adopter16' does not conform to protocol 'ProtocolParallel2'}} expected-note {{add stubs for conformance}} {{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n\n    func Bar4() {\n        <#code#>\n    \}\n}}
 
 protocol ProtocolParallel3 {
-  func foo1() // expected-note{{protocol requires function 'foo1()' with type '() -> ()'; add a stub for conformance}}{{+7:56-56=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n}}
-  func foo2() // expected-note{{protocol requires function 'foo2()' with type '() -> ()'; add a stub for conformance}}{{+6:56-56=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n}}
+  func foo1() // expected-note{{protocol requires function 'foo1()' with type '() -> ()'}}
+  func foo2() // expected-note{{protocol requires function 'foo2()' with type '() -> ()'}}
 }
 protocol ProtocolParallel4 {
   func bar1()
   func bar2()
 }
-class Adopter17: ProtocolParallel3, ProtocolParallel4 { // expected-error {{type 'Adopter17' does not conform to protocol 'ProtocolParallel3'}}
+class Adopter17: ProtocolParallel3, ProtocolParallel4 { // expected-error {{type 'Adopter17' does not conform to protocol 'ProtocolParallel3'}} expected-note {{add stubs for conformance}} {{56-56=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n}}
   func bar1() {}
   func bar2() {}
 }
 
 protocol ProtocolHasSubscriptFunction {
-  func `subscript`() // expected-note{{protocol requires function 'subscript()' with type '() -> ()'; add a stub for conformance}} {{+2:74-74=\n    func `subscript`() {\n        <#code#>\n    \}\n}}
+  func `subscript`() // expected-note{{protocol requires function 'subscript()' with type '() -> ()'}}
 }
-class ProtocolHasSubscriptFunctionAdopter: ProtocolHasSubscriptFunction { // expected-error{{type 'ProtocolHasSubscriptFunctionAdopter' does not conform to protocol 'ProtocolHasSubscriptFunction'}}
+class ProtocolHasSubscriptFunctionAdopter: ProtocolHasSubscriptFunction { // expected-error{{type 'ProtocolHasSubscriptFunctionAdopter' does not conform to protocol 'ProtocolHasSubscriptFunction'}} expected-note {{add stubs for conformance}} {{74-74=\n    func `subscript`() {\n        <#code#>\n    \}\n}}
 
 }
 
 protocol ProtocolHasConsumingRequirement {
-  __consuming func foo() // expected-note {{protocol requires function 'foo()' with type '() -> ()'; add a stub for conformance}} {{+2:81-81=\n    func foo() {\n        <#code#>\n    \}\n}}
+  __consuming func foo() // expected-note {{protocol requires function 'foo()' with type '() -> ()'}}
 }
-struct ProtocolHasConsumingRequirementAdopter: ProtocolHasConsumingRequirement { // expected-error {{type 'ProtocolHasConsumingRequirementAdopter' does not conform to protocol 'ProtocolHasConsumingRequirement'}}
+struct ProtocolHasConsumingRequirementAdopter: ProtocolHasConsumingRequirement { // expected-error {{type 'ProtocolHasConsumingRequirementAdopter' does not conform to protocol 'ProtocolHasConsumingRequirement'}} expected-note {{add stubs for conformance}} {{81-81=\n    func foo() {\n        <#code#>\n    \}\n}}
 
 }

--- a/test/decl/protocol/conforms/fixit_stub_batch_mode.swift
+++ b/test/decl/protocol/conforms/fixit_stub_batch_mode.swift
@@ -1,3 +1,3 @@
 // RUN: %target-typecheck-verify-swift -enable-batch-mode %S/Inputs/fixit_stub_batch_mode_helper.swift
 
-extension C: P {} // expected-error{{type 'C' does not conform to protocol 'P'}}
+extension C: P {} // expected-error{{type 'C' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}

--- a/test/decl/protocol/conforms/fixit_stub_editor.swift
+++ b/test/decl/protocol/conforms/fixit_stub_editor.swift
@@ -3,26 +3,26 @@
 
 // RUN: %target-swift-frontend -typecheck %s -I %t -verify -diagnostics-editor-mode
 
-protocol P0_A { associatedtype T }
+protocol P0_A { associatedtype T } // expected-note{{protocol requires nested type 'T'}}
 protocol P0_B { associatedtype T }
 
 class C0: P0_A, P0_B {} // expected-error{{type 'C0' does not conform to protocol 'P0_A'}} expected-error{{type 'C0' does not conform to protocol 'P0_B'}} expected-note{{add stubs for conformance}}{{23-23=\n    typealias T = <#type#>\n}}
 
 protocol P1 {
   @available(*, deprecated)
-  func foo1()
-  func foo2()
-  func foo3(arg: Int, arg2: String)
-  func foo4<T: P1>(_: T)
+  func foo1() // expected-note{{protocol requires function 'foo1()' with type '() -> ()'}}
+  func foo2() // expected-note{{protocol requires function 'foo2()' with type '() -> ()'}}
+  func foo3(arg: Int, arg2: String) // expected-note{{protocol requires function 'foo3(arg:arg2:)' with type '(Int, String) -> ()'}}
+  func foo4<T: P1>(_: T) // expected-note{{protocol requires function 'foo4' with type '<T> (T) -> ()'}}
 }
 
 protocol P2 {
-  func bar1()
-  func bar2()
+  func bar1() // expected-note{{protocol requires function 'bar1()' with type '() -> ()'}}
+  func bar2() // expected-note{{protocol requires function 'bar2()' with type '() -> ()'}}
 
   func foo2()
   func foo3(arg: Int, arg2: String)
-  func foo3(arg: Int, arg2: Int)
+  func foo3(arg: Int, arg2: Int)  // expected-note{{protocol requires function 'foo3(arg:arg2:)' with type '(Int, Int) -> ()'}}
   func foo4<T: P1>(_: T)
   func foo4<T: P2>(_: T)
 }
@@ -31,15 +31,15 @@ class C1 : P1, P2 {} // expected-error{{type 'C1' does not conform to protocol '
 
 protocol P3 {
   associatedtype T1
-  associatedtype T2
-  associatedtype T3
+  associatedtype T2 // expected-note{{protocol requires nested type 'T2'}}
+  associatedtype T3 // expected-note{{protocol requires nested type 'T3'}}
 }
 
 protocol P4 : P3 {
-  associatedtype T1
-  associatedtype T4 = T1
-  associatedtype T5 = T2
-  associatedtype T6 = T3
+  associatedtype T1 // expected-note{{protocol requires nested type 'T1'}}
+  associatedtype T4 = T1 // expected-note{{protocol requires nested type 'T4'}}
+  associatedtype T5 = T2 // expected-note{{protocol requires nested type 'T5'}}
+  associatedtype T6 = T3 // expected-note{{protocol requires nested type 'T6'}}
 }
 
 class C2 : P4 {} // expected-error{{type 'C2' does not conform to protocol 'P4'}} expected-error{{type 'C2' does not conform to protocol 'P3'}} expected-note{{add stubs for conformance}}{{16-16=\n    typealias T1 = <#type#>\n\n    typealias T2 = <#type#>\n\n    typealias T3 = <#type#>\n}}
@@ -51,10 +51,10 @@ protocol P5 {
 }
 
 protocol P6: P5 {
-  func foo1()
-  func foo2(arg: Int, arg2: String)
-  func foo2(arg: Int, arg2: Int)
-  func foo3<T: P3>(_: T)
+  func foo1() // expected-note{{protocol requires function 'foo1()' with type '() -> ()'}}
+  func foo2(arg: Int, arg2: String) // expected-note{{protocol requires function 'foo2(arg:arg2:)' with type '(Int, String) -> ()'}}
+  func foo2(arg: Int, arg2: Int) // expected-note{{protocol requires function 'foo2(arg:arg2:)' with type '(Int, Int) -> ()'}}
+  func foo3<T: P3>(_: T) // expected-note{{protocol requires function 'foo3' with type '<T> (T) -> ()'}}
   func foo3<T: P4>(_: T)
 }
 
@@ -69,8 +69,8 @@ class C3 : P6 {} // expected-error{{type 'C3' does not conform to protocol 'P5'}
 // =============================================================================
 
 protocol MutabilityProto {
-  mutating func foo()
-  subscript() -> Int { get nonmutating set }
+  mutating func foo() // expected-note2 {{protocol requires function 'foo()' with type '() -> ()'}}
+  subscript() -> Int { get nonmutating set } // expected-note2{{protocol requires subscript with type '() -> Int'}}
 }
 
 class Class1: MutabilityProto { // expected-error{{type 'Class1' does not conform to protocol 'MutabilityProto'}} expected-note{{add stubs for conformance}} {{32-32=\n    func foo() {\n        <#code#>\n    \}\n\n    subscript() -> Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
@@ -88,8 +88,8 @@ struct Struct2: ExternalMutabilityProto { // expected-error{{type 'Struct2' does
 }
 
 protocol PropertyMutabilityProto {
-  var computed: Int { mutating get nonmutating set }
-  var stored: Int { mutating get set }
+  var computed: Int { mutating get nonmutating set }  // expected-note3 {{protocol requires property 'computed' with type 'Int'}}
+  var stored: Int { mutating get set } // expected-note3 {{protocol requires property 'stored' with type 'Int'}}
 }
 
 class Class3: PropertyMutabilityProto { // expected-error{{type 'Class3' does not conform to protocol 'PropertyMutabilityProto'}} expected-note{{add stubs for conformance}} {{40-40=\n    var computed: Int\n\n    var stored: Int\n}}
@@ -106,7 +106,7 @@ extension Class4: PropertyMutabilityProto { // expected-error{{type 'Class4' doe
 
 protocol FooProto {
  typealias CompletionType = (Int) -> Void
- func doSomething(then completion: @escaping CompletionType)
+ func doSomething(then completion: @escaping CompletionType) // expected-note{{protocol requires function 'doSomething(then:)' with type '(@escaping FooType.CompletionType) -> ()' (aka '(@escaping (Int) -> ()) -> ()')}}
 }
 
 struct FooType : FooProto { // expected-error {{type 'FooType' does not conform to protocol 'FooProto'}} expected-note {{add stubs for conformance}} {{28-28=\n    func doSomething(then completion: @escaping CompletionType) {\n        <#code#>\n    \}\n}}

--- a/test/decl/protocol/conforms/fixit_stub_editor_implied.swift
+++ b/test/decl/protocol/conforms/fixit_stub_editor_implied.swift
@@ -1,13 +1,16 @@
 // RUN: %target-typecheck-verify-swift -serialize-diagnostics-path %t.diag
 
 protocol P1 {
-  func foo1()
-  func foo2()
+  func foo1() // expected-note{{protocol requires function 'foo1()' with type '() -> ()}}
+  func foo2() // expected-note{{protocol requires function 'foo2()' with type '() -> ()}}
 }
 
 protocol P2 {
-  func bar1()
-  func bar2()
+  func bar1() // expected-note{{protocol requires function 'bar1()' with type '() -> ()}}
+  func bar2() // expected-note{{protocol requires function 'bar2()' with type '() -> ()}}
 }
 
-class C1 : P1, P2 {} // expected-error{{type 'C1' does not conform to protocol 'P1'}} expected-error{{type 'C1' does not conform to protocol 'P2'}} expected-note{{add stubs for conformance}}{{20-20=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n}}
+class C1 : P1, P2 {} 
+// expected-error@-1 {{type 'C1' does not conform to protocol 'P1'}} 
+// expected-error@-2 {{type 'C1' does not conform to protocol 'P2'}} 
+// expected-note@-3 {{add stubs for conformance}}{{20-20=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n}}

--- a/test/decl/protocol/conforms/init.swift
+++ b/test/decl/protocol/conforms/init.swift
@@ -31,7 +31,7 @@ class C1c : P1 {
 
 struct S2 : P1 { } // okay
 
-enum E2 : P1 { } // expected-error{{type 'E2' does not conform to protocol 'P1'}}
+enum E2 : P1 { } // expected-error{{type 'E2' does not conform to protocol 'P1'}} expected-note {{add stubs for conformance}}
 
 final class C2a : P1 { } // okay
 

--- a/test/decl/protocol/conforms/isolated_any.swift
+++ b/test/decl/protocol/conforms/isolated_any.swift
@@ -12,5 +12,6 @@ protocol AnnotatedEnqueuer {
   func enqueue(operation: @escaping @isolated(any) @Sendable () async -> Result)
 }
 
-// expected-error @+1 {{type 'A<T>' does not conform to protocol 'AnnotatedEnqueuer'}}
+// expected-error@+2 {{type 'A<T>' does not conform to protocol 'AnnotatedEnqueuer'}}
+// expected-note@+1 {{add stubs for conformance}}
 extension A : AnnotatedEnqueuer {}

--- a/test/decl/protocol/conforms/nsobject.swift
+++ b/test/decl/protocol/conforms/nsobject.swift
@@ -4,16 +4,16 @@
 
 import Foundation
 
-class A: NSObjectProtocol { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'A' should inherit 'NSObject' instead}}{{10-26=NSObject}}
+class A: NSObjectProtocol { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'A' should inherit 'NSObject' instead}}{{10-26=NSObject}} expected-note {{add stubs for conformance}}
 
 @objc protocol Other: NSObjectProtocol { }
 
-class B: Other { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'B' should inherit 'NSObject' instead}}
+class B: Other { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'B' should inherit 'NSObject' instead}} expected-note {{add stubs for conformance}}
 
 class C { }
 
-class D: C, NSObjectProtocol { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'D' should inherit 'NSObject' instead}}
+class D: C, NSObjectProtocol { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'D' should inherit 'NSObject' instead}} expected-note {{add stubs for conformance}}
 
 class E { }
 
-extension E: NSObjectProtocol { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'E' should inherit 'NSObject' instead}}
+extension E: NSObjectProtocol { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'E' should inherit 'NSObject' instead}} expected-note {{add stubs for conformance}}

--- a/test/decl/protocol/conforms/objc_async.swift
+++ b/test/decl/protocol/conforms/objc_async.swift
@@ -37,7 +37,7 @@ class C3: ConcurrentProtocol {
 
 // Conform but forget to supply either. Also an error.
 // FIXME: Suppress one of the notes?
-class C4: ConcurrentProtocol { // expected-error{{type 'C4' does not conform to protocol 'ConcurrentProtocol'}}
+class C4: ConcurrentProtocol { // expected-error{{type 'C4' does not conform to protocol 'ConcurrentProtocol'}} expected-note {{add stubs for conformance}}
 }
 
 class C5 {

--- a/test/decl/protocol/conforms/self.swift
+++ b/test/decl/protocol/conforms/self.swift
@@ -57,7 +57,7 @@ class SillyClass {}
 
 protocol HasDefault {
   func foo()
-  // expected-note@-1 {{protocol requires function 'foo()' with type '() -> ()'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'foo()' with type '() -> ()'}}
 }
 
 extension HasDefault where Self == SillyClass {
@@ -67,6 +67,7 @@ extension HasDefault where Self == SillyClass {
 
 extension SillyClass : HasDefault {}
 // expected-error@-1 {{type 'SillyClass' does not conform to protocol 'HasDefault'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 // This is OK, though
 class SeriousClass {}

--- a/test/decl/protocol/conforms/typed_throws.swift
+++ b/test/decl/protocol/conforms/typed_throws.swift
@@ -19,11 +19,12 @@ protocol VeryThrowing {
 
   var prop1: Int { get throws }
   var prop2: Int { get throws(MyError) }
-  var prop3: Int { get throws(HomeworkError) } // expected-note{{protocol requires property 'prop3' with type 'Int'; add a stub for conformance}}
+  var prop3: Int { get throws(HomeworkError) } // expected-note{{protocol requires property 'prop3' with type 'Int'}}
                                                // FIXME: poor diagnostic above
   var prop4: Int { get throws(SuperError) }
 }
 
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1{{type 'ConformingToVeryThrowing' does not conform to protocol 'VeryThrowing'}}
 struct ConformingToVeryThrowing: VeryThrowing {
   func f() throws(MyError) { } // okay to make type more specific

--- a/test/decl/protocol/conforms/variadic_generic_type.swift
+++ b/test/decl/protocol/conforms/variadic_generic_type.swift
@@ -3,11 +3,12 @@
 // Generic parameter packs cannot witness associated type requirements
 protocol HasAssoc {
   associatedtype A
-  // expected-note@-1 {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  // expected-note@-1 {{protocol requires nested type 'A'}}
 }
 
 struct HasPack<each A>: HasAssoc {}
 // expected-error@-1 {{type 'HasPack<repeat each A>' does not conform to protocol 'HasAssoc'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 protocol P {}
 

--- a/test/decl/protocol/deserialized_witness_mismatch.swift
+++ b/test/decl/protocol/deserialized_witness_mismatch.swift
@@ -9,8 +9,9 @@ import deserialized_witness_mismatch_other
 
 protocol HasCurrent {
   var current: Self { get }
-  // expected-note@-1 {{protocol requires property 'current' with type 'TimeZone'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires property 'current' with type 'TimeZone'}}
 }
 
 extension TimeZone : HasCurrent {}
 // expected-error@-1 {{type 'TimeZone' does not conform to protocol 'HasCurrent'}}
+// expected-note@-2 {{add stubs for conformance}}

--- a/test/decl/protocol/effectful_properties.swift
+++ b/test/decl/protocol/effectful_properties.swift
@@ -5,21 +5,21 @@
 
 protocol None {
   associatedtype V
-  // expected-note@+2 {{protocol requires property 'someProp' with type 'CA_N.V' (aka 'Int'); add a stub for conformance}}
-  // expected-note@+1 2 {{protocol requires property 'someProp' with type 'Self.V'; add a stub for conformance}}
+  // expected-note@+2 {{protocol requires property 'someProp' with type 'CA_N.V' (aka 'Int')}}
+  // expected-note@+1 2 {{protocol requires property 'someProp' with type 'Self.V'}}
   var someProp : V { get }
 }
 
 protocol T {
   associatedtype V
-  // expected-note@+2 {{protocol requires property 'someProp' with type 'CAT_T.V' (aka 'Int'); add a stub for conformance}}
-  // expected-note@+1 {{protocol requires property 'someProp' with type 'Self.V'; add a stub for conformance}}
+  // expected-note@+2 {{protocol requires property 'someProp' with type 'CAT_T.V' (aka 'Int')}}
+  // expected-note@+1 {{protocol requires property 'someProp' with type 'Self.V'}}
   var someProp : V { get throws }
 }
 
 protocol A {
   associatedtype V
-  // expected-note@+1 2 {{protocol requires property 'someProp' with type 'Self.V'; add a stub for conformance}}
+  // expected-note@+1 2 {{protocol requires property 'someProp' with type 'Self.V'}}
   var someProp : V { get async }
 }
 
@@ -51,21 +51,25 @@ class CN_AT : AT   { typealias V = Int; var someProp : Int { _read {yield 0} } }
 
 // Remaining conformances test the limit check for kinds of effects allowed
 
+// expected-note@+3 {{add stubs for conformance}}
 // expected-note@+2 3 {{candidate throws, but protocol does not allow it}}
 // expected-error@+1 {{type 'CT_N' does not conform to protocol 'None'}}
 class CT_N : None { typealias V = Int; var someProp : Int { get throws {0} } }
 class CT_T : T    { typealias V = Int; var someProp : Int { get throws {0} } }
 
+// expected-note@+3 {{add stubs for conformance}}
 // expected-note@+2 {{candidate throws, but protocol does not allow it}}
 // expected-error@+1{{type 'CT_A' does not conform to protocol 'A'}}
 class CT_A : A    { typealias V = Int; var someProp : Int { get throws {0} } }
 class CT_AT : AT   { typealias V = Int; var someProp : Int { get throws {0} } }
 // ------ ------ ------ ------ ------ ------ ------ ------ ------ ------
 
+// expected-note@+3 {{add stubs for conformance}} 
 // expected-note@+2 3 {{candidate is 'async', but protocol requirement is not}}
 // expected-error@+1 {{type 'CA_N' does not conform to protocol 'None'}}
 struct CA_N : None { typealias V = Int; var someProp : Int { get async {0} } }
 
+// expected-note@+3 {{add stubs for conformance}}
 // expected-note@+2 {{candidate is 'async', but protocol requirement is not}}
 // expected-error@+1 {{type 'CA_T' does not conform to protocol 'T'}}
 class CA_T : T    { typealias V = Int; var someProp : Int { get async {0} } }
@@ -76,18 +80,21 @@ enum CA_AT : AT   { typealias V = Int; var someProp : Int { get async {0} } }
 
 // I put these on separate lines to ensure diagnostics point to the right thing.
 
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CAT_N' does not conform to protocol 'None'}}
 class CAT_N : None { typealias V = Int;
   // expected-note@+2 {{candidate throws, but protocol does not allow it}}
   // expected-note@+1 2 {{candidate is 'async', but protocol requirement is not}}
   var someProp : Int { get async throws {0} }
 }
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CAT_T' does not conform to protocol 'T'}}
 enum CAT_T : T    { typealias V = Int;
   // expected-note@+2 {{candidate throws, but protocol does not allow it}}
   // expected-note@+1 2 {{candidate is 'async', but protocol requirement is not}}
   var someProp : Int { get async throws {0} }
 }
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CAT_A' does not conform to protocol 'A'}}
 class CAT_A : A    { typealias V = Int;
   // expected-note@+1 {{candidate throws, but protocol does not allow it}}
@@ -162,29 +169,29 @@ protocol AsyncThrowsSub {
 
 struct SN_N : NoneSub
   { subscript(_ i : Int) -> Bool { get { true } }}
-class SA_N : NoneSub // expected-error{{type 'SA_N' does not conform to protocol 'NoneSub'}}
+class SA_N : NoneSub // expected-error{{type 'SA_N' does not conform to protocol 'NoneSub'}} expected-note {{add stubs for conformance}}
   { subscript(_ i : Int) -> Bool { get async { true } }} // expected-note{{candidate is 'async', but protocol requirement is not}}
-class ST_N : NoneSub // expected-error{{type 'ST_N' does not conform to protocol 'NoneSub'}}
+class ST_N : NoneSub // expected-error{{type 'ST_N' does not conform to protocol 'NoneSub'}} expected-note {{add stubs for conformance}}
   { subscript(_ i : Int) -> Bool { get throws { true } }} // expected-note{{candidate throws, but protocol does not allow it}}
-class SAT_N : NoneSub // expected-error{{type 'SAT_N' does not conform to protocol 'NoneSub'}}
+class SAT_N : NoneSub // expected-error{{type 'SAT_N' does not conform to protocol 'NoneSub'}} expected-note {{add stubs for conformance}}
   { subscript(_ i : Int) -> Bool { get async throws { true } }} // expected-note{{candidate is 'async', but protocol requirement is not}}
 
 class SN_A : AsyncSub
   { subscript(_ i : Int) -> Bool { get { true } }}
 struct SA_A : AsyncSub
   { subscript(_ i : Int) -> Bool { get async { true } }}
-enum ST_A : AsyncSub // expected-error{{type 'ST_A' does not conform to protocol 'AsyncSub'}}
+enum ST_A : AsyncSub // expected-error{{type 'ST_A' does not conform to protocol 'AsyncSub'}} expected-note {{add stubs for conformance}}
   { subscript(_ i : Int) -> Bool { get throws { true } }} // expected-note{{candidate throws, but protocol does not allow it}}
-class SAT_A : AsyncSub // expected-error{{type 'SAT_A' does not conform to protocol 'AsyncSub'}}
+class SAT_A : AsyncSub // expected-error{{type 'SAT_A' does not conform to protocol 'AsyncSub'}} expected-note {{add stubs for conformance}}
   { subscript(_ i : Int) -> Bool { get async throws { true } }} // expected-note{{candidate throws, but protocol does not allow it}}
 
 class SN_T : ThrowsSub
   { subscript(_ i : Int) -> Bool { get { true } }}
-class SA_T : ThrowsSub // expected-error{{type 'SA_T' does not conform to protocol 'ThrowsSub'}}
+class SA_T : ThrowsSub // expected-error{{type 'SA_T' does not conform to protocol 'ThrowsSub'}} expected-note {{add stubs for conformance}}
   { subscript(_ i : Int) -> Bool { get async { true } }} // expected-note{{candidate is 'async', but protocol requirement is not}}
 struct ST_T : ThrowsSub
   { subscript(_ i : Int) -> Bool { get throws { true } }}
-struct SAT_T : ThrowsSub // expected-error{{type 'SAT_T' does not conform to protocol 'ThrowsSub'}}
+struct SAT_T : ThrowsSub // expected-error{{type 'SAT_T' does not conform to protocol 'ThrowsSub'}} expected-note {{add stubs for conformance}}
   { subscript(_ i : Int) -> Bool { get async throws { true } }} // expected-note{{candidate is 'async', but protocol requirement is not}}
 
 class SN_AT : AsyncThrowsSub
@@ -239,17 +246,17 @@ func composed4<U : T & None >(u : U) {
 // redefining the protocols to make sure the fix-its are matched
 
 protocol NoEffects {
-// expected-note@+1 2 {{protocol requires property 'someProp' with type 'Int'; add a stub for conformance}}
+// expected-note@+1 2 {{protocol requires property 'someProp' with type 'Int'}}
   var someProp : Int { get }
 }
 
 protocol Throws {
-  // expected-note@+1 2 {{protocol requires property 'someProp' with type 'Int'; add a stub for conformance}}
+  // expected-note@+1 2 {{protocol requires property 'someProp' with type 'Int'}}
   var someProp : Int { get throws }
 }
 
 protocol Async {
-  // expected-note@+1 3 {{protocol requires property 'someProp' with type 'Int'; add a stub for conformance}}
+  // expected-note@+1 3 {{protocol requires property 'someProp' with type 'Int'}}
   var someProp : Int { get async }
 }
 
@@ -266,9 +273,11 @@ extension CN_AT : AsyncByInheritance, ThrowsByInheritance, AsyncThrowsByInherita
 
 extension CT_N : Throws {}
 
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CT_N' does not conform to protocol 'NoEffects'}}
 extension CT_N : ThrowsByInheritance {}
 
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CT_N' does not conform to protocol 'Async'}}
 extension CT_N : AsyncByInheritance {}
 
@@ -276,20 +285,25 @@ extension CT_N : AsyncByInheritance {}
 
 extension CA_N : Async {}
 
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CA_N' does not conform to protocol 'NoEffects'}}
 extension CA_N : AsyncByInheritance {}
 
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CA_N' does not conform to protocol 'Throws'}}
 extension CA_N : ThrowsByInheritance {}
 
 // ----- -----
 
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CAT_N' does not conform to protocol 'Async'}}
 extension CAT_N : Async {}
 
+// expected-note@+2 {{add stubs for conformance}}
 // expected-error@+1 {{type 'CAT_N' does not conform to protocol 'Throws'}}
 extension CAT_N : Throws {}
 
+// expected-note@+3 {{add stubs for conformance}}
 // expected-error@+2 {{type 'CAT_T' does not conform to protocol 'Async'}}
 // expected-error@+1 {{type 'CAT_T' does not conform to protocol 'Throws'}}
 extension CAT_T : AsyncThrowsByInheritance {}

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -923,8 +923,9 @@ do {
 
 class BadConformanceClass: CompositionBrokenClassConformance_a {}
 // expected-error@-1 {{type 'BadConformanceClass' does not conform to protocol 'CompositionBrokenClassConformance_a'}}
+// expected-note@-2 {{add stubs for conformance}}
 protocol CompositionBrokenClassConformance_a {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
 }
 protocol CompositionBrokenClassConformance_b: CompositionBrokenClassConformance_a {
   func method(_: A)

--- a/test/decl/protocol/protocol_enum_witness.swift
+++ b/test/decl/protocol/protocol_enum_witness.swift
@@ -5,56 +5,68 @@
 // Requirement is settable, so witness cannot satisfy it //
 
 protocol Foo1 {
-  static var bar: Self { get set } // expected-note {{protocol requires property 'bar' with type 'Bar1'; add a stub for conformance}}
+  static var bar: Self { get set } // expected-note {{protocol requires property 'bar' with type 'Bar1'}}
 }
 
-enum Bar1: Foo1 { // expected-error {{type 'Bar1' does not conform to protocol 'Foo1'}}
+enum Bar1: Foo1 { 
+  // expected-error@-1 {{type 'Bar1' does not conform to protocol 'Foo1'}}
+  // expected-note@-2 {{add stubs for conformance}}
   case bar // expected-note {{candidate is not settable, but protocol requires it}}
 }
 
 // Witness has associated values, which is unsupported //
 
 protocol Foo2 {
-  static var bar: Self { get set } // expected-note {{protocol requires property 'bar' with type 'Bar2'; add a stub for conformance}}
+  static var bar: Self { get set } // expected-note {{protocol requires property 'bar' with type 'Bar2'}}
 }
 
-enum Bar2: Foo2 { // expected-error {{type 'Bar2' does not conform to protocol 'Foo2'}}
+enum Bar2: Foo2 { 
+  // expected-error@-1 {{type 'Bar2' does not conform to protocol 'Foo2'}}
+  // expected-note@-2 {{add stubs for conformance}}
   case bar(Int) // expected-note {{candidate is an enum case with associated values, but protocol does not allow it}}
 }
 
 protocol Foo3 {
-  static var bar: Self { get } // expected-note {{protocol requires property 'bar' with type 'Bar3'; add a stub for conformance}}
+  static var bar: Self { get } // expected-note {{protocol requires property 'bar' with type 'Bar3'}}
 }
 
-enum Bar3: Foo3 { // expected-error {{type 'Bar3' does not conform to protocol 'Foo3'}}
+enum Bar3: Foo3 { 
+  // expected-error@-1 {{type 'Bar3' does not conform to protocol 'Foo3'}}
+  // expected-note@-2 {{add stubs for conformance}}
   case bar(Int) // expected-note {{candidate is an enum case with associated values, but protocol does not allow it}}
 }
 
 // Requirement is not static, so it cannot be witnessed by the enum case //
 
 protocol Foo4 {
-  var bar: Self { get } // expected-note {{protocol requires property 'bar' with type 'Bar4'; add a stub for conformance}}
+  var bar: Self { get } // expected-note {{protocol requires property 'bar' with type 'Bar4'}}
 }
 
-enum Bar4: Foo4 { // expected-error {{type 'Bar4' does not conform to protocol 'Foo4'}}
+enum Bar4: Foo4 { 
+  // expected-error@-1 {{type 'Bar4' does not conform to protocol 'Foo4'}}
+  // expected-note@-2 {{add stubs for conformance}}
   case bar // expected-note {{candidate operates on a type, not an instance as required}}
 }
 
 protocol Foo5 {
-  var bar: Self { get set } // expected-note {{protocol requires property 'bar' with type 'Bar5'; add a stub for conformance}}
+  var bar: Self { get set } // expected-note {{protocol requires property 'bar' with type 'Bar5'}}
 }
 
-enum Bar5: Foo5 { // expected-error {{type 'Bar5' does not conform to protocol 'Foo5'}}
+enum Bar5: Foo5 { 
+  // expected-error@-1 {{type 'Bar5' does not conform to protocol 'Foo5'}}
+  // expected-note@-2 {{add stubs for conformance}}
   case bar // expected-note {{candidate operates on a type, not an instance as required}}
 }
 
 // Requirement does not have Self type, so it cannot be witnessed by the enum case //
 
 protocol Foo6 {
-  static var bar: Int { get } // expected-note {{protocol requires property 'bar' with type 'Int'; add a stub for conformance}}
+  static var bar: Int { get } // expected-note {{protocol requires property 'bar' with type 'Int'}}
 }
 
-enum Bar6: Foo6 { // expected-error {{type 'Bar6' does not conform to protocol 'Foo6'}}
+enum Bar6: Foo6 { 
+  // expected-error@-1 {{type 'Bar6' does not conform to protocol 'Foo6'}}
+  // expected-note@-2 {{add stubs for conformance}}
   case bar // expected-note {{candidate has non-matching type '(Bar6.Type) -> Bar6'}}
 }
 
@@ -101,20 +113,24 @@ enum Bar10: Foo10 {
 // Witness does not have a payload, but requirement is a function
 
 protocol Foo11 {
-  static func bar(h: Int) -> Self // expected-note {{protocol requires function 'bar(h:)' with type '(Int) -> Bar11'; add a stub for conformance}}
+  static func bar(h: Int) -> Self // expected-note {{protocol requires function 'bar(h:)' with type '(Int) -> Bar11'}}
 }
 
-enum Bar11: Foo11 { // expected-error {{type 'Bar11' does not conform to protocol 'Foo11'}}
+enum Bar11: Foo11 { 
+  // expected-error@-1 {{type 'Bar11' does not conform to protocol 'Foo11'}}
+  // expected-note@-2 {{add stubs for conformance}}
   case bar // expected-note {{candidate has non-matching type '(Bar11.Type) -> Bar11'}}
 }
 
 // Witness is static, but requirement is not
 
 protocol Foo12 {
-  func bar(i: Int) -> Self // expected-note {{protocol requires function 'bar(i:)' with type '(Int) -> Bar12'; add a stub for conformance}}
+  func bar(i: Int) -> Self // expected-note {{protocol requires function 'bar(i:)' with type '(Int) -> Bar12'}}
 }
 
-enum Bar12: Foo12 { // expected-error {{type 'Bar12' does not conform to protocol 'Foo12'}}
+enum Bar12: Foo12 { 
+  // expected-error@-1 {{type 'Bar12' does not conform to protocol 'Foo12'}}
+  // expected-note@-2 {{add stubs for conformance}}
   case bar // expected-note {{candidate operates on a type, not an instance as required}}
 }
 

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -18,7 +18,7 @@ protocol BaseProto {}
 
 protocol ProtoRefinesClass : Generic<Int>, BaseProto {
   func requirementUsesClassTypes(_: ConcreteAlias, _: GenericAlias)
-  // expected-note@-1 {{protocol requires function 'requirementUsesClassTypes' with type '(Generic<Int>.ConcreteAlias, Generic<Int>.GenericAlias) -> ()' (aka '(String, (Int, Int)) -> ()'); add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'requirementUsesClassTypes' with type '(Generic<Int>.ConcreteAlias, Generic<Int>.GenericAlias) -> ()' (aka '(String, (Int, Int)) -> ()')}}
 }
 
 func duplicateOverload<T : ProtoRefinesClass>(_: T) {}
@@ -111,6 +111,7 @@ class BadConformingClass2 : Generic<String>, ProtoRefinesClass {
   // expected-error@-1 {{'ProtoRefinesClass' requires that 'BadConformingClass2' inherit from 'Generic<Int>'}}
   // expected-note@-2 {{requirement specified as 'Self' : 'Generic<Int>' [with Self = BadConformingClass2]}}
   // expected-error@-3 {{type 'BadConformingClass2' does not conform to protocol 'ProtoRefinesClass'}}
+  // expected-note@-4 {{add stubs for conformance}}
 
   // expected-note@+1 {{candidate has non-matching type '(BadConformingClass2.ConcreteAlias, BadConformingClass2.GenericAlias) -> ()' (aka '(String, (String, String)) -> ()')}}
   func requirementUsesClassTypes(_: ConcreteAlias, _: GenericAlias) {

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -19,7 +19,7 @@ protocol BaseProto {}
 
 protocol ProtoRefinesClass where Self : Generic<Int>, Self : BaseProto {
   func requirementUsesClassTypes(_: ConcreteAlias, _: GenericAlias)
-  // expected-note@-1 {{protocol requires function 'requirementUsesClassTypes' with type '(Generic<Int>.ConcreteAlias, Generic<Int>.GenericAlias) -> ()' (aka '(String, (Int, Int)) -> ()'); add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'requirementUsesClassTypes' with type '(Generic<Int>.ConcreteAlias, Generic<Int>.GenericAlias) -> ()' (aka '(String, (Int, Int)) -> ()')}}
 }
 
 func duplicateOverload<T : ProtoRefinesClass>(_: T) {}
@@ -112,6 +112,7 @@ class BadConformingClass2 : Generic<String>, ProtoRefinesClass {
   // expected-error@-1 {{'ProtoRefinesClass' requires that 'BadConformingClass2' inherit from 'Generic<Int>'}}
   // expected-note@-2 {{requirement specified as 'Self' : 'Generic<Int>' [with Self = BadConformingClass2]}}
   // expected-error@-3 {{type 'BadConformingClass2' does not conform to protocol 'ProtoRefinesClass'}}
+  // expected-note@-4 {{add stubs for conformance}}
 
   // expected-note@+1 {{candidate has non-matching type '(BadConformingClass2.ConcreteAlias, BadConformingClass2.GenericAlias) -> ()' (aka '(String, (String, String)) -> ()')}}
   func requirementUsesClassTypes(_: ConcreteAlias, _: GenericAlias) {

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -71,22 +71,30 @@ extension X2 : CustomStringConvertible {
 
 // Explicit conformance checks (unsuccessful)
 
-struct NotPrintableS : Any, CustomStringConvertible {} // expected-error{{type 'NotPrintableS' does not conform to protocol 'CustomStringConvertible'}}
+struct NotPrintableS : Any, CustomStringConvertible {} 
+// expected-error@-1 {{type 'NotPrintableS' does not conform to protocol 'CustomStringConvertible'}}
+// expected-note@-2 {{add stubs for conformance}}
 
-class NotPrintableC : CustomStringConvertible, Any {} // expected-error{{type 'NotPrintableC' does not conform to protocol 'CustomStringConvertible'}}
+class NotPrintableC : CustomStringConvertible, Any {} 
+// expected-error@-1 {{type 'NotPrintableC' does not conform to protocol 'CustomStringConvertible'}}
+// expected-note@-2 {{add stubs for conformance}}
 
-enum NotPrintableO : Any, CustomStringConvertible {} // expected-error{{type 'NotPrintableO' does not conform to protocol 'CustomStringConvertible'}}
+enum NotPrintableO : Any, CustomStringConvertible {} 
+// expected-error@-1 {{type 'NotPrintableO' does not conform to protocol 'CustomStringConvertible'}}
+// expected-note@-2 {{add stubs for conformance}}
 
-struct NotFormattedPrintable : FormattedPrintable { // expected-error{{type 'NotFormattedPrintable' does not conform to protocol 'CustomStringConvertible'}}
+struct NotFormattedPrintable : FormattedPrintable { 
+  // expected-error@-1 {{type 'NotFormattedPrintable' does not conform to protocol 'CustomStringConvertible'}}
+  // expected-note@-2 {{add stubs for conformance}}
   func print(format: TestFormat) {} 
 }
 
 // Protocol compositions in inheritance clauses
 protocol Left {
-  func l() // expected-note {{protocol requires function 'l()' with type '() -> ()'; add a stub for conformance}}
+  func l() // expected-note {{protocol requires function 'l()' with type '() -> ()'}}
 }
 protocol Right {
-  func r() // expected-note {{protocol requires function 'r()' with type '() -> ()'; add a stub for conformance}}
+  func r() // expected-note {{protocol requires function 'r()' with type '() -> ()'}}
 }
 typealias Both = Left & Right
 
@@ -97,6 +105,7 @@ protocol Up : Both {
 struct DoesNotConform : Up {
   // expected-error@-1 {{type 'DoesNotConform' does not conform to protocol 'Left'}}
   // expected-error@-2 {{type 'DoesNotConform' does not conform to protocol 'Right'}}
+  // expected-note@-3 {{add stubs for conformance}}
   func u() {}
 }
 
@@ -140,7 +149,9 @@ struct IsSimpleAssoc : SimpleAssoc {
   struct Associated {}
 }
 
-struct IsNotSimpleAssoc : SimpleAssoc {} // expected-error{{type 'IsNotSimpleAssoc' does not conform to protocol 'SimpleAssoc'}}
+struct IsNotSimpleAssoc : SimpleAssoc {} 
+// expected-error@-1 {{type 'IsNotSimpleAssoc' does not conform to protocol 'SimpleAssoc'}} 
+// expected-note@-2 {{add stubs for conformance}} 
 
 protocol StreamWithAssoc {
   associatedtype Element
@@ -158,7 +169,9 @@ struct AWordStreamType : StreamWithAssoc {
   func get() -> Int {}
 }
 
-struct NotAStreamType : StreamWithAssoc { // expected-error{{type 'NotAStreamType' does not conform to protocol 'StreamWithAssoc'}}
+struct NotAStreamType : StreamWithAssoc { 
+  // expected-error@-1 {{type 'NotAStreamType' does not conform to protocol 'StreamWithAssoc'}}
+  // expected-note@-2 {{add stubs for conformance}}
   typealias Element = Float
   func get() -> Int {} // expected-note{{candidate has non-matching type '() -> Int'}}
 }
@@ -196,7 +209,9 @@ extension IntIterator : SequenceViaStream {
   typealias SequenceStreamTypeType = IntIterator
 }
 
-struct NotSequence : SequenceViaStream { // expected-error{{type 'NotSequence' does not conform to protocol 'SequenceViaStream'}}
+struct NotSequence : SequenceViaStream { 
+  // expected-error@-1 {{type 'NotSequence' does not conform to protocol 'SequenceViaStream'}}
+  // expected-note@-2 {{add stubs for conformance}}
   typealias SequenceStreamTypeType = Int // expected-note{{possibly intended match 'NotSequence.SequenceStreamTypeType' (aka 'Int') does not conform to 'IteratorProtocol'}}
   func makeIterator() -> Int {}
 }
@@ -240,11 +255,15 @@ struct HasIntMax : IntMaxable {
   func intmax(first: Int, rest: Int...) -> Int {}
 }
 
-struct NotIntMax1 : IntMaxable  { // expected-error{{type 'NotIntMax1' does not conform to protocol 'IntMaxable'}}
+struct NotIntMax1 : IntMaxable  { 
+  // expected-error@-1 {{type 'NotIntMax1' does not conform to protocol 'IntMaxable'}}
+  // expected-note@-2 {{add stubs for conformance}}
   func intmax(first: Int, rest: [Int]) -> Int {} // expected-note{{candidate has non-matching type '(Int, [Int]) -> Int'}}
 }
 
-struct NotIntMax2 : IntMaxable { // expected-error{{type 'NotIntMax2' does not conform to protocol 'IntMaxable'}}
+struct NotIntMax2 : IntMaxable { 
+  // expected-error@-1 {{type 'NotIntMax2' does not conform to protocol 'IntMaxable'}}
+  // expected-note@-2 {{add stubs for conformance}}
   func intmax(first: Int, rest: Int) -> Int {} // expected-note{{candidate has non-matching type '(Int, Int) -> Int'}}
 }
 
@@ -259,7 +278,9 @@ struct HasIsEqual : IsEqualComparable {
   func isEqual(other: HasIsEqual) -> Bool {}
 }
 
-struct WrongIsEqual : IsEqualComparable { // expected-error{{type 'WrongIsEqual' does not conform to protocol 'IsEqualComparable'}}
+struct WrongIsEqual : IsEqualComparable { 
+  // expected-error@-1 {{type 'WrongIsEqual' does not conform to protocol 'IsEqualComparable'}}
+  // expected-note@-2 {{add stubs for conformance}}
   func isEqual(other: Int) -> Bool {}  // expected-note{{candidate has non-matching type '(Int) -> Bool'}}
 }
 
@@ -275,7 +296,9 @@ protocol InstanceP {
 struct StaticS1 : StaticP {
   static func f() {}
 }
-struct StaticS2 : InstanceP { // expected-error{{type 'StaticS2' does not conform to protocol 'InstanceP'}}
+struct StaticS2 : InstanceP { 
+  // expected-error@-1 {{type 'StaticS2' does not conform to protocol 'InstanceP'}}
+  // expected-note@-2 {{add stubs for conformance}}
   static func f() {} // expected-note{{candidate operates on a type, not an instance as required}}
 }
 struct StaticAndInstanceS : InstanceP {
@@ -382,7 +405,9 @@ protocol NonObjCProtocol : class { //expected-note{{protocol 'NonObjCProtocol' d
   func bar()
 }
 
-class DoesntConformToObjCProtocol : ObjCProtocol { // expected-error{{type 'DoesntConformToObjCProtocol' does not conform to protocol 'ObjCProtocol'}}
+class DoesntConformToObjCProtocol : ObjCProtocol { 
+  // expected-error@-1 {{type 'DoesntConformToObjCProtocol' does not conform to protocol 'ObjCProtocol'}}
+  // expected-note@-2 {{add stubs for conformance}}
 }
 
 @objc protocol ObjCProtocolRefinement : ObjCProtocol { }
@@ -400,7 +425,9 @@ protocol P2 {
 
 struct X3<T : P1> where T.Assoc : P2 {}
 
-struct X4 : P1 { // expected-error{{type 'X4' does not conform to protocol 'P1'}}
+struct X4 : P1 { 
+  // expected-error@-1 {{type 'X4' does not conform to protocol 'P1'}}
+  // expected-note@-2 {{add stubs for conformance}}
   func getX1() -> X3<X4> { return X3() }
 }
 
@@ -437,7 +464,9 @@ func g<T : C2>(_ x : T) {
   x as P2 // expected-error{{cannot convert value of type 'T' to type 'any P2' in coercion}}
 }
 
-class C3 : P1 {} // expected-error{{type 'C3' does not conform to protocol 'P1'}}
+class C3 : P1 {} 
+// expected-error@-1 {{type 'C3' does not conform to protocol 'P1'}}
+// expected-note@-2 {{add stubs for conformance}}
 func h<T : C3>(_ x : T) {
   _ = x as any P1
 }
@@ -457,7 +486,9 @@ protocol P4 {
   associatedtype T // expected-note {{protocol requires nested type 'T'}}
 }
 
-class C4 : P4 { // expected-error {{type 'C4' does not conform to protocol 'P4'}}
+class C4 : P4 { 
+  // expected-error@-1 {{type 'C4' does not conform to protocol 'P4'}}
+  // expected-note@-2 {{add stubs for conformance}}
   associatedtype T = Int  // expected-error {{associated types can only be defined in a protocol; define a type or introduce a 'typealias' to satisfy an associated type requirement}} {{3-17=typealias}}
 }
 

--- a/test/decl/protocol/protocols_in_library.swift
+++ b/test/decl/protocol/protocols_in_library.swift
@@ -3,7 +3,7 @@
 struct X {
   struct Inner : Proto {
   }
-  struct Inner2 : Proto2 { // expected-error {{type 'X.Inner2' does not conform to protocol 'Proto2'}}
+  struct Inner2 : Proto2 { // expected-error {{type 'X.Inner2' does not conform to protocol 'Proto2'}} expected-note {{add stubs for conformance}}
   }
 }
 

--- a/test/decl/protocol/req/associated_type_typealias_implements.swift
+++ b/test/decl/protocol/req/associated_type_typealias_implements.swift
@@ -4,7 +4,7 @@ protocol P { }
 
 protocol Q {
   associatedtype T
-  associatedtype U // expected-note 2{{protocol requires nested type 'U'; add nested type 'U' for conformance}}
+  associatedtype U // expected-note 2{{protocol requires nested type 'U'}}
 }
 
 protocol R: Q {
@@ -25,14 +25,18 @@ struct Y1: R {
   // okay: infers U = XU
 }
 
-struct Y2: R { // expected-error{{type 'Y2' does not conform to protocol 'Q'}}
+struct Y2: R { 
+  // expected-error@-1 {{type 'Y2' does not conform to protocol 'Q'}}
+  // expected-note@-2 {{add stubs for conformance}}
   typealias T = XTWithoutP
 
   // FIXME: More detail from diagnostic.
   // error: T: P fails
 }
 
-struct Y3: Q { // expected-error{{type 'Y3' does not conform to protocol 'Q'}}
+struct Y3: Q { 
+  // expected-error@-1 {{type 'Y3' does not conform to protocol 'Q'}}
+  // expected-note@-2 {{add stubs for conformance}}
   typealias T = XT
   // FIXME: More detail from diagnostic.
 }

--- a/test/decl/protocol/req/dynamic_self.swift
+++ b/test/decl/protocol/req/dynamic_self.swift
@@ -18,7 +18,7 @@ protocol P {
 func takesP(_: P) {} // OK
 
 // Error: Missing witnesses.
-class W : P {} // expected-error{{type 'W' does not conform to protocol 'P'}}
+class W : P {} // expected-error{{type 'W' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
 
 // Okay: Self method in class.
 class X : P {
@@ -62,7 +62,7 @@ struct GS<T> : P {
   func f() -> GS { self }
 }
 
-struct SError : P { // expected-error{{type 'SError' does not conform to protocol 'P'}}
+struct SError : P { // expected-error{{type 'SError' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
   var p: Int { 0 } // expected-note{{candidate has non-matching type 'Int'}}
   subscript() -> Int { 0 } // expected-note{{candidate has non-matching type '() -> Int'}}
   func f() -> Int { 0 } // expected-note{{candidate has non-matching type '() -> Int'}}
@@ -81,7 +81,7 @@ enum GE<T> : P {
   func f() -> GE { self }
 }
 
-enum EError : P { // expected-error{{type 'EError' does not conform to protocol 'P'}}
+enum EError : P { // expected-error{{type 'EError' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
   var p: Int { 0 } // expected-note{{candidate has non-matching type 'Int'}}
   subscript() -> Int { 0 } // expected-note{{candidate has non-matching type '() -> Int'}}
   func f() -> Int { 0 } // expected-note{{candidate has non-matching type '() -> Int'}}

--- a/test/decl/protocol/req/func.swift
+++ b/test/decl/protocol/req/func.swift
@@ -61,18 +61,18 @@ struct X2g : P2 {
 }
 
 // Static/non-static mismatch.
-struct X2w : P2 { // expected-error{{type 'X2w' does not conform to protocol 'P2'}}
+struct X2w : P2 { // expected-error{{type 'X2w' does not conform to protocol 'P2'}} expected-note {{add stubs for conformance}}
   typealias Assoc = X1a
   static func f1(_ x: X1a) { } // expected-note{{candidate operates on a type, not an instance as required}}
 }
 
 // Deduction of type that doesn't meet requirements
-struct X2x : P2 { // expected-error{{type 'X2x' does not conform to protocol 'P2'}}
+struct X2x : P2 { // expected-error{{type 'X2x' does not conform to protocol 'P2'}} expected-note {{add stubs for conformance}}
   func f1(x: Int) { }
 }
 
 // Mismatch in parameter types
-struct X2y : P2 { // expected-error{{type 'X2y' does not conform to protocol 'P2'}}
+struct X2y : P2 { // expected-error{{type 'X2y' does not conform to protocol 'P2'}} expected-note {{add stubs for conformance}}
   typealias Assoc = X1a
   func f1(x: X1b) { }
 }
@@ -101,7 +101,7 @@ prefix func ~~(_: X3a) -> X1a {}
 // FIXME: Add example with overloaded prefix/postfix
 
 // Prefix/postfix mismatch.
-struct X3z : P3 { // expected-error{{type 'X3z' does not conform to protocol 'P3'}}
+struct X3z : P3 { // expected-error{{type 'X3z' does not conform to protocol 'P3'}} expected-note {{add stubs for conformance}}
   typealias Assoc = X1a
 }
 
@@ -122,7 +122,7 @@ struct X4a : P4 {
 postfix func ~~(_: X4a) -> X1a {}
 
 // Prefix/postfix mismatch.
-struct X4z : P4 { // expected-error{{type 'X4z' does not conform to protocol 'P4'}}
+struct X4z : P4 { // expected-error{{type 'X4z' does not conform to protocol 'P4'}} expected-note {{add stubs for conformance}}
   typealias Assoc = X1a
 }
 
@@ -190,7 +190,7 @@ protocol P6 {
   func foo(_ x: Int)
   func bar(x: Int) // expected-note{{protocol requires function 'bar(x:)' with type '(Int) -> ()'}}
 }
-struct X6 : P6 { // expected-error{{type 'X6' does not conform to protocol 'P6'}}
+struct X6 : P6 { // expected-error{{type 'X6' does not conform to protocol 'P6'}} expected-note {{add stubs for conformance}}
   func foo(_ x: Missing) { } // expected-error{{cannot find type 'Missing' in scope}}
   func bar() { }
 }
@@ -206,7 +206,7 @@ protocol P6Ownership {
   __consuming func mismatch__consuming_mutating(x: Int) // expected-note {{protocol requires function 'mismatch__consuming_mutating(x:)' with type '(Int) -> ()'}}
   mutating func mismatch__mutating_consuming(x: Int)
 }
-struct X6Ownership : P6Ownership { // expected-error{{type 'X6Ownership' does not conform to protocol 'P6Ownership'}}
+struct X6Ownership : P6Ownership { // expected-error{{type 'X6Ownership' does not conform to protocol 'P6Ownership'}} expected-note {{add stubs for conformance}}
   func thunk__shared(_ x: Int) { } // OK
   func mismatch__shared(_ x: __shared Int) { } // OK
   func mismatch__owned(x: __owned Int) { } // OK

--- a/test/decl/protocol/req/properties.swift
+++ b/test/decl/protocol/req/properties.swift
@@ -24,7 +24,7 @@ class PropertyGet_ComputedGet : PropertyGet {
   var x : Int { return 0 }  // ok
 }
 
-struct PropertyGet_StaticVar : PropertyGet {  // expected-error {{type 'PropertyGet_StaticVar' does not conform to protocol 'PropertyGet'}}
+struct PropertyGet_StaticVar : PropertyGet {  // expected-error {{type 'PropertyGet_StaticVar' does not conform to protocol 'PropertyGet'}} expected-note {{add stubs for conformance}}
   static var x : Int = 42  // expected-note {{candidate operates on a type, not an instance as required}}
 }
 
@@ -41,7 +41,7 @@ class PropertyGetSet_Stored : PropertyGetSet {
   var x : Int = 0  // ok
 }
 
-class PropertyGetSet_Immutable : PropertyGetSet {  // expected-error {{type 'PropertyGetSet_Immutable' does not conform to protocol 'PropertyGetSet'}}
+class PropertyGetSet_Immutable : PropertyGetSet {  // expected-error {{type 'PropertyGetSet_Immutable' does not conform to protocol 'PropertyGetSet'}} expected-note {{add stubs for conformance}}
   let x : Int = 0  // expected-note {{candidate is not settable, but protocol requires it}}
 }
 
@@ -49,6 +49,6 @@ class PropertyGetSet_ComputedGetSet : PropertyGetSet {
   var x : Int { get { return 42 } set {} }  // ok
 }
 
-class PropertyGetSet_ComputedGet : PropertyGetSet {  // expected-error {{type 'PropertyGetSet_ComputedGet' does not conform to protocol 'PropertyGetSet'}}
+class PropertyGetSet_ComputedGet : PropertyGetSet {  // expected-error {{type 'PropertyGetSet_ComputedGet' does not conform to protocol 'PropertyGetSet'}} expected-note {{add stubs for conformance}}
   var x : Int { return 42 }  // expected-note {{candidate is not settable, but protocol requires it}}
 }

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -22,21 +22,21 @@ class X<T> where T == X {
 protocol CircularAssocTypeDefault {
   associatedtype Z = Z // expected-error{{associated type 'Z' references itself}}
   // expected-note@-1{{type declared here}}
-  // expected-note@-2{{protocol requires nested type 'Z'; add nested type 'Z' for conformance}}
+  // expected-note@-2{{protocol requires nested type 'Z'}}
 
   associatedtype Z2 = Z3
-  // expected-note@-1{{protocol requires nested type 'Z2'; add nested type 'Z2' for conformance}}
+  // expected-note@-1{{protocol requires nested type 'Z2'}}
   associatedtype Z3 = Z2
-  // expected-note@-1{{protocol requires nested type 'Z3'; add nested type 'Z3' for conformance}}
+  // expected-note@-1{{protocol requires nested type 'Z3'}}
 
   associatedtype Z4 = Self.Z4 // expected-error{{associated type 'Z4' references itself}}
   // expected-note@-1{{type declared here}}
-  // expected-note@-2{{protocol requires nested type 'Z4'; add nested type 'Z4' for conformance}}
+  // expected-note@-2{{protocol requires nested type 'Z4'}}
 
   associatedtype Z5 = Self.Z6
-  // expected-note@-1{{protocol requires nested type 'Z5'; add nested type 'Z5' for conformance}}
+  // expected-note@-1{{protocol requires nested type 'Z5'}}
   associatedtype Z6 = Self.Z5
-  // expected-note@-1{{protocol requires nested type 'Z6'; add nested type 'Z6' for conformance}}
+  // expected-note@-1{{protocol requires nested type 'Z6'}}
 }
 
 struct ConformsToCircularAssocTypeDefault : CircularAssocTypeDefault { }

--- a/test/decl/protocol/req/subscript.swift
+++ b/test/decl/protocol/req/subscript.swift
@@ -22,7 +22,9 @@ struct S1 : P1 {
   }
 }
 
-struct S1Error : P1 { // expected-error{{type 'S1Error' does not conform to protocol 'P1'}}
+struct S1Error : P1 { 
+  // expected-error@-1 {{type 'S1Error' does not conform to protocol 'P1'}}
+  // expected-note@-2 {{add stubs for conformance}}
   subscript (i: Int) -> Double { // expected-note{{candidate has non-matching type '(Int) -> Double'}}
     get {
       return Double(i)
@@ -38,7 +40,7 @@ struct S1Error : P1 { // expected-error{{type 'S1Error' does not conform to prot
 
 
 protocol SubscriptGet {
-  subscript(a : Int) -> Int { get } // expected-note {{protocol requires subscript with type '(Int) -> Int'; add a stub for conformance}}
+  subscript(a : Int) -> Int { get } // expected-note {{protocol requires subscript with type '(Int) -> Int'}}
 }
 
 class SubscriptGet_Get : SubscriptGet {
@@ -60,7 +62,9 @@ protocol SubscriptGetSet {
   subscript(a : Int) -> Int { get set }   // expected-note {{protocol requires subscript with type '(Int) -> Int'}}
 }
 
-class SubscriptGetSet_Get : SubscriptGetSet {  // expected-error {{type 'SubscriptGetSet_Get' does not conform to protocol 'SubscriptGetSet'}}
+class SubscriptGetSet_Get : SubscriptGetSet { 
+  // expected-error@-1 {{type 'SubscriptGetSet_Get' does not conform to protocol 'SubscriptGetSet'}}
+  // expected-note@-2 {{add stubs for conformance}}
   subscript(a : Int) -> Int { return 0 }   // expected-note {{candidate is not settable, but protocol requires it}}
 }
 
@@ -78,7 +82,7 @@ protocol Initable {
 
 protocol GenericSubscriptProtocol {
   subscript<T : Initable>(t: T.Type) -> T { get set }
-  // expected-note@-1 {{protocol requires subscript with type '<T> (T.Type) -> T'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires subscript with type '<T> (T.Type) -> T'}}
 }
 
 struct GenericSubscriptWitness : GenericSubscriptProtocol {
@@ -93,13 +97,14 @@ struct GenericSubscriptWitness : GenericSubscriptProtocol {
 
 struct GenericSubscriptNoWitness : GenericSubscriptProtocol {}
 // expected-error@-1 {{type 'GenericSubscriptNoWitness' does not conform to protocol 'GenericSubscriptProtocol'}}
+// expected-note@-2 {{add stubs for conformance}}
 
 //===----------------------------------------------------------------------===//
 // Static subscript requirements
 //===----------------------------------------------------------------------===//
 
 protocol StaticSubscriptGet {
-  static subscript(a : Int) -> Int { get } // expected-note {{protocol requires subscript with type '(Int) -> Int'; add a stub for conformance}}
+  static subscript(a : Int) -> Int { get } // expected-note {{protocol requires subscript with type '(Int) -> Int'}}
 }
 
 class StaticSubscriptGet_Get : StaticSubscriptGet {
@@ -115,7 +120,9 @@ protocol StaticSubscriptGetSet {
   static subscript(a : Int) -> Int { get set }   // expected-note {{protocol requires subscript with type '(Int) -> Int'}}
 }
 
-class StaticSubscriptGetSet_Get : StaticSubscriptGetSet {  // expected-error {{type 'StaticSubscriptGetSet_Get' does not conform to protocol 'StaticSubscriptGetSet'}}
+class StaticSubscriptGetSet_Get : StaticSubscriptGetSet {
+  // expected-error@-1 {{type 'StaticSubscriptGetSet_Get' does not conform to protocol 'StaticSubscriptGetSet'}}
+  // expected-note@-2 {{add stubs for conformance}}
   static subscript(a : Int) -> Int { return 0 }   // expected-note {{candidate is not settable, but protocol requires it}}
 }
 
@@ -123,5 +130,9 @@ class StaticSubscriptGetSet_GetSet : StaticSubscriptGetSet {
   static subscript(a : Int) -> Int { get { return 42 } set {} }  // ok
 }
 
-extension SubscriptGet_Get: StaticSubscriptGet {} // expected-error {{type 'SubscriptGet_Get' does not conform to protocol 'StaticSubscriptGet'}}
-extension StaticSubscriptGet_Get: SubscriptGet {} // expected-error {{type 'StaticSubscriptGet_Get' does not conform to protocol 'SubscriptGet'}}
+extension SubscriptGet_Get: StaticSubscriptGet {} 
+// expected-error@-1 {{type 'SubscriptGet_Get' does not conform to protocol 'StaticSubscriptGet'}}
+// expected-note@-2 {{add stubs for conformance}}
+extension StaticSubscriptGet_Get: SubscriptGet {} 
+// expected-error@-1 {{type 'StaticSubscriptGet_Get' does not conform to protocol 'SubscriptGet'}}
+// expected-note@-2 {{add stubs for conformance}}

--- a/test/decl/protocol/req/unavailable.swift
+++ b/test/decl/protocol/req/unavailable.swift
@@ -19,7 +19,7 @@ protocol NonObjCProto {
   func good()
 }
 
-class Bar : NonObjCProto { // expected-error {{type 'Bar' does not conform to protocol 'NonObjCProto'}}
+class Bar : NonObjCProto { // expected-error {{type 'Bar' does not conform to protocol 'NonObjCProto'}} expected-note {{add stubs for conformance}}
   func good() {}
 }
 

--- a/test/decl/protocol/req/unsatisfiable.swift
+++ b/test/decl/protocol/req/unsatisfiable.swift
@@ -5,7 +5,7 @@ protocol P {
   associatedtype B
 
   func f<T: P>(_: T) where T.A == Self.A, T.A == Self.B // expected-error{{instance method requirement 'f' cannot add constraint 'Self.A == Self.B' on 'Self'}}
-  // expected-note@-1 {{protocol requires function 'f' with type '<T> (T) -> ()'; add a stub for conformance}}
+  // expected-note@-1 {{protocol requires function 'f' with type '<T> (T) -> ()'}}
 }
 
 extension P {
@@ -13,7 +13,9 @@ extension P {
   // expected-note@-1 {{candidate would match if 'X' was the same type as 'X.B' (aka 'Int')}}
 }
 
-struct X : P { // expected-error {{type 'X' does not conform to protocol 'P'}}
+struct X : P { 
+  // expected-error@-1 {{type 'X' does not conform to protocol 'P'}}
+  // expected-note@-2 {{add stubs for conformance}}
   typealias A = X
   typealias B = Int
 }
@@ -65,11 +67,12 @@ protocol P6 {
 
   func foo() where T == U
   // expected-error@-1 {{instance method requirement 'foo()' cannot add constraint 'Self.T == Self.U' on 'Self'}}
-  // expected-note@-2 {{protocol requires function 'foo()' with type '() -> ()'; add a stub for conformance}}
+  // expected-note@-2 {{protocol requires function 'foo()' with type '() -> ()'}}
 }
 
 struct S2 : P6 {
   // expected-error@-1 {{type 'S2' does not conform to protocol 'P6'}}
+  // expected-note@-2 {{add stubs for conformance}}
   typealias T = Int
   typealias U = String
 

--- a/test/decl/protocol/req/witness_fix_its.swift
+++ b/test/decl/protocol/req/witness_fix_its.swift
@@ -8,17 +8,17 @@ postfix operator ^^^^
 import OtherOS
 
 protocol Foo {
-  var bar1: Int { get set } // expected-note {{protocol requires property 'bar1' with type 'Int'; add a stub for conformance}}
-  static var bar2: Int { get set } // expected-note {{protocol requires property 'bar2' with type 'Int'; add a stub for conformance}}
-  var bar3: Int { get set } // expected-note {{protocol requires property 'bar3' with type 'Int'; add a stub for conformance}}
-  static prefix func ^^^(value: Self) -> Int // expected-note {{protocol requires function '^^^' with type '(ConformsToFoo) -> Int'; add a stub for conformance}}
-  static postfix func ^^^^(value: Self) -> Int // expected-note {{protocol requires function '^^^^' with type '(ConformsToFoo) -> Int'; add a stub for conformance}}
-  func bar4(closure: () throws -> Int) rethrows // expected-note {{protocol requires function 'bar4(closure:)' with type '(() throws -> Int) throws -> ()'; add a stub for conformance}}
-  var bar5: Int { get set } // expected-note {{protocol requires property 'bar5' with type 'Int'; add a stub for conformance}}
-  static subscript(_ pos: Int) -> Int { get } // expected-note {{protocol requires subscript with type '(Int) -> Int'; add a stub for conformance}}
+  var bar1: Int { get set } // expected-note {{protocol requires property 'bar1' with type 'Int'}}
+  static var bar2: Int { get set } // expected-note {{protocol requires property 'bar2' with type 'Int'}}
+  var bar3: Int { get set } // expected-note {{protocol requires property 'bar3' with type 'Int'}}
+  static prefix func ^^^(value: Self) -> Int // expected-note {{protocol requires function '^^^' with type '(ConformsToFoo) -> Int'}}
+  static postfix func ^^^^(value: Self) -> Int // expected-note {{protocol requires function '^^^^' with type '(ConformsToFoo) -> Int'}}
+  func bar4(closure: () throws -> Int) rethrows // expected-note {{protocol requires function 'bar4(closure:)' with type '(() throws -> Int) throws -> ()'}}
+  var bar5: Int { get set } // expected-note {{protocol requires property 'bar5' with type 'Int'}}
+  static subscript(_ pos: Int) -> Int { get } // expected-note {{protocol requires subscript with type '(Int) -> Int'}}
 }
 
-struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not conform to protocol 'Foo'}}
+struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not conform to protocol 'Foo'}} expected-note {{add stubs for conformance}}
   let bar1: Int // expected-note {{candidate is not settable, but protocol requires it}}{{3-6=var}}
   var bar2: Int // expected-note {{candidate operates on an instance, not a type as required}}{{3-3=static }}
   static var bar3: Int = 1 // expected-note {{candidate operates on a type, not an instance as required}}{{3-10=}}
@@ -32,10 +32,10 @@ struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not co
 }
 
 protocol Foo1 {
-  subscript(value: Bool) -> Bool { get set } // expected-note {{protocol requires subscript with type '(Bool) -> Bool'; add a stub for conformance}}
+  subscript(value: Bool) -> Bool { get set } // expected-note {{protocol requires subscript with type '(Bool) -> Bool'}}
 }
 
-struct ConformsToFoo1: Foo1 { // expected-error {{type 'ConformsToFoo1' does not conform to protocol 'Foo1'}}
+struct ConformsToFoo1: Foo1 { // expected-error {{type 'ConformsToFoo1' does not conform to protocol 'Foo1'}} expected-note {{add stubs for conformance}}
   subscript(value: Bool) -> Bool { return false } // expected-note {{candidate is not settable, but protocol requires it}}{{none}}
 }
 
@@ -43,7 +43,9 @@ struct ConformsToFoo1: Foo1 { // expected-error {{type 'ConformsToFoo1' does not
 // This protocol requirement must conflict with the one in
 // witness_fix_its_other_module.swift.
 protocol RenameableProtocol {
-  var name: String { get set } // expected-note {{protocol requires property 'name' with type 'String'; add a stub for conformance}}
+  var name: String { get set } // expected-note {{protocol requires property 'name' with type 'String'}}
 }
 
-extension Linux: RenameableProtocol {} // expected-error {{type 'Linux' does not conform to protocol 'RenameableProtocol'}}
+extension Linux: RenameableProtocol {} 
+// expected-error@-1 {{type 'Linux' does not conform to protocol 'RenameableProtocol'}}
+// expected-note@-2 {{add stubs for conformance}}

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -63,8 +63,9 @@ class C2: Actor {
 @available(SwiftStdlib 5.1, *)
 class C3: Actor {
   // expected-error@-1{{type 'C3' does not conform to protocol 'Actor'}}
-  // expected-error@-2{{non-actor type 'C3' cannot conform to the 'Actor' protocol}}
-  // expected-warning@-3{{non-final class 'C3' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
+  // expected-note@-2{{add stubs for conformance}}
+  // expected-error@-3{{non-actor type 'C3' cannot conform to the 'Actor' protocol}}
+  // expected-warning@-4{{non-final class 'C3' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   nonisolated func enqueue(_ job: UnownedJob) { }
 }
 

--- a/test/decl/protocol/special/coding/enum_coding_key.swift
+++ b/test/decl/protocol/special/coding/enum_coding_key.swift
@@ -35,16 +35,16 @@ let _ = IntKey(intValue: 3)
 
 // Enums with a different raw value conforming to CodingKey should not get
 // implicit derived conformance.
-enum Int8Key : Int8, CodingKey { // expected-error {{type 'Int8Key' does not conform to protocol 'CodingKey'}}
+enum Int8Key : Int8, CodingKey { // expected-error {{type 'Int8Key' does not conform to protocol 'CodingKey'}} expected-note {{add stubs for conformance}}
     case a = -1, b = 0, c = 1
 }
 
 // Structs conforming to CodingKey should not get implicit derived conformance.
-struct StructKey : CodingKey { // expected-error {{type 'StructKey' does not conform to protocol 'CodingKey'}}
+struct StructKey : CodingKey { // expected-error {{type 'StructKey' does not conform to protocol 'CodingKey'}} expected-note {{add stubs for conformance}}
 }
 
 // Classes conforming to CodingKey should not get implicit derived conformance.
-class ClassKey : CodingKey { //expected-error {{type 'ClassKey' does not conform to protocol 'CodingKey'}}
+class ClassKey : CodingKey { //expected-error {{type 'ClassKey' does not conform to protocol 'CodingKey'}} expected-note {{add stubs for conformance}}
 }
 
 // Types which are valid for CodingKey derived conformance should not get that

--- a/test/decl/protocol/special/comparable/comparable_unsupported.swift
+++ b/test/decl/protocol/special/comparable/comparable_unsupported.swift
@@ -5,6 +5,7 @@
 struct NotComparableStruct: Comparable {
   // expected-error@-1 {{type 'NotComparableStruct' does not conform to protocol 'Comparable'}}
   // expected-note@-2 {{automatic synthesis of 'Comparable' is not supported for struct declarations}}
+  // expected-note@-3 {{add stubs for conformance}}
   var value = 0
 }
 
@@ -13,6 +14,7 @@ class NotComparableClass: Comparable {
   // expected-note@-2 {{automatic synthesis of 'Comparable' is not supported for class declarations}}
   // expected-error@-3 {{type 'NotComparableClass' does not conform to protocol 'Equatable'}}
   // expected-note@-4 {{automatic synthesis of 'Equatable' is not supported for class declarations}}
+  // expected-note@-5 {{add stubs for conformance}}
   var value = 1
 }
 
@@ -21,6 +23,7 @@ class NotComparableClass: Comparable {
 enum NotComparableEnumOne: Int, Comparable {
   // expected-error@-1 {{type 'NotComparableEnumOne' does not conform to protocol 'Comparable'}}
   // expected-note@-2 {{enum declares raw type 'Int', preventing synthesized conformance of 'NotComparableEnumOne' to 'Comparable'}}
+  // expected-note@-3 {{add stubs for conformance}}
   case value
 }
 
@@ -30,6 +33,7 @@ enum NotComparableEnumOne: Int, Comparable {
 
 enum EnumWithUnavailableCase: Comparable {
   // expected-error@-1 {{type 'EnumWithUnavailableCase' does not conform to protocol 'Comparable'}}
+  // expected-note@-2 {{add stubs for conformance}}
   case available
 
   @available(*, unavailable)
@@ -38,6 +42,7 @@ enum EnumWithUnavailableCase: Comparable {
 
 enum EnumWithUnavailableCaseAndAssociatedValue: Comparable {
   // expected-error@-1 {{type 'EnumWithUnavailableCaseAndAssociatedValue' does not conform to protocol 'Comparable'}}
+  // expected-note@-2 {{add stubs for conformance}}
   enum SomeComparable: Comparable {}
 
   case none
@@ -48,6 +53,7 @@ enum EnumWithUnavailableCaseAndAssociatedValue: Comparable {
 
 enum EnumWithUnavailableCaseAndAssociatedValue2: Comparable {
   // expected-error@-1 {{type 'EnumWithUnavailableCaseAndAssociatedValue2' does not conform to protocol 'Comparable'}}
+  // expected-note@-2 {{add stubs for conformance}}
   enum SomeComparable: Comparable {}
 
   case this(SomeComparable)
@@ -60,6 +66,7 @@ enum EnumWithUnavailableCaseAndAssociatedValue2: Comparable {
 
 enum NotComparableEnumTwo: Comparable {
   // expected-error@-1 {{type 'NotComparableEnumTwo' does not conform to protocol 'Comparable'}}
+  // expected-note@-2 {{add stubs for conformance}}
   struct NotComparable: Equatable {}
   case value(NotComparable)
   // expected-note@-1 {{associated value type 'NotComparableEnumTwo.NotComparable' does not conform to protocol 'Comparable', preventing synthesized conformance of 'NotComparableEnumTwo' to 'Comparable'}}

--- a/test/decl/subscript/addressors.swift
+++ b/test/decl/subscript/addressors.swift
@@ -112,7 +112,7 @@ protocol HasMutableSubscript {
   subscript(index: Int) -> Int { get set } // expected-note {{protocol requires}}
 }
 
-struct DisobedientImmutableAddressor: HasMutableSubscript { // expected-error {{does not conform}}
+struct DisobedientImmutableAddressor: HasMutableSubscript { // expected-error {{does not conform}} expected-note {{add stubs for conformance}}
   subscript(index: Int) -> Int { // expected-note {{candidate is not settable}}
     unsafeAddress { return someValidAddress() }
   }
@@ -140,7 +140,7 @@ protocol HasMutatingMutableSubscript {
 
 // We allow mutating accessor requirements to be implemented by non-mutating accessors.
 
-struct DisobedientImmutableAddressor2: HasMutatingMutableSubscript { // expected-error {{does not conform}}
+struct DisobedientImmutableAddressor2: HasMutatingMutableSubscript { // expected-error {{does not conform}} expected-note {{add stubs for conformance}}
   subscript(index: Int) -> Int { // expected-note {{candidate is not settable}}
     unsafeAddress { return someValidAddress() }
   }
@@ -165,7 +165,7 @@ protocol HasNonMutatingMutableSubscript {
   subscript(index: Int) -> Int { get nonmutating set } // expected-note {{protocol requires}}
 }
 
-struct DisobedientNonMutatingMutableAddressor: HasNonMutatingMutableSubscript { // expected-error {{does not conform}}
+struct DisobedientNonMutatingMutableAddressor: HasNonMutatingMutableSubscript { // expected-error {{does not conform}} expected-note {{add stubs for conformance}}
   subscript(index: Int) -> Int {
     unsafeAddress { return someValidAddress() }
     unsafeMutableAddress { return someValidAddress() } // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -333,12 +333,14 @@ protocol ErrorQ {
   associatedtype Y
 }
 protocol ErrorP {
-  associatedtype X: ErrorQ // expected-note {{protocol requires nested type 'X'; add nested type 'X' for conformance}}
+  associatedtype X: ErrorQ // expected-note {{protocol requires nested type 'X'}}
 }
 
 typealias ErrorA<T: ErrorP> = T.X.Y
 
-struct ErrorB : ErrorP { // expected-error {{type 'ErrorB' does not conform to protocol 'ErrorP'}}
+struct ErrorB : ErrorP { 
+  // expected-error@-1 {{type 'ErrorB' does not conform to protocol 'ErrorP'}}
+  // expected-note@-2 {{add stubs for conformance}}
   typealias X = ErrorC // expected-note {{possibly intended match 'ErrorB.X' (aka 'ErrorC') does not conform to 'ErrorQ'}}
 }
 

--- a/test/multifile/Inputs/external-protocol-conformance/A.swift
+++ b/test/multifile/Inputs/external-protocol-conformance/A.swift
@@ -5,6 +5,6 @@ protocol P {
   associatedtype Assoc: PHelper // expected-note {{protocol requires nested type 'Assoc'}}
 }
 
-struct A : P { // expected-error {{type 'A' does not conform to protocol 'P'}}
+struct A : P { // expected-error {{type 'A' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}
   typealias Assoc = Int // expected-note {{possibly intended match 'A.Assoc' (aka 'Int') does not conform to 'PHelper'}}
 }

--- a/test/multifile/Inputs/protocol-conformance/broken.swift
+++ b/test/multifile/Inputs/protocol-conformance/broken.swift
@@ -1,1 +1,1 @@
-extension X : P { } // expected-error{{type 'X' does not conform to protocol 'P'}}
+extension X : P { } // expected-error{{type 'X' does not conform to protocol 'P'}} expected-note {{add stubs for conformance}}

--- a/test/multifile/protocol-conformance-broken.swift
+++ b/test/multifile/protocol-conformance-broken.swift
@@ -2,7 +2,7 @@
 
 // rdar://problem/29689007
 protocol P {
-  associatedtype AT // expected-note{{protocol requires nested type 'AT'; add nested type 'AT' for conformance}}
+  associatedtype AT // expected-note{{protocol requires nested type 'AT'}}
   func f() -> AT
 }
 

--- a/test/stdlib/BinaryIntegerRequirements.swift
+++ b/test/stdlib/BinaryIntegerRequirements.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4
 
-struct MyInt: FixedWidthInteger { // expected-error {{type 'MyInt' does not conform to protocol 'BinaryInteger'}}
+struct MyInt: FixedWidthInteger { // expected-error {{type 'MyInt' does not conform to protocol 'BinaryInteger'}} expected-note {{add stubs for conformance}}
   typealias IntegerLiteralType = Int
   static let isSigned = false
   init(integerLiteral value: Int) { fatalError() }

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -26,7 +26,7 @@ func bad_containers_3(bc: BadContainer3) {
 
 struct BadIterator1 {}
 
-struct BadContainer4 : Sequence { // expected-error{{type 'BadContainer4' does not conform to protocol 'Sequence'}}
+struct BadContainer4 : Sequence { // expected-error{{type 'BadContainer4' does not conform to protocol 'Sequence'}} expected-note {{add stubs for conformance}}
   typealias Iterator = BadIterator1 // expected-note{{possibly intended match 'BadContainer4.Iterator' (aka 'BadIterator1') does not conform to 'IteratorProtocol'}}
   func makeIterator() -> BadIterator1 { }
 }

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -298,11 +298,12 @@ class C : any Empty {} // expected-error {{inheritance from non-protocol, non-cl
 
 enum E : any Empty { // expected-error {{raw type 'any Empty' is not expressible by a string, integer, or floating-point literal}}
 // expected-error@-1 {{'E' declares raw type 'any Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
-// expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'any Empty' is not Equatable}}
+// expected-note@-2 {{add stubs for conformance}}
+// expected-error@-3 {{RawRepresentable conformance cannot be synthesized because raw type 'any Empty' is not Equatable}}
   case hack
 }
 
-enum EE : Equatable, any Empty { // expected-error {{raw type 'any Empty' is not expressible by a string, integer, or floating-point literal}}
+enum EE : Equatable, any Empty { // expected-error {{raw type 'any Empty' is not expressible by a string, integer, or floating-point literal}} expected-note {{add stubs for conformance}}
 // expected-error@-1 {{'EE' declares raw type 'any Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'any Empty' is not Equatable}}
 // expected-error@-3 {{raw type 'any Empty' must appear first in the enum inheritance clause}}

--- a/test/type/implicit_some/explicit_existential.swift
+++ b/test/type/implicit_some/explicit_existential.swift
@@ -7,10 +7,12 @@ protocol Foo { }
 var x: any Foo
 
 protocol SelfAsType {
-  var x: Self { get } // expected-note{{protocol requires property 'x' with type 'U'; add a stub for conformance}}
+  var x: Self { get } // expected-note{{protocol requires property 'x' with type 'U'}}
 }
 
-struct U : SelfAsType { // expected-error{{type 'U' does not conform to protocol 'SelfAsType'}}
+struct U : SelfAsType { 
+  // expected-error@-1{{type 'U' does not conform to protocol 'SelfAsType'}}
+  // expected-note@-2 {{add stubs for conformance}}
   var x: any SelfAsType { self } // expected-note {{candidate has non-matching type 'any SelfAsType'}}
 }
 
@@ -235,6 +237,7 @@ class C : any Empty {} // expected-error {{inheritance from non-protocol, non-cl
 enum E : any Empty { // expected-error {{raw type 'any Empty' is not expressible by a string, integer, or floating-point literal}}
 // expected-error@-1 {{'E' declares raw type 'any Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'any Empty' is not Equatable}}
+// expected-note@-3 {{add stubs for conformance}} 
   case hack
 }
 
@@ -242,6 +245,7 @@ enum EE : Equatable, any Empty { // expected-error {{raw type 'any Empty' is not
 // expected-error@-1 {{'EE' declares raw type 'any Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'any Empty' is not Equatable}}
 // expected-error@-3 {{raw type 'any Empty' must appear first in the enum inheritance clause}}
+// expected-note@-4 {{add stubs for conformance}} 
   case hack
 }
 

--- a/test/type/parameterized_protocol.swift
+++ b/test/type/parameterized_protocol.swift
@@ -31,7 +31,7 @@ protocol Invalid5<Element, Element> {
 
 protocol Sequence<Element> {
   associatedtype Element
-  // expected-note@-1 2{{protocol requires nested type 'Element'; add nested type 'Element' for conformance}}
+  // expected-note@-1 2{{protocol requires nested type 'Element'}}
 }
 
 extension Sequence {
@@ -61,6 +61,7 @@ protocol IntSequence : Sequence<Int> {}
 struct SillyStruct : Sequence<Int> {}
 // expected-error@-1 {{cannot inherit from protocol type with generic argument 'Sequence<Int>'}}
 // expected-error@-2 {{type 'SillyStruct' does not conform to protocol 'Sequence'}}
+// expected-note@-3 {{add stubs for conformance}}
 
 
 /// Parameterized protocol in generic parameter inheritance clause
@@ -215,6 +216,7 @@ protocol TestCompositionProtocol1 {
 struct TestStructComposition : Sequence<Int> & Sendable {}
 // expected-error@-1 {{cannot inherit from protocol type with generic argument 'Sequence<Int>'}}
 // expected-error@-2 {{type 'TestStructComposition' does not conform to protocol 'Sequence'}}
+// expected-note@-3 {{add stubs for conformance}}
 
 
 /// Conflicts

--- a/validation-test/ParseableInterface/broken-optionset.swiftinterface
+++ b/validation-test/ParseableInterface/broken-optionset.swiftinterface
@@ -28,6 +28,6 @@ public struct BrokenOptions : Swift.OptionSet {
 
 // CHECK: error: type 'BrokenOptions' does not conform to protocol 'OptionSet'
 // CHECK: error: type 'BrokenOptions' does not conform to protocol 'ExpressibleByArrayLiteral'
-// CHECK: note: protocol requires nested type 'Element'; add nested type 'Element' for conformance
-// CHECK: note: protocol requires nested type 'ArrayLiteralElement'; add nested type 'ArrayLiteralElement' for conformance
+// CHECK: note: protocol requires nested type 'Element'
+// CHECK: note: protocol requires nested type 'ArrayLiteralElement'
 // CHECK: error: failed to verify module interface of 'Broken' due to the errors above; the textual interface may be broken by project issues, differences between compilers

--- a/validation-test/Sema/SwiftUI/rdar57410798.swift
+++ b/validation-test/Sema/SwiftUI/rdar57410798.swift
@@ -6,6 +6,7 @@ import SwiftUI
 
 enum ColorScheme: CaseIterable, Hashable, Equatable, Identifiable {
 // expected-error@-1 {{type 'ColorScheme' does not conform to protocol 'Identifiable'}}
+// expected-note@-2 {{add stubs for conformance}}
   case `default`
   case pink
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar90419017.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar90419017.swift
@@ -8,7 +8,7 @@ case message
 struct NewItemResponse {}
 
 protocol Publisher {
-  associatedtype Output // expected-note {{protocol requires nested type 'Output'; add nested type 'Output' for conformance}}
+  associatedtype Output // expected-note {{protocol requires nested type 'Output'}}
 }
 
 extension Publisher {
@@ -20,7 +20,9 @@ func fetchFile<T>(name: String) -> MyPublisher<T, APIError> {
   fatalError()
 }
 
-struct ReplaceError<Upstream> : Publisher { // expected-error {{type 'ReplaceError<Upstream>' does not conform to protocol 'Publisher'}}
+struct ReplaceError<Upstream> : Publisher { 
+  // expected-error@-1 {{type 'ReplaceError<Upstream>' does not conform to protocol 'Publisher'}}
+  // expected-note@-2 {{add stubs for conformance}}
   typealias Output = Upstream.Output // expected-error {{'Output' is not a member type of type 'Upstream'}}
   typealias Failure = Never
 }

--- a/validation-test/compiler_crashers_2_fixed/0160-rdar41141944.swift
+++ b/validation-test/compiler_crashers_2_fixed/0160-rdar41141944.swift
@@ -4,11 +4,12 @@
 import Foundation
 
 @objc protocol P {
-  func foo(a arg: Int) // expected-note {{protocol requires function 'foo(a:)' with type '(Int) -> ()'; add a stub for conformance}}
+  func foo(a arg: Int) // expected-note {{protocol requires function 'foo(a:)' with type '(Int) -> ()'}}
 }
 
 class C : P {
 // expected-error@-1 {{type 'C' does not conform to protocol 'P'}}
+// expected-note@-2 {{add stubs for conformance}}
   var foo: Float = 0.75
   // expected-note@-1 {{'foo' previously declared here}}
   func foo() {}

--- a/validation-test/compiler_crashers_2_fixed/0161-issue-49119.swift
+++ b/validation-test/compiler_crashers_2_fixed/0161-issue-49119.swift
@@ -3,7 +3,7 @@
 // https://github.com/apple/swift/issues/49119
 
 protocol P {
-    associatedtype A: P // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+    associatedtype A: P // expected-note {{protocol requires nested type 'A'}} 
 }
 
 struct Type<Param> {}
@@ -11,6 +11,7 @@ extension Type: P where Param: P, Param.A == Type<Param> {
   // expected-error@-1 {{extension of generic struct 'Type' has self-referential generic requirements}}
   // expected-note@-2 {{through reference here}}
   // expected-error@-3 {{type 'Type<Param>' does not conform to protocol 'P'}}
+  // expected-note@-4 {{add stubs for conformance}}
   typealias A = Param
   // expected-note@-1 2{{through reference here}}
   // expected-note@-2 {{possibly intended match 'Type<Param>.A' (aka 'Param') does not conform to 'P'}}

--- a/validation-test/compiler_crashers_2_fixed/0163-issue-50566.swift
+++ b/validation-test/compiler_crashers_2_fixed/0163-issue-50566.swift
@@ -5,10 +5,11 @@
 struct Foo<T> {}
 
 protocol P1 {
-    associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+    associatedtype A // expected-note {{protocol requires nested type 'A'}}
 }
 extension Foo: P1 where A : P1 {}
 // expected-error@-1 {{extension of generic struct 'Foo' has self-referential generic requirements}}
 // expected-note@-2 {{while resolving type 'A'}}
 // expected-note@-3 2{{through reference here}}
 // expected-error@-4 {{type 'Foo<T>' does not conform to protocol 'P1'}}
+// expected-note@-5 {{add stubs for conformance}} 

--- a/validation-test/compiler_crashers_2_fixed/issue-55443.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-55443.swift
@@ -2,7 +2,7 @@
 
 // https://github.com/apple/swift/issues/55443
 
-enum FooString: String { // expected-error {{'FooString' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum FooString: String { // expected-error {{'FooString' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case bar1 = #file // expected-error {{use of '#file' literal as raw value for enum case is not supported}}
   case bar2 = #function // expected-error {{use of '#function' literal as raw value for enum case is not supported}}
   case bar3 = #filePath // expected-error {{use of '#filePath' literal as raw value for enum case is not supported}}
@@ -11,7 +11,7 @@ enum FooString: String { // expected-error {{'FooString' declares raw type 'Stri
   case bar6 = #dsohandle // expected-error {{cannot convert value of type 'UnsafeRawPointer' to raw type 'String'}}
 }
 
-enum FooInt: Int { // expected-error {{'FooInt' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
+enum FooInt: Int { // expected-error {{'FooInt' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{add stubs for conformance}}
   case bar1 = #file // expected-error {{cannot convert value of type 'String' to raw type 'Int'}}
   case bar2 = #function // expected-error {{cannot convert value of type 'String' to raw type 'Int'}}
   case bar3 = #filePath // expected-error {{cannot convert value of type 'String' to raw type 'Int'}}

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -70,9 +70,10 @@ struct AnotherGoodIndexable1 : Indexable {
   subscript(pos: Int) -> Int { return 0 }
 }
 
-// expected-warning@+3 {{'Indexable' is deprecated: renamed to 'Collection'}}
-// expected-error@+2 {{type 'BadIndexable2' does not conform to protocol 'Collection'}}
-// expected-note@+1 {{use 'Collection' instead}}
+// expected-warning@+4 {{'Indexable' is deprecated: renamed to 'Collection'}}
+// expected-error@+3 {{type 'BadIndexable2' does not conform to protocol 'Collection'}}
+// expected-note@+2 {{use 'Collection' instead}}
+// expected-note@+1 {{add stubs for conformance}}
 struct BadIndexable2 : Indexable {
   var startIndex: Int { return 0 }
   var endIndex: Int { return 0 }


### PR DESCRIPTION
Some editors use diagnostics from SourceKit to replace build issues. This causes issues if the diagnostics from SourceKit are formatted differently than the build issues. Make sure they are rendered the same way, removing most uses of `DiagnosticsEditorMode`.

To do so, always emit the `add stubs for conformance` note (which previously was only emitted in editor mode) and remove all `; add <something>` suffixes from notes that state which requirements are missing. 

rdar://129283608