### PR TITLE
Fix diagnosis in Range with mismatched generic arguments

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9386,3 +9386,34 @@ bool InvalidTypeAsKeyPathSubscriptIndex::diagnoseAsError() {
   emitDiagnostic(diag::cannot_convert_type_to_keypath_subscript_index, ArgType);
   return true;
 }
+
+bool OperatorArgumentMismatchFailure::diagnoseAsError() {
+  if (lhs->isEqual(rhs)) {
+    emitDiagnostic(diag::cannot_apply_binop_to_same_args, operatorName.str(),
+                   lhs);
+  } else {
+    emitDiagnostic(diag::cannot_apply_binop_to_args, operatorName.str(),
+                   lhs, rhs);
+  }
+
+  diagnoseAsNote();
+  return true;
+}
+
+bool OperatorArgumentMismatchFailure::diagnoseAsNote() {
+
+  auto stringifyPairs = [](std::pair<Type, Type> params) -> std::string {
+    return "(" + params.first->getString() + ", " + params.second->getString() + ")";
+  };
+
+  std::set<std::string> parameters;
+  for (auto parameterPair : matchingParamLists) {
+    auto pairString = stringifyPairs(parameterPair);
+    parameters.insert(pairString);
+  }
+
+  emitDiagnostic(diag::suggest_partial_overloads,
+                 /*isResult*/ false, operatorName.str(),
+                 llvm::join(parameters, ", "));
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3196,6 +3196,26 @@ public:
   bool diagnoseAsError() override;
 };
 
+class OperatorArgumentMismatchFailure final : public FailureDiagnostic {
+  Identifier operatorName;
+  Type lhs;
+  Type rhs;
+  SmallVector<std::pair<Type, Type>, 2> matchingParamLists;
+
+public:
+  OperatorArgumentMismatchFailure(const Solution &solution,
+                                  Identifier operatorName,
+                                  Type lhs,
+                                  Type rhs,
+                                  SmallVector<std::pair<Type, Type>, 2> matchingParamLists,
+                                  ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), operatorName(operatorName),
+  lhs(lhs), rhs(rhs), matchingParamLists(matchingParamLists) {}
+
+  bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15236,7 +15236,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowGenericFunctionSpecialization:
   case FixKind::IgnoreGenericSpecializationArityMismatch:
   case FixKind::IgnoreKeyPathSubscriptIndexMismatch:
-  case FixKind::AllowMemberRefOnExistential: {
+  case FixKind::AllowMemberRefOnExistential:
+  case FixKind::IgnoreOperatorArgumentMismatch: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
   case FixKind::IgnoreThrownErrorMismatch: {

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -569,6 +569,10 @@ public:
         break;
     }
 
+    if (mergeOperatorFixesIfPossible()) {
+      return suspend(std::make_unique<SplitterStep>(CS, Solutions));
+    }
+
     return done(/*isSuccess=*/AnySolved);
   }
 
@@ -598,6 +602,13 @@ protected:
     return false;
   }
 
+  /// If at the end of this binding step the only fixes are for mismatched
+  /// argument types on the same operator, attempt to merge them into a
+  /// single fix.
+  virtual bool mergeOperatorFixesIfPossible() {
+    return false;
+  }
+
   bool needsToComputeNext() const { return Producer.needsToComputeNext(); }
 
   ConstraintLocator *getLocator() const { return Producer.getLocator(); }
@@ -622,6 +633,8 @@ public:
         TypeVar(bindings.getTypeVariable()) {}
 
   void setup() override;
+
+  bool mergeOperatorFixesIfPossible() override;
 
   StepResult resume(bool prevFailed) override;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4889,13 +4889,12 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
     auto firstChoiceType = overload.choices[0].getBaseType();
     if (!firstChoiceType)
       return false;
-    CanType referenceType = firstChoiceType->getCanonicalType();
 
     for (auto &choice : overload.choices) {
       Type choiceType = choice.getBaseType();
       if (!choiceType || choiceType->hasTypeVariable())
         return false;
-      if (choiceType->getCanonicalType() != referenceType)
+      if (!choiceType->isEqual(firstChoiceType))
         return false;
     }
   }
@@ -4954,12 +4953,14 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
   llvm::SmallDenseMap<std::pair<GenericTypeParamType *, SourceLoc>,
                       SmallVector<Type, 4>>
       conflicts;
+  SmallVector<ConstraintLocator *, 4> conflictingCalleeLocators;
 
   for (const auto &entry : genericParams) {
     auto *typeVar = entry.first;
     auto GP = entry.second;
 
     swift::SmallSetVector<Type, 4> arguments;
+    swift::SmallSetVector<ConstraintLocator *, 4> calleeLocators;
     for (const auto &solution : solutions) {
       auto type = solution.typeBindings.lookup(typeVar);
       // Type variables gathered from a solution's type binding context may not
@@ -4983,10 +4984,37 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
       }
 
       arguments.insert(type);
+      calleeLocators.insert(solution.getCalleeLocator(typeVar->getImpl().getLocator()));
     }
 
-    if (arguments.size() > 1)
+    if (arguments.size() > 1) {
       conflicts[GP].append(arguments.begin(), arguments.end());
+      if (calleeLocators.size() == 1)
+        conflictingCalleeLocators.push_back(calleeLocators.front());
+    }
+  }
+  
+  // Special handling with better diagnostics if the callee with
+  // conflicting generic arguments is an operator.
+  for (auto &calleeLocator : conflictingCalleeLocators) {
+    auto refDecl = castToExpr(calleeLocator->getAnchor())->getReferencedDecl();
+    if (!refDecl)
+      continue;
+    DeclName calleeName = refDecl.getDecl()->getName();
+    if (calleeName.isOperator()) {
+      auto *anchor = castToExpr(calleeLocator->getAnchor());
+      // Use tailored ambiguity diagnostics for "applied" operators
+      // (e.g. `1 + 2`) only.
+      if (auto *parentExpr = cs.getParentExpr(anchor)) {
+        if (auto *apply = dyn_cast<ApplyExpr>(parentExpr)) {
+          if (apply->getFn() == anchor) {
+            diagnoseOperatorAmbiguity(cs, calleeName.getBaseIdentifier(), solutions,
+                                      calleeLocator);
+            return true;
+          }
+        }
+      }
+    }
   }
 
   auto getGenericTypeDecl = [&](ArchetypeType *archetype) -> ValueDecl * {

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -329,3 +329,10 @@ enum I60954 {
   }
   init?<S>(_ string: S) where S: StringProtocol {} // expected-note{{where 'S' = 'I60954'}}
 }
+
+// https://github.com/swiftlang/swift/issues/72533
+func f_72533() {
+  let foo: Int = 1
+  Int(foo)..<Int16.max
+  // expected-error@-1{{conflicting arguments to generic parameter 'Self'}}
+}

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -334,7 +334,9 @@ enum I60954 {
 func f_72533() {
   Int.min..<Int16.max
   // expected-error@-1{{binary operator '..<' cannot be applied to operands of type 'Int' and 'Int16'}}
+  // expected-note@-2{{overloads for '..<' exist with these partially matching parameter lists: (Int, Int), (Int16, Int16)}}
   let foo: Int = 1
   Int(foo)..<Int16.max
   // expected-error@-1{{binary operator '..<' cannot be applied to operands of type 'Int' and 'Int16'}}
+  // expected-note@-2{{overloads for '..<' exist with these partially matching parameter lists: (Int, Int), (Int16, Int16)}}
 }

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -332,7 +332,9 @@ enum I60954 {
 
 // https://github.com/swiftlang/swift/issues/72533
 func f_72533() {
+  Int.min..<Int16.max
+  // expected-error@-1{{binary operator '..<' cannot be applied to operands of type 'Int' and 'Int16'}}
   let foo: Int = 1
   Int(foo)..<Int16.max
-  // expected-error@-1{{conflicting arguments to generic parameter 'Self'}}
+  // expected-error@-1{{binary operator '..<' cannot be applied to operands of type 'Int' and 'Int16'}}
 }


### PR DESCRIPTION
Attempt to improve the diagnostic error when a `Range` contains arguments of different types that are the result of a function with different overloads.
```swift
let foo: Int = 1
Int(foo)..<Int16.max
        `- error: type of expression is ambiguous without a type annotation
```
When the compiler tries to find a solution (with fixes) for the expression above, it tries different overloads for `Int.init(_:)`, even though all of them resolve to `-> Int` and could not cause a misdiagnosis in `diagnoseConflictingGenericArguments()`. However, since the solution diff contains overloads, `diagnoseConflictingGenericArguments()` exits early, missing the more specific diagnosis.

Instead of outright rejecting any conflicting generic arguments diagnosis when the solutions contain different overloads, check first whether these overloads could result in different generic arguments by themselves, and allow `diagnoseConflictingGenericArguments()` to continue if they all resolve to the same type. 

By doing that, the correct error is emitted:
```swift
let foo: Int = 1
Int(foo)..<Int16.max
        `- error: conflicting arguments to generic parameter 'Self' ('Int' vs. 'Int16')
```
What do you think? Does this look like a possible approach?

(Fixes #72533)