### PR TITLE
[cxx-interop] Allow initializing `std::map` from Swift Dictionary

### DIFF
--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -51,6 +51,20 @@ public protocol CxxDictionary<Key, Value> {
 }
 
 extension CxxDictionary {
+  /// Creates a C++ map containing the elements of a Swift Dictionary.
+  ///
+  /// This initializes the map by copying every key and value of the dictionary.
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of entries in the Swift
+  ///   dictionary
+  @inlinable
+  public init(_ dictionary: Dictionary<Key, Value>) where Key: Hashable {
+    self.init()
+    for (key, value) in dictionary {
+      self[key] = value
+    }
+  }
+
   @inlinable
   public subscript(key: Key) -> Value? {
     get {

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -28,6 +28,49 @@ StdMapTestSuite.test("init") {
   expectTrue(m.empty())
 }
 
+StdMapTestSuite.test("Map.init(_: Dictionary<Int, Int>)") {
+  let swiftDict: [Int32 : Int32] = [-1: 2, 2: 3, 33: 44]
+  let m = Map(swiftDict)
+  expectEqual(m.size(), 3)
+
+  expectEqual(m[-1], 2)
+  expectEqual(m[2], 3)
+  expectEqual(m[33], 44)
+
+  let emptySwiftDict: [Int32 : Int32] = [:]
+  let emptyM = Map(emptySwiftDict)
+  expectEqual(emptyM.size(), 0)
+}
+
+/// Same as above, but for std::unordered_map.
+StdMapTestSuite.test("UnorderedMap.init(_: Dictionary<Int, Int>)") {
+  let swiftDict: [Int32 : Int32] = [-1 : 2, 2 : 3, 33 : 44]
+  let m = UnorderedMap(swiftDict)
+  expectEqual(m.size(), 3)
+
+  expectEqual(m[-1], 2)
+  expectEqual(m[2], 3)
+  expectEqual(m[33], 44)
+
+  let emptySwiftDict: [Int32 : Int32] = [:]
+  let emptyM = UnorderedMap(emptySwiftDict)
+  expectEqual(emptyM.size(), 0)
+}
+
+StdMapTestSuite.test("MapStrings.init(_: Dictionary<std.string, std.string>)") {
+  let swiftDict = [std.string("abc") : std.string("123"),
+                   std.string() : std.string("empty")]
+  let m = MapStrings(swiftDict)
+  expectEqual(m.size(), 2)
+
+  expectEqual(m[std.string("abc")], std.string("123"))
+  expectEqual(m[std.string()], std.string("empty"))
+
+  let emptySwiftDict: [std.string : std.string] = [:]
+  let emptyM = MapStrings(emptySwiftDict)
+  expectEqual(emptyM.size(), 0)
+}
+
 StdMapTestSuite.test("Map.subscript") {
   // This relies on the `std::map` conformance to `CxxDictionary` protocol.
   var m = initMap()


### PR DESCRIPTION
This adds initializers for `std::map` and `std::unordered_map` that take a Swift dictionary as a single parameter.

rdar://133691563

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
