### PR TITLE
[6.0] Don't use @_moveOnly anymore in stdlib

### DIFF
--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -193,8 +193,7 @@ extension UnownedJob: CustomStringConvertible {
 @available(SwiftStdlib 5.9, *)
 @available(*, deprecated, renamed: "ExecutorJob")
 @frozen
-@_moveOnly
-public struct Job: Sendable {
+public struct Job: ~Copyable, Sendable {
   internal var context: Builtin.Job
 
   @usableFromInline
@@ -262,8 +261,7 @@ extension Job {
 /// you don't generally interact with jobs directly.
 @available(SwiftStdlib 5.9, *)
 @frozen
-@_moveOnly
-public struct ExecutorJob: Sendable {
+public struct ExecutorJob: ~Copyable, Sendable {
   internal var context: Builtin.Job
 
   @usableFromInline

--- a/stdlib/public/Synchronization/Atomics/Atomic.swift
+++ b/stdlib/public/Synchronization/Atomics/Atomic.swift
@@ -17,8 +17,7 @@ import Builtin
 @frozen
 @_rawLayout(like: Value.AtomicRepresentation)
 @_staticExclusiveOnly
-@_moveOnly
-public struct Atomic<Value: AtomicRepresentable> {
+public struct Atomic<Value: AtomicRepresentable>: ~Copyable {
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent

--- a/stdlib/public/Synchronization/Atomics/AtomicLazyReference.swift
+++ b/stdlib/public/Synchronization/Atomics/AtomicLazyReference.swift
@@ -17,8 +17,7 @@
 @available(SwiftStdlib 6.0, *)
 @frozen
 @_staticExclusiveOnly
-@_moveOnly
-public struct AtomicLazyReference<Instance: AnyObject> {
+public struct AtomicLazyReference<Instance: AnyObject>: ~Copyable {
   @usableFromInline
   let storage: Atomic<Unmanaged<Instance>?>
 


### PR DESCRIPTION
* **Explanation**: These were used for compatibility with older compilers, but newer compilers means newer features. Let's use them.
* **Scope**: Stdlib generated interface
* **Risk**: Low. This is purely a cosmetic change for these types so that they appear as `: ~Copyable` in interfaces instead of printing an underscored attribute.
* **Testing**: CI testing
* **Issue**: N/A
* **Reviewer**: N/A

There is no main branch PR because these types are `@_moveOnly` only on the 6.0 branch.
