### PR TITLE
[cherry-pick release/6.0][Shims] Don't redeclare lgamma_r in macOS 15.0 and associated SDKs

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/LibcShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcShims.h
@@ -170,11 +170,16 @@ long double _stdlib_squareRootl(long double _self) {
 // Apple's math.h does not declare lgamma_r() etc by default, but they're
 // unconditionally exported by libsystem_m.dylib in all OS versions that
 // support Swift development; we simply need to provide declarations here.
-#if defined(__APPLE__)
+// In the macOS 15.0, iOS 18.0, et al SDKs, math.h unconditionally declares
+// lgamma_r() when building for Swift. Detect those SDKs by checking for a
+// header which was added in those versions. (Redeclaring the function
+// would cause an error where `lgamma_r` is ambiguous between the SDK
+// `_math.lgamma_r` and this `SwiftShims.lgamma_r`.)
+#if defined(__APPLE__) && !__has_include(<_modules/_math_h.h>)
 float lgammaf_r(float x, int *psigngam);
 double lgamma_r(double x, int *psigngam);
 long double lgammal_r(long double x, int *psigngam);
-#endif // defined(__APPLE__)
+#endif // defined(__APPLE__) && !__has_include(<_modules/_math_h.h>)
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
macOS 15.0, iOS 18.0, et al has started unconditionally declaring `lgamma_r` in <math.h>, add a __has_include in SwiftShims to detect that and not redeclare it when building against those SDK versions.

rdar://115192929