### PR TITLE
[6.0][SourceKit] Run interface generation request on a deep stack

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -912,7 +912,7 @@ static void
 handleRequestEditorOpenInterface(const RequestDict &Req,
                                  SourceKitCancellationToken CancellationToken,
                                  ResponseReceiver Rec) {
-  {
+  handleSemanticRequest(Req, Rec, [Req, Rec]() {
     SmallVector<const char *, 8> Args;
     if (getCompilerArgumentsForRequestOrEmitError(Req, Args, Rec))
       return;
@@ -929,7 +929,7 @@ handleRequestEditorOpenInterface(const RequestDict &Req,
     std::optional<StringRef> InterestedUSR = Req.getString(KeyInterestedUSR);
     return Rec(editorOpenInterface(*Name, *ModuleName, GroupName, Args,
                                    SynthesizedExtension, InterestedUSR));
-  }
+  });
 }
 
 static void handleRequestEditorOpenHeaderInterface(


### PR DESCRIPTION
- **Explanation**: Building the generated interface for WinSDK can overflow the stack. Treat it as a semantic request to run it on a large stack.
- **Scope**: SourceKit generated interface
- **Risk**: Low, this promotes the interface generated interface request to a larger stack
- **Testing**: Manually verified that building the generated interface for WinSDK doesn’t overflow the stack anymore on Windows
- **Issue**: swiftlang/sourcekit-lsp#1115, rdar://123944504
- **Reviewer**:  @hamishknight on https://github.com/swiftlang/swift/pull/75576