### PR TITLE
Ownership: infer from contextual parameter's type

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11835,10 +11835,19 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
         if (contextualParam->isIsolated() && !flags.isIsolated() && paramDecl)
           isolatedParams.insert(paramDecl);
 
+        // Carry-over the ownership specifier from the contextual parameter.
+        auto paramOwnership =
+            contextualParam->getParameterFlags().getOwnershipSpecifier();
+
+        // `sending` is already carried over; skip this related ownership kind.
+        if (paramOwnership == ParamSpecifier::ImplicitlyCopyableConsuming)
+          paramOwnership = flags.getOwnershipSpecifier();
+
         param = param.withFlags(flags.withInOut(contextualParam->isInOut())
                                     .withVariadic(contextualParam->isVariadic())
                                     .withIsolated(contextualParam->isIsolated())
-                                    .withSending(contextualParam->isSending()));
+                                    .withSending(contextualParam->isSending())
+                                    .withOwnershipSpecifier(paramOwnership));
       }
     }
 

--- a/test/Sema/moveonly_closure_ownership_inference.swift
+++ b/test/Sema/moveonly_closure_ownership_inference.swift
@@ -1,0 +1,69 @@
+// RUN: %target-swift-frontend %s -emit-sil -verify
+
+struct NC: ~Copyable {
+  func borrow() {}
+  consuming func consume() {}
+  mutating func mutate () {}
+}
+
+struct Box<Wrapped: ~Copyable> {
+  consuming func map(_ transform: (consuming Wrapped)->Void) {  }
+}
+
+struct Tree: ~Copyable {
+  static func insert(_ box: consuming Box<Self>) {
+    box.map { x  in x.insert() }
+  }
+
+  consuming func insert() {  }
+}
+
+func withConsuming(_ body: (consuming NC) -> Void) {
+  body(NC())
+}
+
+func withBorrowing(_ body: (borrowing NC) -> Void) {
+  body(NC())
+}
+
+func withMutating(_ body: (inout NC) -> Void) {
+  var nc = NC()
+  body(&nc)
+}
+
+func withShared(_ body: (__shared NC) -> Void) {
+  body(NC())
+}
+
+func withOwned(_ body: (__owned NC) -> Void) {
+  body(NC())
+}
+
+withMutating { nc in
+    nc.mutate()
+}
+
+withConsuming { nc in
+    nc.consume()
+}
+
+withBorrowing { // expected-error {{'$0' is borrowed and cannot be consumed}}
+  $0.borrow()
+  $0.consume() // expected-note {{consumed here}}
+}
+
+withShared { // expected-error {{'$0' is borrowed and cannot be consumed}}
+  $0.borrow()
+  $0.consume() // expected-note {{consumed here}}
+}
+
+withOwned {
+  $0.consume()
+}
+
+do {
+  let clos: (consuming NC) -> Void = {
+    $0.consume()
+  }
+  clos(NC())
+}


### PR DESCRIPTION
We were not carrying-over the ownership specifier in the constraint solver when forming the closure's inferred type from its contextual type.

resolves rdar://118133048