### PR TITLE
[Runtime] Use Runtime types for size/stride in TargetValueWitnessTypes.

### DIFF
--- a/include/swift/ABI/ValueWitnessTable.h
+++ b/include/swift/ABI/ValueWitnessTable.h
@@ -119,8 +119,8 @@ public:
 
   // Handle the data witnesses explicitly so we can use more specific
   // types for the flags enums.
-  typedef size_t size;
-  typedef size_t stride;
+  typedef typename Runtime::StoredSize size;
+  typedef typename Runtime::StoredSize stride;
   typedef TargetValueWitnessFlags<typename Runtime::StoredSize> flags;
   typedef uint32_t extraInhabitantCount;
 };


### PR DESCRIPTION
We want to use Runtime::StoredSize so the layout is correct when using an external Runtime template. size_t is correct in-process but may not be correct out of process.