### PR TITLE
ModuleInterface: Skip attributes referencing SPI platforms

### DIFF
--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -91,6 +91,10 @@ bool inheritsAvailabilityFromPlatform(PlatformKind Child, PlatformKind Parent);
 llvm::VersionTuple canonicalizePlatformVersion(
     PlatformKind platform, const llvm::VersionTuple &version);
 
+/// Returns true if \p Platform should be considered to be SPI and therefore not
+/// printed in public `.swiftinterface` files, for example.
+bool isPlatformSPI(PlatformKind Platform);
+
 } // end namespace swift
 
 #endif

--- a/lib/AST/PlatformKind.cpp
+++ b/lib/AST/PlatformKind.cpp
@@ -262,3 +262,25 @@ llvm::VersionTuple swift::canonicalizePlatformVersion(
 
   return version;
 }
+
+bool swift::isPlatformSPI(PlatformKind Platform) {
+  switch (Platform) {
+  case PlatformKind::macOS:
+  case PlatformKind::macOSApplicationExtension:
+  case PlatformKind::iOS:
+  case PlatformKind::iOSApplicationExtension:
+  case PlatformKind::macCatalyst:
+  case PlatformKind::macCatalystApplicationExtension:
+  case PlatformKind::tvOS:
+  case PlatformKind::tvOSApplicationExtension:
+  case PlatformKind::watchOS:
+  case PlatformKind::watchOSApplicationExtension:
+  case PlatformKind::visionOS:
+  case PlatformKind::visionOSApplicationExtension:
+  case PlatformKind::OpenBSD:
+  case PlatformKind::Windows:
+  case PlatformKind::none:
+    return false;
+  }
+  llvm_unreachable("bad PlatformKind");
+}


### PR DESCRIPTION
When printing the public `.swiftinterface` for a `-library-level=api` module, skip emitting `@available`, `@backDeployed`, and `@_originallyDefinedIn` attributes that reference "SPI" platforms.

Resolves rdar://133990140.
