### PR TITLE
Sema: Check the availability of conformance type witnesses

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -51,6 +51,10 @@ WARNING(error_in_future_swift_version,none,
         "%0; this is an error in the Swift %1 language mode",
         (DiagnosticInfo *, unsigned))
 
+WARNING(error_in_a_future_swift_version,none,
+        "%0; this will be an error in a future Swift language mode",
+        (DiagnosticInfo *))
+
 // Generic disambiguation
 NOTE(while_parsing_as_left_angle_bracket,none,
      "while parsing this '<' as a type parameter bracket", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3126,7 +3126,7 @@ NOTE(declared_protocol_conformance_here,none,
 
 ERROR(witness_unavailable,none,
         "unavailable %kind0 was used to satisfy a requirement of protocol %1%select{|: %2}2",
-        (const ValueDecl *, Identifier, StringRef))
+        (const ValueDecl *, const ProtocolDecl *, StringRef))
 
 WARNING(witness_deprecated,none,
         "deprecated default implementation is used to satisfy %kind0 required by "
@@ -6781,7 +6781,7 @@ WARNING(availability_enum_element_no_potential_warn,
 
 ERROR(availability_protocol_requires_version,
       none, "protocol %0 requires %1 to be available in %2 %3 and newer",
-      (Identifier, DeclName, StringRef, llvm::VersionTuple))
+      (const ProtocolDecl *, const ValueDecl *, StringRef, llvm::VersionTuple))
 
 NOTE(availability_protocol_requirement_here, none,
      "protocol requirement here", ())

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -405,8 +405,13 @@ InFlightDiagnostic::limitBehaviorUntilSwiftVersion(
     // in a message that this will become an error in a later Swift
     // version. We do this before limiting the behavior, because
     // wrapIn will result in the behavior of the wrapping diagnostic.
-    if (limit >= DiagnosticBehavior::Warning)
-      wrapIn(diag::error_in_future_swift_version, majorVersion);
+    if (limit >= DiagnosticBehavior::Warning) {
+      if (majorVersion > 6) {
+        wrapIn(diag::error_in_a_future_swift_version);
+      } else {
+        wrapIn(diag::error_in_future_swift_version, majorVersion);
+      }
+    }
 
     limitBehavior(limit);
   }

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -187,6 +187,12 @@ public:
   /// Get the ExportabilityReason for diagnostics. If this is 'None', there
   /// are no restrictions on referencing unexported declarations.
   std::optional<ExportabilityReason> getExportabilityReason() const;
+
+  /// If \p decl is unconditionally unavailable in this context, and the context
+  /// is not also unavailable in the same way, then this returns the specific
+  /// `@available` attribute that makes the decl unavailable. Otherwise, returns
+  /// nullptr.
+  const AvailableAttr *shouldDiagnoseDeclAsUnavailable(const Decl *decl) const;
 };
 
 /// Check if a declaration is exported as part of a module's external interface.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1689,8 +1689,9 @@ SelfAccessKindRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
 }
 
 bool TypeChecker::isAvailabilitySafeForConformance(
-    ProtocolDecl *proto, ValueDecl *requirement, ValueDecl *witness,
-    DeclContext *dc, AvailabilityContext &requirementInfo) {
+    const ProtocolDecl *proto, const ValueDecl *requirement,
+    const ValueDecl *witness, const DeclContext *dc,
+    AvailabilityContext &requirementInfo) {
 
   // We assume conformances in
   // non-SourceFiles have already been checked for availability.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4784,6 +4784,63 @@ static void diagnoseInvariantSelfRequirement(
       .warnUntilSwiftVersion(6);
 }
 
+static bool diagnoseTypeWitnessAvailability(
+    NormalProtocolConformance *conformance, const TypeDecl *witness,
+    const AssociatedTypeDecl *assocType, const ExportContext &where) {
+  auto dc = conformance->getDeclContext();
+  auto &ctx = dc->getASTContext();
+  if (ctx.LangOpts.DisableAvailabilityChecking)
+    return false;
+
+  // In Swift 6 and earlier type witness availability diagnostics are warnings.
+  const unsigned warnBeforeVersion = 7;
+  bool shouldError =
+      ctx.LangOpts.EffectiveLanguageVersion.isVersionAtLeast(warnBeforeVersion);
+
+  if (auto attr = where.shouldDiagnoseDeclAsUnavailable(witness)) {
+    ctx.addDelayedConformanceDiag(
+        conformance, shouldError,
+        [witness, assocType, attr](NormalProtocolConformance *conformance) {
+          SourceLoc loc = getLocForDiagnosingWitness(conformance, witness);
+          EncodedDiagnosticMessage encodedMessage(attr->Message);
+          auto &ctx = conformance->getDeclContext()->getASTContext();
+          ctx.Diags
+              .diagnose(loc, diag::witness_unavailable, witness,
+                        conformance->getProtocol(), encodedMessage.Message)
+              .warnUntilSwiftVersion(warnBeforeVersion);
+
+          emitDeclaredHereIfNeeded(ctx.Diags, loc, witness);
+          ctx.Diags.diagnose(assocType, diag::kind_declname_declared_here,
+                             DescriptiveDeclKind::Requirement,
+                             assocType->getName());
+        });
+  }
+
+  auto requiredAvailability = AvailabilityContext::alwaysAvailable();
+  if (!TypeChecker::isAvailabilitySafeForConformance(conformance->getProtocol(),
+                                                     assocType, witness, dc,
+                                                     requiredAvailability)) {
+    auto requiredRange = requiredAvailability.getOSVersion();
+    ctx.addDelayedConformanceDiag(
+        conformance, shouldError,
+        [witness, requiredRange](NormalProtocolConformance *conformance) {
+          SourceLoc loc = getLocForDiagnosingWitness(conformance, witness);
+          auto &ctx = conformance->getDeclContext()->getASTContext();
+          ctx.Diags
+              .diagnose(loc, diag::availability_protocol_requires_version,
+                        conformance->getProtocol(), witness,
+                        prettyPlatformString(targetPlatform(ctx.LangOpts)),
+                        requiredRange.getLowerEndpoint())
+              .warnUntilSwiftVersion(warnBeforeVersion);
+
+          emitDeclaredHereIfNeeded(ctx.Diags, loc, witness);
+        });
+    return true;
+  }
+
+  return false;
+}
+
 /// Check whether the type witnesses satisfy the protocol's requirement
 /// signature. Also checks access level of type witnesses and availiability
 /// of associated conformances.
@@ -4905,6 +4962,10 @@ static void ensureRequirementsAreSatisfied(ASTContext &ctx,
                                         DiagnoseUsableFromInline(typeDecl));
       }
     }
+
+    // The type witness must be as available as the associated type.
+    if (auto witness = type->getAnyNominal())
+      diagnoseTypeWitnessAvailability(conformance, witness, assocType, where);
 
     // Make sure any associated type witnesses don't make reference to a
     // type we can't emit metadata for, or we're going to have trouble at

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4313,8 +4313,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
           diags.diagnose(
               diagLoc, diag::availability_protocol_requires_version,
-              conformance->getProtocol()->getName(),
-              witness->getName(),
+              conformance->getProtocol(), witness,
               prettyPlatformString(targetPlatform(ctx.LangOpts)),
               check.RequiredAvailability.getOSVersion().getLowerEndpoint());
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
@@ -4385,9 +4384,8 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
           auto *attr = AvailableAttr::isUnavailable(witness);
           EncodedDiagnosticMessage EncodedMessage(attr->Message);
-          diags.diagnose(diagLoc, diag::witness_unavailable,
-                         witness, conformance->getProtocol()->getName(),
-                         EncodedMessage.Message);
+          diags.diagnose(diagLoc, diag::witness_unavailable, witness,
+                         conformance->getProtocol(), EncodedMessage.Message);
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
           diags.diagnose(requirement, diag::kind_declname_declared_here,
                          DescriptiveDeclKind::Requirement,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -990,10 +990,10 @@ bool diagnoseConformanceExportability(SourceLoc loc,
 /// is sufficient to safely conform to the requirement in the context
 /// the provided conformance. On return, requiredAvailability holds th
 /// availability levels required for conformance.
-bool
-isAvailabilitySafeForConformance(ProtocolDecl *proto, ValueDecl *requirement,
-                                 ValueDecl *witness, DeclContext *dc,
-                                 AvailabilityContext &requiredAvailability);
+bool isAvailabilitySafeForConformance(
+    const ProtocolDecl *proto, const ValueDecl *requirement,
+    const ValueDecl *witness, const DeclContext *dc,
+    AvailabilityContext &requiredAvailability);
 
 /// Returns an over-approximation of the range of operating system versions
 /// that could the passed-in location could be executing upon for

--- a/test/decl/protocol/associated_type_witness_availability.swift
+++ b/test/decl/protocol/associated_type_witness_availability.swift
@@ -1,0 +1,168 @@
+// RUN: %swift -typecheck -verify -target %target-cpu-apple-macosx12 %s
+// REQUIRES: OS=macosx
+
+protocol ProtoWithAssocType {
+  associatedtype A // expected-note * {{requirement 'A' declared here}}
+}
+
+struct ConformsToProtoWithAssocType_WitnessOld: ProtoWithAssocType {
+  @available(macOS 11, *)
+  struct A {} // Ok, A is less available than its parent but more available than the deployment target
+}
+
+struct ConformsToProtoWithAssocType_WitnessSame: ProtoWithAssocType {
+  @available(macOS 12, *)
+  struct A {} // Ok, A is less available than its parent but available at the deployment target
+}
+
+struct ConformsToProtoWithAssocType_WitnessTooNew: ProtoWithAssocType {
+  @available(macOS 13, *)
+  struct A {} // expected-warning {{protocol 'ProtoWithAssocType' requires 'A' to be available in macOS 12 and newer; this will be an error in a future Swift language mode}}
+}
+
+struct ConformsToProtoWithAssocTypeInExtension_WitnessOld {}
+
+extension ConformsToProtoWithAssocTypeInExtension_WitnessOld: ProtoWithAssocType {
+  @available(macOS 11, *)
+  struct A {} // Ok, A is less available than its parent but more available than the deployment target
+}
+
+struct ConformsToProtoWithAssocTypeInExtension_WitnessSame {}
+
+extension ConformsToProtoWithAssocTypeInExtension_WitnessSame: ProtoWithAssocType {
+  @available(macOS 12, *)
+  struct A {} // Ok, A is less available than its parent but available at the deployment target
+}
+
+struct ConformsToProtoWithAssocTypeInExtension_WitnessTooNew {}
+
+extension ConformsToProtoWithAssocTypeInExtension_WitnessTooNew: ProtoWithAssocType {
+  @available(macOS 13, *)
+  struct A {} // expected-warning {{protocol 'ProtoWithAssocType' requires 'A' to be available in macOS 12 and newer; this will be an error in a future Swift language mode}}
+}
+
+@available(macOS 13, *)
+struct ConformsToProtoWithAssocType_NewerConformance: ProtoWithAssocType {
+  struct A {} // Ok, A is as available as the conformance
+}
+
+struct ConformsToProtoWithAssocTypeInExtension_NewerConformance {}
+
+@available(macOS 13, *)
+extension ConformsToProtoWithAssocTypeInExtension_NewerConformance: ProtoWithAssocType {
+  struct A {} // Ok, A is as available as the conformance
+}
+
+@available(macOS 13, *)
+struct ConformsToProtoWithAssocType_NewerAndWitnessTooNew: ProtoWithAssocType {
+  @available(macOS 14, *)
+  struct A {} // expected-warning {{protocol 'ProtoWithAssocType' requires 'A' to be available in macOS 13 and newer; this will be an error in a future Swift language mode}}
+}
+
+struct ConformsToProtoWithAssocType_WitnessUnavailable: ProtoWithAssocType {
+  @available(macOS, unavailable)
+  struct A {} // expected-warning {{unavailable struct 'A' was used to satisfy a requirement of protocol 'ProtoWithAssocType'; this will be an error in a future Swift language mode}}
+}
+
+struct ConformsToProtoWithAssocType_WitnessUnavailableInExtension: ProtoWithAssocType {
+  // expected-warning@-1 {{unavailable struct 'A' was used to satisfy a requirement of protocol 'ProtoWithAssocType'; this will be an error in a future Swift language mode}}
+}
+
+extension ConformsToProtoWithAssocType_WitnessUnavailableInExtension {
+  @available(macOS, unavailable)
+  struct A {} // expected-note {{'A' declared here}}
+}
+
+struct ConformsToProtoWithAssocType_WitnessInUnavailableExtension: ProtoWithAssocType {
+  // expected-warning@-1 {{unavailable struct 'A' was used to satisfy a requirement of protocol 'ProtoWithAssocType'; this will be an error in a future Swift language mode}}
+}
+
+@available(macOS, unavailable)
+extension ConformsToProtoWithAssocType_WitnessInUnavailableExtension {
+  struct A {} // expected-note {{'A' declared here}}
+}
+
+struct ConformsToProtoWithAssocType_WitnessUnavailableMessage: ProtoWithAssocType {
+  @available(*, unavailable, message: "Just don't")
+  struct A {} // expected-warning {{unavailable struct 'A' was used to satisfy a requirement of protocol 'ProtoWithAssocType': Just don't; this will be an error in a future Swift language mode}}
+}
+
+struct ConformsToProtoWithAssocType_WitnessObsoleted: ProtoWithAssocType {
+  @available(macOS, obsoleted: 11)
+  struct A {} // expected-warning {{unavailable struct 'A' was used to satisfy a requirement of protocol 'ProtoWithAssocType'; this will be an error in a future Swift language mode}}
+}
+
+struct ConformsToProtoWithAssocType_WitnessIntroInSwift99: ProtoWithAssocType {
+  @available(swift, introduced: 99)
+  struct A {} // expected-warning {{unavailable struct 'A' was used to satisfy a requirement of protocol 'ProtoWithAssocType'; this will be an error in a future Swift language mode}}
+}
+
+@available(macOS, unavailable)
+struct ConformsToProtoWithAssocType_Unavailable: ProtoWithAssocType {
+  struct A {} // Ok, the conformance is unavailable too.
+}
+
+@available(macOS, unavailable)
+struct ConformsToProtoWithAssocType_WitnessAndConformanceUnavailable: ProtoWithAssocType {
+  @available(macOS, unavailable)
+  struct A {} // Ok, the conformance is unavailable too.
+}
+
+protocol ProtoWithNewAssocType {
+  @available(macOS 13, *)
+  associatedtype A
+}
+
+struct ConformsToProtoWithNewAssocType_WitnessOld: ProtoWithNewAssocType {
+  struct A {} // Ok, A has always been available
+}
+
+struct ConformsToProtoWithNewAssocType_WitnessSame: ProtoWithNewAssocType {
+  @available(macOS 13, *)
+  struct A {} // Ok, A is as available as the associated type requirement
+}
+
+struct ConformsToProtoWithNewAssocType_WitnessTooNew: ProtoWithNewAssocType {
+  @available(macOS 14, *)
+  struct A {} // expected-warning {{protocol 'ProtoWithNewAssocType' requires 'A' to be available in macOS 13 and newer; this will be an error in a future Swift language mode}}
+}
+
+protocol ProtoWithAssocTypeAndReq {
+  associatedtype A
+
+  @available(macOS 13, *)
+  func req(_ a: A)
+}
+
+@available(macOS 11, *)
+struct InferredOld {} // Ok, InferredOld is less available than its parent but more available than the deployment target
+
+struct ConformsToProtoWithAssocTypeAndReq_InferredWitnessOld: ProtoWithAssocTypeAndReq {
+
+  func req(_ a: InferredOld) {}
+}
+
+@available(macOS 12, *)
+struct InferredSame {} // Ok, InferredSame is less available than its parent but available at the deployment target
+
+struct ConformsToProtoWithAssocTypeAndReq_InferredWitnessSame: ProtoWithAssocTypeAndReq {
+  func req(_ a: InferredSame) {}
+}
+
+@available(macOS 13, *)
+struct InferredTooNew {} // expected-note {{'InferredTooNew' declared here}}
+
+struct ConformsToProtoWithAssocTypeAndReq_InferredWitnessTooNew: ProtoWithAssocTypeAndReq {
+  // expected-warning@-1 {{protocol 'ProtoWithAssocTypeAndReq' requires 'InferredTooNew' to be available in macOS 12 and newer; this will be an error in a future Swift language mode}}
+
+  @available(macOS 13, *)
+  func req(_ a: InferredTooNew) {}
+}
+
+@available(macOS, unavailable)
+struct ConformsToProtoWithAssocTypeAndReq_InferredUnavailable: ProtoWithAssocTypeAndReq {
+  @available(macOS, unavailable)
+  struct InferredUnavailable {}
+
+  func req(_ a: InferredUnavailable) {}
+}

--- a/test/decl/protocol/associated_type_witness_availability_swift7.swift
+++ b/test/decl/protocol/associated_type_witness_availability_swift7.swift
@@ -1,0 +1,22 @@
+// RUN: %swift -typecheck -verify -target %target-cpu-apple-macosx12 %s -swift-version 7
+// REQUIRES: OS=macosx
+// REQUIRES: swift7
+
+protocol ProtoWithAssocType {
+  associatedtype A // expected-note {{requirement 'A' declared here}}
+}
+
+struct WitnessSame: ProtoWithAssocType {
+  @available(macOS 12, *)
+  struct A {} // Ok, A is less available than its parent but available at the deployment target
+}
+
+struct WitnessTooNew: ProtoWithAssocType { // expected-error {{type 'WitnessTooNew' does not conform to protocol 'ProtoWithAssocType'}}
+  @available(macOS 13, *)
+  struct A {} // expected-error {{protocol 'ProtoWithAssocType' requires 'A' to be available in macOS 12 and newer}}
+}
+
+struct WitnessUnavailable: ProtoWithAssocType { // expected-error {{type 'WitnessUnavailable' does not conform to protocol 'ProtoWithAssocType'}}
+  @available(macOS, unavailable)
+  struct A {} // expected-error {{unavailable struct 'A' was used to satisfy a requirement of protocol 'ProtoWithAssocType'}}
+}


### PR DESCRIPTION
The type satisfying a protocol requirement must be at least as available as the associated type for the requirement. This has always been a potential soundness hole that should have been checked, but it is especially important to diagnose these issues now that associated type requirements can have their own availability (https://github.com/swiftlang/swift/pull/70735). Unfortunately, these diagnostics cannot be introduced as errors since doing so would break source compatibility for existing libraries so for now they are staged as warnings until a post Swift 6 language mode is available.

Resolves rdar://134093006.