### PR TITLE
[cxx-interop] Support reexposing C structs from Swift to C++

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -134,9 +134,9 @@ private:
     if (auto *record = dyn_cast<clang::CXXRecordDecl>(typeDecl))
       return record->isTrivial();
 
-    // FIXME: If we can get plain clang::RecordDecls here, we need to figure out
-    //        how nontrivial (i.e. ARC) fields work.
-    assert(!isa<clang::RecordDecl>(typeDecl));
+    // Structs with ARC members are not considered trivial.
+    if (auto *record = dyn_cast<clang::RecordDecl>(typeDecl))
+      return !record->hasObjectMember();
 
     // C-family enums are always trivial.
     return isa<clang::EnumDecl>(typeDecl);

--- a/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
@@ -6,9 +6,15 @@
 // REQUIRES: objc_interop
 
 import CoreFoundation
+import Foundation
 
 public func foobar(_ a: CFData) -> Bool {
     true
 }
 
+public func networkThing() -> in_addr? {
+    return nil
+}
+
 // CHECK: SWIFT_EXTERN bool $s17UseCoreFoundation6foobarySbSo9CFDataRefaF(CFDataRef _Nonnull a) SWIFT_NOEXCEPT SWIFT_CALL; // foobar(_:)
+// CHECK: SWIFT_INLINE_THUNK swift::Optional<in_addr> networkThing() noexcept SWIFT_SYMBOL("s:17UseCoreFoundation12networkThingSo7in_addrVSgyF") SWIFT_WARN_UNUSED_RESULT {


### PR DESCRIPTION
Previously, when a Swift API referenced a C struct (that is not a C++ struct), we did not expose said API to C++. The reason was that we do not have support yet for non-trivial structs (structs with ARC fields). This patch introduces logic to determine if a C struct is trivial and lets us expose trivial C structs from Swift to C++.

rdar://111812577
