### PR TITLE
mangling: support inverse conformance requirement mangling in the old re-mangler

### DIFF
--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -3051,5 +3051,7 @@ ManglingError Remangler::mangleHasSymbolQuery(Node *node, unsigned depth) {
 ManglingError
 Remangler::mangleDependentGenericInverseConformanceRequirement(Node *node,
                                                                unsigned depth) {
-  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
+  DEMANGLER_ASSERT(node->getNumChildren() == 2, node);
+  RETURN_IF_ERROR(mangleConstrainedType(node->getChild(0), depth + 1));
+  return mangle(node->getChild(1), depth + 1);
 }

--- a/test/IRGen/non-copyable-class-mangling.swift
+++ b/test/IRGen/non-copyable-class-mangling.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend %s -emit-ir -o /dev/null
+
+// Check that we don't crash on this in the old re-mangler.
+// rdar://133333754
+
+struct S<T> where T: ~Copyable {
+  final class C {
+    let x = 27
+  }
+}
+


### PR DESCRIPTION
This is needed to emit ObjC class names for classes inside generic types with e.g. non-copyable requirements.
Fixes a compiler crash in IRGen.

rdar://133333754
