### PR TITLE
[SourceKit] Add optional declarations array to interface gen request

### DIFF
--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift
@@ -44,39 +44,55 @@ func f(s : inout [Int]) {
 // CHECK-DECLARATIONS-ARRAY: {{^}}]{{$}}
 
 // public class MyClass
-// CHECK-DECLARATIONS-ARRAY: key.kind:{{.*}}class
-// CHECK-DECLARATIONS-ARRAY-NEXT: key.usr
-// CHECK-DECLARATIONS-ARRAY-SAME: swift_mod
-// CHECK-DECLARATIONS-ARRAY-SAME: MyClass
+// CHECK-DECLARATIONS-ARRAY: key.kind:
+// CHECK-DECLARATIONS-ARRAY-SAME: decl
+// CHECK-DECLARATIONS-ARRAY-SAME: class
+// CHECK-DECLARATIONS-ARRAY-NEXT: key.usr:
+// could check for parts of the usr, but as the .response files always check for exact matches, do the same here
+// CHECK-DECLARATIONS-ARRAY-SAME: s:9swift_mod7MyClassC
+// check that offsets are there, but not zero, as that might mean offsets are broken (none of the declaration offsets in this file should be zero)
+// CHECK-DECLARATIONS-ARRAY-NOT: key.offset:{{.*}}{{^[0-9]}}0{{^[0-9]}}
+// CHECK-DECLARATIONS-ARRAY: key.offset
 
 // public func pub_method
-// CHECK-DECLARATIONS-ARRAY: key.kind:{{.*}}method.instance
-// CHECK-DECLARATIONS-ARRAY-NEXT: key.usr
-// CHECK-DECLARATIONS-ARRAY-SAME: swift_mod
-// CHECK-DECLARATIONS-ARRAY-SAME: MyClass
-// CHECK-DECLARATIONS-ARRAY-SAME: pub_method
+// CHECK-DECLARATIONS-ARRAY: key.kind:
+// CHECK-DECLARATIONS-ARRAY-SAME: decl
+// CHECK-DECLARATIONS-ARRAY-SAME: method.instance
+// CHECK-DECLARATIONS-ARRAY-NEXT: key.usr:
+// CHECK-DECLARATIONS-ARRAY-SAME: s:9swift_mod7MyClassC10pub_methodyyF
+// CHECK-DECLARATIONS-ARRAY-NOT: key.offset:{{.*}}{{^[0-9]}}0{{^[0-9]}}
+// CHECK-DECLARATIONS-ARRAY: key.offset
 
 // CHECK-DECLARATIONS-ARRAY-NOT: int_method
 // CHECK-DECLARATIONS-ARRAY-NOT: fp_method
 // CHECK-DECLARATIONS-ARRAY-NOT: priv_method
 
 // public protocol MyProto
-// CHECK-DECLARATIONS-ARRAY: key.kind:{{.*}}protocol
+// CHECK-DECLARATIONS-ARRAY: key.kind:
+// CHECK-DECLARATIONS-ARRAY-SAME: decl
+// CHECK-DECLARATIONS-ARRAY-SAME: protocol
 // CHECK-DECLARATIONS-ARRAY-NEXT: key.usr
-// CHECK-DECLARATIONS-ARRAY-SAME: swift_mod
-// CHECK-DECLARATIONS-ARRAY-SAME: MyProto
+// CHECK-DECLARATIONS-ARRAY-SAME: s:9swift_mod7MyProtoP
+// CHECK-DECLARATIONS-ARRAY-NOT: key.offset:{{.*}}{{^[0-9]}}0{{^[0-9]}}
+// CHECK-DECLARATIONS-ARRAY: key.offset
 
 // associatedtype Assoc
-// CHECK-DECLARATIONS-ARRAY: key.kind:{{.*}}associatedtype
+// CHECK-DECLARATIONS-ARRAY: key.kind:
+// CHECK-DECLARATIONS-ARRAY-SAME: decl
+// CHECK-DECLARATIONS-ARRAY-SAME: associatedtype
 // CHECK-DECLARATIONS-ARRAY-NEXT: key.usr
-// CHECK-DECLARATIONS-ARRAY-SAME: swift_mod
-// CHECK-DECLARATIONS-ARRAY-SAME: Assoc
+// CHECK-DECLARATIONS-ARRAY-SAME: s:9swift_mod7MyProtoP5AssocQa
+// CHECK-DECLARATIONS-ARRAY-NOT: key.offset:{{.*}}{{^[0-9]}}0{{^[0-9]}}
+// CHECK-DECLARATIONS-ARRAY: key.offset
 
 // public func pub_function
-// CHECK-DECLARATIONS-ARRAY: key.kind:{{.*}}function.free
+// CHECK-DECLARATIONS-ARRAY: key.kind:
+// CHECK-DECLARATIONS-ARRAY-SAME: decl
+// CHECK-DECLARATIONS-ARRAY-SAME: function.free
 // CHECK-DECLARATIONS-ARRAY-NEXT: key.usr
-// CHECK-DECLARATIONS-ARRAY-SAME: swift_mod
-// CHECK-DECLARATIONS-ARRAY-SAME: pub_function
+// CHECK-DECLARATIONS-ARRAY-SAME: s:9swift_mod12pub_functionSiyF
+// CHECK-DECLARATIONS-ARRAY-NOT: key.offset:{{.*}}{{^[0-9]}}0{{^[0-9]}}
+// CHECK-DECLARATIONS-ARRAY: key.offset
 
 // CHECK-DECLARATIONS-ARRAY-NOT: int_function
 // CHECK-DECLARATIONS-ARRAY-NOT: fp_function

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift
@@ -33,3 +33,51 @@ func f(s : inout [Int]) {
 // RUN: %swift -emit-module -o /dev/null -emit-module-interface-path %t.mod/swift_mod.swiftinterface -O %S/Inputs/swift_mod.swift -parse-as-library -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
 // RUN: %sourcekitd-test -req=interface-gen -module swift_mod -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.mod -module-cache-path %t.mod/mcp > %t.response
 // RUN: %diff -u %s.from_swiftinterface.response %t.response
+
+// Separately test whether the optional declarations array contains the expected information from Inputs/swift_mod.swift
+// RUN: %sourcekitd-test -req=interface-gen -req-opts=enabledeclarations=true -module swift_mod -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.mod -module-cache-path %t.mod/mcp | %FileCheck -check-prefix=CHECK-DECLARATIONS-ARRAY %s
+// check that the other arrays are still there as normal, by checking for a unique identifying member in each
+// CHECK-DECLARATIONS-ARRAY-DAG: key.kind:{{.*}}ref.associatedtype
+// CHECK-DECLARATIONS-ARRAY-DAG: key.kind:{{.*}}syntaxtype
+// CHECK-DECLARATIONS-ARRAY-DAG: key.substructure
+
+// CHECK-DECLARATIONS-ARRAY: {{^}}]{{$}}
+
+// public class MyClass
+// CHECK-DECLARATIONS-ARRAY: key.kind:{{.*}}class
+// CHECK-DECLARATIONS-ARRAY-NEXT: key.usr
+// CHECK-DECLARATIONS-ARRAY-SAME: swift_mod
+// CHECK-DECLARATIONS-ARRAY-SAME: MyClass
+
+// public func pub_method
+// CHECK-DECLARATIONS-ARRAY: key.kind:{{.*}}method.instance
+// CHECK-DECLARATIONS-ARRAY-NEXT: key.usr
+// CHECK-DECLARATIONS-ARRAY-SAME: swift_mod
+// CHECK-DECLARATIONS-ARRAY-SAME: MyClass
+// CHECK-DECLARATIONS-ARRAY-SAME: pub_method
+
+// CHECK-DECLARATIONS-ARRAY-NOT: int_method
+// CHECK-DECLARATIONS-ARRAY-NOT: fp_method
+// CHECK-DECLARATIONS-ARRAY-NOT: priv_method
+
+// public protocol MyProto
+// CHECK-DECLARATIONS-ARRAY: key.kind:{{.*}}protocol
+// CHECK-DECLARATIONS-ARRAY-NEXT: key.usr
+// CHECK-DECLARATIONS-ARRAY-SAME: swift_mod
+// CHECK-DECLARATIONS-ARRAY-SAME: MyProto
+
+// associatedtype Assoc
+// CHECK-DECLARATIONS-ARRAY: key.kind:{{.*}}associatedtype
+// CHECK-DECLARATIONS-ARRAY-NEXT: key.usr
+// CHECK-DECLARATIONS-ARRAY-SAME: swift_mod
+// CHECK-DECLARATIONS-ARRAY-SAME: Assoc
+
+// public func pub_function
+// CHECK-DECLARATIONS-ARRAY: key.kind:{{.*}}function.free
+// CHECK-DECLARATIONS-ARRAY-NEXT: key.usr
+// CHECK-DECLARATIONS-ARRAY-SAME: swift_mod
+// CHECK-DECLARATIONS-ARRAY-SAME: pub_function
+
+// CHECK-DECLARATIONS-ARRAY-NOT: int_function
+// CHECK-DECLARATIONS-ARRAY-NOT: fp_function
+// CHECK-DECLARATIONS-ARRAY-NOT: priv_function

--- a/tools/SourceKit/docs/Protocol.md
+++ b/tools/SourceKit/docs/Protocol.md
@@ -362,6 +362,7 @@ Welcome to SourceKit.  Type ':help' for assistance.
     <key.modulename>:       (string) // Full module name, e.g. "Foundation.NSArray"
     [opt] <key.compilerargs> [string*] // array of zero or more strings for the compiler arguments
                                        // e.g ["-sdk", "/path/to/sdk"]
+    [opt] <key.enabledeclarations> (int) // 0 by default, 1 to enable the declarations array in the output
 }
 ```
 
@@ -369,9 +370,11 @@ Welcome to SourceKit.  Type ':help' for assistance.
 
 This will return the Swift interface of the specified module.
 
-- `key.sourcetext`: The pretty-printed module interface in swift source code
+- `key.sourcetext`: The pretty-printed module interface in swift source code.
 - `key.syntaxmap`: An array of syntactic annotations, same as the one returned for the source.request.editor.open request.
 - `key.annotations`: An array of semantic annotations, same as the one returned for the source.request.editor.open request.
+- `key.substructure`: An array of dictionaries representing ranges of structural elements in the result description, such as the parameters of a function.
+- (optional, only if `key.enabledeclarations: 1`) `key.declarations`: An array of declarations, containing the kind, USR (if available), offset, and length of the declaration.
 
 All SourceKit requests that don't modify the source buffer should work on the
 opened document, by passing the associated 'name' for the document.

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -391,8 +391,8 @@ public:
   virtual void handleSemanticAnnotation(unsigned Offset, unsigned Length,
                                         UIdent Kind, bool isSystem) = 0;
 
-  virtual void handleDeclaration(unsigned Offset, unsigned Length,
-                                 UIdent Kind, StringRef USR) = 0;
+  virtual void handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind,
+                                 StringRef USR) = 0;
 
   virtual void beginDocumentSubStructure(unsigned Offset, unsigned Length,
                                          UIdent Kind, UIdent AccessLevel,

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -391,7 +391,8 @@ public:
   virtual void handleSemanticAnnotation(unsigned Offset, unsigned Length,
                                         UIdent Kind, bool isSystem) = 0;
 
-  virtual void handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind, StringRef USR) = 0;
+  virtual void handleDeclaration(unsigned Offset, unsigned Length,
+                                 UIdent Kind, StringRef USR) = 0;
 
   virtual void beginDocumentSubStructure(unsigned Offset, unsigned Length,
                                          UIdent Kind, UIdent AccessLevel,

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -391,6 +391,8 @@ public:
   virtual void handleSemanticAnnotation(unsigned Offset, unsigned Length,
                                         UIdent Kind, bool isSystem) = 0;
 
+  virtual void handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind, StringRef USR) = 0;
+
   virtual void beginDocumentSubStructure(unsigned Offset, unsigned Length,
                                          UIdent Kind, UIdent AccessLevel,
                                          UIdent SetterAccessLevel,

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -68,6 +68,7 @@ public:
     std::string Text;
     std::vector<TextReference> References;
     std::vector<TextDecl> Decls;
+    /// Do not clear the map or erase elements, without keeping the Decls vector in sync
     llvm::StringMap<TextDecl> USRMap;
   };
 
@@ -160,6 +161,9 @@ public:
         DeclUSRs.emplace_back(VD, USR);
         auto iterator = Info.USRMap.insert_or_assign(USR, Entry).first;
         // Set the USR in the declarations to the key in the USRMap, because the lifetime of that matches/exceeds the lifetime of Decls
+        // String keys in the StringMap are heap allocated and only get destroyed on explicit erase() or clear() calls, or on destructor calls
+        // (the ProgrammersManual description itself also states that StringMap "only ever copies a string if a value is inserted").
+        // Thus this never results in a dangling reference, as the USRMap is never cleared and no elements are erased in its lifetime.
         Info.Decls.back().USR = iterator->getKey();
       }
     }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -68,7 +68,8 @@ public:
     std::string Text;
     std::vector<TextReference> References;
     std::vector<TextDecl> Decls;
-    /// Do not clear the map or erase elements, without keeping the Decls vector in sync
+    /// Do not clear the map or erase elements,
+    /// without keeping the Decls vector in sync
     llvm::StringMap<TextDecl> USRMap;
   };
 
@@ -160,10 +161,14 @@ public:
         StringRef USR = OS.str();
         DeclUSRs.emplace_back(VD, USR);
         auto iterator = Info.USRMap.insert_or_assign(USR, Entry).first;
-        // Set the USR in the declarations to the key in the USRMap, because the lifetime of that matches/exceeds the lifetime of Decls
-        // String keys in the StringMap are heap allocated and only get destroyed on explicit erase() or clear() calls, or on destructor calls
-        // (the ProgrammersManual description itself also states that StringMap "only ever copies a string if a value is inserted").
-        // Thus this never results in a dangling reference, as the USRMap is never cleared and no elements are erased in its lifetime.
+        // Set the USR in the declarations to the key in the USRMap, because the
+        // lifetime of that matches/exceeds the lifetime of Decls String keys in
+        // the StringMap are heap allocated and only get destroyed on explicit
+        // erase() or clear() calls, or on destructor calls (the Programmer's
+        // Manual description itself also states that StringMap "only ever
+        // copies a string if a value is inserted").
+        // Thus this never results in a dangling reference, as the USRMap is
+        // never cleared and no elements are erased in its lifetime.
         Info.Decls.back().USR = iterator->getKey();
       }
     }
@@ -273,16 +278,18 @@ static void reportSemanticAnnotations(const SourceTextInfo &IFaceInfo,
   }
 }
 
-/// Create the declarations array (sourcekitd::DeclarationsArrayBuilder) from the SourceTextInfo about declarations
+/// Create the declarations array (sourcekitd::DeclarationsArrayBuilder) from
+/// the SourceTextInfo about declarations
 static void reportDeclarations(const SourceTextInfo &IFaceInfo,
-                                      EditorConsumer &Consumer) {
+                               EditorConsumer &Consumer) {
   for (auto &Dcl : IFaceInfo.Decls) {
-    if(!Dcl.Dcl)
+    if (!Dcl.Dcl)
       continue;
     UIdent Kind = SwiftLangSupport::getUIDForDecl(Dcl.Dcl);
     if (Kind.isInvalid())
       continue;
-    Consumer.handleDeclaration(Dcl.Range.Offset, Dcl.Range.Length, Kind, Dcl.USR);
+    Consumer.handleDeclaration(Dcl.Range.Offset, Dcl.Range.Length, Kind,
+                               Dcl.USR);
   }
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -162,11 +162,11 @@ public:
         DeclUSRs.emplace_back(VD, USR);
         auto iterator = Info.USRMap.insert_or_assign(USR, Entry).first;
         // Set the USR in the declarations to the key in the USRMap, because the
-        // lifetime of that matches/exceeds the lifetime of Decls String keys in
-        // the StringMap are heap allocated and only get destroyed on explicit
-        // erase() or clear() calls, or on destructor calls (the Programmer's
-        // Manual description itself also states that StringMap "only ever
-        // copies a string if a value is inserted").
+        // lifetime of that matches/exceeds the lifetime of Decls. String keys
+        // in the StringMap are heap allocated and only get destroyed on
+        // explicit erase() or clear() calls, or on destructor calls (the
+        // Programmer's Manual description itself also states that StringMap
+        // "only ever copies a string if a value is inserted").
         // Thus this never results in a dangling reference, as the USRMap is
         // never cleared and no elements are erased in its lifetime.
         Info.Decls.back().USR = iterator->getKey();

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -56,6 +56,8 @@ public:
     const Decl *Dcl = nullptr;
     /// The range in the interface source.
     TextRange Range;
+    /// The USR, if the declaration has one
+    StringRef USR;
 
     TextDecl(const Decl *D, TextRange Range)
       : Dcl(D), Range(Range) {}
@@ -155,8 +157,10 @@ public:
           OS << TargetUSR;
         }
         StringRef USR = OS.str();
-        Info.USRMap[USR] = Entry;
         DeclUSRs.emplace_back(VD, USR);
+        auto iterator = Info.USRMap.insert_or_assign(USR, Entry).first;
+        // Set the USR in the declarations to the key in the USRMap, because the lifetime of that matches/exceeds the lifetime of Decls
+        Info.Decls.back().USR = iterator->getKey();
       }
     }
   }
@@ -262,6 +266,19 @@ static void reportSemanticAnnotations(const SourceTextInfo &IFaceInfo,
     unsigned Offset = Ref.Range.Offset;
     unsigned Length = Ref.Range.Length;
     Consumer.handleSemanticAnnotation(Offset, Length, Kind, IsSystem);
+  }
+}
+
+/// Create the declarations array (sourcekitd::DeclarationsArrayBuilder) from the SourceTextInfo about declarations
+static void reportDeclarations(const SourceTextInfo &IFaceInfo,
+                                      EditorConsumer &Consumer) {
+  for (auto &Dcl : IFaceInfo.Decls) {
+    if(!Dcl.Dcl)
+      continue;
+    UIdent Kind = SwiftLangSupport::getUIDForDecl(Dcl.Dcl);
+    if (Kind.isInvalid())
+      continue;
+    Consumer.handleDeclaration(Dcl.Range.Offset, Dcl.Range.Length, Kind, Dcl.USR);
   }
 }
 
@@ -593,6 +610,8 @@ void SwiftInterfaceGenContext::reportEditorInfo(EditorConsumer &Consumer) const 
   reportSyntacticAnnotations(Impl.TextCI, Consumer);
   reportDocumentStructure(Impl.TextCI, Consumer);
   reportSemanticAnnotations(Impl.Info, Consumer);
+
+  reportDeclarations(Impl.Info, Consumer);
   Consumer.finished();
 }
 

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -2456,11 +2456,12 @@ static void printInterfaceGen(sourcekitd_variant_t Info, bool CheckASCII) {
   sourcekitd_variant_t structure =
       sourcekitd_variant_dictionary_get_value(Info, KeySubStructure);
   printRawVariant(structure);
-  sourcekitd_variant_t declarations = 
+  sourcekitd_variant_t declarations =
       sourcekitd_variant_dictionary_get_value(Info, KeyDeclarations);
-  // only output declarations if there are any (because this might have been disabled in the request itself)
-  if(sourcekitd_variant_get_type(declarations) != SOURCEKITD_VARIANT_TYPE_NULL)
-      printRawVariant(declarations);
+  // only output declarations if there are any (because this might have been
+  // disabled in the request itself)
+  if (sourcekitd_variant_get_type(declarations) != SOURCEKITD_VARIANT_TYPE_NULL)
+    printRawVariant(declarations);
 }
 
 static void printRelatedIdents(sourcekitd_variant_t Info, StringRef Filename,

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1069,6 +1069,9 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
                                                Opts.InterestedUSR.c_str());
     if (!Opts.USR.empty())
       sourcekitd_request_dictionary_set_string(Req, KeyUSR, Opts.USR.c_str());
+
+    // add possible EnableDeclarations in particular
+    addRequestOptionsDirect(Req, Opts);
     break;
 
   case SourceKitRequest::FindInterfaceDoc:
@@ -2453,6 +2456,11 @@ static void printInterfaceGen(sourcekitd_variant_t Info, bool CheckASCII) {
   sourcekitd_variant_t structure =
       sourcekitd_variant_dictionary_get_value(Info, KeySubStructure);
   printRawVariant(structure);
+  sourcekitd_variant_t declarations = 
+      sourcekitd_variant_dictionary_get_value(Info, KeyDeclarations);
+  // only output declarations if there are any (because this might have been disabled in the request itself)
+  if(sourcekitd_variant_get_type(declarations) != SOURCEKITD_VARIANT_TYPE_NULL)
+      printRawVariant(declarations);
 }
 
 static void printRelatedIdents(sourcekitd_variant_t Info, StringRef Filename,

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DeclarationsArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DeclarationsArray.h
@@ -28,9 +28,7 @@ public:
   DeclarationsArrayBuilder();
   ~DeclarationsArrayBuilder();
 
-  void add(SourceKit::UIdent Kind,
-           unsigned Offset,
-           unsigned Length,
+  void add(SourceKit::UIdent Kind, unsigned Offset, unsigned Length,
            llvm::StringRef USR);
 
   bool empty() const;

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DeclarationsArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DeclarationsArray.h
@@ -1,0 +1,47 @@
+//===--- DeclarationsArray.h - ----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// This is an array used in the response to editor.open.interface requests.
+// It contains all declarations, identified by their Kind, Offset, and Length,
+// and optionally includes a USR, if the declaration has one.
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_SOURCEKITD_DECLARATIONS_ARRAY_H
+#define LLVM_SOURCEKITD_DECLARATIONS_ARRAY_H
+
+#include "sourcekitd/Internal.h"
+
+namespace sourcekitd {
+
+VariantFunctions *getVariantFunctionsForDeclarationsArray();
+
+/// Builds an array for declarations by kind, offset, length, and optionally USR
+class DeclarationsArrayBuilder {
+public:
+  DeclarationsArrayBuilder();
+  ~DeclarationsArrayBuilder();
+
+  void add(SourceKit::UIdent Kind,
+           unsigned Offset,
+           unsigned Length,
+           llvm::StringRef USR);
+
+  bool empty() const;
+
+  std::unique_ptr<llvm::MemoryBuffer> createBuffer();
+
+private:
+  struct Implementation;
+  Implementation &Impl;
+};
+
+} // namespace sourcekitd
+
+#endif

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -49,6 +49,7 @@ static const unsigned ProtocolMinorVersion = 0;
 
 enum class CustomBufferKind {
   TokenAnnotationsArray,
+  DeclarationsArray,
   DocSupportAnnotationArray,
   CodeCompletionResultsArray,
   DocStructureArray,

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -9,6 +9,7 @@ add_sourcekit_library(sourcekitdAPI
   DocSupportAnnotationArray.cpp
   RawData.cpp
   sourcekitdAPI-Common.cpp
+  DeclarationsArray.cpp
   TokenAnnotationsArray.cpp
   ExpressionTypeArray.cpp
   VariableTypeArray.cpp

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DeclarationsArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DeclarationsArray.cpp
@@ -148,7 +148,8 @@ struct CompactVariantFuncs<DeclarationsArray> {
 
   template <typename FnTy>
   static auto getElement(sourcekitd_variant_t dict, sourcekitd_uid_t key,
-                const FnTy &Fn) -> decltype(Fn(nullptr, nullptr, 0, 0, nullptr)) {
+                const FnTy &Fn) -> decltype(Fn(nullptr, nullptr, 0, 0,
+                                               nullptr)) {
     void *Buf = (void*)dict.data[1];
     size_t Index = dict.data[2];
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DeclarationsArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DeclarationsArray.cpp
@@ -1,0 +1,231 @@
+//===--- DeclarationsArray.cpp --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "sourcekitd/DeclarationsArray.h"
+#include "SourceKit/Core/LLVM.h"
+#include "SourceKit/Support/UIdent.h"
+#include "sourcekitd/CompactArray.h"
+#include "sourcekitd/DictionaryKeys.h"
+
+#include "llvm/Support/MemoryBuffer.h"
+
+using namespace SourceKit;
+using namespace sourcekitd;
+
+struct DeclarationsArrayBuilder::Implementation {
+  CompactArrayBuilder<UIdent,
+                      unsigned,
+                      unsigned,
+                      StringRef> Builder;
+};
+
+DeclarationsArrayBuilder::DeclarationsArrayBuilder()
+  : Impl(*new Implementation()) {
+
+}
+
+DeclarationsArrayBuilder::~DeclarationsArrayBuilder() {
+  delete &Impl;
+}
+
+void DeclarationsArrayBuilder::add(
+    UIdent Kind,
+    unsigned Offset,
+    unsigned Length,
+    StringRef USR) {
+
+  Impl.Builder.addEntry(Kind,
+                        Offset,
+                        Length,
+                        USR);
+}
+
+bool DeclarationsArrayBuilder::empty() const {
+  return Impl.Builder.empty();
+}
+
+std::unique_ptr<llvm::MemoryBuffer>
+DeclarationsArrayBuilder::createBuffer() {
+  return Impl.Builder.createBuffer(CustomBufferKind::DeclarationsArray);
+}
+
+namespace {
+
+class DeclarationsArray {
+public:
+  typedef CompactArrayReader<sourcekitd_uid_t,
+                             unsigned,
+                             unsigned,
+                             const char*> CompactArrayReaderTy;
+
+  static void readElements(void *Buf, size_t Index,
+                           sourcekitd_uid_t &Kind,
+                           unsigned &Offset,
+                           unsigned &Length,
+                           const char* &USR) {
+    CompactArrayReaderTy Reader(Buf);
+    Reader.readEntries(Index,
+                   Kind,
+                   Offset,
+                   Length,
+                   USR);
+  }
+
+  static bool apply(sourcekitd_uid_t Kind,
+                    unsigned Offset,
+                    unsigned Length,
+                    const char* USR,
+                    llvm::function_ref<bool(sourcekitd_uid_t,
+                                            sourcekitd_variant_t)> applier) {
+
+#define APPLY(K, Ty, Field)                              \
+  do {                                                   \
+    sourcekitd_uid_t key = SKDUIDFromUIdent(K);          \
+    sourcekitd_variant_t var = make##Ty##Variant(Field); \
+    if (!applier(key, var)) return false;                \
+  } while (0)
+
+    APPLY(KeyKind, UID, Kind);
+    APPLY(KeyOffset, Int, Offset);
+    APPLY(KeyLength, Int, Length);
+    if (USR != nullptr && std::strcmp(USR, "") != 0)
+      APPLY(KeyUSR, String, USR);
+
+    return true;
+  }
+
+  static int64_t getInt(sourcekitd_uid_t Key,
+                        sourcekitd_uid_t Kind,
+                        unsigned Offset,
+                        unsigned Length,
+                        const char* USR) {
+    if (Key == SKDUIDFromUIdent(KeyOffset))
+      return Offset;
+    if (Key == SKDUIDFromUIdent(KeyLength))
+      return Length;
+    return 0;
+  }
+
+  static sourcekitd_uid_t getUID(sourcekitd_uid_t Key,
+                                 sourcekitd_uid_t Kind,
+                                 unsigned Offset,
+                                 unsigned Length,
+                                 const char* USR) {
+    if (Key == SKDUIDFromUIdent(KeyKind))
+      return Kind;
+    return nullptr;
+  }
+
+  static const char* getString(sourcekitd_uid_t Key,
+                                 sourcekitd_uid_t Kind,
+                                 unsigned Offset,
+                                 unsigned Length,
+                                 const char* USR) {
+    if (Key == SKDUIDFromUIdent(KeyUSR))
+      return USR;
+    return nullptr;
+  }
+};
+
+} // end anonymous namespace
+
+namespace sourcekitd {
+
+template <>
+struct CompactVariantFuncs<DeclarationsArray> {
+  static sourcekitd_variant_type_t get_type(sourcekitd_variant_t var) {
+    return SOURCEKITD_VARIANT_TYPE_DICTIONARY;
+  }
+
+  template <typename FnTy>
+  static auto getElement(sourcekitd_variant_t dict, sourcekitd_uid_t key,
+                const FnTy &Fn) -> decltype(Fn(nullptr, nullptr, 0, 0, nullptr)) {
+    void *Buf = (void*)dict.data[1];
+    size_t Index = dict.data[2];
+
+    sourcekitd_uid_t Kind;
+    unsigned Offset;
+    unsigned Length;
+    const char* USR;
+    DeclarationsArray::readElements(Buf, Index,
+                                        Kind, Offset, Length, USR);
+
+    return Fn(key, Kind, Offset, Length, USR);
+  }
+  
+  static bool
+  dictionary_apply(sourcekitd_variant_t dict,
+                   llvm::function_ref<bool(sourcekitd_uid_t,
+                                           sourcekitd_variant_t)> applier) {
+    void *Buf = (void*)dict.data[1];
+    size_t Index = dict.data[2];
+
+    sourcekitd_uid_t Kind;
+    unsigned Offset;
+    unsigned Length;
+    const char* USR;
+    DeclarationsArray::readElements(Buf, Index,
+                                        Kind, Offset, Length, USR);
+    return DeclarationsArray::apply(Kind, Offset, Length, USR, applier);
+  }
+
+  static int64_t dictionary_get_int64(sourcekitd_variant_t dict,
+                                      sourcekitd_uid_t key) {
+
+    return getElement(dict, key, DeclarationsArray::getInt);
+  }
+
+  static sourcekitd_uid_t dictionary_get_uid(sourcekitd_variant_t dict,
+                                             sourcekitd_uid_t key) {
+
+    return getElement(dict, key, DeclarationsArray::getUID);
+  }
+
+  static const char* dictionary_get_string(sourcekitd_variant_t dict,
+                                                sourcekitd_uid_t key) {
+
+    return getElement(dict, key, DeclarationsArray::getString);
+  }
+
+  static VariantFunctions Funcs;
+};
+
+VariantFunctions CompactVariantFuncs<DeclarationsArray>::Funcs = {
+  get_type,
+  nullptr/*Annot_array_apply*/,
+  nullptr/*Annot_array_get_bool*/,
+  nullptr/*Annot_array_get_count*/,
+  nullptr/*Annot_array_get_int64*/,
+  nullptr/*Annot_array_get_string*/,
+  nullptr/*Annot_array_get_uid*/,
+  nullptr/*Annot_array_get_value*/,
+  nullptr/*Annot_bool_get_value*/,
+  dictionary_apply,
+  nullptr/*Annot_dictionary_get_bool*/,
+  dictionary_get_int64,
+  dictionary_get_string,
+  nullptr/*Annot_dictionary_get_value*/,
+  dictionary_get_uid,
+  nullptr/*Annot_string_get_length*/,
+  nullptr/*Annot_string_get_ptr*/,
+  nullptr/*Annot_int64_get_value*/,
+  nullptr/*Annot_uid_get_value*/,
+  nullptr/*Annot_data_get_size*/,
+  nullptr/*Annot_data_get_ptr*/,
+};
+
+} // namespace sourcekitd
+
+VariantFunctions *
+sourcekitd::getVariantFunctionsForDeclarationsArray() {
+  return &CompactArrayFuncs<DeclarationsArray>::Funcs;
+}

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
@@ -10,24 +10,24 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "sourcekitd/DeclarationsArray.h"
-#include "sourcekitd/DictionaryKeys.h"
-#include "sourcekitd/Internal.h"
-#include "sourcekitd/CodeCompletionResultsArray.h"
-#include "sourcekitd/DocStructureArray.h"
-#include "sourcekitd/DocSupportAnnotationArray.h"
-#include "sourcekitd/RawData.h"
-#include "sourcekitd/TokenAnnotationsArray.h"
-#include "sourcekitd/ExpressionTypeArray.h"
-#include "sourcekitd/VariableTypeArray.h"
-#include "sourcekitd/Logging.h"
 #include "SourceKit/Core/LLVM.h"
 #include "SourceKit/Support/UIdent.h"
-#include "swift/Basic/ThreadSafeRefCounted.h"
+#include "sourcekitd/CodeCompletionResultsArray.h"
+#include "sourcekitd/DeclarationsArray.h"
+#include "sourcekitd/DictionaryKeys.h"
+#include "sourcekitd/DocStructureArray.h"
+#include "sourcekitd/DocSupportAnnotationArray.h"
+#include "sourcekitd/ExpressionTypeArray.h"
+#include "sourcekitd/Internal.h"
+#include "sourcekitd/Logging.h"
+#include "sourcekitd/RawData.h"
+#include "sourcekitd/TokenAnnotationsArray.h"
+#include "sourcekitd/VariableTypeArray.h"
 #include "swift/Basic/StringExtras.h"
+#include "swift/Basic/ThreadSafeRefCounted.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/StringRef.h"
 
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -979,8 +979,9 @@ static sourcekitd_variant_t variantFromSKDObject(SKDObjectRef Object) {
         return {{ (uintptr_t)getVariantFunctionsForTokenAnnotationsArray(),
           (uintptr_t)DataObject->getDataPtr(), 0 }};
       case CustomBufferKind::DeclarationsArray:
-        return {{ (uintptr_t)sourcekitd::getVariantFunctionsForDeclarationsArray(),
-          (uintptr_t)DataObject->getDataPtr(), 0 }};
+        return {
+            {(uintptr_t)sourcekitd::getVariantFunctionsForDeclarationsArray(),
+             (uintptr_t)DataObject->getDataPtr(), 0}};
       case CustomBufferKind::DocSupportAnnotationArray:
         return {{ (uintptr_t)getVariantFunctionsForDocSupportAnnotationArray(),
           (uintptr_t)DataObject->getDataPtr(), 0 }};

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "sourcekitd/DeclarationsArray.h"
 #include "sourcekitd/DictionaryKeys.h"
 #include "sourcekitd/Internal.h"
 #include "sourcekitd/CodeCompletionResultsArray.h"
@@ -247,6 +248,7 @@ public:
   sourcekitd_variant_type_t getVariantType() const override {
     switch (getBufferKind()) {
       case CustomBufferKind::TokenAnnotationsArray:
+      case CustomBufferKind::DeclarationsArray:
       case CustomBufferKind::DocSupportAnnotationArray:
       case CustomBufferKind::CodeCompletionResultsArray:
       case CustomBufferKind::DocStructureArray:
@@ -975,6 +977,9 @@ static sourcekitd_variant_t variantFromSKDObject(SKDObjectRef Object) {
     switch(DataObject->getBufferKind()) {
       case CustomBufferKind::TokenAnnotationsArray:
         return {{ (uintptr_t)getVariantFunctionsForTokenAnnotationsArray(),
+          (uintptr_t)DataObject->getDataPtr(), 0 }};
+      case CustomBufferKind::DeclarationsArray:
+        return {{ (uintptr_t)sourcekitd::getVariantFunctionsForDeclarationsArray(),
           (uintptr_t)DataObject->getDataPtr(), 0 }};
       case CustomBufferKind::DocSupportAnnotationArray:
         return {{ (uintptr_t)getVariantFunctionsForDocSupportAnnotationArray(),

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -10,17 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "SourceKit/Support/UIdent.h"
 #include "sourcekitd/CodeCompletionResultsArray.h"
+#include "sourcekitd/DeclarationsArray.h"
 #include "sourcekitd/DictionaryKeys.h"
 #include "sourcekitd/DocStructureArray.h"
 #include "sourcekitd/DocSupportAnnotationArray.h"
-#include "sourcekitd/TokenAnnotationsArray.h"
 #include "sourcekitd/ExpressionTypeArray.h"
-#include "sourcekitd/VariableTypeArray.h"
-#include "sourcekitd/DeclarationsArray.h"
 #include "sourcekitd/RawData.h"
 #include "sourcekitd/RequestResponsePrinterBase.h"
-#include "SourceKit/Support/UIdent.h"
+#include "sourcekitd/TokenAnnotationsArray.h"
+#include "sourcekitd/VariableTypeArray.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -771,8 +771,8 @@ static sourcekitd_variant_t variantFromXPCObject(xpc_object_t obj) {
       return {{ (uintptr_t)getVariantFunctionsForTokenAnnotationsArray(),
                 (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
     case CustomBufferKind::DeclarationsArray:
-      return {{ (uintptr_t)getVariantFunctionsForDeclarationsArray(),
-                (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
+      return {{(uintptr_t)getVariantFunctionsForDeclarationsArray(),
+               (uintptr_t)CUSTOM_BUF_START(obj), 0}};
     case CustomBufferKind::DocSupportAnnotationArray:
       return {{ (uintptr_t)getVariantFunctionsForDocSupportAnnotationArray(),
                 (uintptr_t)CUSTOM_BUF_START(obj), 0 }};

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -11,13 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "sourcekitd/CodeCompletionResultsArray.h"
-#include "sourcekitd/DeclarationsArray.h"
 #include "sourcekitd/DictionaryKeys.h"
 #include "sourcekitd/DocStructureArray.h"
 #include "sourcekitd/DocSupportAnnotationArray.h"
 #include "sourcekitd/TokenAnnotationsArray.h"
 #include "sourcekitd/ExpressionTypeArray.h"
 #include "sourcekitd/VariableTypeArray.h"
+#include "sourcekitd/DeclarationsArray.h"
 #include "sourcekitd/RawData.h"
 #include "sourcekitd/RequestResponsePrinterBase.h"
 #include "SourceKit/Support/UIdent.h"

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "sourcekitd/CodeCompletionResultsArray.h"
+#include "sourcekitd/DeclarationsArray.h"
 #include "sourcekitd/DictionaryKeys.h"
 #include "sourcekitd/DocStructureArray.h"
 #include "sourcekitd/DocSupportAnnotationArray.h"
@@ -618,11 +619,9 @@ static sourcekitd_variant_type_t XPCVar_get_type(sourcekitd_variant_t var) {
   if (type == XPC_TYPE_DATA) {
     switch(CUSTOM_BUF_KIND(obj)) {
     case CustomBufferKind::TokenAnnotationsArray:
-      return SOURCEKITD_VARIANT_TYPE_ARRAY;
+    case CustomBufferKind::DeclarationsArray:
     case CustomBufferKind::DocSupportAnnotationArray:
-      return SOURCEKITD_VARIANT_TYPE_ARRAY;
     case CustomBufferKind::CodeCompletionResultsArray:
-      return SOURCEKITD_VARIANT_TYPE_ARRAY;
     case CustomBufferKind::DocStructureArray:
     case CustomBufferKind::InheritedTypesArray:
     case CustomBufferKind::DocStructureElementArray:
@@ -770,6 +769,9 @@ static sourcekitd_variant_t variantFromXPCObject(xpc_object_t obj) {
     switch(CUSTOM_BUF_KIND(obj)) {
     case CustomBufferKind::TokenAnnotationsArray:
       return {{ (uintptr_t)getVariantFunctionsForTokenAnnotationsArray(),
+                (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
+    case CustomBufferKind::DeclarationsArray:
+      return {{ (uintptr_t)getVariantFunctionsForDeclarationsArray(),
                 (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
     case CustomBufferKind::DocSupportAnnotationArray:
       return {{ (uintptr_t)getVariantFunctionsForDocSupportAnnotationArray(),

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -3774,7 +3774,8 @@ void SKEditorConsumer::handleSemanticAnnotation(unsigned Offset,
 void SKEditorConsumer::handleDeclaration(unsigned Offset, unsigned Length,
                                          UIdent Kind, StringRef USR) {
   assert(Kind.isValid());
-  Declarations.add(Kind, Offset, Length, USR);
+  if(this->Opts.EnableDeclarations)
+      Declarations.add(Kind, Offset, Length, USR);
 }
 
 void

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -280,10 +280,12 @@ editorOpenHeaderInterface(StringRef Name, StringRef HeaderName,
                           StringRef swiftVersion,
                           bool EnableDeclarations);
 
-static void editorOpenSwiftSourceInterface(
-    StringRef Name, StringRef SourceName, ArrayRef<const char *> Args,
-    SourceKitCancellationToken CancellationToken, ResponseReceiver Rec,
-    bool EnableDeclarations);
+static void
+editorOpenSwiftSourceInterface(StringRef Name, StringRef SourceName,
+                               ArrayRef<const char *> Args,
+                               SourceKitCancellationToken CancellationToken,
+                               ResponseReceiver Rec,
+                               bool EnableDeclarations);
 
 static void
 editorOpenSwiftTypeInterface(StringRef TypeUsr, ArrayRef<const char *> Args,
@@ -941,7 +943,8 @@ handleRequestEditorOpenInterface(const RequestDict &Req,
     Req.getInt64(KeySynthesizedExtension, SynthesizedExtension,
                  /*isOptional=*/true);
     std::optional<StringRef> InterestedUSR = Req.getString(KeyInterestedUSR);
-    bool EnableDeclarations = Req.getOptionalInt64(KeyEnableDeclarations).value_or(false);
+    bool EnableDeclarations =
+        Req.getOptionalInt64(KeyEnableDeclarations).value_or(false);
     return Rec(editorOpenInterface(*Name, *ModuleName, GroupName, Args,
                                    SynthesizedExtension, InterestedUSR,
                                    EnableDeclarations));
@@ -976,11 +979,11 @@ static void handleRequestEditorOpenHeaderInterface(
       if (swiftVerVal.has_value())
         swiftVer = std::to_string(*swiftVerVal);
     }
-    bool EnableDeclarations = Req.getOptionalInt64(KeyEnableDeclarations).value_or(false);
-    return Rec(editorOpenHeaderInterface(*Name, *HeaderName, Args,
-                                         UsingSwiftArgs.value_or(false),
-                                         SynthesizedExtension, swiftVer,
-                                         EnableDeclarations));
+    bool EnableDeclarations =
+        Req.getOptionalInt64(KeyEnableDeclarations).value_or(false);
+    return Rec(editorOpenHeaderInterface(
+        *Name, *HeaderName, Args, UsingSwiftArgs.value_or(false),
+        SynthesizedExtension, swiftVer, EnableDeclarations));
   }
 }
 
@@ -998,10 +1001,10 @@ static void handleRequestEditorOpenSwiftSourceInterface(
     if (!FileName.has_value())
       return Rec(createErrorRequestInvalid("missing 'key.sourcefile'"));
     // Reporting the declarations array is off by default
-    bool EnableDeclarations = Req.getOptionalInt64(KeyEnableDeclarations).value_or(false);
-    return editorOpenSwiftSourceInterface(*Name, *FileName, Args,
-                                          CancellationToken, Rec,
-                                          EnableDeclarations);
+    bool EnableDeclarations =
+        Req.getOptionalInt64(KeyEnableDeclarations).value_or(false);
+    return editorOpenSwiftSourceInterface(
+        *Name, *FileName, Args, CancellationToken, Rec, EnableDeclarations);
   }
 }
 
@@ -3550,7 +3553,8 @@ public:
   void handleSemanticAnnotation(unsigned Offset, unsigned Length, UIdent Kind,
                                 bool isSystem) override;
 
-  void handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind, StringRef USR) override;
+  void handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind,
+                         StringRef USR) override;
 
   bool documentStructureEnabled() override { return Opts.EnableStructure; }
 
@@ -3743,10 +3747,9 @@ sourcekitd_response_t SKEditorConsumer::createResponse() {
   if (Opts.EnableStructure) {
     Dict.setCustomBuffer(KeySubStructure, DocStructure.createBuffer());
   }
-  if(Opts.EnableDeclarations){
+  if (Opts.EnableDeclarations) {
     Dict.setCustomBuffer(KeyDeclarations, Declarations.createBuffer());
   }
-
 
   return RespBuilder.createResponse();
 }
@@ -3776,7 +3779,8 @@ void SKEditorConsumer::handleSemanticAnnotation(unsigned Offset,
   SemanticAnnotations.add(Kind, Offset, Length, isSystem);
 }
 
-void SKEditorConsumer::handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind, StringRef USR) {
+void SKEditorConsumer::handleDeclaration(unsigned Offset, unsigned Length,
+                                         UIdent Kind, StringRef USR) {
   assert(Kind.isValid());
   Declarations.add(Kind, Offset, Length, USR);
 }

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -10,14 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "sourcekitd/DeclarationsArray.h"
-#include "sourcekitd/Service.h"
 #include "sourcekitd/CodeCompletionResultsArray.h"
+#include "sourcekitd/DeclarationsArray.h"
 #include "sourcekitd/DictionaryKeys.h"
 #include "sourcekitd/DocStructureArray.h"
 #include "sourcekitd/DocSupportAnnotationArray.h"
-#include "sourcekitd/TokenAnnotationsArray.h"
 #include "sourcekitd/ExpressionTypeArray.h"
+#include "sourcekitd/Service.h"
+#include "sourcekitd/TokenAnnotationsArray.h"
 #include "sourcekitd/VariableTypeArray.h"
 
 #include "SourceKit/Core/Context.h"
@@ -265,27 +265,22 @@ static sourcekitd_response_t editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
                                         ArrayRef<const char *> Args,
                                         std::optional<VFSOptions> vfsOptions);
 
-static sourcekitd_response_t
-editorOpenInterface(StringRef Name, StringRef ModuleName,
-                    std::optional<StringRef> Group, ArrayRef<const char *> Args,
-                    bool SynthesizedExtensions,
-                    std::optional<StringRef> InterestedUSR,
-                    bool EnableDeclarations);
+static sourcekitd_response_t editorOpenInterface(
+    StringRef Name, StringRef ModuleName, std::optional<StringRef> Group,
+    ArrayRef<const char *> Args, bool SynthesizedExtensions,
+    std::optional<StringRef> InterestedUSR, bool EnableDeclarations);
 
 static sourcekitd_response_t
 editorOpenHeaderInterface(StringRef Name, StringRef HeaderName,
-                          ArrayRef<const char *> Args,
-                          bool UsingSwiftArgs,
-                          bool SynthesizedExtensions,
-                          StringRef swiftVersion,
+                          ArrayRef<const char *> Args, bool UsingSwiftArgs,
+                          bool SynthesizedExtensions, StringRef swiftVersion,
                           bool EnableDeclarations);
 
 static void
 editorOpenSwiftSourceInterface(StringRef Name, StringRef SourceName,
                                ArrayRef<const char *> Args,
                                SourceKitCancellationToken CancellationToken,
-                               ResponseReceiver Rec,
-                               bool EnableDeclarations);
+                               ResponseReceiver Rec, bool EnableDeclarations);
 
 static void
 editorOpenSwiftTypeInterface(StringRef TypeUsr, ArrayRef<const char *> Args,
@@ -3610,12 +3605,10 @@ static sourcekitd_response_t editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
   return EditC.createResponse();
 }
 
-static sourcekitd_response_t
-editorOpenInterface(StringRef Name, StringRef ModuleName,
-                    std::optional<StringRef> Group, ArrayRef<const char *> Args,
-                    bool SynthesizedExtensions,
-                    std::optional<StringRef> InterestedUSR,
-                    bool EnableDeclarations) {
+static sourcekitd_response_t editorOpenInterface(
+    StringRef Name, StringRef ModuleName, std::optional<StringRef> Group,
+    ArrayRef<const char *> Args, bool SynthesizedExtensions,
+    std::optional<StringRef> InterestedUSR, bool EnableDeclarations) {
   SKEditorConsumerOptions Opts;
   Opts.EnableSyntaxMap = true;
   Opts.EnableStructure = true;
@@ -3629,10 +3622,11 @@ editorOpenInterface(StringRef Name, StringRef ModuleName,
 
 /// Getting the interface from a swift source file differs from getting interfaces
 /// from headers or modules for its performing asynchronously.
-static void editorOpenSwiftSourceInterface(
-    StringRef Name, StringRef HeaderName, ArrayRef<const char *> Args,
-    SourceKitCancellationToken CancellationToken, ResponseReceiver Rec,
-    bool EnableDeclarations) {
+static void
+editorOpenSwiftSourceInterface(StringRef Name, StringRef HeaderName,
+                               ArrayRef<const char *> Args,
+                               SourceKitCancellationToken CancellationToken,
+                               ResponseReceiver Rec, bool EnableDeclarations) {
   SKEditorConsumerOptions Opts;
   Opts.EnableSyntaxMap = true;
   Opts.EnableStructure = true;
@@ -3674,10 +3668,8 @@ static sourcekitd_response_t editorConvertMarkupToXML(StringRef Source) {
 
 static sourcekitd_response_t
 editorOpenHeaderInterface(StringRef Name, StringRef HeaderName,
-                          ArrayRef<const char *> Args,
-                          bool UsingSwiftArgs,
-                          bool SynthesizedExtensions,
-                          StringRef swiftVersion,
+                          ArrayRef<const char *> Args, bool UsingSwiftArgs,
+                          bool SynthesizedExtensions, StringRef swiftVersion,
                           bool EnableDeclarations) {
   SKEditorConsumerOptions Opts;
   Opts.EnableSyntaxMap = true;

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -69,7 +69,8 @@ private:
     Annotations.push_back({Offset, Length, Kind, isSystem});
   }
 
-  void handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind, StringRef USR) override {}
+  void handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind,
+                         StringRef USR) override {}
 
   bool documentStructureEnabled() override { return false; }
 

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -69,6 +69,8 @@ private:
     Annotations.push_back({Offset, Length, Kind, isSystem});
   }
 
+  void handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind, StringRef USR) override {}
+
   bool documentStructureEnabled() override { return false; }
 
   void beginDocumentSubStructure(unsigned Offset, unsigned Length,

--- a/unittests/SourceKit/SwiftLang/NullEditorConsumer.h
+++ b/unittests/SourceKit/SwiftLang/NullEditorConsumer.h
@@ -29,7 +29,8 @@ class NullEditorConsumer : public EditorConsumer {
   void handleSemanticAnnotation(unsigned Offset, unsigned Length, UIdent Kind,
                                 bool isSystem) override {}
 
-  void handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind, StringRef USR) override {}
+  void handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind,
+                         StringRef USR) override {}
 
   bool documentStructureEnabled() override { return false; }
 

--- a/unittests/SourceKit/SwiftLang/NullEditorConsumer.h
+++ b/unittests/SourceKit/SwiftLang/NullEditorConsumer.h
@@ -29,6 +29,8 @@ class NullEditorConsumer : public EditorConsumer {
   void handleSemanticAnnotation(unsigned Offset, unsigned Length, UIdent Kind,
                                 bool isSystem) override {}
 
+  void handleDeclaration(unsigned Offset, unsigned Length, UIdent Kind, StringRef USR) override {}
+
   bool documentStructureEnabled() override { return false; }
 
   void beginDocumentSubStructure(

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -67,6 +67,8 @@ UID_KEYS = [
     KEY('ModuleImportDepth', 'key.moduleimportdepth'),
     KEY('NumBytesToErase', 'key.num_bytes_to_erase'),
     KEY('NotRecommended', 'key.not_recommended'),
+    KEY('Declarations', 'key.declarations'),
+    KEY('EnableDeclarations', 'key.enabledeclarations'),
     KEY('Annotations', 'key.annotations'),
     KEY('SemanticTokens', 'key.semantic_tokens'),
     KEY('DiagnosticStage', 'key.diagnostic_stage'),


### PR DESCRIPTION
Introduces the new `DeclarationsArrayBuilder` and adds it to the EditorConsumer. Declaration info always includes a kind, offset, and length, and includes a USR where applicable.
As the USR is already available for editor.open.interface type requests, this doesn't compute any new information, it just exposes more of what's there already.

The array can be enabled by setting `key.enabledeclarations` to true.