### PR TITLE
Export an SPI function to get the full Swift runtime version.

### DIFF
--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -20,6 +20,7 @@
 #define SWIFT_BASIC_VERSION_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/shims/Visibility.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/VersionTuple.h"
@@ -186,6 +187,14 @@ StringRef getCurrentCompilerChannel();
 /// version that's going to be presented as some new concrete version to the
 /// users.
 unsigned getUpcomingCxxInteropCompatVersion();
+
+/// Copy the full version of the Swift runtime (as would be returned from
+/// `getSwiftFullVersion()`.)
+///
+/// - Returns: A UTF-8 C string containing the full version of the Swift
+///   runtime. The caller is responsible for `free()`ing this string when done.
+SWIFT_RUNTIME_STDLIB_SPI
+char *_swift_copyFullVersion(void);
 
 } // end namespace version
 } // end namespace swift

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -22,6 +22,8 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <array>
+#include <cstring>
 #include <vector>
 
 #define TOSTR2(X) #X
@@ -87,6 +89,26 @@ raw_ostream &operator<<(raw_ostream &os, const Version &version) {
   os << version[0];
   for (size_t i = 1, e = version.size(); i != e; ++i)
     os << '.' << version[i];
+  return os;
+}
+
+template <size_t InternalLen>
+static SmallString<InternalLen> &operator +=(SmallString<InternalLen> &buf, unsigned int value) {
+  std::array<char, 64> valueBuf;
+  snprintf(valueBuf.data(), valueBuf.size(), "%u", value);
+  buf += valueBuf.data();
+  return buf;
+}
+
+template <size_t InternalLen>
+static SmallString<InternalLen> &operator +=(SmallString<InternalLen> &buf, const Version &version) {
+  if (version.empty())
+    return buf;
+  buf += version[0];
+  for (size_t i = 1, e = version.size(); i != e; ++i) {
+    buf += ".";
+    buf += version[i];
+  }
   return os;
 }
 
@@ -277,7 +299,8 @@ static SmallString<256> getSwiftFullVersionImpl(Version effectiveVersion) {
 #endif
 
   if (effectiveVersion != Version::getCurrentLanguageVersion()) {
-    buf += " effective-" << effectiveVersion;
+    buf += " effective-";
+    buf += effectiveVersion;
   }
 
 #if defined(SWIFT_COMPILER_VERSION)


### PR DESCRIPTION
This PR adds an exported function that returns the same string you'd get from `swift --version` at the command line.

Swift Testing needs to be able to report its version for diagnostic purposes, especially when used in CI environments where it may be non-trivial to manually invoke `swift --version`. This function can be used by Swift Testing to report its version which, when included in the toolchain rather than built as a package, should simply equal that of the toolchain itself.

This PR also changes the mechanism used when building this string from `std::string` to LLVM's `SmallString`. `std::string` uses global operator new which may be overridden in client code in ways that cause crashes or unexpected behaviour. `SmallString` uses `std::malloc()` instead.