### PR TITLE
[cxx-interop] Print `inline` instead of `static inline` for template specializations

### DIFF
--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -200,7 +200,7 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
 
     if (!isCForwardDefinition) {
       os << "template<>\n";
-      os << "static inline const constexpr bool isUsableInGenericContext<"
+      os << "inline const constexpr bool isUsableInGenericContext<"
          << typeInfo.name << "> = true;\n\n";
     }
 


### PR DESCRIPTION
This was fixed in 14413d9d90e3df0aea39e684a2f6cd358ab08579 but then lost when a05b3051fa24262154f0ad03f614cfbef3529d33 was merged in. Bring it back.