### PR TITLE
[cxx-interop] Support operator[] with multiple parameters

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1659,6 +1659,10 @@ void DeclAndTypeClangFunctionPrinter::printCxxSubscriptAccessorMethod(
     Type resultTy, bool isDefinition,
     std::optional<IRABIDetailsProvider::MethodDispatchInfo> dispatchInfo) {
   assert(accessor->isGetter());
+  // operator[] with multiple parameters only supported C++23 and up.
+  bool multiParam = accessor->getParameters()->size() > 1;
+  if (multiParam)
+    os << "#if __cplusplus >= 202302L\n";
   FunctionSignatureModifiers modifiers;
   if (isDefinition)
     modifiers.qualifierContext = typeDeclContext;
@@ -1671,6 +1675,8 @@ void DeclAndTypeClangFunctionPrinter::printCxxSubscriptAccessorMethod(
   declAndTypePrinter.printAvailability(os, accessor->getStorage());
   if (!isDefinition) {
     os << ";\n";
+    if (multiParam)
+      os << "#endif // #if __cplusplus >= 202302L\n";
     return;
   }
   os << " {\n";
@@ -1680,6 +1686,8 @@ void DeclAndTypeClangFunctionPrinter::printCxxSubscriptAccessorMethod(
       accessor->getModuleContext(), resultTy, accessor->getParameters(),
       /*hasThrows=*/false, nullptr, /*isStatic=*/false, dispatchInfo);
   os << "  }\n";
+  if (multiParam)
+    os << "#endif // #if __cplusplus >= 202302L\n";
 }
 
 bool DeclAndTypeClangFunctionPrinter::hasKnownOptionalNullableCxxMapping(

--- a/test/Interop/SwiftToCxx/functions/swift-operators.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-operators.swift
@@ -3,6 +3,7 @@
 // RUN: %FileCheck %s < %t/operators.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/operators.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+// RUN: %check-interop-cxx-header-in-clang(%t/operators.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++23)
 
 // CHECK-LABEL: namespace Operators SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Operators") {
 
@@ -12,20 +13,34 @@
 
 // CHECK: }
 
-public struct IntBox { var x: CInt }
+public struct IntBox {
+  var x: CInt
+
+  public subscript(x: CInt) -> CInt {
+    return x
+  } 
+
+  public subscript(x: CInt, _: CInt) -> CInt {
+    return x
+  } 
+}
+
+// CHECK: #if __cplusplus >= 202302L
+// CHECK-NEXT: SWIFT_INLINE_THUNK int operator [](int x, int _2) const SWIFT_SYMBOL("s:9Operators6IntBoxVys5Int32VAE_AEtcig");
+// CHECK-NEXT: #endif // #if __cplusplus >= 202302L
 
 public func -(lhs: IntBox, rhs: IntBox) -> CInt {
   return lhs.x - rhs.x
 }
 
 // CHECK: SWIFT_INLINE_THUNK int operator-(const IntBox& lhs, const IntBox& rhs) noexcept SWIFT_SYMBOL("s:9Operators1soiys5Int32VAA6IntBoxV_AFtF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK:   return _impl::$s9Operators1soiys5Int32VAA6IntBoxV_AFtF(_impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(lhs)), _impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(rhs)));
-// CHECK: }
+// CHECK-NEXT:   return _impl::$s9Operators1soiys5Int32VAA6IntBoxV_AFtF(_impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(lhs)), _impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(rhs)));
+// CHECK-NEXT: }
 
 public func ==(lhs: IntBox, rhs: IntBox) -> Bool {
   return lhs.x == rhs.x
 }
 
 // CHECK: SWIFT_INLINE_THUNK bool operator==(const IntBox& lhs, const IntBox& rhs) noexcept SWIFT_SYMBOL("s:9Operators2eeoiySbAA6IntBoxV_ADtF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK:   return _impl::$s9Operators2eeoiySbAA6IntBoxV_ADtF(_impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(lhs)), _impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(rhs)));
-// CHECK: }
+// CHECK-NEXT:   return _impl::$s9Operators2eeoiySbAA6IntBoxV_ADtF(_impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(lhs)), _impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(rhs)));
+// CHECK-NEXT: }


### PR DESCRIPTION
C++ only support multiparameter operator[] in C++23 and up. Change the code to protect such overloaded operators with a C++ language mode check.

rdar://133539699