### PR TITLE
Add MCCAS support to SwiftCaching.cpp

### DIFF
--- a/test/CAS/swift-scan-test-mccas.swift
+++ b/test/CAS/swift-scan-test-mccas.swift
@@ -1,0 +1,35 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-backend -cas-backend-mode=verify -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+
+// RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- %target-swift-frontend -cache-compile-job -cas-backend -cas-backend-mode=verify -Rcache-compile-job %s \
+// RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
+// RUN:   @%t/MyApp.cmd > %t/key.casid
+
+// RUN: %target-swift-frontend -cache-compile-job -cas-backend -cas-backend-mode=verify -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd
+
+// RUN: %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas | %FileCheck %s --check-prefix=CHECK-QUERY
+
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- %target-swift-frontend -cache-compile-job -cas-backend -cas-backend-mode=verify -Rcache-compile-job %s \
+// RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test2.o -cas-path %t/cas \
+// RUN:   @%t/MyApp.cmd
+
+// RUN: diff %t/Test.swiftmodule %t/Test2.swiftmodule
+// RUN: diff %t/test.o %t/test2.o
+
+// CHECK-QUERY: Cached Compilation for key "llvmcas://{{.*}}" has 4 outputs:
+// CHECK-QUERY-NEXT: object: llvmcas://
+// CHECK-QUERY-NEXT: dependencies: llvmcas://
+// CHECK-QUERY-NEXT: swiftmodule: llvmcas://
+// CHECK-QUERY-NEXT: cached-diagnostics: llvmcas://
+
+func testFunc() {}

--- a/tools/libSwiftScan/SwiftCaching.cpp
+++ b/tools/libSwiftScan/SwiftCaching.cpp
@@ -39,6 +39,7 @@
 #include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
 #include "llvm/CAS/CASReference.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/MCCAS/MCCASObjectV1.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
@@ -940,6 +941,8 @@ static llvm::Error replayCompilation(SwiftScanReplayInstance &Instance,
   };
   SmallVector<OutputEntry> OutputProxies;
   std::optional<llvm::cas::ObjectProxy> DiagnosticsOutput;
+  bool UseCASBackend = Invocation.getIRGenOptions().UseCASBackend;
+  std::string ObjFile;
 
   swift::cas::CachedResultLoader Loader(CAS, Comp.Output);
   if (auto Err = Loader.replay(
@@ -952,6 +955,9 @@ static llvm::Error replayCompilation(SwiftScanReplayInstance &Instance,
             auto Proxy = CAS.getProxy(Ref);
             if (!Proxy)
               return Proxy.takeError();
+
+            if (Kind == file_types::ID::TY_Object && UseCASBackend)
+              ObjFile = OutputPath->second;
 
             if (Kind == file_types::ID::TY_CachedDiagnostics) {
               assert(!DiagnosticsOutput && "more than 1 diagnostics found");
@@ -1000,8 +1006,13 @@ static llvm::Error replayCompilation(SwiftScanReplayInstance &Instance,
     auto File = Backend.createFile(Output.Path);
     if (!File)
       return File.takeError();
-
-    *File << Output.Proxy.getData();
+    if (UseCASBackend && Output.Path == ObjFile) {
+      auto Schema = std::make_unique<llvm::mccasformats::v1::MCSchema>(CAS);
+      if (auto E = Schema->serializeObjectFile(Output.Proxy, *File))
+        Inst.getDiags().diagnose(SourceLoc(), diag::error_mccas,
+                                 toString(std::move(E)));
+    } else
+      *File << Output.Proxy.getData();
     if (auto E = File->keep())
       return E;
 


### PR DESCRIPTION
To materialize the object file correctly on a cache hit when MCCAS is enabled, if lib_InternalSwiftScan.dylib is used to detect the cache hit, we need to add MCCAS support to the replay code in SwiftCaching.cpp

rdar://134426931 ([MCCAS] FIx bug with swift caching where object files are incorrect on a cache hit)