### PR TITLE
[Sema] Improve handling of `fallthrough` in `if`/`switch` expressions

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1491,10 +1491,10 @@ BridgedDoCatchStmt BridgedDoCatchStmt_createParsed(
     BridgedNullableTypeRepr cThrownType, BridgedStmt cBody,
     BridgedArrayRef cCatches);
 
-SWIFT_NAME("BridgedFallthroughStmt.createParsed(_:loc:)")
+SWIFT_NAME("BridgedFallthroughStmt.createParsed(loc:declContext:)")
 BridgedFallthroughStmt
-BridgedFallthroughStmt_createParsed(BridgedASTContext cContext,
-                                    BridgedSourceLoc cLoc);
+BridgedFallthroughStmt_createParsed(BridgedSourceLoc cLoc,
+                                    BridgedDeclContext cDC);
 
 SWIFT_NAME("BridgedForEachStmt.createParsed(_:labelInfo:forLoc:tryLoc:awaitLoc:"
            "pattern:inLoc:sequence:whereLoc:whereExpr:body:)")

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1328,8 +1328,9 @@ ERROR(single_value_stmt_branch_empty,none,
       "expected expression in branch of '%0' expression",
       (StmtKind))
 ERROR(single_value_stmt_branch_must_end_in_result,none,
-      "non-expression branch of '%0' expression may only end with a 'throw'",
-      (StmtKind))
+      "non-expression branch of '%0' expression may only end with a 'throw'"
+      "%select{| or 'fallthrough'}1",
+      (StmtKind, bool))
 ERROR(cannot_jump_in_single_value_stmt,none,
       "cannot use '%0' to transfer control out of '%1' expression",
       (StmtKind, StmtKind))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1331,7 +1331,7 @@ ERROR(single_value_stmt_branch_must_end_in_result,none,
       "non-expression branch of '%0' expression may only end with a 'throw'",
       (StmtKind))
 ERROR(cannot_jump_in_single_value_stmt,none,
-      "cannot '%0' in '%1' when used as expression",
+      "cannot use '%0' to transfer control out of '%1' expression",
       (StmtKind, StmtKind))
 WARNING(effect_marker_on_single_value_stmt,none,
       "'%0' has no effect on '%1' expression", (StringRef, StmtKind))

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1613,6 +1613,7 @@ public:
   }
 
   DeclContext *getDeclContext() const { return DC; }
+  void setDeclContext(DeclContext *newDC) { DC = newDC; }
 
   static bool classof(const Stmt *S) {
     return S->getKind() == StmtKind::Break;
@@ -1648,6 +1649,7 @@ public:
   }
 
   DeclContext *getDeclContext() const { return DC; }
+  void setDeclContext(DeclContext *newDC) { DC = newDC; }
 
   static bool classof(const Stmt *S) {
     return S->getKind() == StmtKind::Continue;

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1159,36 +1159,29 @@ public:
 /// FallthroughStmt - The keyword "fallthrough".
 class FallthroughStmt : public Stmt {
   SourceLoc Loc;
-  CaseStmt *FallthroughSource;
-  CaseStmt *FallthroughDest;
+  DeclContext *DC;
 
-public:
-  FallthroughStmt(SourceLoc Loc, std::optional<bool> implicit = std::nullopt)
+  FallthroughStmt(SourceLoc Loc, DeclContext *DC,
+                  std::optional<bool> implicit = std::nullopt)
       : Stmt(StmtKind::Fallthrough, getDefaultImplicitFlag(implicit, Loc)),
-        Loc(Loc), FallthroughSource(nullptr), FallthroughDest(nullptr) {}
+        Loc(Loc), DC(DC) {}
+public:
+  static FallthroughStmt *createParsed(SourceLoc Loc, DeclContext *DC);
 
   SourceLoc getLoc() const { return Loc; }
 
   SourceRange getSourceRange() const { return Loc; }
 
+  DeclContext *getDeclContext() const { return DC; }
+  void setDeclContext(DeclContext *newDC) { DC = newDC; }
+
   /// Get the CaseStmt block from which the fallthrough transfers control.
-  /// Set during Sema. (May stay null if fallthrough is invalid.)
-  CaseStmt *getFallthroughSource() const { return FallthroughSource; }
-  void setFallthroughSource(CaseStmt *C) {
-    assert(!FallthroughSource && "fallthrough source already set?!");
-    FallthroughSource = C;
-  }
+  /// Returns \c nullptr if the fallthrough is invalid.
+  CaseStmt *getFallthroughSource() const;
 
   /// Get the CaseStmt block to which the fallthrough transfers control.
-  /// Set during Sema.
-  CaseStmt *getFallthroughDest() const {
-    assert(FallthroughDest && "fallthrough dest is not set until Sema");
-    return FallthroughDest;
-  }
-  void setFallthroughDest(CaseStmt *C) {
-    assert(!FallthroughDest && "fallthrough dest already set?!");
-    FallthroughDest = C;
-  }
+  /// Returns \c nullptr if the fallthrough is invalid.
+  CaseStmt *getFallthroughDest() const;
 
   static bool classof(const Stmt *S) {
     return S->getKind() == StmtKind::Fallthrough;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4162,6 +4162,29 @@ public:
   bool isCached() const { return true; }
 };
 
+struct FallthroughSourceAndDest {
+  CaseStmt *Source;
+  CaseStmt *Dest;
+};
+
+/// Lookup the source and destination of a 'fallthrough'.
+class FallthroughSourceAndDestRequest
+    : public SimpleRequest<FallthroughSourceAndDestRequest,
+                           FallthroughSourceAndDest(const FallthroughStmt *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  FallthroughSourceAndDest evaluate(Evaluator &evaluator,
+                                    const FallthroughStmt *FS) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 /// Precheck a ReturnStmt, which involves some initial validation, as well as
 /// applying a conversion to a FailStmt if needed.
 class PreCheckReturnStmtRequest

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -482,6 +482,9 @@ SWIFT_REQUEST(TypeChecker, BreakTargetRequest,
 SWIFT_REQUEST(TypeChecker, ContinueTargetRequest,
               LabeledStmt *(const ContinueStmt *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, FallthroughSourceAndDestRequest,
+              FallthroughSourceAndDest(const FallthroughStmt *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, PreCheckReturnStmtRequest,
               Stmt *(ReturnStmt *, DeclContext *),
               Cached, NoLocationInfo)

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -2005,9 +2005,9 @@ BridgedDoCatchStmt BridgedDoCatchStmt_createParsed(
 }
 
 BridgedFallthroughStmt
-BridgedFallthroughStmt_createParsed(BridgedASTContext cContext,
-                                    BridgedSourceLoc cLoc) {
-  return new (cContext.unbridged()) FallthroughStmt(cLoc.unbridged());
+BridgedFallthroughStmt_createParsed(BridgedSourceLoc cLoc,
+                                    BridgedDeclContext cDC) {
+  return FallthroughStmt::createParsed(cLoc.unbridged(), cDC.unbridged());
 }
 
 BridgedForEachStmt BridgedForEachStmt_createParsed(

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -989,6 +989,23 @@ LabeledStmt *ContinueStmt::getTarget() const {
   return evaluateOrDefault(eval, ContinueTargetRequest{this}, nullptr);
 }
 
+FallthroughStmt *FallthroughStmt::createParsed(SourceLoc Loc, DeclContext *DC) {
+  auto &ctx = DC->getASTContext();
+  return new (ctx) FallthroughStmt(Loc, DC);
+}
+
+CaseStmt *FallthroughStmt::getFallthroughSource() const {
+  auto &eval = getDeclContext()->getASTContext().evaluator;
+  return evaluateOrDefault(eval, FallthroughSourceAndDestRequest{this}, {})
+      .Source;
+}
+
+CaseStmt *FallthroughStmt::getFallthroughDest() const {
+  auto &eval = getDeclContext()->getASTContext().evaluator;
+  return evaluateOrDefault(eval, FallthroughSourceAndDestRequest{this}, {})
+      .Dest;
+}
+
 SourceLoc swift::extractNearestSourceLoc(const Stmt *S) {
   return S->getStartLoc();
 }

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -339,8 +339,8 @@ extension ASTGenVisitor {
 
   func generate(fallThroughStmt node: FallThroughStmtSyntax) -> BridgedFallthroughStmt {
     return .createParsed(
-      self.ctx,
-      loc: self.generateSourceLoc(node.fallthroughKeyword)
+      loc: self.generateSourceLoc(node.fallthroughKeyword),
+      declContext: self.declContext
     )
   }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -648,8 +648,8 @@ ParserResult<Stmt> Parser::parseStmt(bool fromASTGen) {
     if (LabelInfo) diagnose(LabelInfo.Loc, diag::invalid_label_on_stmt);
     if (tryLoc.isValid()) diagnose(tryLoc, diag::try_on_stmt, Tok.getText());
 
-    return makeParserResult(
-        new (Context) FallthroughStmt(consumeToken(tok::kw_fallthrough)));
+    auto loc = consumeToken(tok::kw_fallthrough);
+    return makeParserResult(FallthroughStmt::createParsed(loc, CurDeclContext));
   }
   case tok::pound_assert:
     if (LabelInfo) diagnose(LabelInfo.Loc, diag::invalid_label_on_stmt);

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -1794,7 +1794,7 @@ private:
   }
 
   ASTNode visitFallthroughStmt(FallthroughStmt *fallthroughStmt) {
-    if (checkFallthroughStmt(context.getAsDeclContext(), fallthroughStmt))
+    if (checkFallthroughStmt(fallthroughStmt))
       hadError = true;
     return fallthroughStmt;
   }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4478,7 +4478,7 @@ private:
           // default.
           Diags.diagnose(branch->getEndLoc(),
                          diag::single_value_stmt_branch_must_end_in_result,
-                         S->getKind());
+                         S->getKind(), isa<SwitchStmt>(S));
         }
         break;
       }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1593,6 +1593,8 @@ namespace {
         BS->setDeclContext(NewDC);
       if (auto *CS = dyn_cast<ContinueStmt>(S))
         CS->setDeclContext(NewDC);
+      if (auto *FS = dyn_cast<FallthroughStmt>(S))
+        FS->setDeclContext(NewDC);
 
       return Action::Continue(S);
     }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1588,6 +1588,12 @@ namespace {
         for (auto *CaseVar : CS->getCaseBodyVariablesOrEmptyArray())
           CaseVar->setDeclContext(NewDC);
       }
+      // A few statements store DeclContexts, update them.
+      if (auto *BS = dyn_cast<BreakStmt>(S))
+        BS->setDeclContext(NewDC);
+      if (auto *CS = dyn_cast<ContinueStmt>(S))
+        CS->setDeclContext(NewDC);
+
       return Action::Continue(S);
     }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1433,7 +1433,7 @@ LabeledStmt *findBreakOrContinueStmtTarget(ASTContext &ctx,
 /// Check the correctness of a 'fallthrough' statement.
 ///
 /// \returns true if an error occurred.
-bool checkFallthroughStmt(DeclContext *dc, FallthroughStmt *stmt);
+bool checkFallthroughStmt(FallthroughStmt *stmt);
 
 /// Check for restrictions on the use of the @unknown attribute on a
 /// case statement.

--- a/test/Constraints/issue-71273.swift
+++ b/test/Constraints/issue-71273.swift
@@ -15,7 +15,7 @@ func testLocalFn() {
 func testLocalBinding() {
   bar() {
     let _ = if .random() { return () } else { 0 }
-    // expected-error@-1 {{cannot 'return' in 'if' when used as expression}}
+    // expected-error@-1 {{cannot use 'return' to transfer control out of 'if' expression}}
     return ()
   }
 }

--- a/test/Constraints/rdar114402042.swift
+++ b/test/Constraints/rdar114402042.swift
@@ -8,7 +8,7 @@ func test() {
   foo {
     bar(if true { return } else { return })
     // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
-    // expected-error@-2 2{{cannot 'return' in 'if' when used as expression}}
+    // expected-error@-2 2{{cannot use 'return' to transfer control out of 'if' expression}}
   }
   foo {
     bar(if true { { return } } else { { return } })

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -659,3 +659,36 @@ struct LazyProp {
     0
   }
 }
+
+func testNestedFallthrough1() throws -> Int {
+  let x = if .random() {
+    switch Bool.random() {
+    case true:
+      fallthrough
+    case false:
+      break
+    }
+    throw Err()
+  } else {
+    0
+  }
+  return x
+}
+
+func testNestedFallthrough2() throws -> Int {
+  let x = if .random() {
+    switch Bool.random() {
+    case true:
+      if .random() {
+        fallthrough
+      }
+      break
+    case false:
+      break
+    }
+    throw Err()
+  } else {
+    0
+  }
+  return x
+}

--- a/test/SILGen/switch_expr.swift
+++ b/test/SILGen/switch_expr.swift
@@ -197,6 +197,23 @@ func testFallthrough2() -> Int {
 // CHECK:       dealloc_stack [[RESULT]] : $*Int
 // CHECK:       return [[VAL_RESULT:[%0-9]+]] : $Int
 
+func testFallthrough3() throws -> Int {
+  switch Bool.random() {
+  case true:
+    switch Bool.random() {
+    case true:
+      if .random() {
+        fallthrough
+      }
+      throw Err()
+    case false:
+      1
+    }
+  case false:
+    0
+  }
+}
+
 func testClosure() throws -> Int {
   let fn = {
     switch Bool.random() {

--- a/test/SILGen/switch_expr.swift
+++ b/test/SILGen/switch_expr.swift
@@ -168,6 +168,35 @@ func testFallthrough() throws -> Int {
 // CHECK:       dealloc_stack [[RESULT]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 
+func testFallthrough2() -> Int {
+  let x = switch Bool.random() {
+  case true:
+    fallthrough
+  case false:
+    1
+  }
+  return x
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s11switch_expr16testFallthrough2SiyF : $@convention(thin) () -> Int {
+// CHECK:       [[RESULT:%[0-9]+]] = alloc_stack $Int
+// CHECK:       switch_value {{%[0-9]+}} : $Builtin.Int1, case {{%[0-9]+}}: [[TRUEBB:bb[0-9]+]], case {{%[0-9]+}}: [[FALSEBB:bb[0-9]+]]
+//
+// CHECK:       [[TRUEBB]]:
+// CHECK-NEXT:  br [[ENDBB:bb[0-9]+]]
+//
+// CHECK:       [[FALSEBB]]:
+// CHECK-NEXT:  br [[ENDBB]]
+//
+// CHECK:       [[ENDBB]]:
+// CHECK:       [[ONELIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 1
+// CHECK:       [[ONE:%[0-9]+]] = apply {{%[0-9]+}}([[ONELIT]], {{%[0-9]+}})
+// CHECK:       store [[ONE]] to [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL_RESULT:%[0-9]+]] = move_value [var_decl] [[VAL]] : $Int
+// CHECK:       dealloc_stack [[RESULT]] : $*Int
+// CHECK:       return [[VAL_RESULT:[%0-9]+]] : $Int
+
 func testClosure() throws -> Int {
   let fn = {
     switch Bool.random() {

--- a/test/expr/unary/do_expr.swift
+++ b/test/expr/unary/do_expr.swift
@@ -147,7 +147,7 @@ func testReturn1() -> Int {
     try throwsError()
   } catch {
     if .random() {
-      return 0 // expected-error {{cannot 'return' in 'do-catch' when used as expression}}
+      return 0 // expected-error {{cannot use 'return' to transfer control out of 'do-catch' expression}}
     }
     then 0
   }

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -987,6 +987,63 @@ func return4() throws -> Int {
   return i
 }
 
+// https://github.com/swiftlang/swift/issues/75880
+func fallthrough1() throws {
+  switch Bool.random() {
+  case true:
+    let _ = if .random() {
+      if .random () {
+        fallthrough // expected-error {{cannot use 'fallthrough' to transfer control out of 'if' expression}}
+      }
+      throw Err()
+    } else {
+      0
+    }
+  case false:
+    break
+  }
+}
+
+func fallthrough2() throws -> Int {
+  let x = switch Bool.random() {
+  case true:
+    if .random() {
+      if .random () {
+        fallthrough // expected-error {{cannot use 'fallthrough' to transfer control out of 'if' expression}}
+      }
+      throw Err()
+    } else {
+      0
+    }
+  case false:
+    1
+  }
+  return x
+}
+
+func fallthrough3() -> Int {
+  let x = switch Bool.random() {
+  case true:
+    if .random() {
+      fallthrough // expected-error {{cannot use 'fallthrough' to transfer control out of 'if' expression}}
+    } else {
+      0
+    }
+  case false:
+    1
+  }
+  return x
+}
+
+func fallthrough4() -> Int {
+  let x = if .random() {
+    fallthrough // expected-error {{'fallthrough' is only allowed inside a switch}}
+  } else {
+    0
+  }
+  return x
+}
+
 // MARK: Effect specifiers
 
 func tryIf1() -> Int {

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -340,7 +340,7 @@ struct TestFailableInit {
     let y = if x {
       0
     } else {
-      return nil // expected-error {{cannot 'return' in 'if' when used as expression}}
+      return nil // expected-error {{cannot use 'return' to transfer control out of 'if' expression}}
     }
     _ = y
   }
@@ -605,16 +605,16 @@ func returnBranches1() -> Int {
 
 func returnBranchVoid() {
   return if .random() { return } else { return () }
-  // expected-error@-1 2{{cannot 'return' in 'if' when used as expression}}
+  // expected-error@-1 2{{cannot use 'return' to transfer control out of 'if' expression}}
 }
 
 func returnBranchBinding() -> Int {
   let x = if .random() {
     // expected-warning@-1 {{constant 'x' inferred to have type 'Void', which may be unexpected}}
     // expected-note@-2 {{add an explicit type annotation to silence this warning}}
-    return 0 // expected-error {{cannot 'return' in 'if' when used as expression}}
+    return 0 // expected-error {{cannot use 'return' to transfer control out of 'if' expression}}
   } else {
-    return 1 // expected-error {{cannot 'return' in 'if' when used as expression}}
+    return 1 // expected-error {{cannot use 'return' to transfer control out of 'if' expression}}
   }
   return x // expected-error {{cannot convert return expression of type 'Void' to return type 'Int'}}
 }
@@ -648,9 +648,9 @@ func returnBranches5() throws -> Int {
   let i = if .random() {
     // expected-warning@-1 {{constant 'i' inferred to have type 'Void', which may be unexpected}}
     // expected-note@-2 {{add an explicit type annotation to silence this warning}}
-    return 0 // expected-error {{cannot 'return' in 'if' when used as expression}}
+    return 0 // expected-error {{cannot use 'return' to transfer control out of 'if' expression}}
   } else {
-    return 1 // expected-error {{cannot 'return' in 'if' when used as expression}}
+    return 1 // expected-error {{cannot use 'return' to transfer control out of 'if' expression}}
   }
   let j = if .random() {
     // expected-warning@-1 {{constant 'j' inferred to have type 'Void', which may be unexpected}}
@@ -702,7 +702,7 @@ func returnBranches6PoundIf2() -> Int {
 func returnBranches7() -> Int {
   let i = if .random() {
     print("hello")
-    return 0  // expected-error {{cannot 'return' in 'if' when used as expression}}
+    return 0  // expected-error {{cannot use 'return' to transfer control out of 'if' expression}}
   } else {
     1
   }
@@ -710,7 +710,7 @@ func returnBranches7() -> Int {
 }
 
 func returnBranches8() -> Int {
-  let i = if .random() { return 1 } else { 0 }  // expected-error {{cannot 'return' in 'if' when used as expression}}
+  let i = if .random() { return 1 } else { 0 }  // expected-error {{cannot use 'return' to transfer control out of 'if' expression}}
   return i
 }
 
@@ -914,7 +914,7 @@ func break1() -> Int {
   switch true {
   case true:
     let j = if .random() {
-      break // expected-error {{cannot 'break' in 'if' when used as expression}}
+      break // expected-error {{cannot use 'break' to transfer control out of 'if' expression}}
     } else {
       0
     }
@@ -927,7 +927,7 @@ func break1() -> Int {
 func continue1() -> Int {
   for _ in 0 ... 5 {
     let i = if true { continue } else { 1 }
-    // expected-error@-1 {{cannot 'continue' in 'if' when used as expression}}
+    // expected-error@-1 {{cannot use 'continue' to transfer control out of 'if' expression}}
     return i
   }
 }
@@ -941,7 +941,7 @@ func return1() -> Int {
         while true {
           switch 0 {
           default:
-            return 0 // expected-error {{cannot 'return' in 'if' when used as expression}}
+            return 0 // expected-error {{cannot use 'return' to transfer control out of 'if' expression}}
           }
         }
       }

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -1212,6 +1212,16 @@ func fallthrough5() -> Int {
   return x
 }
 
+func fallthrough6() -> Int {
+  let x = switch true {
+  case true:
+    0
+  case false:
+    fallthrough // expected-error {{'fallthrough' without a following 'case' or 'default' block}}
+  }
+  return x
+}
+
 func breakAfterNeverExpr() -> String {
   // We avoid turning this into a switch expression because of the 'break'.
   switch Bool.random() {

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -400,7 +400,7 @@ struct TestFailableInit {
     case true:
       0
     case false:
-      return nil // expected-error {{cannot 'return' in 'switch' when used as expression}}
+      return nil // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
     }
     _ = y
   }
@@ -757,7 +757,7 @@ func returnBranches1() -> Int {
 
 func returnBranchVoid() {
   return switch Bool.random() { case true: return case false: return () }
-  // expected-error@-1 2{{cannot 'return' in 'switch' when used as expression}}
+  // expected-error@-1 2{{cannot use 'return' to transfer control out of 'switch' expression}}
 }
 
 func returnBranchBinding() -> Int {
@@ -765,9 +765,9 @@ func returnBranchBinding() -> Int {
     // expected-warning@-1 {{constant 'x' inferred to have type 'Void', which may be unexpected}}
     // expected-note@-2 {{add an explicit type annotation to silence this warning}}
   case true:
-    return 0 // expected-error {{cannot 'return' in 'switch' when used as expression}}
+    return 0 // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
   case false:
-    return 1 // expected-error {{cannot 'return' in 'switch' when used as expression}}
+    return 1 // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
   }
   return x // expected-error {{cannot convert return expression of type 'Void' to return type 'Int'}}
 }
@@ -807,9 +807,9 @@ func returnBranches5() -> Int {
     // expected-warning@-1 {{constant 'i' inferred to have type 'Void', which may be unexpected}}
     // expected-note@-2 {{add an explicit type annotation to silence this warning}}
   case true:
-    return 0 // expected-error {{cannot 'return' in 'switch' when used as expression}}
+    return 0 // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
   case false:
-    return 1 // expected-error {{cannot 'return' in 'switch' when used as expression}}
+    return 1 // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
   }
   return i // expected-error {{cannot convert return expression of type 'Void' to return type 'Int'}}
 }
@@ -861,7 +861,7 @@ func returnBranches7() -> Int {
   let i = switch Bool.random() {
   case true:
     print("hello")
-    return 0 // expected-error {{cannot 'return' in 'switch' when used as expression}}
+    return 0 // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
   case false:
     1
   }
@@ -871,7 +871,7 @@ func returnBranches7() -> Int {
 func returnBranches8() -> Int {
   let i = switch Bool.random() {
   case true:
-    return 1 // expected-error {{cannot 'return' in 'switch' when used as expression}}
+    return 1 // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
   case false:
     0
   }
@@ -1173,7 +1173,7 @@ func fallthrough2() -> Int {
     if .random() {
       fallthrough
     }
-    return 1 // expected-error {{cannot 'return' in 'switch' when used as expression}}
+    return 1 // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
   case false:
     0
   }

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -820,7 +820,7 @@ func returnBranches6() -> Int {
   case true:
     print("hello")
     0 // expected-warning {{integer literal is unused}}
-    // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+    // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw' or 'fallthrough'}}
   case false:
     1
   }
@@ -835,7 +835,7 @@ func returnBranches6PoundIf() -> Int {
     print("hello")
     0 // expected-warning {{integer literal is unused}}
     #endif
-    // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+    // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw' or 'fallthrough'}}
   case false:
     1
   }
@@ -850,7 +850,7 @@ func returnBranches6PoundIf2() -> Int {
     print("hello")
     0
     #endif
-    // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+    // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw' or 'fallthrough'}}
   case false:
     1
   }
@@ -882,7 +882,7 @@ func returnBranches9() -> Int {
   let i = switch Bool.random() {
   case true:
     print("hello")
-    if .random() {} // expected-error {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+    if .random() {} // expected-error {{non-expression branch of 'switch' expression may only end with a 'throw' or 'fallthrough'}}
   case false:
     1
   }
@@ -898,7 +898,7 @@ func returnBranches10() -> Int {
       0 // expected-warning {{integer literal is unused}}
     case false:
       2 // expected-warning {{integer literal is unused}}
-    } // expected-error {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+    } // expected-error {{non-expression branch of 'switch' expression may only end with a 'throw' or 'fallthrough'}}
   case false:
     1
   }
@@ -914,7 +914,7 @@ func returnBranches11() -> Int {
       "" // expected-warning {{string literal is unused}}
     case false:
       2 // expected-warning {{integer literal is unused}}
-    } // expected-error {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+    } // expected-error {{non-expression branch of 'switch' expression may only end with a 'throw' or 'fallthrough'}}
   case false:
     1
   }
@@ -1059,7 +1059,7 @@ func testPoundIfBranch3() -> Int {
     #if false
     0
     #endif
-  // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+  // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw' or 'fallthrough'}}
   case false:
     0
   }
@@ -1100,7 +1100,7 @@ func testPoundIfBranch6() -> Int {
     0
     #endif
     0 // expected-warning {{integer literal is unused}}
-    // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+    // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw' or 'fallthrough'}}
   case false:
     1
   }
@@ -1174,6 +1174,38 @@ func fallthrough2() -> Int {
       fallthrough
     }
     return 1 // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
+  case false:
+    0
+  }
+  return x
+}
+
+func fallthrough3() -> Int {
+  let x = switch true {
+  case true:
+    fallthrough
+  case false:
+    0
+  }
+  return x
+}
+
+func fallthrough4() -> Int {
+  let x = switch true {
+  case true:
+    fallthrough
+    return 0 // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
+  case false:
+    0
+  }
+  return x
+}
+
+func fallthrough5() -> Int {
+  let x = switch true {
+  case true:
+    fallthrough
+    print(0) // expected-error {{non-expression branch of 'switch' expression may only end with a 'throw' or 'fallthrough'}}
   case false:
     0
   }

--- a/test/stmt/then_stmt_exec.swift
+++ b/test/stmt/then_stmt_exec.swift
@@ -8,9 +8,9 @@
 // Required for experimental features
 // REQUIRES: asserts
 
-func testDefer(_ x: Bool) -> Int {
+func testDeferIf(_ x: Bool) -> Int {
   defer {
-    print("defer fn")
+    print("defer testDeferIf")
   }
   let x = if x {
     defer {
@@ -24,9 +24,55 @@ func testDefer(_ x: Bool) -> Int {
   print("after if")
   return x
 }
-_ = testDefer(true)
+_ = testDeferIf(true)
 
 // CHECK:      enter if
 // CHECK-NEXT: defer if
 // CHECK-NEXT: after if
-// CHECK-NEXT: defer fn
+// CHECK-NEXT: defer testDeferIf
+
+func testDeferSwitch(_ x: Bool) -> Int {
+  defer {
+    print("defer testDeferSwitch")
+  }
+  let x = switch x {
+  case true:
+    defer {
+      print("defer case true")
+    }
+    print("enter case true")
+    fallthrough
+  case false:
+    defer {
+      print("defer case false")
+    }
+    print("enter case false")
+    then 1
+  }
+  print("after switch")
+  return x
+}
+_ = testDeferSwitch(true)
+// CHECK:      enter case true
+// CHECK-NEXT: defer case true
+// CHECK-NEXT: enter case false
+// CHECK-NEXT: defer case false
+// CHECK-NEXT: after switch
+// CHECK-NEXT: defer testDeferSwitch
+
+func testFallthrough(_ x: Bool) -> Int {
+  var z = 0
+  let y: Int
+  let x = switch x {
+  case true:
+    z = 1
+    fallthrough
+  case false:
+    y = 2
+    then 3
+  }
+  return x + y + z
+}
+print("fallthrough: \(testFallthrough(true))")
+
+// CHECK: fallthrough: 6


### PR DESCRIPTION
Remove the restriction on `fallthrough` as the last statement in a `switch` expression, and prevent fallthrough from jumping out of `if` expressions.

rdar://127670432
rdar://133845101
Resolves #75880