### PR TITLE
[region-isolation] Move the region isolation logging decls out of PartitionUtils.h -> RegionIsolation.h

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -20,6 +20,7 @@
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/RegionIsolation.h"
 #include "swift/SILOptimizer/Utils/SILIsolationInfo.h"
 
 #include "llvm/ADT/MapVector.h"
@@ -35,32 +36,6 @@
 namespace swift {
 
 namespace PartitionPrimitives {
-
-extern bool REGIONBASEDISOLATION_ENABLE_LOGGING;
-
-#ifdef REGIONBASEDISOLATION_LOG
-#error "REGIONBASEDISOLATION_LOG already defined?!"
-#endif
-
-#define REGIONBASEDISOLATION_LOG(...)                                          \
-  do {                                                                         \
-    if (PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_LOGGING) {            \
-      __VA_ARGS__;                                                             \
-    }                                                                          \
-  } while (0);
-
-extern bool REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING;
-
-#ifdef REGIONBASEDISOLATION_VERBOSE_LOG
-#error "REGIONBASEDISOLATION_VERBOSE_LOG already defined?!"
-#endif
-
-#define REGIONBASEDISOLATION_VERBOSE_LOG(...)                                  \
-  do {                                                                         \
-    if (PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING) {    \
-      __VA_ARGS__;                                                             \
-    }                                                                          \
-  } while (0);
 
 struct Element {
   unsigned num;

--- a/include/swift/SILOptimizer/Utils/RegionIsolation.h
+++ b/include/swift/SILOptimizer/Utils/RegionIsolation.h
@@ -1,0 +1,61 @@
+//===--- RegionIsolation.h ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file This file just declares some command line options that are used for
+/// the various parts of region analysis based diagnostics.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_UTILS_REGIONANALYSIS_H
+#define SWIFT_SILOPTIMIZER_UTILS_REGIONANALYSIS_H
+
+namespace swift {
+
+namespace regionisolation {
+
+enum class LoggingFlag {
+  Off = 0,
+  Normal = 0x1,
+  Verbose = 0x3,
+};
+
+extern LoggingFlag ENABLE_LOGGING;
+
+#ifdef REGIONBASEDISOLATION_LOG
+#error "REGIONBASEDISOLATION_LOG already defined?!"
+#endif
+
+#ifdef REGIONBASEDISOLATION_VERBOSE_LOG
+#error "REGIONBASEDISOLATION_VERBOSE_LOG already defined?!"
+#endif
+
+#define REGIONBASEDISOLATION_LOG(...)                                          \
+  do {                                                                         \
+    if (swift::regionisolation::ENABLE_LOGGING !=                              \
+        swift::regionisolation::LoggingFlag::Off) {                            \
+      __VA_ARGS__;                                                             \
+    }                                                                          \
+  } while (0);
+
+#define REGIONBASEDISOLATION_VERBOSE_LOG(...)                                  \
+  do {                                                                         \
+    if (swift::regionisolation::ENABLE_LOGGING ==                              \
+        swift::regionisolation::LoggingFlag::Verbose) {                        \
+      __VA_ARGS__;                                                             \
+    }                                                                          \
+  } while (0);
+
+} // namespace regionisolation
+
+} // namespace swift
+
+#endif

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(swiftSILOptimizer PRIVATE
   LexicalDestroyFolding.cpp
   LoopUtils.cpp
   OptimizerStatsUtils.cpp
+  RegionIsolation.cpp
   PartialApplyCombiner.cpp
   PartitionUtils.cpp
   PerformanceInlinerUtils.cpp

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -21,37 +21,9 @@
 #include "swift/SIL/SILGlobalVariable.h"
 #include "swift/SILOptimizer/Utils/VariableNameUtils.h"
 
-#include "llvm/Support/CommandLine.h"
-
 using namespace swift;
 using namespace swift::PatternMatch;
 using namespace swift::PartitionPrimitives;
-
-//===----------------------------------------------------------------------===//
-//                               MARK: Logging
-//===----------------------------------------------------------------------===//
-
-bool swift::PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_LOGGING;
-
-static llvm::cl::opt<bool, true> // The parser
-    RegionBasedIsolationLog(
-        "sil-regionbasedisolation-log",
-        llvm::cl::desc("Enable logging for SIL region based isolation "
-                       "diagnostics"),
-        llvm::cl::Hidden,
-        llvm::cl::location(
-            swift::PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_LOGGING));
-
-bool swift::PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING;
-
-static llvm::cl::opt<bool, true> // The parser
-    RegionBasedIsolationVerboseLog(
-        "sil-regionbasedisolation-verbose-log",
-        llvm::cl::desc("Enable verbose logging for SIL region based isolation "
-                       "diagnostics"),
-        llvm::cl::Hidden,
-        llvm::cl::location(swift::PartitionPrimitives::
-                               REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING));
 
 //===----------------------------------------------------------------------===//
 //                             MARK: PartitionOp

--- a/lib/SILOptimizer/Utils/RegionIsolation.cpp
+++ b/lib/SILOptimizer/Utils/RegionIsolation.cpp
@@ -1,0 +1,36 @@
+//===--- RegionIsolation.cpp ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Utils/RegionIsolation.h"
+
+#include "llvm/Support/CommandLine.h"
+
+using namespace swift;
+using namespace regionisolation;
+
+//===----------------------------------------------------------------------===//
+//                               MARK: Logging
+//===----------------------------------------------------------------------===//
+
+LoggingFlag swift::regionisolation::ENABLE_LOGGING;
+
+static llvm::cl::opt<LoggingFlag, true> // The parser
+    RegionBasedIsolationLog(
+        "sil-regionbasedisolation-log",
+        llvm::cl::desc("Enable logging for SIL region based isolation "
+                       "diagnostics"),
+        llvm::cl::Hidden,
+        llvm::cl::values(
+            clEnumValN(LoggingFlag::Off, "none", "no logging"),
+            clEnumValN(LoggingFlag::Normal, "on", "non verbose logging"),
+            clEnumValN(LoggingFlag::Verbose, "verbose", "verbose logging")),
+        llvm::cl::location(swift::regionisolation::ENABLE_LOGGING));


### PR DESCRIPTION
These do not specifically have to do with PartitionUtils... they are really logging options for the whole infrastructure, so it makes sense to have them in the a different file.