### PR TITLE
[ASTGen] Implement #if config handling using the SwiftIfConfig library

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -246,6 +246,9 @@ SWIFT_NAME("BridgedASTContext.langOptsGetCompilerVersion(self:_:)")
 SwiftInt BridgedASTContext_langOptsGetCompilerVersion(BridgedASTContext cContext,
                                                       SwiftInt* _Nullable * _Nonnull cComponents);
 
+/* Deallocate an array of Swift int values that was allocated in C++. */
+void deallocateIntBuffer(SwiftInt * _Nullable cComponents);
+
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedCanImportVersion : size_t {
   CanImportUnversioned,
   CanImportVersion,

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -48,6 +48,7 @@ int swift_ASTGen_roundTripCheck(void *_Nonnull sourceFile);
 /// Emit parser diagnostics for given source file.. Returns non-zero if any
 /// diagnostics were emitted.
 int swift_ASTGen_emitParserDiagnostics(
+    BridgedASTContext astContext,
     void *_Nonnull diagEngine, void *_Nonnull sourceFile, int emitOnlyErrors,
     int downgradePlaceholderErrorsToWarnings);
 

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -195,6 +195,10 @@ namespace {
   }
 }
 
+void deallocateIntBuffer(SwiftInt * _Nullable cComponents) {
+  free(cComponents);
+}
+
 SwiftInt BridgedASTContext_langOptsGetLanguageVersion(BridgedASTContext cContext,
                                                       SwiftInt** cComponents) {
   auto theVersion = cContext.unbridged().LangOpts.EffectiveLanguageVersion;

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 add_pure_swift_host_library(swiftASTGen STATIC
   Sources/ASTGen/ASTGen.swift
+  Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
   Sources/ASTGen/Bridge.swift
   Sources/ASTGen/CompilerBuildConfiguration.swift
   Sources/ASTGen/DeclAttrs.swift

--- a/lib/ASTGen/Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
@@ -25,6 +25,7 @@ extension ASTGenVisitor {
   /// produced due to the evaluation.
   func activeClause(in node: IfConfigDeclSyntax) -> IfConfigClauseSyntax? {
     // Determine the active clause.
+    var buildConfiguration = self.buildConfiguration
     buildConfiguration.conditionLoc = generateSourceLoc(node)
     let (activeClause, diagnostics) = node.activeClause(in: buildConfiguration)
     diagnoseAll(diagnostics)

--- a/lib/ASTGen/Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
@@ -1,0 +1,76 @@
+//===--- ASTGen+CompilerBuildConfiguration.swift --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftIfConfig
+import SwiftSyntax
+
+/// Enumeration that separates an #if config decl from the underlying element.
+enum IfConfigOrUnderlying<Element> {
+  case ifConfigDecl(IfConfigDeclSyntax)
+  case underlying(Element)
+}
+
+extension ASTGenVisitor {
+  /// Determine the active clause for the given #if, emitting any diagnostics
+  /// produced due to the evaluation.
+  func activeClause(in node: IfConfigDeclSyntax) -> IfConfigClauseSyntax? {
+    // Determine the active clause.
+    buildConfiguration.conditionLoc = generateSourceLoc(node)
+    let (activeClause, diagnostics) = node.activeClause(in: buildConfiguration)
+    diagnoseAll(diagnostics)
+
+    return activeClause
+  }
+
+  /// Visit a collection of elements that may contain #if clauses within it
+  /// within it, recursing into the active clauses and to ensure that every
+  /// active element is visited.
+  /// - Parameters:
+  ///   - elements: A syntax collection that can config `IfConfigDeclSyntax`
+  ///     nodes in it.
+  ///   - flatElementType: The element type within the syntax collection for the
+  ///     non-#if case.
+  ///   - split: Splits an element in elements into the two cases: #if config
+  ///     or a flat element.
+  ///   - body: The body that handles each syntax node of type FlatElement.
+  func visitIfConfigElements<Elements, FlatElement>(
+    _ elements: Elements,
+    of flatElementType: FlatElement.Type,
+    split: (Elements.Element) -> IfConfigOrUnderlying<FlatElement>,
+    body: (FlatElement) -> Void
+  ) where Elements: SyntaxCollection, FlatElement: SyntaxProtocol {
+    for element in elements {
+      switch split(element) {
+      case .ifConfigDecl(let ifConfigDecl):
+        if let activeClause = self.activeClause(in: ifConfigDecl),
+           let activeElements = activeClause.elements {
+          guard let activeElements = activeElements._syntaxNode.as(Elements.self) else {
+            fatalError("Parser produced invalid nesting of #if decls")
+          }
+
+          visitIfConfigElements(
+            activeElements,
+            of: FlatElement.self,
+            split: split,
+            body: body
+          )
+        }
+
+      case .underlying(let element):
+        body(element)
+    }
+    }
+  }
+}
+
+

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -76,6 +76,8 @@ struct ASTGenVisitor {
 
   let ctx: BridgedASTContext
 
+  let buildConfiguration: CompilerBuildConfiguration
+
   fileprivate let allocator: SwiftSyntax.BumpPtrAllocator = .init(initialSlabSize: 256)
 
   /// Fallback legacy parser used when ASTGen doesn't have the generate(_:)
@@ -94,12 +96,20 @@ struct ASTGenVisitor {
     self.declContext = declContext
     self.ctx = astContext
     self.legacyParse = legacyParser
+    self.buildConfiguration = CompilerBuildConfiguration(
+      ctx: ctx,
+      conditionLoc: BridgedSourceLoc(at: AbsolutePosition(utf8Offset: 0), in: sourceBuffer)
+    )
   }
 
   func generate(sourceFile node: SourceFileSyntax) -> [BridgedDecl] {
     var out = [BridgedDecl]()
 
-    for element in node.statements {
+    visitIfConfigElements(
+      node.statements,
+      of: CodeBlockItemSyntax.self,
+      split: Self.splitCodeBlockItemIfConfig
+    ) { element in
       let loc = self.generateSourceLoc(element)
       let swiftASTNodes = generate(codeBlockItem: element)
       switch swiftASTNodes {
@@ -259,6 +269,11 @@ extension ASTGenVisitor {
       diagnostic: diagnostic,
       diagnosticSeverity: diagnostic.diagMessage.severity
     )
+  }
+
+  /// Emits the given diagnostics via the C++ diagnostic engine.
+  func diagnoseAll(_ diagnostics: [Diagnostic]) {
+    diagnostics.forEach(diagnose)
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -123,7 +123,7 @@ final class CompilerBuildConfiguration: BuildConfiguration {
     var bitWidthsBuf: UnsafeMutablePointer<SwiftInt>? = nil
     let count = ctx.langOptsGetTargetAtomicBitWidths(&bitWidthsBuf)
     let bitWidths = Array(UnsafeMutableBufferPointer(start: bitWidthsBuf, count: count))
-    bitWidthsBuf?.deallocate()
+    deallocateIntBuffer(bitWidthsBuf);
     return bitWidths
   }
 
@@ -140,7 +140,7 @@ final class CompilerBuildConfiguration: BuildConfiguration {
     let version = VersionTuple(
       components: Array(UnsafeMutableBufferPointer(start: componentsBuf, count: count))
     )
-    componentsBuf?.deallocate()
+    deallocateIntBuffer(componentsBuf);
     return version
   }
 
@@ -150,7 +150,7 @@ final class CompilerBuildConfiguration: BuildConfiguration {
     let version = VersionTuple(
       components: Array(UnsafeMutableBufferPointer(start: componentsBuf, count: count))
     )
-    componentsBuf?.deallocate()
+    deallocateIntBuffer(componentsBuf);
     return version
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -18,7 +18,7 @@ import SwiftSyntax
 
 /// A build configuration that uses the compiler's ASTContext to answer
 /// queries.
-final class CompilerBuildConfiguration: BuildConfiguration {
+struct CompilerBuildConfiguration: BuildConfiguration {
   let ctx: BridgedASTContext
   var conditionLoc: BridgedSourceLoc
 

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -18,9 +18,14 @@ import SwiftSyntax
 
 /// A build configuration that uses the compiler's ASTContext to answer
 /// queries.
-struct CompilerBuildConfiguration: BuildConfiguration {
+final class CompilerBuildConfiguration: BuildConfiguration {
   let ctx: BridgedASTContext
-  let conditionLoc: BridgedSourceLoc
+  var conditionLoc: BridgedSourceLoc
+
+  init(ctx: BridgedASTContext, conditionLoc: BridgedSourceLoc) {
+    self.ctx = ctx
+    self.conditionLoc = conditionLoc
+  }
 
   func isCustomConditionSet(name: String) throws -> Bool {
     var name = name

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -13,6 +13,8 @@
 import ASTBridging
 import BasicBridging
 import SwiftDiagnostics
+import SwiftIfConfig
+
 @_spi(ExperimentalLanguageFeatures) @_spi(RawSyntax) import SwiftSyntax
 
 extension ASTGenVisitor {
@@ -52,17 +54,15 @@ extension ASTGenVisitor {
     }
 
     // '@' attributes.
-    for node in node.attributes {
-      switch node {
-      case .attribute(let node):
-        addAttribute(self.generateDeclAttribute(attribute: node))
-      case .ifConfigDecl:
-        fatalError("unimplemented")
-#if RESILIENT_SWIFT_SYNTAX
-      @unknown default:
-        fatalError()
-#endif
+    visitIfConfigElements(node.attributes, of: AttributeSyntax.self) { element in
+      switch element {
+      case .ifConfigDecl(let ifConfigDecl):
+        return .ifConfigDecl(ifConfigDecl)
+      case .attribute(let attribute):
+        return .underlying(attribute)
       }
+    } body: { attribute in
+      addAttribute(self.generateDeclAttribute(attribute: attribute))
     }
 
     func genStatic(node: DeclModifierSyntax, spelling: BridgedStaticSpelling) {

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -12,6 +12,7 @@
 
 import ASTBridging
 import SwiftDiagnostics
+import SwiftIfConfig
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
 import SwiftParserDiagnostics
 import SwiftSyntax
@@ -142,20 +143,10 @@ public func roundTripCheck(
   }
 }
 
-extension Syntax {
-  /// Whether this syntax node is or is enclosed within a #if.
-  fileprivate var isInIfConfig: Bool {
-    if self.is(IfConfigDeclSyntax.self) {
-      return true
-    }
-
-    return parent?.isInIfConfig ?? false
-  }
-}
-
 /// Emit diagnostics within the given source file.
 @_cdecl("swift_ASTGen_emitParserDiagnostics")
 public func emitParserDiagnostics(
+  ctx: BridgedASTContext,
   diagEnginePtr: UnsafeMutableRawPointer,
   sourceFilePtr: UnsafeMutablePointer<UInt8>,
   emitOnlyErrors: CInt,
@@ -172,11 +163,18 @@ public func emitParserDiagnostics(
     )
 
     let diagnosticEngine = BridgedDiagnosticEngine(raw: diagEnginePtr)
+    let buildConfiguration = CompilerBuildConfiguration(
+      ctx: ctx,
+      conditionLoc:
+        BridgedSourceLoc(
+        at: AbsolutePosition(utf8Offset: 0),
+        in: sourceFile.pointee.buffer
+      )
+    )
+
     for diag in diags {
-      // Skip over diagnostics within #if, because we don't know whether
-      // we are in an active region or not.
-      // FIXME: This heuristic could be improved.
-      if diag.node.isInIfConfig {
+      // If the diagnostic is in an unparsed #if region, don't emit it.
+      if diag.node.isActive(in: buildConfiguration).state == .unparsed {
         continue
       }
 

--- a/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
@@ -22,19 +22,16 @@ extension ASTGenVisitor {
     }
 
     let attrs = BridgedTypeAttributes.new()
-    for node in node.attributes {
-      switch node {
-      case .attribute(let node):
-        guard let attr = self.generateTypeAttribute(attribute: node) else {
-          continue
-        }
-        attrs.add(attr);
-      case .ifConfigDecl:
-        fatalError("unimplemented")
-#if RESILIENT_SWIFT_SYNTAX
-      @unknown default:
-        fatalError()
-#endif
+    visitIfConfigElements(node.attributes, of: AttributeSyntax.self) { element in
+      switch element {
+      case .ifConfigDecl(let ifConfigDecl):
+        return .ifConfigDecl(ifConfigDecl)
+      case .attribute(let attribute):
+        return .underlying(attribute)
+      }
+    } body: { attribute in
+      if let attr = self.generateTypeAttribute(attribute: attribute) {
+        attrs.add(attr)
       }
     }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -267,7 +267,7 @@ void Parser::parseTopLevelItems(SmallVectorImpl<ASTNode> &items) {
   if (parsingOpts.contains(ParsingFlags::ValidateNewParserDiagnostics) &&
       !Context.Diags.hadAnyError()) {
     auto hadSyntaxError = swift_ASTGen_emitParserDiagnostics(
-        &Context.Diags, exportedSourceFile,
+        Context, &Context.Diags, exportedSourceFile,
         /*emitOnlyErrors=*/true,
         /*downgradePlaceholderErrorsToWarnings=*/
         Context.LangOpts.Playground ||
@@ -346,7 +346,7 @@ void Parser::parseSourceFileViaASTGen(
   // If we're supposed to emit diagnostics from the parser, do so now.
   if (!suppressDiagnostics) {
     auto hadSyntaxError = swift_ASTGen_emitParserDiagnostics(
-        &Context.Diags, exportedSourceFile, /*emitOnlyErrors=*/false,
+        Context, &Context.Diags, exportedSourceFile, /*emitOnlyErrors=*/false,
         /*downgradePlaceholderErrorsToWarnings=*/langOpts.Playground ||
             langOpts.WarnOnEditorPlaceholder);
     if (hadSyntaxError && Context.Diags.hadAnyError() &&

--- a/test/ASTGen/if_config.swift
+++ b/test/ASTGen/if_config.swift
@@ -3,8 +3,8 @@
 // REQUIRES: asserts
 
 #if NOT_SET
-func f { } // FIXME: Error once the parser diagnostics generator knows to
-           // evaluate the active clause.
+func f { } // expected-error{{expected parameter clause in function signature}}
+           // expected-note@-1{{insert parameter clause}}{{7-8=}}{{8-8=(}}{{8-8=) }}
 #endif
 
 #if compiler(>=10.0)

--- a/test/ASTGen/if_config.swift
+++ b/test/ASTGen/if_config.swift
@@ -1,0 +1,70 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ParserASTGen -DDISCARDABLE -DNONSENDABLE -swift-version 6
+/// -enable-experimental-feature requires an asserts build
+// REQUIRES: asserts
+
+#if NOT_SET
+func f { } // FIXME: Error once the parser diagnostics generator knows to
+           // evaluate the active clause.
+#endif
+
+#if compiler(>=10.0)
+bad code is not diagnosed
+#endif
+
+#if canImport(NoSuchModule)
+func g() { }
+#else
+func h() { }
+#endif
+
+
+func testH() {
+  h()
+}
+
+// Declaration attributes
+#if DISCARDABLE
+@discardableResult
+#endif
+func ignorable() -> Int { 5 }
+
+
+func testIgnorable() {
+  ignorable() // no warning
+}
+
+// Type attributes
+// FIXME: Something isn't getting converted properly when I try to put an #if
+// within the type attributes.
+typealias CallbackType = () -> Void
+
+func acceptMaybeSendable(body: CallbackType) { }
+
+func testMaybeSendable() {
+  var x = 10
+  acceptMaybeSendable {
+    x += 1
+  }
+  print(x)
+}
+
+// Switch cases
+enum SafetyError: Error {
+case unsafe
+
+#if NONSENDABLE
+case nonSendable
+#endif
+}
+
+extension SafetyError {
+  var description: String {
+    switch self {
+    case .unsafe: "unsafe"
+
+#if NONSENDABLE
+    case .nonSendable: "non-sendable"
+#endif
+    }
+  }
+}


### PR DESCRIPTION
Wherever there is a syntax collection in the syntax tree that can involve an `#if` clause, evaluate the `#if` conditions to find the active clause, then recurse into the active clause (if one exists) to "flatten" the translated collection to only contain active elements.

Note that this does not yet handle #if for postfix expressions.
