### PR TITLE
[swift-reflection-dump] Dump info about type descriptors.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2668,6 +2668,32 @@ public:
     
     return nullptr;
   }
+
+  const RelativeDirectPointerIntPair<TargetContextDescriptor<Runtime>,
+                                     TypeReferenceKind> *
+  getDirectPointer() const {
+    switch (getTypeKind()) {
+    case TypeReferenceKind::DirectTypeDescriptor:
+      return &DirectNominalTypeDescriptor;
+
+    default:
+      return nullptr;
+    }
+  }
+
+  const RelativeDirectPointerIntPair<
+      TargetSignedPointer<Runtime, TargetContextDescriptor<Runtime> *
+                                       __ptrauth_swift_type_descriptor>,
+      TypeReferenceKind> *
+  getIndirectPointer() const {
+    switch (getTypeKind()) {
+    case TypeReferenceKind::IndirectTypeDescriptor:
+      return &IndirectNominalTypeDescriptor;
+
+    default:
+      return nullptr;
+    }
+  }
 };
 
 using TypeMetadataRecord = TargetTypeMetadataRecord<InProcess>;
@@ -4416,16 +4442,21 @@ public:
       ->Stub.get();
   }
 
+  const MetadataListCount &getCanonicalMetadataPrespecializationsCount() const {
+    assert(this->hasCanonicalMetadataPrespecializations());
+    return *this->template getTrailingObjects<MetadataListCount>();
+  }
+
   llvm::ArrayRef<Metadata> getCanonicalMetadataPrespecializations() const {
     if (!this->hasCanonicalMetadataPrespecializations()) {
       return {};
     }
 
-    auto *listCount = this->template getTrailingObjects<MetadataListCount>();
+    auto listCount = getCanonicalMetadataPrespecializationsCount();
     auto *list = this->template getTrailingObjects<MetadataListEntry>();
     return llvm::ArrayRef<Metadata>(
         reinterpret_cast<const Metadata *>(list),
-        listCount->count
+        listCount.count
         );
   }
 
@@ -4434,11 +4465,11 @@ public:
       return {};
     }
 
-    auto *listCount = this->template getTrailingObjects<MetadataListCount>();
+    auto listCount = getCanonicalMetadataPrespecializationsCount();
     auto *list = this->template getTrailingObjects<MetadataAccessorListEntry>();
     return llvm::ArrayRef<MetadataAccessor>(
         reinterpret_cast<const MetadataAccessor *>(list),
-        listCount->count
+        listCount.count
         );
   }
 
@@ -4587,16 +4618,21 @@ public:
     return TargetStructMetadata<Runtime>::getGenericArgumentOffset();
   }
 
+  const MetadataListCount &getCanonicalMetadataPrespecializationsCount() const {
+    assert(this->hasCanonicalMetadataPrespecializations());
+    return *this->template getTrailingObjects<MetadataListCount>();
+  }
+
   llvm::ArrayRef<Metadata> getCanonicalMetadataPrespecializations() const {
     if (!this->hasCanonicalMetadataPrespecializations()) {
       return {};
     }
 
-    auto *listCount = this->template getTrailingObjects<MetadataListCount>();
+    auto listCount = getCanonicalMetadataPrespecializationsCount();
     auto *list = this->template getTrailingObjects<MetadataListEntry>();
     return llvm::ArrayRef<Metadata>(
         reinterpret_cast<const Metadata *>(list),
-        listCount->count
+        listCount.count
         );
   }
 
@@ -4748,16 +4784,21 @@ public:
     return *this->template getTrailingObjects<SingletonMetadataInitialization>();
   }
 
+  const MetadataListCount &getCanonicalMetadataPrespecializationsCount() const {
+    assert(this->hasCanonicalMetadataPrespecializations());
+    return *this->template getTrailingObjects<MetadataListCount>();
+  }
+
   llvm::ArrayRef<Metadata> getCanonicalMetadataPrespecializations() const {
     if (!this->hasCanonicalMetadataPrespecializations()) {
       return {};
     }
 
-    auto *listCount = this->template getTrailingObjects<MetadataListCount>();
+    auto listCount = getCanonicalMetadataPrespecializationsCount();
     auto *list = this->template getTrailingObjects<MetadataListEntry>();
     return llvm::ArrayRef<Metadata>(
         reinterpret_cast<const Metadata *>(list),
-        listCount->count
+        listCount.count
         );
   }
 

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -329,6 +329,10 @@ public:
         ObjectFileFormat.getSectionName(ReflectionSectionKind::builtin));
     auto CaptureSec = findMachOSectionByName(
         ObjectFileFormat.getSectionName(ReflectionSectionKind::capture));
+    auto TypeMdSec = findMachOSectionByName(
+        ObjectFileFormat.getSectionName(ReflectionSectionKind::typemd));
+    auto TypeMd2Sec = findMachOSectionByName(
+        ObjectFileFormat.getSectionName(ReflectionSectionKind::typemd2));
     auto TypeRefMdSec = findMachOSectionByName(
         ObjectFileFormat.getSectionName(ReflectionSectionKind::typeref));
     auto ReflStrMdSec = findMachOSectionByName(
@@ -342,6 +346,8 @@ public:
         AssocTySec.first == nullptr &&
         BuiltinTySec.first == nullptr &&
         CaptureSec.first == nullptr &&
+        TypeMdSec.first == nullptr &&
+        TypeMd2Sec.first == nullptr &&
         TypeRefMdSec.first == nullptr &&
         ReflStrMdSec.first == nullptr &&
         ConformMdSec.first == nullptr &&
@@ -352,6 +358,8 @@ public:
                            {AssocTySec.first, AssocTySec.second},
                            {BuiltinTySec.first, BuiltinTySec.second},
                            {CaptureSec.first, CaptureSec.second},
+                           {TypeMdSec.first, TypeMdSec.second},
+                           {TypeMd2Sec.first, TypeMd2Sec.second},
                            {TypeRefMdSec.first, TypeRefMdSec.second},
                            {ReflStrMdSec.first, ReflStrMdSec.second},
                            {ConformMdSec.first, ConformMdSec.second},
@@ -464,6 +472,10 @@ public:
         ObjectFileFormat.getSectionName(ReflectionSectionKind::builtin));
     auto CaptureSec = findCOFFSectionByName(
         ObjectFileFormat.getSectionName(ReflectionSectionKind::capture));
+    auto TypeMdSec = findCOFFSectionByName(
+        ObjectFileFormat.getSectionName(ReflectionSectionKind::typemd));
+    auto TypeMd2Sec = findCOFFSectionByName(
+        ObjectFileFormat.getSectionName(ReflectionSectionKind::typemd2));
     auto TypeRefMdSec = findCOFFSectionByName(
         ObjectFileFormat.getSectionName(ReflectionSectionKind::typeref));
     auto ReflStrMdSec = findCOFFSectionByName(
@@ -477,6 +489,8 @@ public:
         AssocTySec.first == nullptr &&
         BuiltinTySec.first == nullptr &&
         CaptureSec.first == nullptr &&
+        TypeMdSec.first == nullptr &&
+        TypeMd2Sec.first == nullptr &&
         TypeRefMdSec.first == nullptr &&
         ReflStrMdSec.first == nullptr &&
         ConformMdSec.first == nullptr &&
@@ -487,6 +501,8 @@ public:
                            {AssocTySec.first, AssocTySec.second},
                            {BuiltinTySec.first, BuiltinTySec.second},
                            {CaptureSec.first, CaptureSec.second},
+                           {TypeMdSec.first, TypeMdSec.second},
+                           {TypeMd2Sec.first, TypeMd2Sec.second},
                            {TypeRefMdSec.first, TypeRefMdSec.second},
                            {ReflStrMdSec.first, ReflStrMdSec.second},
                            {ConformMdSec.first, ConformMdSec.second},
@@ -681,6 +697,10 @@ public:
         ObjectFileFormat.getSectionName(ReflectionSectionKind::builtin), true);
     auto CaptureSec = findELFSectionByName(
         ObjectFileFormat.getSectionName(ReflectionSectionKind::capture), true);
+    auto TypeMdSec = findELFSectionByName(
+        ObjectFileFormat.getSectionName(ReflectionSectionKind::typemd), true);
+    auto TypeMd2Sec = findELFSectionByName(
+        ObjectFileFormat.getSectionName(ReflectionSectionKind::typemd2), true);
     auto TypeRefMdSec = findELFSectionByName(
         ObjectFileFormat.getSectionName(ReflectionSectionKind::typeref), true);
     auto ReflStrMdSec = findELFSectionByName(
@@ -698,12 +718,15 @@ public:
     // We succeed if at least one of the sections is present in the
     // ELF executable.
     if (FieldMdSec.first || AssocTySec.first || BuiltinTySec.first ||
-        CaptureSec.first || TypeRefMdSec.first || ReflStrMdSec.first ||
-        ConformMdSec.first || MPEnumMdSec.first) {
+        CaptureSec.first || TypeMdSec.first || TypeMd2Sec.first ||
+        TypeRefMdSec.first || ReflStrMdSec.first || ConformMdSec.first ||
+        MPEnumMdSec.first) {
       ReflectionInfo info = {{FieldMdSec.first, FieldMdSec.second},
                              {AssocTySec.first, AssocTySec.second},
                              {BuiltinTySec.first, BuiltinTySec.second},
                              {CaptureSec.first, CaptureSec.second},
+                             {TypeMdSec.first, TypeMdSec.second},
+                             {TypeMd2Sec.first, TypeMd2Sec.second},
                              {TypeRefMdSec.first, TypeRefMdSec.second},
                              {ReflStrMdSec.first, ReflStrMdSec.second},
                              {ConformMdSec.first, ConformMdSec.second},
@@ -724,6 +747,10 @@ public:
         ObjectFileFormat.getSectionName(ReflectionSectionKind::builtin), false);
     CaptureSec = findELFSectionByName(
         ObjectFileFormat.getSectionName(ReflectionSectionKind::capture), false);
+    TypeMdSec = findELFSectionByName(
+        ObjectFileFormat.getSectionName(ReflectionSectionKind::typemd), false);
+    TypeMd2Sec = findELFSectionByName(
+        ObjectFileFormat.getSectionName(ReflectionSectionKind::typemd2), false);
     TypeRefMdSec = findELFSectionByName(
         ObjectFileFormat.getSectionName(ReflectionSectionKind::typeref), false);
     ReflStrMdSec = findELFSectionByName(
@@ -737,12 +764,15 @@ public:
       return {};
 
     if (FieldMdSec.first || AssocTySec.first || BuiltinTySec.first ||
-        CaptureSec.first || TypeRefMdSec.first || ReflStrMdSec.first ||
-        ConformMdSec.first || MPEnumMdSec.first) {
+        CaptureSec.first || TypeMdSec.first || TypeMd2Sec.first ||
+        TypeRefMdSec.first || ReflStrMdSec.first || ConformMdSec.first ||
+        MPEnumMdSec.first) {
       ReflectionInfo info = {{FieldMdSec.first, FieldMdSec.second},
                              {AssocTySec.first, AssocTySec.second},
                              {BuiltinTySec.first, BuiltinTySec.second},
                              {CaptureSec.first, CaptureSec.second},
+                             {TypeMdSec.first, TypeMdSec.second},
+                             {TypeMd2Sec.first, TypeMd2Sec.second},
                              {TypeRefMdSec.first, TypeRefMdSec.second},
                              {ReflStrMdSec.first, ReflStrMdSec.second},
                              {ConformMdSec.first, ConformMdSec.second},
@@ -860,6 +890,7 @@ public:
     auto Sections = {
         ReflectionSectionKind::fieldmd, ReflectionSectionKind::assocty,
         ReflectionSectionKind::builtin, ReflectionSectionKind::capture,
+        ReflectionSectionKind::typemd,  ReflectionSectionKind::typemd2,
         ReflectionSectionKind::typeref, ReflectionSectionKind::reflstr,
         ReflectionSectionKind::conform, ReflectionSectionKind::mpenum};
 
@@ -888,6 +919,8 @@ public:
                            {Pairs[5].first, Pairs[5].second},
                            {Pairs[6].first, Pairs[6].second},
                            {Pairs[7].first, Pairs[7].second},
+                           {Pairs[8].first, Pairs[8].second},
+                           {Pairs[9].first, Pairs[9].second},
                            PotentialModuleNames};
     return addReflectionInfo(Info);
   }

--- a/include/swift/RemoteInspection/RuntimeHeaders/llvm/BinaryFormat/Swift.def
+++ b/include/swift/RemoteInspection/RuntimeHeaders/llvm/BinaryFormat/Swift.def
@@ -22,6 +22,8 @@ HANDLE_SWIFT_SECTION(fieldmd, "__swift5_fieldmd", "swift5_fieldmd", ".sw5flmd")
 HANDLE_SWIFT_SECTION(assocty, "__swift5_assocty", "swift5_assocty", ".sw5asty")
 HANDLE_SWIFT_SECTION(builtin, "__swift5_builtin", "swift5_builtin", ".sw5bltn")
 HANDLE_SWIFT_SECTION(capture, "__swift5_capture", "swift5_capture", ".sw5cptr")
+HANDLE_SWIFT_SECTION(typemd, "__swift5_types", "swift5_types", ".sw5tymd")
+HANDLE_SWIFT_SECTION(typemd2, "__swift5_types2", "swift5_types2", ".sw5tym2")
 HANDLE_SWIFT_SECTION(typeref, "__swift5_typeref", "swift5_typeref", ".sw5tyrf")
 HANDLE_SWIFT_SECTION(reflstr, "__swift5_reflstr", "swift5_reflstr", ".sw5rfst")
 HANDLE_SWIFT_SECTION(conform, "__swift5_proto", "swift5_protocol_conformances",

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -32,6 +32,7 @@
 #include <ostream>
 #include <sstream>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace swift {
@@ -253,6 +254,8 @@ struct ReflectionInfo {
   AssociatedTypeSection AssociatedType;
   BuiltinTypeSection Builtin;
   CaptureSection Capture;
+  GenericSection TypeMetadata;
+  GenericSection TypeMetadata2;
   GenericSection TypeReference;
   GenericSection ReflectionString;
   GenericSection Conformance;
@@ -798,6 +801,296 @@ public:
 
     template <template <typename Runtime> class ObjCInteropKind,
               unsigned PointerSize>
+    void dumpTypeMetadataSection(std::ostream &stream) {
+      using Runtime = External<RuntimeTarget<PointerSize>>;
+      using Record = TargetTypeMetadataRecord<Runtime>;
+
+      // Sometimes the compiler emits multiple records pointing to the same
+      // descriptor. Track what we've seen in a set and don't dump the same
+      // thing more than once.
+      std::unordered_set<uint64_t> dumpedDescriptors;
+
+      for (const auto &reflectionInfo : ReflectionInfos) {
+        for (const auto &section :
+             {reflectionInfo.TypeMetadata, reflectionInfo.TypeMetadata2}) {
+          if (section.size() == 0)
+            break;
+
+          auto begin = section.startAddress();
+          auto end = section.endAddress();
+
+          auto size = end.getAddressData() - begin.getAddressData();
+          if (size % sizeof(Record) != 0) {
+            stream << "Typeref section size " << size
+                   << " is not evenly divisible by record size "
+                   << sizeof(Record) << " - section is invalid.\n";
+            break;
+          }
+
+          for (auto addr = begin; addr != end;
+               addr = addr.atByteOffset(sizeof(Record))) {
+            auto index = (addr.getAddressData() - begin.getAddressData()) /
+                         sizeof(Record);
+            auto *record =
+                reinterpret_cast<const Record *>(addr.getLocalBuffer());
+
+            // The record may be a direct or indirect relative pointer. Resolve
+            // the address from the record.
+            remote::RemoteAddress descriptorAddress{nullptr};
+            if (auto *directPtr = record->getDirectPointer()) {
+              descriptorAddress = remote::RemoteAddress(
+                  addr.atByteOffset(directPtr->getOffset()).getAddressData());
+            } else if (auto indirectPtr = record->getIndirectPointer()) {
+              // We won't try to handle indirect pointers. They'll point to
+              // descriptors in other images and we don't care to dump those.
+              // They'll be included in that image's types if we dump that
+              // image's types directly.
+              continue;
+            }
+
+            if (!descriptorAddress) {
+              stream << "Unable to resolve descriptor at index " << index
+                     << ".\n";
+              continue;
+            }
+
+            // Check if we've seen it already.
+            if (dumpedDescriptors.find(descriptorAddress.getAddressData()) !=
+                dumpedDescriptors.end())
+              continue;
+            dumpedDescriptors.insert(descriptorAddress.getAddressData());
+
+            // Dump the descriptor we found.
+            dumpContextDescriptor<ObjCInteropKind, PointerSize>(
+                descriptorAddress, index, stream);
+          }
+        }
+      }
+    }
+
+    template <template <typename Runtime> class ObjCInteropKind,
+              unsigned PointerSize>
+    void dumpContextDescriptor(remote::RemoteAddress descriptorAddress,
+                               unsigned index, std::ostream &stream) {
+      using Runtime = External<ObjCInteropKind<RuntimeTarget<PointerSize>>>;
+
+      // Read the flags to find out what kind of thing this is.
+      auto result = Builder.OpaqueByteReader(descriptorAddress,
+                                             sizeof(ContextDescriptorFlags));
+      if (!result) {
+        stream << "Unable to read descriptor flags at index " << index
+               << ", descriptor address 0x" << std::hex
+               << descriptorAddress.getAddressData() << ".\n\n";
+        return;
+      }
+      auto flagsPtr = result.get();
+      auto flags = *reinterpret_cast<const ContextDescriptorFlags *>(flagsPtr);
+
+      // Helper to read trailing objects. Returns a unique_ptr<void> and a raw
+      // pointer matching the type of `start` whose lifetime is tied to the
+      // unique_ptr.
+      auto readTrailingObjects = [&](const auto *start, unsigned count) {
+        auto size = count * sizeof(*start);
+        auto delta = (uint64_t)start - (uint64_t)flagsPtr;
+        auto address = descriptorAddress.getAddressData() + delta;
+        auto result =
+            Builder.OpaqueByteReader(remote::RemoteAddress(address), size);
+        auto resultPtr = reinterpret_cast<decltype(start)>(result.get());
+        return std::make_pair(std::move(result), resultPtr);
+      };
+
+      auto nameReader =
+          QualifiedContextNameReader<ObjCInteropKind, PointerSize>(
+              Builder.OpaqueByteReader, Builder.OpaqueStringReader,
+              Builder.OpaquePointerReader, Builder.OpaqueDynamicSymbolResolver);
+      std::string name = "<unable to read name>";
+      auto maybeName = nameReader.readFullyQualifiedTypeName(
+          descriptorAddress.getAddressData());
+      if (maybeName)
+        name = *maybeName;
+
+      // Helper for dumping generic contexts.
+      auto dumpGenericContext = [&](auto descriptor) {
+        if (!descriptor->isGeneric())
+          return;
+
+        auto &genericContextInitial = descriptor->getFullGenericContextHeader();
+        auto [ptr, genericContext] =
+            readTrailingObjects(&genericContextInitial, 1);
+        if (!genericContext) {
+          stream << "  Unable to read generic context.\n";
+          return;
+        }
+
+        stream << "  generic parameters: " << genericContext->Base.NumParams
+               << "\n";
+        stream << "  generic requirements: "
+               << genericContext->Base.NumRequirements << "\n";
+        stream << "  key arguments: " << genericContext->Base.NumKeyArguments
+               << "\n";
+        if (genericContext->Base.Flags.hasTypePacks())
+          stream << "  has type packs: true\n";
+        if (genericContext->Base.Flags.hasConditionalInvertedProtocols())
+          stream << "  has conditional inverted protocols: true\n";
+      };
+
+      // Helper for dumping inverted protocols.
+      auto dumpInvertedProtocols = [&](auto descriptor) {
+        if (!descriptor->hasInvertibleProtocols())
+          return;
+
+        const InvertibleProtocolSet &protosInitial =
+            descriptor->getInvertedProtocols();
+        auto [ptr, protos] = readTrailingObjects(&protosInitial, 1);
+        if (!protos) {
+          stream << "  Unable to read invertible protocols.\n";
+          return;
+        }
+
+        stream << "  invertible protocols: ";
+
+        bool didPrint = false;
+#define INVERTIBLE_PROTOCOL(Name, Bit)                                         \
+  if (protos->contains##Name()) {                                              \
+    if (didPrint)                                                              \
+      stream << ", ";                                                          \
+    didPrint = true;                                                           \
+    stream << "~" << #Name;                                                    \
+  }
+#include "swift/ABI/InvertibleProtocols.def"
+        if (protos->hasUnknownProtocols()) {
+          if (didPrint)
+            stream << ", ";
+          stream << "and unknown protocols, raw bits 0x" << std::hex
+                 << protos->rawBits();
+        }
+        stream << "\n";
+      };
+
+      // Helper for dumping initialization info.
+      auto dumpInitialization = [&](auto descriptor) {
+        if (descriptor->hasForeignMetadataInitialization())
+          stream << "  has foreign metadata initialization: true\n";
+        if (descriptor->hasSingletonMetadataInitialization())
+          stream << "  has singleton metadata initialization: true\n";
+      };
+
+      // Helper for dumping canonical prespecializations.
+      auto dumpCanonicalMetadataPrespecializations = [&](auto descriptor) {
+        if (!descriptor->hasCanonicalMetadataPrespecializations())
+          return;
+
+        auto &countInitial =
+            descriptor->getCanonicalMetadataPrespecializationsCount();
+        auto [ptr, countPtr] = readTrailingObjects(&countInitial, 1);
+        stream << "  canonical metadata prespecializations: " << countPtr->count
+               << "\n";
+      };
+
+      // Get the descriptor kind and dump the contents accordingly.
+      switch (auto kind = flags.getKind()) {
+      case ContextDescriptorKind::Class: {
+        stream << "class " << name << ":\n";
+
+        using Descriptor = TargetClassDescriptor<Runtime>;
+        auto result =
+            Builder.OpaqueByteReader(descriptorAddress, sizeof(Descriptor));
+        if (!result) {
+          stream << "  Unable to read class descriptor.\n";
+          return;
+        }
+
+        auto descriptor = reinterpret_cast<const Descriptor *>(result.get());
+
+        if (descriptor->SuperclassType) {
+          auto superclassTypeFieldOffset =
+              (uint64_t)&descriptor->SuperclassType - (uint64_t)descriptor;
+          auto superclassTypeFieldAddress =
+              descriptorAddress.getAddressData() + superclassTypeFieldOffset;
+          auto superclassTypeAddress =
+              superclassTypeFieldAddress +
+              (uint64_t)(int64_t)descriptor->SuperclassType;
+          auto superclassTypeRef = readTypeRef(superclassTypeAddress);
+          auto demangled = Builder.demangleTypeRef(superclassTypeRef);
+          auto name = Demangle::nodeToString(demangled);
+          stream << "  superclass: " << name << "\n";
+        }
+
+        stream << "  immediate members: " << descriptor->NumImmediateMembers
+               << "\n";
+        stream << "  fields: " << descriptor->NumFields << "\n";
+        if (descriptor->isActor())
+          stream << "  is actor: true\n";
+        if (descriptor->isDefaultActor())
+          stream << "  is default actor: true\n";
+        if (descriptor->hasVTable())
+          stream << "  has vtable: true\n";
+        if (descriptor->hasOverrideTable())
+          stream << "  has override table: true\n";
+        if (descriptor->hasResilientSuperclass())
+          stream << "  has resilient superclass: true\n";
+        dumpGenericContext(descriptor);
+        dumpInvertedProtocols(descriptor);
+        dumpInitialization(descriptor);
+        dumpCanonicalMetadataPrespecializations(descriptor);
+
+        break;
+      }
+
+      case ContextDescriptorKind::Enum: {
+        stream << "enum " << name << ":\n";
+
+        using Descriptor = TargetEnumDescriptor<Runtime>;
+        auto result =
+            Builder.OpaqueByteReader(descriptorAddress, sizeof(Descriptor));
+        if (!result) {
+          stream << "  Unable to read enum descriptor.\n";
+          return;
+        }
+
+        auto descriptor = reinterpret_cast<const Descriptor *>(result.get());
+
+        stream << "  payload cases: " << descriptor->getNumPayloadCases()
+               << "\n";
+        stream << "  empty cases: " << descriptor->getNumEmptyCases() << "\n";
+        dumpGenericContext(descriptor);
+        dumpInvertedProtocols(descriptor);
+        dumpInitialization(descriptor);
+        dumpCanonicalMetadataPrespecializations(descriptor);
+        break;
+      }
+
+      case ContextDescriptorKind::Struct: {
+        stream << "struct " << name << ":\n";
+
+        using Descriptor = TargetStructDescriptor<Runtime>;
+        auto result =
+            Builder.OpaqueByteReader(descriptorAddress, sizeof(Descriptor));
+        if (!result) {
+          stream << "  Unable to read enum descriptor.\n";
+          return;
+        }
+
+        auto descriptor = reinterpret_cast<const Descriptor *>(result.get());
+
+        stream << "  fields: " << descriptor->NumFields << "\n";
+        dumpGenericContext(descriptor);
+        dumpInvertedProtocols(descriptor);
+        dumpInitialization(descriptor);
+        dumpCanonicalMetadataPrespecializations(descriptor);
+        break;
+      }
+
+      default:
+        stream << "unhandled kind " << (unsigned)kind << " " << name << ".\n";
+        break;
+      }
+
+      stream << "\n";
+    }
+
+    template <template <typename Runtime> class ObjCInteropKind,
+              unsigned PointerSize>
     void dumpAllSections(std::ostream &stream) {
       stream << "FIELDS:\n";
       stream << "=======\n";
@@ -822,6 +1115,10 @@ public:
       stream << "MULTI-PAYLOAD ENUM DESCRIPTORS:\n";
       stream << "===============================\n";
       dumpMultiPayloadEnumSection(stream);
+      stream << "\n";
+      stream << "TYPES:\n";
+      stream << "===============================\n";
+      dumpTypeMetadataSection<ObjCInteropKind, PointerSize>(stream);
       stream << "\n";
     }
   };

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -268,6 +268,8 @@ swift_reflection_addReflectionInfo(SwiftReflectionContextRef ContextRef,
         sectionFromInfo<BuiltinTypeDescriptorIterator>(Info,
                                                        Info.builtin_types),
         sectionFromInfo<CaptureDescriptorIterator>(Info, Info.capture),
+        ReflectionSection<const void *>(nullptr, 0),
+        ReflectionSection<const void *>(nullptr, 0),
         sectionFromInfo<const void *>(Info, Info.type_references),
         sectionFromInfo<const void *>(Info, Info.reflection_strings),
         ReflectionSection<const void *>(nullptr, 0),
@@ -291,6 +293,8 @@ void swift_reflection_addReflectionMappingInfo(
             Info.builtin_types),
         reflectionSectionFromLocalAndRemote<CaptureDescriptorIterator>(
             Info.capture),
+        ReflectionSection<const void *>(nullptr, 0),
+        ReflectionSection<const void *>(nullptr, 0),
         reflectionSectionFromLocalAndRemote<const void *>(Info.type_references),
         reflectionSectionFromLocalAndRemote<const void *>(
             Info.reflection_strings),

--- a/test/Reflection/type_descriptors.swift
+++ b/test/Reflection/type_descriptors.swift
@@ -1,0 +1,348 @@
+// UNSUPPORTED: OS=windows-msvc
+//
+// LC_DYLD_CHAINED_FIXUPS decode not currently supported (default on visionOS)
+// UNSUPPORTED: OS=xros
+//
+// Temporarily disable on AArch64 Linux (rdar://88451721)
+// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
+
+// rdar://100558042
+// UNSUPPORTED: CPU=arm64e
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata %s -o %t/type_descriptors
+// RUN: %target-swift-reflection-dump %t/type_descriptors | %t/type_descriptors | %FileCheck %s
+
+// swift-reflection-dump dumps types in the order they appear in the binary. We
+// don't want to encode that order in the tests and break the test just because
+// the order changed.
+//
+// To address that, we pass the output of swift-reflection-dump through this
+// program, which serves the dual purpose of containing a bunch of types we want
+// to dump as part of the test, and also getting the dump output into an
+// order-independent form. This bit of code reads swift-reflection-dump's output
+// and re-outputs the type dump section in a consistently sorted order.
+var sawTypes = false
+var outputChunks: [String] = []
+while let line = readLine(strippingNewline: false) {
+  if !sawTypes {
+    if line.starts(with: "TYPES:") {
+      sawTypes = true
+      _ = readLine() // Skip over the ==== divider.
+    }
+    continue
+  }
+
+  // Skip blank lines.
+  if line == "\n" {
+    continue
+  }
+
+  if line.starts(with: "  ") && !outputChunks.isEmpty {
+    outputChunks[outputChunks.count - 1] += line
+  } else {
+    outputChunks.append(line)
+  }
+}
+for chunk in outputChunks.sorted() {
+  print(chunk)
+}
+
+// Helper function to get the compiler to emit a prespecialization.
+@inline(never)
+private func prespecialize<T>(_ t: T) {
+    withExtendedLifetime(t) { t in }
+}
+
+// ===========================
+// BEGIN TYPES AND CHECK LINES
+// ===========================
+
+// Types are sorted by kind and name (e.g. 'struct A' comes before 'struct B',
+// but 'enum Z' comes before either). New types need to be added in the right
+// place.
+
+
+// Begin classes.
+
+
+class GenericClass1<T> {
+  var x: T?
+}
+// CHECK: class type_descriptors.GenericClass1:
+// CHECK-NEXT:   immediate members: 6
+// CHECK-NEXT:   fields: 1
+// CHECK-NEXT:   has vtable: true
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 1
+
+class GenericClass2<T, U> {
+  var x: T?
+  var y: U?
+}
+// CHECK: class type_descriptors.GenericClass2:
+// CHECK-NEXT:   immediate members: 11
+// CHECK-NEXT:   fields: 2
+// CHECK-NEXT:   has vtable: true
+// CHECK-NEXT:   generic parameters: 2
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 2
+
+class GenericClassWithPrespecializations<T> {
+  var x: T?
+}
+prespecialize(GenericClassWithPrespecializations<Int>.self)
+// CHECK: class type_descriptors.GenericClassWithPrespecializations:
+// CHECK-NEXT:   immediate members: 6
+// CHECK-NEXT:   fields: 1
+// CHECK-NEXT:   has vtable: true
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 1
+// CHECK-NEXT:   canonical metadata prespecializations: 1
+
+class GenericSubclass<T, U>: GenericClass1<T> {
+  var y: U?
+}
+// CHECK: class type_descriptors.GenericSubclass:
+// CHECK-NEXT:   superclass: type_descriptors.GenericClass1<A>
+// CHECK-NEXT:   immediate members: 6
+// CHECK-NEXT:   fields: 1
+// CHECK-NEXT:   has vtable: true
+// CHECK-NEXT:   has override table: true
+// CHECK-NEXT:   generic parameters: 2
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 2
+
+class GenericSubclassOfNongeneric<T>: NongenericClass {
+  var y: T?
+}
+// CHECK: class type_descriptors.GenericSubclassOfNongeneric:
+// CHECK-NEXT:   superclass: type_descriptors.NongenericClass
+// CHECK-NEXT:   immediate members: 5
+// CHECK-NEXT:   fields: 1
+// CHECK-NEXT:   has vtable: true
+// CHECK-NEXT:   has override table: true
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 1
+class NongenericClass {
+  var x: Int?
+}
+// CHECK: class type_descriptors.NongenericClass:
+// CHECK-NEXT:   immediate members: 5
+// CHECK-NEXT:   fields: 1
+// CHECK-NEXT:   has vtable: true
+
+class NongenericSubclass: NongenericClass {
+  var y: Int?
+}
+// CHECK: class type_descriptors.NongenericSubclass:
+// CHECK-NEXT:   superclass: type_descriptors.NongenericClass
+// CHECK-NEXT:   immediate members: 4
+// CHECK-NEXT:   fields: 1
+// CHECK-NEXT:   has vtable: true
+// CHECK-NEXT:   has override table: true
+
+class NongenericSubclassOfGeneric: GenericClass1<Int> {
+  var y: Int?
+}
+// CHECK: class type_descriptors.NongenericSubclassOfGeneric:
+// CHECK-NEXT:   superclass: type_descriptors.GenericClass1<Swift.Int>
+// CHECK-NEXT:   immediate members: 4
+// CHECK-NEXT:   fields: 1
+// CHECK-NEXT:   has vtable: true
+// CHECK-NEXT:   has override table: true
+// CHECK-NEXT:   has singleton metadata initialization: true
+
+
+// Begin enums.
+
+
+enum GenericConditionallyCopyableEnum<T: ~Copyable>: ~Copyable {
+  case a(T), b
+}
+extension GenericConditionallyCopyableEnum: Copyable where T: Copyable {}
+// CHECK: enum type_descriptors.GenericConditionallyCopyableEnum:
+// CHECK-NEXT:   payload cases: 1
+// CHECK-NEXT:   empty cases: 1
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 1
+// CHECK-NEXT:   key arguments: 1
+// CHECK-NEXT:   has conditional inverted protocols: true
+// CHECK-NEXT:   invertible protocols: ~Copyable
+
+enum GenericEnum1<T> {
+  case a(T), b
+}
+// CHECK: enum type_descriptors.GenericEnum1:
+// CHECK-NEXT:   payload cases: 1
+// CHECK-NEXT:   empty cases: 1
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 1
+
+enum GenericEnum2<T, U> {
+  case a(T), b(U), c
+}
+// CHECK: enum type_descriptors.GenericEnum2:
+// CHECK-NEXT:   payload cases: 2
+// CHECK-NEXT:   empty cases: 1
+// CHECK-NEXT:   generic parameters: 2
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 2
+
+enum GenericEnumWithPrespecializations<T> {
+  case a(T), b
+}
+prespecialize(GenericEnumWithPrespecializations<Int>.self)
+prespecialize(GenericEnumWithPrespecializations<NongenericEnum0>.self)
+// CHECK: enum type_descriptors.GenericEnumWithPrespecializations:
+// CHECK-NEXT:   payload cases: 1
+// CHECK-NEXT:   empty cases: 1
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 1
+// CHECK-NEXT:   canonical metadata prespecializations: 2
+
+enum GenericNoncopyableEnum<T>: ~Copyable {
+  case a, b
+}
+// CHECK: enum type_descriptors.GenericNoncopyableEnum:
+// CHECK-NEXT:   payload cases: 0
+// CHECK-NEXT:   empty cases: 2
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 1
+// CHECK-NEXT:   invertible protocols: ~Copyable
+
+enum GenericNoncopyableEnumNoncopyableParam<T: ~Copyable>: ~Copyable {
+  case a(T), b
+}
+// CHECK: enum type_descriptors.GenericNoncopyableEnumNoncopyableParam:
+// CHECK-NEXT:   payload cases: 1
+// CHECK-NEXT:   empty cases: 1
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 1
+// CHECK-NEXT:   key arguments: 1
+// CHECK-NEXT:   invertible protocols: ~Copyable
+
+enum NongenericEnum0 {
+  case a, b, c, d
+}
+// CHECK: enum type_descriptors.NongenericEnum0:
+// CHECK-NEXT:   payload cases: 0
+// CHECK-NEXT:   empty cases: 4
+
+enum NongenericEnum1 {
+  case a, b, c(Int)
+}
+// CHECK: enum type_descriptors.NongenericEnum1:
+// CHECK-NEXT:   payload cases: 1
+// CHECK-NEXT:   empty cases: 2
+
+enum NongenericEnum2 {
+  case a, b, c(Int), d(Int)
+}
+// CHECK: enum type_descriptors.NongenericEnum2:
+// CHECK-NEXT:   payload cases: 2
+// CHECK-NEXT:   empty cases: 2
+
+enum NongenericNoncopyableEnum: ~Copyable {
+  case a(Int), b, c
+}
+// CHECK: enum type_descriptors.NongenericNoncopyableEnum:
+// CHECK-NEXT:   payload cases: 1
+// CHECK-NEXT:   empty cases: 2
+// CHECK-NEXT:   invertible protocols: ~Copyable
+
+
+// Begin structs.
+
+
+struct GenericConditionallyCopyableStruct<T: ~Copyable>: ~Copyable {
+  var a: T
+  var b: T
+}
+extension GenericConditionallyCopyableStruct: Copyable where T: Copyable {}
+// CHECK: struct type_descriptors.GenericConditionallyCopyableStruct:
+// CHECK-NEXT:   fields: 2
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 1
+// CHECK-NEXT:   key arguments: 1
+// CHECK-NEXT:   has conditional inverted protocols: true
+// CHECK-NEXT:   invertible protocols: ~Copyable
+
+struct GenericNoncopyableStruct<T>: ~Copyable {
+  var a: Int
+  var b: Int
+}
+// CHECK: struct type_descriptors.GenericNoncopyableStruct:
+// CHECK-NEXT:   fields: 2
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 1
+// CHECK-NEXT:   invertible protocols: ~Copyable
+
+struct GenericNoncopyableStructNoncopyableParam<T: ~Copyable>: ~Copyable {
+  var a: T
+  var b: T
+}
+// CHECK: struct type_descriptors.GenericNoncopyableStructNoncopyableParam:
+// CHECK-NEXT:   fields: 2
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 1
+// CHECK-NEXT:   key arguments: 1
+// CHECK-NEXT:   invertible protocols: ~Copyable
+
+struct GenericStruct1<T> {
+  var a: T
+  var b: Int
+  var c: Int
+}
+// CHECK: struct type_descriptors.GenericStruct1:
+// CHECK-NEXT:   fields: 3
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 1
+
+struct GenericStruct2<T, U> {
+  var a: T
+  var b: U
+}
+// CHECK: struct type_descriptors.GenericStruct2:
+// CHECK-NEXT:   fields: 2
+// CHECK-NEXT:   generic parameters: 2
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 2
+
+struct GenericStructWithPrespecializations<T> {
+  var a: T
+  var b: Int
+  var c: Int
+}
+prespecialize(GenericStructWithPrespecializations<Int>.self)
+prespecialize(GenericStructWithPrespecializations<NongenericStruct>.self)
+// CHECK: struct type_descriptors.GenericStructWithPrespecializations:
+// CHECK-NEXT:   fields: 3
+// CHECK-NEXT:   generic parameters: 1
+// CHECK-NEXT:   generic requirements: 0
+// CHECK-NEXT:   key arguments: 1
+// CHECK-NEXT:   canonical metadata prespecializations: 2
+
+struct NongenericNoncopyableStruct: ~Copyable {
+  var a: Int
+  var b: Int
+}
+// CHECK: struct type_descriptors.NongenericNoncopyableStruct:
+// CHECK-NEXT:   fields: 2
+// CHECK-NEXT:   invertible protocols: ~Copyable
+
+struct NongenericStruct {
+  var a: Int
+  var b: Int
+}
+// CHECK: struct type_descriptors.NongenericStruct:
+// CHECK-NEXT:   fields: 2


### PR DESCRIPTION
This adds a new TYPES section to the output which prints info about descriptors found in the `swift_types` and `swift_types2` sections.

Note: this depends on a small `llvm-project` change, PR here: https://github.com/swiftlang/llvm-project/pull/9108