### PR TITLE
[cxx][windows] fix the CxxStdlib build for recent MSVC versions after…

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -21,13 +21,27 @@ extension std.string {
   ///   Swift string.
   public init(_ string: String) {
     self = string.withCString(encodedAs: UTF8.self) { buffer in
+#if os(Windows)
+      // Use the 2 parameter constructor.
+      // The MSVC standard library has a enable_if template guard
+      // on the 3 parameter constructor, and thus it's not imported into Swift.
+      std.string(buffer, string.utf8.count)
+#else
       std.string(buffer, string.utf8.count, .init())
+#endif
     }
   }
 
   public init(_ string: UnsafePointer<CChar>?) {
     if let str = string {
+#if os(Windows)
+      // Use the 2 parameter constructor.
+      // The MSVC standard library has a enable_if template guard
+      // on the 3 parameter constructor, and thus it's not imported into Swift.
+      self.init(str, UTF8._nullCodeUnitOffset(in: str))
+#else
       self.init(str, UTF8._nullCodeUnitOffset(in: str), .init())
+#endif
     } else {
       self.init()
     }


### PR DESCRIPTION
… recent regression

The build regressed after cbaef38968b5f5ae5201a3ef4135e8380d1db5d6 as newer versions of MSVC that aren't used in the OSS CI yet fail to build CxxStdlib now
