### PR TITLE
[SourceKit] Make `SwiftASTConsumer::failed` pure virtual

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -42,8 +42,6 @@ using namespace SourceKit;
 using namespace swift;
 using namespace swift::sys;
 
-void SwiftASTConsumer::failed(StringRef Error) { }
-
 //===----------------------------------------------------------------------===//
 // SwiftInvocation
 //===----------------------------------------------------------------------===//

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -223,7 +223,7 @@ public:
 
   /// Creation of the AST failed due to \p Error. The request corresponding to
   /// this consumer should fail.
-  virtual void failed(StringRef Error);
+  virtual void failed(StringRef Error) = 0;
 
   /// The consumer was cancelled by the \c requestCancellation method and the \c
   /// ASTBuildOperation creating the AST for this consumer honored the request.

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2633,6 +2633,11 @@ void SwiftLangSupport::getSemanticTokens(
     void cancelled() override {
       Receiver(RequestResult<SemanticTokensResult>::cancelled());
     }
+
+    void failed(StringRef Error) override {
+      LOG_WARN_FUNC("semantic tokens failed: " << Error);
+      Receiver(RequestResult<SemanticTokensResult>::fromError(Error));
+    }
   };
 
   auto Consumer = std::make_shared<SemanticTokensConsumer>(InputBufferName,

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1811,6 +1811,11 @@ static void computeDiagnostics(
     void cancelled() override {
       Receiver(RequestResult<DiagnosticsResult>::cancelled());
     }
+
+    void failed(StringRef Error) override {
+      LOG_WARN_FUNC("diagnostics failed: " << Error);
+      Receiver(RequestResult<DiagnosticsResult>::fromError(Error));
+    }
   };
 
   auto Consumer = std::make_shared<DiagnosticsConsumer>(std::move(Receiver));


### PR DESCRIPTION
Previously, if a semantic tokens request or diagnostic request failed, we wouldn’t return any response.
