### PR TITLE
[Demangling] Handle end of text in demangleSpecAttributes to avoid

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -3433,7 +3433,12 @@ NodePointer Demangler::demangleSpecAttributes(Node::Kind SpecKind) {
   bool isSerialized = nextIf('q');
   bool asyncRemoved = nextIf('a');
 
-  int PassID = (int)nextChar() - '0';
+  char c = nextChar();
+  if (c == 0) {
+    // End of text.
+    return nullptr;
+  }
+  int PassID = (int)c - '0';
   if (PassID < 0 || PassID >= MAX_SPECIALIZATION_PASS) {
     assert(false && "unexpected pass id");
     return nullptr;


### PR DESCRIPTION
assertion `false && "unexpected pass id"' failed on truncated pass ids.

Exposed by copy and paste error dropping the pass id. e.g.  $ss16IndexingIteratorV4next7ElementQzSgyFSnySiG_Tg vs $ss16IndexingIteratorV4next7ElementQzSgyFSnySiG_Tg5