### PR TITLE
[IRGen][DebugInfo] Emit declarations for CFunctionPointer reps

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2971,6 +2971,7 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
        Rep == SILFunctionTypeRepresentation::ObjCMethod ||
        Rep == SILFunctionTypeRepresentation::WitnessMethod ||
        Rep == SILFunctionTypeRepresentation::CXXMethod ||
+       Rep == SILFunctionTypeRepresentation::CFunctionPointer ||
        Rep == SILFunctionTypeRepresentation::Thin)) {
     llvm::DISubprogram::DISPFlags SPFlags = llvm::DISubprogram::toSPFlags(
         /*IsLocalToUnit=*/Fn ? Fn->hasInternalLinkage() : true,

--- a/test/DebugInfo/method-declaration.swift
+++ b/test/DebugInfo/method-declaration.swift
@@ -1,4 +1,7 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -gdwarf-types -o - | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -primary-file %t/a.swift -import-objc-header %t/objc.h -enable-objc-interop -emit-ir -gdwarf-types -o - | %FileCheck %s
 
 // Verify that we added a declaration for a method.
 
@@ -8,6 +11,7 @@
 // CHECK: define{{.*}}bar_method{{.*}} !dbg ![[BAR_METHOD_DEF_DBG:[0-9]+]]
 // CHECK: define{{.*}}a_function{{.*}} !dbg ![[FUNC_DEF_DBG:[0-9]+]]
 
+//--- a.swift
 // CHECK-DAG: ![[FOO_DBG:[0-9]+]] = !DICompositeType(tag: {{.*}} name: "Foo", {{.*}} identifier:
 public struct Foo {
 // CHECK-DAG: ![[FOO_STATIC_METHOD_DEF_DBG]] = distinct !DISubprogram(name: "foo_static_method"{{.*}}, scope: ![[FOO_DBG]]{{.*}}DISPFlagDefinition{{.*}}, declaration: ![[FOO_STATIC_METHOD_DECL_DBG:[0-9]+]]
@@ -16,6 +20,13 @@ public struct Foo {
 // CHECK-DAG: ![[FOO_METHOD_DEF_DBG]] = distinct !DISubprogram(name: "foo_method"{{.*}}, scope: ![[FOO_DBG]]{{.*}}DISPFlagDefinition{{.*}}, declaration: ![[FOO_METHOD_DECL_DBG:[0-9]+]]
 // CHECK-DAG: ![[FOO_METHOD_DECL_DBG]] = !DISubprogram(name: "foo_method"{{.*}}, scope: ![[FOO_DBG]]
     func foo_method() {}
+
+// CHECK-DAG: !DISubprogram(linkageName: "$s1a3FooVACycfcyycfU_To"
+// CHECK-SAME: scope: ![[FOO_DBG]]
+// CHECK-SAME: declaration: !
+    init() {
+        let _ = ObjCGoo(myVal:{})
+    }
 }
 
 // CHECK-DAG: ![[BAR_DBG:[0-9]+]] = !DICompositeType(tag: {{.*}} name: "Bar", {{.*}} identifier:
@@ -35,3 +46,7 @@ public class Bar {
 // CHECK-SAME: )
 func a_function() {}
 
+//--- objc.h
+@interface ObjCGoo
+- (instancetype)initWithMyVal:(void (*)())myVal;
+@end

--- a/test/DebugInfo/method-declaration.swift
+++ b/test/DebugInfo/method-declaration.swift
@@ -7,6 +7,7 @@
 
 // CHECK: define{{.*}}foo_static_method{{.*}} !dbg ![[FOO_STATIC_METHOD_DEF_DBG:[0-9]+]]
 // CHECK: define{{.*}}foo_method{{.*}} !dbg ![[FOO_METHOD_DEF_DBG:[0-9]+]]
+// CHECK: define{{.*}}s1a3FooVACycfcyycfU_To{{.*}} !dbg ![[COMPILER_GEN_METHOD_DEF_DBG:[0-9]+]]
 // CHECK: define{{.*}}bar_static_method{{.*}} !dbg ![[BAR_STATIC_METHOD_DEF_DBG:[0-9]+]]
 // CHECK: define{{.*}}bar_method{{.*}} !dbg ![[BAR_METHOD_DEF_DBG:[0-9]+]]
 // CHECK: define{{.*}}a_function{{.*}} !dbg ![[FUNC_DEF_DBG:[0-9]+]]
@@ -20,10 +21,8 @@ public struct Foo {
 // CHECK-DAG: ![[FOO_METHOD_DEF_DBG]] = distinct !DISubprogram(name: "foo_method"{{.*}}, scope: ![[FOO_DBG]]{{.*}}DISPFlagDefinition{{.*}}, declaration: ![[FOO_METHOD_DECL_DBG:[0-9]+]]
 // CHECK-DAG: ![[FOO_METHOD_DECL_DBG]] = !DISubprogram(name: "foo_method"{{.*}}, scope: ![[FOO_DBG]]
     func foo_method() {}
-
-// CHECK-DAG: !DISubprogram(linkageName: "$s1a3FooVACycfcyycfU_To"
-// CHECK-SAME: scope: ![[FOO_DBG]]
-// CHECK-SAME: declaration: !
+// CHECK-DAG: ![[COMPILER_GEN_METHOD_DEF_DBG]] = distinct !DISubprogram(linkageName: "$s1a3FooVACycfcyycfU_To"{{.*}}, scope: ![[FOO_DBG]]{{.*}}DISPFlagDefinition{{.*}}, declaration: ![[COMPILER_GEN_METHOD_DECL_DBG:[0-9]+]]
+// CHECK-DAG: ![[COMPILER_GEN_METHOD_DECL_DBG]] = !DISubprogram(linkageName: "$s1a3FooVACycfcyycfU_To"{{.*}}, scope: ![[FOO_DBG]]
     init() {
         let _ = ObjCGoo(myVal:{})
     }


### PR DESCRIPTION
There is a verification pass to check that some `DISubprograms` have declarations.
https://github.com/swiftlang/llvm-project/commit/1e608f9c11656122c9ad2e2cb8e427302ccd1208#diff-7f0021f2c6cd747015d1e98778f5d97944fd1ca5448e5750b3b1b637b0cf8323R1496-R1504

I suspect that https://github.com/swiftlang/swift/commit/81953efcfbaf6e9dcaa3bd87c3142a7e7e7072c3 and later https://github.com/swiftlang/swift/commit/e0e7a08a319c183d9f5628202407a2bfeccf5852 aim to fix some of these cases. In the test case, I've managed to find a compiler-generated `DISubprogram` that fails this verification and I've found that adding a case for `CFunctionPointer` fixes this.

According to the comments, `CFunctionPointer` is nearly identical to `CXXMethod`, so I figured it was safe to add here.
https://github.com/swiftlang/swift/blob/795bfb91acfadd73d05053c88c0f1b1c0d64cdb4/include/swift/AST/ExtInfo.h#L258-L261

Resolves https://github.com/swiftlang/swift/issues/74583
