### PR TITLE
Fix build error with gcc in swift demangling code

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -44,14 +44,14 @@ class NodeFactory {
   /// The end of the current slab.
   char *End = nullptr;
 
-  struct Slab {
+  struct AllocatedSlab {
     // The previously allocated slab.
-    Slab *Previous;
+    AllocatedSlab *Previous;
     // Tail allocated memory starts here.
   };
   
   /// The head of the single-linked slab list.
-  Slab *CurrentSlab = nullptr;
+  AllocatedSlab *CurrentSlab = nullptr;
 
   /// The size of the previously allocated slab. This may NOT be the size of
   /// CurrentSlab, in the case where a checkpoint has been popped.
@@ -66,7 +66,7 @@ class NodeFactory {
                      & ~((uintptr_t)Alignment - 1));
   }
 
-  static void freeSlabs(Slab *slab);
+  static void freeSlabs(AllocatedSlab *slab);
 
   /// If not null, the NodeFactory from which this factory borrowed free memory.
   NodeFactory *BorrowedFrom = nullptr;
@@ -149,8 +149,8 @@ public:
       // No. We have to malloc a new slab.
       // We double the slab size for each allocated slab.
       SlabSize = std::max(SlabSize * 2, ObjectSize + alignof(T));
-      size_t AllocSize = sizeof(Slab) + SlabSize;
-      Slab *newSlab = (Slab *)malloc(AllocSize);
+      size_t AllocSize = sizeof(AllocatedSlab) + SlabSize;
+      AllocatedSlab *newSlab = (AllocatedSlab *)malloc(AllocSize);
 
       // Insert the new slab in the single-linked list of slabs.
       newSlab->Previous = CurrentSlab;
@@ -225,7 +225,7 @@ public:
   /// A checkpoint which captures the allocator's state at any given time. A
   /// checkpoint can be popped to free all allocations made since it was made.
   struct Checkpoint {
-    Slab *Slab;
+    AllocatedSlab *Slab;
     char *CurPtr;
     char *End;
   };

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -481,9 +481,9 @@ Node* Node::findByKind(Node::Kind kind, int maxDepth) {
 // NodeFactory member functions //
 //////////////////////////////////
 
-void NodeFactory::freeSlabs(Slab *slab) {
+void NodeFactory::freeSlabs(AllocatedSlab *slab) {
   while (slab) {
-    Slab *prev = slab->Previous;
+    AllocatedSlab *prev = slab->Previous;
     free(slab);
     slab = prev;
   }
@@ -543,7 +543,7 @@ void NodeFactory::popCheckpoint(NodeFactory::Checkpoint checkpoint) {
     // checkpoint's slab is less than 1/16th of the current slab's space. We
     // won't repeatedly allocate and deallocate the current slab. The size
     // doubles each time so we'll quickly pass the threshold.
-    Slab *savedSlab = nullptr;
+    AllocatedSlab *savedSlab = nullptr;
     if (CurrentSlab) {
       size_t checkpointSlabFreeSpace = checkpoint.End - checkpoint.CurPtr;
       size_t currentSlabSize = End - (char *)(CurrentSlab + 1);


### PR DESCRIPTION
Fixes:

    third_party/swift/include/swift/Demangling/Demangler.h:228:11:
      error: declaration of ‘swift::Demangle::NodeFactory::Slab* swift::Demangle::NodeFactory::Checkpoint::Slab’
             changes meaning of ‘Slab’ [-fpermissive]
      228 |     Slab *Slab;
          |           ^~~~
    third_party/swift/include/swift/Demangling/Demangler.h:47:10:
      note: ‘Slab’ declared here as ‘struct swift::Demangle::NodeFactory::Slab’
       47 |   struct Slab {
          |          ^~~~

No intended behavior change.