### PR TITLE
Eagerly emit getters at Onone.

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -576,6 +576,10 @@ struct SILDeclRef {
   /// for e.g a lazy variable getter.
   bool hasUserWrittenCode() const;
 
+  /// Returns true if this is a function that should be emitted because it is
+  /// accessible in the debugger.
+  bool shouldBeEmittedForDebugger() const;
+
   /// Return the scope in which the parent class of a method (i.e. class
   /// containing this declaration) can be subclassed, returning NotApplicable if
   /// this is not a method, there is no such class, or the class cannot be

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1198,8 +1198,9 @@ void SILGenModule::emitOrDelayFunction(SILDeclRef constant) {
   auto emitAfter = lastEmittedFunction;
 
   // Implicit decls may be delayed if they can't be used externally.
-  auto linkage = constant.getLinkage(ForDefinition);
-  bool mayDelay = !constant.hasUserWrittenCode() &&
+  auto linkage = constant.getLinkage(ForDefinition);;
+  bool mayDelay = !constant.shouldBeEmittedForDebugger() &&
+                  !constant.hasUserWrittenCode() &&
                   !constant.isDynamicallyReplaceable() &&
                   !isPossiblyUsedExternally(linkage, M.isWholeModule());
 

--- a/test/IRGen/preserve_for_debugger.swift
+++ b/test/IRGen/preserve_for_debugger.swift
@@ -55,6 +55,8 @@ class Baz: Foo {
 
 struct Qux {
   @Bar(wrappedValue: Baz()) private var baz: Baz
+  // Baz instance that is never accessed.
+  @Bar(wrappedValue: Baz()) private var baz2: Baz
 
     func f() {
         print(self.baz) // break here
@@ -64,3 +66,4 @@ let qux = Qux()
 qux.f()
 
 // CHECK: !DISubprogram(name: "baz.get"
+// CHECK: !DISubprogram(name: "baz2.get"


### PR DESCRIPTION
Force SILGen to also eagerly emit getters when compiling at Onone. The reason for this is that getters (even not user-written ones, generated by result builders) can, and are often called by users debugging swift programs, and should be available for that reason.

rdar://133329303
