### PR TITLE
Add missing `REQUIRES` for `enum_floating_point_raw_value.swift`

### DIFF
--- a/test/Parse/enum_floating_point_raw_value.swift
+++ b/test/Parse/enum_floating_point_raw_value.swift
@@ -3,6 +3,7 @@
 // FIXME: this test only passes on platforms which have Float80.
 // <rdar://problem/19508460> Floating point enum raw values are not portable
 
+// REQUIRES: CPU=i386 || CPU=x86_64
 
 // Windows does not support FP80
 // XFAIL: OS=windows-msvc


### PR DESCRIPTION
I accidentally removed this.