### PR TITLE
VTableSpecializer: fix a crash for methods which have their own generic parameters

### DIFF
--- a/test/embedded/classes-non-final-method-no-stdlib.swift
+++ b/test/embedded/classes-non-final-method-no-stdlib.swift
@@ -6,3 +6,23 @@ public class MyClass {
   func foo<T>(t: T) { } // expected-error {{classes cannot have non-final generic fuctions in embedded Swift}}
   func bar() { }
 }
+
+final class C2<Element> {
+  // TODO: this shouldn't be a problem because the class is final
+  init<T>(x: T) { } // expected-error {{classes cannot have non-final generic fuctions in embedded Swift}}
+}
+
+struct S {}
+
+func testit2() -> C2<S> {
+  return C2(x: S())
+}
+
+open class C3<X> {
+  public func foo<T>(t: T) {} // expected-error {{classes cannot have non-final generic fuctions in embedded Swift}}
+}
+
+func testit3() -> C3<S> {
+  return C3<S>()
+}
+

--- a/test/embedded/generic-classes.swift
+++ b/test/embedded/generic-classes.swift
@@ -46,6 +46,52 @@ public func makeInner() -> Outer<Int>.Inner {
   return Outer<Int>.Inner()
 }
 
+final class List<Element> where Element: ~Copyable {
+  init(x: Element) where Element: Copyable { }
+}
+
+func testList() -> List<Int> {
+  return List(x: 0)
+}
+
+open class OpenClass<Element> where Element: ~Copyable {
+  public func foo(x: Element) where Element: Copyable { }
+}
+
+func testOpenClass() -> OpenClass<Int> {
+  return OpenClass()
+}
+
+
+class Base<T> {
+  func foo(_: T) {}
+}
+
+class Derived<T>: Base<Array<T>> {}
+
+func testBaseDerived() -> Derived<Int> {
+  return Derived()
+}
+
+class Base2<T> {
+  func foo(_: T) {}
+}
+
+class Derived2<T>: Base2<(T, T)> {}
+
+func testBaseDerived2() -> Derived2<Int> {
+  return Derived2()
+}
+
+class Base3<T> {
+  func foo(_: T) {}
+}
+class Derived3<T, U>: Base3<(T, U)> {}
+
+func testBaseDerived3() -> Derived3<Int, Bool> {
+  return Derived3()
+}
+
 @main
 struct Main {
   static func main() {
@@ -56,6 +102,11 @@ struct Main {
     let x = SubClass2()
     x.test()
     makeInner().foo()
+    testList()
+    testOpenClass()
+    testBaseDerived()
+    testBaseDerived2()
+    testBaseDerived3()
   }
 }
 


### PR DESCRIPTION
rdar://133334324
