### PR TITLE
[build.ps1] Enable LLDB tests in Windows x86_64 builds.

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -568,7 +568,7 @@ function Invoke-VsDevShell($Arch) {
   if ($ToBatch) {
     Write-Output "call `"$VSInstallRoot\Common7\Tools\VsDevCmd.bat`" $DevCmdArguments"
   } else {
-    # This dll path is valid for VS2019 and VS2022, but it was under a vsdevcmd subfolder in VS2017 
+    # This dll path is valid for VS2019 and VS2022, but it was under a vsdevcmd subfolder in VS2017
     Import-Module "$VSInstallRoot\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
     Enter-VsDevShell -VsInstallPath $VSInstallRoot -SkipAutomaticLocation -DevCmdArguments $DevCmdArguments
 
@@ -1229,7 +1229,7 @@ function Build-WiXProject() {
   $ProductVersionArg = $ProductVersion
   if (-not $Bundle) {
     # WiX v4 will accept a semantic version string for Bundles,
-    # but Packages still require a purely numerical version number, 
+    # but Packages still require a purely numerical version number,
     # so trim any semantic versioning suffixes
     $ProductVersionArg = [regex]::Replace($ProductVersion, "[-+].*", "")
   }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -588,7 +588,7 @@ function Invoke-VsDevShell($Arch) {
       $env:INCLUDE += ";$WinSDKIncludePath"
       $env:LIB += ";$WinSDKVerLibRoot\ucrt\$($Arch.ShortName);$WinSDKVerLibRoot\um\$($Arch.ShortName)"
       $env:LIBPATH += ";$env:WindowsLibPath"
-      $env:PATH += ";$env:WindowsSdkVerBinPath\$($Arch.ShortName);$env:WindowsSdkBinPath\$($Arch.ShortName)"
+      $env:Path += ";$env:WindowsSdkVerBinPath\$($Arch.ShortName);$env:WindowsSdkBinPath\$($Arch.ShortName)"
       $env:UCRTVersion = $WinSDKVersionRevisionZero
       $env:UniversalCRTSdkDir = $CustomWinSDKRoot
     }
@@ -1329,6 +1329,10 @@ function Build-Compilers() {
     } else {
       Get-HostProjectBinaryCache Compilers
     }
+
+    $RuntimeBinaryCache = Get-TargetProjectBinaryCache $Arch Runtime
+    $CMarkGFMDLLDir="$($BuildArch.BinaryCache)\cmark-gfm-0.29.0.gfm.13\src"
+    $PythonDLLDir="$BinaryCache\Python$HostArchName-$PythonVersion\tools"
     $BuildTools = Join-Path -Path (Get-BuildProjectBinaryCache BuildTools) -ChildPath bin
 
     if ($TestClang -or $TestLLD -or $TestLLDB -or $TestLLVM -or $TestSwift) {
@@ -1343,7 +1347,94 @@ function Build-Compilers() {
 
       if ($TestClang) { $Targets += @("check-clang") }
       if ($TestLLD) { $Targets += @("check-lld") }
-      if ($TestLLDB) { $Targets += @("check-lldb") }
+      if ($TestLLDB) {
+        $Targets += @("check-lldb")
+
+        function Select-LitTestOverrides {
+          param([string] $TestStatus)
+
+          $MatchingLines=(Get-Content $PSScriptRoot/windows-llvm-lit-test-overrides.txt | Select-String -Pattern "`^${TestStatus}.*$")
+          $TestNames=$MatchingLines | ForEach-Object { ($_ -replace $TestStatus,"").Trim() }
+          return $TestNames
+        }
+
+        # Override some test results with llvm-lit.
+        $TestsToXFail=Select-LitTestOverrides "xfail"
+        $TestsToSkip=Select-LitTestOverrides "skip"
+        $env:LIT_XFAIL=$TestsToXFail -join ";"
+        $env:LIT_FILTER_OUT="($($TestsToSkip -join '|'))"
+
+        # lldb.exe loads these libraries which must be found on PATH.
+        # * swiftCore.dll
+        # * cmark-gfm.dll
+        # * python39.dll
+        # * dbghelp.dll
+        $env:Path="$RuntimeBinaryCache\bin;${env:Path}"
+        $env:Path="$CMarkGFMDLLDir;${env:Path}"
+        $env:Path="$BinaryCache\Python$HostArchName-$PythonVersion\tools;${env:Path}"
+        $env:Path="$VSInstallRoot\VC\Tools\Llvm\x64\bin;${env:Path}"
+
+        # The lldb test Python module needs these libraries.
+        # Python3.8+ doesn't search for dlls on PATH so we must copy them into the module's directory.
+        # TODO(https://github.com/llvm/llvm-project/issues/46235): Find a way to do this by modifying
+        # bindings/python.swig instead.
+        $LLDBPythonModuleDir="$CompilersBinaryCache\lib\site-packages\lldb"
+        cp $RuntimeBinaryCache\bin\swiftCore.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftBasicFormat.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftCompilerPluginMessageHandling.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftDiagnostics.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftIDEUtils.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftIfConfig.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftInProcPluginServer.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftLibraryPluginProvider.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftMacros.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftOperators.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftParser.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftParserDiagnostics.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftRefactor.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftSyntax.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftSyntaxBuilder.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftSyntaxMacroExpansion.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\SwiftSyntaxMacros.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftBasicFormat.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftCompilerPluginMessageHandling.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftDiagnostics.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftIDEUtils.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftIfConfig.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftLibraryPluginProvider.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftOperators.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftParser.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftParserDiagnostics.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftRefactor.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftSyntax.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftSyntaxBuilder.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftSyntaxMacroExpansion.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_CompilerSwiftSyntaxMacros.dll $LLDBPythonModuleDir
+        cp $CompilersBinaryCache\bin\_InternalSwiftScan.dll $LLDBPythonModuleDir
+        cp $CMarkGFMDLLDir\cmark-gfm.dll $LLDBPythonModuleDir
+
+        $TestingDefines += @{
+          LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS = "YES";
+          # Optional LLDB deps. For testing, only Python is needed.
+          LLDB_ENABLE_PYTHON = "YES";
+          LLDB_ENABLE_LIBEDIT = "NO";
+          LLDB_ENABLE_CURSES = "NO";
+          LLDB_ENABLE_LZMA = "NO";
+          LLDB_ENABLE_LIBXML2 = "NO";
+          LLDB_ENABLE_LUA = "NO";
+          # These are passed to LLDB's dotest.py.
+          # Watchpoint tests fail on windows. See https://github.com/llvm/llvm-project/issues/22140.
+          # LLDB's python module requires Swift runtimelibs and cmark-gfm.dll.
+          LLDB_TEST_USER_ARGS = "--skip-category=watchpoint";
+          LLVM_ENABLE_PROJECTS = "clang;clang-tools-extra;lld;lldb";
+          LLVM_ENABLE_DIA_SDK = "YES";
+          # gtest sharding breaks llvm-lit's --xfail and LIT_XFAIL inputs. See https://github.com/llvm/llvm-project/issues/102264.
+          LLVM_LIT_ARGS = "-v --no-gtest-sharding --show-xfail --show-unsupported";
+
+          # LLDB Unit tests link against this library.
+          LLVM_UNITTEST_LINK_FLAGS = "$($Arch.SDKInstallRoot)\usr\lib\swift\windows\$($Arch.LLVMName)\swiftCore.lib";
+        }
+      }
       if ($TestLLVM) { $Targets += @("check-llvm") }
       if ($TestSwift) { $Targets += @("check-swift", "SwiftCompilerPlugin") }
     } else {
@@ -1405,6 +1496,8 @@ function Build-Compilers() {
         SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE = "$SourceCache\swift-syntax";
         SWIFT_PATH_TO_STRING_PROCESSING_SOURCE = "$SourceCache\swift-experimental-string-processing";
         SWIFT_PATH_TO_SWIFT_SDK = (Get-PinnedToolchainSDK);
+        CMAKE_C_COMPILER_LAUNCHER = "ccache";
+        CMAKE_CXX_COMPILER_LAUNCHER = "ccache";
         "cmark-gfm_DIR" = "$($Arch.ToolchainInstallRoot)\usr\lib\cmake";
       })
   }

--- a/utils/windows-llvm-lit-test-overrides.txt
+++ b/utils/windows-llvm-lit-test-overrides.txt
@@ -1,0 +1,121 @@
+# build.ps1 overrides the status of each test in this file when LLVM tests are run with lit.
+#
+# Only full test names should be used. For example: "lldb-api :: TestName/Foo.py".
+# Please attach an issue URL to each test or group of tests, especially those that
+# are skipped. For flakey tests, please file an issue at swiftlang/llvm-project with
+# the "flakey-test" label.
+#
+# Allowed labels:
+# - skip      Skip the test (Use sparingly, for UNRESOLVED tests which can't be marked XFAIL).
+# - xfail     Mark the test as XFAIL
+
+# https://github.com/thebrowsercompany/swift-build/issues/196
+xfail lldb-api :: commands/apropos/with-process/TestAproposWithProcess.py
+xfail lldb-api :: commands/command/nested_alias/TestNestedAlias.py
+xfail lldb-api :: commands/expression/entry-bp/TestExprEntryBP.py
+xfail lldb-api :: commands/expression/nested/TestNestedExpressions.py
+xfail lldb-api :: commands/memory/write/TestMemoryWrite.py
+xfail lldb-api :: commands/settings/use_source_cache/TestUseSourceCache.py
+xfail lldb-api :: functionalities/breakpoint/address_breakpoints/TestAddressBreakpoints.py
+xfail lldb-api :: functionalities/breakpoint/auto_continue/TestBreakpointAutoContinue.py
+xfail lldb-api :: functionalities/breakpoint/breakpoint_conditions/TestBreakpointConditions.py
+xfail lldb-api :: functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
+xfail lldb-api :: functionalities/breakpoint/step_over_breakpoint/TestStepOverBreakpoint.py
+xfail lldb-api :: functionalities/conditional_break/TestConditionalBreak.py
+xfail lldb-api :: functionalities/memory/find/TestMemoryFind.py
+xfail lldb-api :: lang/c/anonymous/TestAnonymous.py
+xfail lldb-api :: lang/c/array_types/TestArrayTypes.py
+xfail lldb-api :: lang/c/enum_types/TestEnumTypes.py
+xfail lldb-api :: lang/c/forward/TestForwardDeclaration.py
+xfail lldb-api :: lang/c/function_types/TestFunctionTypes.py
+xfail lldb-api :: lang/c/non-mangled/TestCNonMangled.py
+xfail lldb-api :: lang/c/register_variables/TestRegisterVariables.py
+xfail lldb-api :: lang/c/set_values/TestSetValues.py
+xfail lldb-api :: lang/c/shared_lib/TestSharedLib.py
+xfail lldb-api :: lang/cpp/class_types/TestClassTypes.py
+xfail lldb-api :: lang/cpp/inlines/TestInlines.py
+xfail lldb-api :: lang/cpp/unique-types4/TestUniqueTypes4.py
+xfail lldb-api :: python_api/compile_unit/TestCompileUnitAPI.py
+xfail lldb-api :: python_api/thread/TestThreadAPI.py
+xfail lldb-api :: source-manager/TestSourceManager.py
+xfail lldb-shell :: Driver/TestConvenienceVariables.test
+xfail lldb-shell :: Recognizer/verbose_trap.test
+xfail lldb-shell :: Settings/TestEchoCommands.test
+xfail lldb-shell :: Swift/MissingVFSOverlay.test
+xfail lldb-shell :: Swift/No.swiftmodule.test
+xfail lldb-shell :: Swift/ToolchainMismatch.test
+xfail lldb-shell :: Swift/global.test
+xfail lldb-shell :: Swift/runtime-initialization.test
+xfail lldb-shell :: SwiftREPL/Basic.test
+xfail lldb-shell :: SwiftREPL/BreakpointSimple.test
+xfail lldb-shell :: SwiftREPL/Class.test
+xfail lldb-shell :: SwiftREPL/ClosureScope.test
+xfail lldb-shell :: SwiftREPL/ComputedProperties.test
+xfail lldb-shell :: SwiftREPL/Deadlock.test
+xfail lldb-shell :: SwiftREPL/DiagnosticOptions.test
+xfail lldb-shell :: SwiftREPL/Dict.test
+xfail lldb-shell :: SwiftREPL/ErrorReturn.test
+xfail lldb-shell :: SwiftREPL/ExclusivityREPL.test
+xfail lldb-shell :: SwiftREPL/ExistentialTypes.test
+xfail lldb-shell :: SwiftREPL/GenericTypealias.test
+xfail lldb-shell :: SwiftREPL/Generics.test
+xfail lldb-shell :: SwiftREPL/ImportError.test
+xfail lldb-shell :: SwiftREPL/LookupAfterImport.test
+xfail lldb-shell :: SwiftREPL/LookupWithAttributedImport.test
+xfail lldb-shell :: SwiftREPL/MetatypeRepl.test
+xfail lldb-shell :: SwiftREPL/OpenClass.test
+xfail lldb-shell :: SwiftREPL/Optional.test
+xfail lldb-shell :: SwiftREPL/OptionalUnowned.test
+xfail lldb-shell :: SwiftREPL/PropertyWrapperTopLevel.test
+xfail lldb-shell :: SwiftREPL/RecursiveClass.test
+xfail lldb-shell :: SwiftREPL/Redefinition.test
+xfail lldb-shell :: SwiftREPL/RedirectInput.test
+xfail lldb-shell :: SwiftREPL/RedirectInputNoSuchFile.test
+xfail lldb-shell :: SwiftREPL/RedirectInputUnreadable.test
+xfail lldb-shell :: SwiftREPL/Regex.test
+xfail lldb-shell :: SwiftREPL/SimpleExpressions.test
+xfail lldb-shell :: SwiftREPL/Struct.test
+xfail lldb-shell :: SwiftREPL/Subclassing.test
+xfail lldb-shell :: SwiftREPL/SwiftInterface.test
+xfail lldb-shell :: SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
+xfail lldb-shell :: SwiftREPL/SwiftTypeLookup.test
+xfail lldb-shell :: SwiftREPL/SyntaxError.test
+xfail lldb-shell :: SwiftREPL/UninitVariables.test
+xfail lldb-shell :: SwiftREPL/ZeroSizeStruct.test
+xfail lldb-shell :: SwiftREPL/enum-singlecase.test
+xfail lldb-shell :: SwiftREPL/one-char-string.test
+xfail lldb-shell :: SymbolFile/DWARF/x86/dead-code-filtering.yaml
+xfail lldb-shell :: SymbolFile/NativePDB/local-variables.cpp
+xfail lldb-shell :: SymbolFile/NativePDB/stack_unwinding01.cpp
+xfail lldb-unit :: Symbol/./SymbolTests.exe
+
+# https://github.com/llvm/llvm-project/issues/101710
+xfail lldb-shell :: Unwind/windows-unaligned-x86_64.test
+
+# https://github.com/llvm/llvm-project/issues/62983
+skip lldb-api :: functionalities/var_path/TestVarPath.py
+
+# https://github.com/swiftlang/llvm-project/issues/9073
+skip lldb-api :: lang/c/trampoline_stepping/TestTrampolineStepping.py
+
+# https://github.com/swiftlang/llvm-project/issues/9072
+skip lldb-api :: lang/cpp/bitfields/TestCppBitfields.py
+
+# https://github.com/swiftlang/llvm-project/issues/9074
+skip lldb-api :: functionalities/breakpoint/breakpoint_command/TestBreakpointCommandsFromPython.py
+
+# https://github.com/swiftlang/llvm-project/issues/9099
+skip lldb-api :: tools/lldb-server/TestGdbRemoteLaunch.py
+
+# https://github.com/swiftlang/llvm-project/issues/9100 
+skip lldb-api :: tools/lldb-server/TestLldbGdbServer.py
+
+# https://github.com/swiftlang/llvm-project/issues/9101
+skip lldb-api :: tools/lldb-server/TestGdbRemote_qThreadStopInfo.py
+
+# TODO: File bugs as these are all flakey
+skip lldb-api :: functionalities/archives/TestBSDArchives.py
+skip lldb-api :: tools/lldb-server/TestGdbRemoteThreadsInStopReply.py
+skip lldb-shell :: Swift/astcontext_error.test
+skip lldb-shell :: Swift/cond-breakpoint.test
+


### PR DESCRIPTION
Related to https://github.com/swiftlang/llvm-project/issues/9141

This PR enables the LLDB test suite on Windows builds of the swift toolchain. As a reference, I've built and run all of the LLDB llvm/llvm-project tests locally (There is not Windows x86_64 CI for upstream LLVM, only aarch64) and all of the tests pass without modification. However, in this fork, many of the tests fail. This hints that the failures are due to changes contained in this fork that must be addressed. To avoid handling these all at once, a file at `utils/windows-llvm-lit-test-overrides.txt` is introduced which marks tests as `XFAIL` or skipped (if flaky) with tracking issues to provide us with a list of tests to fix.

