### PR TITLE
[IRGen] Add a direct reference to Obj-C classes in their symbolic references.

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -496,6 +496,19 @@ getTypeRefImpl(IRGenModule &IGM,
   auto SymbolicName =
     useFlatUnique ? Mangler.mangleTypeForFlatUniqueTypeRef(sig, type)
                   : Mangler.mangleTypeForReflection(IGM, sig, type);
+
+  // If this is a symbolic reference to an imported Objective-C class, track
+  // it so that we record a direct pointer to the class when we emit the
+  // symbolic reference. This keeps it alive for the linker (when
+  // intentionally not using `-ObjC` or `-force_load`).
+  if (auto nominalTy = type->getAnyNominal()) {
+    if (auto classTy = llvm::dyn_cast<ClassDecl>(nominalTy)) {
+      if (classTy->isObjC() && classTy->hasClangNode() &&
+          classTy->hasSuperclass() && !classTy->isForeign()) {
+        SymbolicName.ObjCClassRef = classTy;
+      }
+    }
+  }
   return {IGM.getAddrOfStringForTypeRef(SymbolicName, role),
           SymbolicName.runtimeSizeInBytes()};
 }

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -148,8 +148,8 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
   SymbolicReferences.clear();
   
   body();
-  
-  return {finalize(), std::move(SymbolicReferences)};
+
+  return {finalize(), std::move(SymbolicReferences), nullptr};
 }
 
 SymbolicMangling
@@ -212,7 +212,7 @@ IRGenMangler::mangleTypeForFlatUniqueTypeRef(CanGenericSignature sig,
   appendType(type, sig);
 
   assert(SymbolicReferences.empty());
-  return {finalize(), {}};
+  return {finalize(), {}, nullptr};
 }
 
 std::string IRGenMangler::mangleProtocolConformanceDescriptor(

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -34,7 +34,18 @@ struct SymbolicMangling {
   std::string String;
   std::vector<std::pair<Mangle::ASTMangler::SymbolicReferent, unsigned>>
     SymbolicReferences;
-  
+  ClassDecl *ObjCClassRef;
+
+  SymbolicMangling(
+      std::string String,
+      std::vector<std::pair<Mangle::ASTMangler::SymbolicReferent, unsigned>>
+          SymbolicReferences,
+      ClassDecl *ObjCClassRef)
+      : String(String), SymbolicReferences(SymbolicReferences),
+        ObjCClassRef(ObjCClassRef) {}
+
+  SymbolicMangling() : SymbolicMangling("", {}, nullptr) {}
+
   unsigned runtimeSizeInBytes() const {
     return String.size();
   }

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -345,7 +345,8 @@ llvm::Constant *IRGenModule::getAddrOfStringForMetadataRef(
 
 llvm::Constant *IRGenModule::getAddrOfStringForTypeRef(StringRef str,
                                                        MangledTypeRefRole role){
-  return getAddrOfStringForTypeRef(SymbolicMangling{str.str(), {}}, role);
+  return getAddrOfStringForTypeRef(SymbolicMangling{str.str(), {}, nullptr},
+                                   role);
 }
 
 llvm::Constant *IRGenModule::getAddrOfStringForTypeRef(
@@ -470,7 +471,16 @@ llvm::Constant *IRGenModule::getAddrOfStringForTypeRef(
   
   // And a null terminator!
   S.addInt(Int8Ty, 0);
-  
+
+  // Append a pointer to the external Obj-C class, if present, after the null
+  // terminator. This ensures that the linker doesn't strip those classes if
+  // the user is intentionally linking without `-ObjC` or `-force_load`.
+  if (mangling.ObjCClassRef) {
+    S.addRelativeAddress(getAddrOfLLVMVariableOrGOTEquivalent(
+                             LinkEntity::forObjCClassRef(mangling.ObjCClassRef))
+                             .getValue());
+  }
+
   auto finished = S.finishAndCreateFuture();
   auto var = new llvm::GlobalVariable(Module, finished.getType(),
                                       /*constant*/ true,

--- a/test/ClangImporter/Inputs/custom-modules/GenericType.h
+++ b/test/ClangImporter/Inputs/custom-modules/GenericType.h
@@ -1,0 +1,9 @@
+@import Foundation;
+
+@interface GenericClass<T> : NSObject
+- (instancetype)initWithValue:(T)value;
+@end
+
+@interface AnotherGenericClass<T> : NSObject
+- (instancetype)initWithValue:(T)value;
+@end

--- a/test/ClangImporter/Inputs/custom-modules/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/module.modulemap
@@ -57,6 +57,11 @@ module EnumExhaustivity {
 
 module ExternIntX { header "x.h" }
 
+module GenericModule {
+  header "GenericType.h"
+  export *
+}
+
 module HasSubmodule {
   link framework "HasSubmodule"
   module Submodule {

--- a/test/ClangImporter/generic-symbol-refs.swift
+++ b/test/ClangImporter/generic-symbol-refs.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -module-name generic_symbol_refs -I %S/Inputs/custom-modules -emit-ir %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import Foundation
+import GenericModule
+
+func foo() {
+  _ = GenericClass<NSString>(value: "hello" as NSString)
+  // CHECK: @"OBJC_CLASS_REF_$_GenericClass" = private externally_initialized global ptr @"OBJC_CLASS_$_GenericClass", section "__DATA,__objc_classrefs,regular,no_dead_strip"
+  // CHECK: @"OBJC_CLASS_$_GenericClass" = external global %objc_class
+  // CHECK: @"symbolic So12GenericClassC" = linkonce_odr hidden constant <{ [17 x i8], i8, i32 }> <{ [17 x i8] c"So12GenericClassC", i8 0, i32 trunc (i64 sub (i64 ptrtoint (ptr @"OBJC_CLASS_REF_$_GenericClass" to i64), i64 ptrtoint (ptr getelementptr inbounds (<{ [17 x i8], i8, i32 }>, ptr @"symbolic So12GenericClassC", i32 0, i32 2) to i64)) to i32) }>, section "__TEXT,__swift5_typeref, regular", no_sanitize_address
+  // CHECK-NOT: @"symbolic So12GenericClassC" = linkonce_odr hidden constant <{ [17 x i8], i8 }> <{ [17 x i8] c"So12GenericClassC", i8 0 }>, section "__TEXT,__swift5_typeref, regular", no_sanitize_address
+
+  _ = GenericClass<AnotherGenericClass<NSString>>(value: .init(value: "hello" as NSString))
+  // CHECK: @"OBJC_CLASS_REF_$_AnotherGenericClass" = private externally_initialized global ptr @"OBJC_CLASS_$_AnotherGenericClass", section "__DATA,__objc_classrefs,regular,no_dead_strip"
+  // CHECK: @"OBJC_CLASS_$_AnotherGenericClass" = external global %objc_class
+  // CHECK: @"symbolic So19AnotherGenericClassC" = linkonce_odr hidden constant <{ [24 x i8], i8, i32 }> <{ [24 x i8] c"So19AnotherGenericClassC", i8 0, i32 trunc (i64 sub (i64 ptrtoint (ptr @"OBJC_CLASS_REF_$_AnotherGenericClass" to i64), i64 ptrtoint (ptr getelementptr inbounds (<{ [24 x i8], i8, i32 }>, ptr @"symbolic So19AnotherGenericClassC", i32 0, i32 2) to i64)) to i32) }>, section "__TEXT,__swift5_typeref, regular", no_sanitize_address
+  // CHECK-NOT: @"symbolic So19AnotherGenericClassC" = linkonce_odr hidden constant <{ [24 x i8], i8 }> <{ [24 x i8] c"So19AnotherGenericClassC", i8 0 }>, section "__TEXT,__swift5_typeref, regular", no_sanitize_address
+
+  // CHECK: @llvm.compiler.used =
+  // CHECK-DAG: ptr @"OBJC_CLASS_REF_$_GenericClass"
+  // CHECK-DAG: ptr @"OBJC_CLASS_REF_$_AnotherGenericClass"
+  // CHECK-SAME: , section "llvm.metadata"
+}


### PR DESCRIPTION
In some cases, users may want to intentionally link certain Obj-C dependencies without `-ObjC` or `-force_load`. When Swift references a generic Obj-C class, it uses the mangled name type metadata accessors, and no direct reference to the class symbol is emitted in the object code. (This differs from Clang, where naming the class in source does emit such a reference.)

This change appends a relative pointer to that symbol after the null terminator of the mangled symbolic reference. It will therefore not be considered part of the name, but will keep the symbol alive for the linker.

Context: https://forums.swift.org/t/odd-behavior-involving-generic-obj-c-classes-and-type-metadata-accessors/73265
