### PR TITLE
Frontend: Allow `-enable-experimental-feature` to specify upcoming features

### DIFF
--- a/test/Concurrency/isolated_default_arguments_serialized.swift
+++ b/test/Concurrency/isolated_default_arguments_serialized.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedDefaultArguments.swiftmodule -module-name SerializedDefaultArguments -enable-upcoming-feature IsolatedDefaultValues %S/Inputs/serialized_default_arguments.swift
 
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature IsolatedDefaultValues
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 5 -I %t -enable-upcoming-feature RegionBasedIsolation -enable-upcoming-feature IsolatedDefaultValues -enable-upcoming-feature StrictConcurrency
 
 // REQUIRES: concurrency
 

--- a/test/Concurrency/predates_concurrency_import_swift6.swift
+++ b/test/Concurrency/predates_concurrency_import_swift6.swift
@@ -3,7 +3,6 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 
 // RUN: %target-swift-frontend -swift-version 6 -I %t %s -emit-sil -o /dev/null -verify -parse-as-library
-// RUN: %target-swift-frontend -swift-version 6 -I %t %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation -parse-as-library
 
 @preconcurrency import NonStrictModule
 @preconcurrency import StrictModule

--- a/test/Concurrency/property_initializers_swift6.swift
+++ b/test/Concurrency/property_initializers_swift6.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -strict-concurrency=complete -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -strict-concurrency=complete -emit-sil -o /dev/null -verify %s -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 

--- a/test/Frontend/upcoming_feature.swift
+++ b/test/Frontend/upcoming_feature.swift
@@ -12,9 +12,13 @@
 // RUN: %target-swift-frontend -typecheck -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature UnknownFeature %s
 // RUN: %target-swift-frontend -typecheck -enable-upcoming-feature UnknownFeature -enable-upcoming-feature ConciseMagicFile %s
 
+// For compatibility when a feature graduates, it's fine to refer to an
+// upcoming feature as an experimental feature.
+// RUN: %target-swift-frontend -typecheck -enable-experimental-feature ConciseMagicFile %s
 
 // It's not fine to provide a feature that's in the specified language version.
 // RUN: not %target-swift-frontend -typecheck -enable-upcoming-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -enable-experimental-feature ConciseMagicFile -swift-version 6 %s 2>&1 | %FileCheck %s
 
 // CHECK: error: upcoming feature 'ConciseMagicFile' is already enabled as of Swift version 6
 

--- a/test/Sema/access-level-import-flag-check.swift
+++ b/test/Sema/access-level-import-flag-check.swift
@@ -19,7 +19,6 @@
 // RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault \
 // RUN:   -package-name package -verify
-// REQUIRES: asserts
 
 /// swiftinterfaces don't need the flag.
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift -verify-additional-prefix default-swift-mode-
 // RUN: %target-typecheck-verify-swift -swift-version 6 -verify-additional-prefix swift-6-
 // RUN: %target-typecheck-verify-swift -enable-upcoming-feature ExistentialAny -verify-additional-prefix explicit-any- -verify-additional-prefix default-swift-mode-
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ExistentialAny -verify-additional-prefix explicit-any- -verify-additional-prefix default-swift-mode-
 
 
 protocol HasSelfRequirements {


### PR DESCRIPTION
During the lifecycle of a feature, it may start as an experimental feature and then graduate to become an upcoming feature. To preserve compatibility with projects that adopted the feature when it was experimental, `-enable-experimental-feature` ought to be able to enable upcoming features, too.

Since projects may use `-enable-experimental-feature` for compatibility with an older toolchain that does not have the feature as an upcoming feature, there is no warning when the flag is used to enable an upcoming feature.

Note that if the semantics of a feature change when it graduates from experimental to upcoming, then the feature must be renamed so that projects using the experimental feature have an opportunity opt-in to the new semantics of the upcoming feature.

Resolves rdar://134276783.
