### PR TITLE
[6.0] Disable the SwiftFoundation macro build on Windows

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1453,6 +1453,7 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
         dispatch_DIR = "$DispatchBinaryCache\cmake\modules";
         SwiftSyntax_DIR = "$SwiftSyntaxDir";
         _SwiftFoundation_SourceDIR = "$SourceCache\swift-foundation";
+        SwiftFoundation_BUILD_MACROS = "NO";
         _SwiftFoundationICU_SourceDIR = "$SourceCache\swift-foundation-icu";
         _SwiftCollections_SourceDIR = "$SourceCache\swift-collections"
       } + $TestingDefines)


### PR DESCRIPTION
This is needed to keep the same behavior as was implemented prior to https://github.com/apple/swift-foundation/pull/838.