### PR TITLE
utils: adjust the swift-testing build to match style

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -398,7 +398,7 @@ enum TargetComponent {
   Dispatch
   Foundation
   XCTest
-  SwiftTesting
+  Testing
 }
 
 function Get-TargetProjectBinaryCache($Arch, [TargetComponent]$Project) {
@@ -1831,8 +1831,8 @@ function Build-XCTest([Platform]$Platform, $Arch, [switch]$Test = $false) {
   }
 }
 
-function Build-SwiftTesting([Platform]$Platform, $Arch, [switch]$Test = $false) {
-  $SwiftTestingBinaryCache = Get-TargetProjectBinaryCache $Arch SwiftTesting
+function Build-Testing([Platform]$Platform, $Arch, [switch]$Test = $false) {
+  $SwiftTestingBinaryCache = Get-TargetProjectBinaryCache $Arch Testing
 
   Isolate-EnvVars {
     if ($Test) {
@@ -2467,7 +2467,7 @@ if (-not $SkipBuild) {
     Invoke-BuildStep Build-TestingMacros -Build Windows $BuildArch
     Invoke-BuildStep Build-Foundation Windows $Arch
     Invoke-BuildStep Build-XCTest Windows $Arch
-    Invoke-BuildStep Build-SwiftTesting Windows $Arch
+    Invoke-BuildStep Build-Testing Windows $Arch
     Invoke-BuildStep Write-PlatformInfoPlist $Arch
   }
 
@@ -2482,7 +2482,7 @@ if (-not $SkipBuild) {
     Invoke-BuildStep Build-Dispatch Android $Arch
     Invoke-BuildStep Build-Foundation Android $Arch
     Invoke-BuildStep Build-XCTest Android $Arch
-    Invoke-BuildStep Build-SwiftTesting Android $Arch
+    Invoke-BuildStep Build-Testing Android $Arch
     Invoke-BuildStep Write-PlatformInfoPlist $Arch
   }
 }
@@ -2567,7 +2567,7 @@ if (-not $IsCrossCompiling) {
     Build-XCTest Windows $HostArch -Test
   }
   if ($Test -contains "testing") {
-    Build-SwiftTesting Windows $HostArch -Test
+    Build-Testing Windows $HostArch -Test
   }
   if ($Test -contains "llbuild") { Build-LLBuild $HostArch -Test }
   if ($Test -contains "swiftpm") { Test-PackageManager $HostArch }


### PR DESCRIPTION
This renames the `Build-*` phase associated with building swift-testing. Rather than name it `Build-SwiftTesting` match the other functions and name it `Build-Testing`.