### PR TITLE
Enable swift-corelibs-foundation tests on Windows

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1669,18 +1669,23 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
         -Arch $HostArch
     }
 
-    # swift-corelibs-foundation tests are disabled since the package does not build for Windows yet
-    # $OutDir = Join-Path -Path $HostArch.BinaryCache -ChildPath foundation-tests
+    $OutDir = Join-Path -Path $HostArch.BinaryCache -ChildPath foundation-tests
+    $ShortArch = $Arch.LLVMName
 
-    # Isolate-EnvVars {
-    #   $env:SWIFTCI_USE_LOCAL_DEPS=1
-    #   $env:DISPATCH_INCLUDE_PATH="$($Arch.SDKInstallRoot)/usr/lib/swift"
-    #   Build-SPMProject `
-    #     -Test `
-    #     -Src $SourceCache\swift-corelibs-foundation `
-    #     -Bin $OutDir `
-    #     -Arch $HostArch
-    # }
+    Isolate-EnvVars {
+      $env:SWIFTCI_USE_LOCAL_DEPS=1
+      $env:DISPATCH_INCLUDE_PATH="$($Arch.SDKInstallRoot)/usr/lib/swift"
+      $env:LIBXML_LIBRARY_PATH="$LibraryRoot/libxml2-2.11.5/usr/lib/$Platform/$ShortArch"
+      $env:LIBXML_INCLUDE_PATH="$LibraryRoot/libxml2-2.11.5/usr/include/libxml2"
+      $env:ZLIB_LIBRARY_PATH="$LibraryRoot/zlib-1.3.1/usr/lib/$Platform/$ShortArch"
+      $env:CURL_LIBRARY_PATH="$LibraryRoot/curl-8.9.1/usr/lib/$Platform/$ShortArch"
+      $env:CURL_INCLUDE_PATH="$LibraryRoot/curl-8.9.1/usr/include"
+      Build-SPMProject `
+        -Test `
+        -Src $SourceCache\swift-corelibs-foundation `
+        -Bin $OutDir `
+        -Arch $HostArch
+    }
   } else {
     $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch
     $FoundationBinaryCache = Get-TargetProjectBinaryCache $Arch Foundation


### PR DESCRIPTION
Now that we've gotten the SwiftPM build of swift-corelibs-foundation up and running on Windows, we can run its tests as part of the toolchain test suite. We need to pass some environment variables indicating where libxml2/zlib/curl have been built since those can't be declared as SwiftPM dependencies (similar to the dispatch path, except we also need to provide paths to the static libraries themselves since these are in build folders and not the install folder)
