### PR TITLE
[SILGen]: extend uninhabited parameter checks to `self` param

### DIFF
--- a/test/SILGen/functions_uninhabited_param.swift
+++ b/test/SILGen/functions_uninhabited_param.swift
@@ -42,3 +42,42 @@ func empty_custom_product(_ xs: (E, Int)) { // expected-note {{'xs' is of type '
   print() // expected-warning{{will never be executed}}
 }
 
+//===--- Uninhabited self parameters
+
+extension Never {
+  var unreachableComputed: Int { // expected-note{{'self' is of type 'Never' which cannot be constructed because it is an enum with no cases}}
+    42 // expected-warning{{will never be executed}}
+  }
+
+  subscript(_ i: Int) -> Int { // expected-note{{'self' is of type 'Never' which cannot be constructed because it is an enum with no cases}}
+    42 // expected-warning{{will never be executed}}
+  }
+
+  func unreachableMethod() -> Int { // expected-note{{'self' is of type 'Never' which cannot be constructed because it is an enum with no cases}}
+    42 // expected-warning{{will never be executed}}
+  }
+
+  func unreachableMethodWithParam(_ x: Int) -> Int { // expected-note{{'self' is of type 'Never' which cannot be constructed because it is an enum with no cases}}
+    42 // expected-warning{{will never be executed}}
+  }
+
+  func unreachableMethodWithUninhabitedParam(_ p0: Int, _ p1: Self, _ p2: Never) -> Int { // expected-note{{'p1' is of type 'Never' which cannot be constructed because it is an enum with no cases}}
+    42 // expected-warning{{will never be executed}}
+  }
+
+  func unreachableWithNestedDecls() -> Int { // expected-note{{'self' is of type 'Never' which cannot be constructed because it is an enum with no cases}}
+    func g() -> Int { 42 }
+    let c = { g() } // expected-warning{{will never be executed}}
+    return c()
+  }
+}
+
+protocol P {
+  var prop: Int { get }
+  func uncallable(_ n: Never)
+}
+
+extension Never: P {
+  var prop: Int { fatalError() }
+  func uncallable(_ n: Never) {}
+}


### PR DESCRIPTION
SILGenProlog contains logic to emit an unreachable location if a function contains a structurally uninhabited parameter. This change extends this logic to include the `self` parameter, so instance members of structurally uninhabited types will produce the same diagnostics and have the same SIL emission behavior.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
