### PR TITLE
[Sema] Treat `@usableFromInline package` decls from interface as public and skip access checks

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2973,6 +2973,14 @@ public:
   /// \c \@usableFromInline, \c \@inlinalbe, and \c \@_alwaysEmitIntoClient
   bool isUsableFromInline() const;
 
+  /// Treat as public and allow skipping access checks if the following conditions
+  /// are met:
+  /// - This decl has a package access level,
+  /// - Has a @usableFromInline (or other inlinable) attribute,
+  /// - And is defined in a module built from a public or private
+  ///   interface that does not contain package-name.
+  bool isPackageEffectivelyPublic() const;
+
   /// Returns \c true if this declaration is *not* intended to be used directly
   /// by application developers despite the visibility.
   bool shouldHideFromEditor() const;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2979,7 +2979,7 @@ public:
   /// - Has a @usableFromInline (or other inlinable) attribute,
   /// - And is defined in a module built from a public or private
   ///   interface that does not contain package-name.
-  bool isPackageEffectivelyPublic() const;
+  bool isInterfacePackageEffectivelyPublic() const;
 
   /// Returns \c true if this declaration is *not* intended to be used directly
   /// by application developers despite the visibility.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -727,7 +727,7 @@ def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
 
 def disable_print_package_name_for_non_package_interface :
   Flag<["-"], "disable-print-package-name-for-non-package-interface">,
-  Flags<[FrontendOption, NoDriverOption, ModuleInterfaceOption, HelpHidden]>,
+  Flags<[FrontendOption, NoDriverOption, HelpHidden]>,
   HelpText<"Disable adding package name to public or private interface">;
 
 def lto : Joined<["-"], "lto=">,

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1016,7 +1016,7 @@ public:
         if (!D->getASTContext().isAccessControlDisabled()) {
           if (D->getFormalAccessScope().isPublic() &&
               D->getFormalAccess() < AccessLevel::Public &&
-              !D->isPackageEffectivelyPublic()) {
+              !D->isInterfacePackageEffectivelyPublic()) {
             Out << "non-public decl has no formal access scope\n";
             D->dump(Out);
             abort();

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1015,7 +1015,8 @@ public:
         PrettyStackTraceDecl debugStack("verifying access", D);
         if (!D->getASTContext().isAccessControlDisabled()) {
           if (D->getFormalAccessScope().isPublic() &&
-              D->getFormalAccess() < AccessLevel::Public) {
+              D->getFormalAccess() < AccessLevel::Public &&
+              !D->isPackageEffectivelyPublic()) {
             Out << "non-public decl has no formal access scope\n";
             D->dump(Out);
             abort();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4212,7 +4212,7 @@ bool ValueDecl::isUsableFromInline() const {
   return false;
 }
 
-bool ValueDecl::isPackageEffectivelyPublic() const {
+bool ValueDecl::isInterfacePackageEffectivelyPublic() const {
   // If a package decl has a @usableFromInline (or other inlinable)
   // attribute, and is defined in a module built from interface, it
   // can be referenced by another module that imports it even though
@@ -4319,7 +4319,7 @@ static AccessLevel getAdjustedFormalAccess(const ValueDecl *VD,
   if (useDC && VD->getASTContext().isAccessControlDisabled())
     return getMaximallyOpenAccessFor(VD);
 
-  if (VD->isPackageEffectivelyPublic())
+  if (VD->isInterfacePackageEffectivelyPublic())
     return AccessLevel::Public;
 
   if (treatUsableFromInlineAsPublic &&
@@ -4504,7 +4504,7 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
   case AccessLevel::Package: {
     auto pkg = resultDC->getPackageContext(/*lookupIfNotCurrent*/ true);
     if (!pkg) {
-      if (VD->isPackageEffectivelyPublic())
+      if (VD->isInterfacePackageEffectivelyPublic())
         return AccessScope::getPublic();
       // Instead of reporting and failing early, return the scope of resultDC to
       // allow continuation (should still non-zero exit later if in script mode)
@@ -4641,7 +4641,7 @@ static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
   if (VD->getASTContext().isAccessControlDisabled())
     return true;
 
-  if (VD->isPackageEffectivelyPublic())
+  if (VD->isInterfacePackageEffectivelyPublic())
     return true;
 
   auto access = getAccessLevel();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4277,6 +4277,9 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           requiredAccessScope.requiredAccessForDiagnostics();
         auto proto = conformance->getProtocol();
         auto protoAccessScope = proto->getFormalAccessScope(DC);
+        if (proto->isPackageEffectivelyPublic())
+          return;
+
         bool protoForcesAccess =
           requiredAccessScope.hasEqualDeclContextWith(protoAccessScope);
         auto diagKind = protoForcesAccess

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4277,7 +4277,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           requiredAccessScope.requiredAccessForDiagnostics();
         auto proto = conformance->getProtocol();
         auto protoAccessScope = proto->getFormalAccessScope(DC);
-        if (proto->isPackageEffectivelyPublic())
+        if (proto->isInterfacePackageEffectivelyPublic())
           return;
 
         bool protoForcesAccess =

--- a/test/ModuleInterface/package_interface_disable_package_name.swift
+++ b/test/ModuleInterface/package_interface_disable_package_name.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
 /// Do not print package-name for public or private interfaces
-// RUN: %target-build-swift -emit-module %s -I %t \
+// RUN: %target-build-swift -emit-module %t/Bar.swift -I %t \
 // RUN:   -module-name Bar -package-name foopkg \
 // RUN:   -enable-library-evolution -swift-version 6 \
 // RUN:   -package-name barpkg \
@@ -20,16 +21,23 @@
 // CHECK-PRIVATE-NOT: -package-name barpkg
 // CHECK-PACKAGE-NOT: -package-name foopkg
 
-// CHECK-PUBLIC:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar
-// CHECK-PRIVATE:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar
-// CHECK-PACKAGE:  -enable-library-evolution -swift-version 6 -disable-print-package-name-for-non-package-interface -module-name Bar -package-name barpkg
+// CHECK-PUBLIC:  -enable-library-evolution -swift-version 6 -module-name Bar
+// CHECK-PRIVATE:  -enable-library-evolution -swift-version 6 -module-name Bar
+// CHECK-PACKAGE:  -enable-library-evolution -swift-version 6 -module-name Bar -package-name barpkg
 
 /// Verify building modules from non-package interfaces succeeds without the package-name flag.
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -verify
+// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -package-name barpkg -verify
+
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.private.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -verify
+// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -package-name barpkg -verify
+
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.package.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -package-name barpkg -experimental-package-interface-load -verify
 
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: rm -rf %t/Bar.swiftinterface
@@ -37,7 +45,7 @@
 // RUN: rm -rf %t/Bar.package.swiftinterface
 
 /// By default, -package-name is printed in all interfaces.
-// RUN: %target-build-swift -emit-module %s -I %t \
+// RUN: %target-build-swift -emit-module %t/Bar.swift -I %t \
 // RUN:   -module-name Bar -package-name barpkg \
 // RUN:   -enable-library-evolution -swift-version 6 \
 // RUN:   -emit-module-interface-path %t/Bar.swiftinterface \
@@ -52,11 +60,46 @@
 
 /// Building modules from non-package interfaces with package-name (default mode) should succeed.
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+// RUN: %target-swift-frontend -typecheck %t/ExpectFail.swift -I %t -package-name barpkg -verify
+
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.private.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+// RUN: %target-swift-frontend -typecheck %t/ExpectFail.swift -I %t -package-name barpkg -verify
+
 // RUN: rm -rf %t/Bar.swiftmodule
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Bar.package.swiftinterface -o %t/Bar.swiftmodule -module-name Bar
+// RUN: %target-swift-frontend -typecheck %t/Use.swift -I %t -package-name barpkg -experimental-package-interface-load -verify
 
+//--- Bar.swift
 public struct PubStruct {}
 @_spi(bar) public struct SPIStruct {}
 package struct PkgStruct {}
+
+@usableFromInline
+package struct UfiPkgStruct {
+  @usableFromInline
+  package var ufiPkgVar: PubStruct
+  
+  package var pkgVar: PubStruct
+  
+  @usableFromInline
+  package init(_ x: PubStruct, _ y: PubStruct) {
+    ufiPkgVar = x
+    pkgVar = y
+  }
+}
+
+
+//--- Use.swift
+import Bar
+
+func use(_ arg: PubStruct) -> PubStruct {
+  return UfiPkgStruct(arg, arg).ufiPkgVar
+}
+
+//--- ExpectFail.swift
+import Bar // expected-error {{module 'Bar' is in package 'barpkg' but was built from a non-package interface; modules of the same package can only be loaded if built from source or package interface}}
+
+func use(_ arg: PubStruct) -> PubStruct {
+  return UfiPkgStruct(arg, arg).ufiPkgVar
+}

--- a/test/Sema/accessibility_package_import_interface.swift
+++ b/test/Sema/accessibility_package_import_interface.swift
@@ -6,18 +6,14 @@
 // RUN:   -module-name Dep -swift-version 5 -I %t \
 // RUN:   -package-name myPkg \
 // RUN:   -enable-library-evolution \
+// RUN:   -disable-print-package-name-for-non-package-interface \
 // RUN:   -emit-module-path %t/Dep.swiftmodule \
 // RUN:   -emit-module-interface-path %t/Dep.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/Dep.private.swiftinterface
 
-// TEST Dep private interface should contain the package name
-// RUN: %target-swift-typecheck-module-from-interface(%t/Dep.private.swiftinterface) -module-name Dep -I %t
-// RUN: %FileCheck %s --check-prefix=CHECK-DEP-PRIVATE < %t/Dep.private.swiftinterface
-// CHECK-DEP-PRIVATE: -package-name myPkg
-
 // TEST Dep.swiftmodule should contain package name and package symbols
 // RUN: llvm-bcanalyzer --dump %t/Dep.swiftmodule | %FileCheck %s --check-prefix=CHECK-DEP-BC
-// CHECK-DEP-BC: <MODULE_PACKAGE_NAME abbrevid=6/> blob data = 'myPkg'
+// CHECK-DEP-BC: <MODULE_PACKAGE_NAME {{.*}}> blob data = 'myPkg'
 
 // TEST Lib should load Dep.swiftmodule and access package decls if in the same package and error if not
 // RUN: %target-swift-frontend -typecheck %t/Lib.swift -package-name myPkg -I %t
@@ -39,9 +35,9 @@
 // RUN:   -module-name Dep -I %t \
 // RUN:   -o %t/Dep.swiftmodule
 
-// TEST Dep binary built from interface should contain package name but no package symbols
+// TEST Dep binary built from interface should not contain package name or package symbols.
 // RUN: llvm-bcanalyzer --dump %t/Dep.swiftmodule | %FileCheck %s --check-prefix=CHECK-DEP-INTER-BC
-// CHECK-DEP-INTER-BC: <MODULE_PACKAGE_NAME abbrevid=7/> blob data = 'myPkg'
+// CHECK-DEP-INTER-BC-NOT: <MODULE_PACKAGE_NAME {{.*}}> blob data = 'myPkg'
 
 // TEST Lib should error on loading Dep built from interface and accessing package symbols (unless usableFromInline or inlinable)
 // RUN: %target-swift-frontend -typecheck %t/Lib.swift -package-name myPkg -I %t -verify
@@ -59,6 +55,7 @@
 // RUN:   -module-name LibPass -swift-version 5 -I %t \
 // RUN:   -package-name myPkg \
 // RUN:   -enable-library-evolution \
+// RUN:   -disable-print-package-name-for-non-package-interface \
 // RUN:   -emit-module-path %t/LibPass.swiftmodule \
 // RUN:   -emit-module-interface-path %t/LibPass.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/LibPass.private.swiftinterface
@@ -86,8 +83,11 @@
 @usableFromInline
 package class PackageKlassUFI {
   @usableFromInline package init() {}
-  @usableFromInline package var packageVarUFI: String = "pkgUFI"
   package var packageVar: String = "pkg"
+
+  @usableFromInline package var packageVarUFI: String = "pkgUFI"
+  // expected-note@-1 * {{'packageVarUFI' declared here}}
+  // expected-error@-1 * {{'packageVarUFI' declared here}}
 }
 
 package func packageFunc() {
@@ -109,7 +109,7 @@ public func publicFuncInlinable() {
 }
 
 //--- Lib.swift
-import Dep // expected-error {{module 'Dep' is in package 'myPkg' but was built from a non-package interface; modules of the same package can only be loaded if built from source or package interface}}
+import Dep
 
 public func libFunc() {
   publicFuncInlinable()
@@ -118,8 +118,7 @@ public func libFunc() {
   packageFunc() // expected-error {{cannot find 'packageFunc' in scope}}
   let x = PackageKlassUFI()
   let y = x.packageVarUFI
-  let z = x.packageVar // expected-error {{value of type 'PackageKlassUFI' has no member 'packageVar'}}
-  print(x, y, z)
+  print(x, y)
 }
 
 

--- a/test/Sema/accessibility_package_inline_interface.swift
+++ b/test/Sema/accessibility_package_inline_interface.swift
@@ -1,16 +1,16 @@
 // RUN: %empty-directory(%t)
-// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -module-name Utils1 %t/Utils.swift -emit-module -emit-module-path %t/Utils1.swiftmodule -package-name myLib -swift-version 5
 // RUN: test -f %t/Utils1.swiftmodule
 
-// RUN: %target-swift-frontend -module-name Utils %t/Utils.swift -emit-module -emit-module-interface-path %t/Utils.swiftinterface -package-name myLib -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -module-name Utils %t/Utils.swift -emit-module -emit-module-interface-path %t/Utils.swiftinterface -package-name myLib -enable-library-evolution -swift-version 5 -disable-print-package-name-for-non-package-interface
+
 // RUN: test -f %t/Utils.swiftinterface
 // RUN: %target-swift-typecheck-module-from-interface(%t/Utils.swiftinterface) -I%t
 
 // RUN: %FileCheck %s -check-prefix CHECK-UTILS < %t/Utils.swiftinterface
 // CHECK-UTILS: -module-name Utils
-// CHECK-UTILS: -package-name myLib
 // CHECK-UTILS: @usableFromInline
 // CHECK-UTILS: package class PackageKlassProto {
 // CHECK-UTILS:   @usableFromInline
@@ -70,7 +70,7 @@
 // CHECK-UTILS: }
 
 
-// BEGIN Utils.swift
+//--- Utils.swift
 package protocol PackageProto {
   var pkgVar: Double { get set }
   func pkgFunc()

--- a/test/Sema/accessibility_package_interface.swift
+++ b/test/Sema/accessibility_package_interface.swift
@@ -5,7 +5,7 @@
 // RUN:   -module-name Utils -swift-version 5 -I %t \
 // RUN:   -package-name swift-utils.log \
 // RUN:   -enable-library-evolution \
-// RUN:   -emit-module-path %t/Utils.swiftmodule \
+// RUN:   -disable-print-package-name-for-non-package-interface \
 // RUN:   -emit-module-interface-path %t/Utils.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/Utils.private.swiftinterface
 
@@ -18,7 +18,6 @@
 // CHECK-PUBLIC-UTILS-NOT: package class PackageKlass
 // CHECK-PUBLIC-UTILS-NOT: package var pkgVar
 // CHECK-PUBLIC-UTILS: -module-name Utils
-// CHECK-PUBLIC-UTILS: -package-name swift-utils.log
 // CHECK-PUBLIC-UTILS: public func publicFunc()
 // CHECK-PUBLIC-UTILS: @usableFromInline
 // CHECK-PUBLIC-UTILS: package func ufiPackageFunc()
@@ -39,7 +38,6 @@
 // CHECK-PRIVATE-UTILS-NOT: package class PackageKlass
 // CHECK-PRIVATE-UTILS-NOT: package var pkgVar
 // CHECK-PRIVATE-UTILS: -module-name Utils
-// CHECK-PRIVATE-UTILS: -package-name swift-utils.log
 // CHECK-PRIVATE-UTILS: public func publicFunc()
 // CHECK-PRIVATE-UTILS: @usableFromInline
 // CHECK-PRIVATE-UTILS: package func ufiPackageFunc()
@@ -51,20 +49,19 @@
 // CHECK-PRIVATE-UTILS: @usableFromInline
 // CHECK-PRIVATE-UTILS: package var ufiPkgVar
 
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Utils.private.swiftinterface  -module-name Utils -I %t -o %t/Utils.swiftmodule
+
 // RUN: %target-swift-frontend -emit-module %t/Client.swift \
 // RUN:   -module-name Client -swift-version 5 -I %t \
 // RUN:   -package-name swift-utils.log \
 // RUN:   -enable-library-evolution \
+// RUN:   -disable-print-package-name-for-non-package-interface \
 // RUN:   -emit-module-path %t/Client.swiftmodule \
 // RUN:   -emit-module-interface-path %t/Client.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface
 
-// RUN: rm -rf %t/Utils.swiftmodule
-// RUN: rm -rf %t/Client.swiftmodule
-
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t -verify
 // RUN: %FileCheck %s --check-prefix=CHECK-PUBLIC-CLIENT < %t/Client.swiftinterface
-// CHECK-PUBLIC-CLIENT: -package-name swift-utils.log
 // CHECK-PUBLIC-CLIENT: @inlinable public func clientFunc()
 // CHECK-PUBLIC-CLIENT: publicFunc()
 // CHECK-PUBLIC-CLIENT: ufiPackageFunc()
@@ -113,6 +110,7 @@ import Utils
 @inlinable public func clientFunc() -> String {
   publicFunc()
   ufiPackageFunc()
+//  return UfiPackageKlass().ufiPkgVar
   let u = UfiPackageKlass()
   return u.ufiPkgVar
 }

--- a/test/Serialization/load_package_module.swift
+++ b/test/Serialization/load_package_module.swift
@@ -12,6 +12,7 @@
 // RUN:   -module-name LibInterface -swift-version 5 -I %t \
 // RUN:   -package-name libPkg \
 // RUN:   -enable-library-evolution \
+// RUN:   -disable-print-package-name-for-non-package-interface \
 // RUN:   -emit-module-path %t/LibBinary.swiftmodule \
 // RUN:   -emit-module-interface-path %t/LibInterface.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/LibInterface.private.swiftinterface
@@ -19,20 +20,12 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/LibInterface.swiftinterface) -I %t
 // RUN: %FileCheck %s --check-prefix=CHECK-PUBLIC < %t/LibInterface.swiftinterface
 // CHECK-PUBLIC: -module-name LibInterface
-// CHECK-PUBLIC: -package-name
 
-// RUN: %target-swift-typecheck-module-from-interface(%t/LibInterface.private.swiftinterface) -module-name LibInterface -I %t
-// RUN: %FileCheck %s --check-prefix=CHECK-PRIVATE < %t/LibInterface.private.swiftinterface
-// CHECK-PRIVATE: -package-name libPkg
+// RUN: %target-swift-typecheck-module-from-interface(%t/LibInterface.private.swiftinterface) -module-name LibInterface -I %t -verify
 
-// RUN: not %target-swift-frontend -typecheck %t/ClientLoadInterface.swift -package-name otherPkg -I %t 2> %t/resultX.output
-// RUN: %FileCheck %s -check-prefix CHECK-X < %t/resultX.output
-// CHECK-X: error: cannot find 'packageLog' in scope
+// RUN: %target-swift-frontend -typecheck %t/ClientLoadInterface.swift -package-name otherPkg -I %t -verify
 
-// RUN: not %target-swift-frontend -typecheck %t/ClientLoadInterface.swift -package-name libPkg -I %t 2> %t/resultY.output
-// RUN: %FileCheck %s -check-prefix CHECK-Y < %t/resultY.output
-// CHECK-Y: error: module 'LibInterface' is in package 'libPkg' but was built from a non-package interface; modules of the same package can only be loaded if built from source or package interface: {{.*}}LibInterface.private.swiftinterface
-
+// RUN: %target-swift-frontend -typecheck %t/ClientLoadInterface.swift -package-name libPkg -I %t -verify
 
 //--- Lib.swift
 public func publicLog(_ level: Int) {}
@@ -45,7 +38,7 @@ import LibInterface
 
 func someFunc() {
   publicLog(1)
-  packageLog(2)
+  packageLog(2) // expected-error {{cannot find 'packageLog' in scope}}
 }
 
 //--- ClientLoadBinary.swift

--- a/test/Serialization/module_package_name.swift
+++ b/test/Serialization/module_package_name.swift
@@ -6,17 +6,15 @@
 // RUN: llvm-bcanalyzer -dump %t/Logging.swiftmodule | %FileCheck %s -check-prefix CHECK-BLOB
 // CHECK-BLOB: <MODULE_PACKAGE_NAME abbrevid=5/> blob data = 'MyLoggingPkg'
 
-// RUN: %target-swift-frontend -module-name Logging -package-name MyLoggingPkg %t/File.swift -emit-module -emit-module-interface-path %t/Logging.swiftinterface -emit-private-module-interface-path %t/Logging.private.swiftinterface -swift-version 5 -enable-library-evolution -I %t
+// RUN: %target-swift-frontend -module-name Logging -package-name MyLoggingPkg %t/File.swift -emit-module -emit-module-interface-path %t/Logging.swiftinterface -emit-private-module-interface-path %t/Logging.private.swiftinterface -swift-version 5 -enable-library-evolution -I %t -disable-print-package-name-for-non-package-interface
 
 // RUN: %target-swift-typecheck-module-from-interface(%t/Logging.swiftinterface) -I %t
 // RUN: %FileCheck %s --check-prefix=CHECK-PUBLIC < %t/Logging.swiftinterface
 // CHECK-PUBLIC: -module-name Logging
-// CHECK-PUBLIC: -package-name
 
 // RUN: %target-swift-typecheck-module-from-interface(%t/Logging.private.swiftinterface) -module-name Logging -I %t
 // RUN: %FileCheck %s --check-prefix=CHECK-PRIVATE < %t/Logging.private.swiftinterface
 // CHECK-PRIVATE: -module-name Logging
-// CHECK-PRIVATE: -package-name MyLoggingPkg
 
 //--- File.swift
 public func log(level: Int) {}


### PR DESCRIPTION
If a package decl has a `@usableFromInline` (or other inlinable) attribute, and is defined in a module built from interface, it
can be referenced by another module that imports it even though the defining interface module does not have package-name (such as public or private interface with `-disable-print-package-name-for-non-package-interface`); in such case, type check on the decl fails due to the missing package-name. This PR treats the decl as public and skip type/access checks.

Resolves rdar://133319906
