### PR TITLE
cmake: add `llvm-ml` to the windows toolchain build

### DIFF
--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -96,6 +96,7 @@ set(LLVM_TOOLCHAIN_TOOLS
       llvm-dwp
       llvm-lib
       llvm-lipo
+      llvm-ml
       llvm-mt
       llvm-nm
       llvm-objcopy

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -136,6 +136,7 @@ set(LLVM_TOOLCHAIN_TOOLS
       llvm-dwp
       llvm-lib
       llvm-lipo
+      llvm-ml
       llvm-mt
       llvm-nm
       llvm-objcopy


### PR DESCRIPTION
`llvm-ml` is a replacement for `ml` which is the MSVC assembler. This is useful on Windows and should be part of the distribution to ensure that we have a complete toolchain.