### PR TITLE
[DebugInfo] Remove debug info from outlined async helper functions

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3114,7 +3114,7 @@ void IRGenModule::createReplaceableProlog(IRGenFunction &IGF, SILFunction *f) {
     // Index of swiftasync context | ((index of swiftself) << 8).
     arguments.push_back(IGM.getInt32(paramAttributeFlags));
     arguments.push_back(currentResumeFn);
-    auto resumeProjFn = IGF.getOrCreateResumePrjFn(true /*forProlog*/);
+    auto resumeProjFn = IGF.getOrCreateResumePrjFn();
     arguments.push_back(
         Builder.CreateBitOrPointerCast(resumeProjFn, IGM.Int8PtrTy));
     auto dispatchFn = IGF.createAsyncDispatchFn(

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2899,9 +2899,6 @@ IRGenFunction::createAsyncDispatchFn(const FunctionPointer &fnPtr,
   dispatch->setDoesNotThrow();
   dispatch->addFnAttr(llvm::Attribute::AlwaysInline);
   IRGenFunction dispatchIGF(IGM, dispatch);
-  // Don't emit debug info if we are generating a function for the prologue.
-  if (IGM.DebugInfo && Builder.getCurrentDebugLocation())
-    IGM.DebugInfo->emitOutlinedFunction(dispatchIGF, dispatch, CurFn->getName());
   auto &Builder = dispatchIGF.Builder;
   auto it = dispatchIGF.CurFn->arg_begin(), end = dispatchIGF.CurFn->arg_end();
   llvm::Value *fnPtrArg = &*(it++);
@@ -2987,9 +2984,6 @@ llvm::Function *IRGenFunction::createAsyncSuspendFn() {
   suspendFn->setDoesNotThrow();
   suspendFn->addFnAttr(llvm::Attribute::AlwaysInline);
   IRGenFunction suspendIGF(IGM, suspendFn);
-  if (IGM.DebugInfo)
-    IGM.DebugInfo->emitOutlinedFunction(suspendIGF, suspendFn,
-                                        CurFn->getName());
   auto &Builder = suspendIGF.Builder;
 
   llvm::Value *resumeFunction = suspendFn->getArg(0);

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -178,7 +178,7 @@ public:
                                        bool restoreCurrentContext = true);
 
   llvm::Value *emitAsyncResumeProjectContext(llvm::Value *callerContextAddr);
-  llvm::Function *getOrCreateResumePrjFn(bool forPrologue = false);
+  llvm::Function *getOrCreateResumePrjFn();
   llvm::Function *createAsyncDispatchFn(const FunctionPointer &fnPtr,
                                         ArrayRef<llvm::Value *> args);
   llvm::Function *createAsyncDispatchFn(const FunctionPointer &fnPtr,

--- a/test/DebugInfo/async-await-no-debug-info-outlined-funcs.swift
+++ b/test/DebugInfo/async-await-no-debug-info-outlined-funcs.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-frontend %s -emit-irgen -g -o - \
+// RUN:    -module-name M  -disable-availability-checking \
+// RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK
+
+// REQUIRES: concurrency
+
+// Check that all the helper "outlined" functions do not have debug information.
+
+func ASYNC___1___() async -> Int {
+  return 42
+}
+
+func ASYNC___2___() async -> Int {
+  print("hello")
+  var x = await ASYNC___1___()
+  x += await ASYNC___1___()
+  return x
+}
+
+// CHECK-LABEL: define {{.*}} @"$s1M12ASYNC___1___SiyYaF.0"
+// CHECK-NOT: !dbg
+// CHECK: ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define {{.*}} @"$s1M12ASYNC___2___SiyYaF.1"
+// CHECK-NOT: !dbg
+// CHECK: ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define {{.*}} @"$s1M12ASYNC___2___SiyYaF.0"
+// CHECK-NOT: !dbg
+// CHECK: ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define {{.*}} @"$s1M12ASYNC___2___SiyYaF.0.1"
+// CHECK-NOT: !dbg
+// CHECK: ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define {{.*}} @"$s1M12ASYNC___2___SiyYaF.0.2"
+// CHECK-NOT: !dbg
+// CHECK: ret void
+// CHECK-NEXT: }

--- a/test/DebugInfo/async-await-no-debug-info-outlined-funcs.swift
+++ b/test/DebugInfo/async-await-no-debug-info-outlined-funcs.swift
@@ -22,9 +22,19 @@ func ASYNC___2___() async -> Int {
 // CHECK: ret void
 // CHECK-NEXT: }
 
+// CHECK-LABEL: define {{.*}} @__swift_async_resume_get_context
+// CHECK-NOT: !dbg
+// CHECK: ret ptr
+// CHECK-NEXT: }
+
 // CHECK-LABEL: define {{.*}} @"$s1M12ASYNC___2___SiyYaF.1"
 // CHECK-NOT: !dbg
 // CHECK: ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define {{.*}} @__swift_async_resume_project_context
+// CHECK-NOT: !dbg
+// CHECK: ret ptr
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define {{.*}} @"$s1M12ASYNC___2___SiyYaF.0"

--- a/test/IRGen/async/get_async_continuation.sil
+++ b/test/IRGen/async/get_async_continuation.sil
@@ -69,11 +69,10 @@ bb0:
 // CHECK:      {{musttail call swifttailcc|tail call swiftcc}} void @swift_continuation_await(ptr %0)
 // CHECK-NEXT: ret void
 
-// CHECK: define {{.*}} void @async_continuation.0(ptr %0, ptr %1){{.*}}!dbg ![[DBG:[0-9]+]]
+// CHECK: define {{.*}} void @async_continuation.0(ptr %0, ptr %1)
 // CHECK-NOT: define
 // CHECK:  tail call swift{{(tail)?}}cc void %{{.*}}(ptr swiftasync %1)
 // CHECK-NEXT:  ret void
-// CHECK: ![[DBG]] = distinct !DISubprogram(linkageName: "async_continuation"
 
 sil @async_continuation : $@async () -> () {
 entry:


### PR DESCRIPTION
rdar://133849022

These two commits remove debug information from the two pairs of functions:

* `__swift_async_resume_project_context` and `__swift_async_resume_get_context`
* async dispatch/suspend functions

From the commit message:

    Those functions are effectively outlined functions with an alwaysinline
    attribute. By removing their debug info and relying on the inliner to propagate
    the call site location to the inlined instructions, we restore the "original"
    locations as if the function had never been outlined.

    This is technically relying on an implementation detail of the inliner, but it
    seems to be the simplest way of addressing this issue.
