### PR TITLE
Re-enable Interpreter/objc_implementation_objc_client.m test

### DIFF
--- a/test/Interpreter/objc_implementation_objc_client.m
+++ b/test/Interpreter/objc_implementation_objc_client.m
@@ -1,5 +1,3 @@
-// REQUIRES: rdar101497120
-
 //
 // Build objc_implementation.framework
 //


### PR DESCRIPTION
This test was disabled over a year ago due to what may have been a standard library bug; however, the failure no longer reproduces in commonly-tested configurations.

Experimentally re-enable the test to find out whether it is still failing in *any* tested configuration or whether we can simply leave it turned on.

Fixes rdar://101497120 (maybe).