### PR TITLE
tests: don't run SILOptimizer/devirt_deinits.swift with OS stdlibs

### DIFF
--- a/test/SILOptimizer/devirt_deinits.swift
+++ b/test/SILOptimizer/devirt_deinits.swift
@@ -20,6 +20,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: embedded_stdlib
 
+// UNSUPPORTED: use_os_stdlib
+
 @inline(never)
 func log(_ s: StaticString) {
   print(s)


### PR DESCRIPTION
rdar://134239853
