### PR TITLE
Add SWIFT_BUILD_SWIFT_SYNTAX check on PrintingDiagnosticConsumer

### DIFF
--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -42,9 +42,11 @@ class PrintingDiagnosticConsumer : public DiagnosticConsumer {
   SmallVector<std::string, 1> BufferedEducationalNotes;
   bool SuppressOutput = false;
 
+#if SWIFT_BUILD_SWIFT_SYNTAX
   /// swift-syntax rendering
   DiagnosticBridge DiagBridge;
-
+#endif
+ 
 public:
   PrintingDiagnosticConsumer(llvm::raw_ostream &stream = llvm::errs());
   ~PrintingDiagnosticConsumer();


### PR DESCRIPTION
Hello Team, 

i think that this check is needed to be able to compile the compiler without `SWIFT_BUILD_SWIFT_SYNTAX` enabled
otherwise you will get 

```
Undefined symbols for architecture arm64:
  "swift::DiagnosticBridge::~DiagnosticBridge()", referenced from:
      swift::PrintingDiagnosticConsumer::~PrintingDiagnosticConsumer() in libswiftFrontend.a[20](PrintingDiagnosticConsumer.cpp.o)
ld: symbol(s) not found for architecture arm64
```

Resolves https://github.com/swiftlang/swift/issues/75939

