### PR TITLE
[Concurrency] Compute the source of actor isolation in `ActorIsolationRequest`.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -275,9 +275,13 @@ public:
   void print(llvm::raw_ostream &os) const;
 
   void printForSIL(llvm::raw_ostream &os) const;
-
+  
+  /// Print the given isolation for diagnostics. If \c asNoun is \c false,
+  /// the participle adjective form is printed, e.g. "main actor-isolated".
+  /// Otherwise, the noun form is printed, e.g. "main actor isolation".
   void printForDiagnostics(llvm::raw_ostream &os,
-                           StringRef openingQuotationMark = "'") const;
+                           StringRef openingQuotationMark = "'",
+                           bool asNoun = false) const;
 
   SWIFT_DEBUG_DUMPER(dump());
 
@@ -287,8 +291,67 @@ public:
   SWIFT_DEBUG_DUMPER(dumpForDiagnostics());
 };
 
+struct IsolationSource {
+  enum Kind : uint8_t {
+    /// Isolation is written in an explicit attribute.
+    Explicit,
+    /// Isolation is inferred from the enclosing lexical context.
+    LexicalContext,
+    /// Isolation is inferred from conformance to a protocol.
+    Conformance,
+    /// Isolation is inherited from a superclass.
+    Superclass,
+    /// Isolation is inferred from an overridden superclass method.
+    Override,
+    /// Isolation is inferred from \c @main.
+    MainFunction,
+    /// Isolation is inferred in top-level code.
+    TopLevelCode,
+    /// Unspecified isolation, which defaults to \c nonisolated.
+    None,
+  };
+
+  using InferenceSource =
+      llvm::PointerUnion<Decl *, AbstractClosureExpr *>;
+
+  /// The declaration with the original isolation attribute.
+  InferenceSource inferenceSource;
+  Kind kind;
+
+  IsolationSource(InferenceSource inferenceSource = nullptr,
+                  Kind kind = Kind::None)
+      : inferenceSource(inferenceSource), kind(kind) {}
+
+  bool isInferred() const {
+    return (kind != None) && (kind != Explicit);
+  }
+
+  void printForDiagnostics(llvm::raw_ostream &os,
+                           StringRef openingQuotationMark = "'") const;
+};
+
+struct InferredActorIsolation {
+  ActorIsolation isolation;
+  IsolationSource source;
+
+  static InferredActorIsolation forUnspecified() {
+    return {
+      ActorIsolation::forUnspecified(),
+      IsolationSource()
+    };
+  }
+
+  bool preconcurrency() const {
+    return isolation.preconcurrency();
+  }
+};
+
 /// Determine how the given value declaration is isolated.
 ActorIsolation getActorIsolation(ValueDecl *value);
+
+/// Infer the actor isolation of the given declaration, including
+/// the source of isolation inference.
+InferredActorIsolation getInferredActorIsolation(ValueDecl *value);
 
 /// Trampoline for AbstractClosureExpr::getActorIsolation.
 ActorIsolation

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -140,6 +140,7 @@ namespace swift {
     VersionTuple,
     LayoutConstraint,
     ActorIsolation,
+    IsolationSource,
     Diagnostic,
     ClangDecl
   };
@@ -175,6 +176,7 @@ namespace swift {
       llvm::VersionTuple VersionVal;
       LayoutConstraint LayoutConstraintVal;
       ActorIsolation ActorIsolationVal;
+      IsolationSource IsolationSourceVal;
       DiagnosticInfo *DiagnosticVal;
       const clang::NamedDecl *ClangDecl;
     };
@@ -281,6 +283,11 @@ namespace swift {
     DiagnosticArgument(ActorIsolation AI)
       : Kind(DiagnosticArgumentKind::ActorIsolation),
         ActorIsolationVal(AI) {
+    }
+
+    DiagnosticArgument(IsolationSource IS)
+      : Kind(DiagnosticArgumentKind::IsolationSource),
+        IsolationSourceVal(IS){
     }
 
     DiagnosticArgument(DiagnosticInfo *D)
@@ -400,6 +407,11 @@ namespace swift {
     ActorIsolation getAsActorIsolation() const {
       assert(Kind == DiagnosticArgumentKind::ActorIsolation);
       return ActorIsolationVal;
+    }
+
+    IsolationSource getAsIsolationSource() const {
+      assert(Kind == DiagnosticArgumentKind::IsolationSource);
+      return IsolationSourceVal;
     }
 
     DiagnosticInfo *getAsDiagnostic() const {

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5535,6 +5535,10 @@ NOTE(actor_isolated_sync_func_value,none,
      "calls function of type %0 from outside of its actor context are "
      "implicitly asynchronous",
      (Type))
+NOTE(actor_isolation_source,none,
+     "%noun0 inferred from %1",
+     (ActorIsolation, IsolationSource))
+
 NOTE(note_distributed_actor_isolated_method,none,
      "distributed actor-isolated %kind0 declared here",
      (const ValueDecl *))

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1536,7 +1536,7 @@ public:
 /// Determine the actor isolation for the given declaration.
 class ActorIsolationRequest :
     public SimpleRequest<ActorIsolationRequest,
-                         ActorIsolation(ValueDecl *),
+                         InferredActorIsolation(ValueDecl *),
                          RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -1544,7 +1544,8 @@ public:
 private:
   friend SimpleRequest;
 
-  ActorIsolation evaluate(Evaluator &evaluator, ValueDecl *value) const;
+  InferredActorIsolation evaluate(Evaluator &evaluator,
+                                  ValueDecl *value) const;
 
 public:
   // Caching

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11295,10 +11295,15 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
 }
 
 ActorIsolation swift::getActorIsolation(ValueDecl *value) {
+  return getInferredActorIsolation(value).isolation;
+}
+
+InferredActorIsolation
+swift::getInferredActorIsolation(ValueDecl *value) {
   auto &ctx = value->getASTContext();
   return evaluateOrDefault(
       ctx.evaluator, ActorIsolationRequest{value},
-      ActorIsolation::forUnspecified());
+      InferredActorIsolation::forUnspecified());
 }
 
 ActorIsolation swift::getActorIsolationOfContext(

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1012,8 +1012,16 @@ static void formatDiagnosticArgument(StringRef Modifier,
         << FormatOpts.ClosingQuotationMark;
     break;
   case DiagnosticArgumentKind::ActorIsolation: {
-    assert(Modifier.empty() && "Improper modifier for ActorIsolation argument");
+    assert((Modifier.empty() || Modifier == "noun") &&
+           "Improper modifier for ActorIsolation argument");
     auto isolation = Arg.getAsActorIsolation();
+    isolation.printForDiagnostics(Out, FormatOpts.OpeningQuotationMark,
+                                  /*asNoun*/ Modifier == "noun");
+    break;
+  }
+  case DiagnosticArgumentKind::IsolationSource: {
+    assert(Modifier.empty() && "Improper modifier for IsolationSource argument");
+    auto isolation = Arg.getAsIsolationSource();
     isolation.printForDiagnostics(Out, FormatOpts.OpeningQuotationMark);
     break;
   }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1804,19 +1804,20 @@ ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
 }
 
 void ActorIsolation::printForDiagnostics(llvm::raw_ostream &os,
-                                         StringRef openingQuotationMark) const {
+                                         StringRef openingQuotationMark,
+                                         bool asNoun) const {
   switch (*this) {
   case ActorIsolation::ActorInstance:
-    os << "actor-isolated";
+    os << "actor" << (asNoun ? " isolation" : "-isolated");
     break;
 
   case ActorIsolation::GlobalActor: {
     if (isMainActor()) {
-      os << "main actor-isolated";
+      os << "main actor" << (asNoun ? " isolation" : "-isolated");
     } else {
       Type globalActor = getGlobalActor();
       os << "global actor " << openingQuotationMark << globalActor.getString()
-         << openingQuotationMark << "-isolated";
+         << openingQuotationMark << (asNoun ? " isolation" : "-isolated");
     }
     break;
   }
@@ -1939,6 +1940,52 @@ void swift::simple_display(
         out << state.getGlobalActor().getString();
       }
       break;
+  }
+}
+
+void IsolationSource::printForDiagnostics(
+    llvm::raw_ostream &os,
+    StringRef openingQuotationMark) const {
+  switch (this->kind) {
+  case IsolationSource::Explicit:
+    os << "explicit isolation";
+    return;
+
+  case IsolationSource::None:
+    os << "unspecified isolation";
+    return;
+
+  case IsolationSource::MainFunction:
+    os << "@main";
+    return;
+
+  case IsolationSource::TopLevelCode:
+    os << "top-level code";
+    return;
+
+  case IsolationSource::LexicalContext:
+    os << "enclosing context";
+    return;
+
+  case IsolationSource::Override:
+    os << "overridden superclass method";
+    return;
+
+  case IsolationSource::Conformance:
+    os << "conformance to ";
+    break;
+
+  case IsolationSource::Superclass:
+    os << "inheritance from ";
+    break;
+  }
+
+  auto *decl = inferenceSource.dyn_cast<Decl *>();
+  os << Decl::getDescriptiveKindName(decl->getDescriptiveKind());
+  if (auto *vd = dyn_cast<ValueDecl>(decl)) {
+    os << " " << openingQuotationMark;
+    vd->getName().printPretty(os);
+    os << openingQuotationMark;
   }
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3764,16 +3764,22 @@ namespace {
           }
         } else {
           if (calleeDecl) {
+            auto calleeIsolation = getInferredActorIsolation(calleeDecl);
             auto preconcurrency = getContextIsolation().preconcurrency() ||
-              getActorIsolation(calleeDecl).preconcurrency();
+                calleeIsolation.preconcurrency();
 
             ctx.Diags.diagnose(
-                               apply->getLoc(), diag::actor_isolated_call_decl,
-                               *unsatisfiedIsolation,
-                               calleeDecl,
-                               getContextIsolation())
-            .warnUntilSwiftVersionIf(preconcurrency, 6);
+              apply->getLoc(), diag::actor_isolated_call_decl,
+              *unsatisfiedIsolation,
+              calleeDecl,
+              getContextIsolation())
+                .warnUntilSwiftVersionIf(preconcurrency, 6);
             calleeDecl->diagnose(diag::actor_isolated_sync_func, calleeDecl);
+            if (auto source = calleeIsolation.source.isInferred()) {
+              calleeDecl->diagnose(diag::actor_isolation_source,
+                                   calleeIsolation.isolation,
+                                   calleeIsolation.source);
+            }
           } else {
             ctx.Diags.diagnose(
                                apply->getLoc(), diag::actor_isolated_call, *unsatisfiedIsolation,
@@ -4714,7 +4720,7 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
 }
 
 /// Infer isolation from witnessed protocol requirements.
-static std::optional<ActorIsolation>
+static std::optional<InferredActorIsolation>
 getIsolationFromWitnessedRequirements(ValueDecl *value) {
   // Associated types cannot have isolation, so there's no such inference for
   // type witnesses.
@@ -4818,19 +4824,25 @@ getIsolationFromWitnessedRequirements(ValueDecl *value) {
   if (isolatedRequirements.size() != 1)
     return std::nullopt;
 
-  return std::get<1>(isolatedRequirements.front());
+  auto requirement = isolatedRequirements.front();
+  auto isolation = std::get<1>(requirement);
+  auto *protocol = std::get<0>(requirement)->getProtocol();
+  return InferredActorIsolation{
+    isolation,
+    IsolationSource(protocol, IsolationSource::Conformance)
+  };
 }
 
 /// Compute the isolation of a nominal type from the conformances that
 /// are directly specified on the type.
-static std::optional<ActorIsolation>
+static std::optional<InferredActorIsolation>
 getIsolationFromConformances(NominalTypeDecl *nominal) {
   auto &ctx = nominal->getASTContext();
 
   if (isa<ProtocolDecl>(nominal))
     return std::nullopt;
 
-  std::optional<ActorIsolation> foundIsolation;
+  std::optional<InferredActorIsolation> foundIsolation;
   for (auto conformance :
        nominal->getLocalConformances(ConformanceLookupKind::NonStructural)) {
 
@@ -4861,11 +4873,14 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
 
     case ActorIsolation::GlobalActor:
       if (!foundIsolation) {
-        foundIsolation = protoIsolation;
+        foundIsolation = {
+          protoIsolation,
+          IsolationSource(proto, IsolationSource::Conformance)
+        };
         continue;
       }
 
-      if (*foundIsolation != protoIsolation)
+      if (foundIsolation->isolation != protoIsolation)
         return std::nullopt;
 
       break;
@@ -4876,9 +4891,9 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
 }
 
 /// Compute the isolation of a protocol
-static std::optional<ActorIsolation>
+static std::optional<InferredActorIsolation>
 getIsolationFromInheritedProtocols(ProtocolDecl *protocol) {
-  std::optional<ActorIsolation> foundIsolation;
+  std::optional<InferredActorIsolation> foundIsolation;
   bool conflict = false;
 
   auto inferIsolation = [&](ValueDecl *decl) {
@@ -4894,11 +4909,14 @@ getIsolationFromInheritedProtocols(ProtocolDecl *protocol) {
 
     case ActorIsolation::GlobalActor:
       if (!foundIsolation) {
-        foundIsolation = protoIsolation;
+        foundIsolation = {
+          protoIsolation,
+          IsolationSource(decl, IsolationSource::Conformance)
+        };
         return;
       }
 
-      if (*foundIsolation != protoIsolation)
+      if (foundIsolation->isolation != protoIsolation)
         conflict = true;
 
       return;
@@ -5312,7 +5330,7 @@ static void checkDeclWithIsolatedParameter(ValueDecl *value) {
   }
 }
 
-ActorIsolation ActorIsolationRequest::evaluate(
+InferredActorIsolation ActorIsolationRequest::evaluate(
     Evaluator &evaluator, ValueDecl *value) const {
   auto &ctx = value->getASTContext();
 
@@ -5321,7 +5339,10 @@ ActorIsolation ActorIsolationRequest::evaluate(
   if (evaluateOrDefault(evaluator, HasIsolatedSelfRequest{value}, false)) {
     auto actor = value->getDeclContext()->getSelfNominalTypeDecl();
     assert(actor && "could not find the actor that 'self' is isolated to");
-    return ActorIsolation::forActorInstanceSelf(value);
+    return {
+      ActorIsolation::forActorInstanceSelf(value),
+      IsolationSource()
+    };
   }
 
   // If this declaration has an isolated parameter, it's isolated to that
@@ -5339,7 +5360,10 @@ ActorIsolation ActorIsolationRequest::evaluate(
       actorType = paramType;
     }
     if (auto actor = actorType->getAnyActor())
-      return ActorIsolation::forActorInstanceParameter(param, *paramIdx);
+      return {
+        ActorIsolation::forActorInstanceParameter(param, *paramIdx),
+        IsolationSource()
+      };
   }
 
   // Diagnose global state that is not either immutable plus Sendable or
@@ -5427,7 +5451,10 @@ ActorIsolation ActorIsolationRequest::evaluate(
               fd->getLoc(), diag::main_function_must_be_mainActor);
         }
       }
-      return *mainIsolation;
+      return {
+        *mainIsolation,
+        IsolationSource(fd, IsolationSource::MainFunction)
+      };
     }
   }
   // If this declaration has one of the actor isolation attributes, report
@@ -5439,12 +5466,16 @@ ActorIsolation ActorIsolationRequest::evaluate(
         checkClassGlobalActorIsolation(classDecl, *isolationFromAttr);
     }
 
-    return checkGlobalIsolation(*isolationFromAttr);
+    return {
+      checkGlobalIsolation(*isolationFromAttr),
+      IsolationSource(/*source*/nullptr, IsolationSource::Explicit)
+    };
   }
 
   // Determine the default isolation for this declaration, which may still be
   // overridden by other inference rules.
   ActorIsolation defaultIsolation = ActorIsolation::forUnspecified();
+  IsolationSource defaultIsolationSource;
 
   if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
     // A @Sendable function is assumed to be actor-independent.
@@ -5466,6 +5497,8 @@ ActorIsolation ActorIsolationRequest::evaluate(
   if (overriddenValue) {
     // use the overridden decl's iso as the default isolation for this decl.
     defaultIsolation = getOverriddenIsolationFor(value);
+    defaultIsolationSource =
+        IsolationSource(overriddenValue, IsolationSource::Override);
     overriddenIso = defaultIsolation;
   }
 
@@ -5555,8 +5588,15 @@ ActorIsolation ActorIsolationRequest::evaluate(
   // context if it global or was captured.
   if (auto func = dyn_cast<FuncDecl>(value)) {
     if (func->isLocalCapture() && !func->isSendable()) {
-      switch (auto enclosingIsolation =
-                  getActorIsolationOfContext(func->getDeclContext())) {
+      auto *dc = func->getDeclContext();
+      llvm::PointerUnion<Decl *, AbstractClosureExpr *> inferenceSource;
+      if (auto *closure = dyn_cast<AbstractClosureExpr>(dc)) {
+        inferenceSource = closure;
+      } else {
+        inferenceSource = dc->getAsDecl();
+      }
+
+      switch (auto enclosingIsolation = getActorIsolationOfContext(dc)) {
       case ActorIsolation::Nonisolated:
       case ActorIsolation::NonisolatedUnsafe:
       case ActorIsolation::Unspecified:
@@ -5567,10 +5607,16 @@ ActorIsolation ActorIsolationRequest::evaluate(
         llvm_unreachable("context cannot have erased isolation");
 
       case ActorIsolation::ActorInstance:
-        return inferredIsolation(enclosingIsolation);
+        return {
+          inferredIsolation(enclosingIsolation),
+          IsolationSource(inferenceSource, IsolationSource::LexicalContext)
+        };
 
       case ActorIsolation::GlobalActor:
-        return inferredIsolation(enclosingIsolation);
+        return {
+          inferredIsolation(enclosingIsolation),
+          IsolationSource(inferenceSource, IsolationSource::LexicalContext)
+        };
       }
     }
   }
@@ -5578,7 +5624,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
   // If this is an accessor, use the actor isolation of its storage
   // declaration.
   if (auto accessor = dyn_cast<AccessorDecl>(value)) {
-    return getActorIsolation(accessor->getStorage());
+    return getInferredActorIsolation(accessor->getStorage());
   }
 
   if (auto var = dyn_cast<VarDecl>(value)) {
@@ -5589,27 +5635,42 @@ ActorIsolation ActorIsolationRequest::evaluate(
              StrictConcurrency::Complete ||
          var->getDeclContext()->isAsyncContext())) {
       if (Type mainActor = var->getASTContext().getMainActorType())
-        return inferredIsolation(
+        return {
+          inferredIsolation(
             ActorIsolation::forGlobalActor(mainActor))
-                .withPreconcurrency(var->preconcurrency());
+              .withPreconcurrency(var->preconcurrency()),
+          IsolationSource(/*source*/nullptr, IsolationSource::TopLevelCode)
+        };
     }
-    if (auto isolation = getActorIsolationFromWrappedProperty(var))
-      return inferredIsolation(isolation);
+    if (auto isolation = getActorIsolationFromWrappedProperty(var)) {
+      return {
+        inferredIsolation(isolation),
+        IsolationSource(/*source*/nullptr, IsolationSource::None)
+      };
+    }
   }
 
   // If this is a dynamic replacement for another function, use the
   // actor isolation of the function it replaces.
   if (auto replacedDecl = value->getDynamicallyReplacedDecl()) {
-    if (auto isolation = getActorIsolation(replacedDecl))
-      return inferredIsolation(isolation);
+    if (auto isolation = getActorIsolation(replacedDecl)) {
+      return {
+        inferredIsolation(isolation),
+        IsolationSource(replacedDecl, IsolationSource::None)
+      };
+    }
   }
 
   if (shouldInferAttributeInContext(value->getDeclContext())) {
     // If the declaration witnesses a protocol requirement that is isolated,
     // use that.
     if (auto witnessedIsolation = getIsolationFromWitnessedRequirements(value)) {
-      if (auto inferred = inferredIsolation(*witnessedIsolation))
-        return inferred;
+      if (auto inferred = inferredIsolation(witnessedIsolation->isolation)) {
+        return {
+          inferred,
+          witnessedIsolation->source
+        };
+      }
     }
 
     // If the declaration is a class with a superclass that has specified
@@ -5621,15 +5682,19 @@ ActorIsolation ActorIsolationRequest::evaluate(
           if (superclassIsolation.requiresSubstitution()) {
             Type superclassType = classDecl->getSuperclass();
             if (!superclassType)
-              return ActorIsolation::forUnspecified();
+              return InferredActorIsolation::forUnspecified();
 
             SubstitutionMap subs = superclassType->getMemberSubstitutionMap(
                 classDecl);
             superclassIsolation = superclassIsolation.subst(subs);
           }
 
-          if (auto inferred = inferredIsolation(superclassIsolation))
-            return inferred;
+          if (auto inferred = inferredIsolation(superclassIsolation)) {
+            return {
+              inferred,
+              IsolationSource(superclassDecl, IsolationSource::Superclass)
+            };
+          }
         }
       }
     }
@@ -5637,17 +5702,26 @@ ActorIsolation ActorIsolationRequest::evaluate(
     if (auto nominal = dyn_cast<NominalTypeDecl>(value)) {
       // If the declaration is a nominal type and any of the protocols to which
       // it directly conforms is isolated to a global actor, use that.
-      if (auto conformanceIsolation = getIsolationFromConformances(nominal))
-        if (auto inferred = inferredIsolation(*conformanceIsolation))
-          return inferred;
+      if (auto conformanceIsolation = getIsolationFromConformances(nominal)) {
+        if (auto inferred = inferredIsolation(conformanceIsolation->isolation)) {
+          return {
+            inferred,
+            conformanceIsolation->source
+          };
+        }
+      }
 
       // For a protocol, inherit isolation from the directly-inherited
       // protocols.
       if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability)) {
         if (auto proto = dyn_cast<ProtocolDecl>(nominal)) {
           if (auto protoIsolation = getIsolationFromInheritedProtocols(proto)) {
-            if (auto inferred = inferredIsolation(*protoIsolation))
-              return inferred;
+            if (auto inferred = inferredIsolation(protoIsolation->isolation)) {
+              return {
+                inferred,
+                protoIsolation->source
+              };
+            }
           }
         }
       }
@@ -5655,8 +5729,12 @@ ActorIsolation ActorIsolationRequest::evaluate(
       // Before Swift 6: If the declaration is a nominal type and any property
       // wrappers on its stored properties require isolation, use that.
       if (auto wrapperIsolation = getIsolationFromWrappers(nominal)) {
-        if (auto inferred = inferredIsolation(*wrapperIsolation))
-          return inferred;
+        if (auto inferred = inferredIsolation(*wrapperIsolation)) {
+          return {
+            inferred,
+            IsolationSource()
+          };
+        }
       }
     }
   }
@@ -5671,15 +5749,23 @@ ActorIsolation ActorIsolationRequest::evaluate(
     // attributes, use that.
     if (auto ext = dyn_cast<ExtensionDecl>(value->getDeclContext())) {
       if (auto isolationFromAttr = getIsolationFromAttributes(ext)) {
-        return inferredIsolation(*isolationFromAttr, onlyGlobal);
+        return {
+          inferredIsolation(*isolationFromAttr, onlyGlobal),
+          IsolationSource(ext, IsolationSource::Explicit)
+        };
       }
     }
 
     // If the declaration is in a nominal type (or extension thereof) that
     // has isolation, use that.
     if (auto selfTypeDecl = value->getDeclContext()->getSelfNominalTypeDecl()) {
-      if (auto selfTypeIsolation = getActorIsolation(selfTypeDecl))
-        return inferredIsolation(selfTypeIsolation, onlyGlobal);
+      auto selfTypeIsolation = getInferredActorIsolation(selfTypeDecl);
+      if (selfTypeIsolation.isolation) {
+        return {
+          inferredIsolation(selfTypeIsolation.isolation, onlyGlobal),
+          selfTypeIsolation.source
+        };
+      }
     }
   }
 
@@ -5687,14 +5773,20 @@ ActorIsolation ActorIsolationRequest::evaluate(
   if (value->getAttrs().hasAttribute<IBActionAttr>()) {
     ASTContext &ctx = value->getASTContext();
     if (Type mainActor = ctx.getMainActorType()) {
-      return inferredIsolation(
+      return {
+        inferredIsolation(
           ActorIsolation::forGlobalActor(mainActor)
-              .withPreconcurrency(true));
+              .withPreconcurrency(true)),
+        IsolationSource(),
+      };
     }
   }
 
   // Default isolation for this member.
-  return checkGlobalIsolation(defaultIsolation);
+  return {
+    checkGlobalIsolation(defaultIsolation),
+    defaultIsolationSource
+  };
 }
 
 bool HasIsolatedSelfRequest::evaluate(

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -3721,8 +3721,15 @@ private:
            // callee is isolated to an actor.
            auto callee = call->getCalledValue(/*skipFunctionConversions=*/true);
            if (callee) {
-             Ctx.Diags.diagnose(diag.expr.getStartLoc(), diag::actor_isolated_sync_func,
+             auto calleeIsolation = getInferredActorIsolation(callee);
+             Ctx.Diags.diagnose(diag.expr.getStartLoc(),
+                                diag::actor_isolated_sync_func,
                                 callee);
+             if (calleeIsolation.source.isInferred()) {
+               callee->diagnose(diag::actor_isolation_source,
+                                calleeIsolation.isolation,
+                                calleeIsolation.source);
+             }
            } else {
              Ctx.Diags.diagnose(
                  diag.expr.getStartLoc(), diag::actor_isolated_sync_func_value,

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1659,3 +1659,33 @@ actor SafeMutatingCall {
     _ = try await self.iterator.next()
   }
 }
+
+
+@MainActor
+func testLocalFunctoinIsolation() {
+  func isolatedLocalFn() {}
+  // expected-note@-1 {{calls to local function 'isolatedLocalFn()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-2 {{main actor isolation inferred from enclosing context}}
+
+
+  nonisolated func nonisolatedLocalFn() {
+    isolatedLocalFn()
+    // expected-error@-1 {{call to main actor-isolated local function 'isolatedLocalFn()' in a synchronous nonisolated context}}
+  }
+}
+
+class SuperWithIsolatedMethod {
+  @MainActor
+  func isolatedMethod() {}
+}
+
+class InferIsolationViaOverride: SuperWithIsolatedMethod {
+  override func isolatedMethod() {}
+  // expected-note@-1 {{calls to instance method 'isolatedMethod()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-2 {{main actor isolation inferred from overridden superclass method}}
+
+  nonisolated func callIsolated() {
+    isolatedMethod()
+    // expected-error@-1 {{call to main actor-isolated instance method 'isolatedMethod()' in a synchronous nonisolated context}}
+  }
+}

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -58,7 +58,9 @@ protocol P2 {
 
 struct S5_P2: P2 {
   func f() { } // expected-note{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-  // expected-complete-tns-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-1 {{main actor isolation inferred from conformance to protocol 'P2'}}
+  // expected-complete-tns-note @-2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-tns-note @-3 {{main actor isolation inferred from conformance to protocol 'P2'}}}
   func g() { }
 }
 

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -144,6 +144,7 @@ topLevelSyncFunction(&value)
 
 class Sub: Super {
   func f() { }
+  // expected-note@-1 {{global actor 'SomeGlobalActor' isolation inferred from inheritance from class 'Super'}}
 
   func g() {
     Task.detached {

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -68,6 +68,7 @@ protocol P2 {
 
 class C1: P1 {
   func method() { } // expected-note {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-1 {{global actor 'SomeGlobalActor' isolation inferred from conformance to protocol 'P1'}}
 
   @OtherGlobalActor func testMethod() {
     method() // expected-error {{call to global actor 'SomeGlobalActor'-isolated instance method 'method()' in a synchronous global actor 'OtherGlobalActor'-isolated context}}
@@ -77,6 +78,8 @@ class C1: P1 {
 
 class C2: P2 {
   func method1() { }  // expected-note {{calls to instance method 'method1()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-1 {{global actor 'SomeGlobalActor' isolation inferred from conformance to protocol 'P2'}}
+
   func method2() { }
 
   @OtherGlobalActor func testMethod() {
@@ -88,7 +91,10 @@ class C2: P2 {
 
 struct AllInP1: P1 {
   func method() { } // expected-note {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-1 {{global actor 'SomeGlobalActor' isolation inferred from conformance to protocol 'P1'}}
+
   func other() { } // expected-note {{calls to instance method 'other()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-1 {{global actor 'SomeGlobalActor' isolation inferred from conformance to protocol 'P1'}}
 }
 
 func testAllInP1(ap1: AllInP1) { // expected-note 2 {{add '@SomeGlobalActor' to make global function 'testAllInP1(ap1:)' part of global actor 'SomeGlobalActor'}}
@@ -102,6 +108,7 @@ struct NotAllInP1 {
 
 extension NotAllInP1: P1 {
   func method() { } // expected-note{{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-1 {{global actor 'SomeGlobalActor' isolation inferred from conformance to protocol 'P1'}}
 }
 
 func testNotAllInP1(nap1: NotAllInP1) { // expected-note{{add '@SomeGlobalActor' to make global function 'testNotAllInP1(nap1:)' part of global actor 'SomeGlobalActor'}}
@@ -136,10 +143,12 @@ extension C3 {
 
 class C4: C3 {
   func method3() { }  // expected-note {{calls to instance method 'method3()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-1 {{global actor 'SomeGlobalActor' isolation inferred from inheritance from class 'C3'}}
 }
 
 extension C4 {
   func method4() { }  // expected-note {{calls to instance method 'method4()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-1 {{global actor 'SomeGlobalActor' isolation inferred from inheritance from class 'C3'}}
 }
 
 class C5 {

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -217,6 +217,7 @@ class MainActorPreconcurrency {}
 class InferMainActorPreconcurrency: MainActorPreconcurrency {
   static func predatesConcurrency() {}
   // expected-note@-1 {{calls to static method 'predatesConcurrency()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-2 {{main actor isolation inferred from inheritance from class 'MainActorPreconcurrency'}}
 }
 
 nonisolated func blah() {


### PR DESCRIPTION
Every time I see a new project failure that says `expression is ‘async’ but not marked with ‘await’` or other actor isolation error, and the callee is not `async` or explicitly annotated with a global actor attribute, I go on a hunt for where the isolation may have been inferred from. To save time searching for the source of actor isolation inference, this change records the source of actor isolation in `ActorIsolationRequest`.

For example:

```swift
@MainActor
protocol P {}

struct S: P {
  func f() {}
}

func call(s: S) {
  s.f()
}
```

The above code now produces the following diagnostics:

```
 error: call to main actor-isolated instance method 'f()' in a synchronous nonisolated context
 3 | 
 4 | struct S: P {
 5 |   func f() {}
   |        |- note: calls to instance method 'f()' from outside of its actor context are implicitly asynchronous
   |        `- note: main actor isolation inferred from conformance to protocol 'P'
 6 | }
 7 | 
 8 | func call(s: S) {
   |      `- note: add '@MainActor' to make global function 'call(s:)' part of global actor 'MainActor'
 9 |   s.f()
   |     `- error: call to main actor-isolated instance method 'f()' in a synchronous nonisolated context
10 | }
11 | 
```

The note `main actor isolation inferred from conformance to protocol 'P'` is new with this change.

This information is currently only used as an attached note to one error produced by the actor isolation checker, but this should be used in many more places. The source of actor isolation inference could also potentially be surfaced by SourceKit requests in the future.

Resolves: rdar://119905790