### PR TITLE
Remove trivially dead instructions

### DIFF
--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1879,7 +1879,11 @@ void ConstantFolder::initializeWorklist(SILFunction &f) {
       auto *inst = &*ii;
       ++ii;
 
-      // TODO: Eliminate trivially dead instructions here.
+      // Eliminate trivially dead instructions.
+      if (!inst->mayHaveSideEffects() && inst->use_empty()) {
+        inst->eraseFromParent();
+        continue;
+      }
 
       // If `I` is a floating-point literal instruction where the literal is
       // inf, it means the input has a literal that overflows even


### PR DESCRIPTION
Resolve the TODO by checking if an instruction has no uses and has no side effects.