### PR TITLE
Deployment-gate treatment of protocols without witness tables as never-dependent

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1048,7 +1048,8 @@ static bool protocolCanHaveDependentConformance(ProtocolDecl *proto) {
   ASTContext &ctx = proto->getASTContext();
   if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget(
           ctx.LangOpts.Target)) {
-    if (runtimeCompatVersion < llvm::VersionTuple(6, 0))
+    if (runtimeCompatVersion < llvm::VersionTuple(6, 0) &&
+        proto->isSpecificProtocol(KnownProtocolKind::Sendable))
       return true;
   }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -39,6 +39,7 @@
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/Platform.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILDeclRef.h"
@@ -1032,6 +1033,28 @@ static bool isSynthesizedNonUnique(const RootProtocolConformance *conformance) {
   return false;
 }
 
+/// Determine whether a protocol can ever have a dependent conformance.
+static bool protocolCanHaveDependentConformance(ProtocolDecl *proto) {
+  // Objective-C protocols have never been able to have a dependent conformance.
+  if (proto->isObjC())
+    return false;
+
+  // Prior to Swift 6.0, only Objective-C protocols were never able to have
+  // a dependent conformance. This is overly pessimistic when the protocol
+  // is a marker protocol (since they don't have requirements), but we must
+  // retain backward compatibility with binaries built for earlier deployment
+  // targets that concluded that these protocols might involve dependent
+  // conformances.
+  ASTContext &ctx = proto->getASTContext();
+  if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget(
+          ctx.LangOpts.Target)) {
+    if (runtimeCompatVersion < llvm::VersionTuple(6, 0))
+      return true;
+  }
+
+  return Lowering::TypeConverter::protocolRequiresWitnessTable(proto);
+}
+
 static bool isDependentConformance(
               IRGenModule &IGM,
               const RootProtocolConformance *rootConformance,
@@ -1064,7 +1087,7 @@ static bool isDependentConformance(
       continue;
 
     auto assocProtocol = req.getProtocolDecl();
-    if (!Lowering::TypeConverter::protocolRequiresWitnessTable(assocProtocol))
+    if (!protocolCanHaveDependentConformance(assocProtocol))
       continue;
 
     auto assocConformance =

--- a/test/IRGen/protocol_resilience_sendable.swift
+++ b/test/IRGen/protocol_resilience_sendable.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
+
+// RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos14.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-BEFORE
+// RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos15.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-AFTER
+
+// REQUIRES: OS=macosx
+
+import resilient_protocol
+
+func acceptResilientSendableBase<T: ResilientSendableBase>(_: T.Type) { }
+
+// CHECK-USAGE: define{{.*}}swiftcc void @"$s28protocol_resilience_sendable25passResilientSendableBaseyyF"()
+func passResilientSendableBase() {
+  // CHECK-USAGE-NOT: ret
+  // CHECK-USAGE: [[METATYPE:%.*]] = extractvalue
+  // CHECK-USAGE-BEFORE: [[WITNESS_TABLE:%.*]] = call ptr @"$s18resilient_protocol27ConformsToResilientSendableVAcA0eF4BaseAAWl"()
+  // CHECK-USAGE-BEFORE-NEXT: call swiftcc void @"$s28protocol_resilience_sendable27acceptResilientSendableBaseyyxm010resilient_A00efG0RzlF"(ptr [[METATYPE]], ptr [[METATYPE]], ptr [[WITNESS_TABLE]])
+  // CHECK-USAGE-AFTER-NEXT: call swiftcc void @"$s28protocol_resilience_sendable27acceptResilientSendableBaseyyxm010resilient_A00efG0RzlF"(ptr [[METATYPE]], ptr [[METATYPE]], ptr @"$s18resilient_protocol27ConformsToResilientSendableVAA0eF4BaseAAWP")
+  acceptResilientSendableBase(ConformsToResilientSendable.self)
+}

--- a/test/Inputs/resilient_protocol.swift
+++ b/test/Inputs/resilient_protocol.swift
@@ -44,3 +44,17 @@ public protocol ResilientSelfDefault : ResilientBaseProtocol {
 @_fixed_layout public protocol OtherFrozenProtocol {
   func protocolMethod()
 }
+
+public protocol ResilientSendableBase: Sendable {
+  func f()
+}
+
+public protocol ResilientSendable: ResilientSendableBase {
+  func g()
+}
+
+
+public struct ConformsToResilientSendable: ResilientSendable {
+  public func f() { }
+  public func g() { }
+}


### PR DESCRIPTION
Within Swift 6.0, we expanded an optimization for witness tables that that allowed direct access to the witness table for conformances to any protocol that can never have a witness table, rather than requiring access through `swift_getWitnessTable` that might need to instantiate the witness table.

The previous optimization only covered Objective-C protocols, but Swift 6.0 expanded that to marker protocols (such as `Sendable`) as well.

However, this constituted an ABI break when a Swift 6.0 compiler uses a witness table that comes from a library built with an earlier version of Swift, when the protocol inherits from Sendable but the conformance to that protocol otherwise does not require an instantiation function. In such cases, Swift 6.0 would generate code that directly accesses the uninstantiated witness table symbol, which will have NULL entries for any conformance in it that was considered "dependent" by the earlier Swift compiler.

Introduce a deployment target check to guard the new optimization. Specifically, when building for a deployment target that predates Swift 6.0, treat conformances to marker protocols as if they might be dependent (so the access patterns go through `swift_getWitnessTable` for potential instantiation on older platforms). For newer deployment targets, use the more efficent direct access pattern.

Fixes rdar://133157093, fixes https://github.com/swiftlang/swift/issues/75155
