### PR TITLE
utils: raise `PinnedVersion` to an argument

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -114,6 +114,7 @@ param(
   [string] $ProductVersion = "0.0.0",
   [string] $PinnedBuild = "",
   [string] $PinnedSHA256 = "",
+  [string] $PinnedVersion = "",
   [string] $PythonVersion = "3.9.10",
   [string] $AndroidNDKVersion = "r26b",
   [string] $WinSDKVersion = "",


### PR DESCRIPTION
This is required so that we can use a custom pinned toolchain. The three arguments required are:
  - `PinnedBuild` (URL to toolchain)
  - `PinnedSHA256` (SHA256 for installer)
  - `PinnedVersion` (toolchain version)

Prior to this, we would error out as `PinnedVersion` would be unset and could not be specified as it was not an argument.