### PR TITLE
[cxx-interop] Fix reverse interop crash when using raw modules

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -284,11 +284,10 @@ public:
     if (!isa<clang::TypeDecl>(typeDecl->getClangDecl()))
       return;
     // Get the underlying clang type from a type alias decl or record decl.
-    auto clangType =
-        clang::QualType(
-            cast<clang::TypeDecl>(typeDecl->getClangDecl())->getTypeForDecl(),
-            0)
-            .getCanonicalType();
+    auto clangDecl = typeDecl->getClangDecl();
+    auto clangType = clangDecl->getASTContext()
+                         .getTypeDeclType(cast<clang::TypeDecl>(clangDecl))
+                         .getCanonicalType();
     if (!isa<clang::RecordType>(clangType.getTypePtr()))
       return;
     auto it = seenClangTypes.insert(clangType.getTypePtr());

--- a/test/Interop/CxxToSwiftToCxx/span/span-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/span/span-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-span.swift -typecheck -module-name UseSpan -emit-clang-header-path %t/UseSpan.h -I %t -enable-experimental-cxx-interop -Xcc -std=c++20 -clang-header-expose-decls=all-public
+// RUN: %target-swift-frontend -typecheck %t/use-span.swift -typecheck -module-name UseSpan -emit-clang-header-path %t/UseSpan.h -I %t -enable-experimental-cxx-interop -Xcc -Xclang -Xcc -fmodule-format=raw -Xcc -std=c++20 -clang-header-expose-decls=all-public
 
 // RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-span.cpp -I %t -o %t/swift-cxx-execution.o
 // RUN: %target-interop-build-swift %t/use-span.swift -o %t/swift-cxx-execution -Xlinker %t/swift-cxx-execution.o -module-name UseSpan -Xfrontend -entry-point-function-name -Xfrontend swiftMain -I %t -O -Xcc --std=c++20
@@ -21,6 +21,10 @@
 using Span = std::span<int>;
 using SpanOfString = std::span<std::string>;
 
+namespace ns {
+  using SpanOfConstUInt8 = std::span<const uint8_t>;
+}
+
 static int staticArr[] = {1, 2, 3};
 static Span staticSpan = {staticArr};
 
@@ -34,47 +38,44 @@ module CxxTest {
 //--- use-span.swift
 import CxxTest
 
-@_expose(Cxx)
 public func createEmptySpan() -> Span {
   return Span()
 }
 
-@_expose(Cxx)
 public func printSpan() {
   print("{\(staticSpan[0]), \(staticSpan[1]), \(staticSpan[2])}")
 }
 
-@_expose(Cxx)
 public func printSpan(_ sp: Span) {
   print("{\(sp[0]), \(sp[1]), \(sp[2])}")
 }
 
-@_expose(Cxx)
 public func printSpanOfString(_ sp: SpanOfString) {
   print("{\(sp[0]), \(sp[1]), \(sp[2])}")
 }
 
-@_expose(Cxx)
 public func passthroughSpan(_ sp: Span) -> Span {
   return sp;
 }
 
-@_expose(Cxx)
 public func changeSpan(_ sp: inout Span) {
   sp[0] = 0;
 }
 
-@_expose(Cxx)
 public func mapSpan(_ sp: Span) {
   let result = sp.map { $0 + 3 }
   print(result)
 }
 
-@_expose(Cxx)
 public func receiveArr(_ arr: inout [Int32]) -> Span {
   arr.withUnsafeMutableBufferPointer { ubpointer in 
     return Span(ubpointer);
   }
+}
+
+public typealias SpanConstUInt8 = ns.SpanOfConstUInt8
+
+public func receiveSpanAlias(_ sp1: SpanConstUInt8, _ sp2: SpanConstUInt8) {
 }
 
 //--- use-span.cpp


### PR DESCRIPTION
Some fields in the AST are cached values that are populated lazily. We should not use those values directly as in case they are not yet computed we get back null pointers. Use ASTContext instead which can call the slow path if the cache is not yet populated.

rdar://132746445
