### PR TITLE
[Runtime] Repair build of `getenv` mode in `EnvironmentVariables.cpp`

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -247,11 +247,11 @@ void swift::runtime::environment::initialize(void *context) {
   // everywhere.
 #define VARIABLE(name, type, defaultValue, help)                               \
   do {                                                                         \
-    const char name##_string = getenv(#name);                                  \
+    const char *name##_string = getenv(#name);                                 \
     if (name##_string)                                                         \
       name##_isSet_variable = true;                                            \
     name##_variable = parse_##type(#name, name##_string, defaultValue);        \
-  } while (0)
+  } while (0);
 #include "EnvironmentVariables.def"
 
   // Print help if requested.

--- a/test/IRGen/yield_result.sil
+++ b/test/IRGen/yield_result.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
 import Builtin
 
@@ -103,7 +103,7 @@ bb0(%outt : $*T, %t : $*T):
   // CHECK:    br i1 [[IS_UNWIND]], label %[[UNWIND_BB:.*]], label %[[RESUME_BB:.*]]
 
   // CHECK:[[RESUME_BB]]:
-  // CHECK: [[VW_PTR:%.*]] = getelementptr inbounds ptr, ptr [[TYPE]], i64 -1
+  // CHECK: [[VW_PTR:%.*]] = getelementptr inbounds ptr, ptr [[TYPE]], [[INT]] -1
   // CHECK: [[VW:%.*]] = load ptr, ptr [[VW_PTR]]
   // CHECK: [[ASSIGN_PTR:%.*]] = getelementptr inbounds ptr, ptr [[VW]], i32 3
   // CHECK: [[ASSIGN:%.*]] = load ptr, ptr [[ASSIGN_PTR]]
@@ -126,7 +126,7 @@ sil [ossa] @test_coro_ret_indirect : $(Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int64):
   // CHECK: [[ARG_COPY:%.*]] = alloca i64
   // CHECK: [[INDIRECT_RET:%.*]] = alloca i64
-  // CHECK: [[FRAME:%.*]] = alloca [32 x i8]
+  // CHECK: [[FRAME:%.*]] = alloca [[[BUFFER_SIZE]] x i8]
   %coro = function_ref @coro_ret_indirect : $@yield_once @convention(thin) <T> (@in T) -> (@yields @in T, @out T)
   %temp = alloc_stack $Builtin.Int64
   store %0 to [trivial] %temp : $*Builtin.Int64
@@ -134,7 +134,7 @@ bb0(%0 : $Builtin.Int64):
   %out = alloc_stack $Builtin.Int64
 
   // CHECK: store i64 [[ARG]], ptr [[ARG_COPY]]
-  // CHECK: [[CTX:%.*]] = getelementptr inbounds [32 x i8], ptr [[FRAME]], i32 0, i32 0
+  // CHECK: [[CTX:%.*]] = getelementptr inbounds [[[BUFFER_SIZE]] x i8], ptr [[FRAME]], i32 0, i32 0
   // CHECK: [[CORO:%.*]] = call ptr @llvm.coro.prepare.retcon(ptr @coro_ret_indirect)
   // CHECK: [[FRAME:%.*]] = call swiftcc { ptr, ptr } [[CORO]](ptr{{.*}} [[CTX]], ptr [[INDIRECT_RET]], ptr noalias [[ARG_COPY]], ptr getelementptr inbounds (%swift.full_existential_type, ptr @{{.*}}
 


### PR DESCRIPTION
Follow-up fix to 4b3a197dc2eb0e1c83b847b250f448aa765ad4d5

The return tyep should be `const char *` not `const char`, and each line of xmacro does not have a semicolon, so we need it in the `VARIABLE` definition side.

```
/home/build-user/swift/include/swift/Runtime/../../../stdlib/public/runtime/EnvironmentVariables.def:25:1: error: cannot initialize a variable of type 'const char' with an rvalue of type 'char *'
   25 | VARIABLE(SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION, bool, false,
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   26 |          "Enable additional metadata allocation tracking for swift-inspect to "
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   27 |          "use.")
      |          ~~~~~~~
/home/build-user/swift/stdlib/public/runtime/EnvironmentVariables.cpp:250:16: note: expanded from macro 'VARIABLE'
  250 |     const char name##_string = getenv(#name);                                  \
      |                ^               ~~~~~~~~~~~~~
<scratch space>:42:1: note: expanded from here
   42 | SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION_string
      | ^
```
https://ci.swift.org/job/oss-swift-pr-test-crosscompile-wasm-ubuntu-20_04/1285/console
