### PR TITLE
[stdlib][test] Remove problematic `else` branches in availability checks

### DIFF
--- a/test/stdlib/BridgedObjectDebuggerSupport.swift
+++ b/test/stdlib/BridgedObjectDebuggerSupport.swift
@@ -80,8 +80,6 @@ StringForPrintObjectTests.test("NSStringUTF8") {
 
   if #available(SwiftStdlib 6.1, *) {
     expectEqual("🏂☃❅❆❄︎⛄️❄️\n", printed)
-  } else {
-    expectEqual("\"🏂☃❅❆❄︎⛄️❄️\"\n", printed)
   }
 
   expectEqual(printed, debug)

--- a/test/stdlib/DebuggerSupport.swift
+++ b/test/stdlib/DebuggerSupport.swift
@@ -106,11 +106,6 @@ if #available(SwiftStdlib 6.1, *) {
     let printed = _stringForPrintObject("hello\nworld")
     expectEqual(printed, "hello\nworld\n")
   }
-} else {
-  StringForPrintObjectTests.test("String") {
-    let printed = _stringForPrintObject("hello\nworld")
-    expectEqual(printed, "\"hello\\nworld\"\n")
-  }
 }
 
 class RefCountedObj {


### PR DESCRIPTION
Testing the old behaviour can cause issues when the new availability gets properly defined. Just check the new behaviour, which is what we are doing in other stdlib tests.