### PR TITLE
Disable DCE of dead lexical borrows

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -47,12 +47,9 @@ namespace {
 // FIXME: Reconcile the similarities between this and
 //        isInstructionTriviallyDead.
 static bool seemsUseful(SILInstruction *I) {
-  // Even though begin_access/destroy_value/copy_value/end_lifetime have
-  // side-effects, they can be DCE'ed if they do not have useful
-  // dependencies/reverse dependencies
-  if (isa<BeginAccessInst>(I) || isa<CopyValueInst>(I) ||
-      isa<DestroyValueInst>(I) || isa<EndLifetimeInst>(I) ||
-      isa<EndBorrowInst>(I))
+  // Even though begin_access/copy_value have side-effects, they can be DCE'ed
+  // if they do not have useful dependencies.
+  if (isa<BeginAccessInst>(I) || isa<CopyValueInst>(I))
     return false;
 
   // A load [copy] is okay to be DCE'ed if there are no useful dependencies

--- a/test/Interpreter/moveonly_consuming_param.swift
+++ b/test/Interpreter/moveonly_consuming_param.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -Xfrontend -enable-ossa-modules) | %FileCheck %s
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION
DCE of dead lexical borrows can lead to illegal lifetime shortening. Disable this 

