### PR TITLE
Test: fix convenience_init_peer_delegation.swift

### DIFF
--- a/test/Interpreter/convenience_init_peer_delegation.swift
+++ b/test/Interpreter/convenience_init_peer_delegation.swift
@@ -1,34 +1,39 @@
 // RUN: %empty-directory(%t)
 //
-// RUN: %target-build-swift %s -Xfrontend -disable-objc-attr-requires-foundation-module -o %t/main
+// RUN: %target-build-swift %s -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 // RUN: %empty-directory(%t)
 //
 // RUN: sed -e 's/required//g' < %s > %t/without_required.swift
-// RUN: %target-build-swift %t/without_required.swift -Xfrontend -disable-objc-attr-requires-foundation-module -o %t/without_required
+// RUN: %target-build-swift %t/without_required.swift -o %t/without_required
 // RUN: %target-codesign %t/without_required
 // RUN: %target-run %t/without_required | %FileCheck %s
 
 // RUN: %empty-directory(%t)
 //
-// RUN: %target-build-swift %s -Xfrontend -disable-objc-attr-requires-foundation-module -o %t/main -swift-version 5
+// RUN: %target-build-swift %s -o %t/main -swift-version 5
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 // RUN: %empty-directory(%t)
 //
 // RUN: sed -e 's/required//g' < %s > %t/without_required.swift
-// RUN: %target-build-swift %t/without_required.swift -Xfrontend -disable-objc-attr-requires-foundation-module -o %t/without_required -swift-version 5
+// RUN: %target-build-swift %t/without_required.swift -o %t/without_required -swift-version 5
 // RUN: %target-codesign %t/without_required
 // RUN: %target-run %t/without_required | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// REQUIRES: foundation
 // XFAIL: CPU=arm64e
 
+// Because of the use of 'sed' in this test.
+// REQUIRES: shell
+
 import Darwin
+import Foundation
 
 class Base {
   init(swift: ()) {

--- a/test/Interpreter/convenience_init_peer_delegation.swift
+++ b/test/Interpreter/convenience_init_peer_delegation.swift
@@ -32,6 +32,10 @@
 // Because of the use of 'sed' in this test.
 // REQUIRES: shell
 
+// rdar://133393259 fails in optimized tests.
+// UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
+
 import Darwin
 import Foundation
 


### PR DESCRIPTION
Workaround an issue in this test by disabling it in certain testing environments

related to rdar://133393259