### PR TITLE
Fix another cross-compile build failure.

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2288,7 +2288,7 @@ function Build-TestingMacros() {
 
   $SwiftSDK = $null
   if ($Build) {
-    $SwiftSDK = $HostArch.SDKInstallRoot
+    $SwiftSDK = $BuildArch.SDKInstallRoot
   }
 
   $Targets = if ($Build) {
@@ -2302,6 +2302,12 @@ function Build-TestingMacros() {
     $InstallDir = "$($Arch.ToolchainInstallRoot)\usr"
   }
 
+  $SwiftSyntaxCMakeModules = if ($Build -and $HostArch -ne $BuildArch) {
+    Get-BuildProjectCMakeModules Compilers
+  } else {
+    Get-HostProjectCMakeModules Compilers
+  }
+
   Build-CMakeProject `
     -Src $SourceCache\swift-testing\Sources\TestingMacros `
     -Bin $TestingMacrosBinaryCache `
@@ -2312,7 +2318,7 @@ function Build-TestingMacros() {
     -SwiftSDK:$SwiftSDK `
     -BuildTargets $Targets `
     -Defines @{
-      SwiftSyntax_DIR = (Get-HostProjectCMakeModules Compilers);
+      SwiftSyntax_DIR = $SwiftSyntaxCMakeModules;
     }
 }
 


### PR DESCRIPTION
This fix is similar to https://github.com/swiftlang/swift/pull/75970 but for `Build-TestingMacros`.

This will fix https://ci-external.swift.org/view/all/job/swift-main-windows-toolchain-arm64/420/