### PR TITLE
SILGen: Skip SIL verification and optimization if errors were emitted

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -193,11 +193,7 @@ extension LifetimeDependence {
     if arg.isIndirectResult {
       return nil
     }
-    guard let scope = Scope(base: arg, context) else {
-      // Ignore invalid argument types.
-      return nil
-    }
-    self.scope = scope
+    self.scope = Scope(base: arg, context)!
     self.dependentValue = arg
   }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1643,6 +1643,13 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
     return writeSIL(*SM, PSPs, Instance, Invocation.getSILOptions());
   }
 
+  // In lazy typechecking mode, SILGen may have triggered requests which
+  // resulted in errors. We don't want to proceed with optimization or
+  // serialization if there were errors since the SIL may be incomplete or
+  // invalid.
+  if (Context.TypeCheckerOpts.EnableLazyTypecheck && Context.hadError())
+    return true;
+
   if (Action == FrontendOptions::ActionType::EmitSIBGen) {
     serializeSIB(SM.get(), PSPs, Context, MSF);
     return Context.hadError();

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -95,6 +95,11 @@ SILGenModule::~SILGenModule() {
       f.setLinkage(SILLinkage::PublicExternal);
   }
 
+  // Skip verification if a lazy typechecking error occurred.
+  auto &ctx = getASTContext();
+  if (ctx.TypeCheckerOpts.EnableLazyTypecheck && ctx.hadError())
+    return;
+
   M.verifyIncompleteOSSA();
 }
 


### PR DESCRIPTION
In lazy typechecking mode, errors in the program may only be discovered during SILGen, which can leave the SIL in a bad state for subsequent stages of compilation. If errors were detected, skip SIL verification and optimization to prevent knock-on failures.

Partially reverts https://github.com/swiftlang/swift/pull/75428, which included a more targeted fix for one of the possible knock-on effects of bad SIL coming out of SILGen.

Resolves rdar://132107752.
