### PR TITLE
[stdlib] fix sendability of ManagedBufferPointer

### DIFF
--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -374,6 +374,9 @@ public struct ManagedBufferPointer<
   }
 }
 
+@available(*, unavailable)
+extension ManagedBufferPointer: Sendable where Element: ~Copyable {}
+
 extension ManagedBufferPointer where Element: ~Copyable {
   /// The stored `Header` instance.
   @_preInverseGenerics

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -387,6 +387,12 @@ func testPointersAreNotSendable() {
     testSendable(rawMutableBuffer) // expected-warning {{conformance of 'UnsafeMutableRawBufferPointer' to 'Sendable' is unavailable}}
     testSendable(rawMutableBuffer.makeIterator()) // expected-warning {{conformance of 'UnsafeRawBufferPointer.Iterator' to 'Sendable' is unavailable}}
   }
+
+  func testManagedBuffers(buffer1: ManagedBuffer<Int, Int>, buffer2: ManagedBufferPointer<Int, Int>) {
+    testSendable(buffer1) // expected-warning {{conformance of 'ManagedBuffer<Header, Element>' to 'Sendable' is unavailable}}
+
+    testSendable(buffer2) // expected-warning {{conformance of 'ManagedBufferPointer<Header, Element>' to 'Sendable' is unavailable}}
+  }
 }
 
 @available(*, unavailable)


### PR DESCRIPTION
`ManagedBufferPointer` was inferred to be `Sendable`. While there may be a defect in the inference, this change simply fixes it by adding an unavailable conformance.

Addresses rdar://133343460
