### PR TITLE
Optimizer: some improvements for alias analysis in several utilities

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -574,11 +574,7 @@ private enum MemoryLocation {
   var isLetValue: Bool {
     switch self {
     case .memoryAddress(let addr):
-      switch addr.accessBase {
-        case .global(let global): return global.isLet
-        case .class(let rea):     return rea.fieldIsLet
-        default:                  return false
-      }
+      return addr.accessBase.isLet
     case .modifyAccessScope:
       return false
     }

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -309,6 +309,11 @@ struct AliasAnalysis {
       if destroy.destroyedValue.type.isNoEscapeFunction {
         return .noEffects
       }
+      if destroy.isDeadEnd {
+        // We don't have to take deinit effects into acount for a `destroy_value [dead_end]`.
+        // Such destroys are lowered to no-ops and will not call any deinit.
+        return .noEffects
+      }
       return defaultEffects(of: destroy, on: memLoc)
 
     default:

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -571,7 +571,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
           switch uacUse.instruction {
           case is IsUniqueInst:
             break
-          case is LoadInst, is LoadBorrowInst:
+          case is LoadInst, is LoadBorrowInst, is ApplyInst, is TryApplyInst:
             if followLoads(at: path) {
               return .abortWalk
             }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -625,16 +625,6 @@ private struct EscapesToValueVisitor : EscapeVisitor {
 }
 
 extension Function {
-  var globalOfGlobalInitFunction: GlobalVariable? {
-    if isGlobalInitFunction,
-       let ret = returnInstruction,
-       let atp = ret.returnedValue as? AddressToPointerInst,
-       let ga = atp.address as? GlobalAddrInst {
-      return ga.global
-    }
-    return nil
-  }
-
   var initializedGlobal: GlobalVariable? {
     if !isGlobalInitOnceFunction {
       return nil

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -506,6 +506,11 @@ final public class UnmanagedAutoreleaseValueInst : RefCountingInst {}
 
 final public class DestroyValueInst : Instruction, UnaryInstruction {
   public var destroyedValue: Value { operand.value }
+
+  /// True if this `destroy_value` is inside a dead-end block is only needed to formally
+  /// end the lifetime of its operand.
+  /// Such `destroy_value` instructions are lowered to no-ops.
+  public var isDeadEnd: Bool { bridged.DestroyValueInst_isDeadEnd() }
 }
 
 final public class DestroyAddrInst : Instruction, UnaryInstruction {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -951,6 +951,7 @@ struct BridgedInstruction {
 
   BRIDGED_INLINE SwiftInt ProjectBoxInst_fieldIndex() const;
   BRIDGED_INLINE bool EndCOWMutationInst_doKeepUnique() const;
+  BRIDGED_INLINE bool DestroyValueInst_isDeadEnd() const;
   BRIDGED_INLINE SwiftInt EnumInst_caseIndex() const;
   BRIDGED_INLINE SwiftInt UncheckedEnumDataInst_caseIndex() const;
   BRIDGED_INLINE SwiftInt InitEnumDataAddrInst_caseIndex() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1111,6 +1111,10 @@ bool BridgedInstruction::EndCOWMutationInst_doKeepUnique() const {
   return getAs<swift::EndCOWMutationInst>()->doKeepUnique();
 }
 
+bool BridgedInstruction::DestroyValueInst_isDeadEnd() const {
+  return getAs<swift::DestroyValueInst>()->isDeadEnd();
+}
+
 SwiftInt BridgedInstruction::EnumInst_caseIndex() const {
   return getAs<swift::EnumInst>()->getCaseIndex();
 }

--- a/test/SILOptimizer/accessutils.sil
+++ b/test/SILOptimizer/accessutils.sil
@@ -370,6 +370,85 @@ bb0:
 
 sil_global @global1 : $Int64
 sil_global @global2 : $Int64
+sil_global @somePointer : $Builtin.RawPointer
+
+sil [global_init] [ossa] @addressor_of_global1 : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @global1 : $*Int64
+  %1 = address_to_pointer %0 : $*Int64 to $Builtin.RawPointer
+  return %1 : $Builtin.RawPointer
+}
+
+sil [global_init] [ossa] @external_addressor_of_global1 : $@convention(thin) () -> Builtin.RawPointer
+
+sil [global_init] [ossa] @wrong_addressor_of_global1 : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @somePointer : $*Builtin.RawPointer
+  %1 = load [trivial] %0 : $*Builtin.RawPointer
+  return %1 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: Accesses for testSimpleGlobal
+// CHECK-NEXT:  Value:   %0 = global_addr @global1 : $*Int64
+// CHECK-NEXT:    Scope: base
+// CHECK-NEXT:    Base: global - @global1
+// CHECK-NEXT:    Path: ""
+// CHECK-NEXT:     no Storage paths
+// CHECK-NEXT:  End accesses for testSimpleGlobal
+sil [ossa] @testSimpleGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = global_addr @global1 : $*Int64
+  %1 = load [trivial] %0 : $*Int64
+  return %1 : $Int64
+}
+
+// CHECK-LABEL: Accesses for testGlobalViaAddressor
+// CHECK-NEXT:  Value:   %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+// CHECK-NEXT:    Scope: base
+// CHECK-NEXT:    Base: global - @global1
+// CHECK-NEXT:    Path: ""
+// CHECK-NEXT:     no Storage paths
+// CHECK-NEXT:  End accesses for testGlobalViaAddressor
+sil [ossa] @testGlobalViaAddressor : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = function_ref @addressor_of_global1 : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+  %3 = load [trivial] %2 : $*Int64
+  return %3 : $Int64
+}
+
+// CHECK-LABEL: Accesses for testGlobalViaUnknwonAddressor
+// CHECK-NEXT:  Value:   %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+// CHECK-NEXT:    Scope: base
+// CHECK-NEXT:    Base: pointer -   %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+// CHECK-NEXT:    Path: ""
+// CHECK-NEXT:     no Storage paths
+// CHECK-NEXT:  End accesses for testGlobalViaUnknwonAddressor
+sil [ossa] @testGlobalViaUnknwonAddressor : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = function_ref @external_addressor_of_global1 : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+  %3 = load [trivial] %2 : $*Int64
+  return %3 : $Int64
+}
+
+// CHECK-LABEL: Accesses for testGlobalViaWrongAddressor
+// CHECK-NEXT:  Value:   %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+// CHECK-NEXT:    Scope: base
+// CHECK-NEXT:    Base: pointer -   %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+// CHECK-NEXT:    Path: ""
+// CHECK-NEXT:     no Storage paths
+// CHECK-NEXT:  End accesses for testGlobalViaWrongAddressor
+sil [ossa] @testGlobalViaWrongAddressor : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = function_ref @wrong_addressor_of_global1 : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+  %3 = load [trivial] %2 : $*Int64
+  return %3 : $Int64
+}
 
 sil @coro : $@yield_once @convention(thin) () -> @yields @inout Int64
 

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -48,6 +48,12 @@ sil @non_escaping_class_argument : $@convention(thin) (@guaranteed X) -> () {
 sil @inout_class_argument : $@convention(thin) (@inout X) -> () {
 [%0: noescape **]
 }
+sil @inout_class_argument2 : $@convention(thin) (@inout XandIntClass) -> () {
+[%0: noescape **]
+}
+sil @inout_class_argument3 : $@convention(thin) (@inout XandIntClass) -> @error Error {
+[%0: noescape **]
+}
 sil @container_argument : $@convention(thin) (@guaranteed Container) -> ()
 sil @take_closure_as_addr : $@convention(thin) (@in @callee_guaranteed () -> ()) -> ()
 sil @take_closure_as_addr_noescape : $@convention(thin) (@in @callee_guaranteed () -> ()) -> () {
@@ -813,6 +819,9 @@ bb0(%0 :  @owned $X):
 
 // CHECK-LABEL: Address escape information for test_unchecked_addr_cast:
 // CHECK:       value:  %1 = alloc_stack $X
+// CHECK:         ==>   %10 = apply %9(%4) : $@convention(thin) (@inout XandIntClass) -> ()
+// CHECK:         ==>   try_apply %11(%4) : $@convention(thin) (@inout XandIntClass) -> @error any Error, normal bb1, error bb2
+// CHECK:         -     %15 = apply %14() : $@convention(thin) () -> ()
 // CHECK-NEXT:  End function test_unchecked_addr_cast
 sil [ossa] @test_unchecked_addr_cast : $@convention(thin) (@owned X) -> @owned XandIntClass {
 bb0(%0 :  @owned $X):
@@ -824,25 +833,19 @@ bb0(%0 :  @owned $X):
   %6 = load_borrow %4 : $*XandIntClass
   end_borrow %6 : $XandIntClass
   %8 = load [take] %4 : $*XandIntClass
+  %9 = function_ref @inout_class_argument2 : $@convention(thin) (@inout XandIntClass) -> ()
+  %10 = apply %9(%4) : $@convention(thin) (@inout XandIntClass) -> ()
+  %11 = function_ref @inout_class_argument3 : $@convention(thin) (@inout XandIntClass) -> @error Error
+  try_apply %11(%4) : $@convention(thin) (@inout XandIntClass) -> @error Error, normal bb1, error bb2
+
+bb1(%13 : $()):
+  %14 = function_ref @no_arguments : $@convention(thin) () -> ()
+  %15 = apply %14() : $@convention(thin) () -> ()
   dealloc_stack %1 : $*X
   return %8 : $XandIntClass
-}
 
-// CHECK-LABEL: Address escape information for test_unchecked_addr_cast_escaping:
-// CHECK:       value:  %1 = alloc_stack $X
-// CHECK-NEXT:  ==>   %6 = apply %5(%4) : $@convention(thin) (@inout X) -> ()
-// CHECK-NEXT:  End function test_unchecked_addr_cast_escaping
-sil [ossa] @test_unchecked_addr_cast_escaping : $@convention(thin) (@owned XandIntClass) -> () {
-bb0(%0 :  @owned $XandIntClass):
-  %1 = alloc_stack $XandIntClass
-  store %0 to [init] %1 : $*XandIntClass
-  fix_lifetime %1 : $*XandIntClass
-  %4 = unchecked_addr_cast %1 : $*XandIntClass to $*X
-  %5 = function_ref @inout_class_argument : $@convention(thin) (@inout X) -> ()
-  %6 = apply %5(%4) : $@convention(thin) (@inout X) -> ()
-  dealloc_stack %1 : $*XandIntClass
-  %8 = tuple ()
-  return %8 : $()
+bb2(%17 : $Error):
+  unreachable
 }
 
 // CHECK-LABEL: Address escape information for test_store_borrow:

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -1457,3 +1457,17 @@ bb0:
   %3 = unchecked_ref_cast %1 : $Derived to $X
   return %2 : $X
 }
+
+// CHECK-LABEL: Escape information for test_unchecked_addr_cast:
+// CHECK: global:   %1 = alloc_ref $X
+// CHECK: End function test_unchecked_addr_cast
+sil @test_unchecked_addr_cast : $@convention(thin) () -> @owned Builtin.RawPointer {
+bb0:
+  %0 = alloc_stack $X
+  %1 = alloc_ref $X
+  store %1 to %0 : $*X
+  %3 = unchecked_addr_cast %0 : $*X to $*Builtin.RawPointer
+  %4 = load %3 : $*Builtin.RawPointer
+  dealloc_stack %0 : $*X
+  return %4 : $Builtin.RawPointer
+}

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -1009,6 +1009,36 @@ bb0 (%0 : $*C):
   return %2 : $()
 }
 
+// CHECK-LABEL: @test_destroy_value_with_effects
+// CHECK:       PAIR #1.
+// CHECK-NEXT:     destroy_value %0 : $X
+// CHECK-NEXT:     %2 = ref_element_addr %1 : $X, #X.x
+// CHECK-NEXT:   r=1,w=1
+sil [ossa] @test_destroy_value_with_effects : $@convention(thin) (@owned X) -> () {
+bb0 (%0 : @owned $X):
+  %1 = begin_borrow %0 : $X
+  %2 = ref_element_addr %1 : $X, #X.x
+  fix_lifetime %2 : $*X
+  end_borrow %1 : $X
+  destroy_value %0 : $X
+  unreachable
+}
+
+// CHECK-LABEL: @test_deadend_destroy_value
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      destroy_value [dead_end] %0 : $X
+// CHECK-NEXT:      %2 = ref_element_addr %1 : $X, #X.x
+// CHECK-NEXT:    r=0,w=0
+sil [ossa] @test_deadend_destroy_value : $@convention(thin) (@owned X) -> () {
+bb0 (%0 : @owned $X):
+  %1 = begin_borrow %0 : $X
+  %2 = ref_element_addr %1 : $X, #X.x
+  fix_lifetime %2 : $*X
+  end_borrow %1 : $X
+  destroy_value [dead_end] %0 : $X
+  unreachable
+}
+
 // CHECK-LABEL: @test_copy_value
 // CHECK: PAIR #1.
 // CHECK-NEXT:     %2 = copy_value %1 : $C

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -882,6 +882,81 @@ bb0:
   return %8 : $()
 }
 
+sil [global_init] @addressor_of_globalC : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalC : $*C
+  %1 = address_to_pointer %0 : $*C to $Builtin.RawPointer
+  return %1 : $Builtin.RawPointer
+}
+
+sil [global_init] @addressor_of_globalCVar : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalCVar : $*C
+  %1 = address_to_pointer %0 : $*C to $Builtin.RawPointer
+  return %1 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: @testGlobalViaAddressorLet
+// CHECK:      PAIR #2.
+// CHECK-NEXT:     %5 = apply %4() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*C
+// CHECK-NEXT:   r=1,w=0
+sil @testGlobalViaAddressorLet : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @addressor_of_globalC : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*C
+  %3 = load %2 : $*C
+  %4 = function_ref @nouser_func : $@convention(thin) () -> ()
+  %5 = apply %4() : $@convention(thin) () -> ()
+  %6 = function_ref @read_C : $@convention(thin) (@in_guaranteed C) -> ()
+  %7 = apply %6(%2) : $@convention(thin) (@in_guaranteed C) -> ()
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: @testGlobalViaAddressorVar
+// CHECK:      PAIR #2.
+// CHECK-NEXT:     %5 = apply %4() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*C
+// CHECK-NEXT:   r=1,w=1
+sil @testGlobalViaAddressorVar : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @addressor_of_globalCVar : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*C
+  %3 = load %2 : $*C
+  %4 = function_ref @nouser_func : $@convention(thin) () -> ()
+  %5 = apply %4() : $@convention(thin) () -> ()
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: @testGlobalAliasing
+// CHECK:      PAIR #6.
+// CHECK-NEXT:     store %0 to %3 : $*C
+// CHECK-NEXT:     %3 = pointer_to_address %2 : $Builtin.RawPointer to [strict] $*C
+// CHECK-NEXT:   r=0,w=1
+// CHECK:      PAIR #7.
+// CHECK-NEXT:     store %0 to %3 : $*C
+// CHECK-NEXT:     %6 = pointer_to_address %5 : $Builtin.RawPointer to [strict] $*C
+// CHECK-NEXT:   r=0,w=0
+sil @testGlobalAliasing : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : $C):
+  %1 = function_ref @addressor_of_globalCVar : $@convention(thin) () -> Builtin.RawPointer
+  %2 = apply %1() : $@convention(thin) () -> Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to [strict] $*C
+  %4 = function_ref @addressor_of_globalC : $@convention(thin) () -> Builtin.RawPointer
+  %5 = apply %4() : $@convention(thin) () -> Builtin.RawPointer
+  %6 = pointer_to_address %5 : $Builtin.RawPointer to [strict] $*C
+  %7 = global_addr @globalCVar : $*C
+  store %0 to %3 : $*C
+  fix_lifetime %3 : $*C
+  fix_lifetime %6 : $*C
+  %9 = tuple ()
+  return %9 : $()
+}
+
 // ===-----------------------------------------------------------------------===
 // Test the effect of a [deinit] access on a global 'let'
 //


### PR DESCRIPTION
* Handle `destroy_value [dead_end]`  in `AliasAnalylsis.computeMemoryEffect`: We don't have to take deinit effects into account for a `destroy_value [dead_end]`. Such destroys are lowered to no-ops and will not call any deinit.
* A small refactoring: use `AccessBase.isLet` instead of duplicating the code in `MemoryLocation.isLetValue`.
* Handle more use types for `unchecked_addr_cast` in `EscapeInfo`.
* Recognize addressor calls of globals as a "global" access base in `AccessUtils`.