### PR TITLE
Sema: Fix override availability checking for protocols

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1774,9 +1774,9 @@ static bool isAvailabilitySafeForOverride(ValueDecl *override,
 
   // Allow overrides that are not as available as the base decl as long as the
   // override is as available as its context.
-  auto overrideTypeAvailability = AvailabilityInference::inferForType(
-      override->getDeclContext()->getSelfTypeInContext());
-  
+  auto overrideTypeAvailability = AvailabilityInference::availableRange(
+      override->getDeclContext()->getSelfNominalTypeDecl(), ctx);
+
   return overrideTypeAvailability.isContainedIn(overrideInfo);
 }
 

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -218,6 +218,44 @@ class SubClassOverridingPotentiallyUnavailableMethod : ClassWithPotentiallyUnava
   }
 }
 
+protocol BaseProto {
+  associatedtype A
+
+  var property: A { get set } // expected-note {{overridden declaration is here}}
+
+  @available(OSX 10.51, *)
+  var newProperty: A { get set } // expected-note {{overridden declaration is here}}
+
+  func method() // expected-note {{overridden declaration is here}}
+}
+
+protocol RefinesBaseProto_AsAvailableOverrides: BaseProto {
+  var property: A { get set }
+
+  @available(OSX 10.51, *)
+  var newProperty: A { get set }
+
+  func method()
+}
+
+protocol RefinesBaseProto_LessAvailableOverrides: BaseProto {
+  @available(OSX 10.52, *)
+  var property: A { get set } // expected-error {{overriding 'property' must be as available as declaration it overrides}}
+
+  @available(OSX 10.52, *)
+  var newProperty: A { get set } // expected-error {{overriding 'newProperty' must be as available as declaration it overrides}}
+
+  @available(OSX 10.52, *)
+  func method()  // expected-error {{overriding 'method' must be as available as declaration it overrides}}
+}
+
+@available(OSX 10.52, *)
+protocol RefinesBaseProto_LessAvailable: BaseProto {
+  var property: A { get set }
+  var newProperty: A { get set }
+  func method()
+}
+
 class ClassWithPotentiallyUnavailableOverloadedMethod {
   @available(OSX, introduced: 10.9)
   func overloadedMethod() {}


### PR DESCRIPTION
Given the following test case, override availability checking produced an erroneus diagnostic:

```
@available(macOS 10.15, *)
protocol P {
    associatedtype A
    var a: A { get set }
}

@available(macOS 13.0, *)
protocol Q: P {
    // error: overriding _modify accessor for 'a' must be as available as
    //        declaration it overrides
    var a: A { get set }
}
```

The synthesized `_modify` accessor in `Q` is explicitly marked available in macOS 13, which is less available than the `_modify` accessor in `P`. The availability of `Q` should limit the required availability of the override and prevent the diagnostic, but the implementation had a bug where it checked the availability of the context's type instead of the contextual self type's declaration. In the example, the context's type is `Self` which does not have annotated availability.

Resolves rdar://133573707.
