### PR TITLE
[RemoteMirror] Optimize brute-force search in getCaptureDescriptor()

### DIFF
--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -534,6 +534,12 @@ public:
     /// Indexes of Reflection Infos we've already processed.
     llvm::DenseSet<size_t> ProcessedReflectionInfoIndexes;
 
+    /// Cache for capture descriptor lookups.
+    std::unordered_map<uint64_t /* remote address*/,
+                       RemoteRef<CaptureDescriptor>>
+        CaptureDescriptorsByAddress;
+    uint32_t CaptureDescriptorsByAddressLastReflectionInfoCache = 0;
+
     /// Cache for field info lookups.
     std::unordered_map<std::string, RemoteRef<FieldDescriptor>>
         FieldTypeInfoCache;


### PR DESCRIPTION
Optimize a brute-force search for `RemoteRef<CaptureDescriptor>`s  in `TypeRefBuilder::ReflectionTypeDescriptorFinder:: getCaptureDescriptor()` by looking them up in a lazily-created map instead.

Resolves rdar://134380804.
