### PR TITLE
:cherries: [cxx-interop] Disable c++ execution header with libstdcxx versions >= 11

### DIFF
--- a/stdlib/public/Cxx/libstdcxx/libstdcxx.h
+++ b/stdlib/public/Cxx/libstdcxx/libstdcxx.h
@@ -1,7 +1,9 @@
+#include "cstddef"
+
 // C++17 and newer:
 
 // <execution> includes tbb headers, which might not be installed.
 // Only include <execution> if tbb is installed.
-#if __has_include("execution") && __has_include(<tbb/blocked_range.h>)
+#if __has_include("execution") && __has_include(<tbb/blocked_range.h>) && (!defined(_GLIBCXX_RELEASE) || (_GLIBCXX_RELEASE < 11))
 #include "execution"
 #endif


### PR DESCRIPTION
Workaround for https://github.com/swiftlang/swift/issues/75661

Backport form:

Explanation: Removes cyclic dependency from libstdc++ overlay when tbb library is installed on linux
Scope: This change un-breaks linking C++ libraries that are built with C++17, 20, 23 and 26.
Issues: https://github.com/swiftlang/swift/issues/75661
Original PRs: https://github.com/swiftlang/swift/pull/75662
Risk: Very low, any projects that were trying to use c++17+ and libstdc++11+ did not build before this change
Testing: Local testing with the test case in the issue, CI testing
Reviewers: @egorzhdan 
