### PR TITLE
Runtime: Fix `-Wmissing-field-initializers` warnings in DispatchShims.h

### DIFF
--- a/include/swift/Runtime/DispatchShims.h
+++ b/include/swift/Runtime/DispatchShims.h
@@ -31,7 +31,11 @@ swift_dispatch_thread_get_current_override_qos_floor()
     return dispatch_thread_get_current_override_qos_floor();
   }
 
-  return (dispatch_thread_override_info_s) {0};
+  return (dispatch_thread_override_info_s){
+      0,                     // can_override
+      0,                     // unused
+      QOS_CLASS_UNSPECIFIED, // override_qos_floor
+  };
 }
 
 static inline int

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -140,6 +140,6 @@ class WeakObjC {
 // CHECK:  i32 1, !"Objective-C Image Info Version", i32 0}
 // CHECK:  i32 1, !"Objective-C Image Info Section", !"__DATA,__objc_imageinfo,regular,no_dead_strip"}
 //   100730624 == (6 << 24) | (1 << 16) | (7 << 8).
-//     5 and 8 is the current major.minor version. 7 is the Swift ABI version.
+//     6 and 1 is the current major.minor version. 7 is the Swift ABI version.
 // CHECK:  i32 4, !"Objective-C Garbage Collection", i32 100730624}
 // CHECK:  i32 1, !"Swift Version", i32 7}


### PR DESCRIPTION
Also, update an out of date comment in `test/IRGen/objc.swift`.