### PR TITLE
[region-isolation] Re-group diagnostics in header based on which diagnostic emitter they are used by.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -935,55 +935,39 @@ NOTE(sil_referencebinding_inout_binding_here, none,
 //                  MARK: Region Based Isolation Diagnostics
 //===----------------------------------------------------------------------===//
 
-NOTE(regionbasedisolation_maybe_race, none,
-     "access can happen concurrently", ())
-NOTE(regionbasedisolation_inout_sending_must_be_reinitialized, none,
-     "'inout sending' parameter must be reinitialized before function exit with a non-actor isolated value",
-     ())
+// READ THIS: Please when adding diagnostics for region based isolation, keep
+// them ordered in sections depending on which emitter uses it. It makes it
+// easier for people unfamiliar with the code to quickly see which diagnostics
+// are used by which of the SendNonSendable emitters use.
+
+//===
+// Misc
+
 ERROR(regionbasedisolation_unknown_pattern, none,
       "pattern that the region based isolation checker does not understand how to check. Please file a bug",
       ())
+NOTE(regionbasedisolation_maybe_race, none,
+     "access can happen concurrently", ())
+NOTE(regionbasedisolation_type_is_non_sendable, none,
+      "%0 is a non-Sendable type",
+      (Type))
+
+//===
+// Use After Send Emitter
 
 ERROR(regionbasedisolation_named_transfer_yields_race, none,
       "sending %0 risks causing data races",
       (Identifier))
-NOTE(regionbasedisolation_type_is_non_sendable, none,
-      "%0 is a non-Sendable type",
-      (Type))
 ERROR(regionbasedisolation_type_transfer_yields_race, none,
       "sending value of non-Sendable type %0 risks causing data races",
       (Type))
-
 NOTE(regionbasedisolation_type_use_after_transfer, none,
       "sending value of non-Sendable type %0 to %1 callee risks causing data races between %1 and local %2 uses",
       (Type, ActorIsolation, ActorIsolation))
 NOTE(regionbasedisolation_type_use_after_transfer_callee, none,
-      "sending value of non-Sendable type %0 to %1 %2 %3 risks causing data races between %1 and local %4 uses",
-      (Type, ActorIsolation, DescriptiveDeclKind, DeclName, ActorIsolation))
-NOTE(regionbasedisolation_type_isolated_capture_yields_race, none,
-      "sending value of non-Sendable type %0 to %1 closure due to closure capture risks causing races in between %1 and %2 uses",
-      (Type, ActorIsolation, ActorIsolation))
-
-ERROR(regionbasedisolation_inout_sending_cannot_be_actor_isolated, none,
-      "'inout sending' parameter %0 cannot be %1at end of function",
-      (Identifier, StringRef))
-NOTE(regionbasedisolation_inout_sending_cannot_be_actor_isolated_note, none,
-      "%1%0 risks causing races in between %1uses and caller uses since caller assumes value is not actor isolated",
-      (Identifier, StringRef))
-
-ERROR(regionbasedisolation_out_sending_cannot_be_actor_isolated_type, none,
-      "returning a %1 %0 value as a 'sending' result risks causing data races",
-      (Type, StringRef))
-NOTE(regionbasedisolation_out_sending_cannot_be_actor_isolated_note_type, none,
-      "returning a %1 %0 value risks causing races since the caller assumes the value can be safely sent to other isolation domains",
-      (Type, StringRef))
-
-ERROR(regionbasedisolation_out_sending_cannot_be_actor_isolated_named, none,
-      "returning %1 %0 as a 'sending' result risks causing data races",
-      (Identifier, StringRef))
-NOTE(regionbasedisolation_out_sending_cannot_be_actor_isolated_note_named, none,
-      "returning %1 %0 risks causing data races since the caller assumes that %0 can be safely sent to other isolation domains",
-      (Identifier, StringRef))
+     "sending value of non-Sendable type %0 to %1 %2 %3 risks causing data "
+     "races between %1 and local %4 uses",
+     (Type, ActorIsolation, DescriptiveDeclKind, DeclName, ActorIsolation))
 
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
      "sending %1%0 to %2 callee risks causing data races between %2 and local %3 uses",
@@ -992,38 +976,22 @@ NOTE(regionbasedisolation_named_info_transfer_yields_race_callee, none,
      "sending %1%0 to %2 %3 %4 risks causing data races between %2 and local %5 uses",
      (Identifier, StringRef, ActorIsolation, DescriptiveDeclKind, DeclName, ActorIsolation))
 
-NOTE(regionbasedisolation_named_transfer_non_transferrable, none,
-      "sending %1%0 to %2 callee risks causing data races between %2 and %3 uses",
-      (Identifier, StringRef, ActorIsolation, StringRef))
-NOTE(regionbasedisolation_named_transfer_non_transferrable_callee, none,
-      "sending %1%0 to %2 %3 %4 risks causing data races between %2 and %5 uses",
-      (Identifier, StringRef, ActorIsolation, DescriptiveDeclKind, DeclName, StringRef))
+// Use after transfer closure.
+NOTE(regionbasedisolation_type_isolated_capture_yields_race, none,
+      "sending value of non-Sendable type %0 to %1 closure due to closure capture risks causing races in between %1 and %2 uses",
+      (Type, ActorIsolation, ActorIsolation))
+
+// Value captured in async let and reused.
 NOTE(regionbasedisolation_named_nonisolated_asynclet_name, none,
       "sending %0 into async let risks causing data races between async let uses and local uses",
       (Identifier))
 
-NOTE(regionbasedisolation_named_transfer_into_sending_param, none,
-     "%0%1 is passed as a 'sending' parameter; Uses in callee may race with later %0uses",
-     (StringRef, Identifier))
-NOTE(regionbasedisolation_named_notransfer_transfer_into_result, none,
-     "%0%1 cannot be a 'sending' result. %2 uses may race with caller uses",
-     (StringRef, Identifier, StringRef))
 NOTE(regionbasedisolation_named_value_used_after_explicit_sending, none,
       "%0 used after being passed as a 'sending' parameter; Later uses could race",
       (Identifier))
 NOTE(regionbasedisolation_named_isolated_closure_yields_race, none,
       "%0%1 is captured by a %2 closure. %2 uses in closure may race against later %3 uses",
       (StringRef, Identifier, ActorIsolation, ActorIsolation))
-NOTE(regionbasedisolation_typed_tns_passed_to_sending, none,
-     "Passing %0 value of non-Sendable type %1 as a 'sending' parameter risks causing races inbetween %0 uses and uses reachable from the callee",
-     (StringRef, Type))
-NOTE(regionbasedisolation_typed_tns_passed_to_sending_callee, none,
-     "Passing %0 value of non-Sendable type %1 as a 'sending' parameter to %2 %3 risks causing races inbetween %0 uses and uses reachable from %3",
-     (StringRef, Type, DescriptiveDeclKind, DeclName))
-
-NOTE(regionbasedisolation_named_transfer_nt_asynclet_capture, none,
-      "sending %1 %0 into async let risks causing data races between nonisolated and %1 uses",
-      (Identifier, StringRef))
 
 NOTE(regionbasedisolation_typed_use_after_sending, none,
       "Passing value of non-Sendable type %0 as a 'sending' argument risks causing races in between local and caller code",
@@ -1032,6 +1000,35 @@ NOTE(regionbasedisolation_typed_use_after_sending_callee, none,
       "Passing value of non-Sendable type %0 as a 'sending' argument to %1 %2 risks causing races in between local and caller code",
       (Type, DescriptiveDeclKind, DeclName))
 
+//===
+// Sending Never Sendable Emitter
+
+NOTE(regionbasedisolation_named_transfer_non_transferrable, none,
+      "sending %1%0 to %2 callee risks causing data races between %2 and %3 uses",
+      (Identifier, StringRef, ActorIsolation, StringRef))
+NOTE(regionbasedisolation_named_transfer_non_transferrable_callee, none,
+      "sending %1%0 to %2 %3 %4 risks causing data races between %2 and %5 uses",
+      (Identifier, StringRef, ActorIsolation, DescriptiveDeclKind, DeclName, StringRef))
+
+NOTE(regionbasedisolation_named_transfer_into_sending_param, none,
+     "%0%1 is passed as a 'sending' parameter; Uses in callee may race with "
+     "later %0uses",
+     (StringRef, Identifier))
+NOTE(regionbasedisolation_named_notransfer_transfer_into_result, none,
+     "%0%1 cannot be a 'sending' result. %2 uses may race with caller uses",
+     (StringRef, Identifier, StringRef))
+NOTE(regionbasedisolation_typed_tns_passed_to_sending, none,
+     "Passing %0 value of non-Sendable type %1 as a 'sending' parameter risks "
+     "causing races inbetween %0 uses and uses reachable from the callee",
+     (StringRef, Type))
+
+NOTE(regionbasedisolation_typed_tns_passed_to_sending_callee, none,
+     "Passing %0 value of non-Sendable type %1 as a 'sending' parameter to %2 %3 risks causing races inbetween %0 uses and uses reachable from %3",
+     (StringRef, Type, DescriptiveDeclKind, DeclName))
+
+NOTE(regionbasedisolation_named_transfer_nt_asynclet_capture, none,
+      "sending %1 %0 into async let risks causing data races between nonisolated and %1 uses",
+      (Identifier, StringRef))
 NOTE(regionbasedisolation_typed_transferneversendable_via_arg, none,
       "sending %0 value of non-Sendable type %1 to %2 callee risks causing races in between %0 and %2 uses",
       (StringRef, Type, ActorIsolation))
@@ -1039,9 +1036,43 @@ NOTE(regionbasedisolation_typed_transferneversendable_via_arg_callee, none,
       "sending %0 value of non-Sendable type %1 to %2 %3 %4 risks causing races in between %0 and %2 uses",
       (StringRef, Type, ActorIsolation, DescriptiveDeclKind, DeclName))
 
-// Misc Error.
+// Error that is only used when the send non sendable emitter cannot discover any
+// information to give a better diagnostic.
 ERROR(regionbasedisolation_task_or_actor_isolated_transferred, none,
       "task or actor isolated value cannot be sent", ())
+
+//===
+// InOut Sending Emitter
+
+NOTE(regionbasedisolation_inout_sending_must_be_reinitialized, none,
+     "'inout sending' parameter must be reinitialized before function exit with a non-actor isolated value",
+     ())
+ERROR(regionbasedisolation_inout_sending_cannot_be_actor_isolated, none,
+      "'inout sending' parameter %0 cannot be %1at end of function",
+      (Identifier, StringRef))
+NOTE(regionbasedisolation_inout_sending_cannot_be_actor_isolated_note, none,
+      "%1%0 risks causing races in between %1uses and caller uses since caller assumes value is not actor isolated",
+      (Identifier, StringRef))
+
+//===
+// Out Sending
+
+ERROR(regionbasedisolation_out_sending_cannot_be_actor_isolated_type, none,
+      "returning a %1 %0 value as a 'sending' result risks causing data races",
+      (Type, StringRef))
+NOTE(regionbasedisolation_out_sending_cannot_be_actor_isolated_note_type, none,
+      "returning a %1 %0 value risks causing races since the caller assumes the value can be safely sent to other isolation domains",
+      (Type, StringRef))
+ERROR(regionbasedisolation_out_sending_cannot_be_actor_isolated_named, none,
+      "returning %1 %0 as a 'sending' result risks causing data races",
+      (Identifier, StringRef))
+NOTE(regionbasedisolation_out_sending_cannot_be_actor_isolated_note_named, none,
+      "returning %1 %0 risks causing data races since the caller assumes that %0 can be safely sent to other isolation domains",
+      (Identifier, StringRef))
+
+//===----------------------------------------------------------------------===//
+//                           MARK: Misc Diagnostics
+//===----------------------------------------------------------------------===//
 
 // TODO: print the name of the nominal type
 ERROR(deinit_not_visible, none,


### PR DESCRIPTION
It just makes it easier to reason about which diagnostics one is changing as one is working on them.

This is NFC.

----

Just peeling the onion.