### PR TITLE
Enable swift-foundation tests on Windows in toolchain builds

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -60,7 +60,7 @@ set TMPDIR=%BuildRoot%\tmp
 set NINJA_STATUS=[%%f/%%t][%%p][%%es] 
 
 :: Build the -Test argument, if any, by subtracting skipped tests
-set TestArg=-Test swift,dispatch,xctest,
+set TestArg=-Test swift,dispatch,foundation,xctest,
 for %%I in (%SKIP_TESTS%) do (call set TestArg=%%TestArg:%%I,=%%)
 if "%TestArg:~-1%"=="," (set TestArg=%TestArg:~0,-1%) else (set TestArg= )
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1651,17 +1651,18 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
         -Arch $HostArch
     }
 
-    $OutDir = Join-Path -Path $HostArch.BinaryCache -ChildPath foundation-tests
+    # swift-corelibs-foundation tests are disabled since the package does not build for Windows yet
+    # $OutDir = Join-Path -Path $HostArch.BinaryCache -ChildPath foundation-tests
 
-    Isolate-EnvVars {
-      $env:SWIFTCI_USE_LOCAL_DEPS=1
-      $env:DISPATCH_INCLUDE_PATH="$($Arch.SDKInstallRoot)/usr/lib/swift"
-      Build-SPMProject `
-        -Test `
-        -Src $SourceCache\swift-corelibs-foundation `
-        -Bin $OutDir `
-        -Arch $HostArch
-    }
+    # Isolate-EnvVars {
+    #   $env:SWIFTCI_USE_LOCAL_DEPS=1
+    #   $env:DISPATCH_INCLUDE_PATH="$($Arch.SDKInstallRoot)/usr/lib/swift"
+    #   Build-SPMProject `
+    #     -Test `
+    #     -Src $SourceCache\swift-corelibs-foundation `
+    #     -Bin $OutDir `
+    #     -Arch $HostArch
+    # }
   } else {
     $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch
     $SwiftSyntaxDir = Get-HostProjectCMakeModules Compilers


### PR DESCRIPTION
This enables swift-foundation tests to run in Windows toolchain builds. swift-corelibs-foundation tests are still disabled since the SwiftPM package does not yet build for Windows (we still need it to be able to correctly find libxml/curl dependencies)