### PR TITLE
IRGen: metadata for noncopyable exist. metatype

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -245,6 +245,12 @@ getRuntimeVersionThatSupportsDemanglingType(CanType type) {
       }
     }
 
+    // Any composition with an inverse will need the 6.0 runtime to demangle.
+    if (auto pct = dyn_cast<ProtocolCompositionType>(t)) {
+      if (pct->hasInverse())
+        return addRequirement(Swift_6_0);
+    }
+
     return false;
   });
 

--- a/test/IRGen/noncopyable_metadata_requests.swift
+++ b/test/IRGen/noncopyable_metadata_requests.swift
@@ -126,3 +126,17 @@ func testNOTCopyableOptional() {
 }
 testNOTCopyableOptional()
 // CHECK: Optional.bar(2)
+
+
+// NEW: define hidden swiftcc void @"$s4main26check_existential_metatype4withyypRi_s_XPXpSg_tF"
+// NEW: call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$sypRi_s_XPXpSgMD")
+// NEW: }
+
+// OLD: define hidden swiftcc void @"$s4main26check_existential_metatype4withyypRi_s_XPXpSg_tF"
+// OLD: call swiftcc %swift.metadata_response @"$sypRi_s_XPXpSgMa"
+// OLD: }
+func check_existential_metatype(with x: (any ~Copyable.Type)?) {
+  x.map { print("passed type = \($0)") }
+}
+check_existential_metatype(with: NC.self)
+// CHECK: passed type = NC


### PR DESCRIPTION
Missed a case when determining the strategy to use for obtaining the metadata for a noncopyable existential metatype. Without this patch, trying to use a metatype like `any ~Copyable.Type` can cause a crash at runtime when setting a deployment target that predates Swift 6.0, due to that runtime not knowing how to demangle inverses.

resolves rdar://134280902