### PR TITLE
Mark Differentiable related array methods with inlinable for big performance boost

### DIFF
--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -21,6 +21,7 @@ extension Array where Element: Differentiable {
   /// multiplied with itself `count` times.
   @frozen
   public struct DifferentiableView {
+    @usableFromInline
     var _base: [Element]
   }
 }
@@ -28,12 +29,13 @@ extension Array where Element: Differentiable {
 extension Array.DifferentiableView: Differentiable
 where Element: Differentiable {
   /// The viewed array.
+  @inlinable
   public var base: [Element] {
     get { _base }
     _modify { yield &_base }
   }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: base)
   func _vjpBase() -> (
     value: [Element], pullback: (Array<Element>.TangentVector) -> TangentVector
@@ -41,7 +43,7 @@ where Element: Differentiable {
     return (base, { $0 })
   }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: base)
   func _jvpBase() -> (
     value: [Element], differential: (Array<Element>.TangentVector) -> TangentVector
@@ -50,9 +52,10 @@ where Element: Differentiable {
   }
 
   /// Creates a differentiable view of the given array.
+  @inlinable
   public init(_ base: [Element]) { self._base = base }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: init(_:))
   static func _vjpInit(_ base: [Element]) -> (
     value: Array.DifferentiableView, pullback: (TangentVector) -> TangentVector
@@ -60,7 +63,7 @@ where Element: Differentiable {
     return (Array.DifferentiableView(base), { $0 })
   }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: init(_:))
   static func _jvpInit(_ base: [Element]) -> (
     value: Array.DifferentiableView, differential: (TangentVector) -> TangentVector
@@ -71,6 +74,7 @@ where Element: Differentiable {
   public typealias TangentVector =
     Array<Element.TangentVector>.DifferentiableView
 
+  @inlinable
   public mutating func move(by offset: TangentVector) {
     if offset.base.isEmpty {
       return
@@ -88,6 +92,7 @@ where Element: Differentiable {
 
 extension Array.DifferentiableView: Equatable
 where Element: Differentiable & Equatable {
+  @inlinable
   public static func == (
     lhs: Array.DifferentiableView,
     rhs: Array.DifferentiableView
@@ -98,6 +103,7 @@ where Element: Differentiable & Equatable {
 
 extension Array.DifferentiableView: ExpressibleByArrayLiteral
 where Element: Differentiable {
+  @inlinable
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
@@ -123,10 +129,12 @@ extension Array.DifferentiableView: CustomReflectable {
 extension Array.DifferentiableView: AdditiveArithmetic
 where Element: AdditiveArithmetic & Differentiable {
 
+  @inlinable
   public static var zero: Array.DifferentiableView {
     return Array.DifferentiableView([])
   }
-
+  
+  @inlinable
   public static func + (
     lhs: Array.DifferentiableView,
     rhs: Array.DifferentiableView
@@ -143,6 +151,7 @@ where Element: AdditiveArithmetic & Differentiable {
     return Array.DifferentiableView(zip(lhs.base, rhs.base).map(+))
   }
 
+  @inlinable
   public static func - (
     lhs: Array.DifferentiableView,
     rhs: Array.DifferentiableView
@@ -180,6 +189,7 @@ extension Array: Differentiable where Element: Differentiable {
   public typealias TangentVector =
     Array<Element.TangentVector>.DifferentiableView
 
+  @inlinable
   public mutating func move(by offset: TangentVector) {
     var view = DifferentiableView(self)
     view.move(by: offset)
@@ -192,7 +202,7 @@ extension Array: Differentiable where Element: Differentiable {
 //===----------------------------------------------------------------------===//
 
 extension Array where Element: Differentiable {
-  @usableFromInline
+  @inlinable
   @derivative(of: subscript)
   func _vjpSubscript(index: Int) -> (
     value: Element, pullback: (Element.TangentVector) -> TangentVector
@@ -207,7 +217,7 @@ extension Array where Element: Differentiable {
     return (self[index], pullback)
   }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: subscript)
   func _jvpSubscript(index: Int) -> (
     value: Element, differential: (TangentVector) -> Element.TangentVector
@@ -218,7 +228,7 @@ extension Array where Element: Differentiable {
     return (self[index], differential)
   }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: +)
   static func _vjpConcatenate(_ lhs: Self, _ rhs: Self) -> (
     value: Self,
@@ -241,7 +251,7 @@ extension Array where Element: Differentiable {
     return (lhs + rhs, pullback)
   }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: +)
   static func _jvpConcatenate(_ lhs: Self, _ rhs: Self) -> (
     value: Self,
@@ -261,7 +271,7 @@ extension Array where Element: Differentiable {
 
 
 extension Array where Element: Differentiable {
-  @usableFromInline
+  @inlinable
   @derivative(of: append)
   mutating func _vjpAppend(_ element: Element) -> (
     value: Void, pullback: (inout TangentVector) -> Element.TangentVector
@@ -274,7 +284,7 @@ extension Array where Element: Differentiable {
     })
   }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: append)
   mutating func _jvpAppend(_ element: Element) -> (
     value: Void,
@@ -286,7 +296,7 @@ extension Array where Element: Differentiable {
 }
 
 extension Array where Element: Differentiable {
-  @usableFromInline
+  @inlinable
   @derivative(of: +=)
   static func _vjpAppend(_ lhs: inout Self, _ rhs: Self) -> (
     value: Void, pullback: (inout TangentVector) -> TangentVector
@@ -302,7 +312,7 @@ extension Array where Element: Differentiable {
     })
   }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: +=)
   static func _jvpAppend(_ lhs: inout Self, _ rhs: Self) -> (
     value: Void, differential: (inout TangentVector, TangentVector) -> Void
@@ -313,7 +323,7 @@ extension Array where Element: Differentiable {
 }
 
 extension Array where Element: Differentiable {
-  @usableFromInline
+  @inlinable
   @derivative(of: init(repeating:count:))
   static func _vjpInit(repeating repeatedValue: Element, count: Int) -> (
     value: Self, pullback: (TangentVector) -> Element.TangentVector
@@ -326,7 +336,7 @@ extension Array where Element: Differentiable {
     )
   }
 
-  @usableFromInline
+  @inlinable
   @derivative(of: init(repeating:count:))
   static func _jvpInit(repeating repeatedValue: Element, count: Int) -> (
     value: Self, differential: (Element.TangentVector) -> TangentVector


### PR DESCRIPTION
This PR marks several methods in ArrayDifferentiation.swift with @inlinable adding much more opportunity for specialisation. This leads to huge performance increases and much lower memory usage in a few Differentiable example programs using Array and Array.DifferentiableView.

Main increase is due to being able to specialise Array.DifferentiableView's + operator from it's conformance to AdditiveArithmetic and therefore further being able to inline function calls and not having to go through the protocol witness table.

Technically we do restrict ourselves wrt future changes to the `DifferentiableView` implementation since the internals are now marked `@usableFromInline`. We currently think this is acceptable since Differentiation currently is not shipped to an ABI stable platform. 

Some performance numbers:
The benchmark I'm using is a reimplementation of the original SwiftForTensorflow example found here: https://github.com/tensorflow/swift-models/tree/2fb0b92e1291b730fd1a5cd8a3b107c8e75c7d7a/Examples/Shallow-Water-PDE
This was implemented on top of the Tensor type that S4TF introduced. 
My example uses an Array for storage. 

For the benchmark I've set the amount of iterations to 1 so I'm benchmarking the wall clock time and malloc of running a forward pass and pullback once through an array of `resolution * resolution` and `duration` amount of time steps 
Every tilmestep the benchmark applies the Laplace operator to every cell of the array. 
I ran my benchmark for values of 10 and 20 for both of these variables. You can find the results below. As you can see the difference in performance is quite enormous ranging from at least 20x in both categories to 60-70x

```
----------------------------------------------------------------------------------------------------------------------------
Optimization res: 10, duration: 10 metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ms) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  alpha                   │  323301 │  326631 │  328466 │  331612 │  336331 │  346292 │  346705 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │   15549 │   15704 │   15909 │   16204 │   16368 │   17957 │   23918 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │ -307752 │ -310927 │ -312557 │ -315408 │ -319963 │ -328335 │ -322787 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      95 │      95 │      95 │      95 │      95 │      95 │      93 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│           Malloc (total) (K) *           │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  alpha                   │    3640 │    3640 │    3640 │    3640 │    3640 │    3640 │    3640 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │     131 │     131 │     131 │     131 │     131 │     131 │     131 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │   -3509 │   -3509 │   -3509 │   -3509 │   -3509 │   -3509 │   -3509 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      96 │      96 │      96 │      96 │      96 │      96 │      96 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

----------------------------------------------------------------------------------------------------------------------------
Optimization res: 10, duration: 20 metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ms) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  alpha                   │  641372 │  646447 │  649593 │  655360 │  662700 │  684196 │  741245 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │   30743 │   31080 │   31293 │   31687 │   32195 │   32997 │   33447 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │ -610629 │ -615367 │ -618300 │ -623673 │ -630505 │ -651199 │ -707798 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      95 │      95 │      95 │      95 │      95 │      95 │      95 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│           Malloc (total) (K) *           │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  alpha                   │    7233 │    7233 │    7233 │    7233 │    7233 │    7233 │    7233 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │     261 │     261 │     261 │     261 │     261 │     261 │     261 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │   -6972 │   -6972 │   -6972 │   -6972 │   -6972 │   -6972 │   -6972 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      96 │      96 │      96 │      96 │      96 │      96 │      96 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

----------------------------------------------------------------------------------------------------------------------------
Optimization res: 20, duration: 10 metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ms) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  alpha                   │ 5645665 │ 5679088 │ 5708448 │ 5796528 │ 6027215 │ 6033953 │ 6033953 │      18 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │  180295 │  181535 │  182452 │  184287 │  188350 │  209977 │  213960 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │ -54653… │ -54975… │ -55259… │ -56122… │ -58388… │ -58239… │ -58199… │      82 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      97 │      97 │      97 │      97 │      97 │      97 │      96 │      82 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│           Malloc (total) (K) *           │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  alpha                   │      68 │      68 │      68 │      68 │      68 │      68 │      68 │      18 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │       1 │       1 │       1 │       1 │       1 │       1 │       1 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │     -67 │     -67 │     -67 │     -67 │     -67 │     -67 │     -67 │      82 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      99 │      99 │      99 │      99 │      99 │      99 │      99 │      82 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

----------------------------------------------------------------------------------------------------------------------------
Optimization res: 20, duration: 20 metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ms) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  alpha                   │ 112075… │ 112742… │ 113330… │ 113749… │ 115526… │ 115526… │ 115526… │       9 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │  358827 │  363856 │  367002 │  370672 │  374604 │  392167 │  408872 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │ -10848… │ -10910… │ -10966… │ -11004… │ -11178… │ -11160… │ -11143… │      91 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      97 │      97 │      97 │      97 │      97 │      97 │      96 │      91 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│           Malloc (total) (K) *           │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                  alpha                   │     135 │     135 │     135 │     135 │     135 │     135 │     135 │       9 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │       2 │       2 │       2 │       2 │       2 │       2 │       2 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    -133 │    -133 │    -133 │    -133 │    -133 │    -133 │    -133 │      91 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      99 │      99 │      99 │      99 │      99 │      99 │      99 │      91 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```

