### PR TITLE
SIL: Fix crash with missing existential Sendable conformance

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -235,6 +235,9 @@ public:
         llvm::errs() << "\nsubstitution map:\n";
         Subs.dump(llvm::errs());
         llvm::errs() << "\n";
+        llvm::errs() << "\ncomposed substitution map:\n";
+        substSubs.dump(llvm::errs());
+        llvm::errs() << "\n";
         abort();
       }
     }

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -111,8 +111,7 @@ ProtocolConformanceRef::subst(Type origType, InFlightSubstitution &IFS) const {
   // If the type is an existential, it must be self-conforming.
   if (substType->isExistentialType()) {
     auto optConformance =
-        proto->getModuleContext()->lookupExistentialConformance(substType,
-                                                                proto);
+        ModuleDecl::lookupConformance(substType, proto, /*allowMissing=*/true);
     if (optConformance)
       return optConformance;
 

--- a/test/SILOptimizer/specialize_missing_sendable.swift
+++ b/test/SILOptimizer/specialize_missing_sendable.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-sil %s -O -swift-version 5 | %FileCheck %s
+
+public final class Class<T: Sendable> {
+  @inline(never)
+  public init() {}
+}
+
+public protocol P {}
+
+// CHECK-LABEL: sil @$s27specialize_missing_sendable6callerAA5ClassCyAA1P_pGyF : $@convention(thin) () -> @owned Class<any P> {
+public func caller() -> Class<any P> {
+  // CHECK: function_ref @$s27specialize_missing_sendable5ClassCACyxGycfCAA1P_p_Tgm5 : $@convention(thin) () -> @owned Class<any P>
+  // CHECK: return
+  return Class<any P>()
+}


### PR DESCRIPTION
If a protocol does not inherit Sendable, we still say that the existential type is Sendable in Swift 5 mode. Make sure this doesn't crash the SIL specializer.

Fixes https://github.com/swiftlang/swift/issues/75728