### PR TITLE
[Serialization] Do not serialize unstable hashes

### DIFF
--- a/include/swift/Localization/LocalizationFormat.h
+++ b/include/swift/Localization/LocalizationFormat.h
@@ -71,7 +71,7 @@ public:
   using hash_value_type = uint32_t;
   using offset_type = uint32_t;
 
-  hash_value_type ComputeHash(key_type_ref key) { return llvm::hash_code(key); }
+  hash_value_type ComputeHash(key_type_ref key) { return key; }
 
   std::pair<offset_type, offset_type> EmitKeyDataLength(llvm::raw_ostream &out,
                                                         key_type_ref key,
@@ -113,9 +113,7 @@ public:
     return lhs == rhs;
   }
 
-  hash_value_type ComputeHash(internal_key_type key) {
-    return llvm::hash_code(key);
-  }
+  hash_value_type ComputeHash(internal_key_type key) { return key; }
 
   static std::pair<offset_type, offset_type>
   ReadKeyDataLength(const unsigned char *&data) {

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1116,7 +1116,7 @@ namespace {
     }
 
     hash_value_type ComputeHash(key_type_ref key) {
-      return llvm::DenseMapInfo<SerializedSwiftName>::getHashValue(key);
+      return static_cast<hash_value_type>(key.Kind) + llvm::djbHash(key.Name);
     }
 
     std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,
@@ -1223,7 +1223,8 @@ namespace {
     }
 
     hash_value_type ComputeHash(key_type_ref key) {
-      return static_cast<unsigned>(key.first) + llvm::djbHash(key.second);
+      return static_cast<hash_value_type>(key.first) +
+             llvm::djbHash(key.second);
     }
 
     std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,
@@ -1414,7 +1415,7 @@ namespace {
     }
 
     hash_value_type ComputeHash(internal_key_type key) {
-      return llvm::DenseMapInfo<SerializedSwiftName>::getHashValue(key);
+      return static_cast<hash_value_type>(key.Kind) + llvm::djbHash(key.Name);
     }
 
     static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
@@ -1502,7 +1503,7 @@ namespace {
     }
 
     hash_value_type ComputeHash(internal_key_type key) {
-      return static_cast<unsigned>(key.first) + llvm::djbHash(key.second);
+      return static_cast<hash_value_type>(key.first) + llvm::djbHash(key.second);
     }
 
     static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -282,8 +282,7 @@ const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MAJOR = 1;
 /// Lookup table minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 18; // Unsafe C++ method renaming.
-
+const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 19; // hash functions
 
 /// A lookup table that maps Swift names to the set of Clang
 /// declarations with that particular name.

--- a/lib/Serialization/ModuleFileCoreTableInfo.h
+++ b/lib/Serialization/ModuleFileCoreTableInfo.h
@@ -330,7 +330,7 @@ public:
   }
 
   hash_value_type ComputeHash(internal_key_type key) {
-    return llvm::hash_value(key);
+    return key;
   }
 
   static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
@@ -580,7 +580,7 @@ public:
   internal_key_type GetInternalKey(external_key_type ID) { return ID; }
 
   hash_value_type ComputeHash(internal_key_type key) {
-    return llvm::hash_value(key);
+    return key;
   }
 
   static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 882; // CXXStdlibKind
+const uint16_t SWIFTMODULE_VERSION_MINOR = 883; // hash functions
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -414,7 +414,7 @@ namespace {
     using offset_type = unsigned;
 
     hash_value_type ComputeHash(key_type_ref key) {
-      return llvm::hash_value(static_cast<uint32_t>(key));
+      return key;
     }
 
     std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,
@@ -459,7 +459,7 @@ namespace {
     using offset_type = unsigned;
 
     hash_value_type ComputeHash(key_type_ref key) {
-      return llvm::hash_value(static_cast<uint32_t>(key));
+      return key;
     }
 
     std::pair<unsigned, unsigned>


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/96282 changed `get_execution_seed` to be non-deterministic. Use stable hashes instead.