### PR TITLE
[variable-name-utils] Change internal representation to use StringRef instead of a SILValue

### DIFF
--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -192,6 +192,8 @@ public:
 
   StringRef getName() const { return resultingString; }
 
+  SWIFT_DEBUG_DUMP { llvm::dbgs() << getName() << '\n'; }
+
   /// Given a specific SILValue, construct a VariableNameInferrer and use it to
   /// attempt to infer an identifier for the value.
   static std::optional<Identifier> inferName(SILValue value);

--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -112,8 +112,7 @@ private:
   ///
   /// Has to be a small vector since we push/pop the last segment start. This
   /// lets us speculate when processing phis.
-  VariableNamePathArray<std::variant<SILInstruction *, SILValue, StringRef>, 4>
-      variableNamePath;
+  VariableNamePathArray<StringRef, 4> variableNamePath;
 
   /// The root value of our string.
   ///
@@ -216,7 +215,6 @@ public:
 
 private:
   void drainVariableNamePath();
-  void popSingleVariableName();
 
   /// Finds the SILValue that either provides the direct debug information or
   /// that has a debug_value user that provides the name of the value.

--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -105,6 +105,9 @@ private:
     bool empty() const { return !insertionPointIndex; }
   };
 
+  /// ASTContext for forming identifiers when we need to.
+  ASTContext &astContext;
+
   /// The stacklist that we use to print out variable names.
   ///
   /// Has to be a small vector since we push/pop the last segment start. This
@@ -128,12 +131,13 @@ private:
 
 public:
   VariableNameInferrer(SILFunction *fn, SmallString<64> &resultingString)
-      : variableNamePath(), resultingString(resultingString) {}
+      : astContext(fn->getASTContext()), variableNamePath(),
+        resultingString(resultingString) {}
 
   VariableNameInferrer(SILFunction *fn, Options options,
                        SmallString<64> &resultingString)
-      : variableNamePath(), resultingString(resultingString), options(options) {
-  }
+      : astContext(fn->getASTContext()), variableNamePath(),
+        resultingString(resultingString), options(options) {}
 
   /// Attempts to infer a name from just uses of \p searchValue.
   ///
@@ -238,10 +242,7 @@ private:
       llvm::raw_svector_ostream stream(indexString);
       stream << index;
     }
-    return rootValue->getFunction()
-        ->getASTContext()
-        .getIdentifier(indexString)
-        .str();
+    return astContext.getIdentifier(indexString).str();
   }
 };
 

--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -229,6 +229,18 @@ private:
   /// DebugVariable provided name, attempt to find a root value from its
   /// initialization.
   SILValue getRootValueForTemporaryAllocation(AllocationInst *allocInst);
+
+  StringRef getStringRefForIndex(unsigned index) const {
+    llvm::SmallString<64> indexString;
+    {
+      llvm::raw_svector_ostream stream(indexString);
+      stream << index;
+    }
+    return rootValue->getFunction()
+        ->getASTContext()
+        .getIdentifier(indexString)
+        .str();
+  }
 };
 
 } // namespace swift

--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -109,7 +109,7 @@ private:
   ///
   /// Has to be a small vector since we push/pop the last segment start. This
   /// lets us speculate when processing phis.
-  VariableNamePathArray<PointerUnion<SILInstruction *, SILValue>, 4>
+  VariableNamePathArray<std::variant<SILInstruction *, SILValue, StringRef>, 4>
       variableNamePath;
 
   /// The root value of our string.

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -454,38 +454,38 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     }
 
     if (auto *sei = dyn_cast<StructExtractInst>(searchValue)) {
-      variableNamePath.push_back(sei);
+      variableNamePath.push_back(getNameFromDecl(sei->getField()));
       searchValue = sei->getOperand();
       continue;
     }
 
     if (auto *uedi = dyn_cast<UncheckedEnumDataInst>(searchValue)) {
-      variableNamePath.push_back(uedi);
+      variableNamePath.push_back(getNameFromDecl(uedi->getElement()));
       searchValue = uedi->getOperand();
       continue;
     }
 
     if (auto *tei = dyn_cast<TupleExtractInst>(searchValue)) {
-      variableNamePath.push_back(tei);
+      variableNamePath.push_back(getStringRefForIndex(tei->getFieldIndex()));
       searchValue = tei->getOperand();
       continue;
     }
 
     if (auto *sei = dyn_cast<StructElementAddrInst>(searchValue)) {
-      variableNamePath.push_back(sei);
+      variableNamePath.push_back(getNameFromDecl(sei->getField()));
       searchValue = sei->getOperand();
       continue;
     }
 
     if (auto *tei = dyn_cast<TupleElementAddrInst>(searchValue)) {
-      variableNamePath.push_back(tei);
+      variableNamePath.push_back(getStringRefForIndex(tei->getFieldIndex()));
       searchValue = tei->getOperand();
       continue;
     }
 
-    if (auto *e = dyn_cast<UncheckedTakeEnumDataAddrInst>(searchValue)) {
-      variableNamePath.push_back(e);
-      searchValue = e->getOperand();
+    if (auto *utedai = dyn_cast<UncheckedTakeEnumDataAddrInst>(searchValue)) {
+      variableNamePath.push_back(getNameFromDecl(utedai->getElement()));
+      searchValue = utedai->getOperand();
       continue;
     }
 
@@ -494,7 +494,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     // them and add the case to the variableNamePath.
     if (auto *e = dyn_cast<EnumInst>(searchValue)) {
       if (e->hasOperand()) {
-        variableNamePath.push_back(e);
+        variableNamePath.push_back(getNameFromDecl(e->getElement()));
         searchValue = e->getOperand();
         continue;
       }
@@ -684,43 +684,6 @@ void VariableNameInferrer::popSingleVariableName() {
 
     if (auto m = dyn_cast<MethodInst>(inst)) {
       resultingString += getNameFromDecl(m->getMember().getDecl());
-      return;
-    }
-
-    if (auto *sei = dyn_cast<StructExtractInst>(inst)) {
-      resultingString += getNameFromDecl(sei->getField());
-      return;
-    }
-
-    if (auto *tei = dyn_cast<TupleExtractInst>(inst)) {
-      llvm::raw_svector_ostream stream(resultingString);
-      stream << tei->getFieldIndex();
-      return;
-    }
-
-    if (auto *uedi = dyn_cast<UncheckedEnumDataInst>(inst)) {
-      resultingString += getNameFromDecl(uedi->getElement());
-      return;
-    }
-
-    if (auto *sei = dyn_cast<StructElementAddrInst>(inst)) {
-      resultingString += getNameFromDecl(sei->getField());
-      return;
-    }
-
-    if (auto *tei = dyn_cast<TupleElementAddrInst>(inst)) {
-      llvm::raw_svector_ostream stream(resultingString);
-      stream << tei->getFieldIndex();
-      return;
-    }
-
-    if (auto *uedi = dyn_cast<UncheckedTakeEnumDataAddrInst>(inst)) {
-      resultingString += getNameFromDecl(uedi->getElement());
-      return;
-    }
-
-    if (auto *ei = dyn_cast<EnumInst>(inst)) {
-      resultingString += getNameFromDecl(ei->getElement());
       return;
     }
 

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -362,7 +362,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     if (auto *use = getAnyDebugUse(searchValue)) {
       if (auto debugVar = DebugVarCarryingInst(use->getUser())) {
         assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
-        variableNamePath.push_back(use->getUser());
+        variableNamePath.push_back(debugVar.getName());
 
         // We return the value, not the debug_info.
         return searchValue;
@@ -385,7 +385,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
             if (auto debugVar = DebugVarCarryingInst(debugUse->getUser())) {
               assert(debugVar.getKind() ==
                      DebugVarCarryingInst::Kind::DebugValue);
-              variableNamePath.push_back(debugUse->getUser());
+              variableNamePath.push_back(debugVar.getName());
 
               // We return the value, not the debug_info.
               return searchValue;
@@ -399,7 +399,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
       if (auto *debugUse = getAnyDebugUse(bbi)) {
         if (auto debugVar = DebugVarCarryingInst(debugUse->getUser())) {
           assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
-          variableNamePath.push_back(debugUse->getUser());
+          variableNamePath.push_back(debugVar.getName());
 
           // We return the value, not the debug_info.
           return searchValue;


### PR DESCRIPTION
CONTEXT: This code works by building up a stack of SIL values of values that
need to be transformed into a StringRef as part of generating our name path and
then as a second phase performs the conversion of those values to StringRef as
we pop from the stack.

In this PR, I refactor VariableNameUtils so that the stack will only contain StringRef instead of SIL
entities. This will be accomplished by moving the SIL value -> StringRef code
from the combining part of the algorithm (where we drain the stack) to the
construction of the stack.

The reason why I am doing this is two fold:

1. By just storing StringRef into the stack I am simplifying the code. Today as
mentioned above in the context, we gather up the SILValue we want to process and
then just convert them to StringRef. This means that any time one has to add a
new instruction, one has to update two different pieces of code. By trafficking
in StringRef instead, one only has to update one piece of code.

2. I want to add some simple code that allows for us to get names from closures
which would require me to recurse. I am nervous about putting
values/instructions from different functions in the same data structure. Today
it is safe, but it is bad practice. Instead, by just using StringRef in the
stack, I can avoid this problem.