### PR TITLE
Skip testing swiftformat when testing is skipped

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -961,6 +961,7 @@ skip-test-indexstore-db
 skip-test-sourcekit-lsp
 skip-test-swiftdocc
 skip-test-wasm-stdlib
+skip-test-swiftformat
 
 # Linux package with out test
 [preset: buildbot_linux,no_test]


### PR DESCRIPTION
The no_test preset configurations were still testing swift-format. Adding skip-test-swiftformat in those configurations.