### PR TITLE
[Tests/Distributed] NFC: `distributed_actor_protocol_call_resilient_l…

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_protocol_call_resilient_lib.swift
+++ b/test/Distributed/Runtime/distributed_actor_protocol_call_resilient_lib.swift
@@ -74,6 +74,7 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: remote_run || device_run
 
 //--- ResilientLib.swift
 


### PR DESCRIPTION
…ib` test cannot be run remotely

The test depends on dynamic libraries that a rebuilt on the host and are not transferred to the remote machine.

Resolves: rdar://132714652

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
