### PR TITLE
[Concurrency] Implement a narrow carve out in the isolation override checking for `NSObject.init()`.

### DIFF
--- a/test/ClangImporter/objc_isolation_complete.swift
+++ b/test/ClangImporter/objc_isolation_complete.swift
@@ -32,15 +32,27 @@ class IsolatedSub: NXSender {
   }
 }
 
+class NotSendable {}
+
+@MainActor
+class NSObjectInitOverride: NSObject {
+  var ns: NotSendable
+
+  override init() {
+    self.ns = NotSendable()
+    super.init()
+  }
+}
+
+
 @objc
 @MainActor
 class Test : NSObject {
-  static var shared: Test? // expected-note {{mutation of this static property is only permitted within the actor}}
+  static var shared: Test?
 
   override init() {
     super.init()
 
     Self.shared = self
-    // expected-warning@-1 {{main actor-isolated static property 'shared' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
   }
 }


### PR DESCRIPTION
Overriding `NSObject.init()` within a `@MainActor`-isolated type is difficult-to-impossible, especially if you need to call an initializer from an intermediate superclass that is also `@MainActor`-isolated. Opt-out tools like `MainActor.assumeIsolated` cannot be applied to things like stored property initialization and `super.init()`, making the issue extremely difficult to work around.

This carve-out won't admit a runtime data-race safety hole, because dynamic isolation checks will be inserted in the @objc thunks under `DynamicActorIsolation`, and direct calls will enforce `@MainActor` as usual.

Resolves: https://github.com/swiftlang/swift/issues/75732, rdar://133349184