### PR TITLE
[embedded] Add __ZdlPvm (operator delete with size argument) to concurrency dependency allowlist

### DIFF
--- a/test/embedded/dependencies-concurrency.swift
+++ b/test/embedded/dependencies-concurrency.swift
@@ -17,6 +17,7 @@
 // DEP: __ZNSt3__19to_stringEj
 // DEP: __ZNSt3__19to_stringEy
 // DEP: __ZdlPv
+// DEP: __ZdlPvm
 // DEP: __Znwm
 // DEP: ___assert_rtn
 // DEP: ___error


### PR DESCRIPTION
This is needed to fix rebranch.