### PR TITLE
[6.0][region-isolation] Move logging in front of NDEBUG to make it easier to triage with no asserts compilers

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -562,7 +562,6 @@ public:
 
   void printAsOperand(raw_ostream &OS, bool PrintType = true);
 
-#ifndef NDEBUG
   /// Print the ID of the block, bbN.
   void dumpID(bool newline = true) const;
 
@@ -571,7 +570,6 @@ public:
 
   /// Print the ID of the block with \p Ctx, bbN.
   void printID(SILPrintContext &Ctx, bool newline = true) const;
-#endif
 
   /// getSublistAccess() - returns pointer to member of instruction list
   static InstListType SILBasicBlock::*getSublistAccess() {

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -28,18 +28,12 @@ class RegionAnalysisValueMap;
 
 namespace regionanalysisimpl {
 
-#ifndef NDEBUG
 /// Global bool set only when asserts are enabled to ease debugging by causing
 /// unknown pattern errors to cause an assert so we drop into the debugger.
 extern bool AbortOnUnknownPatternMatchError;
-#endif
 
 static inline bool shouldAbortOnUnknownPatternMatchError() {
-#ifndef NDEBUG
   return AbortOnUnknownPatternMatchError;
-#else
-  return false;
-#endif
 }
 
 using TransferringOperandSetFactory = Partition::TransferringOperandSetFactory;

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -20,6 +20,7 @@
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/RegionIsolation.h"
 #include "swift/SILOptimizer/Utils/SILIsolationInfo.h"
 
 #include "llvm/ADT/MapVector.h"
@@ -35,32 +36,6 @@
 namespace swift {
 
 namespace PartitionPrimitives {
-
-extern bool REGIONBASEDISOLATION_ENABLE_LOGGING;
-
-#ifdef REGIONBASEDISOLATION_LOG
-#error "REGIONBASEDISOLATION_LOG already defined?!"
-#endif
-
-#define REGIONBASEDISOLATION_LOG(...)                                          \
-  do {                                                                         \
-    if (PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_LOGGING) {            \
-      __VA_ARGS__;                                                             \
-    }                                                                          \
-  } while (0);
-
-extern bool REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING;
-
-#ifdef REGIONBASEDISOLATION_VERBOSE_LOG
-#error "REGIONBASEDISOLATION_VERBOSE_LOG already defined?!"
-#endif
-
-#define REGIONBASEDISOLATION_VERBOSE_LOG(...)                                  \
-  do {                                                                         \
-    if (PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING) {    \
-      __VA_ARGS__;                                                             \
-    }                                                                          \
-  } while (0);
 
 struct Element {
   unsigned num;

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -36,17 +36,31 @@ namespace swift {
 
 namespace PartitionPrimitives {
 
-#ifndef NDEBUG
+extern bool REGIONBASEDISOLATION_ENABLE_LOGGING;
+
+#ifdef REGIONBASEDISOLATION_LOG
+#error "REGIONBASEDISOLATION_LOG already defined?!"
+#endif
+
+#define REGIONBASEDISOLATION_LOG(...)                                          \
+  do {                                                                         \
+    if (PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_LOGGING) {            \
+      __VA_ARGS__;                                                             \
+    }                                                                          \
+  } while (0);
+
 extern bool REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING;
+
+#ifdef REGIONBASEDISOLATION_VERBOSE_LOG
+#error "REGIONBASEDISOLATION_VERBOSE_LOG already defined?!"
+#endif
+
 #define REGIONBASEDISOLATION_VERBOSE_LOG(...)                                  \
   do {                                                                         \
     if (PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING) {    \
-      LLVM_DEBUG(__VA_ARGS__);                                                 \
+      __VA_ARGS__;                                                             \
     }                                                                          \
   } while (0);
-#else
-#define REGIONBASEDISOLATION_VERBOSE_LOG(...)
-#endif
 
 struct Element {
   unsigned num;

--- a/include/swift/SILOptimizer/Utils/RegionIsolation.h
+++ b/include/swift/SILOptimizer/Utils/RegionIsolation.h
@@ -1,0 +1,61 @@
+//===--- RegionIsolation.h ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file This file just declares some command line options that are used for
+/// the various parts of region analysis based diagnostics.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_UTILS_REGIONANALYSIS_H
+#define SWIFT_SILOPTIMIZER_UTILS_REGIONANALYSIS_H
+
+namespace swift {
+
+namespace regionisolation {
+
+enum class LoggingFlag {
+  Off = 0,
+  Normal = 0x1,
+  Verbose = 0x3,
+};
+
+extern LoggingFlag ENABLE_LOGGING;
+
+#ifdef REGIONBASEDISOLATION_LOG
+#error "REGIONBASEDISOLATION_LOG already defined?!"
+#endif
+
+#ifdef REGIONBASEDISOLATION_VERBOSE_LOG
+#error "REGIONBASEDISOLATION_VERBOSE_LOG already defined?!"
+#endif
+
+#define REGIONBASEDISOLATION_LOG(...)                                          \
+  do {                                                                         \
+    if (swift::regionisolation::ENABLE_LOGGING !=                              \
+        swift::regionisolation::LoggingFlag::Off) {                            \
+      __VA_ARGS__;                                                             \
+    }                                                                          \
+  } while (0);
+
+#define REGIONBASEDISOLATION_VERBOSE_LOG(...)                                  \
+  do {                                                                         \
+    if (swift::regionisolation::ENABLE_LOGGING ==                              \
+        swift::regionisolation::LoggingFlag::Verbose) {                        \
+      __VA_ARGS__;                                                             \
+    }                                                                          \
+  } while (0);
+
+} // namespace regionisolation
+
+} // namespace swift
+
+#endif

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -290,6 +290,12 @@ public:
     return isolatedValue;
   }
 
+  SILValue maybeGetIsolatedValue() const {
+    if (kind != Task && kind != Actor)
+      return SILValue();
+    return getIsolatedValue();
+  }
+
   /// Return the specific SILValue for the actor that our isolated value is
   /// isolated to if one exists.
   ActorInstance getActorInstance() const {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3227,20 +3227,30 @@ void SILBasicBlock::print(SILPrintContext &Ctx) const {
   SILPrinter(Ctx).print(this);
 }
 
-#ifndef NDEBUG
 void SILBasicBlock::dumpID(bool newline) const {
+#ifndef NDEBUG
   printID(llvm::errs(), newline);
+#else
+  llvm::errs() << "NOASSERTS" << (newline ? "\n" : "");
+#endif
 }
 
 void SILBasicBlock::printID(llvm::raw_ostream &OS, bool newline) const {
+#ifndef NDEBUG
   SILPrintContext Ctx(OS);
   printID(Ctx, newline);
+#else
+  llvm::errs() << "NOASSERTS" << (newline ? "\n" : "");
+#endif
 }
 
 void SILBasicBlock::printID(SILPrintContext &Ctx, bool newline) const {
+#ifndef NDEBUG
   SILPrinter(Ctx).printID(this, newline);
-}
+#else
+  llvm::errs() << "NOASSERTS" << (newline ? "\n" : "");
 #endif
+}
 
 /// Pretty-print the SILFunction to errs.
 void SILFunction::dump(bool Verbose) const {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2351,7 +2351,7 @@ public:
     REGIONBASEDISOLATION_LOG(
         llvm::dbgs() << SEP_STR << "Compiling basic block for function "
                      << basicBlock->getFunction()->getName() << ": ";
-        basicBlock->dumpID(); llvm::dbgs() << SEP_STR;
+        basicBlock->printID(llvm::dbgs()); llvm::dbgs() << SEP_STR;
         basicBlock->print(llvm::dbgs());
         llvm::dbgs() << SEP_STR << "Results:\n";);
     // Translate each SIL instruction to the PartitionOps that it represents if
@@ -3342,12 +3342,7 @@ bool BlockPartitionState::recomputeExitFromEntry(
 void BlockPartitionState::print(llvm::raw_ostream &os) const {
   os << SEP_STR << "BlockPartitionState[needsUpdate=" << needsUpdate
      << "]\nid: ";
-#ifndef NDEBUG
-  auto printID = [&](SILBasicBlock *block) { block->printID(os); };
-#else
-  auto printID = [&](SILBasicBlock *) { os << "NOASSERTS. "; };
-#endif
-  printID(basicBlock);
+  basicBlock->printID(os);
   os << "entry partition: ";
   entryPartition.print(os);
   os << "exit partition: ";
@@ -3360,12 +3355,12 @@ void BlockPartitionState::print(llvm::raw_ostream &os) const {
   os << "└──────────╼\nSuccs:\n";
   for (auto succ : basicBlock->getSuccessorBlocks()) {
     os << "→";
-    printID(succ);
+    succ->printID(os);
   }
   os << "Preds:\n";
   for (auto pred : basicBlock->getPredecessorBlocks()) {
     os << "←";
-    printID(pred);
+    pred->printID(os);
   }
   os << SEP_STR;
 }

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -47,8 +47,6 @@ using namespace swift::PartitionPrimitives;
 using namespace swift::PatternMatch;
 using namespace swift::regionanalysisimpl;
 
-#ifndef NDEBUG
-
 bool swift::regionanalysisimpl::AbortOnUnknownPatternMatchError = false;
 
 static llvm::cl::opt<bool, true> AbortOnUnknownPatternMatchErrorCmdLine(
@@ -58,8 +56,6 @@ static llvm::cl::opt<bool, true> AbortOnUnknownPatternMatchErrorCmdLine(
     llvm::cl::Hidden,
     llvm::cl::location(
         swift::regionanalysisimpl::AbortOnUnknownPatternMatchError));
-
-#endif
 
 //===----------------------------------------------------------------------===//
 //                              MARK: Utilities
@@ -777,8 +773,9 @@ void PartialApplyReachabilityDataflow::add(Operand *op) {
   assert(!propagatedReachability &&
          "Cannot add more operands once reachability is computed");
   SILValue underlyingValue = getRootValue(op->get());
-  LLVM_DEBUG(llvm::dbgs() << "PartialApplyReachability::add.\nValue: "
-                          << underlyingValue << "User: " << *op->getUser());
+  REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                           << "PartialApplyReachability::add.\nValue: "
+                           << underlyingValue << "User: " << *op->getUser());
 
   unsigned bit = getBitForValue(underlyingValue);
   auto &state = blockData[op->getParentBlock()];
@@ -898,8 +895,8 @@ void PartialApplyReachabilityDataflow::propagateReachability() {
     }
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "Propagating Captures Result!\n";
-             print(llvm::dbgs()));
+  REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Propagating Captures Result!\n";
+                           print(llvm::dbgs()));
 }
 
 void PartialApplyReachabilityDataflow::print(llvm::raw_ostream &os) const {
@@ -1176,9 +1173,11 @@ struct PartitionOpBuilder {
 
     Element srcID = lookupValueID(srcOperand->get());
     if (lookupValueID(destValue) == srcID) {
-      LLVM_DEBUG(llvm::dbgs() << "    Skipping assign since tgt and src have "
-                                 "the same representative.\n");
-      LLVM_DEBUG(llvm::dbgs() << "    Rep ID: %%" << srcID.num << ".\n");
+      REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                               << "    Skipping assign since tgt and src have "
+                                  "the same representative.\n");
+      REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                               << "    Rep ID: %%" << srcID.num << ".\n");
       return;
     }
 
@@ -1433,9 +1432,10 @@ class PartitionOpTranslator {
   RegionAnalysisValueMap &valueMap;
 
   void gatherFlowInsensitiveInformationBeforeDataflow() {
-    LLVM_DEBUG(llvm::dbgs() << ">>> Performing pre-dataflow scan to gather "
-                               "flow insensitive information "
-                            << function->getName() << ":\n");
+    REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                             << ">>> Performing pre-dataflow scan to gather "
+                                "flow insensitive information "
+                             << function->getName() << ":\n");
 
     for (auto &block : *function) {
       for (auto &inst : block) {
@@ -1461,7 +1461,7 @@ class PartitionOpTranslator {
                 isNonSendableType(val->getType())) {
               auto trackVal = getTrackableValue(val, true);
               (void)trackVal;
-              LLVM_DEBUG(trackVal.print(llvm::dbgs()));
+              REGIONBASEDISOLATION_LOG(trackVal.print(llvm::dbgs()));
               continue;
             }
             if (auto *pbi = dyn_cast<ProjectBoxInst>(val)) {
@@ -1489,10 +1489,10 @@ public:
     builder.translator = this;
     gatherFlowInsensitiveInformationBeforeDataflow();
 
-    LLVM_DEBUG(llvm::dbgs() << "Initializing Function Args:\n");
+    REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Initializing Function Args:\n");
     auto functionArguments = function->getArguments();
     if (functionArguments.empty()) {
-      LLVM_DEBUG(llvm::dbgs() << "    None.\n");
+      REGIONBASEDISOLATION_LOG(llvm::dbgs() << "    None.\n");
       functionArgPartition = Partition::singleRegion(SILLocation::invalid(), {},
                                                      historyFactory.get());
       return;
@@ -1509,19 +1509,20 @@ public:
         // NOTE: We do not support today the ability to have multiple parameters
         // transfer together as part of the same region.
         if (isTransferrableFunctionArgument(cast<SILFunctionArgument>(arg))) {
-          LLVM_DEBUG(llvm::dbgs() << "    %%" << state->getID()
-                                  << " (transferring): " << *arg);
+          REGIONBASEDISOLATION_LOG(llvm::dbgs() << "    %%" << state->getID()
+                                                << " (transferring): " << *arg);
           nonSendableSeparateIndices.push_back(state->getID());
           continue;
         }
 
         // Otherwise, it is one of our merged parameters. Add it to the never
         // transfer list and to the region join list.
-        LLVM_DEBUG(llvm::dbgs() << "    %%" << state->getID() << ": ";
-                   state->print(llvm::dbgs()); llvm::dbgs() << *arg);
+        REGIONBASEDISOLATION_LOG(
+            llvm::dbgs() << "    %%" << state->getID() << ": ";
+            state->print(llvm::dbgs()); llvm::dbgs() << *arg);
         nonSendableJoinedIndices.push_back(state->getID());
       } else {
-        LLVM_DEBUG(llvm::dbgs() << "    Sendable: " << *arg);
+        REGIONBASEDISOLATION_LOG(llvm::dbgs() << "    Sendable: " << *arg);
       }
     }
 
@@ -1664,7 +1665,7 @@ public:
         // of our arguments (consider isolated to different actors) or with the
         // isolationInfo we specified. Emit an unknown patten error.
         if (!mergedInfo) {
-          LLVM_DEBUG(
+          REGIONBASEDISOLATION_LOG(
               llvm::dbgs() << "Merge Failure!\n"
                            << "Original Info: ";
               if (originalMergedInfo)
@@ -1828,7 +1829,8 @@ public:
   }
 
   void translateSILPartialApplyAsyncLetBegin(PartialApplyInst *pai) {
-    LLVM_DEBUG(llvm::dbgs() << "Translating Async Let Begin Partial Apply!\n");
+    REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                             << "Translating Async Let Begin Partial Apply!\n");
     // Grab our partial apply and transfer all of its non-sendable
     // parameters. We do not merge the parameters since each individual capture
     // of the async let at the program level is viewed as still being in
@@ -1857,7 +1859,8 @@ public:
   void translateIsolatedPartialApply(PartialApplyInst *pai,
                                      SILIsolationInfo actorIsolation) {
     ApplySite applySite(pai);
-    LLVM_DEBUG(llvm::dbgs() << "Translating Isolated Partial Apply!\n");
+    REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                             << "Translating Isolated Partial Apply!\n");
 
     // For each argument operand.
     for (auto &op : applySite.getArgumentOperands()) {
@@ -2345,15 +2348,16 @@ public:
   /// that define the block's dataflow.
   void translateSILBasicBlock(SILBasicBlock *basicBlock,
                               std::vector<PartitionOp> &foundPartitionOps) {
-    LLVM_DEBUG(llvm::dbgs() << SEP_STR << "Compiling basic block for function "
-                            << basicBlock->getFunction()->getName() << ": ";
-               basicBlock->dumpID(); llvm::dbgs() << SEP_STR;
-               basicBlock->print(llvm::dbgs());
-               llvm::dbgs() << SEP_STR << "Results:\n";);
+    REGIONBASEDISOLATION_LOG(
+        llvm::dbgs() << SEP_STR << "Compiling basic block for function "
+                     << basicBlock->getFunction()->getName() << ": ";
+        basicBlock->dumpID(); llvm::dbgs() << SEP_STR;
+        basicBlock->print(llvm::dbgs());
+        llvm::dbgs() << SEP_STR << "Results:\n";);
     // Translate each SIL instruction to the PartitionOps that it represents if
     // any.
     for (auto &instruction : *basicBlock) {
-      LLVM_DEBUG(llvm::dbgs() << "Visiting: " << instruction);
+      REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Visiting: " << instruction);
       translateSILInstruction(&instruction);
       copy(builder.currentInstPartitionOps,
            std::back_inserter(foundPartitionOps));
@@ -2382,7 +2386,7 @@ public:
   /// Top level switch that translates SIL instructions.
   void translateSILInstruction(SILInstruction *inst) {
     builder.reset(inst);
-    SWIFT_DEFER { LLVM_DEBUG(builder.print(llvm::dbgs())); };
+    SWIFT_DEFER { REGIONBASEDISOLATION_LOG(builder.print(llvm::dbgs())); };
 
     auto computeOpKind = [&]() -> TranslationSemantics {
       switch (inst->getKind()) {
@@ -2394,7 +2398,7 @@ public:
     };
 
     auto kind = computeOpKind();
-    LLVM_DEBUG(llvm::dbgs() << "    Semantics: " << kind << '\n');
+    REGIONBASEDISOLATION_LOG(llvm::dbgs() << "    Semantics: " << kind << '\n');
     switch (kind) {
     case TranslationSemantics::Ignored:
       return;
@@ -3167,7 +3171,8 @@ PartitionOpTranslator::visitRefElementAddrInst(RefElementAddrInst *reai) {
     // And the field is a let... then ignore it. We know that we cannot race on
     // any writes to the field.
     if (reai->getField()->isLet()) {
-      LLVM_DEBUG(llvm::dbgs() << "    Found a let! Not tracking!\n");
+      REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                               << "    Found a let! Not tracking!\n");
       return TranslationSemantics::Ignored;
     }
 
@@ -3186,7 +3191,7 @@ PartitionOpTranslator::visitRefTailAddrInst(RefTailAddrInst *reai) {
     // And our ref_tail_addr is immutable... we can ignore the access since we
     // cannot race against a write to any of these fields.
     if (reai->isImmutable()) {
-      LLVM_DEBUG(
+      REGIONBASEDISOLATION_LOG(
           llvm::dbgs()
           << "    Found an immutable Sendable ref_tail_addr! Not tracking!\n");
       return TranslationSemantics::Ignored;
@@ -3323,14 +3328,14 @@ bool BlockPartitionState::recomputeExitFromEntry(
     // will be surpressed.  will be suppressed
     eval.apply(partitionOp);
   }
-  LLVM_DEBUG(llvm::dbgs() << "    Working Partition: ";
-             workingPartition.print(llvm::dbgs()));
+  REGIONBASEDISOLATION_LOG(llvm::dbgs() << "    Working Partition: ";
+                           workingPartition.print(llvm::dbgs()));
   bool exitUpdated = !Partition::equals(exitPartition, workingPartition);
   exitPartition = workingPartition;
-  LLVM_DEBUG(llvm::dbgs() << "    Exit Partition: ";
-             exitPartition.print(llvm::dbgs()));
-  LLVM_DEBUG(llvm::dbgs() << "    Updated Partition: "
-                          << (exitUpdated ? "yes\n" : "no\n"));
+  REGIONBASEDISOLATION_LOG(llvm::dbgs() << "    Exit Partition: ";
+                           exitPartition.print(llvm::dbgs()));
+  REGIONBASEDISOLATION_LOG(llvm::dbgs() << "    Updated Partition: "
+                                        << (exitUpdated ? "yes\n" : "no\n"));
   return exitUpdated;
 }
 
@@ -3386,7 +3391,8 @@ static bool canComputeRegionsForFunction(SILFunction *fn) {
   }
 
   if (!fn->hasOwnership()) {
-    LLVM_DEBUG(llvm::dbgs() << "Only runs on Ownership SSA, skipping!\n");
+    REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                             << "Only runs on Ownership SSA, skipping!\n");
     return false;
   }
 
@@ -3450,9 +3456,10 @@ void RegionAnalysisFunctionInfo::runDataflow() {
   assert(!solved && "solve should only be called once");
   solved = true;
 
-  LLVM_DEBUG(llvm::dbgs() << SEP_STR << "Performing Dataflow!\n" << SEP_STR);
-  LLVM_DEBUG(llvm::dbgs() << "Values!\n";
-             translator->getValueMap().print(llvm::dbgs()));
+  REGIONBASEDISOLATION_LOG(llvm::dbgs() << SEP_STR << "Performing Dataflow!\n"
+                                        << SEP_STR);
+  REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Values!\n";
+                           translator->getValueMap().print(llvm::dbgs()));
 
   bool anyNeedUpdate = true;
   while (anyNeedUpdate) {
@@ -3462,9 +3469,11 @@ void RegionAnalysisFunctionInfo::runDataflow() {
       auto &blockState = (*blockStates)[block];
       blockState.isLive = true;
 
-      LLVM_DEBUG(llvm::dbgs() << "Block: bb" << block->getDebugID() << "\n");
+      REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                               << "Block: bb" << block->getDebugID() << "\n");
       if (!blockState.needsUpdate) {
-        LLVM_DEBUG(llvm::dbgs() << "    Doesn't need update! Skipping!\n");
+        REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                                 << "    Doesn't need update! Skipping!\n");
         continue;
       }
 
@@ -3474,7 +3483,7 @@ void RegionAnalysisFunctionInfo::runDataflow() {
       // Compute the new entry partition to this block.
       Partition newEntryPartition = blockState.entryPartition;
 
-      LLVM_DEBUG(llvm::dbgs() << "    Visiting Preds!\n");
+      REGIONBASEDISOLATION_LOG(llvm::dbgs() << "    Visiting Preds!\n");
 
       // This loop computes the union of the exit partitions of all
       // predecessors of this block
@@ -3483,9 +3492,9 @@ void RegionAnalysisFunctionInfo::runDataflow() {
 
         // Predecessors that have not been reached yet will have an empty pred
         // state... so just merge them all. Also our initial value of
-        LLVM_DEBUG(llvm::dbgs()
-                       << "    Pred. bb" << predBlock->getDebugID() << ": ";
-                   predState.exitPartition.print(llvm::dbgs()));
+        REGIONBASEDISOLATION_LOG(
+            llvm::dbgs() << "    Pred. bb" << predBlock->getDebugID() << ": ";
+            predState.exitPartition.print(llvm::dbgs()));
         newEntryPartition =
             Partition::join(newEntryPartition, predState.exitPartition);
       }

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -1211,8 +1211,8 @@ void TransferNonSendableImpl::emitUseAfterTransferDiagnostics() {
   if (transferOpToRequireInstMultiMap.empty())
     return;
 
-  REGIONBASEDISOLATION_LOG(llvm::dbgs()
-                           << "Emitting use after transfer diagnostics.\n");
+  REGIONBASEDISOLATION_LOG(
+      llvm::dbgs() << "Emitting Error. Kind: Use After Send diagnostics.\n");
 
   for (auto [transferOp, requireInsts] :
        transferOpToRequireInstMultiMap.getRange()) {
@@ -1964,8 +1964,8 @@ void TransferNonSendableImpl::emitTransferredNonTransferrableDiagnostics() {
   if (transferredNonTransferrableInfoList.empty())
     return;
 
-  REGIONBASEDISOLATION_LOG(
-      llvm::dbgs() << "Emitting transfer non transferrable diagnostics.\n");
+  REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                           << "Emitting Error. Kind: Send Never Sendable.\n");
 
   for (auto info : transferredNonTransferrableInfoList) {
     TransferNonTransferrableDiagnosticInferrer diagnosticInferrer(
@@ -2367,7 +2367,7 @@ struct DiagnosticEvaluator final
     auto rep = info->getValueMap().getRepresentative(transferredVal);
     REGIONBASEDISOLATION_LOG(
         llvm::dbgs()
-        << "    Emitting Use After Transfer Error!\n"
+        << "    Emitting Error. Kind: Use After Send\n"
         << "        Transferring Inst: " << *transferringOp->getUser()
         << "        Transferring Op Value: " << transferringOp->get()
         << "        Require Inst: " << *partitionOp.getSourceInst()
@@ -2383,7 +2383,7 @@ struct DiagnosticEvaluator final
       const PartitionOp &partitionOp, Element transferredVal,
       SILDynamicMergedIsolationInfo isolationRegionInfo) const {
     REGIONBASEDISOLATION_LOG(
-        llvm::dbgs() << "    Emitting TransferNonTransferrable Error!\n"
+        llvm::dbgs() << "    Emitting Error. Kind: Send Non Sendable\n"
                      << "        ID:  %%" << transferredVal << "\n"
                      << "        Rep: "
                      << *info->getValueMap().getRepresentative(transferredVal)
@@ -2402,7 +2402,8 @@ struct DiagnosticEvaluator final
       const PartitionOp &partitionOp, Element inoutSendingVal,
       SILDynamicMergedIsolationInfo isolationRegionInfo) const {
     REGIONBASEDISOLATION_LOG(
-        llvm::dbgs() << "    Emitting InOut Sending ActorIsolated at end of "
+        llvm::dbgs() << "    Emitting Error. Kind: InOut Sending ActorIsolated "
+                        "at end of "
                         "Function Error!\n"
                      << "        ID:  %%" << inoutSendingVal << "\n"
                      << "        Rep: "
@@ -2424,7 +2425,7 @@ struct DiagnosticEvaluator final
       Element actualNonTransferrableValue,
       SILDynamicMergedIsolationInfo isolationRegionInfo) const {
     REGIONBASEDISOLATION_LOG(
-        llvm::dbgs() << "    Emitting TransferNonTransferrable Error!\n"
+        llvm::dbgs() << "    Emitting Error. Kind: Send Non Sendable\n"
                      << "        ID:  %%" << transferredVal << "\n"
                      << "        Rep: "
                      << *info->getValueMap().getRepresentative(transferredVal)
@@ -2469,7 +2470,7 @@ struct DiagnosticEvaluator final
     auto srcRep = info->getValueMap().getRepresentativeValue(srcElement);
     REGIONBASEDISOLATION_LOG(
         llvm::dbgs()
-        << "    Emitting Error! Kind: Assign Isolated Into Sending Result!\n"
+        << "    Emitting Error. Kind: Assign Isolated Into Sending Result!\n"
         << "        Assign Inst: " << *partitionOp.getSourceInst()
         << "        Dest Value: " << *destValue
         << "        Dest Element: " << destElement << '\n'
@@ -2488,7 +2489,8 @@ struct DiagnosticEvaluator final
     auto rep = info->getValueMap().getRepresentative(inoutSendingVal);
     REGIONBASEDISOLATION_LOG(
         llvm::dbgs()
-        << "    Emitting InOut Not Reinitialized At End Of Function!\n"
+        << "    Emitting Error. Kind: InOut Not Reinitialized At End Of "
+           "Function\n"
         << "        Transferring Inst: " << *transferringOp->getUser()
         << "        Transferring Op Value: " << transferringOp->get()
         << "        Require Inst: " << *partitionOp.getSourceInst()

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -353,7 +353,7 @@ struct RequireLiveness {
 } // namespace
 
 void RequireLiveness::processDefBlock() {
-  LLVM_DEBUG(llvm::dbgs() << "    Processing def block!\n");
+  REGIONBASEDISOLATION_LOG(llvm::dbgs() << "    Processing def block!\n");
   // First walk from the beginning of the block to the transfer instruction to
   // see if we have any requires before our def. Once we find one, we can skip
   // the traversal and jump straight to the transfer.
@@ -362,8 +362,9 @@ void RequireLiveness::processDefBlock() {
        ii != ie; ++ii) {
     if (allRequires.contains(&*ii) && !firstRequireBeforeTransferInDefBlock) {
       firstRequireBeforeTransferInDefBlock = &*ii;
-      LLVM_DEBUG(llvm::dbgs() << "        Found transfer before def: "
-                              << *firstRequireBeforeTransferInDefBlock);
+      REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                               << "        Found transfer before def: "
+                               << *firstRequireBeforeTransferInDefBlock);
       break;
     }
   }
@@ -380,7 +381,8 @@ void RequireLiveness::processDefBlock() {
       continue;
 
     finalRequires.insert(&*ii);
-    LLVM_DEBUG(llvm::dbgs() << "        Found transfer after def: " << *ii);
+    REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                             << "        Found transfer after def: " << *ii);
     return;
   }
 }
@@ -397,13 +399,14 @@ void RequireLiveness::processNonDefBlock(SILBasicBlock *block) {
 
 template <typename Collection>
 void RequireLiveness::process(Collection requireInstList) {
-  LLVM_DEBUG(llvm::dbgs() << "==> Performing Require Liveness for: "
-                          << *transferInst);
+  REGIONBASEDISOLATION_LOG(
+      llvm::dbgs() << "==> Performing Require Liveness for: " << *transferInst);
 
   // Then put all of our requires into our allRequires set.
   BasicBlockWorklist initializingWorklist(transferInst->getFunction());
   for (auto require : requireInstList) {
-    LLVM_DEBUG(llvm::dbgs() << "        Require Inst: " << **require);
+    REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                             << "        Require Inst: " << **require);
     allRequires.insert(*require);
     initializingWorklist.pushIfNotVisited(require->getParent());
   }
@@ -415,19 +418,20 @@ void RequireLiveness::process(Collection requireInstList) {
   // If we found /any/ requries after the transferInst, we can bail early since
   // that is guaranteed to dominate all further requires.
   if (!finalRequires.empty()) {
-    LLVM_DEBUG(
+    REGIONBASEDISOLATION_LOG(
         llvm::dbgs()
         << "        Found transfer after def in def block! Exiting early!\n");
     return;
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "        Did not find transfer after def in def "
-                             "block! Walking blocks!\n");
+  REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                           << "        Did not find transfer after def in def "
+                              "block! Walking blocks!\n");
 
   // If we found a transfer in the def block before our def, add it to the block
   // state for the def.
   if (firstRequireBeforeTransferInDefBlock) {
-    LLVM_DEBUG(
+    REGIONBASEDISOLATION_LOG(
         llvm::dbgs()
         << "        Found a require before transfer! Adding to block state!\n");
     auto blockState = blockLivenessInfo.get(transferInst->getParent());
@@ -441,8 +445,9 @@ void RequireLiveness::process(Collection requireInstList) {
     for (auto &inst : *requireBlock) {
       if (!allRequires.contains(&inst))
         continue;
-      LLVM_DEBUG(llvm::dbgs() << "        Mapping Block bb"
-                              << requireBlock->getDebugID() << " to: " << inst);
+      REGIONBASEDISOLATION_LOG(llvm::dbgs() << "        Mapping Block bb"
+                                            << requireBlock->getDebugID()
+                                            << " to: " << inst);
       blockState.get()->setInst(generation, &inst);
       break;
     }
@@ -1206,13 +1211,15 @@ void TransferNonSendableImpl::emitUseAfterTransferDiagnostics() {
   if (transferOpToRequireInstMultiMap.empty())
     return;
 
-  LLVM_DEBUG(llvm::dbgs() << "Emitting use after transfer diagnostics.\n");
+  REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                           << "Emitting use after transfer diagnostics.\n");
 
   for (auto [transferOp, requireInsts] :
        transferOpToRequireInstMultiMap.getRange()) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "Transfer Op. Number: " << transferOp->getOperandNumber()
-               << ". User: " << *transferOp->getUser());
+    REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                             << "Transfer Op. Number: "
+                             << transferOp->getOperandNumber()
+                             << ". User: " << *transferOp->getUser());
 
     // Then look for our requires before we emit any error. We want to emit a
     // single we don't understand error if we do not find the require.
@@ -1957,7 +1964,7 @@ void TransferNonSendableImpl::emitTransferredNonTransferrableDiagnostics() {
   if (transferredNonTransferrableInfoList.empty())
     return;
 
-  LLVM_DEBUG(
+  REGIONBASEDISOLATION_LOG(
       llvm::dbgs() << "Emitting transfer non transferrable diagnostics.\n");
 
   for (auto info : transferredNonTransferrableInfoList) {
@@ -2358,14 +2365,15 @@ struct DiagnosticEvaluator final
     }
 
     auto rep = info->getValueMap().getRepresentative(transferredVal);
-    LLVM_DEBUG(llvm::dbgs()
-               << "    Emitting Use After Transfer Error!\n"
-               << "        Transferring Inst: " << *transferringOp->getUser()
-               << "        Transferring Op Value: " << transferringOp->get()
-               << "        Require Inst: " << *partitionOp.getSourceInst()
-               << "        ID:  %%" << transferredVal << "\n"
-               << "        Rep: " << *rep << "        Transferring Op Num: "
-               << transferringOp->getOperandNumber() << '\n');
+    REGIONBASEDISOLATION_LOG(
+        llvm::dbgs()
+        << "    Emitting Use After Transfer Error!\n"
+        << "        Transferring Inst: " << *transferringOp->getUser()
+        << "        Transferring Op Value: " << transferringOp->get()
+        << "        Require Inst: " << *partitionOp.getSourceInst()
+        << "        ID:  %%" << transferredVal << "\n"
+        << "        Rep: " << *rep << "        Transferring Op Num: "
+        << transferringOp->getOperandNumber() << '\n');
     transferOpToRequireInstMultiMap.insert(
         transferringOp,
         RequireInst::forUseAfterTransfer(partitionOp.getSourceInst()));
@@ -2374,14 +2382,14 @@ struct DiagnosticEvaluator final
   void handleTransferNonTransferrable(
       const PartitionOp &partitionOp, Element transferredVal,
       SILDynamicMergedIsolationInfo isolationRegionInfo) const {
-    LLVM_DEBUG(llvm::dbgs()
-                   << "    Emitting TransferNonTransferrable Error!\n"
-                   << "        ID:  %%" << transferredVal << "\n"
-                   << "        Rep: "
-                   << *info->getValueMap().getRepresentative(transferredVal)
-                   << "        Dynamic Isolation Region: ";
-               isolationRegionInfo.printForDiagnostics(llvm::dbgs());
-               llvm::dbgs() << '\n');
+    REGIONBASEDISOLATION_LOG(
+        llvm::dbgs() << "    Emitting TransferNonTransferrable Error!\n"
+                     << "        ID:  %%" << transferredVal << "\n"
+                     << "        Rep: "
+                     << *info->getValueMap().getRepresentative(transferredVal)
+                     << "        Dynamic Isolation Region: ";
+        isolationRegionInfo.printForDiagnostics(llvm::dbgs());
+        llvm::dbgs() << '\n');
     auto *self = const_cast<DiagnosticEvaluator *>(this);
     auto nonTransferrableValue =
         info->getValueMap().getRepresentative(transferredVal);
@@ -2393,15 +2401,15 @@ struct DiagnosticEvaluator final
   void handleInOutSendingNotDisconnectedAtExitError(
       const PartitionOp &partitionOp, Element inoutSendingVal,
       SILDynamicMergedIsolationInfo isolationRegionInfo) const {
-    LLVM_DEBUG(llvm::dbgs()
-                   << "    Emitting InOut Sending ActorIsolated at end of "
-                      "Function Error!\n"
-                   << "        ID:  %%" << inoutSendingVal << "\n"
-                   << "        Rep: "
-                   << *info->getValueMap().getRepresentative(inoutSendingVal)
-                   << "        Dynamic Isolation Region: ";
-               isolationRegionInfo.printForDiagnostics(llvm::dbgs());
-               llvm::dbgs() << '\n');
+    REGIONBASEDISOLATION_LOG(
+        llvm::dbgs() << "    Emitting InOut Sending ActorIsolated at end of "
+                        "Function Error!\n"
+                     << "        ID:  %%" << inoutSendingVal << "\n"
+                     << "        Rep: "
+                     << *info->getValueMap().getRepresentative(inoutSendingVal)
+                     << "        Dynamic Isolation Region: ";
+        isolationRegionInfo.printForDiagnostics(llvm::dbgs());
+        llvm::dbgs() << '\n');
     auto *self = const_cast<DiagnosticEvaluator *>(this);
     auto nonTransferrableValue =
         info->getValueMap().getRepresentative(inoutSendingVal);
@@ -2415,30 +2423,30 @@ struct DiagnosticEvaluator final
       const PartitionOp &partitionOp, Element transferredVal,
       Element actualNonTransferrableValue,
       SILDynamicMergedIsolationInfo isolationRegionInfo) const {
-    LLVM_DEBUG(llvm::dbgs()
-                   << "    Emitting TransferNonTransferrable Error!\n"
-                   << "        ID:  %%" << transferredVal << "\n"
-                   << "        Rep: "
-                   << *info->getValueMap().getRepresentative(transferredVal)
-                   << "        Dynamic Isolation Region: ";
-               isolationRegionInfo.printForDiagnostics(llvm::dbgs());
-               llvm::dbgs() << '\n');
+    REGIONBASEDISOLATION_LOG(
+        llvm::dbgs() << "    Emitting TransferNonTransferrable Error!\n"
+                     << "        ID:  %%" << transferredVal << "\n"
+                     << "        Rep: "
+                     << *info->getValueMap().getRepresentative(transferredVal)
+                     << "        Dynamic Isolation Region: ";
+        isolationRegionInfo.printForDiagnostics(llvm::dbgs());
+        llvm::dbgs() << '\n');
 
     auto *self = const_cast<DiagnosticEvaluator *>(this);
     // If we have a non-actor introducing fake representative value, just use
     // the value that actually introduced the actor isolation.
     if (auto nonTransferrableValue = info->getValueMap().maybeGetRepresentative(
             actualNonTransferrableValue)) {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "        ActualTransfer: " << nonTransferrableValue);
+      REGIONBASEDISOLATION_LOG(llvm::dbgs() << "        ActualTransfer: "
+                                            << nonTransferrableValue);
       self->transferredNonTransferrable.emplace_back(partitionOp.getSourceOp(),
                                                      nonTransferrableValue,
                                                      isolationRegionInfo);
     } else if (auto *nonTransferrableInst =
                    info->getValueMap().maybeGetActorIntroducingInst(
                        actualNonTransferrableValue)) {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "        ActualTransfer: " << *nonTransferrableInst);
+      REGIONBASEDISOLATION_LOG(llvm::dbgs() << "        ActualTransfer: "
+                                            << *nonTransferrableInst);
       self->transferredNonTransferrable.emplace_back(
           partitionOp.getSourceOp(), nonTransferrableInst, isolationRegionInfo);
     } else {
@@ -2459,7 +2467,7 @@ struct DiagnosticEvaluator final
       SILFunctionArgument *destValue, Element srcElement, SILValue srcValue,
       SILDynamicMergedIsolationInfo srcIsolationRegionInfo) const {
     auto srcRep = info->getValueMap().getRepresentativeValue(srcElement);
-    LLVM_DEBUG(
+    REGIONBASEDISOLATION_LOG(
         llvm::dbgs()
         << "    Emitting Error! Kind: Assign Isolated Into Sending Result!\n"
         << "        Assign Inst: " << *partitionOp.getSourceInst()
@@ -2478,14 +2486,15 @@ struct DiagnosticEvaluator final
                                               Element inoutSendingVal,
                                               Operand *transferringOp) const {
     auto rep = info->getValueMap().getRepresentative(inoutSendingVal);
-    LLVM_DEBUG(llvm::dbgs()
-               << "    Emitting InOut Not Reinitialized At End Of Function!\n"
-               << "        Transferring Inst: " << *transferringOp->getUser()
-               << "        Transferring Op Value: " << transferringOp->get()
-               << "        Require Inst: " << *partitionOp.getSourceInst()
-               << "        ID:  %%" << inoutSendingVal << "\n"
-               << "        Rep: " << *rep << "        Transferring Op Num: "
-               << transferringOp->getOperandNumber() << '\n');
+    REGIONBASEDISOLATION_LOG(
+        llvm::dbgs()
+        << "    Emitting InOut Not Reinitialized At End Of Function!\n"
+        << "        Transferring Inst: " << *transferringOp->getUser()
+        << "        Transferring Op Value: " << transferringOp->get()
+        << "        Require Inst: " << *partitionOp.getSourceInst()
+        << "        ID:  %%" << inoutSendingVal << "\n"
+        << "        Rep: " << *rep << "        Transferring Op Num: "
+        << transferringOp->getOperandNumber() << '\n');
     transferOpToRequireInstMultiMap.insert(
         transferringOp, RequireInst::forInOutReinitializationNeeded(
                             partitionOp.getSourceInst()));
@@ -2544,17 +2553,19 @@ struct DiagnosticEvaluator final
 
 void TransferNonSendableImpl::runDiagnosticEvaluator() {
   // Then for each block...
-  LLVM_DEBUG(llvm::dbgs() << "Walking blocks for diagnostics.\n");
+  REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Walking blocks for diagnostics.\n");
   for (auto [block, blockState] : regionInfo->getRange()) {
-    LLVM_DEBUG(llvm::dbgs() << "|--> Block bb" << block.getDebugID() << "\n");
+    REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                             << "|--> Block bb" << block.getDebugID() << "\n");
 
     if (!blockState.getLiveness()) {
-      LLVM_DEBUG(llvm::dbgs() << "Dead block... skipping!\n");
+      REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Dead block... skipping!\n");
       continue;
     }
 
-    LLVM_DEBUG(llvm::dbgs() << "Entry Partition: ";
-               blockState.getEntryPartition().print(llvm::dbgs()));
+    REGIONBASEDISOLATION_LOG(
+        llvm::dbgs() << "Entry Partition: ";
+        blockState.getEntryPartition().print(llvm::dbgs()));
 
     // Grab its entry partition and setup an evaluator for the partition that
     // has callbacks that emit diagnsotics...
@@ -2571,11 +2582,12 @@ void TransferNonSendableImpl::runDiagnosticEvaluator() {
       eval.apply(partitionOp);
     }
 
-    LLVM_DEBUG(llvm::dbgs() << "Exit Partition: ";
-               workingPartition.print(llvm::dbgs()));
+    REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Exit Partition: ";
+                             workingPartition.print(llvm::dbgs()));
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "Finished walking blocks for diagnostics.\n");
+  REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                           << "Finished walking blocks for diagnostics.\n");
 
   // Now that we have found all of our transferInsts/Requires emit errors.
   transferOpToRequireInstMultiMap.setFrozen();
@@ -2590,8 +2602,8 @@ void TransferNonSendableImpl::runDiagnosticEvaluator() {
 /// state.
 void TransferNonSendableImpl::emitDiagnostics() {
   auto *function = regionInfo->getFunction();
-  LLVM_DEBUG(llvm::dbgs() << "Emitting diagnostics for function "
-                          << function->getName() << "\n");
+  REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Emitting diagnostics for function "
+                                        << function->getName() << "\n");
 
   runDiagnosticEvaluator();
   emitTransferredNonTransferrableDiagnostics();
@@ -2608,14 +2620,15 @@ class TransferNonSendable : public SILFunctionTransform {
 
     auto *functionInfo = getAnalysis<RegionAnalysis>()->get(function);
     if (!functionInfo->isSupportedFunction()) {
-      LLVM_DEBUG(llvm::dbgs() << "===> SKIPPING UNSUPPORTED FUNCTION: "
-                              << function->getName() << '\n');
+      REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                               << "===> SKIPPING UNSUPPORTED FUNCTION: "
+                               << function->getName() << '\n');
 
       return;
     }
 
-    LLVM_DEBUG(llvm::dbgs()
-               << "===> PROCESSING: " << function->getName() << '\n');
+    REGIONBASEDISOLATION_LOG(
+        llvm::dbgs() << "===> PROCESSING: " << function->getName() << '\n');
 
     TransferNonSendableImpl impl(functionInfo);
     impl.emitDiagnostics();

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(swiftSILOptimizer PRIVATE
   LexicalDestroyHoisting.cpp
   LoopUtils.cpp
   OptimizerStatsUtils.cpp
+  RegionIsolation.cpp
   PartialApplyCombiner.cpp
   PartitionUtils.cpp
   PerformanceInlinerUtils.cpp

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -20,37 +20,9 @@
 #include "swift/SIL/SILGlobalVariable.h"
 #include "swift/SILOptimizer/Utils/VariableNameUtils.h"
 
-#include "llvm/Support/CommandLine.h"
-
 using namespace swift;
 using namespace swift::PatternMatch;
 using namespace swift::PartitionPrimitives;
-
-//===----------------------------------------------------------------------===//
-//                               MARK: Logging
-//===----------------------------------------------------------------------===//
-
-bool swift::PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_LOGGING;
-
-static llvm::cl::opt<bool, true> // The parser
-    RegionBasedIsolationLog(
-        "sil-regionbasedisolation-log",
-        llvm::cl::desc("Enable logging for SIL region based isolation "
-                       "diagnostics"),
-        llvm::cl::Hidden,
-        llvm::cl::location(
-            swift::PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_LOGGING));
-
-bool swift::PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING;
-
-static llvm::cl::opt<bool, true> // The parser
-    RegionBasedIsolationVerboseLog(
-        "sil-regionbasedisolation-verbose-log",
-        llvm::cl::desc("Enable verbose logging for SIL region based isolation "
-                       "diagnostics"),
-        llvm::cl::Hidden,
-        llvm::cl::location(swift::PartitionPrimitives::
-                               REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING));
 
 //===----------------------------------------------------------------------===//
 //                             MARK: PartitionOp

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -30,7 +30,16 @@ using namespace swift::PartitionPrimitives;
 //                               MARK: Logging
 //===----------------------------------------------------------------------===//
 
-#ifndef NDEBUG
+bool swift::PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_LOGGING;
+
+static llvm::cl::opt<bool, true> // The parser
+    RegionBasedIsolationLog(
+        "sil-regionbasedisolation-log",
+        llvm::cl::desc("Enable logging for SIL region based isolation "
+                       "diagnostics"),
+        llvm::cl::Hidden,
+        llvm::cl::location(
+            swift::PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_LOGGING));
 
 bool swift::PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING;
 
@@ -42,8 +51,6 @@ static llvm::cl::opt<bool, true> // The parser
         llvm::cl::Hidden,
         llvm::cl::location(swift::PartitionPrimitives::
                                REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING));
-
-#endif
 
 //===----------------------------------------------------------------------===//
 //                             MARK: PartitionOp

--- a/lib/SILOptimizer/Utils/RegionIsolation.cpp
+++ b/lib/SILOptimizer/Utils/RegionIsolation.cpp
@@ -1,0 +1,36 @@
+//===--- RegionIsolation.cpp ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Utils/RegionIsolation.h"
+
+#include "llvm/Support/CommandLine.h"
+
+using namespace swift;
+using namespace regionisolation;
+
+//===----------------------------------------------------------------------===//
+//                               MARK: Logging
+//===----------------------------------------------------------------------===//
+
+LoggingFlag swift::regionisolation::ENABLE_LOGGING;
+
+static llvm::cl::opt<LoggingFlag, true> // The parser
+    RegionBasedIsolationLog(
+        "sil-regionbasedisolation-log",
+        llvm::cl::desc("Enable logging for SIL region based isolation "
+                       "diagnostics"),
+        llvm::cl::Hidden,
+        llvm::cl::values(
+            clEnumValN(LoggingFlag::Off, "none", "no logging"),
+            clEnumValN(LoggingFlag::Normal, "on", "non verbose logging"),
+            clEnumValN(LoggingFlag::Verbose, "verbose", "verbose logging")),
+        llvm::cl::location(swift::regionisolation::ENABLE_LOGGING));


### PR DESCRIPTION
Explanation: [region-isolation] Move logging in front of NDEBUG to make it easier to triage with no asserts compilers

This is just an attempt to make it easier to triage reported issues from no-asserts compilers. Today we compile those out, so I need to always compile an asserts compiler to do a basic triage. By moving this in front of NDEBUG, we ensure that we can enable this logging in no-asserts compilers.

Radars:

- rdar://133701799

Original PRs:

- https://github.com/swiftlang/swift/pull/75760
- https://github.com/swiftlang/swift/pull/75810

Risk: Low. This just adds a new macro instead of LLVM_DEBUG that enables/disables the debugging error msgs in the same manner except controlled by a different command line option that is available when asserts are disabled.

