### PR TITLE
Fix cross-compile build failure.

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1481,7 +1481,7 @@ function Build-FoundationMacros() {
 
   $SwiftSDK = $null
   if ($Build) {
-    $SwiftSDK = $HostArch.SDKInstallRoot
+    $SwiftSDK = $BuildArch.SDKInstallRoot
   }
 
   $Targets = if ($Build) {
@@ -1495,6 +1495,12 @@ function Build-FoundationMacros() {
     $InstallDir = "$($Arch.ToolchainInstallRoot)\usr"
   }
 
+  $SwiftSyntaxCMakeModules = if ($Build -and $HostArch -ne $BuildArch) {
+    Get-BuildProjectCMakeModules Compilers
+  } else {
+    Get-HostProjectCMakeModules Compilers
+  }
+
   Build-CMakeProject `
     -Src $SourceCache\swift-foundation\Sources\FoundationMacros `
     -Bin $FoundationMacrosBinaryCache `
@@ -1505,7 +1511,7 @@ function Build-FoundationMacros() {
     -SwiftSDK:$SwiftSDK `
     -BuildTargets $Targets `
     -Defines @{
-      SwiftSyntax_DIR = (Get-HostProjectCMakeModules Compilers);
+      SwiftSyntax_DIR = $SwiftSyntaxCMakeModules;
     }
 }
 


### PR DESCRIPTION
In Build-FoundationMacros, use the build Swift SDK for the build case and when cross-compiling, use the swift syntax build from the build arch binary cache as opposed to the host arch binary cache or else the architecture mismatch will happen.

Cherrypick commit https://github.com/swiftlang/swift/pull/75970/commits/3054eab6b084ed1223780c512fb2fac69c9bdee9
