### PR TITLE
[6.0] Deployment-gate treatment of protocols without witness tables as never-dependent

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -38,6 +38,7 @@
 #include "swift/AST/PackConformance.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/Basic/Platform.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILDeclRef.h"
@@ -1028,6 +1029,28 @@ static bool isSynthesizedNonUnique(const RootProtocolConformance *conformance) {
   return false;
 }
 
+/// Determine whether a protocol can ever have a dependent conformance.
+static bool protocolCanHaveDependentConformance(ProtocolDecl *proto) {
+  // Objective-C protocols have never been able to have a dependent conformance.
+  if (proto->isObjC())
+    return false;
+
+  // Prior to Swift 6.0, only Objective-C protocols were never able to have
+  // a dependent conformance. This is overly pessimistic when the protocol
+  // is a marker protocol (since they don't have requirements), but we must
+  // retain backward compatibility with binaries built for earlier deployment
+  // targets that concluded that these protocols might involve dependent
+  // conformances.
+  ASTContext &ctx = proto->getASTContext();
+  if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget(
+          ctx.LangOpts.Target)) {
+    if (runtimeCompatVersion < llvm::VersionTuple(6, 0))
+      return true;
+  }
+
+  return Lowering::TypeConverter::protocolRequiresWitnessTable(proto);
+}
+
 static bool isDependentConformance(
               IRGenModule &IGM,
               const RootProtocolConformance *rootConformance,
@@ -1060,7 +1083,7 @@ static bool isDependentConformance(
       continue;
 
     auto assocProtocol = req.getProtocolDecl();
-    if (!Lowering::TypeConverter::protocolRequiresWitnessTable(assocProtocol))
+    if (!protocolCanHaveDependentConformance(assocProtocol))
       continue;
 
     auto assocConformance =

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1044,7 +1044,8 @@ static bool protocolCanHaveDependentConformance(ProtocolDecl *proto) {
   ASTContext &ctx = proto->getASTContext();
   if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget(
           ctx.LangOpts.Target)) {
-    if (runtimeCompatVersion < llvm::VersionTuple(6, 0))
+    if (runtimeCompatVersion < llvm::VersionTuple(6, 0) &&
+        proto->isSpecificProtocol(KnownProtocolKind::Sendable))
       return true;
   }
 

--- a/test/IRGen/protocol_resilience_sendable.swift
+++ b/test/IRGen/protocol_resilience_sendable.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
+
+// RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos14.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-BEFORE
+// RUN: %target-swift-frontend -I %t -emit-ir %s -target %target-cpu-apple-macos15.0 | %FileCheck %s -DINT=i%target-ptrsize -check-prefix=CHECK-USAGE -check-prefix=CHECK-USAGE-AFTER
+
+// REQUIRES: OS=macosx
+
+import resilient_protocol
+
+func acceptResilientSendableBase<T: ResilientSendableBase>(_: T.Type) { }
+
+// CHECK-USAGE: define{{.*}}swiftcc void @"$s28protocol_resilience_sendable25passResilientSendableBaseyyF"()
+func passResilientSendableBase() {
+  // CHECK-USAGE-NOT: ret
+  // CHECK-USAGE: [[METATYPE:%.*]] = extractvalue
+  // CHECK-USAGE-BEFORE: [[WITNESS_TABLE:%.*]] = call ptr @"$s18resilient_protocol27ConformsToResilientSendableVAcA0eF4BaseAAWl"()
+  // CHECK-USAGE-BEFORE-NEXT: call swiftcc void @"$s28protocol_resilience_sendable27acceptResilientSendableBaseyyxm010resilient_A00efG0RzlF"(ptr [[METATYPE]], ptr [[METATYPE]], ptr [[WITNESS_TABLE]])
+  // CHECK-USAGE-AFTER-NEXT: call swiftcc void @"$s28protocol_resilience_sendable27acceptResilientSendableBaseyyxm010resilient_A00efG0RzlF"(ptr [[METATYPE]], ptr [[METATYPE]], ptr @"$s18resilient_protocol27ConformsToResilientSendableVAA0eF4BaseAAWP")
+  acceptResilientSendableBase(ConformsToResilientSendable.self)
+}

--- a/test/Inputs/resilient_protocol.swift
+++ b/test/Inputs/resilient_protocol.swift
@@ -44,3 +44,17 @@ public protocol ResilientSelfDefault : ResilientBaseProtocol {
 @_fixed_layout public protocol OtherFrozenProtocol {
   func protocolMethod()
 }
+
+public protocol ResilientSendableBase: Sendable {
+  func f()
+}
+
+public protocol ResilientSendable: ResilientSendableBase {
+  func g()
+}
+
+
+public struct ConformsToResilientSendable: ResilientSendable {
+  public func f() { }
+  public func g() { }
+}


### PR DESCRIPTION
- **Explanation**: Within Swift 6.0, we expanded an optimization for witness tables that that allowed direct access to the witness table for conformances to any protocol that can never have a witness table, rather than requiring access through `swift_getWitnessTable` that might need to instantiate the witness table. However, this broke back-deployment for conformances affected by this, because client code built with Swift 6.0 would assume that the `swift_getWitnessTable` call was unnecessary (and skip it), while binaries built with older compilers still required it. Limit this optimization to Swift 6.0-and-newer deployment targets.
  - **Scope**: Affects binaries that access otherwise non-dependent conformances from resilient libraries built with pre-Swift 6.0 compilers where the involved protocols inherit from `Sendable`. In other words, *very narrow*.
  - **Issues**: rdar://133157093, https://github.com/swiftlang/swift/issues/75155
  - **Original PRs**: https://github.com/swiftlang/swift/pull/75769
  - **Risk**: Very low. We're backing off to an older access pattern when targeting platforms with older Swift runtimes, without affecting code built for platforms with newer Swift runtimes.
  - **Testing**: Tested against an affected framework, plus new tests
  - **Reviewers**: @aschwaighofer 
