### PR TITLE
fix the swift library code size comparison in the run_smoke_bench script

### DIFF
--- a/benchmark/scripts/run_smoke_bench
+++ b/benchmark/scripts/run_smoke_bench
@@ -275,7 +275,8 @@ def test_performance(
 
 def report_code_size(opt_level, old_dir, new_dir, architecture, platform, output_file):
     if opt_level == "swiftlibs":
-        files = glob.glob(os.path.join(old_dir, "lib", "swift", platform, "*.dylib"))
+        p = os.path.join(old_dir, "lib", "swift", platform, architecture, "*.dylib")
+        files = glob.glob(p)
     else:
         files = glob.glob(
             os.path.join(old_dir, opt_level + "-" + architecture + "*" +


### PR DESCRIPTION
In some configurations the script mixed up the build architectures and accidentally reported the code size difference between the x86 and arm.
