### PR TITLE
Dependency Scanning: Address `-Wmissing-field-initializers` warnings

### DIFF
--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -229,7 +229,8 @@ static swiftscan_dependency_graph_t generateHollowDiagnosticOutput(
                                           c_string_utils::create_null(),
                                           c_string_utils::create_null(),
                                           c_string_utils::create_null(),
-                                          nullptr};
+                                          nullptr,
+                                          c_string_utils::create_null()};
   hollowMainModuleInfo->details = hollowDetails;
 
   // Empty Link Library set

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -739,7 +739,8 @@ generateFullDependencyGraph(const CompilerInstance &instance,
                              .CASBridgingHeaderIncludeTreeRootID.c_str()),
             /*CacheKey*/ create_clone(""),
             createMacroDependencySet(
-                swiftSourceDeps->textualModuleDetails.macroDependencies)};
+                swiftSourceDeps->textualModuleDetails.macroDependencies),
+            /*userModuleVersion*/ create_clone("")};
       } else if (swiftPlaceholderDeps) {
         details->kind = SWIFTSCAN_DEPENDENCY_INFO_SWIFT_PLACEHOLDER;
         details->swift_placeholder_details = {


### PR DESCRIPTION
Fix warnings introduced by https://github.com/swiftlang/swift/pull/75734.
