### PR TITLE
[region-isolation] Improve debug logging

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -323,6 +323,12 @@ public:
     return (kind == Task || kind == Actor) && bool(isolatedValue);
   }
 
+  SILValue maybeGetIsolatedValue() const {
+    if (!hasIsolatedValue())
+      return {};
+    return getIsolatedValue();
+  }
+
   static SILIsolationInfo getDisconnected(bool isUnsafeNonIsolated) {
     return {Kind::Disconnected,
             isUnsafeNonIsolated ? Flag::UnsafeNonIsolated : Flag::None};

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -2216,7 +2216,7 @@ struct DiagnosticEvaluator final
                      << "        Rep: "
                      << *info->getValueMap().getRepresentative(transferredVal)
                      << "        Dynamic Isolation Region: ";
-        isolationRegionInfo.printForDiagnostics(llvm::dbgs());
+        isolationRegionInfo.printForOneLineLogging(llvm::dbgs());
         llvm::dbgs() << '\n');
     auto *self = const_cast<DiagnosticEvaluator *>(this);
     auto nonTransferrableValue =
@@ -2236,7 +2236,7 @@ struct DiagnosticEvaluator final
                      << "        Rep: "
                      << *info->getValueMap().getRepresentative(inoutSendingVal)
                      << "        Dynamic Isolation Region: ";
-        isolationRegionInfo.printForDiagnostics(llvm::dbgs());
+        isolationRegionInfo.printForOneLineLogging(llvm::dbgs());
         llvm::dbgs() << '\n');
     auto *self = const_cast<DiagnosticEvaluator *>(this);
     auto nonTransferrableValue =
@@ -2257,7 +2257,7 @@ struct DiagnosticEvaluator final
                      << "        Rep: "
                      << *info->getValueMap().getRepresentative(transferredVal)
                      << "        Dynamic Isolation Region: ";
-        isolationRegionInfo.printForDiagnostics(llvm::dbgs());
+        isolationRegionInfo.printForOneLineLogging(llvm::dbgs());
         llvm::dbgs() << '\n');
 
     auto *self = const_cast<DiagnosticEvaluator *>(this);

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -2217,7 +2217,16 @@ struct DiagnosticEvaluator final
                      << *info->getValueMap().getRepresentative(transferredVal)
                      << "        Dynamic Isolation Region: ";
         isolationRegionInfo.printForOneLineLogging(llvm::dbgs());
-        llvm::dbgs() << '\n');
+        llvm::dbgs() << '\n';
+        if (auto isolatedValue = isolationRegionInfo->maybeGetIsolatedValue()) {
+          llvm::dbgs() << "        Isolated Value: " << isolatedValue;
+          auto name = inferNameHelper(isolatedValue);
+          llvm::dbgs() << "        Isolated Value Name: "
+                       << (name.has_value() ? name->get() : "none") << '\n';
+        } else {
+          llvm::dbgs() << "        Isolated Value: none\n";
+        }
+    );
     auto *self = const_cast<DiagnosticEvaluator *>(this);
     auto nonTransferrableValue =
         info->getValueMap().getRepresentative(transferredVal);


### PR DESCRIPTION
This PR just causes us to print out the isolated value in the debug logging when we are emitting a send never sendable error. As we introduce isolation history, this will become more and more useful.