### PR TITLE
[cxx-interop] Emit type metadata for foreign types more often

### DIFF
--- a/test/Interop/CxxToSwiftToCxx/link-cxx-type-metadata-accessor.swift
+++ b/test/Interop/CxxToSwiftToCxx/link-cxx-type-metadata-accessor.swift
@@ -17,6 +17,14 @@ struct CxxStruct {
     int x;
 };
 
+struct CxxStruct2 {
+    inline CxxStruct2(int x) : x(x) {}
+    inline CxxStruct2(const CxxStruct &other) : x(other.x) {}
+    inline ~CxxStruct2() {}
+
+    int x;
+};
+
 //--- module.modulemap
 module CxxTest {
     header "header.h"
@@ -30,6 +38,12 @@ public func retCxxStruct() -> CxxStruct {
     return CxxStruct(2)
 }
 
+#if !os(Windows)
+public func retCxxStruct2() -> CxxStruct2? {
+    return CxxStruct2(2)
+}
+#endif
+
 //--- use-swift-cxx-types.cpp
 
 #include "header.h"
@@ -38,5 +52,8 @@ public func retCxxStruct() -> CxxStruct {
 
 int main() {
   auto x = UseCxx::retCxxStruct();
+#ifndef _WIN32
+  auto y = UseCxx::retCxxStruct2();
+#endif
   return 0;
 }


### PR DESCRIPTION
Metadata for foreign types are emitted lazily, when SILGen generates a reference to it. Unfortunately, C++ reverse interop can also introduce references to such metadata in the generated header when types are used as generic arguments. This adds a type visitor to make note of the type metadata use for those generic arguments in public APIs when C++ interop is enabled. Fixes #75593

rdar://132925256