### PR TITLE
[Module] Use stricter module hash

### DIFF
--- a/test/ScanDependencies/module_hash.swift
+++ b/test/ScanDependencies/module_hash.swift
@@ -14,7 +14,7 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -O \
 // RUN:   -o %t/deps-3.json -Xcc -fapplication-extension -I %t/include
 
-/// Check module hash for the swiftmodule. 1 and 2 should match, but not 3.
+/// Check module hash for the swiftmodule. They should all not match.
 // RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-1.json Library modulePath > %t/path-1
 // RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-2.json Library modulePath > %t/path-2
 // RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-3.json Library modulePath > %t/path-3

--- a/test/ScanDependencies/module_hash_macos.swift
+++ b/test/ScanDependencies/module_hash_macos.swift
@@ -1,0 +1,47 @@
+// REQUIRES: OS=macosx, objc_interop
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Different version should not match.
+// RUN: %target-swift-frontend -target %module-target-triple -scan-dependencies -module-name Test %t/main.swift -module-cache-path %t/clang-module-cache \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -O \
+// RUN:   -o %t/deps-now.json -I %t/include
+// RUN: %target-swift-frontend -target %module-target-future -scan-dependencies -module-name Test %t/main.swift -module-cache-path %t/clang-module-cache \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -O \
+// RUN:   -o %t/deps-future.json -I %t/include
+// RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-now.json Library modulePath > %t/path-now
+// RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-future.json Library modulePath > %t/path-future
+// RUN: not diff %t/path-now %t/path-future
+
+/// Application extension should not match.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test %t/main.swift -module-cache-path %t/clang-module-cache \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -O \
+// RUN:   -o %t/deps.json -I %t/include
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test %t/main.swift -module-cache-path %t/clang-module-cache \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -O \
+// RUN:   -o %t/deps-ae.json -I %t/include -application-extension
+// RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps.json Library modulePath > %t/path
+// RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps-ae.json Library modulePath > %t/path-ae
+// RUN: not diff %t/path %t/path-ae
+
+//--- main.swift
+import Library
+
+//--- include/Library.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Library -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -user-module-version 1.0
+import Swift
+@_exported import A
+@inlinable
+public func test() {
+    foo()
+}
+
+//--- include/a.h
+void foo(void);
+
+//--- include/module.modulemap
+module A {
+  header "a.h"
+  export *
+}


### PR DESCRIPTION
Use a stricter module hash for modules as moving towards more explicit modules. Previously, a normalized target triple without deployment target is used as part of the module hash, with the assumption that deployment target should not change binary module generated.

In reality, the binary module compilation also needs to provide the typecheck for all interface to ensure the underlying C/ObjC module that built with the correct deployment target does provide the interfaces to pass typecheck. Using a stricter module hash can avoid the potentially confusing error when importing the module.

This commit adds following to module hash to distinguish swiftmodules.
* Deployment target
* -application-extension

rdar://134301179

