### PR TITLE
Include utility for std::pair

### DIFF
--- a/include/swift/Runtime/PrebuiltStringMap.h
+++ b/include/swift/Runtime/PrebuiltStringMap.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <cstring>
 #include <optional>
+#include <utility>
 
 namespace swift {
 


### PR DESCRIPTION
Debian 12 and Fedora 39 don't implicitly include utility in any of the includes used by `PrebuildStringMap.h`, so the use of std::pair was causing build failures.