### PR TITLE
[wasm] Mark `errno` as nonisolated(unsafe) in wasi-libc

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -527,6 +527,34 @@ if("WASI" IN_LIST SWIFT_SDKS)
                                  DESTINATION "lib/swift_static/${arch_subdir}"
                                  COMPONENT sdk-overlay)
     endif()
+
+    set(wasilibc_apinotes_source "SwiftWASILibc.apinotes")
+    add_custom_command_target(
+      copy_wasilibc_apinotes_resource
+      COMMAND
+        "${CMAKE_COMMAND}" "-E" "make_directory" ${SWIFTLIB_DIR}/apinotes ${SWIFTSTATICLIB_DIR}/apinotes
+      COMMAND
+        "${CMAKE_COMMAND}" "-E" "copy_if_different"
+          "${CMAKE_CURRENT_SOURCE_DIR}/${wasilibc_apinotes_source}" ${SWIFTLIB_DIR}/apinotes
+      COMMAND
+        "${CMAKE_COMMAND}" "-E" "copy_if_different"
+          "${CMAKE_CURRENT_SOURCE_DIR}/${wasilibc_apinotes_source}" ${SWIFTSTATICLIB_DIR}/apinotes
+      OUTPUT
+        ${SWIFTLIB_DIR}/apinotes/${wasilibc_apinotes_source}
+        ${SWIFTSTATICLIB_DIR}/apinotes/${wasilibc_apinotes_source}
+      COMMENT "Copying WASILibc API notes to resource directories")
+
+    list(APPEND wasilibc_modulemap_target_list ${copy_wasilibc_apinotes_resource})
+    add_dependencies(sdk-overlay ${copy_wasilibc_apinotes_resource})
+    swift_install_in_component(FILES "${wasilibc_apinotes_source}"
+                               DESTINATION "lib/swift/apinotes"
+                               COMPONENT sdk-overlay)
+    if(SWIFT_BUILD_STATIC_STDLIB)
+      swift_install_in_component(FILES "${wasilibc_apinotes_source}"
+                                 DESTINATION "lib/swift_static/apinotes"
+                                 COMPONENT sdk-overlay)
+    endif()
+
   endforeach()
 endif()
 add_custom_target(wasilibc_modulemap DEPENDS ${wasilibc_modulemap_target_list})

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -84,11 +84,6 @@ func _convertDarwinBooleanToBool(_ x: DarwinBoolean) -> Bool {
 
 #endif
 
-// wasi-libc defines `errno` in a way ClangImporter can understand, so we don't
-// need to define shims for it. On the contrary, if we define the shim, we will
-// get an ambiguity error when importing WASILibc module and SwiftWASILibc Clang
-// module (or a Clang module that re-exports SwiftWASILibc).
-#if !os(WASI)
 //===----------------------------------------------------------------------===//
 // sys/errno.h
 //===----------------------------------------------------------------------===//
@@ -101,7 +96,6 @@ public var errno : Int32 {
     return _swift_stdlib_setErrno(val)
   }
 }
-#endif
 
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/Platform/SwiftWASILibc.apinotes
+++ b/stdlib/public/Platform/SwiftWASILibc.apinotes
@@ -1,0 +1,5 @@
+Name: SwiftWASILibc
+Globals:
+  # errno macro is importable but we provide explicit Swift wrapper
+  - Name: errno
+    SwiftPrivate: true

--- a/test/stdlib/WASILibcAPI.swift
+++ b/test/stdlib/WASILibcAPI.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -typecheck -swift-version 6 %s -verify
+// REQUIRES: executable_test
+// REQUIRES: OS=wasi
+
+import WASILibc
+
+// errno is a global thread-local variable, so it should be accessible
+// from any context.
+
+enum TestErrno {
+  static func testSyncContext() {
+    _ = errno
+    errno = 0
+  }
+  static func testAsyncContext() async {
+    _ = errno
+    errno = 0
+  }
+}


### PR DESCRIPTION
This patch is a workaround to reflect the fact that `errno` is thread-local and can be accessed from any actor. This is a temporary solution until we have [`__swift_attr__` support in apinotes](https://github.com/swiftlang/swift/issues/75819) or [`thread_local` support in ClangImporter](https://github.com/swiftlang/swift/issues/75820).

This change is required to build swift-corelibs-foundation with Swift 6 language mode.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
