### PR TITLE
[embedded] Add StringSwitch.swift to the embedded stdlib

### DIFF
--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -178,7 +178,9 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
   @inlinable
   @inline(__always)
   internal init(native: Native) {
+    #if !$Embedded
     _internalInvariant(_usesNativeSwiftReferenceCounting(NativeClass.self))
+    #endif
     rawValue = native
   }
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -179,7 +179,7 @@ split_embedded_sources(
   EMBEDDED StringRangeReplaceableCollection.swift
   EMBEDDED StringStorage.swift
   EMBEDDED StringStorageBridge.swift
-    NORMAL StringSwitch.swift
+  EMBEDDED StringSwitch.swift
   EMBEDDED StringTesting.swift
   EMBEDDED StringUnicodeScalarView.swift
   EMBEDDED StringUTF16View.swift

--- a/test/embedded/string-switch.swift
+++ b/test/embedded/string-switch.swift
@@ -1,0 +1,18 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -wmo -Xlinker %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswiftUnicodeDataTables.a) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+enum MyEnum: String {
+    case foo
+    case bar
+}
+
+var e = MyEnum.foo
+print(e.rawValue)
+e = MyEnum.bar
+print(e.rawValue)
+// CHECK: foo
+// CHECK: bar

--- a/test/embedded/string-switch.swift
+++ b/test/embedded/string-switch.swift
@@ -3,7 +3,7 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: OS=macosx
 
 enum MyEnum: String {
     case foo


### PR DESCRIPTION
We today crash when trying to use a String-backed enum:
```
enum MyEnum: String {
    case foo
    case bar
}
...
<unknown>:0: error: cannot find '_findStringSwitchCase' in scope
expression kind should not survive to SILGen
UNREACHABLE executed at /home/build-user/swift/lib/SILGen/ASTVisitor.h:52!
```


Let's fix that by adding StringSwitch to the embedded stdlib builds.

rdar://133418304
