### PR TITLE
Update misleading error message on APIDigester

### DIFF
--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -2492,7 +2492,7 @@ public:
       InitInvoke.getFrontendOptions().PreferInterfaceForModules.push_back(M);
     }
     if (Modules.empty()) {
-      llvm::errs() << "Need to specify -include-all or -module <name>\n";
+      llvm::errs() << "Need to specify -module <name>\n";
       exit(1);
     }
     return 0;


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

According to this PR: https://github.com/swiftlang/swift/pull/37206, llvm options are not used in the APIDigester and it uses options from the frontend shared option table. 

When running `swift api-digester` without `-module MODULE` flag returns `Need to specify -include-all or -module <name>` this message, which is quite invalid since `-include-all` option is no longer available. 

This PR removes the text about `-include-all` from the error message. 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
