### PR TITLE
[stdlib][test] Update string printing availability checks

### DIFF
--- a/test/stdlib/BridgedObjectDebuggerSupport.swift
+++ b/test/stdlib/BridgedObjectDebuggerSupport.swift
@@ -78,8 +78,10 @@ StringForPrintObjectTests.test("NSStringUTF8") {
   expectEqual("🏂☃❅❆❄︎⛄️❄️", String(reflecting: nsUTF16))
   expectEqual("\"🏂☃❅❆❄︎⛄️❄️\"", String(reflecting: newNSUTF16))
 
-  if #available(SwiftStdlib 6.0, *) {
+  if #available(SwiftStdlib 6.1, *) {
     expectEqual("🏂☃❅❆❄︎⛄️❄️\n", printed)
+  } else {
+    expectEqual("\"🏂☃❅❆❄︎⛄️❄️\"\n", printed)
   }
 
   expectEqual(printed, debug)

--- a/test/stdlib/DebuggerSupport.swift
+++ b/test/stdlib/DebuggerSupport.swift
@@ -101,10 +101,15 @@ StringForPrintObjectTests.test("DontBridgeThisStruct") {
 }
 #endif
 
-if #available(SwiftStdlib 6.0, *) {
+if #available(SwiftStdlib 6.1, *) {
   StringForPrintObjectTests.test("String") {
     let printed = _stringForPrintObject("hello\nworld")
     expectEqual(printed, "hello\nworld\n")
+  }
+} else {
+  StringForPrintObjectTests.test("String") {
+    let printed = _stringForPrintObject("hello\nworld")
+    expectEqual(printed, "\"hello\\nworld\"\n")
   }
 }
 


### PR DESCRIPTION
The change in behaviour that this check covered is not currently in 6.0, only in main. Update the availability check to use stdlib 6.1.

Found this by running tests from main branch against a 6.0 stdlib build.