### PR TITLE
Fix the borrowed-from verifier and fix a few passes which caused a verifier error

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Verifier.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Verifier.swift
@@ -67,7 +67,7 @@ extension BorrowedFromInst : VerifyableInstruction {
     var existingEVs = ValueSet(insertContentsOf: enclosingValues, context)
     defer { existingEVs.deinitialize() }
 
-    for computedEV in enclosingValues {
+    for computedEV in computedEVs {
       require(existingEVs.contains(computedEV),
                    "\(computedEV)\n  missing in enclosing values of \(self)")
     }

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -620,6 +620,7 @@ class SILCombine : public SILFunctionTransform {
     bool Changed = Combiner.runOnFunction(*getFunction());
 
     if (Changed) {
+      updateBorrowedFrom(getPassManager(), getFunction());
       // Invalidate everything.
       invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);
     }

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -62,6 +62,7 @@
 #include "swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h"
 #include "swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
 #include "llvm/ADT/SetVector.h"
 
 using namespace swift;
@@ -634,6 +635,7 @@ void CopyPropagation::run() {
 
   // Invalidate analyses.
   if (changed || deleter.hadCallbackInvocation()) {
+    updateBorrowedFrom(getPassManager(), getFunction());
     // Preserves NonLocalAccessBlockAnalysis.
     accessBlockAnalysis->lockInvalidation();
     invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -2296,8 +2296,10 @@ class SILMem2Reg : public SILFunctionTransform {
     bool madeChange = MemoryToRegisters(*f, da->get(f), deb,
                                         accessBlockAnalysis, calleeAnalysis)
                           .run();
-    if (madeChange)
+    if (madeChange) {
+      updateBorrowedFrom(getPassManager(), f);
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+    }
   }
 };
 

--- a/test/SILOptimizer/copy_propagation_borrow.sil
+++ b/test/SILOptimizer/copy_propagation_borrow.sil
@@ -1207,3 +1207,22 @@ bb0(%0 : @guaranteed $C):
   %7 = tuple ()
   return %7 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @test_updating_borrowed_from :
+// CHECK:         borrowed {{.*}} from {{.*}} %0 : $HasObject
+// CHECK-LABEL: } // end sil function 'test_updating_borrowed_from'
+sil [ossa] @test_updating_borrowed_from : $@convention(thin) (@guaranteed HasObject) -> () {
+bb0(%0 : @guaranteed $HasObject):
+  %1 = destructure_struct %0 : $HasObject
+  %2 = copy_value %1 : $C
+  %3 = begin_borrow %2 : $C
+  br bb1(%3 : $C)
+
+bb1(%5 : @reborrow @guaranteed $C):
+  %6 = borrowed %5 : $C from (%2 : $C)
+  end_borrow %6 : $C
+  destroy_value %2 : $C
+  %9 = tuple ()
+  return %9 : $()
+}
+

--- a/test/SILOptimizer/sil_combine_misc_opts.sil
+++ b/test/SILOptimizer/sil_combine_misc_opts.sil
@@ -12,6 +12,10 @@ import Builtin
 
 class Klass {}
 
+struct S {
+  var a: Klass
+}
+
 sil @nativeobject_guaranteed_use : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 
 ///////////
@@ -96,3 +100,22 @@ bb0(%0 : $*Builtin.NativeObject):
   %9999 = tuple()
   return %9999 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @test_updating_borrowed_from :
+// CHECK:         borrowed {{.*}} from {{.*}} %0 : $S
+// CHECK-LABEL: } // end sil function 'test_updating_borrowed_from'
+sil [ossa] @test_updating_borrowed_from : $@convention(thin) (@guaranteed S) -> () {
+bb0(%0 : @guaranteed $S):
+  %1 = destructure_struct %0 : $S
+  %2 = copy_value %1 : $Klass
+  %3 = begin_borrow %2 : $Klass
+  br bb1(%3 : $Klass)
+
+bb1(%5 : @reborrow @guaranteed $Klass):
+  %6 = borrowed %5 : $Klass from (%2 : $Klass)
+  end_borrow %6 : $Klass
+  destroy_value %2 : $Klass
+  %9 = tuple ()
+  return %9 : $()
+}
+


### PR DESCRIPTION
The borrowed-from verifier was basically useless which hid some problems in the optimizer.
This PR fixes the verifier and the hidden problems: missing updating borrowed-from in some passes.