### PR TITLE
Build fix for when the Darwin module is split up

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -14,6 +14,9 @@
 
 import ArgumentParser
 import SwiftRemoteMirror
+#if canImport(string_h)
+import string_h
+#endif
 
 struct DumpConcurrency: ParsableCommand {
   static let configuration = CommandConfiguration(


### PR DESCRIPTION
After the C standard library headers are split out of Darwin, DumpConcurrency.swift no longer sees string.h. Explicitly import <string.h>'s new module when it's available.

rdar://127076885