### PR TITLE
Use the SwiftIfConfig library for evaluating #if conditions

### DIFF
--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -175,6 +175,23 @@ public:
   readDependencySource(const evaluator::DependencyRecorder &) const;
 };
 
+class EvaluateIfConditionRequest
+    : public SimpleRequest<EvaluateIfConditionRequest,
+          std::pair<bool, bool>(SourceFile *, SourceRange conditionRange,
+                                bool shouldEvaluate),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  std::pair<bool, bool> evaluate(
+      Evaluator &evaluator, SourceFile *SF, SourceRange conditionRange,
+      bool shouldEvaluate) const;
+};
+
 /// The zone number for the parser.
 #define SWIFT_TYPEID_ZONE Parse
 #define SWIFT_TYPEID_HEADER "swift/AST/ParseTypeIDZone.def"

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -31,3 +31,6 @@ SWIFT_REQUEST(Parse, ParseTopLevelDeclsRequest,
 SWIFT_REQUEST(Parse, ExportedSourceFileRequest,
               void *(const SourceFile *), Cached,
               NoLocationInfo)
+SWIFT_REQUEST(Parse, EvaluateIfConditionRequest,
+              (std::pair<bool, bool>)(SourceFile *, SourceRange, bool), Uncached,
+              NoLocationInfo)

--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -163,6 +163,15 @@ public:
   }
 
   SWIFT_DEBUG_DUMPER(dump(const SourceManager &SM));
+
+  friend size_t hash_value(SourceRange range) {
+    return llvm::hash_combine(range.Start, range.End);
+  }
+
+  friend void simple_display(raw_ostream &OS, const SourceRange &loc) {
+    // Nothing meaningful to print.
+  }
+
 };
 
 /// A half-open character-based source range.

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -8,7 +8,7 @@ var x = 0
 var y = 0
 #endif
 
-#if foo(BAR) // expected-error {{unexpected platform condition (expected 'os', 'arch', or 'swift')}}
+#if foo(BAR) // expected-error {{invalid conditional compilation expression}}
 var z = 0
 #endif
 
@@ -27,7 +27,7 @@ func h() {}
 #else /* aaa */
 #endif /* bbb */
 
-#if foo.bar() // expected-error {{unexpected platform condition (expected 'os', 'arch', or 'swift')}}
+#if foo.bar() // expected-error {{invalid conditional compilation expression}}
       .baz()
 
 #endif
@@ -67,30 +67,23 @@ struct S {
 #else
 #endif
 
-#if os(ios) // expected-warning {{unknown operating system for build configuration 'os'}} expected-note{{did you mean 'iOS'?}} {{8-11=iOS}}
+#if os(ios)
 #endif
 
-#if os(uOS) // expected-warning {{unknown operating system for build configuration 'os'}} expected-note{{did you mean 'iOS'?}} {{8-11=iOS}}
+#if os(uOS)
 #endif
 
-#if os(xxxxxxd) // expected-warning {{unknown operating system for build configuration 'os'}}
-// expected-note@-1{{did you mean 'Linux'?}} {{8-15=Linux}}
-// expected-note@-2{{did you mean 'FreeBSD'?}} {{8-15=FreeBSD}}
-// expected-note@-3{{did you mean 'Android'?}} {{8-15=Android}}
-// expected-note@-4{{did you mean 'OSX'?}} {{8-15=OSX}}
-// expected-note@-5{{did you mean 'OpenBSD'?}} {{8-15=OpenBSD}}
-// expected-note@-6{{did you mean 'xrOS'?}} {{8-15=xrOS}}
+#if os(xxxxxxd)
 #endif
 
-#if os(bisionos) // expected-warning {{unknown operating system for build configuration 'os'}}
-// expected-note@-1{{did you mean 'visionOS'?}} {{8-16=visionOS}}
+#if os(bisionos)
 
 #endif
 
-#if arch(arn) // expected-warning {{unknown architecture for build configuration 'arch'}} expected-note{{did you mean 'arm'?}} {{10-13=arm}}
+#if arch(arn)
 #endif
 
-#if _endian(mid) // expected-warning {{unknown endianness for build configuration '_endian'}} expected-note{{did you mean 'big'?}} {{13-16=big}}
+#if _endian(mid) // expected-warning {{unknown endianness for build configuration '_endian'}}
 #endif
 
 LABEL: #if true // expected-error {{expected statement}}
@@ -104,7 +97,7 @@ func fn_j() {}
 #endif
 fn_j() // OK
 
-#if foo || bar || nonExistent() // expected-error {{expected argument to platform condition}}
+#if foo || bar || nonExistent() // expected-error {{invalid conditional compilation expression}}
 #endif
 
 #if FOO = false
@@ -123,47 +116,33 @@ undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 #endif
 
 /// Invalid platform condition arguments don't invalidate the whole condition.
+// expected-warning@+1{{unknown endianness}}
 #if !arch(arn) && !os(ystem) && !_endian(ness)
-// expected-warning@-1 {{unknown architecture for build configuration 'arch'}}
-// expected-note@-2 {{did you mean 'arm'?}} {{11-14=arm}}
-// expected-warning@-3 {{unknown operating system for build configuration 'os'}}
-// expected-note@-4 {{did you mean 'OSX'?}} {{23-28=OSX}}
-// expected-note@-5 {{did you mean 'PS4'?}} {{23-28=PS4}}
-// expected-note@-6 {{did you mean 'none'?}} {{23-28=none}}
-// expected-warning@-7 {{unknown endianness for build configuration '_endian'}}
-// expected-note@-8 {{did you mean 'big'?}} {{42-46=big}}
 func fn_k() {}
 #endif
 fn_k()
 
 #if os(cillator) || arch(i3rm)
-// expected-warning@-1 {{unknown operating system for build configuration 'os'}}
-// expected-note@-2 {{did you mean 'macOS'?}} {{8-16=macOS}}
-// expected-note@-3 {{did you mean 'iOS'?}} {{8-16=iOS}}
-// expected-warning@-4 {{unknown architecture for build configuration 'arch'}}
-// expected-note@-5 {{did you mean 'arm'?}} {{26-30=arm}}
-// expected-note@-6 {{did you mean 'i386'?}} {{26-30=i386}}
-// expected-note@-7 {{did you mean 'visionOS'?}} {{8-16=visionOS}}
 func undefinedFunc() // ignored.
 #endif
 undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 
-#if os(simulator) // expected-warning {{unknown operating system for build configuration 'os'}} expected-note {{did you mean 'targetEnvironment'}} {{5-7=targetEnvironment}}
+#if os(simulator)
 #endif
 
-#if arch(iOS) // expected-warning {{unknown architecture for build configuration 'arch'}} expected-note {{did you mean 'os'}} {{5-9=os}}
+#if arch(iOS)
 #endif
 
-#if _endian(arm64) // expected-warning {{unknown endianness for build configuration '_endian'}} expected-note {{did you mean 'arch'}} {{5-12=arch}}
+#if _endian(arm64) // expected-warning {{unknown endianness for build configuration '_endian'}}
 #endif
 
-#if targetEnvironment(_ObjC) // expected-warning {{unknown target environment for build configuration 'targetEnvironment'}} expected-note {{did you mean 'macabi'}} {{23-28=macabi}}
+#if targetEnvironment(_ObjC)
 #endif
 
-#if os(iOS) || os(simulator) // expected-warning {{unknown operating system for build configuration 'os'}} expected-note {{did you mean 'targetEnvironment'}} {{16-18=targetEnvironment}}
+#if os(iOS) || os(simulator)
 #endif
 
-#if arch(ios) // expected-warning {{unknown architecture for build configuration 'arch'}} expected-note {{did you mean 'os'}} {{5-9=os}} expected-note {{did you mean 'iOS'}} {{10-13=iOS}}
+#if arch(ios)
 #endif
 
 #if FOO
@@ -179,5 +158,5 @@ if true {}
 
 // rdar://83017601 Make sure we don't crash
 #if canImport()
-// expected-error@-1 {{expected argument to platform condition}}
+// expected-error@-1 {{'canImport' requires a module name}}
 #endif

--- a/test/Parse/ConditionalCompilation/can_import_in_inactive.swift
+++ b/test/Parse/ConditionalCompilation/can_import_in_inactive.swift
@@ -21,7 +21,7 @@
 #endif
 
 #if canImport(SomeModule)
-// CHECK: :[[@LINE-1]]:15: error: could not find module 'SomeModule' for target '{{.*}}'; found: i386
+// CHECK: :[[@LINE-1]]:{{.*}}: error: could not find module 'SomeModule' for target '{{.*}}'; found: i386
 #endif
 
 import SomeModule

--- a/test/Parse/ConditionalCompilation/can_import_submodule.swift
+++ b/test/Parse/ConditionalCompilation/can_import_submodule.swift
@@ -48,17 +48,17 @@ import A.B.C
 #endif
 
 
-#if canImport(A(_:).B) // expected-error@:15 {{unexpected platform condition argument: expected module name}}
+#if canImport(A(_:).B) // expected-error@:15 {{expected module name}}
 #endif
 
-#if canImport(A.B(c: "arg")) // expected-error@:15 {{unexpected platform condition argument: expected module name}}
+#if canImport(A.B(c: "arg")) // expected-error@:15 {{expected module name}}
 #endif
 
-#if canImport(A(b: 1, c: 2).B.C) // expected-error@:15 {{unexpected platform condition argument: expected module name}}
+#if canImport(A(b: 1, c: 2).B.C) // expected-error@:15 {{expected module name}}
 #endif
 
-#if canImport(A.B("arg")(3).C) // expected-error@:15 {{unexpected platform condition argument: expected module name}}
+#if canImport(A.B("arg")(3).C) // expected-error@:15 {{expected module name}}
 #endif
 
-#if canImport(A.B.C()) // expected-error@:15 {{unexpected platform condition argument: expected module name}}
+#if canImport(A.B.C()) // expected-error@:15 {{expected module name}}
 #endif

--- a/test/Parse/ConditionalCompilation/compiler_version.swift
+++ b/test/Parse/ConditionalCompilation/compiler_version.swift
@@ -34,39 +34,37 @@
   %#^*&
 #endif
 
-#if _compiler_version("700a.*.10") // expected-error {{version component contains non-numeric characters}}
+#if _compiler_version("700a.*.10") // expected-error {{'_compiler_version' version check has invalid version '"700a.*.10"'}}
 #endif
 
 #if _compiler_version("...") // expected-error {{found empty version component}}
-// expected-error@-1 {{found empty version component}}
-// expected-error@-2 {{found empty version component}}
 #endif
 
-#if _compiler_version("") // expected-error {{version requirement is empty}}
+#if _compiler_version("") // expected-error {{found empty version component}}
   let y = 1
 #else
   let thisWillStillParseBecauseConfigIsError = 1
 #endif
 
-#if _compiler_version("700.0.100") // expected-warning {{the second version component is not used for comparison in legacy compiler versions}} {{28-29=*}}
+#if _compiler_version("700.0.100") // expected-warning {{the second version component is not used for comparison in legacy compiler versions}}
 #endif
 
-#if _compiler_version("5.7.100") // expected-warning {{the second version component is not used for comparison in legacy compiler versions; are you trying to encode a new Swift compiler version for compatibility with legacy compilers?}} {{24-27=5007.*}}
+#if _compiler_version("5.7.100") // expected-warning {{the second version component is not used for comparison in legacy compiler versions}}
 #endif
 
 #if _compiler_version("700.*.1.1.1.1") // expected-error {{version must not have more than five components}}
 #endif
 
-#if _compiler_version("9223372.*.1.1.1") // expected-error {{version component out of range: must be in [0, 9223371]}}
+#if _compiler_version("9223372.*.1.1.1") // expected-error {{compiler version component '9223372' is not in the allowed range 0...9223371}}
 #endif
 
-#if _compiler_version("700.*.1000.1.1") // expected-error {{version component out of range: must be in [0, 999]}}
+#if _compiler_version("700.*.1000.1.1") // expected-error {{compiler version component '1000' is not in the allowed range 0...999}}
 #endif
 
-#if _compiler_version("700.*.1.1000.1") // expected-error {{version component out of range: must be in [0, 999]}}
+#if _compiler_version("700.*.1.1000.1") // expected-error {{compiler version component '1000' is not in the allowed range 0...999}}
 #endif
 
-#if _compiler_version("700.*.1.1.1000") // expected-error {{version component out of range: must be in [0, 999]}}
+#if _compiler_version("700.*.1.1.1000") // expected-error {{compiler version component '1000' is not in the allowed range 0...999}}
 #endif
 
 // New style _compiler_version()

--- a/test/Parse/ConditionalCompilation/compoundName_swift4.swift
+++ b/test/Parse/ConditionalCompilation/compoundName_swift4.swift
@@ -2,6 +2,6 @@
 
 /// Reject compound names.
 #if BAR(_:) // expected-error@:5 {{invalid conditional compilation expression}}
-#elseif os(x:)(macOS) // expected-error@:9 {{unexpected platform condition (expected 'os', 'arch', or 'swift')}}
-#elseif os(Linux(foo:bar:)) // expected-error@:12 {{unexpected platform condition argument: expected identifier}}
+#elseif os(x:)(macOS) // expected-error@:9 {{invalid conditional compilation expression}}
+#elseif os(Linux(foo:bar:)) // expected-error@:9 {{'os' requires a single unlabeled argument for the operating system}}
 #endif

--- a/test/Parse/ConditionalCompilation/language_version.swift
+++ b/test/Parse/ConditionalCompilation/language_version.swift
@@ -53,16 +53,16 @@
   %#^*&
 #endif
 
-#if swift(">=7.1") // expected-error@:11 {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
+#if swift(">=7.1") // expected-error@:5 {{'swift' requires a single unlabeled argument for the version comparison}}
 #endif
 
-#if swift("<7.1") // expected-error@:11 {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
+#if swift("<7.1") // expected-error@:5 {{'swift' requires a single unlabeled argument for the version comparison}}
 #endif
 
-#if swift(">=2n.2") // expected-error@:11 {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
+#if swift(">=2n.2") // expected-error@:5 {{'swift' requires a single unlabeled argument for the version comparison}}
 #endif
 
-#if swift("") // expected-error@:11 {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
+#if swift("") // expected-error@:5 {{'swift' requires a single unlabeled argument for the version comparison}}
 #endif
 
 #if swift(>=2.2.1)
@@ -75,13 +75,13 @@ class C {
 #endif
 }
 
-#if swift(>=2.0, *) // expected-error@:11 {{expected only one unlabeled argument to platform condition}}
+#if swift(>=2.0, *) // expected-error@:5 {{'swift' requires a single unlabeled argument for the version comparison}}
 #endif
 
-#if swift(>=, 2.0) // expected-error@:11 {{expected only one unlabeled argument to platform condition}}
+#if swift(>=, 2.0) // expected-error@:5 {{'swift' requires a single unlabeled argument for the version comparison}}
 #endif
 
-#if swift(version: >=2.0) // expected-error@:11 {{expected only one unlabeled argument to platform condition}}
+#if swift(version: >=2.0) // expected-error@:5 {{'swift' requires a single unlabeled argument for the version comparison}}
 #endif
 
 protocol P {

--- a/test/Parse/ConditionalCompilation/macabiTargetEnv.swift
+++ b/test/Parse/ConditionalCompilation/macabiTargetEnv.swift
@@ -3,13 +3,15 @@
 
 // REQUIRES: OS=macosx || OS=maccatalyst
 
-#if targetEnvironment(macabi) // expected-warning {{'macabi' has been renamed to 'macCatalyst'}} {{23-29=macCatalyst}}
+#if targetEnvironment(macabi) // expected-warning {{'macabi' has been renamed to 'macCatalyst'}}
+// expected-note@-1{{replace with 'macCatalyst'}}{{23-29=macCatalyst}}
 func underMacABI() {
   foo() // expected-error {{cannot find 'foo' in scope}}
 }
 #endif
 
-#if !targetEnvironment(macabi) // expected-warning {{'macabi' has been renamed to 'macCatalyst'}} {{24-30=macCatalyst}}
+#if !targetEnvironment(macabi) // expected-warning {{'macabi' has been renamed to 'macCatalyst'}}
+// expected-note@-1{{replace with 'macCatalyst'}}{{24-30=macCatalyst}}
 // This block does not typecheck but the #if prevents it from
 // from being a compiler error.
 let i: SomeType = "SomeString" // no-error
@@ -29,8 +31,6 @@ let i: SomeType = "SomeString" // no-error
 #endif
 
 #if os(macCatalyst)
-// expected-warning@-1 {{unknown operating system for build configuration 'os'}}
-// expected-note@-2 *{{did you mean}}
 func underOSMacCatalyst() {
 }
 #endif

--- a/test/Parse/ConditionalCompilation/pound-if-top-level-2.swift
+++ b/test/Parse/ConditionalCompilation/pound-if-top-level-2.swift
@@ -1,10 +1,12 @@
 // RUN: %target-typecheck-verify-swift
 
-#if 0  // expected-error {{'0' is not a valid conditional compilation expression, use 'false'}} {{5-6=false}}
+#if 0  // expected-error {{'0' is not a valid conditional compilation expression, use 'false'}}
+// expected-note@-1{{replace with Boolean literal 'false'}}{{5-6=false}}
   let x = 1
 #endif
 
-#if 1  // expected-error {{'1' is not a valid conditional compilation expression, use 'true'}} {{5-6=true}}
+#if 1  // expected-error {{'1' is not a valid conditional compilation expression, use 'true'}}
+// expected-note@-1{{replace with Boolean literal 'true'}}{{5-6=true}}
   let x = 1
 #endif
 

--- a/test/Parse/ConditionalCompilation/simulatorTargetEnv.swift
+++ b/test/Parse/ConditionalCompilation/simulatorTargetEnv.swift
@@ -14,26 +14,31 @@ var x = C()
 var y = x
 
 #if os(iOS) && arch(i386)
-// expected-warning @-1 {{platform condition appears to be testing for simulator environment}} {{5-26=targetEnvironment(simulator)}}
+// expected-warning @-1 {{platform condition appears to be testing for simulator environment}}
+// expected-note@-2{{replace with 'targetEnvironment(simulator)'}}{{5-26=targetEnvironment(simulator)}}
 class C1 {}
 #endif
 
 #if arch(i386) && os(iOS)
-// expected-warning @-1 {{platform condition appears to be testing for simulator environment}} {{5-26=targetEnvironment(simulator)}}
+// expected-warning @-1 {{platform condition appears to be testing for simulator environment}}
+// expected-note@-2{{replace with 'targetEnvironment(simulator)'}}{{5-26=targetEnvironment(simulator)}}
 class C2 {}
 #endif
 
 #if arch(i386) && (os(iOS) || os(watchOS))
-// expected-warning @-1 {{platform condition appears to be testing for simulator environment}} {{5-43=targetEnvironment(simulator)}}
+// expected-warning @-1 {{platform condition appears to be testing for simulator environment}}
+// expected-note@-2{{replace with 'targetEnvironment(simulator)'}}{{5-43=targetEnvironment(simulator)}}
 class C3 {}
 #endif
 
 #if (arch(x86_64) || arch(i386)) && (os(iOS) || os(watchOS) || os(tvOS))
-// expected-warning @-1 {{platform condition appears to be testing for simulator environment}} {{5-73=targetEnvironment(simulator)}}
+// expected-warning @-1 {{platform condition appears to be testing for simulator environment}}
+// expected-note@-2{{replace with 'targetEnvironment(simulator)'}}{{5-73=targetEnvironment(simulator)}}
 class C4 {}
 #endif
 
 #if !(arch(x86_64) && os(tvOS))
-// expected-warning @-1 {{platform condition appears to be testing for simulator environment}} {{7-31=targetEnvironment(simulator)}}
+// expected-warning @-1 {{platform condition appears to be testing for simulator environment}}
+// expected-note@-2{{replace with 'targetEnvironment(simulator)'}}{{7-31=targetEnvironment(simulator)}}
 class C5 {}
 #endif

--- a/test/Parse/ifconfig_expr.swift
+++ b/test/Parse/ifconfig_expr.swift
@@ -163,35 +163,42 @@ func canImportVersioned() {
   let a = 1
 #endif
 
-#if canImport(A, unknown: 2.2) // expected-error {{2nd parameter of canImport should be labeled as _version or _underlyingVersion}}
+#if canImport(A, unknown: 2.2) // expected-error {{second parameter of 'canImport' should be labeled as _version or _underlyingVersion}}
   let a = 1
 #endif
   
-#if canImport(A, 2.2) // expected-error {{2nd parameter of canImport should be labeled as _version or _underlyingVersion}}
+
+#if canImport(A,)
+  let a = 1
+#endif
+  
+#if canImport(A, 2.2) // expected-error {{second parameter of 'canImport' should be labeled as _version or _underlyingVersion}}
   let a = 1
 #endif
 
-#if canImport(A, 2.2, 1.1) // expected-error {{canImport can take only two parameters}}
+#if canImport(A, 2.2, 1.1) // expected-error {{'canImport' can take only two parameters}}
   let a = 1
 #endif
   
+// expected-error@+1{{'canImport' version check has invalid version ''}}
 #if canImport(A, _version:) // expected-error {{expected expression in list of expressions}}
   let a = 1
 #endif
 
-#if canImport(A, _version: "") // expected-error {{_version argument cannot be empty}}
+#if canImport(A, _version: "") // expected-error {{'canImport' version check has invalid version '""'}}
   let a = 1
 #endif
   
-#if canImport(A, _version: >=2.2) // expected-error {{cannot parse module version '>=2.2'}}
+#if canImport(A, _version: >=2.2) // expected-error {{'canImport' version check has invalid version '>=2.2'}}
   let a = 1
 #endif
-  
+
+// expected-error@+1{{'canImport' version check has invalid version '20A301'}}
 #if canImport(A, _version: 20A301) // expected-error {{'A' is not a valid digit in integer literal}}
   let a = 1
 #endif
 
-#if canImport(A, _version: "20A301") // expected-error {{cannot parse module version '20A301'}}
+#if canImport(A, _version: "20A301") // expected-error {{'canImport' version check has invalid version '"20A301"'}}
   let a = 1
 #endif
 }

--- a/test/Parse/unknown_platform.swift
+++ b/test/Parse/unknown_platform.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// expected-error@+1{{unexpected platform condition}}
+// expected-error@+1{{invalid conditional compilation expression}}
 #if hasGreeble(blah)
 #endif
 
@@ -13,16 +13,16 @@
 #endif
 
 // This compiler, don't short-circuit.
-// expected-error@+1{{unexpected platform condition}}
+// expected-error@+1{{invalid conditional compilation expression}}
 #if compiler(>=5.7) && hasGreeble(blah)
 #endif
 
 // This compiler, don't short-circuit.
-// expected-error@+1{{unexpected platform condition}}
+// expected-error@+1{{invalid conditional compilation expression}}
 #if compiler(<5.8) || hasGreeble(blah)
 #endif
 
 // Not a "version" check, so don't short-circuit.
-// expected-error@+1{{unexpected platform condition}}
+// expected-error@+1{{invalid conditional compilation expression}}
 #if os(macOS) && hasGreeble(blah)
 #endif

--- a/test/Parse/upcoming_feature.swift
+++ b/test/Parse/upcoming_feature.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
-// expected-error@+1:16{{unexpected platform condition argument: expected feature name}}
+// expected-error@+1:5{{'hasFeature' requires a single unlabeled argument for the feature}}
 #if hasFeature(17)
 #endif

--- a/test/attr/has_attribute.swift
+++ b/test/attr/has_attribute.swift
@@ -21,7 +21,7 @@ UserInaccessibleAreNotAttributes
 #endif
 
 #if hasAttribute(17)
-// expected-error@-1:18 {{unexpected platform condition argument: expected attribute name}}
+// expected-error@-1:5 {{single unlabeled argument for the attribute}}
 #endif
 
 #if !hasAttribute(escaping)


### PR DESCRIPTION
Replace the C++ implementation of `#if` condition operator folding, validation, and evaluation with the corresponding facilities in the SwiftIfConfig library. Leave the C++ implementation in place for now to permit the compiler to continue building without swift-syntax.

There are a few differences in the diagnostics produced relative to the C++ implementation; the second commit shows the actual changes, all of which are benign or are improvements.