### PR TITLE
[build-script] Fix product dependencies

### DIFF
--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -670,6 +670,10 @@ class BuildScriptInvocation(object):
         builder.add_product(products.WasmSwiftSDK,
                             is_enabled=self.args.build_wasmstdlib)
 
+        builder.add_product(products.SwiftTestingMacros,
+                            is_enabled=self.args.build_swift_testing_macros)
+        builder.add_product(products.SwiftTesting,
+                            is_enabled=self.args.build_swift_testing)
         builder.add_product(products.SwiftPM,
                             is_enabled=self.args.build_swiftpm)
         builder.add_product(products.SwiftFoundationTests,
@@ -678,10 +682,6 @@ class BuildScriptInvocation(object):
                             is_enabled=self.args.build_foundation)
         builder.add_product(products.SwiftSyntax,
                             is_enabled=self.args.build_swiftsyntax)
-        builder.add_product(products.SwiftTestingMacros,
-                            is_enabled=self.args.build_swift_testing_macros)
-        builder.add_product(products.SwiftTesting,
-                            is_enabled=self.args.build_swift_testing)
         builder.add_product(products.SwiftFormat,
                             is_enabled=self.args.build_swiftformat)
         builder.add_product(products.SKStressTester,

--- a/utils/swift_build_support/swift_build_support/products/swift_testing.py
+++ b/utils/swift_build_support/swift_build_support/products/swift_testing.py
@@ -17,6 +17,7 @@ from build_swift.build_swift.versions import Version
 from . import cmake_product
 from . import product
 from . import swift
+from . import swift_testing_macros
 
 
 class SwiftTesting(product.Product):
@@ -34,7 +35,8 @@ class SwiftTesting(product.Product):
 
     @classmethod
     def get_dependencies(cls):
-        return [swift.Swift]
+        return [swift.Swift,
+                swift_testing_macros.SwiftTestingMacros]
 
     def should_build(self, host_target):
         return True

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -20,6 +20,7 @@ from . import llbuild
 from . import llvm
 from . import product
 from . import swift
+from . import swift_testing
 from . import xctest
 from .. import shell
 from ..targets import StdlibDeploymentTarget
@@ -141,4 +142,5 @@ class SwiftPM(product.Product):
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,
-                llbuild.LLBuild]
+                llbuild.LLBuild,
+                swift_testing.SwiftTesting]


### PR DESCRIPTION
(Re-apply #75909 as it was accidentally merged, and reverted)

SwiftPM now depends on `SwiftTesting`, `SwiftTesting` depends on `SwiftTestingMacros`

rdar://133946466
