### PR TITLE
SIL: Pass SubstFlags::PreservePackExpansionLevel in a spot in SILVerifier

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6316,7 +6316,9 @@ public:
           SILType::getPrimitiveObjectType(indexedElementType);
         auto substTargetElementSILType =
           targetElementSILType.subst(F.getModule(),
-                                     substTypes, substConformances);
+                                     substTypes, substConformances,
+                                     CanGenericSignature(),
+                                     SubstFlags::PreservePackExpansionLevel);
         requireSameType(indexedElementSILType, substTargetElementSILType,
                         "lanewise-substituted pack element type didn't "
                         "match expected element type");

--- a/validation-test/compiler_crashers_2_fixed/issue-75329.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-75329.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+// https://github.com/swiftlang/swift/issues/75329
+
+struct GPack1<each P, T> {}
+struct GPack2<each P> {
+  struct G<T> {}
+}
+
+func test<each T>(
+  example1: repeat GPack1<repeat each T, each T>,
+  example2: repeat GPack2<repeat each T>.G<each T>
+) {
+  let _ = (repeat each example1) // Boom
+}


### PR DESCRIPTION
I don't like this flag, pack substitution needs a rethink.