### PR TITLE
CMake: Improving missing compiler error message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -968,6 +968,13 @@ if(SWIFT_INCLUDE_TOOLS AND SWIFT_BUILD_SWIFT_SYNTAX)
   if(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|OPENBSD|FREEBSD" AND NOT BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
     message(WARNING "Force setting BOOTSTRAPPING=HOSTTOOLS because Swift parser integration is enabled")
     set(BOOTSTRAPPING_MODE "HOSTTOOLS")
+    if(NOT CMAKE_Swift_COMPILER)
+      message(SEND_ERROR "No Swift compiler found.\n"
+        "Tell CMake where to find the Swift compiler by setting either the "
+        "environment variable \"SWIFTC\" or the CMake cache entry "
+        "CMAKE_Swift_COMPILER to the full path of the compiler, or to the "
+        "compiler name if it is in the PATH")
+    endif()
   endif()
   add_definitions(-DSWIFT_BUILD_SWIFT_SYNTAX)
 endif()


### PR DESCRIPTION
Right now, if you have the new parser enabled and try to configure without an existing Swift compiler, the configuration fails due to a call to 'get_filename_component' with the wrong number of arguments. This is is because the `CMAKE_Swift_COMPILER` is empty and doesn't expand to anything here:

```
get_filename_component(swift_bin_dir ${CMAKE_Swift_COMPILER} DIRECTORY)
```

The current error is not clear about why it failed though. Improving the error message so that other people can look at it and see that it's because the compiler is missing.