### PR TITLE
Take into account pauth address discrimination on arm64e in test matcher

### DIFF
--- a/test/IRGen/yield_result.sil
+++ b/test/IRGen/yield_result.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
 import Builtin
 
@@ -105,6 +105,9 @@ bb0(%outt : $*T, %t : $*T):
   // CHECK:[[RESUME_BB]]:
   // CHECK: [[VW_PTR:%.*]] = getelementptr inbounds ptr, ptr [[TYPE]], [[INT]] -1
   // CHECK: [[VW:%.*]] = load ptr, ptr [[VW_PTR]]
+  // CHECK-arm64e-NEXT: ptrtoint ptr [[VW_PTR]] to i64
+  // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
+  // CHECK-arm64e: [[VW:%.*]] = inttoptr i64 {{%.*}} to ptr
   // CHECK: [[ASSIGN_PTR:%.*]] = getelementptr inbounds ptr, ptr [[VW]], i32 3
   // CHECK: [[ASSIGN:%.*]] = load ptr, ptr [[ASSIGN_PTR]]
   // CHECK: call ptr [[ASSIGN]](ptr [[INDIRECT_RET]], ptr [[ARG]], ptr [[TYPE]]) #2


### PR DESCRIPTION
Fixes #75697
