### PR TITLE
SILVerifier: catch more illegal copies

### DIFF
--- a/include/swift/SIL/AddressWalker.h
+++ b/include/swift/SIL/AddressWalker.h
@@ -92,12 +92,12 @@ private:
   }
 
 public:
-  AddressUseKind walk(SILValue address) &&;
+  AddressUseKind walk(SILValue address);
 };
 
 template <typename Impl>
 inline AddressUseKind
-TransitiveAddressWalker<Impl>::walk(SILValue projectedAddress) && {
+TransitiveAddressWalker<Impl>::walk(SILValue projectedAddress) {
   assert(!didInvalidate);
 
   // When we exit, set the result to be invalidated so we can't use this again.

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3337,7 +3337,7 @@ public:
             "cannot directly copy type with inaccessible ABI");
     require(cai->getModule().getStage() == SILStage::Raw ||
                 (cai->isTakeOfSrc() || !cai->getSrc()->getType().isMoveOnly()),
-            "'MoveOnly' types can only be copied in Raw SIL?!");
+            "MoveOnly types cannot be copied after Raw SIL!");
   }
 
   void checkExplicitCopyAddrInst(ExplicitCopyAddrInst *ecai) {
@@ -3350,6 +3350,9 @@ public:
                     "Store operand type and dest type mismatch");
     require(checkTypeABIAccessible(F, ecai->getDest()->getType()),
             "cannot directly copy type with inaccessible ABI");
+    require(ecai->getModule().getStage() == SILStage::Raw ||
+        (ecai->isTakeOfSrc() || !ecai->getSrc()->getType().isMoveOnly()),
+            "MoveOnly types cannot be copied after Raw SIL!");
   }
 
   void checkMarkUnresolvedMoveAddrInst(MarkUnresolvedMoveAddrInst *SI) {
@@ -3388,7 +3391,7 @@ public:
             "ownership");
     require(I->getModule().getStage() == SILStage::Raw ||
                 !I->getOperand()->getType().isMoveOnly(),
-            "'MoveOnly' types can only be copied in Raw SIL?!");
+            "MoveOnly types cannot be copied after Raw SIL!");
   }
 
   void checkUnownedCopyValueInst(UnownedCopyValueInst *I) {
@@ -3418,6 +3421,9 @@ public:
             "Source value should be an object value");
     require(!I->getOperand()->getType().isTrivial(*I->getFunction()),
             "Source value should be non-trivial");
+    require(I->getModule().getStage() == SILStage::Raw ||
+        !I->getOperand()->getType().isMoveOnly(),
+            "MoveOnly types cannot be copied after Raw SIL!");
   }
 
   void checkDestroyValueInst(DestroyValueInst *I) {

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -3857,7 +3857,7 @@ bool MoveOnlyAddressCheckerPImpl::performSingleCheck(
     RAIILLVMDebug l("main use gathering visitor");
 
     visitor.reset(markedAddress);
-    if (AddressUseKind::Unknown == std::move(visitor).walk(markedAddress)) {
+    if (AddressUseKind::Unknown == visitor.walk(markedAddress)) {
       LLVM_DEBUG(llvm::dbgs()
                  << "Failed access path visit: " << *markedAddress);
       return false;


### PR DESCRIPTION
If there happens to be a bug in the MoveChecker, where a diagnostic was
not emitted, the verifier should catch that.

Canonical SIL should not allow any kind of copy of a noncopyable or
move-only wrapped type.