### PR TITLE
Test: disable on arm64_32 too

### DIFF
--- a/test/SILOptimizer/throws_prediction.swift
+++ b/test/SILOptimizer/throws_prediction.swift
@@ -16,7 +16,7 @@
 // RUN:   -sil-verify-all -module-name=test -emit-sil \
 // RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
 
-// UNSUPPORTED: CPU=armv7k
+// UNSUPPORTED: CPU=armv7k || CPU=arm64_32
 
 // CHECK-DISABLED-NOT: normal_count
 


### PR DESCRIPTION
The word-size difference is contributing to the changes in expected LLVM IR, which are irrelevant changes for what this test covers.