### PR TITLE
[wasm] Fix ambiguous `errno` error when importing WASILibc module

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -84,6 +84,11 @@ func _convertDarwinBooleanToBool(_ x: DarwinBoolean) -> Bool {
 
 #endif
 
+// wasi-libc defines `errno` in a way ClangImporter can understand, so we don't
+// need to define shims for it. On the contrary, if we define the shim, we will
+// get an ambiguity error when importing WASILibc module and SwiftWASILibc Clang
+// module (or a Clang module that re-exports SwiftWASILibc).
+#if !os(WASI)
 //===----------------------------------------------------------------------===//
 // sys/errno.h
 //===----------------------------------------------------------------------===//
@@ -96,6 +101,7 @@ public var errno : Int32 {
     return _swift_stdlib_setErrno(val)
   }
 }
+#endif
 
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This commit fixes an ambiguous `errno` error when importing WASILibc module and SwiftWASILibc Clang module.

The error is caused by the fact that we define a shim for `errno` in `Platform.swift` file, but wasi-libc defines `errno` in a way ClangImporter can understand. We don't need to define shims for it, otherwise we get two candidates for `errno` identifier.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
