### PR TITLE
[Concurrency] Emit a better note when an isolated stored property initializer cannot be used.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -237,6 +237,9 @@ ERROR(use_of_self_before_fully_init,none,
 
 NOTE(stored_property_not_initialized,none,
      "'%0' not initialized", (StringRef))
+NOTE(isolated_property_initializer,none,
+     "%1 default value of '%0' cannot be used in a %2 initalizer",
+     (StringRef, ActorIsolation, ActorIsolation))
 
 ERROR(selfinit_multiple_times,none,
       "'%select{super|self}0.init' called multiple times in initializer",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5635,14 +5635,27 @@ NOTE(in_derived_conformance, none,
 NOTE(in_derived_witness, none,
      "in %0 %1 for derived conformance to %2",
      (DescriptiveDeclKind, DeclName, Type))
-ERROR(non_sendable_param_type,none,
-      "non-sendable type %0 %select{passed in call to %3 %kind2|"
-      "exiting %3 context in call to nonisolated %kind2|"
-      "passed in implicitly asynchronous call to %3 %kind2|"
-      "in parameter of the protocol requirement satisfied by %3 %kind2|"
-      "in parameter of superclass method overridden by %3 %kind2|"
-      "in parameter of %3 '@objc' %kind2}1 cannot cross actor boundary",
-      (Type, unsigned, const ValueDecl *, ActorIsolation))
+
+ERROR(non_sendable_arg_into_actor,none,
+      "non-sendable type %0 cannot be sent into %2 context in call to %kind1",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_arg_exits_actor,none,
+      "non-sendable type %0 cannot exit %2 context in call to nonisolated "
+      "%kind1",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_param_in_witness,none,
+      "non-sendable parameter type %0 cannot be sent from protocol "
+      "requirement %1 into %2 implementation",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_param_in_override,none,
+      "non-sendable parameter type %0 cannot be sent from superclass "
+      "%kind1 into %2 override",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_param_in_objc,none,
+      "non-sendable parameter type %0 of %2 '@objc' %kind1 cannot cross actor "
+      "boundary",
+      (Type, const ValueDecl *, ActorIsolation))
+
 ERROR(non_sendable_result_type,none,
       "non-sendable type %0 returned by %select{call to %3 %kind2|"
       "call from %4 context to nonisolated %kind2|"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5681,16 +5681,27 @@ ERROR(non_sendable_call_result_type,none,
       "non-sendable result type %0 cannot be sent from %1 context in call "
       "to async function",
       (Type, ActorIsolation))
-ERROR(non_sendable_property_type,none,
-      "non-sendable type %0 in %select{"
-      "%select{asynchronous access to %4 %kind1|"
-      "asynchronous access from %4 context to nonisolated %kind1|"
-      "implicitly asynchronous access to %4 %kind1|"
-      "conformance of %4 %kind1 to protocol requirement|"
-      "%4 overriding %kind1|"
-      "%4 '@objc' %kind1}3|captured local %1}2 cannot "
-      "cross %select{actor|task}2 boundary",
-      (Type, const ValueDecl *, bool, unsigned, ActorIsolation))
+
+ERROR(non_sendable_property_exits_actor,none,
+      "non-sendable type %0 of %kind1 cannot exit %2 context",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_property_into_actor,none,
+      "non-sendable type %0 of nonisolated %kind1 cannot be sent to "
+      "%2 context",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_property_in_witness,none,
+      "non-sendable type %0 cannot be returned from %2 implementation "
+      "to caller of protocol requirement %1",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_property_in_override,none,
+      "non-sendable type %0 cannot be returned from %2 override to "
+      "caller of superclass %kind1",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_property_in_objc,none,
+      "non-sendable type %0 returned by %2 '@objc' %kind1 cannot cross "
+      "actor boundary",
+      (Type, const ValueDecl *, ActorIsolation))
+
 ERROR(non_sendable_keypath_capture,none,
       "cannot form key path that captures non-sendable type %0",
       (Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5656,18 +5656,31 @@ ERROR(non_sendable_param_in_objc,none,
       "boundary",
       (Type, const ValueDecl *, ActorIsolation))
 
-ERROR(non_sendable_result_type,none,
-      "non-sendable type %0 returned by %select{call to %3 %kind2|"
-      "call from %4 context to nonisolated %kind2|"
-      "implicitly asynchronous call to %3 %kind2|"
-      "%3 %kind2 satisfying protocol requirement|"
-      "%3 overriding %kind2|"
-      "%3 '@objc' %kind2}1 cannot cross actor boundary",
-      (Type, unsigned, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_result_into_actor,none,
+      "non-sendable result type %0 cannot be sent from %2 context in call "
+      "to %kind1",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_result_exits_actor,none,
+      "non-sendable result type %0 cannot exit %2 context in call to "
+      "nonisolated %kind1",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_result_in_witness,none,
+      "non-sendable type %0 cannot be returned from %2 implementation "
+      "to caller of protocol requirement %1",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_result_in_override,none,
+      "non-sendable type %0 cannot be returned from %2 override to "
+      "caller of superclass %kind1",
+      (Type, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_result_in_objc,none,
+      "non-sendable type %0 returned by %2 '@objc' %kind1 cannot cross "
+      "actor boundary",
+      (Type, const ValueDecl *, ActorIsolation))
+
 ERROR(non_sendable_call_result_type,none,
-      "non-sendable type %0 returned by %select{|implicitly async }1"
-      "call to %2 function cannot cross actor boundary",
-      (Type, bool, ActorIsolation))
+      "non-sendable result type %0 cannot be sent from %1 context in call "
+      "to async function",
+      (Type, ActorIsolation))
 ERROR(non_sendable_property_type,none,
       "non-sendable type %0 in %select{"
       "%select{asynchronous access to %4 %kind1|"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5644,12 +5644,12 @@ ERROR(non_sendable_arg_exits_actor,none,
       "%kind1",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_param_in_witness,none,
-      "non-sendable parameter type %0 cannot be sent from protocol "
-      "requirement %1 into %2 implementation",
+      "non-sendable parameter type %0 cannot be sent from caller of "
+      "protocol requirement %1 into %2 implementation",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_param_in_override,none,
-      "non-sendable parameter type %0 cannot be sent from superclass "
-      "%kind1 into %2 override",
+      "non-sendable parameter type %0 cannot be sent from caller of "
+      "superclass %kind1 into %2 override",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_param_in_objc,none,
       "non-sendable parameter type %0 of %2 '@objc' %kind1 cannot cross actor "

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1165,6 +1165,28 @@ getSendableResultDiag(SendableCheckReason refKind) {
   }
 }
 
+static
+Diag<Type, const ValueDecl *, ActorIsolation>
+getSendablePropertyDiag(SendableCheckReason refKind) {
+  switch (refKind) {
+  case SendableCheckReason::CrossActor:
+  case SendableCheckReason::SynchronousAsAsync:
+    return diag::non_sendable_property_exits_actor;
+
+  case SendableCheckReason::ExitingActor:
+    return diag::non_sendable_property_into_actor;
+
+  case SendableCheckReason::Conformance:
+    return diag::non_sendable_property_in_witness;
+
+  case SendableCheckReason::Override:
+    return diag::non_sendable_property_in_override;
+
+  case SendableCheckReason::ObjC:
+    return diag::non_sendable_property_in_objc;
+  }
+}
+
 bool swift::diagnoseNonSendableTypesInReference(
     Expr *base, ConcreteDeclRef declRef, const DeclContext *fromDC,
     SourceLoc refLoc, SendableCheckReason refKind,
@@ -1245,11 +1267,8 @@ bool swift::diagnoseNonSendableTypesInReference(
     if (diagnoseNonSendableTypes(
             propertyType, fromDC,
             derivedConformanceType, refLoc,
-            diag::non_sendable_property_type,
-            var,
-            var->isLocalCapture(),
-            (unsigned)refKind,
-            getActorIsolation()))
+            getSendablePropertyDiag(refKind),
+            var, getActorIsolation()))
       return true;
   }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -322,12 +322,12 @@ func check() async {
   _ = await BarFrame()
   _ = await FooFrame()
   _ = await BazFrame()
-  // expected-warning@-1 {{non-sendable type 'BazFrame' returned by implicitly async call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary; this is an error in the Swift 6 language mode}}
+  // expected-warning@-1 {{non-sendable result type 'BazFrame' cannot be sent from global actor 'SomeGlobalActor'-isolated context in call to initializer 'init()'; this is an error in the Swift 6 language mode}}
 
   _ = await BarFrame(size: 0)
   _ = await FooFrame(size: 0)
   _ = await BazFrame(size: 0)
-  // expected-warning@-1 {{non-sendable type 'BazFrame' returned by implicitly async call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary; this is an error in the Swift 6 language mode}}
+  // expected-warning@-1 {{non-sendable result type 'BazFrame' cannot be sent from global actor 'SomeGlobalActor'-isolated context in call to initializer 'init(size:)'; this is an error in the Swift 6 language mode}}
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -176,11 +176,11 @@ func someAsyncFunc() async {
   ////////////
   // effectful properties from outside the actor instance
 
-  // expected-warning@+2 {{non-sendable type 'Box' in asynchronous access to actor-isolated property 'effPropA' cannot cross actor boundary}}
+  // expected-warning@+2 {{non-sendable type 'Box' of property 'effPropA' cannot exit actor-isolated context}}
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
   _ = a.effPropA
 
-  // expected-warning@+3 {{non-sendable type 'Box' in implicitly asynchronous access to actor-isolated property 'effPropT' cannot cross actor boundary}}
+  // expected-warning@+3 {{non-sendable type 'Box' of property 'effPropT' cannot exit actor-isolated context}}
   // expected-error@+2{{property access can throw, but it is not marked with 'try' and the error is not handled}}
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
   _ = a.effPropT
@@ -190,8 +190,8 @@ func someAsyncFunc() async {
   _ = a.effPropAT
 
   // (mostly) corrected ones
-  _ = await a.effPropA  // expected-warning {{non-sendable type 'Box' in asynchronous access to actor-isolated property 'effPropA' cannot cross actor boundary}}
-  _ = try! await a.effPropT // expected-warning {{non-sendable type 'Box' in implicitly asynchronous access to actor-isolated property 'effPropT' cannot cross actor boundary}}
+  _ = await a.effPropA  // expected-warning {{non-sendable type 'Box' of property 'effPropA' cannot exit actor-isolated context}}
+  _ = try! await a.effPropT // expected-warning {{non-sendable type 'Box' of property 'effPropT' cannot exit actor-isolated context}}
   _ = try? await a.effPropAT
 
   print("ok!")

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -353,23 +353,23 @@ actor Calculator {
 
 @OrangeActor func doSomething() async {
   let _ = (await bananaAdd(1))(2)
-  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by implicitly async call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable result type '(Int) -> Int' cannot be sent from global actor 'BananaActor'-isolated context in call to global function 'bananaAdd'}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   let _ = await (await bananaAdd(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
-  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by implicitly async call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable result type '(Int) -> Int' cannot be sent from global actor 'BananaActor'-isolated context in call to global function 'bananaAdd'}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   let calc = Calculator()
   
   let _ = (await calc.addCurried(1))(2)
-  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by implicitly async call to actor-isolated function cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable result type '(Int) -> Int' cannot be sent from actor-isolated context in call to instance method 'addCurried'}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   let _ = await (await calc.addCurried(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
-  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by implicitly async call to actor-isolated function cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable result type '(Int) -> Int' cannot be sent from actor-isolated context in call to instance method 'addCurried'}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   let plusOne = await calc.addCurried(await calc.add(0, 1))
-  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by implicitly async call to actor-isolated function cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable result type '(Int) -> Int' cannot be sent from actor-isolated context in call to instance method 'addCurried'}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   let _ = plusOne(2)
 }

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -119,7 +119,7 @@ extension TestActor {
   func passStateIntoDifferentClassMethod() async {
     let other = NonAsyncClass()
     let otherCurry = other.modifyOtherAsync
-    // expected-targeted-complete-tns-warning @-1 {{non-sendable type 'NonAsyncClass' exiting actor-isolated context in call to nonisolated instance method 'modifyOtherAsync' cannot cross actor boundary}}
+    // expected-targeted-complete-tns-warning @-1 {{non-sendable type 'NonAsyncClass' cannot exit actor-isolated context in call to nonisolated instance method 'modifyOtherAsync'}}
     await other.modifyOtherAsync(&value2)
     // expected-error @-1 {{actor-isolated property 'value2' cannot be passed 'inout' to 'async' function call}}
 
@@ -288,11 +288,11 @@ actor ProtectArray {
   func test() async {
     // FIXME: this is invalid too!
     _ = await array.mutateAsynchronously
-    // expected-targeted-complete-tns-warning@-1 {{non-sendable type '@lvalue [Int]' exiting actor-isolated context in call to nonisolated property 'mutateAsynchronously' cannot cross actor boundary}}
+    // expected-targeted-complete-tns-warning@-1 {{non-sendable type '@lvalue [Int]' cannot exit actor-isolated context in call to nonisolated property 'mutateAsynchronously'}}
 
     _ = await array[mutateAsynchronously: 0]
     // expected-error@-1 {{actor-isolated property 'array' cannot be passed 'inout' to 'async' function call}}
-    // expected-targeted-complete-tns-warning@-2 {{non-sendable type 'inout Array<Int>' exiting actor-isolated context in call to nonisolated subscript 'subscript(mutateAsynchronously:)' cannot cross actor boundary}}
+    // expected-targeted-complete-tns-warning@-2 {{non-sendable type 'inout Array<Int>' cannot exit actor-isolated context in call to nonisolated subscript 'subscript(mutateAsynchronously:)'}}
 
     await passToAsync(array[0])
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -153,13 +153,13 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
   // these still do need an await in Swift 5
   _ = await ext.point // expected-warning {{non-sendable type 'Point' in implicitly asynchronous access to main actor-isolated property 'point' cannot cross actor boundary}}
   _ = await anno.point // expected-warning {{non-sendable type 'Point' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated property 'point' cannot cross actor boundary}}
-  // expected-warning@-1 {{non-sendable type 'NoGlobalActorValueType' passed in implicitly asynchronous call to global actor 'SomeGlobalActor'-isolated property 'point' cannot cross actor boundary}}
+  // expected-warning@-1 {{non-sendable type 'NoGlobalActorValueType' cannot be sent into global actor 'SomeGlobalActor'-isolated context in call to property 'point'}}
 
   _ = formance.counter
   _ = anno.counter
 
   // these will always need an await
-  _ = await (formance as MainCounter).counter // expected-warning {{non-sendable type 'any MainCounter' passed in implicitly asynchronous call to main actor-isolated property 'counter' cannot cross actor boundary}}
+  _ = await (formance as MainCounter).counter // expected-warning {{non-sendable type 'any MainCounter' cannot be sent into main actor-isolated context in call to property 'counter'}}
   _ = await ext[1]
   _ = await formance.ticker
   _ = await ext.polygon // expected-warning {{non-sendable type '[Point]' in implicitly asynchronous access to main actor-isolated property 'polygon' cannot cross actor boundary}}
@@ -1662,7 +1662,7 @@ actor SafeMutatingCall {
 
 
 @MainActor
-func testLocalFunctoinIsolation() {
+func testLocalFunctionIsolation() {
   func isolatedLocalFn() {}
   // expected-note@-1 {{calls to local function 'isolatedLocalFn()' from outside of its actor context are implicitly asynchronous}}
   // expected-note@-2 {{main actor isolation inferred from enclosing context}}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -111,7 +111,7 @@ func checkAsyncPropertyAccess() async {
 
   act.text[0] += "hello" // expected-error{{actor-isolated property 'text' can not be mutated from a nonisolated context}}
 
-  _ = act.point  // expected-warning{{non-sendable type 'Point' in implicitly asynchronous access to actor-isolated property 'point' cannot cross actor boundary}}
+  _ = act.point  // expected-warning{{non-sendable type 'Point' of property 'point' cannot exit actor-isolated context}}
   // expected-warning@-1 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-2 {{property access is 'async'}}
 }
@@ -151,8 +151,8 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
                              _ ext: InferredFromContext,
                              _ anno: NoGlobalActorValueType) async {
   // these still do need an await in Swift 5
-  _ = await ext.point // expected-warning {{non-sendable type 'Point' in implicitly asynchronous access to main actor-isolated property 'point' cannot cross actor boundary}}
-  _ = await anno.point // expected-warning {{non-sendable type 'Point' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated property 'point' cannot cross actor boundary}}
+  _ = await ext.point // expected-warning {{non-sendable type 'Point' of property 'point' cannot exit main actor-isolated context}}
+  _ = await anno.point // expected-warning {{non-sendable type 'Point' of property 'point' cannot exit global actor 'SomeGlobalActor'-isolated context}}
   // expected-warning@-1 {{non-sendable type 'NoGlobalActorValueType' cannot be sent into global actor 'SomeGlobalActor'-isolated context in call to property 'point'}}
 
   _ = formance.counter
@@ -162,9 +162,9 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
   _ = await (formance as MainCounter).counter // expected-warning {{non-sendable type 'any MainCounter' cannot be sent into main actor-isolated context in call to property 'counter'}}
   _ = await ext[1]
   _ = await formance.ticker
-  _ = await ext.polygon // expected-warning {{non-sendable type '[Point]' in implicitly asynchronous access to main actor-isolated property 'polygon' cannot cross actor boundary}}
+  _ = await ext.polygon // expected-warning {{non-sendable type '[Point]' of property 'polygon' cannot exit main actor-isolated context}}
   _ = await InferredFromContext.stuff
-  _ = await NoGlobalActorValueType.polygon // expected-warning {{non-sendable type '[Point]' in implicitly asynchronous access to main actor-isolated static property 'polygon' cannot cross actor boundary}}
+  _ = await NoGlobalActorValueType.polygon // expected-warning {{non-sendable type '[Point]' of static property 'polygon' cannot exit main actor-isolated context}}
 }
 
 // expected-warning@+2 {{memberwise initializer for 'NoGlobalActorValueType' cannot be both nonisolated and global actor 'SomeGlobalActor'-isolated; this is an error in the Swift 6 language mode}}
@@ -1049,8 +1049,8 @@ func testCrossModuleLets(actor: OtherModuleActor) async {
   _ = actor.b         // okay
   _ = actor.c // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{property access is 'async'}}
-  // expected-warning@-2{{non-sendable type 'SomeClass' in implicitly asynchronous access to actor-isolated property 'c' cannot cross actor boundary}}
-  _ = await actor.c // expected-warning{{non-sendable type 'SomeClass' in implicitly asynchronous access to actor-isolated property 'c' cannot cross actor boundary}}
+  // expected-warning@-2{{non-sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
+  _ = await actor.c // expected-warning{{non-sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
   _ = await actor.d // okay
 }
 
@@ -1085,8 +1085,8 @@ actor CrossModuleFromInitsActor {
     _ = actor.b         // okay
     _ = actor.c // expected-error{{expression is 'async' but is not marked with 'await'}}
     // expected-note@-1{{property access is 'async'}}
-    // expected-warning@-2{{non-sendable type 'SomeClass' in implicitly asynchronous access to actor-isolated property 'c' cannot cross actor boundary}}
-    _ = await actor.c // expected-warning{{non-sendable type 'SomeClass' in implicitly asynchronous access to actor-isolated property 'c' cannot cross actor boundary}}
+    // expected-warning@-2{{non-sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
+    _ = await actor.c // expected-warning{{non-sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
     _ = await actor.d // okay
   }
 }
@@ -1613,7 +1613,7 @@ class ReferenceActor {
   init() async {
     self.a = ProtectNonSendable()
 
-    // expected-warning@+3 {{non-sendable type 'NonSendable' in implicitly asynchronous access to actor-isolated property 'ns' cannot cross actor boundary}}
+    // expected-warning@+3 {{non-sendable type 'NonSendable' of property 'ns' cannot exit actor-isolated context}}
     // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@+1 {{property access is 'async'}}
     _ = a.ns

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 -emit-sil -o /dev/null -verify -enable-upcoming-feature GlobalActorIsolatedTypesUsability %s
+// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 -emit-sil -o /dev/null -verify %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -65,7 +65,7 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
 
   // these do need await, regardless of reference or value type
   _ = await (formance as any MainCounter).counter
-  // expected-error@-1 {{non-sendable type 'any MainCounter' passed in implicitly asynchronous call to main actor-isolated property 'counter' cannot cross actor boundary}}
+  // expected-error@-1 {{non-sendable type 'any MainCounter' cannot be sent into main actor-isolated context in call to property 'counter'}}
   _ = await ext[1]
   _ = await formance.ticker
   _ = await ext.polygon

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -99,7 +99,7 @@ extension A1 {
     _ = await self.asynchronous(nil)
 
     // Across to a different actor, so Sendable restriction is enforced.
-    _ = other.localLet // expected-warning{{non-sendable type 'NotConcurrent' in implicitly asynchronous access to actor-isolated property 'localLet' cannot cross actor boundary}}
+    _ = other.localLet // expected-warning{{non-sendable type 'NotConcurrent' of property 'localLet' cannot exit actor-isolated context}}
     // expected-warning@-1 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@-2 {{property access is 'async'}}
     _ = await other.synchronous() // expected-warning{{non-sendable result type 'NotConcurrent?' cannot be sent from actor-isolated context in call to instance method 'synchronous()'}}
@@ -140,14 +140,14 @@ enum E {
 func globalTest() async {
   // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@+1 {{property access is 'async'}}
-  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
+  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' of let 'globalValue' cannot exit global actor 'SomeGlobalActor'-isolated context}}
   await globalAsync(a) // expected-tns-warning {{sending 'a' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'SomeGlobalActor'-isolated 'a' to global actor 'SomeGlobalActor'-isolated global function 'globalAsync' risks causing data races between global actor 'SomeGlobalActor'-isolated and local nonisolated uses}}
   await globalSync(a) // expected-tns-note {{access can happen concurrently}}
 
   // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@+1 {{property access is 'async'}}
-  let _ = E.notSafe // expected-warning{{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated static property 'notSafe' cannot cross actor boundary}}
+  let _ = E.notSafe // expected-warning{{non-sendable type 'NotConcurrent?' of static property 'notSafe' cannot exit global actor 'SomeGlobalActor'-isolated context}}
 
 #if ALLOW_TYPECHECKER_ERRORS
   // expected-typechecker-error@+3 {{expression is 'async' but is not marked with 'await'}}
@@ -155,7 +155,7 @@ func globalTest() async {
   // expected-typechecker-note@+1 {{property access is 'async'}}
   globalAsync(E.notSafe)
 
-  // expected-typechecker-warning@-2 {{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated static property 'notSafe' cannot cross actor boundary}}
+  // expected-typechecker-warning@-2 {{non-sendable type 'NotConcurrent?' of static property 'notSafe' cannot exit global actor 'SomeGlobalActor'-isolated context}}
 #endif
 }
 
@@ -177,7 +177,7 @@ class ClassWithGlobalActorInits { // expected-note 2{{class 'ClassWithGlobalActo
 func globalTestMain(nc: NotConcurrent) async {
   // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@+1 {{property access is 'async'}}
-  let a = globalValue // expected-warning {{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
+  let a = globalValue // expected-warning {{non-sendable type 'NotConcurrent?' of let 'globalValue' cannot exit global actor 'SomeGlobalActor'-isolated context}}
   await globalAsync(a) // expected-tns-warning {{sending 'a' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'SomeGlobalActor'-isolated 'a' to global actor 'SomeGlobalActor'-isolated global function 'globalAsync' risks causing data races between global actor 'SomeGlobalActor'-isolated and local main actor-isolated uses}}
   await globalSync(a) // expected-tns-note {{access can happen concurrently}}
@@ -259,7 +259,7 @@ actor ANI {
 }
 
 func testANI(ani: ANI) async {
-  _ = ani.nc // expected-warning{{non-sendable type 'NC' in asynchronous access to nonisolated property 'nc' cannot cross actor boundary}}
+  _ = ani.nc // expected-warning{{non-sendable type 'NC' of property 'nc' cannot exit nonisolated context}}
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -102,7 +102,7 @@ extension A1 {
     _ = other.localLet // expected-warning{{non-sendable type 'NotConcurrent' in implicitly asynchronous access to actor-isolated property 'localLet' cannot cross actor boundary}}
     // expected-warning@-1 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@-2 {{property access is 'async'}}
-    _ = await other.synchronous() // expected-warning{{non-sendable type 'NotConcurrent?' returned by implicitly async call to actor-isolated function cannot cross actor boundary}}
+    _ = await other.synchronous() // expected-warning{{non-sendable result type 'NotConcurrent?' cannot be sent from actor-isolated context in call to instance method 'synchronous()'}}
     _ = await other.asynchronous(nil)
   }
 }
@@ -182,10 +182,10 @@ func globalTestMain(nc: NotConcurrent) async {
   // expected-tns-note @-1 {{sending global actor 'SomeGlobalActor'-isolated 'a' to global actor 'SomeGlobalActor'-isolated global function 'globalAsync' risks causing data races between global actor 'SomeGlobalActor'-isolated and local main actor-isolated uses}}
   await globalSync(a) // expected-tns-note {{access can happen concurrently}}
   _ = await ClassWithGlobalActorInits(nc)
-  // expected-warning @-1 {{non-sendable type 'ClassWithGlobalActorInits' returned by implicitly async call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
+  // expected-warning @-1 {{non-sendable result type 'ClassWithGlobalActorInits' cannot be sent from global actor 'SomeGlobalActor'-isolated context in call to initializer 'init(_:)'}}
   // expected-tns-warning @-2 {{sending 'nc' risks causing data races}}
   // expected-tns-note @-3 {{sending main actor-isolated 'nc' to global actor 'SomeGlobalActor'-isolated initializer 'init(_:)' risks causing data races between global actor 'SomeGlobalActor'-isolated and main actor-isolated uses}}
-  _ = await ClassWithGlobalActorInits() // expected-warning{{non-sendable type 'ClassWithGlobalActorInits' returned by implicitly async call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
+  _ = await ClassWithGlobalActorInits() // expected-warning{{non-sendable result type 'ClassWithGlobalActorInits' cannot be sent from global actor 'SomeGlobalActor'-isolated context in call to initializer 'init()'}}
 }
 
 @SomeGlobalActor

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -270,7 +270,7 @@ protocol AsyncProto {
 }
 
 extension A1: AsyncProto {
-  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable parameter type 'NotConcurrent' cannot be sent from protocol requirement 'asyncMethod' into actor-isolated implementation}}
+  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable parameter type 'NotConcurrent' cannot be sent from caller of protocol requirement 'asyncMethod' into actor-isolated implementation}}
 }
 
 protocol MainActorProto {
@@ -279,7 +279,7 @@ protocol MainActorProto {
 
 class SomeClass: MainActorProto {
   @SomeGlobalActor
-  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable parameter type 'NotConcurrent' cannot be sent from protocol requirement 'asyncMainMethod' into global actor 'SomeGlobalActor'-isolated implementation}}
+  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable parameter type 'NotConcurrent' cannot be sent from caller of protocol requirement 'asyncMainMethod' into global actor 'SomeGlobalActor'-isolated implementation}}
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -270,7 +270,7 @@ protocol AsyncProto {
 }
 
 extension A1: AsyncProto {
-  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of the protocol requirement satisfied by actor-isolated instance method 'asyncMethod' cannot cross actor boundary}}
+  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable parameter type 'NotConcurrent' cannot be sent from protocol requirement 'asyncMethod' into actor-isolated implementation}}
 }
 
 protocol MainActorProto {
@@ -279,7 +279,7 @@ protocol MainActorProto {
 
 class SomeClass: MainActorProto {
   @SomeGlobalActor
-  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of the protocol requirement satisfied by global actor 'SomeGlobalActor'-isolated instance method 'asyncMainMethod' cannot cross actor boundary}}
+  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable parameter type 'NotConcurrent' cannot be sent from protocol requirement 'asyncMainMethod' into global actor 'SomeGlobalActor'-isolated implementation}}
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/global_actor_serialized.swift
+++ b/test/Concurrency/global_actor_serialized.swift
@@ -14,5 +14,5 @@ import SerializedStruct // expected-warning {{add '@preconcurrency' to treat 'Se
 // use it to force the right checks happen.
 func test() async -> Int {
   let x = MySerializedStruct()
-  return await x.counter // expected-error {{non-sendable type 'MySerializedStruct' passed in implicitly asynchronous call to main actor-isolated property 'counter' cannot cross actor boundary}}
+  return await x.counter // expected-error {{non-sendable type 'MySerializedStruct' cannot be sent into main actor-isolated context in call to property 'counter'}}
 }

--- a/test/Concurrency/isolated_default_property_inits.swift
+++ b/test/Concurrency/isolated_default_property_inits.swift
@@ -20,9 +20,11 @@ func requiresMainActor() -> Int { 0 }
 func requiresSomeGlobalActor() -> Int { 0 }
 
 class C1 {
-  // expected-note@+1 2 {{'self.x' not initialized}}
+  // expected-note@+2 {{main actor-isolated default value of 'self.x' cannot be used in a nonisolated initalizer}}
+  // expected-note@+1 {{main actor-isolated default value of 'self.x' cannot be used in a global actor 'SomeGlobalActor'-isolated initalizer}}
   @MainActor var x = requiresMainActor()
-  // expected-note@+1 2 {{'self.y' not initialized}}
+  // expected-note@+2 {{global actor 'SomeGlobalActor'-isolated default value of 'self.y' cannot be used in a nonisolated initalizer}}
+  // expected-note@+1 {{global actor 'SomeGlobalActor'-isolated default value of 'self.y' cannot be used in a main actor-isolated initalizer}}
   @SomeGlobalActor var y = requiresSomeGlobalActor()
   var z = 10
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -96,7 +96,7 @@ public actor MyActor: MyProto {
     await nonisolatedAsyncFunc1(ns1)
     // expected-tns-warning @-1 {{sending 'ns1' risks causing data races}}
     // expected-tns-note @-2 {{sending 'self'-isolated 'ns1' to nonisolated global function 'nonisolatedAsyncFunc1' risks causing data races between nonisolated and 'self'-isolated uses}}
-    _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable type 'NS1' returned by call to nonisolated function cannot cross actor boundary}}
+    _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable result type 'NS1' cannot be sent from nonisolated context in call to global function 'nonisolatedAsyncFunc2()'}}
   }
 }
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -443,7 +443,7 @@ struct DowngradeForPreconcurrency {
       self.x
       // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
       // expected-note@-2 {{property access is 'async'}}
-      // expected-warning@-3 {{non-sendable type 'NonSendable' in implicitly asynchronous access to main actor-isolated property 'x' cannot cross actor boundary; this is an error in the Swift 6 language mode}}
+      // expected-warning@-3 {{non-sendable type 'NonSendable' of property 'x' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
     }
   }
 }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -142,12 +142,12 @@ protocol P {
   func foo(x : () -> ()) -> () {}
 
   func bar(x : () -> ()) -> () {}
-  // expected-warning@-1 {{non-sendable parameter type '() -> ()' cannot be sent from protocol requirement 'bar(x:)' into actor-isolated implementation}}
+  // expected-warning@-1 {{non-sendable parameter type '() -> ()' cannot be sent from caller of protocol requirement 'bar(x:)' into actor-isolated implementation}}
 
   func foo2<T>(x : T) -> () {}
 
   func bar2<T>(x : T) -> () {}
-  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from protocol requirement 'bar2(x:)' into actor-isolated implementation}}
+  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from caller of protocol requirement 'bar2(x:)' into actor-isolated implementation}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -174,12 +174,12 @@ class Sub : Super {
   override nonisolated func foo(x : () -> ()) async {}
 
   override nonisolated func bar(x : () -> ()) async {}
-  // expected-warning@-1 {{non-sendable parameter type '() -> ()' cannot be sent from superclass instance method 'bar(x:)' into nonisolated override}}
+  // expected-warning@-1 {{non-sendable parameter type '() -> ()' cannot be sent from caller of superclass instance method 'bar(x:)' into nonisolated override}}
 
   override nonisolated func foo2<T>(x: T) async {}
 
   override nonisolated func bar2<T>(x: T) async {}
-  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from superclass instance method 'bar2(x:)' into nonisolated override}}
+  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from caller of superclass instance method 'bar2(x:)' into nonisolated override}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -216,8 +216,8 @@ class SuperWUnsafeSubscript {
 class SubWUnsafeSubscript : SuperWUnsafeSubscript {
   override nonisolated subscript<T>(x : T) -> Int {
     get async {
-      // expected-warning@-2{{non-sendable parameter type 'T' cannot be sent from superclass subscript 'subscript(_:)' into nonisolated override}}
-      // expected-warning@-2{{non-sendable parameter type 'T' cannot be sent from superclass getter for subscript 'subscript(_:)' into nonisolated override}}
+      // expected-warning@-2{{non-sendable parameter type 'T' cannot be sent from caller of superclass subscript 'subscript(_:)' into nonisolated override}}
+      // expected-warning@-2{{non-sendable parameter type 'T' cannot be sent from caller of superclass getter for subscript 'subscript(_:)' into nonisolated override}}
       // there really shouldn't be two warnings produced here, see rdar://110846040 (Sendable diagnostics reported twice for subscript getters)
       return 0
     }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -142,12 +142,12 @@ protocol P {
   func foo(x : () -> ()) -> () {}
 
   func bar(x : () -> ()) -> () {}
-  // expected-warning@-1 {{non-sendable type '() -> ()' in parameter of the protocol requirement satisfied by actor-isolated instance method 'bar(x:)' cannot cross actor boundary}}
+  // expected-warning@-1 {{non-sendable parameter type '() -> ()' cannot be sent from protocol requirement 'bar(x:)' into actor-isolated implementation}}
 
   func foo2<T>(x : T) -> () {}
 
   func bar2<T>(x : T) -> () {}
-  // expected-warning@-1 {{non-sendable type 'T' in parameter of the protocol requirement satisfied by actor-isolated instance method 'bar2(x:)' cannot cross actor boundary}}
+  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from protocol requirement 'bar2(x:)' into actor-isolated implementation}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -174,12 +174,12 @@ class Sub : Super {
   override nonisolated func foo(x : () -> ()) async {}
 
   override nonisolated func bar(x : () -> ()) async {}
-  // expected-warning@-1 {{non-sendable type '() -> ()' in parameter of superclass method overridden by nonisolated instance method 'bar(x:)' cannot cross actor boundary}}
+  // expected-warning@-1 {{non-sendable parameter type '() -> ()' cannot be sent from superclass instance method 'bar(x:)' into nonisolated override}}
 
   override nonisolated func foo2<T>(x: T) async {}
 
   override nonisolated func bar2<T>(x: T) async {}
-  // expected-warning@-1 {{non-sendable type 'T' in parameter of superclass method overridden by nonisolated instance method 'bar2(x:)' cannot cross actor boundary}}
+  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from superclass instance method 'bar2(x:)' into nonisolated override}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -216,8 +216,8 @@ class SuperWUnsafeSubscript {
 class SubWUnsafeSubscript : SuperWUnsafeSubscript {
   override nonisolated subscript<T>(x : T) -> Int {
     get async {
-      // expected-warning@-2{{non-sendable type 'T' in parameter of superclass method overridden by nonisolated subscript 'subscript(_:)' cannot cross actor boundary}}
-      // expected-warning@-2{{non-sendable type 'T' in parameter of superclass method overridden by nonisolated getter for subscript 'subscript(_:)' cannot cross actor boundary}}
+      // expected-warning@-2{{non-sendable parameter type 'T' cannot be sent from superclass subscript 'subscript(_:)' into nonisolated override}}
+      // expected-warning@-2{{non-sendable parameter type 'T' cannot be sent from superclass getter for subscript 'subscript(_:)' into nonisolated override}}
       // there really shouldn't be two warnings produced here, see rdar://110846040 (Sendable diagnostics reported twice for subscript getters)
       return 0
     }
@@ -269,10 +269,10 @@ final class NonSendable {
     // expected-tns-note @-2 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
 
     _ = await x
-    // expected-warning@-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
+    // expected-warning@-1 {{non-sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
 
     _ = await self.x
-      // expected-warning@-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
+      // expected-warning@-1 {{non-sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
   }
 
   @MainActor
@@ -294,7 +294,7 @@ func testNonSendableBaseArg() async {
   // expected-tns-note @-2 {{sending 't' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   _ = await t.x
-  // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
+  // expected-warning @-1 {{non-sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
   // expected-tns-note @-2 {{access can happen concurrently}}
 }
 
@@ -309,7 +309,7 @@ func testNonSendableBaseArg2() async {
   // expected-tns-note @-4 {{sending 't' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   _ = await t.y
-  // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to global actor 'CustomActor'-isolated property 'y' cannot cross actor boundary}}
+  // expected-warning @-1 {{non-sendable type 'NonSendable' cannot be sent into global actor 'CustomActor'-isolated context in call to property 'y'}}
   // expected-tns-note @-2 {{access can happen concurrently}}
 }
 

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -53,7 +53,7 @@ protocol AsyncProtocolWithNotSendable {
 actor A3: AsyncProtocolWithNotSendable {
   func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
     get async {
       NotSendable()
     }
@@ -66,7 +66,7 @@ actor A3: AsyncProtocolWithNotSendable {
 actor A4: AsyncProtocolWithNotSendable {
   func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
     get {
       NotSendable()
     }
@@ -111,7 +111,7 @@ protocol AsyncThrowingProtocolWithNotSendable {
 actor A7: AsyncThrowingProtocolWithNotSendable {
   func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
     get async {
       NotSendable()
     }
@@ -124,7 +124,7 @@ actor A7: AsyncThrowingProtocolWithNotSendable {
 actor A8: AsyncThrowingProtocolWithNotSendable {
   func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
     get {
       NotSendable()
     }

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -38,7 +38,7 @@ actor A2: IsolatedWithNotSendableRequirements {
   nonisolated var prop: NotSendable { NotSendable() }
 
   nonisolated func fAsync() async -> NotSendable { NotSendable() }
-  // expected-warning@-1{{non-sendable type 'NotSendable' returned by nonisolated instance method 'fAsync()' satisfying protocol requirement cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable type 'NotSendable' cannot be returned from nonisolated implementation to caller of protocol requirement 'fAsync()'}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -51,7 +51,7 @@ protocol AsyncProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A3: AsyncProtocolWithNotSendable {
-  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying protocol requirement cannot cross actor boundary}}
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
   var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
     get async {
@@ -64,7 +64,7 @@ actor A3: AsyncProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A4: AsyncProtocolWithNotSendable {
-  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying protocol requirement cannot cross actor boundary}}
+  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
   var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
     get {
@@ -109,7 +109,7 @@ protocol AsyncThrowingProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A7: AsyncThrowingProtocolWithNotSendable {
-  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying protocol requirement cannot cross actor boundary}}
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
   var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
     get async {
@@ -122,7 +122,7 @@ actor A7: AsyncThrowingProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A8: AsyncThrowingProtocolWithNotSendable {
-  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying protocol requirement cannot cross actor boundary}}
+  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
   var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
     get {

--- a/test/Concurrency/sendable_override_checking.swift
+++ b/test/Concurrency/sendable_override_checking.swift
@@ -24,10 +24,10 @@ class Super {
 @available(SwiftStdlib 5.1, *)
 class Sub: Super {
   @MainActor override func f(_: NotSendable) async { }
-  // expected-warning@-1{{non-sendable parameter type 'NotSendable' cannot be sent from superclass instance method 'f' into main actor-isolated override}}
+  // expected-warning@-1{{non-sendable parameter type 'NotSendable' cannot be sent from caller of superclass instance method 'f' into main actor-isolated override}}
 
   nonisolated override func g1(_: NotSendable) { } // okay, synchronous
 
   nonisolated override func g2(_: NotSendable) async { }
-  // expected-warning@-1{{non-sendable parameter type 'NotSendable' cannot be sent from superclass instance method 'g2' into nonisolated override}}
+  // expected-warning@-1{{non-sendable parameter type 'NotSendable' cannot be sent from caller of superclass instance method 'g2' into nonisolated override}}
 }

--- a/test/Concurrency/sendable_override_checking.swift
+++ b/test/Concurrency/sendable_override_checking.swift
@@ -24,10 +24,10 @@ class Super {
 @available(SwiftStdlib 5.1, *)
 class Sub: Super {
   @MainActor override func f(_: NotSendable) async { }
-  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of superclass method overridden by main actor-isolated instance method 'f' cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable parameter type 'NotSendable' cannot be sent from superclass instance method 'f' into main actor-isolated override}}
 
   nonisolated override func g1(_: NotSendable) { } // okay, synchronous
 
   nonisolated override func g2(_: NotSendable) async { }
-  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of superclass method overridden by nonisolated instance method 'g2' cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable parameter type 'NotSendable' cannot be sent from superclass instance method 'g2' into nonisolated override}}
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1474,8 +1474,8 @@ actor ActorWithSetter {
   func recursive() async {
     let x = NonSendableKlass()
     await self.recursive!.twoFieldBoxInTuple.1.k2 = x
-    // expected-typechecker-only-warning @-1 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' in implicitly asynchronous access to actor-isolated property 'twoFieldBoxInTuple' cannot cross actor boundary}}
-    // expected-typechecker-only-warning @-2 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' in implicitly asynchronous access to actor-isolated property 'twoFieldBoxInTuple' cannot cross actor boundary}}
+    // expected-typechecker-only-warning @-1 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
+    // expected-typechecker-only-warning @-2 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
 
     await transferToMain(x) // xpected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -1527,8 +1527,8 @@ final actor FinalActorWithSetter {
   func recursive() async {
     let x = NonSendableKlass()
     await self.recursive!.twoFieldBoxInTuple.1.k2 = x
-    // expected-typechecker-only-warning @-1 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' in implicitly asynchronous access to actor-isolated property 'twoFieldBoxInTuple' cannot cross actor boundary}}
-    // expected-typechecker-only-warning @-2 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' in implicitly asynchronous access to actor-isolated property 'twoFieldBoxInTuple' cannot cross actor boundary}}
+    // expected-typechecker-only-warning @-1 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
+    // expected-typechecker-only-warning @-2 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
 
     await transferToMain(x) // xpected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -722,7 +722,7 @@ func asyncLetWithoutCapture() async {
   //
   // NOTE: Error below will go away in next commit.
   async let x: NonSendableKlass = await returnValueFromMain()
-  // expected-warning @-1 {{non-sendable type 'NonSendableKlass' returned by call to main actor-isolated function cannot cross actor boundary}}
+  // expected-warning @-1 {{non-sendable result type 'NonSendableKlass' cannot be sent from main actor-isolated context in call to global function 'returnValueFromMain()'}}
   let y = await x
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -774,7 +774,7 @@ extension NonSendableStruct {
     async let subTask6: NonSendableStruct = self
     // expected-warning @-1 {{sending 'self' risks causing data races}}
     // expected-note @-2 {{sending 'actor'-isolated 'self' into async let risks causing data races between nonisolated and 'actor'-isolated uses}}
-    // expected-warning @-3 {{non-sendable type 'NonSendableStruct' returned by call to nonisolated function cannot cross actor boundary}}
+    // expected-warning @-3 {{non-sendable result type 'NonSendableStruct' cannot be sent from nonisolated context in call to async function}}
     _ = await subTask6
   }
 }

--- a/test/Concurrency/transfernonsendable_defer_and_typecheck_only.swift
+++ b/test/Concurrency/transfernonsendable_defer_and_typecheck_only.swift
@@ -34,7 +34,7 @@ func callActorFuncsFromNonisolated(a : A, ns : NonSendable) async {
     //deferred-warning@-1{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     _ = await a.actorRetsNS()
-    //expected-warning@-1{{non-sendable type 'NonSendable' returned by call to actor-isolated function cannot cross actor boundary}}
+    //expected-warning@-1{{non-sendable result type 'NonSendable' cannot be sent from actor-isolated context in call to instance method 'actorRetsNS()'}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -52,7 +52,7 @@ actor A {
         //deferred-warning@-1{{passing argument of non-sendable type 'NonSendable' outside of actor-isolated context may introduce data races}}
 
         _ = await retsNS()
-        //expected-warning@-1{{non-sendable type 'NonSendable' returned by call to nonisolated function cannot cross actor boundary}}
+        //expected-warning@-1{{non-sendable result type 'NonSendable' cannot be sent from nonisolated context in call to global function 'retsNS()'}}
     }
 
     func callActorFuncsFromDiffActor(ns : NonSendable, a : A) async {
@@ -62,6 +62,6 @@ actor A {
         //deferred-warning@-1{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         _ = await a.actorRetsNS()
-        //expected-warning@-1{{non-sendable type 'NonSendable' returned by call to actor-isolated function cannot cross actor boundary}}
+        //expected-warning@-1{{non-sendable result type 'NonSendable' cannot be sent from actor-isolated context in call to instance method 'actorRetsNS()'}}
     }
 }

--- a/test/Concurrency/transfernonsendable_sending_results.swift
+++ b/test/Concurrency/transfernonsendable_sending_results.swift
@@ -234,7 +234,7 @@ func asyncLetReabstractionThunkTest() async {
 func asyncLetReabstractionThunkTest2() async {
   // We emit the error here since we are returning a main actor isolated value.
   async let newValue: NonSendableKlass = await getMainActorValueAsync()
-  // expected-warning @-1 {{non-sendable type 'NonSendableKlass' returned by call to main actor-isolated function cannot cross actor boundary}}
+  // expected-warning @-1 {{non-sendable result type 'NonSendableKlass' cannot be sent from main actor-isolated context in call to global function 'getMainActorValueAsync()'}}
 
   let _ = await newValue
 
@@ -257,7 +257,7 @@ func asyncLetReabstractionThunkTest2() async {
 @MainActor func asyncLetReabstractionThunkTestGlobalActor2() async {
   // We emit the error here since we are returning a main actor isolated value.
   async let newValue: NonSendableKlass = await getMainActorValueAsync()
-  // expected-warning @-1 {{non-sendable type 'NonSendableKlass' returned by call to main actor-isolated function cannot cross actor boundary}}
+  // expected-warning @-1 {{non-sendable result type 'NonSendableKlass' cannot be sent from main actor-isolated context in call to global function 'getMainActorValueAsync()'}}
 
   let _ = await newValue
 

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -48,7 +48,7 @@ func processFiles(_ a: A, _ anotherFile: borrowing FileDescriptor) async {
   await a.takeMaybeFile(.available(anotherFile))
   _ = A(.available(anotherFile))
 
-  let ns = await a.getRef() // expected-warning {{non-sendable type 'NotSendableMO' returned by implicitly async call to actor-isolated function cannot cross actor boundary}}
+  let ns = await a.getRef() // expected-warning {{non-sendable result type 'NotSendableMO' cannot be sent from actor-isolated context in call to instance method 'getRef()'}}
   await takeNotSendable(ns) // expected-complete-warning {{passing argument of non-sendable type 'NotSendableMO' outside of main actor-isolated context may introduce data races}}
 
   switch (await a.giveFileDescriptor()) {

--- a/validation-test/Sema/SwiftUI/rdar76252310.swift
+++ b/validation-test/Sema/SwiftUI/rdar76252310.swift
@@ -42,7 +42,7 @@ func fromConcurrencyAware() async {
   let view = CoffeeTrackerView() // synthesized 'init' is 'nonisolated'
 
   // expected-note@+3 {{property access is 'async'}}
-  // expected-warning@+2 {{non-sendable type 'some View' in implicitly asynchronous access to main actor-isolated property 'body' cannot cross actor boundary}}
+  // expected-warning@+2 {{non-sendable type 'some View' of property 'body' cannot exit main actor-isolated context}}
   // expected-warning@+1 {{expression is 'async' but is not marked with 'await'}}
   _ = view.body
 


### PR DESCRIPTION
When a stored property initializer requires a specific isolation, an `init` with mismatching isolation cannot use that initial value. Today, the compiler emits misleading notes in that situation. For example:

```swift
@MainActor func f() -> Int { 0 }

class C {
  @MainActor var x = f()

  init() {}
}
```

Currently, the compiler emits the following diagnostics:

```
error: return from initializer without initializing all stored properties
2 | 
3 | class C {
4 |   @MainActor var x = f()
  |                  `- note: 'self.x' not initialized
5 | 
6 |   init() {}
  |           `- error: return from initializer without initializing all stored properties
7 | }
8 | 
```

The attached note is misleading, because `x` sure looks initialized at the declaration! The real problem is that the initializer is `@MainActor`-isolated, so it cannot be used in a `nonisolated` initializer. With this change, the attached note includes the isolation of the default value and the enclosing `init` that has mismatching isolation:

```
error: return from initializer without initializing all stored properties
2 | 
3 | class C {
4 |   @MainActor var x = f()
  |                  `- note: main actor-isolated default value of 'self.x' cannot be used in a nonisolated initalizer
5 | 
6 |   init() {}
  |           `- error: return from initializer without initializing all stored properties
7 | }
8 | 
```

Resolves: https://github.com/swiftlang/swift/issues/74557

(Note that this PR includes the commits from https://github.com/swiftlang/swift/pull/75687. Only the last commit is new)