### PR TITLE
[SymbolGraphGen] don't drop underscored protocol implementation symbols

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -725,11 +725,17 @@ bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
     // Special cases below.
 
     // If we've been asked to skip protocol implementations, filter them out here.
-    if (Walker.Options.SkipProtocolImplementations && getProtocolRequirement(VD)) {
-      // Allow them to stay if they have their own doc comment
-      const auto *DocCommentProvidingDecl = VD->getDocCommentProvidingDecl();
-      if (DocCommentProvidingDecl != VD)
-        return true;
+    if (Walker.Options.SkipProtocolImplementations) {
+      if (const auto *ProtocolRequirement = getProtocolRequirement(VD)) {
+        if (const auto *Protocol = ProtocolRequirement->getDeclContext()->getSelfProtocolDecl()) {
+          if (!Protocol->hasUnderscoredNaming()) {
+            // Allow them to stay if they have their own doc comment
+            const auto *DocCommentProvidingDecl = VD->getDocCommentProvidingDecl();
+            if (DocCommentProvidingDecl != VD)
+              return true;
+          }
+        }
+      }
     }
 
     // Symbols from exported-imported modules should only be included if they

--- a/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
+++ b/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
@@ -25,15 +25,21 @@
 // Same for ExtraStruct.Inner
 // CHECK-DAG: s:27SkipProtocolImplementations11ExtraStructV5InnerV
 
+// HiddenStruct.T should be present because its source protocol is underscored
+// CHECK-DAG: "precise": "s:27SkipProtocolImplementations12HiddenStructV1TV",
+
 // CHECK-LABEL: "relationships": [
 
 // we want to make sure that the conformance relationship itself stays
 // CHECK-DAG: conformsTo
 
-// SomeStruct.otherFunc() and ExtraStruct.Inner should be the only ones with sourceOrigin information
+// There should only be three symbols with sourceOrigin information:
+// - SomeStruct.otherFunc()
+// - ExtraStruct.Inner
+// - HiddenStruct.T
 // (ExtraStruct.Inner will have two sourceOrigins because it has two relationships: a memberOf and a
 // conformsTo)
-// COUNT-COUNT-3: sourceOrigin
+// COUNT-COUNT-4: sourceOrigin
 // COUNT-NOT: sourceOrigin
 
 public protocol SomeProtocol {
@@ -73,3 +79,11 @@ public struct ExtraStruct: OtherProtocol {
 }
 
 extension ExtraStruct.Inner: Sendable {}
+
+public protocol _HiddenProtocol {
+    associatedtype T
+}
+
+public struct HiddenStruct: _HiddenProtocol {
+    public struct T {}
+}


### PR DESCRIPTION
Resolves rdar://133086270

Consider the following Swift code:

```swift
public protocol _HiddenProtocol {
    associatedtype T
}

public class MyClass: _HiddenProtocol {
    public struct T {}
}
```

When using SymbolGraphGen with the `-skip-protocol-implementations` flag, the type `MyClass.T` is hidden from the symbol graph, even though the protocol it's implementing is also hidden. This PR changes the `-skip-protocol-implementations` code to check whether the protocol being implemented has an underscored name before dropping the implementation symbol from the symbol graph.