### PR TITLE
[Android] fix NDK extract location

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -629,7 +629,8 @@ function Fetch-Dependencies {
     (
         [string]$ZipFileName,
         [string]$BinaryCache,
-        [string]$ExtractPath
+        [string]$ExtractPath,
+        [bool]$CreateExtractPath = $true
     )
 
     $source = Join-Path -Path $BinaryCache -ChildPath $ZipFileName
@@ -646,10 +647,13 @@ function Fetch-Dependencies {
         }
     }
 
+    $destination = if ($CreateExtractPath) { $destination } else { $BinaryCache }
+
     Write-Output "Extracting '$ZipFileName' ..."
     New-Item -ItemType Directory -ErrorAction Ignore -Path $BinaryCache | Out-Null
     Expand-Archive -Path $source -DestinationPath $destination -Force
   }
+
 
   function Extract-Toolchain {
     param
@@ -727,7 +731,7 @@ function Fetch-Dependencies {
     $NDKHash = "A478D43D4A45D0D345CDA6BE50D79642B92FB175868D9DC0DFC86181D80F691E"
     DownloadAndVerify $NDKURL "$BinaryCache\android-ndk-$AndroidNDKVersion-windows.zip" $NDKHash
 
-    Extract-ZipFile -ZipFileName "android-ndk-$AndroidNDKVersion-windows.zip" -BinaryCache $BinaryCache -ExtractPath "android-ndk-$AndroidNDKVersion"
+    Extract-ZipFile -ZipFileName "android-ndk-$AndroidNDKVersion-windows.zip" -BinaryCache $BinaryCache -ExtractPath "android-ndk-$AndroidNDKVersion" -CreateExtractPath $false
   }
 
   if ($WinSDKVersion) {


### PR DESCRIPTION
The Android NDK is being extracted with an extra intermediate directory:

  `$BinaryCache\android-ndk-r26b\android-ndk-r26b`

The Android build fails because it expects the NDK contents to live immediately under the directory:

  `$BinaryCache\android-ndk-r26b`

The redundant `android-ndk-r26b` sub-dir comes from the NDK zip archive itself, which we have no control over. To work-around, allow callers of `Extract-ZipFile` to control whether or not it should create the extraction sub-dir. Override the default behavior for NDK extraction only.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
