### PR TITLE
IRGen: We cannot call destroy through metadata of private types of non-copyable fields

### DIFF
--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -46,8 +46,9 @@ protected:
                 IsBitwiseTakable_t bt,
                 IsCopyable_t copy,
                 IsFixedSize_t alwaysFixedSize,
+                IsABIAccessible_t isABIAccessible,
                 SpecialTypeInfoKind stik = SpecialTypeInfoKind::Fixed)
-      : TypeInfo(type, align, pod, bt, copy, alwaysFixedSize, IsABIAccessible, stik),
+      : TypeInfo(type, align, pod, bt, copy, alwaysFixedSize, isABIAccessible, stik),
         SpareBits(spareBits) {
     assert(SpareBits.size() == size.getValueInBits());
     assert(isFixedSize());
@@ -61,8 +62,9 @@ protected:
                 IsBitwiseTakable_t bt,
                 IsCopyable_t copy,
                 IsFixedSize_t alwaysFixedSize,
+                IsABIAccessible_t isABIAccessible,
                 SpecialTypeInfoKind stik = SpecialTypeInfoKind::Fixed)
-      : TypeInfo(type, align, pod, bt, copy, alwaysFixedSize, IsABIAccessible, stik),
+      : TypeInfo(type, align, pod, bt, copy, alwaysFixedSize, isABIAccessible, stik),
         SpareBits(std::move(spareBits)) {
     assert(SpareBits.size() == size.getValueInBits());
     assert(isFixedSize());
@@ -73,7 +75,6 @@ protected:
 public:
   // This is useful for metaprogramming.
   static bool isFixed() { return true; }
-  static IsABIAccessible_t isABIAccessible() { return IsABIAccessible; }
 
   /// Whether this type is known to be empty.
   bool isKnownEmpty(ResilienceExpansion expansion) const {

--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -46,7 +46,7 @@ public:
                    Size size, Alignment align, SpareBitVector &&spareBits)
       : TrivialScalarPairTypeInfo(storageType, size, std::move(spareBits),
                                   align, IsTriviallyDestroyable,
-                                  IsCopyable, IsFixedSize) {}
+                                  IsCopyable, IsFixedSize, IsABIAccessible) {}
 
   static Size getFirstElementSize(IRGenModule &IGM) {
     return IGM.getPointerSize();

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -96,8 +96,8 @@ public:
                              unsigned explosionSize, llvm::Type *ty, Size size,
                              SpareBitVector &&spareBits, Alignment align,
                              IsTriviallyDestroyable_t isTriviallyDestroyable, IsFixedSize_t alwaysFixedSize)
-      : super(fields, explosionSize, ty, size, std::move(spareBits), align,
-              isTriviallyDestroyable, IsCopyable, alwaysFixedSize) {}
+      : super(fields, explosionSize, FieldsAreABIAccessible, ty, size, std::move(spareBits), align,
+              isTriviallyDestroyable, IsCopyable, alwaysFixedSize, IsABIAccessible) {}
 
   Address projectFieldAddress(IRGenFunction &IGF, Address addr, SILType T,
                               const DifferentiableFuncFieldInfo &field) const {
@@ -174,12 +174,14 @@ public:
   }
 
   TypeInfo *createFixed(ArrayRef<DifferentiableFuncFieldInfo> fields,
+                        FieldsAreABIAccessible_t unused,
                         StructLayout &&layout) {
     llvm_unreachable("@differentiable functions are always loadable");
   }
 
   DifferentiableFuncTypeInfo *
   createLoadable(ArrayRef<DifferentiableFuncFieldInfo> fields,
+                 FieldsAreABIAccessible_t unused,
                  StructLayout &&layout, unsigned explosionSize) {
     return DifferentiableFuncTypeInfo::create(
         fields, explosionSize, layout.getType(), layout.getSize(),
@@ -273,8 +275,8 @@ public:
                      unsigned explosionSize, llvm::Type *ty, Size size,
                      SpareBitVector &&spareBits, Alignment align, IsTriviallyDestroyable_t isTriviallyDestroyable,
                      IsFixedSize_t alwaysFixedSize)
-      : super(fields, explosionSize, ty, size, std::move(spareBits), align,
-              isTriviallyDestroyable, IsCopyable, alwaysFixedSize) {}
+      : super(fields, explosionSize, FieldsAreABIAccessible, ty, size, std::move(spareBits), align,
+              isTriviallyDestroyable, IsCopyable, alwaysFixedSize, IsABIAccessible) {}
 
   Address projectFieldAddress(IRGenFunction &IGF, Address addr, SILType T,
                               const LinearFuncFieldInfo &field) const {
@@ -345,11 +347,13 @@ public:
   }
 
   TypeInfo *createFixed(ArrayRef<LinearFuncFieldInfo> fields,
+                        FieldsAreABIAccessible_t areFieldsABIAccessible,
                         StructLayout &&layout) {
     llvm_unreachable("@differentiable functions are always loadable");
   }
 
   LinearFuncTypeInfo *createLoadable(ArrayRef<LinearFuncFieldInfo> fields,
+                                     FieldsAreABIAccessible_t unused,
                                      StructLayout &&layout,
                                      unsigned explosionSize) {
     return LinearFuncTypeInfo::create(

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6675,6 +6675,8 @@ namespace {
   public:
     using EnumTypeInfoBase<Base>::Strategy;
 
+    /// \group Methods delegated to the EnumImplStrategy
+
     unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {
       return Strategy.getFixedExtraInhabitantCount(IGM);
     }

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -180,7 +180,8 @@ protected:
                                  Alignment A,
                                  IsTriviallyDestroyable_t isTriviallyDestroyable,
                                  IsBitwiseTakable_t isBT,
-                                 IsCopyable_t isCopyable);
+                                 IsCopyable_t isCopyable,
+                                 IsABIAccessible_t abiAccessible);
   
 public:
   virtual ~EnumImplStrategy() { }

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -689,7 +689,8 @@ namespace {
                                                 align, IsNotTriviallyDestroyable, \
                                                 IsNotBitwiseTakable, \
                                                 IsCopyable, \
-                                                IsFixedSize), \
+                                                IsFixedSize, \
+                                                IsABIAccessible), \
         IsOptional(isOptional) {} \
     TypeLayoutEntry \
     *buildTypeLayoutEntry(IRGenModule &IGM, \
@@ -747,7 +748,7 @@ namespace {
                                       spareBits, align, \
                                       IsNotTriviallyDestroyable, \
                                       IsCopyable, \
-                                      IsFixedSize), \
+                                      IsFixedSize, IsABIAccessible), \
         Refcounting(refcounting), ValueType(valueTy), IsOptional(isOptional) { \
       assert(refcounting == ReferenceCounting::Native || \
              refcounting == ReferenceCounting::Unknown); \
@@ -816,7 +817,7 @@ namespace {
         bool isOptional) \
       : ScalarExistentialTypeInfoBase(storedProtocols, ty, size, \
                                       spareBits, align, IsTriviallyDestroyable,\
-                                      IsCopyable, IsFixedSize), \
+                                      IsCopyable, IsFixedSize, IsABIAccessible), \
         IsOptional(isOptional) {} \
     TypeLayoutEntry \
     *buildTypeLayoutEntry(IRGenModule &IGM, \
@@ -904,7 +905,7 @@ class OpaqueExistentialTypeInfo final :
     : super(protocols, ty, size,
             std::move(spareBits), align,
             IsNotTriviallyDestroyable, IsBitwiseTakable, IsCopyable,
-            IsFixedSize) {}
+            IsFixedSize, IsABIAccessible) {}
 
 public:
   OpaqueExistentialLayout getLayout() const {
@@ -1402,7 +1403,7 @@ class ExistentialMetatypeTypeInfo final
                                     std::move(spareBits), align,
                                     IsTriviallyDestroyable,
                                     IsCopyable,
-                                    IsFixedSize),
+                                    IsFixedSize, IsABIAccessible),
       MetatypeTI(metatypeTI) {}
 
 public:

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -504,7 +504,7 @@ namespace {
                          IsTriviallyDestroyable_t pod, IsBitwiseTakable_t bt, Size captureOffset)
       : IndirectTypeInfo(type, size, std::move(spareBits), align, pod, bt,
                          IsCopyable,
-                         IsFixedSize),
+                         IsFixedSize, IsABIAccessible),
         CaptureOffset(captureOffset)
     {}
     

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -74,7 +74,7 @@ namespace {
                                     SpareBitVector &&spareBits, \
                                     bool isOptional) \
       : IndirectTypeInfo(type, size, std::move(spareBits), alignment, \
-                         IsNotTriviallyDestroyable, IsNotBitwiseTakable, IsCopyable, IsFixedSize), \
+                         IsNotTriviallyDestroyable, IsNotBitwiseTakable, IsCopyable, IsFixedSize, IsABIAccessible), \
         ValueTypeAndIsOptional(valueType, isOptional) {} \
     void initializeWithCopy(IRGenFunction &IGF, Address destAddr, \
                             Address srcAddr, SILType T, \
@@ -151,7 +151,7 @@ namespace {
       : SingleScalarTypeInfo(type, size, std::move(spareBits), \
                              alignment, IsNotTriviallyDestroyable, \
                              IsCopyable, \
-                             IsFixedSize), \
+                             IsFixedSize, IsABIAccessible), \
         ValueTypeAndIsOptional(valueType, isOptional) {} \
     enum { IsScalarTriviallyDestroyable = false }; \
     TypeLayoutEntry \

--- a/lib/IRGen/GenIntegerLiteral.cpp
+++ b/lib/IRGen/GenIntegerLiteral.cpp
@@ -44,7 +44,7 @@ public:
   IntegerLiteralTypeInfo(llvm::StructType *storageType,
                          Size size, Alignment align, SpareBitVector &&spareBits)
       : TrivialScalarPairTypeInfo(storageType, size, std::move(spareBits), align,
-                            IsTriviallyDestroyable, IsCopyable, IsFixedSize) {}
+                            IsTriviallyDestroyable, IsCopyable, IsFixedSize, IsABIAccessible) {}
 
   static Size getFirstElementSize(IRGenModule &IGM) {
     return IGM.getPointerSize();

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -683,7 +683,7 @@ class RecordTypeInfo<Impl, Base, FieldImpl,
 protected:
   template <class... As> 
   RecordTypeInfo(ArrayRef<FieldImpl> fields, As &&...args)
-    : super(fields, FieldsAreABIAccessible, std::forward<As>(args)...) {}
+    : super(fields, std::forward<As>(args)...) {}
 
   using super::asImpl;
 
@@ -965,12 +965,12 @@ public:
     fieldTypesForLayout.reserve(astFields.size());
 
     auto fieldsABIAccessible = FieldsAreABIAccessible;
-
     unsigned explosionSize = 0;
     for (unsigned i : indices(astFields)) {
       auto &astField = astFields[i];
       // Compute the field's type info.
-      auto &fieldTI = IGM.getTypeInfo(asImpl()->getType(astField));
+      auto fieldTy = asImpl()->getType(astField);
+      auto &fieldTI = IGM.getTypeInfo(fieldTy);
       fieldTypesForLayout.push_back(&fieldTI);
 
       if (!fieldTI.isABIAccessible())
@@ -1003,11 +1003,10 @@ public:
     // Create the type info.
     if (layout.isLoadable()) {
       assert(layout.isFixedLayout());
-      assert(fieldsABIAccessible);
-      return asImpl()->createLoadable(fields, std::move(layout), explosionSize);
+      return asImpl()->createLoadable(fields, fieldsABIAccessible, std::move(layout), explosionSize
+                                      );
     } else if (layout.isFixedLayout()) {
-      assert(fieldsABIAccessible);
-      return asImpl()->createFixed(fields, std::move(layout));
+      return asImpl()->createFixed(fields, fieldsABIAccessible, std::move(layout));
     } else {
       return asImpl()->createNonFixed(fields, fieldsABIAccessible,
                                       std::move(layout));

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -155,6 +155,7 @@ namespace {
     using super::asImpl;
 
   public:
+
     const FieldInfoType &getFieldInfo(VarDecl *field) const {
       // FIXME: cache the physical field index in the VarDecl.
       for (auto &fieldInfo : asImpl().getFields()) {
@@ -275,6 +276,12 @@ namespace {
 
     void destroy(IRGenFunction &IGF, Address address, SILType T,
                  bool isOutlined) const override {
+
+      if (!asImpl().areFieldsABIAccessible()) {
+        emitDestroyCall(IGF, T, address);
+        return;
+      }
+
       // If the struct has a deinit declared, then call it to destroy the
       // value.
       if (!tryEmitDestroyUsingDeinit(IGF, address, T)) {
@@ -390,11 +397,11 @@ namespace {
                                 Alignment align,
                                 const clang::RecordDecl *clangDecl)
         : StructTypeInfoBase(StructTypeInfoKind::LoadableClangRecordTypeInfo,
-                             fields, explosionSize, storageType, size,
-                             std::move(spareBits), align,
+                             fields, explosionSize, FieldsAreABIAccessible,
+                             storageType, size, std::move(spareBits), align,
                              IsTriviallyDestroyable,
                              IsCopyable,
-                             IsFixedSize),
+                             IsFixedSize, IsABIAccessible),
           ClangDecl(clangDecl) {}
 
     TypeLayoutEntry
@@ -484,13 +491,14 @@ namespace {
                                          Alignment align,
                                          const clang::RecordDecl *clangDecl)
         : StructTypeInfoBase(StructTypeInfoKind::AddressOnlyClangRecordTypeInfo,
-                             fields, storageType, size,
+                             fields, FieldsAreABIAccessible, storageType, size,
                              // We can't assume any spare bits in a C++ type
                              // with user-defined special member functions.
                              SpareBitVector(std::optional<APInt>{
                                  llvm::APInt(size.getValueInBits(), 0)}),
                              align, IsNotTriviallyDestroyable,
-                             IsNotBitwiseTakable, IsCopyable, IsFixedSize),
+                             IsNotBitwiseTakable, IsCopyable, IsFixedSize,
+                             IsABIAccessible),
           clangDecl(clangDecl) {
       (void)clangDecl;
     }
@@ -666,7 +674,7 @@ namespace {
                                       Alignment align,
                                       const clang::RecordDecl *clangDecl)
         : StructTypeInfoBase(StructTypeInfoKind::AddressOnlyClangRecordTypeInfo,
-                             fields, storageType, size,
+                             fields, FieldsAreABIAccessible, storageType, size,
                              // We can't assume any spare bits in a C++ type
                              // with user-defined special member functions.
                              SpareBitVector(std::optional<APInt>{
@@ -675,7 +683,7 @@ namespace {
                              IsNotBitwiseTakable,
                              // TODO: Set this appropriately for the type's
                              // C++ import behavior.
-                             IsCopyable, IsFixedSize),
+                             IsCopyable, IsFixedSize, IsABIAccessible),
           ClangDecl(clangDecl) {
       (void)ClangDecl;
     }
@@ -865,21 +873,24 @@ namespace {
   class LoadableStructTypeInfo final
       : public StructTypeInfoBase<LoadableStructTypeInfo, LoadableTypeInfo> {
     using super = StructTypeInfoBase<LoadableStructTypeInfo, LoadableTypeInfo>;
+
   public:
     LoadableStructTypeInfo(ArrayRef<StructFieldInfo> fields,
+                           FieldsAreABIAccessible_t areFieldsABIAccessible,
                            unsigned explosionSize,
                            llvm::Type *storageType, Size size,
                            SpareBitVector &&spareBits,
                            Alignment align,
                            IsTriviallyDestroyable_t isTriviallyDestroyable,
                            IsCopyable_t isCopyable,
-                           IsFixedSize_t alwaysFixedSize)
+                           IsFixedSize_t alwaysFixedSize,
+                           IsABIAccessible_t isABIAccessible)
       : StructTypeInfoBase(StructTypeInfoKind::LoadableStructTypeInfo,
-                           fields, explosionSize,
+                           fields, explosionSize, areFieldsABIAccessible,
                            storageType, size, std::move(spareBits),
                            align, isTriviallyDestroyable,
                            isCopyable,
-                           alwaysFixedSize)
+                           alwaysFixedSize, isABIAccessible)
     {}
 
     void addToAggLowering(IRGenModule &IGM, SwiftAggLowering &lowering,
@@ -942,6 +953,13 @@ namespace {
     
     void consume(IRGenFunction &IGF, Explosion &explosion,
                  Atomicity atomicity, SILType T) const override {
+      if (!areFieldsABIAccessible()) {
+        auto temporary = allocateStack(IGF, T, "deinit.arg").getAddress();
+        initialize(IGF, explosion, temporary, /*outlined*/false);
+        emitDestroyCall(IGF, T, temporary);
+        return;
+      }
+
       // If the struct has a deinit declared, then call it to consume the
       // value.
       if (tryEmitConsumeUsingDeinit(IGF, explosion, T)) {
@@ -960,17 +978,21 @@ namespace {
                                                    FixedTypeInfo>> {
   public:
     // FIXME: Spare bits between struct members.
-    FixedStructTypeInfo(ArrayRef<StructFieldInfo> fields, llvm::Type *T,
+    FixedStructTypeInfo(ArrayRef<StructFieldInfo> fields,
+                        FieldsAreABIAccessible_t areFieldsABIAccessible,
+                        llvm::Type *T,
                         Size size, SpareBitVector &&spareBits,
                         Alignment align,
                         IsTriviallyDestroyable_t isTriviallyDestroyable,
                         IsBitwiseTakable_t isBT,
                         IsCopyable_t isCopyable,
-                        IsFixedSize_t alwaysFixedSize)
+                        IsFixedSize_t alwaysFixedSize,
+                        IsABIAccessible_t isABIAccessible)
       : StructTypeInfoBase(StructTypeInfoKind::FixedStructTypeInfo,
-                           fields, T, size, std::move(spareBits), align,
+                           fields, areFieldsABIAccessible,
+                           T, size, std::move(spareBits), align,
                            isTriviallyDestroyable, isBT, isCopyable,
-                           alwaysFixedSize)
+                           alwaysFixedSize, isABIAccessible)
     {}
 
     TypeLayoutEntry
@@ -1242,9 +1264,15 @@ namespace {
     }
 
     LoadableStructTypeInfo *createLoadable(ArrayRef<StructFieldInfo> fields,
+                                           FieldsAreABIAccessible_t areFieldsABIAccessible,
                                            StructLayout &&layout,
                                            unsigned explosionSize) {
+      IsABIAccessible_t isABIAccessible = IsABIAccessible;
+      if (TheStruct->isNoncopyable() &&
+          !IGM.getSILModule().isTypeMetadataAccessible(TheStruct))
+        isABIAccessible = IsNotABIAccessible;
       return LoadableStructTypeInfo::create(fields,
+                                            areFieldsABIAccessible,
                                             explosionSize,
                                             layout.getType(),
                                             layout.getSize(),
@@ -1252,23 +1280,31 @@ namespace {
                                             layout.getAlignment(),
                                             layout.isTriviallyDestroyable(),
                                             layout.isCopyable(),
-                                            layout.isAlwaysFixedSize());
+                                            layout.isAlwaysFixedSize(),
+                                            isABIAccessible);
     }
 
     FixedStructTypeInfo *createFixed(ArrayRef<StructFieldInfo> fields,
+                                     FieldsAreABIAccessible_t areFieldsABIAccessible,
                                      StructLayout &&layout) {
-      return FixedStructTypeInfo::create(fields, layout.getType(),
+      IsABIAccessible_t isABIAccessible = IsABIAccessible;
+      if (TheStruct->isNoncopyable() &&
+          !IGM.getSILModule().isTypeMetadataAccessible(TheStruct))
+        isABIAccessible = IsNotABIAccessible;
+      return FixedStructTypeInfo::create(fields, areFieldsABIAccessible,
+                                         layout.getType(),
                                          layout.getSize(),
                                          std::move(layout.getSpareBits()),
                                          layout.getAlignment(),
                                          layout.isTriviallyDestroyable(),
                                          layout.isBitwiseTakable(),
                                          layout.isCopyable(),
-                                         layout.isAlwaysFixedSize());
+                                         layout.isAlwaysFixedSize(),
+                                         isABIAccessible);
     }
 
     NonFixedStructTypeInfo *createNonFixed(ArrayRef<StructFieldInfo> fields,
-                                     FieldsAreABIAccessible_t fieldsAccessible,
+                                           FieldsAreABIAccessible_t fieldsAccessible,
                                            StructLayout &&layout) {
       auto structAccessible = IsABIAccessible_t(
         IGM.getSILModule().isTypeMetadataAccessible(TheStruct));

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -256,18 +256,20 @@ namespace {
   public:
     // FIXME: Spare bits between tuple elements.
     LoadableTupleTypeInfo(ArrayRef<TupleFieldInfo> fields,
+                          FieldsAreABIAccessible_t areFieldsABIAccessible,
                           unsigned explosionSize,
                           llvm::Type *ty,
                           Size size, SpareBitVector &&spareBits,
                           Alignment align,
                           IsTriviallyDestroyable_t isTriviallyDestroyable,
                           IsCopyable_t isCopyable,
-                          IsFixedSize_t alwaysFixedSize)
-      : TupleTypeInfoBase(fields, explosionSize,
+                          IsFixedSize_t alwaysFixedSize,
+                          IsABIAccessible_t isABIAccessible)
+      : TupleTypeInfoBase(fields, explosionSize, areFieldsABIAccessible,
                           ty, size, std::move(spareBits), align,
                           isTriviallyDestroyable,
                           isCopyable,
-                          alwaysFixedSize)
+                          alwaysFixedSize, isABIAccessible)
       {}
 
     void addToAggLowering(IRGenModule &IGM, SwiftAggLowering &lowering,
@@ -319,15 +321,18 @@ namespace {
   {
   public:
     // FIXME: Spare bits between tuple elements.
-    FixedTupleTypeInfo(ArrayRef<TupleFieldInfo> fields, llvm::Type *ty,
+    FixedTupleTypeInfo(ArrayRef<TupleFieldInfo> fields,
+                       FieldsAreABIAccessible_t areFieldsABIAccessible,
+                       llvm::Type *ty,
                        Size size, SpareBitVector &&spareBits, Alignment align,
                        IsTriviallyDestroyable_t isTriviallyDestroyable,
                        IsBitwiseTakable_t isBT,
                        IsCopyable_t isCopyable,
-                       IsFixedSize_t alwaysFixedSize)
-      : TupleTypeInfoBase(fields, ty, size, std::move(spareBits), align,
+                       IsFixedSize_t alwaysFixedSize,
+                       IsABIAccessible_t isABIAccessible)
+      : TupleTypeInfoBase(fields, areFieldsABIAccessible, ty, size, std::move(spareBits), align,
                           isTriviallyDestroyable, isBT, isCopyable,
-                          alwaysFixedSize)
+                          alwaysFixedSize, isABIAccessible)
     {}
 
     TypeLayoutEntry
@@ -464,27 +469,35 @@ namespace {
       : RecordTypeBuilder(IGM), TheTuple(theTuple) {}
 
     FixedTupleTypeInfo *createFixed(ArrayRef<TupleFieldInfo> fields,
+                                    FieldsAreABIAccessible_t areFieldsABIAccessible,
                                     StructLayout &&layout) {
-      return FixedTupleTypeInfo::create(fields, layout.getType(),
+      IsABIAccessible_t isABIAccessible = IsABIAccessible_t(areFieldsABIAccessible);
+      return FixedTupleTypeInfo::create(fields, areFieldsABIAccessible,
+                                        layout.getType(),
                                         layout.getSize(),
                                         std::move(layout.getSpareBits()),
                                         layout.getAlignment(),
                                         layout.isTriviallyDestroyable(),
                                         layout.isBitwiseTakable(),
                                         layout.isCopyable(),
-                                        layout.isAlwaysFixedSize());
+                                        layout.isAlwaysFixedSize(),
+                                        isABIAccessible);
     }
 
     LoadableTupleTypeInfo *createLoadable(ArrayRef<TupleFieldInfo> fields,
+                                          FieldsAreABIAccessible_t areFieldsABIAccessible,
                                           StructLayout &&layout,
                                           unsigned explosionSize) {
-      return LoadableTupleTypeInfo::create(fields, explosionSize,
+      IsABIAccessible_t isABIAccessible = IsABIAccessible_t(areFieldsABIAccessible);
+      return LoadableTupleTypeInfo::create(fields, areFieldsABIAccessible,
+                                           explosionSize,
                                            layout.getType(), layout.getSize(),
                                            std::move(layout.getSpareBits()),
                                            layout.getAlignment(),
                                            layout.isTriviallyDestroyable(),
                                            layout.isCopyable(),
-                                           layout.isAlwaysFixedSize());
+                                           layout.isAlwaysFixedSize(),
+                                           isABIAccessible);
     }
 
     NonFixedTupleTypeInfo *createNonFixed(ArrayRef<TupleFieldInfo> fields,

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -970,7 +970,7 @@ namespace {
       : ScalarTypeInfo(ty, Size(0), SpareBitVector{}, Alignment(1),
                        IsTriviallyDestroyable,
                        IsCopyable,
-                       IsFixedSize) {}
+                       IsFixedSize, IsABIAccessible) {}
     unsigned getExplosionSize() const override { return 0; }
     void getSchema(ExplosionSchema &schema) const override {}
     void addToAggLowering(IRGenModule &IGM, SwiftAggLowering &lowering,
@@ -1138,7 +1138,8 @@ namespace {
       : ScalarTypeInfo(storage, size, std::move(spareBits), align,
                        IsTriviallyDestroyable,
                        IsCopyable,
-                       IsFixedSize),
+                       IsFixedSize,
+                       IsABIAccessible),
         ScalarTypes(std::move(scalarTypes))
     {}
     
@@ -1329,7 +1330,7 @@ namespace {
                               IsNotTriviallyDestroyable,
                               IsNotBitwiseTakable,
                               IsNotCopyable,
-                              IsFixedSize) {}
+                              IsFixedSize, IsABIAccessible) {}
   };
 
   /// A TypeInfo implementation for address-only types which can never
@@ -2541,7 +2542,8 @@ public:
                     IsNotTriviallyDestroyable, /* irrelevant */
                     IsNotBitwiseTakable, /* irrelevant */
                     IsCopyable, /* irrelevant */
-                    IsFixedSize /* irrelevant */),
+                    IsFixedSize /* irrelevant */,
+                    IsABIAccessible),
       NumExtraInhabitants(node.NumExtraInhabitants) {}
 
   TypeLayoutEntry

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -3044,7 +3044,7 @@ bool irgen::tryEmitDestroyUsingDeinit(IRGenFunction &IGF, Address address,
 IsABIAccessible_t irgen::isTypeABIAccessibleIfFixedSize(IRGenModule &IGM,
                                                         CanType ty) {
 
-  // Copyable types currently are always fixed size.
+  // Copyable types currently are always ABI-accessible if they're fixed size.
   if (!ty->isNoncopyable())
     return IsABIAccessible;
 
@@ -3054,7 +3054,9 @@ IsABIAccessible_t irgen::isTypeABIAccessibleIfFixedSize(IRGenModule &IGM,
   if (!nom || !nom->getValueTypeDestructor())
     return IsABIAccessible;
 
-  if (IGM.getSILModule().isTypeMetadataAccessible(ty))
+  if (IGM.getSILModule().isTypeMetadataAccessible(ty) ||
+      IGM.getSILModule().lookUpMoveOnlyDeinit(nom,
+                                              false /*deserialize lazily*/))
     return IsABIAccessible;
 
   return IsNotABIAccessible;

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -407,6 +407,12 @@ bool tryEmitConsumeUsingDeinit(IRGenFunction &IGF,
                                Explosion &explosion,
                                SILType T);
 
+/// Most fixed size types currently are always ABI accessible (value operations
+/// can be done without metadata). One notable exception is non-copyable types
+/// with a deinit. Their type metadata is required to call destroy if the deinit
+/// function is not available to the current SIL module.
+IsABIAccessible_t isTypeABIAccessibleIfFixedSize(IRGenModule &IGM, CanType ty);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/LoadableTypeInfo.h
+++ b/lib/IRGen/LoadableTypeInfo.h
@@ -62,11 +62,12 @@ protected:
                    IsTriviallyDestroyable_t pod,
                    IsCopyable_t copy,
                    IsFixedSize_t alwaysFixedSize,
+                   IsABIAccessible_t isABIAccessible,
                    SpecialTypeInfoKind stik = SpecialTypeInfoKind::Loadable)
       : FixedTypeInfo(type, size, spareBits, align, pod,
                       // All currently implemented loadable types are bitwise-takable.
                       IsBitwiseTakable,
-                      copy, alwaysFixedSize, stik) {
+                      copy, alwaysFixedSize, isABIAccessible, stik) {
     assert(isLoadable());
   }
 
@@ -76,11 +77,12 @@ protected:
                    IsTriviallyDestroyable_t pod,
                    IsCopyable_t copy,
                    IsFixedSize_t alwaysFixedSize,
+                   IsABIAccessible_t isABIAccessible,
                    SpecialTypeInfoKind stik = SpecialTypeInfoKind::Loadable)
       : FixedTypeInfo(type, size, std::move(spareBits), align, pod,
                       // All currently implemented loadable types are bitwise-takable.
                       IsBitwiseTakable,
-                      copy, alwaysFixedSize, stik) {
+                      copy, alwaysFixedSize, isABIAccessible, stik) {
     assert(isLoadable());
   }
 

--- a/lib/IRGen/ReferenceTypeInfo.h
+++ b/lib/IRGen/ReferenceTypeInfo.h
@@ -33,7 +33,7 @@ protected:
   ReferenceTypeInfo(llvm::Type *type, Size size, SpareBitVector spareBits,
                     Alignment align, IsTriviallyDestroyable_t pod = IsNotTriviallyDestroyable)
     : LoadableTypeInfo(type, size, spareBits, align, pod, IsCopyable,
-                       IsFixedSize, SpecialTypeInfoKind::Reference)
+                       IsFixedSize, IsABIAccessible, SpecialTypeInfoKind::Reference)
   {}
 
 public:

--- a/lib/IRGen/ScalarTypeInfo.h
+++ b/lib/IRGen/ScalarTypeInfo.h
@@ -280,6 +280,7 @@ protected:
                                           IsTriviallyDestroyable,
                                           IsCopyable,
                                           IsFixedSize,
+                                          IsABIAccessible,
                                           ::std::forward<T>(args)...) {}
 
   const Derived &asDerived() const {

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -208,9 +208,12 @@ public:
   /// actually possible to do ABI operations on it from this current SILModule.
   /// See SILModule::isTypeABIAccessible.
   ///
-  /// All fixed-size types are currently ABI-accessible, although this would
+  /// Almost all fixed-size types are currently ABI-accessible, although this would
   /// not be difficult to change (e.g. if we had an archetype size constraint
   /// that didn't say anything about triviality).
+  /// The exception to this is non-copyable types, non-copyable types need to be
+  /// able to call the metadata to get to the deinit and so their type metadata
+  /// needs to be accessible.
   IsABIAccessible_t isABIAccessible() const {
     return IsABIAccessible_t(Bits.TypeInfo.ABIAccessible);
   }

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -211,8 +211,8 @@ public:
   /// Almost all fixed-size types are currently ABI-accessible, although this would
   /// not be difficult to change (e.g. if we had an archetype size constraint
   /// that didn't say anything about triviality).
-  /// The exception to this is non-copyable types, non-copyable types need to be
-  /// able to call the metadata to get to the deinit and so their type metadata
+  /// The exception to this is non-copyable types, which need to be able to call
+  /// the metadata to get to the deinit and so their type metadata
   /// needs to be accessible.
   IsABIAccessible_t isABIAccessible() const {
     return IsABIAccessible_t(Bits.TypeInfo.ABIAccessible);

--- a/test/IRGen/Inputs/noncopyable_private_other.swift
+++ b/test/IRGen/Inputs/noncopyable_private_other.swift
@@ -1,0 +1,24 @@
+fileprivate struct PrivateType : ~Copyable {
+  let x = 5
+
+  deinit {
+    print("deinit")
+  }
+}
+
+public struct PublicType : ~Copyable {
+  fileprivate let p = PrivateType()
+
+  public init() {}
+}
+
+public enum PublicSinglePayloadEnum : ~Copyable {
+    case empty
+    case some(PrivateType)
+}
+
+public enum PublicMultiPayloadEnum : ~Copyable {
+    case empty
+    case some(PrivateType)
+    case someOther(PrivateType)
+}

--- a/test/IRGen/noncopyable_private.swift
+++ b/test/IRGen/noncopyable_private.swift
@@ -1,0 +1,42 @@
+// RUN: %swift-frontend -primary-file %s %S/Inputs/noncopyable_private_other.swift -emit-ir -o - | %FileCheck %s
+
+public struct SomeStruct : ~Copyable {
+  // PublicType is a struct without a deinit but a non-copyable field with a
+  // deinit of private type. So we can't access the private type's metadata.
+  // Instead we have to call destroy on PublicType's metadata.
+  public let x = PublicType()
+}
+
+// Call the destroy on the `PublicType` metadata instead of its private typed
+// subfield.
+// CHECK: define{{.*}} internal void @"$s19noncopyable_private10SomeStructVwxx"(
+// CHECK: entry
+// CHECK-NOT: define
+// CHECK:  call void %Destroy(ptr {{.*}}, ptr @"$s19noncopyable_private10PublicTypeVN"
+// CHECK:  ret void
+// CHECK: }
+
+// Similar issue with enums.
+
+public struct SomeStructWithSPE : ~Copyable {
+    public let x = PublicSinglePayloadEnum.empty
+}
+
+// CHECK: define{{.*}} internal void @"$s19noncopyable_private17SomeStructWithSPEVwxx"(
+// CHECK: entry:
+// CHECK-NOT: define
+// CHECK:  call void %Destroy(ptr {{.*}}, ptr @"$s19noncopyable_private23PublicSinglePayloadEnumON"
+// CHECK:  ret void
+// CHECK: }
+
+public struct SomeStructWithMPE : ~Copyable {
+    public let x = PublicMultiPayloadEnum.empty
+}
+
+
+// CHECK: define{{.*}} internal void @"$s19noncopyable_private17SomeStructWithMPEVwxx"(
+// CHECK: entry:
+// CHECK-NOT: define
+// CHECK:  call void %Destroy(ptr {{.*}}, ptr @"$s19noncopyable_private22PublicMultiPayloadEnumON"
+// CHECK:  ret void
+// CHECK: }


### PR DESCRIPTION


So call the destroy on the closing type instead.

rdar://133990500

