### PR TITLE
[sema] Fix availability narrowing fixits for macOS >= 11

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1902,8 +1902,8 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
                                  AvailabilityContext(RunningRange))) {
 
     // Only fix situations that are "nearby" versions, meaning
-    // disagreement on a minor-or-less version for non-macOS,
-    // or disagreement on a subminor-or-less version for macOS.
+    // disagreement on a minor-or-less version (subminor-or-less version for
+    // macOS 10.x.y).
     auto RunningVers = RunningRange.getLowerEndpoint();
     auto RequiredVers = RequiredRange.getLowerEndpoint();
     auto Platform = targetPlatform(Context.LangOpts);
@@ -1911,6 +1911,7 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
       return false;
     if ((Platform == PlatformKind::macOS ||
          Platform == PlatformKind::macOSApplicationExtension) &&
+        RunningVers.getMajor() == 10 &&
         !(RunningVers.getMinor().has_value() &&
           RequiredVers.getMinor().has_value() &&
           RunningVers.getMinor().value() ==

--- a/test/Sema/availability_versions_multi.swift
+++ b/test/Sema/availability_versions_multi.swift
@@ -33,18 +33,14 @@ func useFromOtherOn99_51() {
   let o10_9 = OtherIntroduced10_9()
   o10_9.extensionMethodOnOtherIntroduced10_9AvailableOn99_51(o99_51)
   _ = o99_51.returns99_52Introduced99_52() // expected-error {{'returns99_52Introduced99_52()' is only available in macOS 99.52 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
 
   _ = OtherIntroduced99_52()
       // expected-error@-1 {{'OtherIntroduced99_52' is only available in macOS 99.52 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}}
 
   o99_51.extensionMethodOnOtherIntroduced99_51AvailableOn99_52() // expected-error {{'extensionMethodOnOtherIntroduced99_51AvailableOn99_52()' is only available in macOS 99.52 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
 
   _ = OtherIntroduced99_51.NestedIntroduced99_52()
       // expected-error@-1 {{'NestedIntroduced99_52' is only available in macOS 99.52 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}}
 }
 
 @available(OSX, introduced: 99.52)
@@ -54,7 +50,6 @@ func useFromOtherOn99_52() {
   let n99_52 = OtherIntroduced99_51.NestedIntroduced99_52()
   _ = n99_52.returns99_52()
   _ = n99_52.returns99_53() // expected-error {{'returns99_53()' is only available in macOS 99.53 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
 
   // This will trigger validation of the global in availability_in_multi_other.swift
   _ = globalFromOtherOn99_52

--- a/test/attr/attr_availability_narrow.swift
+++ b/test/attr/attr_availability_narrow.swift
@@ -1,69 +1,101 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macos10.15
 // REQUIRES: OS=macosx
 // <rdar://problem/17669805> Suggest narrowing the range of bad availabile checks
 
 import Foundation
 
-@available(macOS 10.50.2, *)
+@available(macOS 50.2, *)
 func foo() { }
 
 func useFoo() {
-  if #available(macOS 10.50.1, *) {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-1:23-30=10.50.2}}
+  if #available(macOS 50.1, *) {
+    foo() // expected-error {{'foo()' is only available in macOS 50.2 or newer}} {{-1:23-27=50.2}}
   }
 }
 
 func useFooDifferentSpelling() {
-  if #available(OSX 10.50.1, *) {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-1:21-28=10.50.2}}
+  if #available(OSX 50.1, *) {
+    foo() // expected-error {{'foo()' is only available in macOS 50.2 or newer}} {{-1:21-25=50.2}}
   }
 }
 
 func useFooAlreadyOkRange() {
-  if #available(OSX 10.51, *) {
+  if #available(OSX 51, *) {
     foo()
   }
 }
 
 func useFooUnaffectedSimilarText() {
-  if #available(iOS 10.50.10, OSX 10.50.1, *) {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-1:35-42=10.50.2}}
+  if #available(iOS 50.10, OSX 50.1, *) {
+    foo() // expected-error {{'foo()' is only available in macOS 50.2 or newer}} {{-1:32-36=50.2}}
   }
 }
 
 func useFooWayOff() {
-    // expected-note@-1{{add @available attribute to enclosing global function}}
+  // expected-note@-1 2 {{add @available attribute to enclosing global function}}
   if #available(OSX 10.10, *) {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}}
+    foo() // expected-error {{'foo()' is only available in macOS 50.2 or newer}}
+    // expected-note@-1{{add 'if #available' version check}}
+  }
+
+  if #available(OSX 49.0, *) {
+    foo() // expected-error {{'foo()' is only available in macOS 50.2 or newer}}
     // expected-note@-1{{add 'if #available' version check}}
   }
 }
 
-@available(OSX 10.50, *)
+@available(OSX 50, *)
 class FooUser {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-3:16-21=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 50.2 or newer}} {{-3:16-18=50.2}}
   }
 }
 
-@available(OSX, introduced: 10.50, obsoleted: 10.50.4)
+@available(OSX, introduced: 50, obsoleted: 50.4)
 class FooUser2 {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-3:29-34=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 50.2 or newer}} {{-3:29-31=50.2}}
   }
 }
 
-@available(OSX, introduced: 10.50, obsoleted: 10.50.4)
+@available(OSX, introduced: 50, obsoleted: 50.4)
 @objc
 class FooUser3 : NSObject {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-4:29-34=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 50.2 or newer}} {{-4:29-31=50.2}}
   }
 }
 
-@available(OSX, introduced: 10.50.4)
+@available(OSX, introduced: 50.4)
 class FooUserOkRange {
   func useFoo() {
     foo()
+  }
+}
+
+@available(macOS 10.50.2, *)
+func foo10() { }
+
+func useFoo10() {
+  if #available(macOS 10.50.1, *) {
+    foo10() // expected-error {{'foo10()' is only available in macOS 10.50.2 or newer}} {{-1:23-30=10.50.2}}
+  }
+}
+
+func useFoo10WayOff() {
+    // expected-note@-1 3 {{add @available attribute to enclosing global function}}
+  if #available(OSX 10.10, *) {
+    foo10() // expected-error {{'foo10()' is only available in macOS 10.50.2 or newer}}
+    // expected-note@-1{{add 'if #available' version check}}
+  }
+
+  if #available(OSX 10.49.0, *) {
+    foo10() // expected-error {{'foo10()' is only available in macOS 10.50.2 or newer}}
+    // expected-note@-1{{add 'if #available' version check}}
+  }
+
+  if #available(OSX 9, *) {
+    foo10() // expected-error {{'foo10()' is only available in macOS 10.50.2 or newer}}
+    // expected-note@-1{{add 'if #available' version check}}
   }
 }


### PR DESCRIPTION
For macOS >= 11 the fixit for narrowing an availability check rather than adding a new one should fire if the major version is the same, like on other platforms.