### PR TITLE
[Test] Make timeout.py signal an error when the timeout is hit.

### DIFF
--- a/test/Inputs/timeout.py
+++ b/test/Inputs/timeout.py
@@ -2,17 +2,17 @@
 
 import subprocess
 import sys
-import threading
 
 
 def watchdog(command, timeout=None):
     process = subprocess.Popen(command)
-    timer = threading.Timer(timeout, process.kill)
     try:
-        timer.start()
-        process.communicate()
-    finally:
-        timer.cancel()
+        process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        sys.exit(
+            'error: command timed out after {} seconds: {}'
+            .format(timeout, ' '.join(sys.argv[2:])))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Print an error message and exit with a non-zero code when we hit the timeout. This makes it clear when a test fails due to a timeout.