### PR TITLE
Serialization: reword diagnostic about serialization channel mismatch

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -864,9 +864,10 @@ ERROR(serialization_module_incompatible_revision,Fatal,
       "rebuild %1 and try again: %2",
       (StringRef, Identifier, StringRef))
 ERROR(serialization_module_incompatible_channel,Fatal,
-      "compiled module was created for a different distribution channel '%0' "
-      "than the local compiler '%1', "
-      "please ensure %2 is found from the expected path: %3",
+      "the binary module for %2 was compiled for '%0', "
+      "it cannot be imported by the current compiler "
+      "which is aligned with '%1'. "
+      "Binary module loaded from path: %3",
       (StringRef, StringRef, Identifier, StringRef))
 ERROR(serialization_missing_single_dependency,Fatal,
       "missing required module '%0'", (StringRef))

--- a/test/Serialization/restrict-swiftmodule-to-channel.swift
+++ b/test/Serialization/restrict-swiftmodule-to-channel.swift
@@ -25,7 +25,7 @@ public func foo() {}
 
 /// 2. Test importing the non-resilient no-channel library from a channel compiler.
 //--- NonResilientClient.swift
-import NonResilientLib // expected-error {{compiled module was created for a different distribution channel '' than the local compiler 'restricted-channel', please ensure 'NonResilientLib' is found from the expected path:}}
+import NonResilientLib // expected-error {{the binary module for 'NonResilientLib' was compiled for '', it cannot be imported by the current compiler which is aligned with 'restricted-channel'. Binary module loaded from path:}}
 foo()
 
 /// Building a NonResilientLib client should reject the import for a tagged compiler
@@ -37,7 +37,7 @@ foo()
 
 /// 3. Test importing the resilient no-channel library.
 //--- ResilientClient.swift
-import ResilientLib // expected-reject-error {{compiled module was created for a different distribution channel '' than the local compiler 'restricted-channel', please ensure 'ResilientLib' is found from the expected path:}}
+import ResilientLib // expected-reject-error {{the binary module for 'ResilientLib' was compiled for '', it cannot be imported by the current compiler which is aligned with 'restricted-channel'. Binary module loaded from path:}}
  // expected-rebuild-remark @-1 {{rebuilding module 'ResilientLib' from interface}}
  // expected-rebuild-note @-2 {{compiled module is out of date}}
  // expected-rebuild-note @-3 {{compiled for a different distribution channel}}
@@ -80,7 +80,7 @@ foo()
 
 /// 4. Test importing the channel restricted library
 //--- ChannelClient.swift
-import ChannelLib // expected-reject-error {{compiled module was created for a different distribution channel 'restricted-channel' than the local compiler 'other-channel', please ensure 'ChannelLib' is found from the expected path}}
+import ChannelLib // expected-reject-error {{the binary module for 'ChannelLib' was compiled for 'restricted-channel', it cannot be imported by the current compiler which is aligned with 'other-channel'. Binary module loaded from path:}}
 foo()
 
 /// Importing ChannelLib should succeed with the same channel.


### PR DESCRIPTION
This diagnostic reports when two compilers that are marked as targeting different distribution channels try to read swiftmodules produced by the other one. Even when the serialization format matches, the distribution channel can be used to differentiate compilers depending on vendor specific concerns.

For a resilient module, this error is usually silently ignored as the reader compiler picks the swiftinterface over the swiftmodule. It is visible to the end user when the module is non-resilient. For such a case, here we try to improve the diagnostic to be more meaningful.

The new diagnostics looks like so:
```
import MyLib // error: the binary module for 'MyLib' was compiled
             // for 'restricted-channel', it cannot be imported by the
             // current compiler which is aligned with 'other-channel'.
             // Binary module loaded from path: .../MyLib.swiftmodule
```

Vendors should pick meaningful channel names to guide users in the direction of the actual solution.