### PR TITLE
Sema: Avoid application extension platforms in `if #available` fix-its

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1978,6 +1978,12 @@ static void fixAvailabilityByAddingVersionCheck(
 
     PlatformKind Target = targetPlatform(Context.LangOpts);
 
+    // Runtime availability checks that specify app extension platforms don't
+    // work, so only suggest checks against the base platform.
+    if (auto TargetRemovingAppExtension =
+            basePlatformForExtensionPlatform(Target))
+      Target = *TargetRemovingAppExtension;
+
     Out << "if #available(" << platformString(Target)
         << " " << RequiredRange.getLowerEndpoint().getAsString()
         << ", *) {\n";

--- a/test/attr/attr_availability_transitive_osx_appext.swift
+++ b/test/attr/attr_availability_transitive_osx_appext.swift
@@ -69,3 +69,11 @@ extension NotOnOSXApplicationExtension {
     osx_extension() // OK
   }
 }
+
+@available(OSXApplicationExtension, introduced: 12)
+func osx_introduced_in_macOS_extesnions_12() {}
+
+func call_osx_introduced_in_macOS_extesnions_12() { // expected-note {{add @available attribute to enclosing global function}} {{1-1=@available(macOSApplicationExtension 12, *)\n}}
+  osx_introduced_in_macOS_extesnions_12() // expected-error {{'osx_introduced_in_macOS_extesnions_12()' is only available in application extensions for macOS 12 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}} {{3-42=if #available(macOS 12, *) {\n      osx_introduced_in_macOS_extesnions_12()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
+}


### PR DESCRIPTION
When the type checker noticed that a declaration with application extension availability markup was used somewhere that it would be potentially unavailable at runtime, the fix-it emitted by the compiler would check for the application extension platform's availability:

```
if #available(macOSApplicationExtension 12, *) {
  // Use potentially unavailable declarations
}
```

This runtime check won't work. The fix-it should just suggest checking the availability of the base, non-extension platform instead.

Resolves rdar://125860317.
