### PR TITLE
[Concurrency] Suggest adding a method, when mutating actor property cross isolation

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -91,9 +91,7 @@ private:
 
   ActorIsolation(Kind kind, Expr *actor, unsigned parameterIndex);
 
-  ActorIsolation(Kind kind, Type globalActor)
-      : globalActor(globalActor), kind(kind), isolatedByPreconcurrency(false),
-        silParsed(false), parameterIndex(0) {}
+  ActorIsolation(Kind kind, Type globalActor);
 
 public:
   // No-argument constructor needed for DenseMap use in PostfixCompletion.cpp
@@ -203,7 +201,6 @@ public:
   }
 
   NominalTypeDecl *getActor() const;
-  NominalTypeDecl *getActorOrNullPtr() const;
 
   VarDecl *getActorInstance() const;
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5455,6 +5455,12 @@ ERROR(distributed_actor_isolated_non_self_reference,none,
       "distributed actor-isolated %kind0 can not be accessed from a "
       "nonisolated context",
       (const ValueDecl *))
+NOTE(note_consider_method_for_isolated_property_mutation,none,
+     "consider declaring an %0 %1 method to perform the mutation",
+     (const NominalTypeDecl *, ActorIsolation))
+NOTE(note_consider_method_for_global_actor_isolated_property_mutation,none, // TODO: de-duplicate with note_consider_method_for_isolated_property_mutation
+     "consider declaring an %0 method to perform the mutation",
+     (ActorIsolation))
 ERROR(conflicting_stored_property_isolation,none,
       "%select{default|memberwise}0 initializer for %1 cannot be both %2 and %3",
       (bool, Type, ActorIsolation, ActorIsolation))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5456,11 +5456,8 @@ ERROR(distributed_actor_isolated_non_self_reference,none,
       "nonisolated context",
       (const ValueDecl *))
 NOTE(note_consider_method_for_isolated_property_mutation,none,
-     "consider declaring an %0 %1 method to perform the mutation",
-     (const NominalTypeDecl *, ActorIsolation))
-NOTE(note_consider_method_for_global_actor_isolated_property_mutation,none, // TODO: de-duplicate with note_consider_method_for_isolated_property_mutation
-     "consider declaring an %0 method to perform the mutation",
-     (ActorIsolation))
+     "consider declaring an isolated method on %0 to perform the mutation",
+     (const NominalTypeDecl *))
 ERROR(conflicting_stored_property_isolation,none,
       "%select{default|memberwise}0 initializer for %1 cannot be both %2 and %3",
       (bool, Type, ActorIsolation, ActorIsolation))

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1853,19 +1853,21 @@ maybeNoteMutatingMethodSuggestion(ASTContext &C,
   }
 
   if (auto actor = isolation.getActor()) {
-      // TODO: isolation is printing without the type name for instance actors,
-      //  it'd be nicer to print with type name and avoid this switch
-      if (isolation.getKind() == swift::ActorIsolation::ActorInstance) {
-        C.Diags.diagnose(
-            memberLoc,
-            diag::note_consider_method_for_isolated_property_mutation,
-            actor, isolation);
-      } else if (isolation.getKind() == swift::ActorIsolation::GlobalActor) {
-        C.Diags.diagnose(
-            memberLoc,
-            diag::note_consider_method_for_global_actor_isolated_property_mutation,
-            isolation);
-      }
+      NominalTypeDecl *actorTy =
+        actor;
+//          (isolation.getKind() == swift::ActorIsolation::ActorInstance ?
+//)
+
+      C.Diags.diagnose(
+          memberLoc,
+          diag::note_consider_method_for_isolated_property_mutation,
+          actor);
+//      } else if (isolation.getKind() == swift::ActorIsolation::GlobalActor) {
+//        C.Diags.diagnose(
+//            memberLoc,
+//            diag::note_consider_method_for_global_actor_isolated_property_mutation,
+//            isolation.getGlobalActor());
+//      }
   }
 }
 

--- a/test/Concurrency/Inputs/GlobalVariables.swift
+++ b/test/Concurrency/Inputs/GlobalVariables.swift
@@ -2,7 +2,7 @@ public struct Globals {
   public static let integerConstant = 0
   public static var integerMutable = 0
 
-  public static nonisolated(unsafe) let nonisolatedUnsafeIntegerConstant = 0
+  public static let nonisolatedUnsafeIntegerConstant = 0
   public static nonisolated(unsafe) var nonisolatedUnsafeIntegerMutable = 0
 
   @MainActor public static var actorInteger = 0

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -233,7 +233,7 @@ func anotherAsyncFunc() async {
   _ = b.balance // expected-error {{actor-isolated instance method 'balance()' can not be partially applied}}
 
   // expected-error@+2{{actor-isolated property 'owner' can not be mutated from a nonisolated context}}
-  // expected-note@+1{{consider declaring an 'BankAccount' actor-isolated method to perform the mutation}}
+  // expected-note@+1{{consider declaring an isolated method on 'BankAccount' to perform the mutation}}
   a.owner = "cat"
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
   _ = b.owner
@@ -282,7 +282,7 @@ func blender(_ peeler : () -> Void) {
   money -= 1200
 
   // expected-error@+2{{global actor 'BananaActor'-isolated var 'dollarsInBananaStand' can not be mutated from global actor 'OrangeActor'}}
-  // expected-note@+1{{consider declaring an global actor 'BananaActor'-isolated method to perform the mutation}}
+  // expected-note@+1{{consider declaring an isolated method on 'BananaActor' to perform the mutation}}
   dollarsInBananaStand = money
 
   // FIXME: these two errors seem a bit redundant.

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -232,7 +232,9 @@ func anotherAsyncFunc() async {
 
   _ = b.balance // expected-error {{actor-isolated instance method 'balance()' can not be partially applied}}
 
-  a.owner = "cat" // expected-error{{actor-isolated property 'owner' can not be mutated from a nonisolated context}}
+  // expected-error@+2{{actor-isolated property 'owner' can not be mutated from a nonisolated context}}
+  // expected-note@+1{{consider declaring an 'BankAccount' actor-isolated method to perform the mutation}}
+  a.owner = "cat"
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
   _ = b.owner
   _ = await b.owner == "cat"
@@ -279,7 +281,9 @@ func blender(_ peeler : () -> Void) {
   var money = await dollarsInBananaStand
   money -= 1200
 
-  dollarsInBananaStand = money // expected-error{{global actor 'BananaActor'-isolated var 'dollarsInBananaStand' can not be mutated from global actor 'OrangeActor'}}
+  // expected-error@+2{{global actor 'BananaActor'-isolated var 'dollarsInBananaStand' can not be mutated from global actor 'OrangeActor'}}
+  // expected-note@+1{{consider declaring an global actor 'BananaActor'-isolated method to perform the mutation}}
+  dollarsInBananaStand = money
 
   // FIXME: these two errors seem a bit redundant.
   // expected-error@+2 {{actor-isolated var 'dollarsInBananaStand' cannot be passed 'inout' to implicitly 'async' function call}}

--- a/test/Concurrency/actor_existentials.swift
+++ b/test/Concurrency/actor_existentials.swift
@@ -31,16 +31,16 @@ func from_isolated_existential2(_ x: isolated any P) async {
 func from_nonisolated(_ x: any P) async {
   await x.f()
   x.prop += 1 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
-  // expected-note@-1 {{consider declaring an 'P' actor-isolated method to perform the mutation}}
+  // expected-note@-1 {{consider declaring an isolated method on 'P' to perform the mutation}}
   x.prop = 100 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
-  // expected-note@-1 {{consider declaring an 'P' actor-isolated method to perform the mutation}}
+  // expected-note@-1 {{consider declaring an isolated method on 'P' to perform the mutation}}
 }
 
 func from_concrete(_ x: A) async {
   x.prop += 1 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
-  // expected-note@-1 {{consider declaring an 'A' actor-isolated method to perform the mutation}}
+  // expected-note@-1 {{consider declaring an isolated method on 'A' to perform the mutation}}
   x.prop = 100 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
-  // expected-note@-1 {{consider declaring an 'A' actor-isolated method to perform the mutation}}
+  // expected-note@-1 {{consider declaring an isolated method on 'A' to perform the mutation}}
 }
 
 func from_isolated_concrete(_ x: isolated A) async {
@@ -58,7 +58,7 @@ nonisolated let act = Act()
 func bad() async {
     // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}
     // expected-error@+2 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
-    // expected-note@+1 {{consider declaring an 'Act' actor-isolated method to perform the mutation}}
+    // expected-note@+1 {{consider declaring an isolated method on 'Act' to perform the mutation}}
     await act.i = 666
 }
 
@@ -70,12 +70,12 @@ extension Act: Proto {}
 func good() async {
     // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}
     // expected-error@+2 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
-    // expected-note@+1 {{consider declaring an 'Proto' actor-isolated method to perform the mutation}}
+    // expected-note@+1 {{consider declaring an isolated method on 'Proto' to perform the mutation}}
     await (act as any Proto).i = 42
     let aIndirect: any Proto = act
 
     // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}
     // expected-error@+2 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
-    // expected-note@+1 {{consider declaring an 'Proto' actor-isolated method to perform the mutation}}
+    // expected-note@+1 {{consider declaring an isolated method on 'Proto' to perform the mutation}}
     await aIndirect.i = 777
 }

--- a/test/Concurrency/actor_existentials.swift
+++ b/test/Concurrency/actor_existentials.swift
@@ -31,12 +31,16 @@ func from_isolated_existential2(_ x: isolated any P) async {
 func from_nonisolated(_ x: any P) async {
   await x.f()
   x.prop += 1 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
+  // expected-note@-1 {{consider declaring an 'P' actor-isolated method to perform the mutation}}
   x.prop = 100 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
+  // expected-note@-1 {{consider declaring an 'P' actor-isolated method to perform the mutation}}
 }
 
 func from_concrete(_ x: A) async {
   x.prop += 1 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
+  // expected-note@-1 {{consider declaring an 'A' actor-isolated method to perform the mutation}}
   x.prop = 100 // expected-error {{actor-isolated property 'prop' can not be mutated from a nonisolated context}}
+  // expected-note@-1 {{consider declaring an 'A' actor-isolated method to perform the mutation}}
 }
 
 func from_isolated_concrete(_ x: isolated A) async {
@@ -52,8 +56,9 @@ actor Act {
 nonisolated let act = Act()
 
 func bad() async {
-    // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}
-    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
+    // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}
+    // expected-error@+2 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
+    // expected-note@+1 {{consider declaring an 'Act' actor-isolated method to perform the mutation}}
     await act.i = 666
 }
 
@@ -63,12 +68,14 @@ protocol Proto: Actor {
 extension Act: Proto {}
 
 func good() async {
-    // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}
-    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
+    // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}
+    // expected-error@+2 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
+    // expected-note@+1 {{consider declaring an 'Proto' actor-isolated method to perform the mutation}}
     await (act as any Proto).i = 42
     let aIndirect: any Proto = act
 
-    // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}
-    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
+    // expected-warning@+3 {{no 'async' operations occur within 'await' expression}}
+    // expected-error@+2 {{actor-isolated property 'i' can not be mutated from a nonisolated context}}
+    // expected-note@+1 {{consider declaring an 'Proto' actor-isolated method to perform the mutation}}
     await aIndirect.i = 777
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -98,23 +98,23 @@ func checkAsyncPropertyAccess() async {
   let act = MyActor()
   let _ : Int = await act.mutable + act.mutable
   act.mutable += 1  // expected-error {{actor-isolated property 'mutable' can not be mutated from a nonisolated context}}
-  // expected-note@-1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
+  // expected-note@-1{{consider declaring an isolated method on 'MyActor' to perform the mutation}}
 
   act.superState += 1 // expected-error {{actor-isolated property 'superState' can not be mutated from a nonisolated context}}
-  // expected-note@-1{{consider declaring an 'MySuperActor' actor-isolated method to perform the mutation}}
+  // expected-note@-1{{consider declaring an isolated method on 'MySuperActor' to perform the mutation}}
 
   act.text[0].append("hello") // expected-error{{actor-isolated property 'text' can not be mutated from a nonisolated context}}
-  // expected-note@-1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
+  // expected-note@-1{{consider declaring an isolated method on 'MyActor' to perform the mutation}}
 
   // this is not the same as the above, because Array is a value type
   var arr = await act.text
   arr[0].append("hello")
 
   act.text.append("no") // expected-error{{actor-isolated property 'text' can not be mutated from a nonisolated context}}
-  // expected-note@-1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
+  // expected-note@-1{{consider declaring an isolated method on 'MyActor' to perform the mutation}}
 
   act.text[0] += "hello" // expected-error{{actor-isolated property 'text' can not be mutated from a nonisolated context}}
-  // expected-note@-1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
+  // expected-note@-1{{consider declaring an isolated method on 'MyActor' to perform the mutation}}
 
   _ = act.point  // expected-warning{{non-sendable type 'Point' of property 'point' cannot exit actor-isolated context}}
   // expected-warning@-1 {{expression is 'async' but is not marked with 'await'}}
@@ -274,11 +274,11 @@ extension MyActor {
     // expected-note@-1{{property access is 'async'}}
     _ = await otherActor.mutable
     otherActor.mutable = 0  // expected-error{{actor-isolated property 'mutable' can not be mutated on a nonisolated actor instance}}
-    // expected-note@-1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
+    // expected-note@-1{{consider declaring an isolated method on 'MyActor' to perform the mutation}}
     acceptInout(&otherActor.mutable)  // expected-error{{actor-isolated property 'mutable' can not be used 'inout' on a nonisolated actor instance}}
     // expected-error@+3{{actor-isolated property 'mutable' can not be mutated on a nonisolated actor instance}}
     // expected-warning@+2{{no 'async' operations occur within 'await' expression}}
-    // expected-note@+1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
+    // expected-note@+1{{consider declaring an isolated method on 'MyActor' to perform the mutation}}
     await otherActor.mutable = 0
 
     _ = otherActor.synchronous()
@@ -450,10 +450,10 @@ actor Crystal {
     _ = await globActorVar + globActorProp
 
     globActorProp = 20 // expected-error {{global actor 'SomeGlobalActor'-isolated property 'globActorProp' can not be mutated on a different actor instance}}
-    // expected-note@-1{{consider declaring an global actor 'SomeGlobalActor'-isolated method to perform the mutation}}
+    // expected-note@-1{{consider declaring an isolated method on 'SomeGlobalActor' to perform the mutation}}
 
     globActorVar = 30 // expected-error {{global actor 'SomeGlobalActor'-isolated property 'globActorVar' can not be mutated on a different actor instance}}
-    // expected-note@-1{{consider declaring an global actor 'SomeGlobalActor'-isolated method to perform the mutation}}
+    // expected-note@-1{{consider declaring an isolated method on 'SomeGlobalActor' to perform the mutation}}
 
     // expected-error@+2 {{global actor 'SomeGlobalActor'-isolated property 'globActorVar' can not be used 'inout' on a different actor instance}}
     // expected-error@+1 {{actor-isolated property 'globActorVar' cannot be passed 'inout' to implicitly 'async' function call}}
@@ -908,7 +908,7 @@ actor SomeActorWithInits {
     func localAsync() async {
       isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
       mutableState += 1 // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
-      // expected-note@-1{{consider declaring an 'SomeActorWithInits' actor-isolated method to perform the mutation}}
+      // expected-note@-1{{consider declaring an isolated method on 'SomeActorWithInits' to perform the mutation}}
       nonisolated()
     }
     Task { await localAsync() }
@@ -1362,7 +1362,7 @@ actor Butterfly {
   nonisolated init(cookies: Void) async {
     self.init()
     self.flapsPerSec += 1 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a nonisolated context}}
-    // expected-note@-1 {{consider declaring an 'Butterfly' actor-isolated method to perform the mutation}}
+    // expected-note@-1 {{consider declaring an isolated method on 'Butterfly' to perform the mutation}}
   }
 
   init(brownies: Void) {

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -98,18 +98,23 @@ func checkAsyncPropertyAccess() async {
   let act = MyActor()
   let _ : Int = await act.mutable + act.mutable
   act.mutable += 1  // expected-error {{actor-isolated property 'mutable' can not be mutated from a nonisolated context}}
+  // expected-note@-1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
 
   act.superState += 1 // expected-error {{actor-isolated property 'superState' can not be mutated from a nonisolated context}}
+  // expected-note@-1{{consider declaring an 'MySuperActor' actor-isolated method to perform the mutation}}
 
   act.text[0].append("hello") // expected-error{{actor-isolated property 'text' can not be mutated from a nonisolated context}}
+  // expected-note@-1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
 
   // this is not the same as the above, because Array is a value type
   var arr = await act.text
   arr[0].append("hello")
 
   act.text.append("no") // expected-error{{actor-isolated property 'text' can not be mutated from a nonisolated context}}
+  // expected-note@-1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
 
   act.text[0] += "hello" // expected-error{{actor-isolated property 'text' can not be mutated from a nonisolated context}}
+  // expected-note@-1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
 
   _ = act.point  // expected-warning{{non-sendable type 'Point' of property 'point' cannot exit actor-isolated context}}
   // expected-warning@-1 {{expression is 'async' but is not marked with 'await'}}
@@ -269,9 +274,11 @@ extension MyActor {
     // expected-note@-1{{property access is 'async'}}
     _ = await otherActor.mutable
     otherActor.mutable = 0  // expected-error{{actor-isolated property 'mutable' can not be mutated on a nonisolated actor instance}}
+    // expected-note@-1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
     acceptInout(&otherActor.mutable)  // expected-error{{actor-isolated property 'mutable' can not be used 'inout' on a nonisolated actor instance}}
-    // expected-error@+2{{actor-isolated property 'mutable' can not be mutated on a nonisolated actor instance}}
-    // expected-warning@+1{{no 'async' operations occur within 'await' expression}}
+    // expected-error@+3{{actor-isolated property 'mutable' can not be mutated on a nonisolated actor instance}}
+    // expected-warning@+2{{no 'async' operations occur within 'await' expression}}
+    // expected-note@+1{{consider declaring an 'MyActor' actor-isolated method to perform the mutation}}
     await otherActor.mutable = 0
 
     _ = otherActor.synchronous()
@@ -443,8 +450,10 @@ actor Crystal {
     _ = await globActorVar + globActorProp
 
     globActorProp = 20 // expected-error {{global actor 'SomeGlobalActor'-isolated property 'globActorProp' can not be mutated on a different actor instance}}
+    // expected-note@-1{{consider declaring an global actor 'SomeGlobalActor'-isolated method to perform the mutation}}
 
     globActorVar = 30 // expected-error {{global actor 'SomeGlobalActor'-isolated property 'globActorVar' can not be mutated on a different actor instance}}
+    // expected-note@-1{{consider declaring an global actor 'SomeGlobalActor'-isolated method to perform the mutation}}
 
     // expected-error@+2 {{global actor 'SomeGlobalActor'-isolated property 'globActorVar' can not be used 'inout' on a different actor instance}}
     // expected-error@+1 {{actor-isolated property 'globActorVar' cannot be passed 'inout' to implicitly 'async' function call}}
@@ -864,7 +873,7 @@ extension SomeClassInActor.ID {
 @available(SwiftStdlib 5.1, *)
 actor SomeActorWithInits {
   // expected-note@+2 2 {{property declared here}}
-  // expected-note@+1 3 {{mutation of this property is only permitted within the actor}}
+  // expected-note@+1 4 {{mutation of this property is only permitted within the actor}}
   var mutableState: Int = 17
   var otherMutableState: Int
   // expected-note@+1 {{mutation of this property is only permitted within the actor}}
@@ -895,6 +904,14 @@ actor SomeActorWithInits {
       nonisolated()
     }
     local()
+
+    func localAsync() async {
+      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode}}
+      mutableState += 1 // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
+      // expected-note@-1{{consider declaring an 'SomeActorWithInits' actor-isolated method to perform the mutation}}
+      nonisolated()
+    }
+    Task { await localAsync() }
 
     let _ = {
       defer {
@@ -990,8 +1007,7 @@ actor SomeActorWithInits {
     }()
   }
 
-
-  func isolated() { } // expected-note 9 {{calls to instance method 'isolated()' from outside of its actor context are implicitly asynchronous}}
+  func isolated() { } // expected-note 10 {{calls to instance method 'isolated()' from outside of its actor context are implicitly asynchronous}}
   nonisolated func nonisolated() {}
 }
 
@@ -1346,6 +1362,7 @@ actor Butterfly {
   nonisolated init(cookies: Void) async {
     self.init()
     self.flapsPerSec += 1 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a nonisolated context}}
+    // expected-note@-1 {{consider declaring an 'Butterfly' actor-isolated method to perform the mutation}}
   }
 
   init(brownies: Void) {

--- a/test/Concurrency/toplevel/async-5-top-level.swift
+++ b/test/Concurrency/toplevel/async-5-top-level.swift
@@ -25,7 +25,7 @@ func nonIsolatedAsync() async {
     // expected-warning@-1:5 {{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
     // expected-warning@-2:9 {{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
     // expected-note@-3:9 {{property access is 'async'}}
-    // expected-note@-4 {{consider declaring an main actor-isolated method to perform the mutation}}
+    // expected-note@-4 {{consider declaring an isolated method on 'MainActor' to perform the mutation}}
 }
 
 @MainActor

--- a/test/Concurrency/toplevel/async-5-top-level.swift
+++ b/test/Concurrency/toplevel/async-5-top-level.swift
@@ -25,6 +25,7 @@ func nonIsolatedAsync() async {
     // expected-warning@-1:5 {{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
     // expected-warning@-2:9 {{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
     // expected-note@-3:9 {{property access is 'async'}}
+    // expected-note@-4 {{consider declaring an main actor-isolated method to perform the mutation}}
 }
 
 @MainActor

--- a/test/Concurrency/toplevel/async-6-top-level.swift
+++ b/test/Concurrency/toplevel/async-6-top-level.swift
@@ -24,6 +24,7 @@ func nonIsolatedAsync() async {
     // expected-error@-1:5 {{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
     // expected-error@-2:9 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@-3:9 {{property access is 'async'}}
+    // expected-note@-4 {{consider declaring an main actor-isolated method to perform the mutation}}
 }
 
 @MainActor

--- a/test/Concurrency/toplevel/async-6-top-level.swift
+++ b/test/Concurrency/toplevel/async-6-top-level.swift
@@ -24,7 +24,7 @@ func nonIsolatedAsync() async {
     // expected-error@-1:5 {{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
     // expected-error@-2:9 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@-3:9 {{property access is 'async'}}
-    // expected-note@-4 {{consider declaring an main actor-isolated method to perform the mutation}}
+    // expected-note@-4 {{consider declaring an isolated method on 'MainActor' to perform the mutation}}
 }
 
 @MainActor

--- a/test/Concurrency/toplevel/no-async-6-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-6-top-level.swift
@@ -26,6 +26,7 @@ func nonIsolatedAsync() async {
   a = a + 10 // expected-error{{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
   // expected-note@-1{{property access is 'async'}}
   // expected-error@-2{{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3{{consider declaring an main actor-isolated method to perform the mutation}}
 }
 
 @MainActor

--- a/test/Concurrency/toplevel/no-async-6-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-6-top-level.swift
@@ -26,7 +26,7 @@ func nonIsolatedAsync() async {
   a = a + 10 // expected-error{{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
   // expected-note@-1{{property access is 'async'}}
   // expected-error@-2{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-3{{consider declaring an main actor-isolated method to perform the mutation}}
+  // expected-note@-3{{consider declaring an isolated method on 'MainActor' to perform the mutation}}
 }
 
 @MainActor


### PR DESCRIPTION
This comes as an idea from the [Why do not actor-isolated properties support 'await' setter](https://forums.swift.org/t/why-do-not-actor-isolated-properties-support-await-setter/73867/26) thread.

The note that
> Actor-isolated property 'colorFill' can not be mutated from the main actor

Leads people to assume that this is somehow "broken" while they could add a metho to perform the mutation and move on.

A developer comments that:

> So I just assumed that this meant that it was fundamentally wrong to
> mutate this actor's properties from another actor, while all I actually
> needed was... a 3 line setter.


resolves rdar://134041422