### PR TITLE
Test: disable on armv7k

### DIFF
--- a/test/SILOptimizer/throws_prediction.swift
+++ b/test/SILOptimizer/throws_prediction.swift
@@ -16,6 +16,8 @@
 // RUN:   -sil-verify-all -module-name=test -emit-sil \
 // RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
 
+// UNSUPPORTED: CPU=armv7k
+
 // CHECK-DISABLED-NOT: normal_count
 
 enum MyError: Error { case err }


### PR DESCRIPTION
There's no reason for this test to run on armv7k, as it is checking something unrelated to architecture in LLVM IR.

rdar://133860924