### PR TITLE
[test] Move availability tests to later fake OS versions

### DIFF
--- a/test/ClangImporter/availability_implicit_macosx.swift
+++ b/test/ClangImporter/availability_implicit_macosx.swift
@@ -1,5 +1,5 @@
-// RUN: %swift -typecheck -verify -target %target-cpu-apple-macosx10.51 %clang-importer-sdk -I %S/Inputs/custom-modules %s %S/Inputs/availability_implicit_macosx_other.swift
-// RUN: not %swift -typecheck -target %target-cpu-apple-macosx10.51 %clang-importer-sdk -I %S/Inputs/custom-modules %s %S/Inputs/availability_implicit_macosx_other.swift 2>&1 | %FileCheck %s '--implicit-check-not=<unknown>:0'
+// RUN: %swift -typecheck -verify -target %target-cpu-apple-macosx51 %clang-importer-sdk -I %S/Inputs/custom-modules %s %S/Inputs/availability_implicit_macosx_other.swift
+// RUN: not %swift -typecheck -target %target-cpu-apple-macosx51 %clang-importer-sdk -I %S/Inputs/custom-modules %s %S/Inputs/availability_implicit_macosx_other.swift 2>&1 | %FileCheck %s '--implicit-check-not=<unknown>:0'
 
 // REQUIRES: OS=macosx
 
@@ -29,15 +29,15 @@ func useClassThatTriggersImportOfPotentiallyUnavailableOptions() {
 }
 
 func directUseShouldStillTriggerDeprecationWarning() {
-  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
-  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in macOS 10.51: Use a different API}}
+  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 51: Use a different API}}
+  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in macOS 51: Use a different API}}
 }
 
-func useInSignature(_ options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
+func useInSignature(_ options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 51: Use a different API}}
 }
 
 class SuperClassWithDeprecatedInitializer {
-  @available(OSX, introduced: 10.9, deprecated: 10.51)
+  @available(OSX, introduced: 10.9, deprecated: 51)
   init() { }
 }
 
@@ -49,15 +49,15 @@ class SubClassWithSynthesizedDesignedInitializerOverride : SuperClassWithDepreca
 }
 
 func callImplicitInitializerOnSubClassWithSynthesizedDesignedInitializerOverride() {
-  _ = SubClassWithSynthesizedDesignedInitializerOverride() // expected-warning {{'init()' was deprecated in macOS 10.51}}
+  _ = SubClassWithSynthesizedDesignedInitializerOverride() // expected-warning {{'init()' was deprecated in macOS 51}}
 }
 
-@available(OSX, introduced: 10.9, deprecated: 10.51)
+@available(OSX, introduced: 10.9, deprecated: 51)
 class NSDeprecatedSuperClass {
   var i : Int = 7 // Causes initializer to be synthesized
 }
 
-class NotDeprecatedSubClassOfDeprecatedSuperClass : NSDeprecatedSuperClass { // expected-warning {{'NSDeprecatedSuperClass' was deprecated in macOS 10.51}}
+class NotDeprecatedSubClassOfDeprecatedSuperClass : NSDeprecatedSuperClass { // expected-warning {{'NSDeprecatedSuperClass' was deprecated in macOS 51}}
 }
 
 func callImplicitInitializerOnNotDeprecatedSubClassOfDeprecatedSuperClass() {
@@ -67,21 +67,21 @@ func callImplicitInitializerOnNotDeprecatedSubClassOfDeprecatedSuperClass() {
   _ = NotDeprecatedSubClassOfDeprecatedSuperClass()
 }
 
-@available(OSX, introduced: 10.9, deprecated: 10.51)
+@available(OSX, introduced: 10.9, deprecated: 51)
 class NSDeprecatedSubClassOfDeprecatedSuperClass : NSDeprecatedSuperClass {
 }
 
 // Tests synthesis of materializeForSet
 class ClassWithLimitedAvailabilityAccessors {
   var limitedGetter: Int {
-    @available(OSX, introduced: 10.52)
+    @available(OSX, introduced: 52)
     get { return 10 }
     set(newVal) {}
   }
 
   var limitedSetter: Int {
     get { return 10 }
-    @available(OSX, introduced: 10.52)
+    @available(OSX, introduced: 52)
     set(newVal) {}
   }
 }
@@ -103,7 +103,7 @@ func unavailableUseInUnavailableFunction() {
 }
 
 
-@available(OSX 10.52, *)
+@available(OSX 52, *)
 func foo() {
   let _ =  SubOfOtherWithInit()
 }

--- a/test/ClangImporter/enum-with-target.swift
+++ b/test/ClangImporter/enum-with-target.swift
@@ -1,5 +1,5 @@
-// RUN: %swift %clang-importer-sdk -target %target-cpu-apple-macosx10.51 -typecheck %s -verify
-// RUN: %swift %clang-importer-sdk -target %target-cpu-apple-macosx10.52 -typecheck %s -verify
+// RUN: %swift %clang-importer-sdk -target %target-cpu-apple-macosx51 -typecheck %s -verify
+// RUN: %swift %clang-importer-sdk -target %target-cpu-apple-macosx52 -typecheck %s -verify
 
 // REQUIRES: OS=macosx
 import Foundation

--- a/test/ClangImporter/objc_factory_method.swift
+++ b/test/ClangImporter/objc_factory_method.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -target %target-cpu-apple-macosx10.51 -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -target %target-cpu-apple-macosx51 -typecheck %s -verify
 
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop
@@ -41,27 +41,27 @@ func testFactoryWithLaterIntroducedInit() {
 
   // Don't prefer more available convenience factory initializer over less
   // available designated initializer
-  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flim:5) // expected-error {{'init(flim:)' is only available in macOS 10.52 or newer}}
+  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flim:5) // expected-error {{'init(flim:)' is only available in macOS 52 or newer}}
     // expected-note @-1 {{add 'if #available' version check}}
   
-  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flam:5) // expected-error {{'init(flam:)' is only available in macOS 10.52 or newer}}
-  // expected-note @-1 {{add 'if #available' version check}}  {{3-63=if #available(macOS 10.52, *) {\n      _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flam:5)\n  \} else {\n      // Fallback on earlier versions\n  \}}}
+  _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flam:5) // expected-error {{'init(flam:)' is only available in macOS 52 or newer}}
+  // expected-note @-1 {{add 'if #available' version check}}  {{3-63=if #available(macOS 52, *) {\n      _ = NSHavingConvenienceFactoryAndLaterDesignatedInit(flam:5)\n  \} else {\n      // Fallback on earlier versions\n  \}}}
 
   
   // Don't prefer more available factory initializer over less
   // available designated initializer
-  _ = NSHavingFactoryAndLaterConvenienceInit(flim:5) // expected-error {{'init(flim:)' is only available in macOS 10.52 or newer}}
+  _ = NSHavingFactoryAndLaterConvenienceInit(flim:5) // expected-error {{'init(flim:)' is only available in macOS 52 or newer}}
   // expected-note @-1 {{add 'if #available' version check}}
   
 
-  _ = NSHavingFactoryAndLaterConvenienceInit(flam:5) // expected-error {{'init(flam:)' is only available in macOS 10.52 or newer}}
+  _ = NSHavingFactoryAndLaterConvenienceInit(flam:5) // expected-error {{'init(flam:)' is only available in macOS 52 or newer}}
   // expected-note @-1 {{add 'if #available' version check}}
 
 
   // When both a convenience factory and a convenience initializer have the
   // same availability, choose the convenience initializer.
-  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flim:5) // expected-warning {{'init(flim:)' was deprecated in macOS 10.51: ConvenienceInit}}
-  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flam:5) // expected-warning {{'init(flam:)' was deprecated in macOS 10.51: ConvenienceInit}}
+  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flim:5) // expected-warning {{'init(flim:)' was deprecated in macOS 51: ConvenienceInit}}
+  _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flam:5) // expected-warning {{'init(flam:)' was deprecated in macOS 51: ConvenienceInit}}
 
   _ = NSHavingConvenienceFactoryAndSameConvenienceInit(flotsam:5) // expected-warning {{'init(flotsam:)' is deprecated: ConvenienceInit}}
   _ = NSHavingConvenienceFactoryAndSameConvenienceInit(jetsam:5) // expected-warning {{'init(jetsam:)' is deprecated: ConvenienceInit}}

--- a/test/Constraints/result_builder_availability.swift
+++ b/test/Constraints/result_builder_availability.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx50
 
 // REQUIRES: OS=macosx
 
@@ -66,43 +66,43 @@ func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) {
 @available(OSX, introduced: 10.9)
 func globalFuncAvailableOn10_9() -> Int { return 9 }
 
-@available(OSX, introduced: 10.51)
-func globalFuncAvailableOn10_51() -> Int { return 10 }
+@available(OSX, introduced: 51)
+func globalFuncAvailableOn51() -> Int { return 10 }
 
-@available(OSX, introduced: 10.52)
-struct Only10_52 { }
+@available(OSX, introduced: 52)
+struct Only52 { }
 
-@available(OSX, introduced: 10.52)
-func globalFuncAvailableOn10_52() -> Only10_52 { .init() }
+@available(OSX, introduced: 52)
+func globalFuncAvailableOn52() -> Only52 { .init() }
 
 tuplify(true) { cond in
   globalFuncAvailableOn10_9()
-  if #available(OSX 10.51, *) {
-    globalFuncAvailableOn10_51()
+  if #available(OSX 51, *) {
+    globalFuncAvailableOn51()
     tuplify(false) { cond2 in
-      if cond, #available(OSX 10.52, *) { 
+      if cond, #available(OSX 52, *) { 
         // expected-warning@-1{{result builder 'TupleBuilder' does not implement 'buildLimitedAvailability'; this code may crash on earlier versions of the OS}}
         cond2
-        globalFuncAvailableOn10_52()
+        globalFuncAvailableOn52()
       } else if true {
-        globalFuncAvailableOn10_52() // expected-error{{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+        globalFuncAvailableOn52() // expected-error{{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1{{add 'if #available' version check}}
       } else if false {
-        globalFuncAvailableOn10_52() // expected-error{{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+        globalFuncAvailableOn52() // expected-error{{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1{{add 'if #available' version check}}
       } else {
-        globalFuncAvailableOn10_52() // expected-error{{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+        globalFuncAvailableOn52() // expected-error{{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1{{add 'if #available' version check}}
       }
-      if cond, #unavailable(OSX 10.52) { 
+      if cond, #unavailable(OSX 52) { 
         // expected-warning@-1{{result builder 'TupleBuilder' does not implement 'buildLimitedAvailability'; this code may crash on earlier versions of the OS}}
         cond2
-        globalFuncAvailableOn10_52() // expected-error{{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+        globalFuncAvailableOn52() // expected-error{{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1{{add 'if #available' version check}}
       } else if true {
-        globalFuncAvailableOn10_52()
+        globalFuncAvailableOn52()
       } else if false {
-        globalFuncAvailableOn10_52()
+        globalFuncAvailableOn52()
       }
     }
   }
@@ -155,18 +155,18 @@ func tuplifyWithAvailabilityErasure<T>(_ cond: Bool, @TupleBuilderAvailability b
 }
 
 tuplifyWithAvailabilityErasure(true) { cond in
-  if cond, #available(OSX 10.52, *) {
-    globalFuncAvailableOn10_52()
+  if cond, #available(OSX 52, *) {
+    globalFuncAvailableOn52()
   }
 
-  if cond, #unavailable(OSX 10.52) {
+  if cond, #unavailable(OSX 52) {
     cond
   } else {
-    globalFuncAvailableOn10_52()
+    globalFuncAvailableOn52()
   }
 
   // https://github.com/apple/swift/issues/63764
-  if #unavailable(OSX 10.52) {
+  if #unavailable(OSX 52) {
     cond // Ok
   }
 }

--- a/test/IDE/print_clang_framework.swift
+++ b/test/IDE/print_clang_framework.swift
@@ -39,11 +39,11 @@
 //
 // REQUIRES: OS=macosx
 
-// FOUNDATION-LABEL: {{^}}/// Aaa.  NSAvailableOnOSX10_51AndIOS8_0.  Bbb.
-// FOUNDATION-NEXT: {{^}}@available(OSX 10.51, *){{$}}
+// FOUNDATION-LABEL: {{^}}/// Aaa.  NSAvailableOnOSX51AndIOS8_0.  Bbb.
+// FOUNDATION-NEXT: {{^}}@available(OSX 51, *){{$}}
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  NSPotentiallyUnavailableOptions.  Bbb.
-// FOUNDATION-NEXT: {{^}}@available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}@available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}struct PotentiallyUnavailableOptions : OptionSet {{{$}}
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  NSOptionsWithUnavailableElement.  Bbb.
@@ -52,11 +52,11 @@
 // FOUNDATION-NEXT: {{^}}  let rawValue: UInt{{$}}
 // FOUNDATION-NEXT: {{^}}  static var first: OptionsWithUnavailableElement { get }{{$}}
 // FOUNDATION-NEXT: {{^}}  static var second: OptionsWithUnavailableElement { get }{{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  static var third: OptionsWithUnavailableElement { get }{{$}}
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  NSUnavailableEnum.  Bbb.
-// FOUNDATION-NEXT: {{^}}@available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}@available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}enum UnavailableEnum : UInt {{{$}}
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  NSEnumWithUnavailableElement.  Bbb.
@@ -65,25 +65,25 @@
 // FOUNDATION-NEXT: {{^}}  var rawValue: UInt { get }{{$}}
 // FOUNDATION-NEXT: {{^}}  case first{{$}}
 // FOUNDATION-NEXT: {{^}}  case second{{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  case third{{$}}
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  UnannotatedFrameworkProtocol.  Bbb.
 // FOUNDATION-NEXT: {{^}}protocol UnannotatedFrameworkProtocol {{{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(with k: AnnotatedFrameworkClass?){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(withNonNullableClass k: AnnotatedFrameworkClass){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(withIUOClass k: AnnotatedFrameworkClass!){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func returnSomething() -> AnnotatedFrameworkClass?{{$}}
 // FOUNDATION-NEXT: {{^}}  func noUnavailableTypesInSignature(){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(with k: AnnotatedFrameworkClass, andLaterClass lk: AnnotatedLaterFrameworkClass){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.53, *)
+// FOUNDATION-NEXT: {{^}}  @available(OSX 53, *)
 // FOUNDATION-NEXT: {{^}}  func someMethodWithAvailability()
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  var someProperty: AnnotatedFrameworkClass { get set }{{$}}
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  AnnotatedFrameworkProtocol.  Bbb.
@@ -94,56 +94,56 @@
 // FOUNDATION-LABEL: /// Aaa.  FrameworkClassConformingToUnannotatedFrameworkProtocol.  Bbb.
 // FOUNDATION-NEXT: {{^}}class FrameworkClassConformingToUnannotatedFrameworkProtocol : NSObject, UnannotatedFrameworkProtocol {{{$}}
 // FOUNDATION-NEXT: {{^}}  init(){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(with k: AnnotatedFrameworkClass?){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(withNonNullableClass k: AnnotatedFrameworkClass){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(withIUOClass k: AnnotatedFrameworkClass!){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func returnSomething() -> AnnotatedFrameworkClass?{{$}}
 // FOUNDATION-NEXT: {{^}}  func noUnavailableTypesInSignature(){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(with k: AnnotatedFrameworkClass, andLaterClass lk: AnnotatedLaterFrameworkClass){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.53, *)
+// FOUNDATION-NEXT: {{^}}  @available(OSX 53, *)
 // FOUNDATION-NEXT: {{^}}  func someMethodWithAvailability()
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.51, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 51, *){{$}}
 // FOUNDATION-NEXT: {{^}}  var someProperty: AnnotatedFrameworkClass{{$}}
 
 // FOUNDATION-LABEL: /// Aaa.  LaterFrameworkClassConformingToUnannotatedFrameworkProtocol.  Bbb.
-// FOUNDATION-NEXT: {{^}}@available(OSX 10.52, *){{$}}
+// FOUNDATION-NEXT: {{^}}@available(OSX 52, *){{$}}
 // FOUNDATION-NEXT: {{^}}class LaterFrameworkClassConformingToUnannotatedFrameworkProtocol : NSObject, UnannotatedFrameworkProtocol {{{$}}
 // FOUNDATION-NEXT: {{^}}  init(){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(with k: AnnotatedFrameworkClass?){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(withNonNullableClass k: AnnotatedFrameworkClass){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(withIUOClass k: AnnotatedFrameworkClass!){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func returnSomething() -> AnnotatedFrameworkClass?{{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func noUnavailableTypesInSignature(){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *){{$}}
 // FOUNDATION-NEXT: {{^}}  func doSomething(with k: AnnotatedFrameworkClass, andLaterClass lk: AnnotatedLaterFrameworkClass){{$}}
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.53, *)
+// FOUNDATION-NEXT: {{^}}  @available(OSX 53, *)
 // FOUNDATION-NEXT: {{^}}  func someMethodWithAvailability()
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *){{$}}
 // FOUNDATION-NEXT: {{^}}  var someProperty: AnnotatedFrameworkClass{{$}}
 }
 
 // FOUNDATION-LABEL: /// Aaa.  FrameworkClassConformingToLaterAnnotatedFrameworkProtocol.  Bbb.
 // FOUNDATION-NEXT: {{^}}class FrameworkClassConformingToLaterAnnotatedFrameworkProtocol : NSObject, LaterAnnotatedFrameworkProtocol {
 // FOUNDATION-NEXT: {{^}}  init()
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *)
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *)
 // FOUNDATION-NEXT: {{^}}  func returnSomething() -> AnnotatedFrameworkClass?
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *)
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *)
 // FOUNDATION-NEXT: {{^}}  func doSomething(with k: AnnotatedFrameworkClass, andLaterClass lk: AnnotatedLaterFrameworkClass)
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *)
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *)
 // FOUNDATION-NEXT: {{^}}  func noUnavailableTypesInSignature()
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.53, *)
+// FOUNDATION-NEXT: {{^}}  @available(OSX 53, *)
 // FOUNDATION-NEXT: {{^}}  func someMethodWithAvailability()
-// FOUNDATION-NEXT: {{^}}  @available(OSX 10.52, *)
+// FOUNDATION-NEXT: {{^}}  @available(OSX 52, *)
 // FOUNDATION-NEXT: {{^}}  var someProperty: AnnotatedFrameworkClass
 }
 

--- a/test/IDE/print_module_bad_target.swift
+++ b/test/IDE/print_module_bad_target.swift
@@ -1,7 +1,7 @@
 // RUN: not %swift-ide-test -source-filename %s -print-module -module-to-print Swift -target x86_64-unknown-solaris
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t -module-name Dummy -target %target-cpu-apple-macosx10.99 %s
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Dummy -target %target-cpu-apple-macosx99 %s
 // RUN: not %target-swift-ide-test -source-filename %s -print-module -module-to-print Dummy -I %t
 
 // REQUIRES: OS=macosx

--- a/test/IRGen/Inputs/weak_import_availability_helper.swift
+++ b/test/IRGen/Inputs/weak_import_availability_helper.swift
@@ -1,10 +1,10 @@
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public func conditionallyAvailableFunction() {}
 
 @available(macOS, unavailable)
 public func unavailableFunction() {}
 
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public var conditionallyAvailableGlobal: Int {
   get {return 0}
   set {}
@@ -16,7 +16,7 @@ public var unavailableGlobal: Int {
   set {}
 }
 
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public struct ConditionallyAvailableStruct {
   public func conditionallyAvailableMethod() {}
 }
@@ -34,7 +34,7 @@ public protocol AlwaysAvailableProtocol {}
 
 public struct AlwaysAvailableStruct {}
 
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 extension AlwaysAvailableStruct : AlwaysAvailableProtocol {}
 
 @available(macOS, unavailable)
@@ -46,6 +46,6 @@ extension AlwaysAvailableStruct : UnavailableProtocol {}
 public enum AlwaysAvailableEnum {
   case alwaysAvailableCase
 
-  @available(macOS 10.50, *)
+  @available(macOS 50, *)
   case conditionallyAvailableCase
 }

--- a/test/IRGen/availability.swift
+++ b/test/IRGen/availability.swift
@@ -19,7 +19,7 @@ import Foundation
 // OPT: s10Foundation11MeasurementVySo17NSUnitTemperature
 
 public func dontHoist() {
-  if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, visionOS 1.1, *) {
+  if #available(macOS 51.0, iOS 54.0, watchOS 57.0, tvOS 54.0, visionOS 51.1, *) {
       let measurement = Measurement<UnitTemperature>(value: Double(42), unit: .celsius)
       print("\(measurement)")
   } else {
@@ -49,13 +49,13 @@ public func dontHoist() {
 // OPT-NOT: call {{.*}} @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
 // OPT: ret void
 public func multipleAvailabilityChecks() {
-  if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, visionOS 1.1, *) {
+  if #available(macOS 51.0, iOS 54.0, watchOS 57.0, tvOS 54.0, visionOS 51.1, *) {
     print("test one")
   }
-  if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, visionOS 1.1, *) {
+  if #available(macOS 51.0, iOS 54.0, watchOS 57.0, tvOS 54.0, visionOS 51.1, *) {
     print("test two")
   }
-  if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, visionOS 1.1, *) {
+  if #available(macOS 51.0, iOS 54.0, watchOS 57.0, tvOS 54.0, visionOS 51.1, *) {
     print("test three")
   }
 }

--- a/test/IRGen/weak_import_associated_conformance_descriptor.swift
+++ b/test/IRGen/weak_import_associated_conformance_descriptor.swift
@@ -22,16 +22,16 @@ public protocol StrongProtoWithWeakLinkedAssoc {
 public struct LibConformsToP: P { }
 
 public protocol StrongProtoWithNewAssoc {
-  @available(macOS 10.50, *)
+  @available(macOS 50, *)
   associatedtype NewerAssoc: P = LibConformsToP
 }
 
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public protocol WeakProtoWithAssoc {
   associatedtype Assoc: P
 }
 
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public protocol WeakProtoWithStrongInheritedAssoc: StrongProtoWithAssoc where Self.Assoc: Q { }
 
 
@@ -60,13 +60,13 @@ struct ConformsToStrongProtoWithNewAssoc: StrongProtoWithNewAssoc {
 }
 
 // CHECK: @"$s7Library18WeakProtoWithAssocP0E0AC_AA1PTn" = extern_weak global %swift.protocol_requirement, align 4
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 struct ConformsToWeakProtoWithAssoc: WeakProtoWithAssoc {
   typealias Assoc = ConformsToP
 }
 
 // CHECK: @"$s7Library33WeakProtoWithStrongInheritedAssocP0G0AA0ecdG0P_AA1QTn" = extern_weak global %swift.protocol_requirement, align 4
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 struct ConformsToWeakProtoWithStrongInheritedAssoc: WeakProtoWithStrongInheritedAssoc {
   typealias Assoc = ConformsToQ
 }

--- a/test/IRGen/weak_import_availability.swift
+++ b/test/IRGen/weak_import_availability.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.50 -emit-module -emit-module-path %t/weak_import_availability_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_availability_helper.swift -enable-library-evolution
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx50 -emit-module -emit-module-path %t/weak_import_availability_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_availability_helper.swift -enable-library-evolution
 //
 // RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-OLD
-// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx10.50 | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
-// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx10.60 | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
+// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx50 | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
+// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx60 | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
 
-// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx10.50 -weak-link-at-target | %FileCheck %s --check-prefixes=CHECK,CHECK-OLD
-// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx10.60 -weak-link-at-target | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
+// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx50 -weak-link-at-target | %FileCheck %s --check-prefixes=CHECK,CHECK-OLD
+// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx60 -weak-link-at-target | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
 
 // REQUIRES: OS=macosx
 
@@ -24,7 +24,7 @@ public func useConditionallyAvailableCase(e: AlwaysAvailableEnum) {
 
 func useConformance<T : AlwaysAvailableProtocol>(_: T.Type) {}
 
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public func useConditionallyAvailableConformance() {
   useConformance(AlwaysAvailableStruct.self)
 }
@@ -45,7 +45,7 @@ public func useUnavailableConformance() {
 
 // CHECK-LABEL: @"$s31weak_import_availability_helper21AlwaysAvailableStructVAA19UnavailableProtocolAAWP" = extern_weak global ptr, align 8
 
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public func callConditionallyAvailableFunction() {
   conditionallyAvailableFunction()
 }
@@ -60,7 +60,7 @@ public func callUnavailableFunction() {
 
 // CHECK-LABEL: declare extern_weak swiftcc void @"$s31weak_import_availability_helper19unavailableFunctionyyF"()
 
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public func useConditionallyAvailableGlobal() {
   _ = conditionallyAvailableGlobal
   conditionallyAvailableGlobal = 0
@@ -89,7 +89,7 @@ public func useUnavailableGlobal() {
 
 func blackHole<T>(_: T) {}
 
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public func useConditionallyAvailableStruct() {
   blackHole(ConditionallyAvailableStruct.self)
 }
@@ -97,7 +97,7 @@ public func useConditionallyAvailableStruct() {
 // CHECK-OLD-LABEL: declare extern_weak swiftcc %swift.metadata_response @"$s31weak_import_availability_helper28ConditionallyAvailableStructVMa"(i64)
 // CHECK-NEW-LABEL: declare swiftcc %swift.metadata_response @"$s31weak_import_availability_helper28ConditionallyAvailableStructVMa"(i64)
 
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public func useNestedConditionallyAvailableStruct() {
   blackHole(ConditionallyAvailableStruct.NestedStruct.self)
 }
@@ -105,7 +105,7 @@ public func useNestedConditionallyAvailableStruct() {
 // CHECK-OLD-LABEL: declare extern_weak swiftcc %swift.metadata_response @"$s31weak_import_availability_helper28ConditionallyAvailableStructV06NestedG0VMa"(i64)
 // CHECK-NEW-LABEL: declare swiftcc %swift.metadata_response @"$s31weak_import_availability_helper28ConditionallyAvailableStructV06NestedG0VMa"(i64)
 
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public func useConditionallyAvailableMethod(s: ConditionallyAvailableStruct) {
   s.conditionallyAvailableMethod()
 }

--- a/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
@@ -125,32 +125,32 @@
 
 // Convenience factory declaration followed by convenience init
 +(instancetype)havingConvenienceFactoryAndLaterConvenienceInitWithFlim:(NSInteger)flim;
--(instancetype)initWithFlim:(NSInteger)flim __attribute__((availability(macosx,introduced=10.52)));
+-(instancetype)initWithFlim:(NSInteger)flim __attribute__((availability(macosx,introduced=52)));
 
 // Convenience init declaration followed by convenience factory
--(instancetype)initWithFlam:(NSInteger)flam __attribute__((availability(macosx,introduced=10.52)));
+-(instancetype)initWithFlam:(NSInteger)flam __attribute__((availability(macosx,introduced=52)));
 +(instancetype)havingConvenienceFactoryAndLaterConvenienceInitWithFlam:(NSInteger)flam;
 @end
 
 @interface NSHavingConvenienceFactoryAndEarlierConvenienceInit : NSObject
 -(instancetype)init NS_DESIGNATED_INITIALIZER;
 
-+(instancetype)havingConvenienceFactoryAndEarlierConvenienceInitWithFlim:(NSInteger)flim __attribute__((availability(macosx,introduced=10.52)));
++(instancetype)havingConvenienceFactoryAndEarlierConvenienceInitWithFlim:(NSInteger)flim __attribute__((availability(macosx,introduced=52)));
 -(instancetype)initWithFlim:(NSInteger)flim;
 
 -(instancetype)initWithFlam:(NSInteger)flam;
-+(instancetype)havingConvenienceFactoryAndEarlierConvenienceInitWithFlam:(NSInteger)flam __attribute__((availability(macosx,introduced=10.52)));
++(instancetype)havingConvenienceFactoryAndEarlierConvenienceInitWithFlam:(NSInteger)flam __attribute__((availability(macosx,introduced=52)));
 @end
 
 @interface NSHavingConvenienceFactoryAndSameConvenienceInit : NSObject
 -(instancetype)init NS_DESIGNATED_INITIALIZER;
 
 // We distinguish between which of these the importer chose by the deprecation message.
-+(instancetype)havingConvenienceFactoryAndSameConvenienceInitWithFlim:(NSInteger)flim __attribute__((availability(macosx,introduced=10.8, deprecated=10.51, message="ConvenienceFactory")));
--(instancetype)initWithFlim:(NSInteger)flim __attribute__((availability(macosx,introduced=10.8, deprecated=10.51, message="ConvenienceInit")));
++(instancetype)havingConvenienceFactoryAndSameConvenienceInitWithFlim:(NSInteger)flim __attribute__((availability(macosx,introduced=10.8, deprecated=51, message="ConvenienceFactory")));
+-(instancetype)initWithFlim:(NSInteger)flim __attribute__((availability(macosx,introduced=10.8, deprecated=51, message="ConvenienceInit")));
 
--(instancetype)initWithFlam:(NSInteger)flam __attribute__((availability(macosx,introduced=10.8, deprecated=10.51, message="ConvenienceInit")));
-+(instancetype)havingConvenienceFactoryAndSameConvenienceInitWithFlam:(NSInteger)flam __attribute__((availability(macosx,introduced=10.8, deprecated=10.51, message="ConvenienceFactory")));
+-(instancetype)initWithFlam:(NSInteger)flam __attribute__((availability(macosx,introduced=10.8, deprecated=51, message="ConvenienceInit")));
++(instancetype)havingConvenienceFactoryAndSameConvenienceInitWithFlam:(NSInteger)flam __attribute__((availability(macosx,introduced=10.8, deprecated=51, message="ConvenienceFactory")));
 
 +(instancetype)havingConvenienceFactoryAndSameConvenienceInitWithFlotsam:(NSInteger)flotsam __attribute__((deprecated("ConvenienceFactory")));
 -(instancetype)initWithFlotsam:(NSInteger)flotsam __attribute__((deprecated("ConvenienceInit")));
@@ -162,9 +162,9 @@
 
 @interface NSHavingConvenienceFactoryAndLaterDesignatedInit : NSObject
 +(instancetype)havingConvenienceFactoryAndLaterDesignatedInitWithFlim:(NSInteger)flim;
--(instancetype)initWithFlim:(NSInteger)flim NS_DESIGNATED_INITIALIZER __attribute__((availability(macosx,introduced=10.52)));
+-(instancetype)initWithFlim:(NSInteger)flim NS_DESIGNATED_INITIALIZER __attribute__((availability(macosx,introduced=52)));
 
--(instancetype)initWithFlam:(NSInteger)flam NS_DESIGNATED_INITIALIZER __attribute__((availability(macosx,introduced=10.52)));
+-(instancetype)initWithFlam:(NSInteger)flam NS_DESIGNATED_INITIALIZER __attribute__((availability(macosx,introduced=52)));
 +(instancetype)havingConvenienceFactoryAndLaterDesignatedInitWithFlam:(NSInteger)flam;
 @end
 
@@ -172,9 +172,9 @@
 -(instancetype)init NS_DESIGNATED_INITIALIZER;
 
 +(NSHavingFactoryAndLaterConvenienceInit *)havingFactoryAndLaterConvenienceInitWithFlim:(NSInteger)flim;
--(instancetype)initWithFlim:(NSInteger)flim __attribute__((availability(macosx,introduced=10.52)));
+-(instancetype)initWithFlim:(NSInteger)flim __attribute__((availability(macosx,introduced=52)));
 
--(instancetype)initWithFlam:(NSInteger)flam __attribute__((availability(macosx,introduced=10.52)));
+-(instancetype)initWithFlam:(NSInteger)flam __attribute__((availability(macosx,introduced=52)));
 +(NSHavingFactoryAndLaterConvenienceInit *)havingFactoryAndLaterConvenienceInitWithFlam:(NSInteger)flam;
 @end
 

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -32,23 +32,23 @@ extern NSUInteger SomeCrazyAppExtensionForbiddenAPI(void)
   __attribute__((availability(ios_app_extension,unavailable,message="Not available in App Extensions")))
   __attribute__((availability(xros_app_extension,unavailable,message="Not available in App Extensions")));
 
-extern NSString *const globalStringAvailableOn10_51 __attribute__((availability(macosx,introduced=10.51)));
-extern NSString *const globalStringAvailableOn10_52 __attribute__((availability(macosx,introduced=10.52)));
+extern NSString *const globalStringAvailableOn51 __attribute__((availability(macosx,introduced=51)));
+extern NSString *const globalStringAvailableOn52 __attribute__((availability(macosx,introduced=52)));
 
-__attribute__((availability(macosx,introduced=10.51)))
-@interface NSAvailableOn10_51 : NSObject
+__attribute__((availability(macosx,introduced=51)))
+@interface NSAvailableOn51 : NSObject
 - (instancetype)init;
-- (instancetype)initWithStringOn10_52:(NSString *)s __attribute__((availability(macosx,introduced=10.52)));
+- (instancetype)initWithStringOn52:(NSString *)s __attribute__((availability(macosx,introduced=52)));
 
-@property NSInteger propertyOn10_52 __attribute__((availability(macosx,introduced=10.52)));
+@property NSInteger propertyOn52 __attribute__((availability(macosx,introduced=52)));
 
-- (void)methodAvailableOn10_52 __attribute__((availability(macosx,introduced=10.52)));
+- (void)methodAvailableOn52 __attribute__((availability(macosx,introduced=52)));
 @end
 
-extern NSAvailableOn10_51 *const globalClassInstanceAvailableOn10_51 __attribute__((availability(macosx,introduced=10.51)));
+extern NSAvailableOn51 *const globalClassInstanceAvailableOn51 __attribute__((availability(macosx,introduced=51)));
 
-__attribute__((availability(macosx,introduced=10.51)))
-@protocol NSProtocolAvailableOn10_51
+__attribute__((availability(macosx,introduced=51)))
+@protocol NSProtocolAvailableOn51
 
 @end
 
@@ -58,35 +58,35 @@ __attribute__((availability(macosx,introduced=10.9)))
 @property NSInteger propertyOn10_9;
 
 // Properties with unavailable accessors declared before property.
-- (void)setPropertyOn10_51WithSetterOn10_52Before:(NSInteger)prop __attribute__((availability(macosx,introduced=10.52)));
-@property NSInteger propertyOn10_51WithSetterOn10_52Before __attribute__((availability(macosx,introduced=10.51)));
+- (void)setPropertyOn51WithSetterOn52Before:(NSInteger)prop __attribute__((availability(macosx,introduced=52)));
+@property NSInteger propertyOn51WithSetterOn52Before __attribute__((availability(macosx,introduced=51)));
 
-- (NSInteger)propertyOn10_51WithGetterOn10_52Before __attribute__((availability(macosx,introduced=10.52)));
-@property NSInteger propertyOn10_51WithGetterOn10_52Before __attribute__((availability(macosx,introduced=10.51)));
+- (NSInteger)propertyOn51WithGetterOn52Before __attribute__((availability(macosx,introduced=52)));
+@property NSInteger propertyOn51WithGetterOn52Before __attribute__((availability(macosx,introduced=51)));
 
 // Properties with unavailable accessors declared after property.
-@property NSInteger propertyOn10_51WithSetterOn10_52After __attribute__((availability(macosx,introduced=10.51)));
-- (void)setPropertyOn10_51WithSetterOn10_52After:(NSInteger)prop __attribute__((availability(macosx,introduced=10.52)));
+@property NSInteger propertyOn51WithSetterOn52After __attribute__((availability(macosx,introduced=51)));
+- (void)setPropertyOn51WithSetterOn52After:(NSInteger)prop __attribute__((availability(macosx,introduced=52)));
 
-@property NSInteger propertyOn10_51WithGetterOn10_52After __attribute__((availability(macosx,introduced=10.51)));
-- (NSInteger)propertyOn10_51WithGetterOn10_52After __attribute__((availability(macosx,introduced=10.52)));
+@property NSInteger propertyOn51WithGetterOn52After __attribute__((availability(macosx,introduced=51)));
+- (NSInteger)propertyOn51WithGetterOn52After __attribute__((availability(macosx,introduced=52)));
 
 // Property with redeclared with a setter in a category
-@property(readonly) NSInteger readOnlyRedeclaredWithSetterInCategory __attribute__((availability(macosx,introduced=10.51)));
+@property(readonly) NSInteger readOnlyRedeclaredWithSetterInCategory __attribute__((availability(macosx,introduced=51)));
 
-- (void)methodAvailableOn10_52 __attribute__((availability(macosx,introduced=10.52)));
+- (void)methodAvailableOn52 __attribute__((availability(macosx,introduced=52)));
 @end
 
 @interface NSAvailableOn10_9 (NSWithPropertyReclarationInACategory)
 
-@property(readwrite) NSInteger readOnlyRedeclaredWithSetterInCategory __attribute__((availability(macosx,introduced=10.51)));
-- (void)setReadOnlyRedeclaredWithSetterInCategory:(NSInteger)prop __attribute__((availability(macosx,introduced=10.52)));
+@property(readwrite) NSInteger readOnlyRedeclaredWithSetterInCategory __attribute__((availability(macosx,introduced=51)));
+- (void)setReadOnlyRedeclaredWithSetterInCategory:(NSInteger)prop __attribute__((availability(macosx,introduced=52)));
 @end
 
-/// Aaa.  NSAvailableOnOSX10_51AndIOS8_0.  Bbb.
-__attribute__((availability(macosx,introduced=10.51)))
+/// Aaa.  NSAvailableOnOSX51AndIOS8_0.  Bbb.
+__attribute__((availability(macosx,introduced=51)))
 __attribute__((availability(ios,introduced=8.0)))
-@interface NSAvailableOnOSX10_51AndIOS8_0 : NSObject
+@interface NSAvailableOnOSX51AndIOS8_0 : NSObject
 
 @end
 
@@ -559,7 +559,7 @@ typedef CF_OPTIONS(unsigned long, CFCalendarUnit) {
   kCFCalendarUnitHour = (1UL << 5),
   kCFCalendarUnitMinute = (1UL << 6),
   kCFCalendarUnitSecond = (1UL << 7),
-  kCFCalendarUnitWeek /*CF_ENUM_DEPRECATED(10_4, 10_51, 2_0, 8_0)*/ = (1UL << 8),
+  kCFCalendarUnitWeek /*CF_ENUM_DEPRECATED(10_4, 51, 2_0, 8_0)*/ = (1UL << 8),
   kCFCalendarUnitWeekday = (1UL << 9),
   kCFCalendarUnitWeekdayOrdinal = (1UL << 10),
   kCFCalendarUnitQuarter /*CF_ENUM_AVAILABLE(10_6, 4_0)*/ = (1UL << 11),
@@ -667,17 +667,17 @@ typedef NS_OPTIONS(NSUInteger, NSBitmapFormat) {
   NSAlphaNonpremultipliedBitmapFormat = 1 << 1, // 0 means is premultiplied
   NSFloatingPointSamplesBitmapFormat  = 1 << 2, // 0 is integer
 
-  NS16BitLittleEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 8),
-  NS32BitLittleEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 9),
-  NS16BitBigEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 10),
-  NS32BitBigEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 11)
+  NS16BitLittleEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(51)*/ = (1 << 8),
+  NS32BitLittleEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(51)*/ = (1 << 9),
+  NS16BitBigEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(51)*/ = (1 << 10),
+  NS32BitBigEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(51)*/ = (1 << 11)
 };
 
 typedef NS_OPTIONS(NSUInteger, NSBitmapFormatReversed) {
-  NS16BitLittleEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 8),
-  NS32BitLittleEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 9),
-  NS16BitBigEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 10),
-  NS32BitBigEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 11),
+  NS16BitLittleEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(51)*/ = (1 << 8),
+  NS32BitLittleEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(51)*/ = (1 << 9),
+  NS16BitBigEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(51)*/ = (1 << 10),
+  NS32BitBigEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(51)*/ = (1 << 11),
 
   NSAlphaFirstBitmapFormatR            = 1 << 0, // 0 means is alpha last (RGBA, CMYKA, etc.)
   NSAlphaNonpremultipliedBitmapFormatR = 1 << 1, // 0 means is premultiplied
@@ -711,13 +711,13 @@ typedef NS_OPTIONS(NSUInteger, NSPotentiallyUnavailableOptions) {
   NSPotentiallyUnavailableOptionsFirst   = (1 << 0),
   NSPotentiallyUnavailableOptionsSecond  = (1 << 1),
   NSPotentiallyUnavailableOptionsThird   = (1 << 2),
-}  __attribute__((availability(macosx, introduced=10.51)));
+}  __attribute__((availability(macosx, introduced=51)));
 
 /// Aaa.  NSOptionsWithUnavailableElement.  Bbb.
 typedef NS_OPTIONS(NSUInteger, NSOptionsWithUnavailableElement) {
   NSOptionsWithUnavailableElementFirst    = (1 << 0),
   NSOptionsWithUnavailableElementSecond   = (1 << 1),
-  NSOptionsWithUnavailableElementThird __attribute__((availability(macosx, introduced=10.51))) = (1 << 2),
+  NSOptionsWithUnavailableElementThird __attribute__((availability(macosx, introduced=51))) = (1 << 2),
 };
 
 /// Aaa.  NSUnavailableEnum.  Bbb.
@@ -725,23 +725,23 @@ typedef NS_ENUM(NSUInteger, NSUnavailableEnum) {
   NSUnavailableEnumFirst,
   NSUnavailableEnumSecond,
   NSUnavailableEnumThird,
-}  __attribute__((availability(macosx, introduced=10.51)));
+}  __attribute__((availability(macosx, introduced=51)));
 
 /// Aaa.  NSEnumWithUnavailableElement.  Bbb.
 typedef NS_ENUM(NSUInteger, NSEnumWithUnavailableElement) {
   NSEnumWithUnavailableElementFirst,
   NSEnumWithUnavailableElementSecond,
-  NSEnumWithUnavailableElementThird __attribute__((availability(macosx, introduced=10.51))),
+  NSEnumWithUnavailableElementThird __attribute__((availability(macosx, introduced=51))),
 };
 
 typedef NS_OPTIONS(NSUInteger, NSDeprecatedOptions) {
   NSDeprecatedOptionsNone = 0,
   NSDeprecatedOptionsFirst   = (1 << 0)
-}  __attribute__((availability(macosx, introduced=10.51, deprecated=10.51, message="Use a different API")));
+}  __attribute__((availability(macosx, introduced=51, deprecated=51, message="Use a different API")));
 
 typedef NS_ENUM(NSUInteger, NSDeprecatedEnum) {
   NSDeprecatedEnumFirst
-} __attribute__((availability(macosx, introduced=10.51, deprecated=10.51, message="Use a different API")));
+} __attribute__((availability(macosx, introduced=51, deprecated=51, message="Use a different API")));
 
 typedef NS_OPTIONS(NSUInteger, NSExplicitlyUnavailableOptions) {
   NSExplicitlyUnavailableOptionsNone = 0,
@@ -759,7 +759,7 @@ typedef NS_OPTIONS(NSUInteger, NSExplicitlyUnavailableOnOSXOptions) {
 @end
 
 @interface NSClassWithDeprecatedOptionsInMethodSignature (ActuallyUseOptions)
-  - (void)someMethodWithDeprecatedOptions:(NSDeprecatedOptions)options __attribute__((availability(macosx, introduced=10.51, deprecated=10.51, message="Use a different API")));
+  - (void)someMethodWithDeprecatedOptions:(NSDeprecatedOptions)options __attribute__((availability(macosx, introduced=51, deprecated=51, message="Use a different API")));
 @end
 
 @interface NSClassWithExplicitlyUnavailableOptionsInMethodSignature : NSObject
@@ -773,7 +773,7 @@ typedef NS_OPTIONS(NSUInteger, NSExplicitlyUnavailableOnOSXOptions) {
 
 @interface NSClassWithPotentiallyUnavailableOptionsInMethodSignature : NSObject
 + (NSClassWithPotentiallyUnavailableOptionsInMethodSignature *) sharedInstance;
-- (void)someMethodWithPotentiallyUnavailableOptions:(NSPotentiallyUnavailableOptions)options __attribute__((availability(macosx, introduced=10.52)));
+- (void)someMethodWithPotentiallyUnavailableOptions:(NSPotentiallyUnavailableOptions)options __attribute__((availability(macosx, introduced=52)));
 @end
 
 @protocol NSWobbling
@@ -931,14 +931,14 @@ typedef struct NonNilableReferences {
 @end
 
 @interface NSClassWithMethodFromNSProtocolWithOptionalRequirement
--(void)optionalRequirement  __attribute__((availability(macosx, introduced=10.51)));
+-(void)optionalRequirement  __attribute__((availability(macosx, introduced=51)));
 @end
 
-__attribute__((availability(macosx, introduced = 10.51)))
+__attribute__((availability(macosx, introduced = 51)))
 @interface AnnotatedFrameworkClass : NSObject
 @end
 
-__attribute__((availability(macosx, introduced = 10.52)))
+__attribute__((availability(macosx, introduced = 52)))
 @interface AnnotatedLaterFrameworkClass : NSObject
 @end
 
@@ -954,7 +954,7 @@ __attribute__((availability(macosx, introduced = 10.52)))
 - (void)doSomethingWithClass:(AnnotatedFrameworkClass *_Nonnull)k
                andLaterClass:(AnnotatedLaterFrameworkClass *_Nonnull)lk;
 
--(void)someMethodWithAvailability __attribute__((availability(macosx,introduced=10.53)));
+-(void)someMethodWithAvailability __attribute__((availability(macosx,introduced=53)));
 
 @property(nonnull) AnnotatedFrameworkClass *someProperty;
 
@@ -971,18 +971,18 @@ __attribute__((availability(macosx, introduced = 10.9)))
 @end
 
 /// Aaa.  LaterFrameworkClassConformingToUnannotatedFrameworkProtocol.  Bbb.
-__attribute__((availability(macosx, introduced = 10.52)))
+__attribute__((availability(macosx, introduced = 52)))
 @interface LaterFrameworkClassConformingToUnannotatedFrameworkProtocol : NSObject<UnannotatedFrameworkProtocol>
 @end
 
 /// Aaa.  LaterAnnotatedFrameworkProtocol.  Bbb.
-__attribute__((availability(macosx, introduced = 10.52)))
+__attribute__((availability(macosx, introduced = 52)))
 @protocol LaterAnnotatedFrameworkProtocol
 - (AnnotatedFrameworkClass * _Nullable) returnSomething;
 - (void)doSomethingWithClass:(AnnotatedFrameworkClass *_Nonnull)k
                andLaterClass:(AnnotatedLaterFrameworkClass *_Nonnull)lk;
 -(void)noUnavailableTypesInSignature;
--(void)someMethodWithAvailability __attribute__((availability(macosx,introduced=10.53)));
+-(void)someMethodWithAvailability __attribute__((availability(macosx,introduced=53)));
 @property(nonnull) AnnotatedFrameworkClass *someProperty;
 @end
 

--- a/test/Interpreter/Inputs/availability_zippered.swift
+++ b/test/Interpreter/Inputs/availability_zippered.swift
@@ -1,7 +1,7 @@
 
 
 public func isMacOSAfterFarFutureOriOSAfterFarFuture() -> Bool {
-  if #available(macOS 10.50, iOS 50.0, *) {
+  if #available(macOS 50, iOS 50.0, *) {
     return true
   }
 
@@ -9,7 +9,7 @@ public func isMacOSAfterFarFutureOriOSAfterFarFuture() -> Bool {
 }
 
 public func isMacOSAfterFarFutureOriOSAfterDistantPast() -> Bool {
-  if #available(macOS 10.50, iOS 1.0, *) {
+  if #available(macOS 50, iOS 1.0, *) {
     return true
   }
 

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -2,22 +2,22 @@
 
 // REQUIRES: OS=macosx
 
-if #available(OSX 10.51, *) {
+if #available(OSX 51, *) {
 }
 
 // Disallow use as an expression.
-if (#available(OSX 10.51, *)) {}  // expected-error {{#available may only be used as condition of an 'if', 'guard'}}
+if (#available(OSX 51, *)) {}  // expected-error {{#available may only be used as condition of an 'if', 'guard'}}
 
-let x = #available(OSX 10.51, *)  // expected-error {{#available may only be used as condition of}}
+let x = #available(OSX 51, *)  // expected-error {{#available may only be used as condition of}}
 
-(#available(OSX 10.51, *) ? 1 : 0) // expected-error {{#available may only be used as condition of an}}
+(#available(OSX 51, *) ? 1 : 0) // expected-error {{#available may only be used as condition of an}}
 
-if !#available(OSX 10.52, *) { // expected-error {{#available cannot be used as an expression, did you mean to use '#unavailable'?}} {{4-15=#unavailable}}
+if !#available(OSX 52, *) { // expected-error {{#available cannot be used as an expression, did you mean to use '#unavailable'?}} {{4-15=#unavailable}}
 }
-if let _ = Optional(5), !#available(OSX 10.52, *) { // expected-error {{#available cannot be used as an expression, did you mean to use '#unavailable'?}} {{25-36=#unavailable}}
+if let _ = Optional(5), !#available(OSX 52, *) { // expected-error {{#available cannot be used as an expression, did you mean to use '#unavailable'?}} {{25-36=#unavailable}}
 }
 
-if #available(OSX 10.51, *) && #available(OSX 10.52, *) { // expected-error {{expected ',' joining parts of a multi-clause condition}} {{28-31=,}}
+if #available(OSX 51, *) && #available(OSX 52, *) { // expected-error {{expected ',' joining parts of a multi-clause condition}} {{25-28=,}}
 }
 
 
@@ -42,34 +42,34 @@ if #available(OSX 0) { // expected-warning {{expected version number; this is an
 if #available(OSX 0.0) { // expected-warning {{expected version number; this is an error in the Swift 6 language mode}}
 }
 
-if #available(OSX 10.51 { // expected-error {{expected ')'}} expected-note {{to match this opening '('}} expected-error {{must handle potential future platforms with '*'}} {{24-24=, *}}
+if #available(OSX 51 { // expected-error {{expected ')'}} expected-note {{to match this opening '('}} expected-error {{must handle potential future platforms with '*'}} {{21-21=, *}}
 }
 
-if #available(iDishwasherOS 10.51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #available(iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 // expected-error@-1 {{must handle potential future platforms with '*'}}
 }
 
-if #available(iDishwasherOS 10.51, *) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #available(iDishwasherOS 51, *) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 }
 
-if #available(macos 10.51, *) { // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{15-20=macOS}}
+if #available(macos 51, *) { // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{15-20=macOS}}
 }
 
-if #available(mscos 10.51, *) { // expected-warning {{unrecognized platform name 'mscos'; did you mean 'macOS'?}} {{15-20=macOS}}
+if #available(mscos 51, *) { // expected-warning {{unrecognized platform name 'mscos'; did you mean 'macOS'?}} {{15-20=macOS}}
 }
 
-if #available(macoss 10.51, *) { // expected-warning {{unrecognized platform name 'macoss'; did you mean 'macOS'?}} {{15-21=macOS}}
+if #available(macoss 51, *) { // expected-warning {{unrecognized platform name 'macoss'; did you mean 'macOS'?}} {{15-21=macOS}}
 }
 
-if #available(mac 10.51, *) { // expected-warning {{unrecognized platform name 'mac'; did you mean 'macOS'?}} {{15-18=macOS}}
+if #available(mac 51, *) { // expected-warning {{unrecognized platform name 'mac'; did you mean 'macOS'?}} {{15-18=macOS}}
 }
 
-if #available(OSX 10.51, OSX 10.52, *) {  // expected-error {{version for 'macOS' already specified}}
+if #available(OSX 51, OSX 52, *) {  // expected-error {{version for 'macOS' already specified}}
 }
 
-if #available(OSX 10.52) { }  // expected-error {{must handle potential future platforms with '*'}} {{24-24=, *}}
+if #available(OSX 52) { }  // expected-error {{must handle potential future platforms with '*'}} {{21-21=, *}}
 
-if #available(OSX 10.51, iOS 8.0) { }  // expected-error {{must handle potential future platforms with '*'}} {{33-33=, *}}
+if #available(OSX 51, iOS 8.0) { }  // expected-error {{must handle potential future platforms with '*'}} {{30-30=, *}}
 
 if #available(iOS 8.0, *) {
 }
@@ -85,33 +85,33 @@ if #available(* { // expected-error {{expected ')' in availability query}} expec
 }
 
 // Multiple platforms
-if #available(OSX 10.51, iOS 8.0, *) {
+if #available(OSX 51, iOS 8.0, *) {
 }
 
 
-if #available(OSX 10.51, { // expected-error {{expected platform name}} // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
+if #available(OSX 51, { // expected-error {{expected platform name}} // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
-if #available(OSX 10.51,) { // expected-error {{expected platform name}}
+if #available(OSX 51,) { // expected-error {{expected platform name}}
 }
 
-if #available(OSX 10.51, iOS { // expected-error {{expected version number}} // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
+if #available(OSX 51, iOS { // expected-error {{expected version number}} // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
-if #available(OSX 10.51, iOS 8.0, iDishwasherOS 10.51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #available(OSX 51, iOS 8.0, iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 // expected-error@-1 {{must handle potential future platforms with '*'}}
 }
 
-if #available(iDishwasherOS 10.51, OSX 10.51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #available(iDishwasherOS 51, OSX 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 // expected-error@-1 {{must handle potential future platforms with '*'}}
 }
 
-if #available(OSX 10.51 || iOS 8.0) {// expected-error {{'||' cannot be used in an availability condition}}
+if #available(OSX 51 || iOS 8.0) {// expected-error {{'||' cannot be used in an availability condition}}
 }
 
 // Emit Fix-It removing un-needed >=, for the moment.
 
-if #available(OSX >= 10.51, *) { // expected-error {{version comparison not needed}} {{19-22=}}
+if #available(OSX >= 51, *) { // expected-error {{version comparison not needed}} {{19-22=}}
 }
 
 // Bool then #available.
@@ -122,7 +122,7 @@ if case 42 = 42, #available(iOS 8.0, *) {}
 if let _ = Optional(42), #available(iOS 8.0, *) {}
 
 // Allow "macOS" as well.
-if #available(macOS 10.51, *) {
+if #available(macOS 51, *) {
 }
 
 

--- a/test/Parse/availability_query_unavailability.swift
+++ b/test/Parse/availability_query_unavailability.swift
@@ -1,21 +1,21 @@
 // RUN: %target-typecheck-verify-swift
 // REQUIRES: OS=macosx
 // This file is mostly an inverted version of availability_query.swift
-if #unavailable(OSX 10.51) {
+if #unavailable(OSX 51) {
 }
 
 // Disallow explicit wildcards.
-if #unavailable(OSX 10.51, *) {} // expected-error {{platform wildcard '*' is always implicit in #unavailable}} {{28-29=}}
+if #unavailable(OSX 51, *) {} // expected-error {{platform wildcard '*' is always implicit in #unavailable}} {{25-26=}}
 // Disallow use as an expression.
-if (#unavailable(OSX 10.51)) {}  // expected-error {{#unavailable may only be used as condition of an 'if', 'guard'}}
-let x = #unavailable(OSX 10.51)  // expected-error {{#unavailable may only be used as condition of}}
-(#unavailable(OSX 10.51) ? 1 : 0) // expected-error {{#unavailable may only be used as condition of an}}
-if !#unavailable(OSX 10.52) { // expected-error {{#unavailable may only be used as condition of an}}
+if (#unavailable(OSX 51)) {}  // expected-error {{#unavailable may only be used as condition of an 'if', 'guard'}}
+let x = #unavailable(OSX 51)  // expected-error {{#unavailable may only be used as condition of}}
+(#unavailable(OSX 51) ? 1 : 0) // expected-error {{#unavailable may only be used as condition of an}}
+if !#unavailable(OSX 52) { // expected-error {{#unavailable may only be used as condition of an}}
 }
-if let _ = Optional(5), !#unavailable(OSX 10.52) { // expected-error {{#unavailable may only be used as condition}}
+if let _ = Optional(5), !#unavailable(OSX 52) { // expected-error {{#unavailable may only be used as condition}}
 }
 
-if #unavailable(OSX 10.51) && #unavailable(OSX 10.52) { // expected-error {{expected ',' joining parts of a multi-clause condition}} {{27-30=,}}
+if #unavailable(OSX 51) && #unavailable(OSX 52) { // expected-error {{expected ',' joining parts of a multi-clause condition}} {{24-27=,}}
 }
 
 
@@ -34,31 +34,31 @@ if #unavailable(OSX { // expected-error {{expected version number}} expected-err
 if #unavailable(OSX) { // expected-error {{expected version number}}
 }
 
-if #unavailable(OSX 10.51 { // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
+if #unavailable(OSX 51 { // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
-if #unavailable(iDishwasherOS 10.51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #unavailable(iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 }
 
-if #unavailable(iDishwasherOS 10.51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #unavailable(iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 }
 
-if #unavailable(macos 10.51) { // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{17-22=macOS}}
+if #unavailable(macos 51) { // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{17-22=macOS}}
 }
 
-if #unavailable(mscos 10.51) { // expected-warning {{unrecognized platform name 'mscos'; did you mean 'macOS'?}} {{17-22=macOS}}
+if #unavailable(mscos 51) { // expected-warning {{unrecognized platform name 'mscos'; did you mean 'macOS'?}} {{17-22=macOS}}
 }
 
-if #unavailable(macoss 10.51) { // expected-warning {{unrecognized platform name 'macoss'; did you mean 'macOS'?}} {{17-23=macOS}}
+if #unavailable(macoss 51) { // expected-warning {{unrecognized platform name 'macoss'; did you mean 'macOS'?}} {{17-23=macOS}}
 }
 
-if #unavailable(mac 10.51) { // expected-warning {{unrecognized platform name 'mac'; did you mean 'macOS'?}} {{17-20=macOS}}
+if #unavailable(mac 51) { // expected-warning {{unrecognized platform name 'mac'; did you mean 'macOS'?}} {{17-20=macOS}}
 }
 
-if #unavailable(OSX 10.51, OSX 10.52) {  // expected-error {{version for 'macOS' already specified}}
+if #unavailable(OSX 51, OSX 52) {  // expected-error {{version for 'macOS' already specified}}
 }
 
-if #unavailable(OSX 10.51, iOS 8.0, *) { }  // expected-error {{platform wildcard '*' is always implicit in #unavailable}} {{37-38=}}
+if #unavailable(OSX 51, iOS 8.0, *) { }  // expected-error {{platform wildcard '*' is always implicit in #unavailable}} {{34-35=}}
 if #unavailable(iOS 8.0) {
 }
 
@@ -73,27 +73,27 @@ if #unavailable(OSX 10 { // expected-error {{expected ')' in availability query}
 }
 
 // Multiple platforms
-if #unavailable(OSX 10.51, iOS 8.0) {
+if #unavailable(OSX 51, iOS 8.0) {
 }
 
 
-if #unavailable(OSX 10.51, { // expected-error {{expected platform name}} // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
+if #unavailable(OSX 51, { // expected-error {{expected platform name}} // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
-if #unavailable(OSX 10.51, iOS { // expected-error {{expected version number}} // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
+if #unavailable(OSX 51, iOS { // expected-error {{expected version number}} // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
-if #unavailable(OSX 10.51, iOS 8.0, iDishwasherOS 10.51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #unavailable(OSX 51, iOS 8.0, iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 }
 
-if #unavailable(iDishwasherOS 10.51, OSX 10.51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #unavailable(iDishwasherOS 51, OSX 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 }
 
-if #unavailable(OSX 10.51 || iOS 8.0) {// expected-error {{'||' cannot be used in an availability condition}}
+if #unavailable(OSX 51 || iOS 8.0) {// expected-error {{'||' cannot be used in an availability condition}}
 }
 
 // Emit Fix-It removing un-needed >=, for the moment.
-if #unavailable(OSX >= 10.51) { // expected-error {{version comparison not needed}} {{21-24=}}
+if #unavailable(OSX >= 51) { // expected-error {{version comparison not needed}} {{21-24=}}
 }
 
 // Bool then #unavailable.
@@ -104,29 +104,29 @@ if case 42 = 42, #unavailable(iOS 8.0) {}
 if let _ = Optional(42), #unavailable(iOS 8.0) {}
 
 // Allow "macOS" as well.
-if #unavailable(macOS 10.51) {
+if #unavailable(macOS 51) {
 }
 
 // Prevent availability and unavailability being present in the same statement.
-if #unavailable(macOS 10.51), #available(macOS 10.52, *) { // expected-error {{#available and #unavailable cannot be in the same statement}}
+if #unavailable(macOS 51), #available(macOS 52, *) { // expected-error {{#available and #unavailable cannot be in the same statement}}
 }
-if #available(macOS 10.51, *), #unavailable(macOS 10.52) { // expected-error {{#available and #unavailable cannot be in the same statement}}
+if #available(macOS 51, *), #unavailable(macOS 52) { // expected-error {{#available and #unavailable cannot be in the same statement}}
 }
-if #available(macOS 10.51, *), #available(macOS 10.55, *), #unavailable(macOS 10.53) { // expected-error {{#available and #unavailable cannot be in the same statement}}
+if #available(macOS 51, *), #available(macOS 55, *), #unavailable(macOS 53) { // expected-error {{#available and #unavailable cannot be in the same statement}}
 }
-if #unavailable(macOS 10.51), #unavailable(macOS 10.55), #available(macOS 10.53, *) { // expected-error {{#available and #unavailable cannot be in the same statement}}
+if #unavailable(macOS 51), #unavailable(macOS 55), #available(macOS 53, *) { // expected-error {{#available and #unavailable cannot be in the same statement}}
 }
-if case 42 = 42, #available(macOS 10.51, *), #unavailable(macOS 10.52) { // expected-error {{#available and #unavailable cannot be in the same statement}}
+if case 42 = 42, #available(macOS 51, *), #unavailable(macOS 52) { // expected-error {{#available and #unavailable cannot be in the same statement}}
 }
-if #available(macOS 10.51, *), case 42 = 42, #unavailable(macOS 10.52) { // expected-error {{#available and #unavailable cannot be in the same statement}}
+if #available(macOS 51, *), case 42 = 42, #unavailable(macOS 52) { // expected-error {{#available and #unavailable cannot be in the same statement}}
 }
 
 // Allow availability and unavailability to mix if they are not in the same statement.
-if #unavailable(macOS 11) {
-  if #available(macOS 10, *) { }
+if #unavailable(macOS 51) {
+  if #available(macOS 50, *) { }
 }
-if #available(macOS 10, *) {
-  if #unavailable(macOS 11) { }
+if #available(macOS 50, *) {
+  if #unavailable(macOS 51) { }
 }
 
 // Diagnose wrong spellings of unavailability

--- a/test/PrintAsObjC/objc_implementation.swift
+++ b/test/PrintAsObjC/objc_implementation.swift
@@ -8,9 +8,9 @@
 // RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module -target %target-stable-abi-triple
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift -target %target-stable-abi-triple
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift -target %target-stable-abi-triple
 // FIXME: END -enable-source-import hackaround
 
 

--- a/test/PrintAsObjC/resilient-ancestry.swift
+++ b/test/PrintAsObjC/resilient-ancestry.swift
@@ -1,12 +1,12 @@
 // Please keep this file in alphabetical order!
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/resilient_struct.swiftmodule %S/../Inputs/resilient_struct.swift -enable-library-evolution
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module-path %t/resilient_objc_class.swiftmodule %S/../Inputs/resilient_objc_class.swift -I %t -enable-library-evolution -emit-objc-header-path %t/resilient_objc_class.h
+// RUN: %target-swift-frontend -target %target-pre-stable-abi-triple -emit-module-path %t/resilient_struct.swiftmodule %S/../Inputs/resilient_struct.swift -enable-library-evolution
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target %target-pre-stable-abi-triple -emit-module-path %t/resilient_objc_class.swiftmodule %S/../Inputs/resilient_objc_class.swift -I %t -enable-library-evolution -emit-objc-header-path %t/resilient_objc_class.h
 
 // RUN: cp %S/Inputs/custom-modules/module.modulemap %t/module.modulemap
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -module-name resilient -emit-objc-header-path %t/resilient.h -I %t -enable-library-evolution
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target %target-pre-stable-abi-triple -typecheck %s -module-name resilient -emit-objc-header-path %t/resilient.h -I %t -enable-library-evolution
 // RUN: %FileCheck %s --check-prefix=NO-STUBS < %t/resilient.h
 // RUN: %check-in-clang %t/resilient.h -I %t
 

--- a/test/SILGen/back_deployed_attr_accessor.swift
+++ b/test/SILGen/back_deployed_attr_accessor.swift
@@ -13,8 +13,8 @@ public struct TopLevelStruct {
   // -- Back deployment thunk for TopLevelStruct.property.getter
   // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvgTwb : $@convention(method) (TopLevelStruct) -> TopLevelStruct
   // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
-  // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
-  // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+  // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+  // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
   // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
   // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
   // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
@@ -34,8 +34,8 @@ public struct TopLevelStruct {
   // CHECK:   return [[RETURN_BB_ARG]] : $TopLevelStruct
 
   // -- Original definition of TopLevelStruct.property.getter
-  // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvg : $@convention(method) (TopLevelStruct) -> TopLevelStruct
-  @backDeployed(before: macOS 10.52)
+  // CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvg : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  @backDeployed(before: macOS 52.1)
   public var property: TopLevelStruct { self }
 }
 

--- a/test/SILGen/back_deployed_attr_accessor_coroutine.swift
+++ b/test/SILGen/back_deployed_attr_accessor_coroutine.swift
@@ -20,8 +20,8 @@ public struct TopLevelStruct {
   // -- Back deployment thunk for TopLevelStruct.property.read
   // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvrTwb : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
   // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
-  // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
-  // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+  // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+  // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
   // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
   // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
   // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
@@ -61,8 +61,8 @@ public struct TopLevelStruct {
   // CHECK:   unwind
 
   // -- Original definition of TopLevelStruct.property.read
-  // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvr : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
-  @backDeployed(before: macOS 10.52)
+  // CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvr : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  @backDeployed(before: macOS 52.1)
   public var property: TopLevelStruct {
     _read { yield self }
   }

--- a/test/SILGen/back_deployed_attr_async_func.swift
+++ b/test/SILGen/back_deployed_attr_async_func.swift
@@ -5,7 +5,7 @@
 // REQUIRES: OS=macosx
 // REQUIRES: concurrency
 
-@available(macOS 10.51, *)
+@available(macOS 51.0, *)
 @usableFromInline func otherFunc() async {}
 
 // -- Fallback definition of asyncFunc()
@@ -19,8 +19,8 @@
 // -- Back deployment thunk for trivialFunc()
 // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy9asyncFuncyyYaFTwb : $@convention(thin) @async () -> ()
 // CHECK: bb0:
-// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
-// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
 // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
@@ -41,15 +41,15 @@
 // CHECK:   return [[RESULT]] : $()
 
 // -- Original definition of trivialFunc()
-// CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy9asyncFuncyyYaF : $@convention(thin) @async () -> ()
-@available(macOS 10.51, *)
-@backDeployed(before: macOS 10.52)
+// CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy9asyncFuncyyYaF : $@convention(thin) @async () -> ()
+@available(macOS 51.0, *)
+@backDeployed(before: macOS 52.1)
 public func asyncFunc() async {
   await otherFunc()
 }
 
-// CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyYaF : $@convention(thin) @async () -> ()
-@available(macOS 10.51, *)
+// CHECK-LABEL: sil hidden [available 51.0] [ossa] @$s11back_deploy6calleryyYaF : $@convention(thin) @async () -> ()
+@available(macOS 51.0, *)
 func caller() async {
   // -- Verify the thunk is called
   // CHECK: {{%.*}} = function_ref @$s11back_deploy9asyncFuncyyYaFTwb : $@convention(thin) @async () -> ()

--- a/test/SILGen/back_deployed_attr_func.swift
+++ b/test/SILGen/back_deployed_attr_func.swift
@@ -13,8 +13,8 @@
 // -- Back deployment thunk for trivialFunc()
 // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy11trivialFuncyyFTwb : $@convention(thin) () -> ()
 // CHECK: bb0:
-// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
-// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
 // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
@@ -35,8 +35,8 @@
 // CHECK:   return [[RESULT]] : $()
 
 // -- Original definition of trivialFunc()
-// CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy11trivialFuncyyF : $@convention(thin) () -> ()
-@backDeployed(before: macOS 10.52)
+// CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy11trivialFuncyyF : $@convention(thin) () -> ()
+@backDeployed(before: macOS 52.1)
 public func trivialFunc() {}
 
 // -- Fallback definition of isNumber(_:)
@@ -48,8 +48,8 @@ public func trivialFunc() {}
 // -- Back deployment thunk for isNumber(_:)
 // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy8isNumberySbSiFTwb : $@convention(thin) (Int) -> Bool
 // CHECK: bb0([[ARG_X:%.*]] : $Int):
-// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
-// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
 // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
@@ -69,8 +69,8 @@ public func trivialFunc() {}
 // CHECK:   return [[RETURN_BB_ARG]] : $Bool
 
 // -- Original definition of isNumber(_:)
-// CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy8isNumberySbSiF : $@convention(thin) (Int) -> Bool
-@backDeployed(before: macOS 10.52)
+// CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy8isNumberySbSiF : $@convention(thin) (Int) -> Bool
+@backDeployed(before: macOS 52.1)
 public func isNumber(_ x: Int) -> Bool {
   return true
 }

--- a/test/SILGen/back_deployed_attr_generic_func.swift
+++ b/test/SILGen/back_deployed_attr_generic_func.swift
@@ -14,8 +14,8 @@
 // -- Back deployment thunk for genericFunc(_:)
 // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy11genericFuncyxxlFTwb : $@convention(thin) <T> (@in_guaranteed T) -> @out T
 // CHECK: bb0([[OUT_ARG:%.*]] : $*T, [[IN_ARG:%.*]] : $*T):
-// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
-// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
 // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
@@ -36,8 +36,8 @@
 // CHECK:   return [[RESULT]] : $()
 
 // -- Original definition of genericFunc(_:)
-// CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy11genericFuncyxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T
-@backDeployed(before: macOS 10.52)
+// CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy11genericFuncyxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T
+@backDeployed(before: macOS 52.1)
 public func genericFunc<T>(_ t: T) -> T {
   return t
 }
@@ -52,8 +52,8 @@ public func genericFunc<T>(_ t: T) -> T {
 // -- Back deployment thunk for genericFuncWithOwnedParam(_:)
 // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy25genericFuncWithOwnedParamyyxnlFTwb : $@convention(thin) <T> (@in T) -> ()
 // CHECK: bb0([[IN_ARG:%.*]] : $*T):
-// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
-// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
 // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
@@ -75,8 +75,8 @@ public func genericFunc<T>(_ t: T) -> T {
 // CHECK:   return [[RESULT]] : $()
 
 // -- Original definition of genericFuncWithOwnedParam(_:)
-// CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy25genericFuncWithOwnedParamyyxnlF : $@convention(thin) <T> (@in T) -> ()
-@backDeployed(before: macOS 10.52)
+// CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy25genericFuncWithOwnedParamyyxnlF : $@convention(thin) <T> (@in T) -> ()
+@backDeployed(before: macOS 52.1)
 public func genericFuncWithOwnedParam<T>(_ t: __owned T) { }
 
 struct S {}

--- a/test/SILGen/back_deployed_attr_struct_init.swift
+++ b/test/SILGen/back_deployed_attr_struct_init.swift
@@ -1,10 +1,10 @@
-// RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
+// RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx50.3 -verify
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx50.3 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 
-@available(macOS 10.50, *)
+@available(macOS 50.3, *)
 public struct TopLevelStruct<T> {
   @usableFromInline var t: T
 
@@ -32,8 +32,8 @@ public struct TopLevelStruct<T> {
   // -- Back deployment thunk for TopLevelStruct.init(_:)
   // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy14TopLevelStructVyACyxGxcfCTwb : $@convention(method) <T> (@in T, @thin TopLevelStruct<T>.Type) -> @out TopLevelStruct<T>
   // CHECK: bb0([[SELF_OUT:%.*]] : $*TopLevelStruct<T>, [[T_ARG:%.*]] : $*T, [[METATYPE_ARG:%.*]] : $@thin TopLevelStruct<T>.Type):
-  // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
-  // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+  // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+  // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
   // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
   // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
   // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
@@ -54,9 +54,9 @@ public struct TopLevelStruct<T> {
   // CHECK:   return [[RESULT]] : $()
 
   // -- Original definition of TopLevelStruct.init(_:)
-  // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy14TopLevelStructVyACyxGxcfC : $@convention(method) <T> (@in T, @thin TopLevelStruct<T>.Type) -> @out TopLevelStruct<T>
-  @available(macOS 10.51, *)
-  @backDeployed(before: macOS 10.52)
+  // CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy14TopLevelStructVyACyxGxcfC : $@convention(method) <T> (@in T, @thin TopLevelStruct<T>.Type) -> @out TopLevelStruct<T>
+  @available(macOS 51.0, *)
+  @backDeployed(before: macOS 52.1)
   public init(_ t: T) {
     self.t = t
   }
@@ -64,9 +64,9 @@ public struct TopLevelStruct<T> {
 
 struct S {}
 
-// CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyAA1SVF : $@convention(thin) (S) -> ()
+// CHECK-LABEL: sil hidden [available 51.0] [ossa] @$s11back_deploy6calleryyAA1SVF : $@convention(thin) (S) -> ()
 // CHECK: bb0([[STRUCT_ARG:%.*]] : $S):
-@available(macOS 10.51, *)
+@available(macOS 51.0, *)
 func caller(_ s: S) {
   // -- Verify the thunk is called
   // CHECK: {{%.*}} = function_ref @$s11back_deploy14TopLevelStructVyACyxGxcfCTwb : $@convention(method) <τ_0_0> (@in τ_0_0, @thin TopLevelStruct<τ_0_0>.Type) -> @out TopLevelStruct<τ_0_0>

--- a/test/SILGen/back_deployed_attr_struct_method.swift
+++ b/test/SILGen/back_deployed_attr_struct_method.swift
@@ -14,8 +14,8 @@ public struct TopLevelStruct {
   // -- Back deployment thunk for TopLevelStruct.trivialMethod()
   // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyFTwb : $@convention(method) (TopLevelStruct) -> ()
   // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
-  // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
-  // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+  // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+  // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
   // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
   // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
   // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
@@ -36,8 +36,8 @@ public struct TopLevelStruct {
   // CHECK:   return [[RESULT]] : $()
 
   // -- Original definition of TopLevelStruct.trivialMethod()
-  // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyF : $@convention(method) (TopLevelStruct) -> ()
-  @backDeployed(before: macOS 10.52)
+  // CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyF : $@convention(method) (TopLevelStruct) -> ()
+  @backDeployed(before: macOS 52.1)
   public func trivialMethod() {}
 }
 

--- a/test/SILGen/back_deployed_attr_throwing_func.swift
+++ b/test/SILGen/back_deployed_attr_throwing_func.swift
@@ -13,8 +13,8 @@
 // -- Back deployment thunk for throwingFunc()
 // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy12throwingFuncyyKFTwb : $@convention(thin) () -> @error any Error
 // CHECK: bb0:
-// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
-// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
 // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
@@ -48,8 +48,8 @@
 // CHECK:   throw [[RETHROW_BB_ARG]] : $any Error
 
 // -- Original definition of throwingFunc()
-// CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy12throwingFuncyyKF : $@convention(thin) () -> @error any Error
-@backDeployed(before: macOS 10.52)
+// CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy12throwingFuncyyKF : $@convention(thin) () -> @error any Error
+@backDeployed(before: macOS 52.1)
 public func throwingFunc() throws {}
 
 // CHECK-LABEL: sil hidden [ossa] @$s11back_deploy6calleryyKF : $@convention(thin) () -> @error any Error

--- a/test/SILOptimizer/Inputs/pre_specialized_module.swift
+++ b/test/SILOptimizer/Inputs/pre_specialized_module.swift
@@ -9,18 +9,18 @@ public class SomeClass {
 
 @_specialize(exported: true, where T == Int)
 @_specialize(exported: true, where T == Double)
-@_specialize(exported: true, availability: macOS 10.50, *; where T == SomeData)
+@_specialize(exported: true, availability: macOS 50, *; where T == SomeData)
 public func publicPrespecialized<T>(_ t: T) {
 }
 
 @_specialize(exported: true, where T == Int)
-@_specialize(exported: true, availability: macOS 10.50, *; where T == SomeData)
+@_specialize(exported: true, availability: macOS 50, *; where T == SomeData)
 @inlinable
 @inline(never)
 public func publicPrespecialized2<T>(_ t: T) { }
 
 @_specialize(exported: true, where T == Int)
-@_specialize(exported: true, availability: macOS 10.50, *; where T == SomeData)
+@_specialize(exported: true, availability: macOS 50, *; where T == SomeData)
 @inlinable
 @inline(never)
 public func publicPrespecializedThrows<T>(_ t: T) throws -> T { return t }

--- a/test/SILOptimizer/Inputs/pre_specialized_module2.swift
+++ b/test/SILOptimizer/Inputs/pre_specialized_module2.swift
@@ -5,6 +5,6 @@ public struct SomeOtherData {
   public init() {}
 }
 
-@_specialize(exported: true, target: publicPrespecialized2(_:), availability: macOS 10.50, *; where T == SomeOtherData)
+@_specialize(exported: true, target: publicPrespecialized2(_:), availability: macOS 50, *; where T == SomeOtherData)
 public func pre_specialize_publicPrespecialized<T>(_ t: T) {
 }

--- a/test/SILOptimizer/Inputs/pre_specialized_module_layouts.swift
+++ b/test/SILOptimizer/Inputs/pre_specialized_module_layouts.swift
@@ -13,7 +13,7 @@ public final class SomeClass: Sendable {
 @_specialize(exported: true, where @_noMetadata T : _BridgeObject)
 @_specialize(exported: true, where @_noMetadata T : _Trivial(64))
 @_specialize(exported: true, where @_noMetadata T : _TrivialStride(96))
-@_specialize(exported: true, availability: macOS 10.50, *; where T == SomeData)
+@_specialize(exported: true, availability: macOS 50, *; where T == SomeData)
 public func publicPrespecialized<T>(_ t: T) {
 }
 
@@ -24,14 +24,14 @@ public func publicPrespecializedWithMarkerProtocol<T: Sendable>(_ t: T) -> T {
 
 @_specialize(exported: true, where T == Int)
 @_specialize(exported: true, where @_noMetadata T : _Class)
-@_specialize(exported: true, availability: macOS 10.50, *; where T == SomeData)
+@_specialize(exported: true, availability: macOS 50, *; where T == SomeData)
 @inlinable
 @inline(never)
 public func publicPrespecialized2<T>(_ t: T) { }
 
 @_specialize(exported: true, where T == Int)
 @_specialize(exported: true, where @_noMetadata T : _Class)
-@_specialize(exported: true, availability: macOS 10.50, *; where T == SomeData)
+@_specialize(exported: true, availability: macOS 50, *; where T == SomeData)
 @inlinable
 @inline(never)
 public func publicPrespecializedThrows<T>(_ t: T) throws -> T { return t }

--- a/test/SILOptimizer/pre_specialize-macos.swift
+++ b/test/SILOptimizer/pre_specialize-macos.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -O -swift-version 5 -enable-library-evolution -emit-module -o /dev/null -emit-module-interface-path %t/pre_specialized_module.swiftinterface %S/Inputs/pre_specialized_module.swift -module-name pre_specialized_module
 // RUN: %target-swift-frontend -I %t -O -swift-version 5 -enable-library-evolution -emit-module -o /dev/null -emit-module-interface-path %t/pre_specialized_module2.swiftinterface %S/Inputs/pre_specialized_module2.swift -module-name pre_specialized_module2
-// RUN: %target-swift-frontend -I %t -O -emit-sil -target %target-cpu-apple-macos11 %s | %FileCheck %s --check-prefix=OPT --check-prefix=CHECK
-// RUN: %target-swift-frontend -I %t -O -emit-sil -target %target-cpu-apple-macosx10.9 %s | %FileCheck %s --check-prefix=NOOPT --check-prefix=CHECK
+// RUN: %target-swift-frontend -I %t -O -emit-sil -target %target-cpu-apple-macos51 %s | %FileCheck %s --check-prefix=OPT --check-prefix=CHECK
+// RUN: %target-swift-frontend -I %t -O -emit-sil -target %target-cpu-apple-macosx49 %s | %FileCheck %s --check-prefix=NOOPT --check-prefix=CHECK
 
 // REQUIRES: OS=macosx && CPU=x86_64
 
@@ -26,5 +26,5 @@ public func usePrespecializedEntryPoints() {
   publicPrespecialized2(SomeOtherData())
 }
 
-// OPT: sil [available 10.50] [noinline] {{.*}}@$s22pre_specialized_module21publicPrespecialized2yyxlFAA8SomeDataV_Ts5 : $@convention(thin) (SomeData) -> ()
-// OPT: sil [available 10.50] [noinline] {{.*}}@$s22pre_specialized_module21publicPrespecialized2yyxlF0a1_B8_module213SomeOtherDataV_Ts5 : $@convention(thin) (SomeOtherData) -> ()
+// OPT: sil [available 50] [noinline] {{.*}}@$s22pre_specialized_module21publicPrespecialized2yyxlFAA8SomeDataV_Ts5 : $@convention(thin) (SomeData) -> ()
+// OPT: sil [available 50] [noinline] {{.*}}@$s22pre_specialized_module21publicPrespecialized2yyxlF0a1_B8_module213SomeOtherDataV_Ts5 : $@convention(thin) (SomeOtherData) -> ()

--- a/test/SILOptimizer/pre_specialize.swift
+++ b/test/SILOptimizer/pre_specialize.swift
@@ -111,11 +111,11 @@ public func usePrespecializedThrowsEntryPoints() throws {
   consume(try publicPrespecializedThrows(SomeData()))
 }
 
-// OPT-macosx: sil [available 10.50] @$s14pre_specialize40usePrespecializedEntryPointsAvailabilityyyF : $@convention(thin) () -> () {
+// OPT-macosx: sil [available 50] @$s14pre_specialize40usePrespecializedEntryPointsAvailabilityyyF : $@convention(thin) () -> () {
 // OPT-macosx:  [[F1:%.*]] = function_ref @$s22pre_specialized_module20publicPrespecializedyyxlFAA8SomeDataV_Ts5 : $@convention(thin) (SomeData) -> ()
 // OPT-macosx:  apply [[F1]](
 // OPT-macosx: } // end sil function '$s14pre_specialize40usePrespecializedEntryPointsAvailabilityyyF'
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public func usePrespecializedEntryPointsAvailability() {
   publicPrespecialized(SomeData())
 }

--- a/test/SILOptimizer/pre_specialize_layouts.swift
+++ b/test/SILOptimizer/pre_specialize_layouts.swift
@@ -283,14 +283,14 @@ public func useLayoutPrespecializedEntryPointWithExistential(_ p: any SomeRefere
   publicPrespecialized(p)
 }
 
-// OPT-macosx: sil [available 10.50] @$s22pre_specialize_layouts40usePrespecializedEntryPointsAvailabilityyyF : $@convention(thin) () -> () {
+// OPT-macosx: sil [available 50] @$s22pre_specialize_layouts40usePrespecializedEntryPointsAvailabilityyyF : $@convention(thin) () -> () {
 // OPT-macosx:  [[F1:%.*]] = function_ref @$s30pre_specialized_module_layouts20publicPrespecializedyyxlFAA8SomeDataV_Ts5 : $@convention(thin) (SomeData) -> ()
 // OPT-macosx:  apply [[F1]](
 // OPT-macosx:  [[F2:%.*]] = function_ref @$s30pre_specialized_module_layouts20publicPrespecializedyyxlFyXl_Ts5 : $@convention(thin) (@guaranteed AnyObject) -> ()
 // OPT-macosx:  [[A1:%.*]] = unchecked_ref_cast {{%.*}} : $SomeClass to $AnyObject
 // OPT-macosx:  apply [[F2]]([[A1]]) : $@convention(thin) (@guaranteed AnyObject) -> ()
 // OPT-macosx: } // end sil function '$s22pre_specialize_layouts40usePrespecializedEntryPointsAvailabilityyyF'
-@available(macOS 10.50, *)
+@available(macOS 50, *)
 public func usePrespecializedEntryPointsAvailability() {
   publicPrespecialized(SomeData())
   publicPrespecialized(SomeClass())

--- a/test/Sema/Inputs/availability_enum_case_other.swift
+++ b/test/Sema/Inputs/availability_enum_case_other.swift
@@ -1,4 +1,4 @@
 public enum Horse {
-  @available(macOS 10.50, *)
+  @available(macOS 50, *)
   case kevin(Int)
 }

--- a/test/Sema/api-availability-only.swift
+++ b/test/Sema/api-availability-only.swift
@@ -3,10 +3,10 @@
 
 // REQUIRES: OS=macosx
 
-@available(macOS 10.52, *)
+@available(macOS 52, *)
 public struct S {}
 
-@available(macOS 10.51, *)
+@available(macOS 51, *)
 public func newFunc() {
   _ = S() // expected-error {{'S' is only available in}}
   // expected-note @-1 {{add 'if #available' version check}}

--- a/test/Sema/availability_define.swift
+++ b/test/Sema/availability_define.swift
@@ -1,32 +1,32 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:   -define-availability "_iOS13Aligned:macOS 10.15, iOS 13.0" \
-// RUN:   -define-availability "_iOS14Aligned:macOS 11.0, iOS 14.0" \
-// RUN:   -define-availability "_iOS14:iOS 14.0" \
-// RUN:   -define-availability "_macOS11_0:macOS 11.0" \
-// RUN:   -define-availability "_myProject 1.0:macOS 11.0" \
-// RUN:   -define-availability "_myProject 2.5:macOS 12.5"
+// RUN:   -define-availability "_iOS53Aligned:macOS 50.0, iOS 53.0" \
+// RUN:   -define-availability "_iOS54Aligned:macOS 51.0, iOS 54.0" \
+// RUN:   -define-availability "_iOS54:iOS 54.0" \
+// RUN:   -define-availability "_macOS51_0:macOS 51.0" \
+// RUN:   -define-availability "_myProject 1.0:macOS 51.0" \
+// RUN:   -define-availability "_myProject 2.5:macOS 52.5"
 
 // RUN: %target-typecheck-verify-swift \
-// RUN:   -enable-experimental-feature AvailabilityMacro='_iOS13Aligned:macOS 10.15, iOS 13.0' \
-// RUN:   -enable-experimental-feature AvailabilityMacro="_iOS14Aligned:macOS 11.0, iOS 14.0" \
-// RUN:   -enable-experimental-feature AvailabilityMacro='_iOS14:iOS 14.0' \
-// RUN:   -enable-experimental-feature AvailabilityMacro="_macOS11_0:macOS 11.0" \
-// RUN:   -enable-experimental-feature AvailabilityMacro='_myProject 1.0:macOS 11.0' \
-// RUN:   -enable-experimental-feature AvailabilityMacro="_myProject 2.5:macOS 12.5"
+// RUN:   -enable-experimental-feature AvailabilityMacro='_iOS53Aligned:macOS 50.0, iOS 53.0' \
+// RUN:   -enable-experimental-feature AvailabilityMacro="_iOS54Aligned:macOS 51.0, iOS 54.0" \
+// RUN:   -enable-experimental-feature AvailabilityMacro='_iOS54:iOS 54.0' \
+// RUN:   -enable-experimental-feature AvailabilityMacro="_macOS51_0:macOS 51.0" \
+// RUN:   -enable-experimental-feature AvailabilityMacro='_myProject 1.0:macOS 51.0' \
+// RUN:   -enable-experimental-feature AvailabilityMacro="_myProject 2.5:macOS 52.5"
 
 // REQUIRES: OS=macosx
 
-@available(_iOS13Aligned, *)
-public func onMacOS10_15() {}
+@available(_iOS53Aligned, *)
+public func onMacOS50() {}
 
-@available(_iOS14Aligned, *)
-public func onMacOS11_0() {}
+@available(_iOS54Aligned, *)
+public func onMacOS51_0() {}
 
-@available(_iOS14, _macOS11_0, tvOS 14.0, *)
+@available(_iOS54, _macOS51_0, tvOS 54.0, *)
 public func composed() {}
 
-@available(_iOS13Aligned, *)
-@available(macOS, deprecated: 10.15)
+@available(_iOS53Aligned, *)
+@available(macOS, deprecated: 50)
 public func onMacOSDeprecated() {}
 
 @available(_myProject, *) // expected-error {{expected declaration}}
@@ -51,25 +51,25 @@ public func brokenVersion() {}
 // expected-error @-1 {{expected 'available' option such as 'unavailable', 'introduced', 'deprecated', 'obsoleted', 'message', or 'renamed'}}
 public func unknownMacro() {}
 
-@available(_iOS14) // expected-error {{must handle potential future platforms with '*'}}
+@available(_iOS54) // expected-error {{must handle potential future platforms with '*'}}
 public func noOtherOSes() {}
 
-@available(_iOS13Aligned, *)
+@available(_iOS53Aligned, *)
 func client() {
-  onMacOS10_15()
-  onMacOS11_0() // expected-error {{is only available in macOS 11.0 or newer}}
+  onMacOS50()
+  onMacOS51_0() // expected-error {{is only available in macOS 51.0 or newer}}
   // expected-note @-1 {{add 'if #available' version check}}
   onMacOSDeprecated()
 
-  if #available(_iOS14Aligned, *) {
-    onMacOS11_0()
+  if #available(_iOS54Aligned, *) {
+    onMacOS51_0()
   }
 
-  if #unavailable(_iOS14Aligned) {
-    onMacOS11_0() // expected-error {{is only available in macOS 11.0 or newer}}
+  if #unavailable(_iOS54Aligned) {
+    onMacOS51_0() // expected-error {{is only available in macOS 51.0 or newer}}
     // expected-note @-1 {{add 'if #available' version check}}
   } else {
-    onMacOS11_0()
+    onMacOS51_0()
   }
 
   if #available(_unknownMacro, *) { } // expected-error {{expected version number}}
@@ -81,40 +81,40 @@ public func doIt(_ closure: () -> ()) {
 
 @inlinable
 public func forbidMacrosInInlinableCode() {
-  if #available(_iOS14Aligned, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
-  if #available(_iOS14, _macOS11_0, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
-  if #available(iOS 14.0, _macOS11_0, tvOS 14.0, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
-  if #unavailable(_iOS14Aligned) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
-  if #unavailable(_iOS14, _macOS11_0) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
-  if #unavailable(iOS 14.0, _macOS11_0, tvOS 14.0) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  if #available(_iOS54Aligned, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  if #available(_iOS54, _macOS51_0, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  if #available(iOS 54.0, _macOS51_0, tvOS 54.0, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  if #unavailable(_iOS54Aligned) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  if #unavailable(_iOS54, _macOS51_0) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  if #unavailable(iOS 54.0, _macOS51_0, tvOS 54.0) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
   doIt {
-    if #available(_iOS14Aligned, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+    if #available(_iOS54Aligned, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
   }
 }
 
 @_alwaysEmitIntoClient
 public func forbidMacrosInInlinableCode1() {
-  if #available(_iOS14Aligned, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
-  if #available(_iOS14, _macOS11_0, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
-  if #available(iOS 14.0, _macOS11_0, tvOS 14.0, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
-  if #unavailable(_iOS14Aligned) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
-  if #unavailable(_iOS14, _macOS11_0) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
-  if #unavailable(iOS 14.0, _macOS11_0, tvOS 14.0) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #available(_iOS54Aligned, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #available(_iOS54, _macOS51_0, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #available(iOS 54.0, _macOS51_0, tvOS 54.0, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #unavailable(_iOS54Aligned) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #unavailable(_iOS54, _macOS51_0) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #unavailable(iOS 54.0, _macOS51_0, tvOS 54.0) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
   doIt {
-    if #available(_iOS14Aligned, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+    if #available(_iOS54Aligned, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
   }
 }
 
-@available(_iOS13Aligned, *)
-@backDeployed(before: _iOS14Aligned)
+@available(_iOS53Aligned, *)
+@backDeployed(before: _iOS54Aligned)
 public func forbidMacrosInInlinableCode2() {
-  if #available(_iOS14Aligned, *) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
-  if #available(_iOS14, _macOS11_0, *) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
-  if #available(iOS 14.0, _macOS11_0, tvOS 14.0, *) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
-  if #unavailable(_iOS14Aligned) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
-  if #unavailable(_iOS14, _macOS11_0) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
-  if #unavailable(iOS 14.0, _macOS11_0, tvOS 14.0) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
+  if #available(_iOS54Aligned, *) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
+  if #available(_iOS54, _macOS51_0, *) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
+  if #available(iOS 54.0, _macOS51_0, tvOS 54.0, *) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
+  if #unavailable(_iOS54Aligned) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
+  if #unavailable(_iOS54, _macOS51_0) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
+  if #unavailable(iOS 54.0, _macOS51_0, tvOS 54.0) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
   doIt {
-    if #available(_iOS14Aligned, *) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
+    if #available(_iOS54Aligned, *) { } // expected-error {{availability macro cannot be used in a '@backDeployed' function}}
   }
 }

--- a/test/Sema/availability_deinit.swift
+++ b/test/Sema/availability_deinit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx50
 
 // REQUIRES: OS=macosx
 
@@ -32,21 +32,21 @@ class DeinitUnavailableMacOS {
 }
 
 class AvailableAtDeploymentTargetDeinit {
-  @available(macOS 10.50, *)
+  @available(macOS 50, *)
   deinit {}
 }
 
 class PotentiallyUnavailableDeinit {
-  @available(macOS 10.51, *) // expected-error {{deinitializer cannot be marked potentially unavailable with '@available'}}
+  @available(macOS 51, *) // expected-error {{deinitializer cannot be marked potentially unavailable with '@available'}}
   deinit {}
 }
 
-@available(macOS 10.51, *)
-func funcAvailable10_51() {}
+@available(macOS 51, *)
+func funcAvailable51() {}
 
 class AlwaysAvailable { // expected-note {{add @available attribute to enclosing class}}
   deinit {
-    funcAvailable10_51() // expected-error {{'funcAvailable10_51()' is only available in macOS 10.51 or newer}}
+    funcAvailable51() // expected-error {{'funcAvailable51()' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
   }
 }

--- a/test/Sema/availability_enum_case.swift
+++ b/test/Sema/availability_enum_case.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -emit-module %S/Inputs/availability_enum_case_other.swift -target %target-cpu-apple-macosx10.50 -emit-module-interface-path %t/availability_enum_case_other.swiftinterface -swift-version 5 -enable-library-evolution
+// RUN: %target-build-swift -emit-module %S/Inputs/availability_enum_case_other.swift -target %target-cpu-apple-macosx50 -emit-module-interface-path %t/availability_enum_case_other.swiftinterface -swift-version 5 -enable-library-evolution
 // RUN: %target-typecheck-verify-swift -I %t
 
-// RUN: %target-build-swift -emit-module %S/Inputs/availability_enum_case_other.swift -target %target-cpu-apple-macosx10.50 -emit-module-interface-path %t/availability_enum_case_other.swiftinterface -swift-version 5 -enable-library-evolution -whole-module-optimization
+// RUN: %target-build-swift -emit-module %S/Inputs/availability_enum_case_other.swift -target %target-cpu-apple-macosx50 -emit-module-interface-path %t/availability_enum_case_other.swiftinterface -swift-version 5 -enable-library-evolution -whole-module-optimization
 // RUN: %target-typecheck-verify-swift -I %t
 
 // REQUIRES: OS=macosx
@@ -14,6 +14,6 @@ func ride(horse: Horse) {
   // expected-note@-1 {{add @available attribute to enclosing global function}}
 
   _ = Horse.kevin
-  // expected-error@-1 {{'kevin' is only available in macOS 10.50 or newer}}
+  // expected-error@-1 {{'kevin' is only available in macOS 50 or newer}}
   // expected-note@-2 {{add 'if #available' version check}}
 }

--- a/test/Sema/availability_global_actor.swift
+++ b/test/Sema/availability_global_actor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx50
 
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx
@@ -9,8 +9,8 @@ actor SomeActor {}
   static let shared = SomeActor()
 }
 
-@available(macOS 10.51, *)
-@globalActor struct Available10_51GA {
+@available(macOS 51, *)
+@globalActor struct Available51GA {
   static let shared = SomeActor()
 }
 
@@ -22,12 +22,12 @@ actor SomeActor {}
 @AlwaysAvailableGA
 struct AlwaysAvailableWithAlwaysAvailableGA {}
 
-@Available10_51GA // expected-error {{'Available10_51GA' is only available in macOS 10.51 or newer}}
-struct AlwaysAvailableWithAvailable10_51GA {} // expected-note {{add @available attribute to enclosing struct}}
+@Available51GA // expected-error {{'Available51GA' is only available in macOS 51 or newer}}
+struct AlwaysAvailableWithAvailable51GA {} // expected-note {{add @available attribute to enclosing struct}}
 
-@available(macOS 10.51, *)
-@Available10_51GA
-struct Always10_51WithAvailable10_51GA {}
+@available(macOS 51, *)
+@Available51GA
+struct Always51WithAvailable51GA {}
 
 @UnavailableGA // expected-error {{'UnavailableGA' is unavailable}}
 struct AlwaysAvailableWithUnavailableGA {}

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -1,140 +1,140 @@
-// RUN: %target-swift-frontend -typecheck -dump-type-refinement-contexts %s > %t.dump 2>&1
+// RUN: %target-swift-frontend -typecheck -dump-type-refinement-contexts %s -target %target-cpu-apple-macos50 > %t.dump 2>&1
 // RUN: %FileCheck --strict-whitespace %s < %t.dump
 
 // REQUIRES: OS=macosx
 
-// CHECK: {{^}}(root versions=[10.{{[0-9]+}},+Inf)
+// CHECK: {{^}}(root versions=[50,+Inf)
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=SomeClass
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someMethod()
-// CHECK-NEXT: {{^}}      (decl versions=[10.53,+Inf) decl=someInnerFunc()
-// CHECK-NEXT: {{^}}      (decl versions=[10.53,+Inf) decl=InnerClass
-// CHECK-NEXT: {{^}}        (decl versions=[10.54,+Inf) decl=innerClassMethod
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someStaticProperty
-// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someStaticProperty
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someStaticPropertyInferredType
-// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someStaticPropertyInferredType
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=multiPatternStaticPropertyA
-// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=multiPatternStaticPropertyA
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someComputedProperty
-// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someComputedProperty
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someOtherMethod()
-@available(OSX 10.51, *)
+// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=SomeClass
+// CHECK-NEXT: {{^}}    (decl versions=[52,+Inf) decl=someMethod()
+// CHECK-NEXT: {{^}}      (decl versions=[53,+Inf) decl=someInnerFunc()
+// CHECK-NEXT: {{^}}      (decl versions=[53,+Inf) decl=InnerClass
+// CHECK-NEXT: {{^}}        (decl versions=[54,+Inf) decl=innerClassMethod
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=someStaticProperty
+// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=someStaticProperty
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=someStaticPropertyInferredType
+// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=someStaticPropertyInferredType
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=multiPatternStaticPropertyA
+// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=multiPatternStaticPropertyA
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=someComputedProperty
+// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=someComputedProperty
+// CHECK-NEXT: {{^}}    (decl versions=[52,+Inf) decl=someOtherMethod()
+@available(OSX 51, *)
 class SomeClass {
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   func someMethod() {
 
-    @available(OSX 10.53, *)
+    @available(OSX 53, *)
     func someInnerFunc() { }
 
-    @available(OSX 10.53, *)
+    @available(OSX 53, *)
     class InnerClass {
-      @available(OSX 10.54, *)
+      @available(OSX 54, *)
       func innerClassMethod() { }
     }
   }
   
   func someUnrefinedMethod() { }
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   static var someStaticProperty: Int = 7
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   static var someStaticPropertyInferredType = 7
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   static var multiPatternStaticPropertyA = 7,
              multiPatternStaticPropertyB = 8
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   var someComputedProperty: Int {
     get { }
     set(v) { }
   }
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   func someOtherMethod() { }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=someFunction()
-@available(OSX 10.51, *)
+// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=someFunction()
+@available(OSX 51, *)
 func someFunction() { }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=SomeProtocol
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=protoMethod()
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=protoProperty
-// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=protoProperty
-@available(OSX 10.51, *)
+// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=SomeProtocol
+// CHECK-NEXT: {{^}}    (decl versions=[52,+Inf) decl=protoMethod()
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=protoProperty
+// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=protoProperty
+@available(OSX 51, *)
 protocol SomeProtocol {
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   func protoMethod() -> Int
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   var protoProperty: Int { get }
 }
 
-// CHECK-NEXT: {{^}}  (decl_implicit versions=[10.13,+Inf) decl=extension.SomeClass
-// CHECK-NEXT: {{^}}    (decl versions=[10.51,+Inf) decl=extension.SomeClass
-// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someExtensionFunction()
-@available(OSX 10.51, *)
+// CHECK-NEXT: {{^}}  (decl_implicit versions=[50,+Inf) decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl versions=[51,+Inf) decl=extension.SomeClass
+// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=someExtensionFunction()
+@available(OSX 51, *)
 extension SomeClass {
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   func someExtensionFunction() { }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=functionWithStmtCondition
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.52,+Inf)
-// CHECK-NEXT: {{^}}      (condition_following_availability versions=[10.53,+Inf)
-// CHECK-NEXT: {{^}}    (if_then versions=[10.53,+Inf)
-// CHECK-NEXT: {{^}}      (condition_following_availability versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}      (if_then versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}        (condition_following_availability versions=[10.55,+Inf)
-// CHECK-NEXT: {{^}}        (decl versions=[10.55,+Inf) decl=funcInGuardElse()
-// CHECK-NEXT: {{^}}        (guard_fallthrough versions=[10.55,+Inf)
-// CHECK-NEXT: {{^}}          (condition_following_availability versions=[10.56,+Inf)
-// CHECK-NEXT: {{^}}          (guard_fallthrough versions=[10.56,+Inf)
-// CHECK-NEXT: {{^}}      (decl versions=[10.57,+Inf) decl=funcInInnerIfElse()
-@available(OSX 10.51, *)
+// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=functionWithStmtCondition
+// CHECK-NEXT: {{^}}    (condition_following_availability versions=[52,+Inf)
+// CHECK-NEXT: {{^}}      (condition_following_availability versions=[53,+Inf)
+// CHECK-NEXT: {{^}}    (if_then versions=[53,+Inf)
+// CHECK-NEXT: {{^}}      (condition_following_availability versions=[54,+Inf)
+// CHECK-NEXT: {{^}}      (if_then versions=[54,+Inf)
+// CHECK-NEXT: {{^}}        (condition_following_availability versions=[55,+Inf)
+// CHECK-NEXT: {{^}}        (decl versions=[55,+Inf) decl=funcInGuardElse()
+// CHECK-NEXT: {{^}}        (guard_fallthrough versions=[55,+Inf)
+// CHECK-NEXT: {{^}}          (condition_following_availability versions=[56,+Inf)
+// CHECK-NEXT: {{^}}          (guard_fallthrough versions=[56,+Inf)
+// CHECK-NEXT: {{^}}      (decl versions=[57,+Inf) decl=funcInInnerIfElse()
+@available(OSX 51, *)
 func functionWithStmtCondition() {
-  if #available(OSX 10.52, *),
+  if #available(OSX 52, *),
      let x = (nil as Int?),
-     #available(OSX 10.53, *) {
-    if #available(OSX 10.54, *) {
-      guard #available(OSX 10.55, *) else {
-        @available(OSX 10.55, *)
+     #available(OSX 53, *) {
+    if #available(OSX 54, *) {
+      guard #available(OSX 55, *) else {
+        @available(OSX 55, *)
         func funcInGuardElse() { }
       }
-      guard #available(OSX 10.56, *) else { }
+      guard #available(OSX 56, *) else { }
     } else {
-      @available(OSX 10.57, *)
+      @available(OSX 57, *)
       func funcInInnerIfElse() { }
     }
   }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=functionWithUnnecessaryStmtCondition
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.53,+Inf)
-// CHECK-NEXT: {{^}}    (if_then versions=[10.53,+Inf)
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}    (if_then versions=[10.54,+Inf)
+// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=functionWithUnnecessaryStmtCondition
+// CHECK-NEXT: {{^}}    (condition_following_availability versions=[53,+Inf)
+// CHECK-NEXT: {{^}}    (if_then versions=[53,+Inf)
+// CHECK-NEXT: {{^}}    (condition_following_availability versions=[54,+Inf)
+// CHECK-NEXT: {{^}}    (if_then versions=[54,+Inf)
 
-@available(OSX 10.51, *)
+@available(OSX 51, *)
 func functionWithUnnecessaryStmtCondition() {
   // Shouldn't introduce refinement context for then branch when unnecessary
-  if #available(OSX 10.51, *) {
+  if #available(OSX 51, *) {
   }
 
   if #available(OSX 10.9, *) {
   }
 
   // Nested in conjunctive statement condition
-  if #available(OSX 10.53, *),
+  if #available(OSX 53, *),
      let x = (nil as Int?),
-     #available(OSX 10.52, *) {
+     #available(OSX 52, *) {
   }
 
-  if #available(OSX 10.54, *),
-     #available(OSX 10.54, *) {
+  if #available(OSX 54, *),
+     #available(OSX 54, *) {
   }
 
   // Wildcard is same as minimum deployment target
@@ -142,7 +142,7 @@ func functionWithUnnecessaryStmtCondition() {
   }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=functionWithUnnecessaryStmtConditionsHavingElseBranch
+// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=functionWithUnnecessaryStmtConditionsHavingElseBranch
 // CHECK-NEXT: {{^}}    (if_else versions=empty
 // CHECK-NEXT: {{^}}      (decl versions=empty decl=funcInInnerIfElse()
 // CHECK-NEXT: {{^}}    (if_else versions=empty
@@ -150,15 +150,15 @@ func functionWithUnnecessaryStmtCondition() {
 // CHECK-NEXT: {{^}}    (guard_else versions=empty
 // CHECK-NEXT: {{^}}    (if_else versions=empty
 
-@available(OSX 10.51, *)
+@available(OSX 51, *)
 func functionWithUnnecessaryStmtConditionsHavingElseBranch(p: Int?) {
   // Else branch context version is bottom when check is unnecessary
-  if #available(OSX 10.51, *) {
+  if #available(OSX 51, *) {
   } else {
-    if #available(OSX 10.52, *) {
+    if #available(OSX 52, *) {
     }
 
-    @available(OSX 10.52, *)
+    @available(OSX 52, *)
     func funcInInnerIfElse() { }
 
     if #available(iOS 7.0, *) {
@@ -188,81 +188,81 @@ func functionWithUnnecessaryStmtConditionsHavingElseBranch(p: Int?) {
   guard #available(iOS 7.0, *),
         #available(iOS 8.0, *) else { }
 
-  if #available(OSX 10.51, *),
-     #available(OSX 10.51, *) {
+  if #available(OSX 51, *),
+     #available(OSX 51, *) {
   } else {
   }
 
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=functionWithWhile()
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.52,+Inf)
-// CHECK-NEXT: {{^}}    (while_body versions=[10.52,+Inf)
-// CHECK-NEXT: {{^}}      (decl versions=[10.54,+Inf) decl=funcInWhileBody()
-@available(OSX 10.51, *)
+// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=functionWithWhile()
+// CHECK-NEXT: {{^}}    (condition_following_availability versions=[52,+Inf)
+// CHECK-NEXT: {{^}}    (while_body versions=[52,+Inf)
+// CHECK-NEXT: {{^}}      (decl versions=[54,+Inf) decl=funcInWhileBody()
+@available(OSX 51, *)
 func functionWithWhile() {
-  while #available(OSX 10.52, *),
+  while #available(OSX 52, *),
         let x = (nil as Int?) {
-    @available(OSX 10.54, *)
+    @available(OSX 54, *)
     func funcInWhileBody() { }
   }
 }
 
-// CHECK-NEXT: {{^}}  (decl_implicit versions=[10.13,+Inf) decl=extension.SomeClass
-// CHECK-NEXT: {{^}}    (decl versions=[10.51,+Inf) decl=extension.SomeClass
-// CHECK-NEXT: {{^}}      (decl_implicit versions=[10.51,+Inf) decl=someStaticPropertyWithClosureInit
-// CHECK-NEXT: {{^}}        (decl versions=[10.52,+Inf) decl=someStaticPropertyWithClosureInit
-// CHECK-NEXT: {{^}}          (condition_following_availability versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}          (if_then versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}      (decl_implicit versions=[10.51,+Inf) decl=someStaticPropertyWithClosureInitInferred
-// CHECK-NEXT: {{^}}        (decl versions=[10.52,+Inf) decl=someStaticPropertyWithClosureInitInferred
-// CHECK-NEXT: {{^}}          (condition_following_availability versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}          (if_then versions=[10.54,+Inf)
-@available(OSX 10.51, *)
+// CHECK-NEXT: {{^}}  (decl_implicit versions=[50,+Inf) decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl versions=[51,+Inf) decl=extension.SomeClass
+// CHECK-NEXT: {{^}}      (decl_implicit versions=[51,+Inf) decl=someStaticPropertyWithClosureInit
+// CHECK-NEXT: {{^}}        (decl versions=[52,+Inf) decl=someStaticPropertyWithClosureInit
+// CHECK-NEXT: {{^}}          (condition_following_availability versions=[54,+Inf)
+// CHECK-NEXT: {{^}}          (if_then versions=[54,+Inf)
+// CHECK-NEXT: {{^}}      (decl_implicit versions=[51,+Inf) decl=someStaticPropertyWithClosureInitInferred
+// CHECK-NEXT: {{^}}        (decl versions=[52,+Inf) decl=someStaticPropertyWithClosureInitInferred
+// CHECK-NEXT: {{^}}          (condition_following_availability versions=[54,+Inf)
+// CHECK-NEXT: {{^}}          (if_then versions=[54,+Inf)
+@available(OSX 51, *)
 extension SomeClass {
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   static var someStaticPropertyWithClosureInit: Int = {
-    if #available(OSX 10.54, *) {
+    if #available(OSX 54, *) {
       return 54
     }
     return 53
   }()
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   static var someStaticPropertyWithClosureInitInferred = {
-    if #available(OSX 10.54, *) {
+    if #available(OSX 54, *) {
       return 54
     }
     return 53
   }()
 }
 
-// CHECK-NEXT: {{^}}  (decl_implicit versions=[10.13,+Inf) decl=wrappedValue
+// CHECK-NEXT: {{^}}  (decl_implicit versions=[50,+Inf) decl=wrappedValue
 
 @propertyWrapper
 struct Wrapper<T> {
   var wrappedValue: T
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=SomeStruct
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someLazyVar
-// CHECK-NEXT: {{^}}      (condition_following_availability versions=[10.52,+Inf)
-// CHECK-NEXT: {{^}}      (guard_fallthrough versions=[10.52,+Inf)
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someWrappedVar
-// CHECK-NEXT: {{^}}      (condition_following_availability versions=[10.52,+Inf)
-// CHECK-NEXT: {{^}}      (guard_fallthrough versions=[10.52,+Inf)
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someMethodAvailable52()
-@available(OSX 10.51, *)
+// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=SomeStruct
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=someLazyVar
+// CHECK-NEXT: {{^}}      (condition_following_availability versions=[52,+Inf)
+// CHECK-NEXT: {{^}}      (guard_fallthrough versions=[52,+Inf)
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=someWrappedVar
+// CHECK-NEXT: {{^}}      (condition_following_availability versions=[52,+Inf)
+// CHECK-NEXT: {{^}}      (guard_fallthrough versions=[52,+Inf)
+// CHECK-NEXT: {{^}}    (decl versions=[52,+Inf) decl=someMethodAvailable52()
+@available(OSX 51, *)
 struct SomeStruct {
   lazy var someLazyVar = {
-    guard #available(OSX 10.52, *) else {
+    guard #available(OSX 52, *) else {
       return someMethod()
     }
     return someMethodAvailable52()
   }()
 
   @Wrapper var someWrappedVar = {
-    guard #available(OSX 10.52, *) else {
+    guard #available(OSX 52, *) else {
       return 51
     }
     return 52
@@ -270,6 +270,6 @@ struct SomeStruct {
 
   func someMethod() -> Int { return 51 }
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   func someMethodAvailable52() -> Int { return 52 }
 }

--- a/test/Sema/availability_script_mode.swift
+++ b/test/Sema/availability_script_mode.swift
@@ -1,14 +1,14 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx50
 
 // REQUIRES: OS=macosx
 
 struct AlwaysAvailable {}
 
-@available(macOS, introduced: 10.50)
-struct Available10_50 {}
+@available(macOS, introduced: 50)
+struct Available50 {}
 
-@available(macOS, introduced: 10.51)
-struct Available10_51 {}
+@available(macOS, introduced: 51)
+struct Available51 {}
 
 @available(macOS, unavailable)
 struct UnavailableOnMacOS {}
@@ -18,14 +18,14 @@ struct UnavailableUnconditionally {}
 
 var alwaysAvailableVar: AlwaysAvailable = .init() // Ok
 
-@available(macOS, introduced: 10.50)
-var availableOn10_50Var: Available10_50 = .init() // Ok
+@available(macOS, introduced: 50)
+var availableOn50Var: Available50 = .init() // Ok
 
 // Script-mode globals have eagerly executed initializers so it isn't safe for
 // them to be unavailable.
 
-@available(macOS, introduced: 10.51) // expected-error {{global variable cannot be marked potentially unavailable with '@available' in script mode}}
-var potentiallyUnavailableVar: Available10_51 = .init()
+@available(macOS, introduced: 51) // expected-error {{global variable cannot be marked potentially unavailable with '@available' in script mode}}
+var potentiallyUnavailableVar: Available51 = .init()
 
 @available(macOS, unavailable) // expected-error {{global variable cannot be marked unavailable with '@available' in script mode}}
 var unavailableOnMacOSVar: UnavailableOnMacOS = .init()

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1,8 +1,8 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50 -disable-objc-attr-requires-foundation-module
-// RUN: not %target-swift-frontend -target %target-cpu-apple-macosx10.50 -disable-objc-attr-requires-foundation-module -typecheck %s 2>&1 | %FileCheck %s '--implicit-check-not=<unknown>:0'
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx50 -disable-objc-attr-requires-foundation-module
+// RUN: not %target-swift-frontend -target %target-cpu-apple-macosx50 -disable-objc-attr-requires-foundation-module -typecheck %s 2>&1 | %FileCheck %s '--implicit-check-not=<unknown>:0'
 
 // Make sure we do not emit availability errors or warnings when -disable-availability-checking is passed
-// RUN: not %target-swift-frontend -target %target-cpu-apple-macosx10.50 -typecheck -disable-objc-attr-requires-foundation-module -disable-availability-checking %s -diagnostic-style llvm 2>&1 | %FileCheck %s '--implicit-check-not=error:' '--implicit-check-not=warning:'
+// RUN: not %target-swift-frontend -target %target-cpu-apple-macosx50 -typecheck -disable-objc-attr-requires-foundation-module -disable-availability-checking %s -diagnostic-style llvm 2>&1 | %FileCheck %s '--implicit-check-not=error:' '--implicit-check-not=warning:'
 
 // REQUIRES: OS=macosx
 
@@ -11,19 +11,19 @@ func markUsed<T>(_ t: T) {}
 @available(OSX, introduced: 10.9)
 func globalFuncAvailableOn10_9() -> Int { return 9 }
 
-@available(OSX, introduced: 10.51)
-func globalFuncAvailableOn10_51() -> Int { return 10 }
+@available(OSX, introduced: 51)
+func globalFuncAvailableOn51() -> Int { return 10 }
 
-@available(OSX, introduced: 10.52)
-func globalFuncAvailableOn10_52() -> Int { return 11 }
+@available(OSX, introduced: 52)
+func globalFuncAvailableOn52() -> Int { return 11 }
 
 // Top level should reflect the minimum deployment target.
 let ignored1: Int = globalFuncAvailableOn10_9()
 
-let ignored2: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+let ignored2: Int = globalFuncAvailableOn51() // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let ignored3: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+let ignored3: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Functions without annotations should reflect the minimum deployment target.
@@ -32,87 +32,87 @@ func functionWithoutAvailability() {
 
   let _: Int = globalFuncAvailableOn10_9()
 
-  let _: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+  let _: Int = globalFuncAvailableOn51() // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+  let _: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Functions with annotations should refine their bodies.
-@available(OSX, introduced: 10.51)
-func functionAvailableOn10_51() {
+@available(OSX, introduced: 51)
+func functionAvailableOn51() {
   let _: Int = globalFuncAvailableOn10_9()
-  let _: Int = globalFuncAvailableOn10_51()
+  let _: Int = globalFuncAvailableOn51()
 
   // Nested functions should get their own refinement context.
-  @available(OSX, introduced: 10.52)
-  func innerFunctionAvailableOn10_52() {
+  @available(OSX, introduced: 52)
+  func innerFunctionAvailableOn52() {
     let _: Int = globalFuncAvailableOn10_9()
-    let _: Int = globalFuncAvailableOn10_51()
-    let _: Int = globalFuncAvailableOn10_52()
+    let _: Int = globalFuncAvailableOn51()
+    let _: Int = globalFuncAvailableOn52()
   }
 
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+  let _: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Still allow other availability annotations on script-mode globals
-@available(OSX, deprecated: 10.51)
+@available(OSX, deprecated: 51)
 var deprecatedGlobalInScriptMode: Int = 5
 
-if #available(OSX 10.51, *) {
-  let _: Int = globalFuncAvailableOn10_51()
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+if #available(OSX 51, *) {
+  let _: Int = globalFuncAvailableOn51()
+  let _: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-if #available(OSX 10.51, *) {
-  let _: Int = globalFuncAvailableOn10_51()
-  let _: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+if #available(OSX 51, *) {
+  let _: Int = globalFuncAvailableOn51()
+  let _: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 } else {
   let _: Int = globalFuncAvailableOn10_9()
-  let _: Int = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+  let _: Int = globalFuncAvailableOn51() // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 @available(iOS, introduced: 8.0)
-func globalFuncAvailableOnOSX10_51AndiOS8_0() -> Int { return 10 }
+func globalFuncAvailableOnOSX51AndiOS8_0() -> Int { return 10 }
 
-if #available(OSX 10.51, iOS 8.0, *) {
-  let _: Int = globalFuncAvailableOnOSX10_51AndiOS8_0()
+if #available(OSX 51, iOS 8.0, *) {
+  let _: Int = globalFuncAvailableOnOSX51AndiOS8_0()
 }
 
 if #available(iOS 9.0, *) {
-  let _: Int = globalFuncAvailableOnOSX10_51AndiOS8_0() // expected-error {{'globalFuncAvailableOnOSX10_51AndiOS8_0()' is only available in macOS 10.51 or newer}}
+  let _: Int = globalFuncAvailableOnOSX51AndiOS8_0() // expected-error {{'globalFuncAvailableOnOSX51AndiOS8_0()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Multiple potentially unavailable references in a single statement
 
-let ignored4: (Int, Int) = (globalFuncAvailableOn10_51(), globalFuncAvailableOn10_52()) // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}  expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+let ignored4: (Int, Int) = (globalFuncAvailableOn51(), globalFuncAvailableOn52()) // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}  expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
     // expected-note@-1 2{{add 'if #available' version check}}
 
 
 _ = globalFuncAvailableOn10_9()
 
-let ignored5 = globalFuncAvailableOn10_51 // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+let ignored5 = globalFuncAvailableOn51 // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-_ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+_ = globalFuncAvailableOn51() // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Overloaded global functions
 @available(OSX, introduced: 10.9)
 func overloadedFunction() {}
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 func overloadedFunction(_ on1010: Int) {}
 
 overloadedFunction()
-overloadedFunction(0) // expected-error {{'overloadedFunction' is only available in macOS 10.51 or newer}}
+overloadedFunction(0) // expected-error {{'overloadedFunction' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Potentially unavailable methods
@@ -123,17 +123,17 @@ class ClassWithPotentiallyUnavailableMethod {
   @available(OSX, introduced: 10.9)
   func methAvailableOn10_9() {}
   
-  @available(OSX, introduced: 10.51)
-  func methAvailableOn10_51() {}
+  @available(OSX, introduced: 51)
+  func methAvailableOn51() {}
   
-  @available(OSX, introduced: 10.51)
-  class func classMethAvailableOn10_51() {}
+  @available(OSX, introduced: 51)
+  class func classMethAvailableOn51() {}
   
   func someOtherMethod() {
     // expected-note@-1 {{add @available attribute to enclosing instance method}}
 
     methAvailableOn10_9()
-    methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+    methAvailableOn51() // expected-error {{'methAvailableOn51()' is only available in macOS 51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
@@ -144,13 +144,13 @@ func callPotentiallyUnavailableMethods(_ o: ClassWithPotentiallyUnavailableMetho
   let m10_9 = o.methAvailableOn10_9
   m10_9()
   
-  let m10_51 = o.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+  let m51 = o.methAvailableOn51 // expected-error {{'methAvailableOn51()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  m10_51()
+  m51()
   
   o.methAvailableOn10_9()
-  o.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+  o.methAvailableOn51() // expected-error {{'methAvailableOn51()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -160,27 +160,27 @@ func callPotentiallyUnavailableMethodsViaIUO(_ o: ClassWithPotentiallyUnavailabl
   let m10_9 = o.methAvailableOn10_9
   m10_9()
   
-  let m10_51 = o.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+  let m51 = o.methAvailableOn51 // expected-error {{'methAvailableOn51()' is only available in macOS 51 or newer}}
       
       // expected-note@-2 {{add 'if #available' version check}}
 
-  m10_51()
+  m51()
   
   o.methAvailableOn10_9()
-  o.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+  o.methAvailableOn51() // expected-error {{'methAvailableOn51()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 func callPotentiallyUnavailableClassMethod() {
       // expected-note@-1 2{{add @available attribute to enclosing global function}}
 
-  ClassWithPotentiallyUnavailableMethod.classMethAvailableOn10_51() // expected-error {{'classMethAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+  ClassWithPotentiallyUnavailableMethod.classMethAvailableOn51() // expected-error {{'classMethAvailableOn51()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
-  let m10_51 = ClassWithPotentiallyUnavailableMethod.classMethAvailableOn10_51 // expected-error {{'classMethAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+  let m51 = ClassWithPotentiallyUnavailableMethod.classMethAvailableOn51 // expected-error {{'classMethAvailableOn51()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  m10_51()
+  m51()
 }
 
 class SubClassWithPotentiallyUnavailableMethod : ClassWithPotentiallyUnavailableMethod {
@@ -189,7 +189,7 @@ class SubClassWithPotentiallyUnavailableMethod : ClassWithPotentiallyUnavailable
         // expected-note@-1 {{add @available attribute to enclosing instance method}}
 
     methAvailableOn10_9()
-    methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+    methAvailableOn51() // expected-error {{'methAvailableOn51()' is only available in macOS 51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
@@ -197,24 +197,24 @@ class SubClassWithPotentiallyUnavailableMethod : ClassWithPotentiallyUnavailable
 class SubClassOverridingPotentiallyUnavailableMethod : ClassWithPotentiallyUnavailableMethod {
         // expected-note@-1 2{{add @available attribute to enclosing class}}
 
-  override func methAvailableOn10_51() {
+  override func methAvailableOn51() {
         // expected-note@-1 2{{add @available attribute to enclosing instance method}}
     methAvailableOn10_9()
-    super.methAvailableOn10_51() // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+    super.methAvailableOn51() // expected-error {{'methAvailableOn51()' is only available in macOS 51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
     let m10_9 = super.methAvailableOn10_9
     m10_9()
     
-    let m10_51 = super.methAvailableOn10_51 // expected-error {{'methAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+    let m51 = super.methAvailableOn51 // expected-error {{'methAvailableOn51()' is only available in macOS 51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
-    m10_51()
+    m51()
   }
   
   func someMethod() {
     methAvailableOn10_9()
     // Calling our override should be fine
-    methAvailableOn10_51()
+    methAvailableOn51()
   }
 }
 
@@ -260,7 +260,7 @@ class ClassWithPotentiallyUnavailableOverloadedMethod {
   @available(OSX, introduced: 10.9)
   func overloadedMethod() {}
 
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   func overloadedMethod(_ on1010: Int) {}
 }
 
@@ -268,7 +268,7 @@ func callPotentiallyUnavailableOverloadedMethod(_ o: ClassWithPotentiallyUnavail
       // expected-note@-1 {{add @available attribute to enclosing global function}}
 
   o.overloadedMethod()
-  o.overloadedMethod(0) // expected-error {{'overloadedMethod' is only available in macOS 10.51 or newer}}
+  o.overloadedMethod(0) // expected-error {{'overloadedMethod' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -280,17 +280,17 @@ class ClassWithPotentiallyUnavailableInitializer {
   @available(OSX, introduced: 10.9)
   required init() {  }
   
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   required init(_ val: Int) {  }
   
   convenience init(s: String) {
         // expected-note@-1 {{add @available attribute to enclosing initializer}}
     
-    self.init(5) // expected-error {{'init(_:)' is only available in macOS 10.51 or newer}}
+    self.init(5) // expected-error {{'init(_:)' is only available in macOS 51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   convenience init(onlyOn1010: String) {
     self.init(5)
   }
@@ -300,12 +300,12 @@ func callPotentiallyUnavailableInitializer() {
       // expected-note@-1 2{{add @available attribute to enclosing global function}}
 
   _ = ClassWithPotentiallyUnavailableInitializer()
-  _ = ClassWithPotentiallyUnavailableInitializer(5) // expected-error {{'init(_:)' is only available in macOS 10.51 or newer}}
+  _ = ClassWithPotentiallyUnavailableInitializer(5) // expected-error {{'init(_:)' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   let i = ClassWithPotentiallyUnavailableInitializer.self
   _ = i.init()
-  _ = i.init(5) // expected-error {{'init(_:)' is only available in macOS 10.51 or newer}}
+  _ = i.init(5) // expected-error {{'init(_:)' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -313,7 +313,7 @@ class SuperWithWithPotentiallyUnavailableInitializer {
   @available(OSX, introduced: 10.9)
   init() {  }
   
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   init(_ val: Int) {  }
 }
 
@@ -323,7 +323,7 @@ class SubOfClassWithPotentiallyUnavailableInitializer : SuperWithWithPotentially
   override init(_ val: Int) {
         // expected-note@-1 {{add @available attribute to enclosing initializer}}
 
-    super.init(5) // expected-error {{'init(_:)' is only available in macOS 10.51 or newer}}
+    super.init(5) // expected-error {{'init(_:)' is only available in macOS 51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
   
@@ -331,7 +331,7 @@ class SubOfClassWithPotentiallyUnavailableInitializer : SuperWithWithPotentially
     super.init()
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   init(on1010: Int) {
     super.init(22)
   }
@@ -344,30 +344,30 @@ class ClassWithPotentiallyUnavailableProperties {
 
   var nonLazyAvailableOn10_9Stored: Int = 9
 
-  @available(OSX, introduced: 10.51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
-  var nonLazyAvailableOn10_51Stored : Int = 10
+  @available(OSX, introduced: 51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  var nonLazyAvailableOn51Stored : Int = 10
 
-  @available(OSX, introduced: 10.51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
-  let nonLazyLetAvailableOn10_51Stored : Int = 10
+  @available(OSX, introduced: 51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  let nonLazyLetAvailableOn51Stored : Int = 10
 
   // Make sure that we don't emit a Fix-It to mark a stored property as potentially unavailable.
   // We don't support potentially unavailable stored properties yet.
-  var storedPropertyOfPotentiallyUnavailableType: ClassAvailableOn10_51? = nil // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  var storedPropertyOfPotentiallyUnavailableType: ClassAvailableOn51? = nil // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
 
   @available(OSX, introduced: 10.9)
   lazy var availableOn10_9Stored: Int = 9
   
-  @available(OSX, introduced: 10.51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
-  lazy var availableOn10_51Stored : Int = 10
+  @available(OSX, introduced: 51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  lazy var availableOn51Stored : Int = 10
 
   @available(OSX, introduced: 10.9)
   var availableOn10_9Computed: Int {
     get {
-      let _: Int = availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available in macOS 10.51 or newer}}
+      let _: Int = availableOn51Stored // expected-error {{'availableOn51Stored' is only available in macOS 51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
       
-      if #available(OSX 10.51, *) {
-        let _: Int = availableOn10_51Stored
+      if #available(OSX 51, *) {
+        let _: Int = availableOn51Stored
       }
       
       return availableOn10_9Stored
@@ -377,63 +377,63 @@ class ClassWithPotentiallyUnavailableProperties {
     }
   }
   
-  @available(OSX, introduced: 10.51)
-  var availableOn10_51Computed: Int {
+  @available(OSX, introduced: 51)
+  var availableOn51Computed: Int {
     get {
-      return availableOn10_51Stored
+      return availableOn51Stored
     }
     set(newVal) {
-      availableOn10_51Stored = newVal
+      availableOn51Stored = newVal
     }
   }
   
-  var propWithSetterOnlyAvailableOn10_51 : Int {
+  var propWithSetterOnlyAvailableOn51 : Int {
       // expected-note@-1 {{add @available attribute to enclosing property}}
     get {
-      _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+      _ = globalFuncAvailableOn51() // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
       return 0
     }
-    @available(OSX, introduced: 10.51)
+    @available(OSX, introduced: 51)
     set(newVal) {
-    _ = globalFuncAvailableOn10_51()
+    _ = globalFuncAvailableOn51()
     }
   }
   
-  var propWithGetterOnlyAvailableOn10_51 : Int {
+  var propWithGetterOnlyAvailableOn51 : Int {
       // expected-note@-1 {{add @available attribute to enclosing property}}
-    @available(OSX, introduced: 10.51)
+    @available(OSX, introduced: 51)
     get {
-      _ = globalFuncAvailableOn10_51()
+      _ = globalFuncAvailableOn51()
       return 0
     }
     set(newVal) {
-      _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+      _ = globalFuncAvailableOn51() // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
     }
   }
   
-  var propWithGetterAndSetterOnlyAvailableOn10_51 : Int {
-    @available(OSX, introduced: 10.51)
+  var propWithGetterAndSetterOnlyAvailableOn51 : Int {
+    @available(OSX, introduced: 51)
     get {
       return 0
     }
-    @available(OSX, introduced: 10.51)
+    @available(OSX, introduced: 51)
     set(newVal) {
     }
   }
   
-  var propWithSetterOnlyAvailableOn10_51ForNestedMemberRef : ClassWithPotentiallyUnavailableProperties {
+  var propWithSetterOnlyAvailableOn51ForNestedMemberRef : ClassWithPotentiallyUnavailableProperties {
     get {
       return ClassWithPotentiallyUnavailableProperties()
     }
-    @available(OSX, introduced: 10.51)
+    @available(OSX, introduced: 51)
     set(newVal) {
     }
   }
   
-  var propWithGetterOnlyAvailableOn10_51ForNestedMemberRef : ClassWithPotentiallyUnavailableProperties {
-    @available(OSX, introduced: 10.51)
+  var propWithGetterOnlyAvailableOn51ForNestedMemberRef : ClassWithPotentiallyUnavailableProperties {
+    @available(OSX, introduced: 51)
     get {
       return ClassWithPotentiallyUnavailableProperties()
     }
@@ -442,82 +442,82 @@ class ClassWithPotentiallyUnavailableProperties {
   }
 }
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 class ClassWithReferencesInInitializers {
-  var propWithInitializer10_51: Int = globalFuncAvailableOn10_51()
+  var propWithInitializer51: Int = globalFuncAvailableOn51()
 
-  var propWithInitializer10_52: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+  var propWithInitializer52: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
 
-  lazy var lazyPropWithInitializer10_51: Int = globalFuncAvailableOn10_51()
+  lazy var lazyPropWithInitializer51: Int = globalFuncAvailableOn51()
 
-  lazy var lazyPropWithInitializer10_52: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+  lazy var lazyPropWithInitializer52: Int = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
 }
 
 func accessPotentiallyUnavailableProperties(_ o: ClassWithPotentiallyUnavailableProperties) {
       // expected-note@-1 17{{add @available attribute to enclosing global function}}
   // Stored properties
   let _: Int = o.availableOn10_9Stored
-  let _: Int = o.availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available in macOS 10.51 or newer}}
+  let _: Int = o.availableOn51Stored // expected-error {{'availableOn51Stored' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   o.availableOn10_9Stored = 9
-  o.availableOn10_51Stored = 10 // expected-error {{'availableOn10_51Stored' is only available in macOS 10.51 or newer}}
+  o.availableOn51Stored = 10 // expected-error {{'availableOn51Stored' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   // Computed Properties
   let _: Int = o.availableOn10_9Computed
-  let _: Int = o.availableOn10_51Computed // expected-error {{'availableOn10_51Computed' is only available in macOS 10.51 or newer}}
+  let _: Int = o.availableOn51Computed // expected-error {{'availableOn51Computed' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   o.availableOn10_9Computed = 9
-  o.availableOn10_51Computed = 10 // expected-error {{'availableOn10_51Computed' is only available in macOS 10.51 or newer}}
+  o.availableOn51Computed = 10 // expected-error {{'availableOn51Computed' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   // Getter allowed on 10.9 but setter is not
-  let _: Int = o.propWithSetterOnlyAvailableOn10_51
-  o.propWithSetterOnlyAvailableOn10_51 = 5 // expected-error {{setter for 'propWithSetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _: Int = o.propWithSetterOnlyAvailableOn51
+  o.propWithSetterOnlyAvailableOn51 = 5 // expected-error {{setter for 'propWithSetterOnlyAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
-  if #available(OSX 10.51, *) {
-    // Setter is allowed on 10.51 and greater
-    o.propWithSetterOnlyAvailableOn10_51 = 5
+  if #available(OSX 51, *) {
+    // Setter is allowed on 51 and greater
+    o.propWithSetterOnlyAvailableOn51 = 5
   }
   
   // Setter allowed on 10.9 but getter is not
-  o.propWithGetterOnlyAvailableOn10_51 = 5
-  let _: Int = o.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  o.propWithGetterOnlyAvailableOn51 = 5
+  let _: Int = o.propWithGetterOnlyAvailableOn51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  if #available(OSX 10.51, *) {
-    // Getter is allowed on 10.51 and greater
-    let _: Int = o.propWithGetterOnlyAvailableOn10_51
+  if #available(OSX 51, *) {
+    // Getter is allowed on 51 and greater
+    let _: Int = o.propWithGetterOnlyAvailableOn51
   }
   
   // Tests for nested member refs
   
   // Both getters are potentially unavailable.
-  let _: Int = o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available in macOS 10.51 or newer}} expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _: Int = o.propWithGetterOnlyAvailableOn51ForNestedMemberRef.propWithGetterOnlyAvailableOn51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn51ForNestedMemberRef' is only available in macOS 51 or newer}} expected-error {{getter for 'propWithGetterOnlyAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 2{{add 'if #available' version check}}
 
   // Nested getter is potentially unavailable, outer getter is available
-  let _: Int = o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.propWithSetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available in macOS 10.51 or newer}}
+  let _: Int = o.propWithGetterOnlyAvailableOn51ForNestedMemberRef.propWithSetterOnlyAvailableOn51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn51ForNestedMemberRef' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   // Nested getter is available, outer getter is potentially unavailable
-  let _:Int = o.propWithSetterOnlyAvailableOn10_51ForNestedMemberRef.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _:Int = o.propWithSetterOnlyAvailableOn51ForNestedMemberRef.propWithGetterOnlyAvailableOn51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   // Both getters are always available.
-  let _: Int = o.propWithSetterOnlyAvailableOn10_51ForNestedMemberRef.propWithSetterOnlyAvailableOn10_51
+  let _: Int = o.propWithSetterOnlyAvailableOn51ForNestedMemberRef.propWithSetterOnlyAvailableOn51
   
   
   // Nesting in source of assignment
   var v: Int
 
-  v = o.propWithGetterOnlyAvailableOn10_51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  v = o.propWithGetterOnlyAvailableOn51 // expected-error {{getter for 'propWithGetterOnlyAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  v = (o.propWithGetterOnlyAvailableOn10_51) // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  v = (o.propWithGetterOnlyAvailableOn51) // expected-error {{getter for 'propWithGetterOnlyAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   _ = v // muffle warning
@@ -526,86 +526,86 @@ func accessPotentiallyUnavailableProperties(_ o: ClassWithPotentiallyUnavailable
   
   func takesInout(_ i : inout Int) { }
   
-  takesInout(&o.propWithGetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because getter for 'propWithGetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  takesInout(&o.propWithGetterOnlyAvailableOn51) // expected-error {{cannot pass as inout because getter for 'propWithGetterOnlyAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  takesInout(&o.propWithSetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because setter for 'propWithSetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  takesInout(&o.propWithSetterOnlyAvailableOn51) // expected-error {{cannot pass as inout because setter for 'propWithSetterOnlyAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
-  takesInout(&o.propWithGetterAndSetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because getter for 'propWithGetterAndSetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}} expected-error {{cannot pass as inout because setter for 'propWithGetterAndSetterOnlyAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  takesInout(&o.propWithGetterAndSetterOnlyAvailableOn51) // expected-error {{cannot pass as inout because getter for 'propWithGetterAndSetterOnlyAvailableOn51' is only available in macOS 51 or newer}} expected-error {{cannot pass as inout because setter for 'propWithGetterAndSetterOnlyAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 2{{add 'if #available' version check}}
 
   takesInout(&o.availableOn10_9Computed)
-  takesInout(&o.propWithGetterOnlyAvailableOn10_51ForNestedMemberRef.availableOn10_9Computed) // expected-error {{getter for 'propWithGetterOnlyAvailableOn10_51ForNestedMemberRef' is only available in macOS 10.51 or newer}}
+  takesInout(&o.propWithGetterOnlyAvailableOn51ForNestedMemberRef.availableOn10_9Computed) // expected-error {{getter for 'propWithGetterOnlyAvailableOn51ForNestedMemberRef' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // _silgen_name
 
 @_silgen_name("SomeName")
-@available(OSX, introduced: 10.51)
-func funcWith_silgen_nameAvailableOn10_51(_ p: ClassAvailableOn10_51?) -> ClassAvailableOn10_51
+@available(OSX, introduced: 51)
+func funcWith_silgen_nameAvailableOn51(_ p: ClassAvailableOn51?) -> ClassAvailableOn51
 
 // Enums
 
-@available(OSX, introduced: 10.51)
-enum EnumIntroducedOn10_51 {
+@available(OSX, introduced: 51)
+enum EnumIntroducedOn51 {
  case Element
 }
 
-@available(OSX, introduced: 10.52)
-enum EnumIntroducedOn10_52 {
+@available(OSX, introduced: 52)
+enum EnumIntroducedOn52 {
  case Element
 }
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 enum CompassPoint {
   case North
   case South
   case East
 
-  @available(OSX, introduced: 10.52)
+  @available(OSX, introduced: 52)
   case West
 
-  case WithAvailableByEnumPayload(p : EnumIntroducedOn10_51)
+  case WithAvailableByEnumPayload(p : EnumIntroducedOn51)
 
   // expected-error@+1 {{enum cases with associated values cannot be marked potentially unavailable with '@available'}}
-  @available(OSX, introduced: 10.52)
-  case WithAvailableByEnumElementPayload(p : EnumIntroducedOn10_52)
+  @available(OSX, introduced: 52)
+  case WithAvailableByEnumElementPayload(p : EnumIntroducedOn52)
 
   // expected-error@+1 2{{enum cases with associated values cannot be marked potentially unavailable with '@available'}}
-  @available(OSX, introduced: 10.52)
-  case WithAvailableByEnumElementPayload1(p : EnumIntroducedOn10_52), WithAvailableByEnumElementPayload2(p : EnumIntroducedOn10_52)
+  @available(OSX, introduced: 52)
+  case WithAvailableByEnumElementPayload1(p : EnumIntroducedOn52), WithAvailableByEnumElementPayload2(p : EnumIntroducedOn52)
 
-  case WithPotentiallyUnavailablePayload(p : EnumIntroducedOn10_52) // expected-error {{'EnumIntroducedOn10_52' is only available in macOS 10.52 or newer}}
+  case WithPotentiallyUnavailablePayload(p : EnumIntroducedOn52) // expected-error {{'EnumIntroducedOn52' is only available in macOS 52 or newer}}
 
-  case WithPotentiallyUnavailablePayload1(p : EnumIntroducedOn10_52), WithPotentiallyUnavailablePayload2(p : EnumIntroducedOn10_52) // expected-error 2{{'EnumIntroducedOn10_52' is only available in macOS 10.52 or newer}}
+  case WithPotentiallyUnavailablePayload1(p : EnumIntroducedOn52), WithPotentiallyUnavailablePayload2(p : EnumIntroducedOn52) // expected-error 2{{'EnumIntroducedOn52' is only available in macOS 52 or newer}}
   
   @available(OSX, unavailable)
-  case WithPotentiallyUnavailablePayload3(p : EnumIntroducedOn10_52)
+  case WithPotentiallyUnavailablePayload3(p : EnumIntroducedOn52)
 }
 
-@available(OSX, introduced: 10.52)
-func functionTakingEnumIntroducedOn10_52(_ e: EnumIntroducedOn10_52) { }
+@available(OSX, introduced: 52)
+func functionTakingEnumIntroducedOn52(_ e: EnumIntroducedOn52) { }
 
 func useEnums() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
-  let _: CompassPoint = .North // expected-error {{'CompassPoint' is only available in macOS 10.51 or newer}}
+  let _: CompassPoint = .North // expected-error {{'CompassPoint' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  if #available(OSX 10.51, *) {
+  if #available(OSX 51, *) {
     let _: CompassPoint = .North
 
-    let _: CompassPoint = .West // expected-error {{'West' is only available in macOS 10.52 or newer}}
+    let _: CompassPoint = .West // expected-error {{'West' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 
-  if #available(OSX 10.52, *) {
+  if #available(OSX 52, *) {
     let _: CompassPoint = .West
   }
 
   // Pattern matching on an enum element does not require it to be definitely available
-  if #available(OSX 10.51, *) {
+  if #available(OSX 51, *) {
     let point: CompassPoint = .North
     switch (point) {
       case .North, .South, .East:
@@ -631,7 +631,7 @@ func useEnums() {
 
         // For the moment, we do not incorporate enum element availability into 
         // TRC construction. Perhaps we should?
-        functionTakingEnumIntroducedOn10_52(p)  // expected-error {{'functionTakingEnumIntroducedOn10_52' is only available in macOS 10.52 or newer}}
+        functionTakingEnumIntroducedOn52(p)  // expected-error {{'functionTakingEnumIntroducedOn52' is only available in macOS 52 or newer}}
           
           // expected-note@-2 {{add 'if #available' version check}}
     }
@@ -647,11 +647,11 @@ class ClassAvailableOn10_9 {
   var someProp : Int = 22
 }
 
-@available(OSX, introduced: 10.51)
-class ClassAvailableOn10_51 { // expected-note {{enclosing scope requires availability of macOS 10.51 or newer}}
+@available(OSX, introduced: 51)
+class ClassAvailableOn51 { // expected-note {{enclosing scope requires availability of macOS 51 or newer}}
   func someMethod() {}
   class func someClassMethod() {
-    let _ = ClassAvailableOn10_51()
+    let _ = ClassAvailableOn51()
   }
   var someProp : Int = 22
 
@@ -664,9 +664,9 @@ class ClassAvailableOn10_51 { // expected-note {{enclosing scope requires availa
   @available(*, unavailable)
   func someMethodUniversallyUnavailable() { }
 
-  @available(OSX, introduced: 10.52)
-  var propWithGetter: Int { // expected-note{{enclosing scope requires availability of macOS 10.52 or newer}}
-    @available(OSX, introduced: 10.51) // expected-error {{getter cannot be more available than enclosing scope}}
+  @available(OSX, introduced: 52)
+  var propWithGetter: Int { // expected-note{{enclosing scope requires availability of macOS 52 or newer}}
+    @available(OSX, introduced: 51) // expected-error {{getter cannot be more available than enclosing scope}}
     get { return 0 }
   }
 }
@@ -674,33 +674,33 @@ class ClassAvailableOn10_51 { // expected-note {{enclosing scope requires availa
 func classAvailability() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
   ClassAvailableOn10_9.someClassMethod()
-  ClassAvailableOn10_51.someClassMethod() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  ClassAvailableOn51.someClassMethod() // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   _ = ClassAvailableOn10_9.self
-  _ = ClassAvailableOn10_51.self // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  _ = ClassAvailableOn51.self // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   let o10_9 = ClassAvailableOn10_9()
-  let o10_51 = ClassAvailableOn10_51() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let o51 = ClassAvailableOn51() // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   o10_9.someMethod()
-  o10_51.someMethod()
+  o51.someMethod()
   
   let _ = o10_9.someProp
-  let _ = o10_51.someProp 
+  let _ = o51.someProp 
 }
 
 func castingPotentiallyUnavailableClass(_ o : AnyObject) {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
-  let _ = o as! ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _ = o as! ClassAvailableOn51 // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = o as? ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _ = o as? ClassAvailableOn51 // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = o is ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _ = o is ClassAvailableOn51 // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -708,8 +708,8 @@ protocol Creatable {
   init()
 }
 
-@available(OSX, introduced: 10.51)
-class ClassAvailableOn10_51_Creatable : Creatable {
+@available(OSX, introduced: 51)
+class ClassAvailableOn51_Creatable : Creatable {
   required init() {}
 }
 
@@ -723,30 +723,30 @@ class ClassWithTwoGenericTypeParameter<T, S> { }
 
 func classViaTypeParameter() {
   // expected-note@-1 9{{add @available attribute to enclosing global function}}
-  let _ : ClassAvailableOn10_51_Creatable = // expected-error {{'ClassAvailableOn10_51_Creatable' is only available in macOS 10.51 or newer}}
+  let _ : ClassAvailableOn51_Creatable = // expected-error {{'ClassAvailableOn51_Creatable' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
       create()
       
   let _ = create() as
-      ClassAvailableOn10_51_Creatable // expected-error {{'ClassAvailableOn10_51_Creatable' is only available in macOS 10.51 or newer}}
+      ClassAvailableOn51_Creatable // expected-error {{'ClassAvailableOn51_Creatable' is only available in macOS 51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = [ClassAvailableOn10_51]() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _ = [ClassAvailableOn51]() // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithGenericTypeParameter<ClassAvailableOn10_51> = ClassWithGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _: ClassWithGenericTypeParameter<ClassAvailableOn51> = ClassWithGenericTypeParameter() // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn10_51, String> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn51, String> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithTwoGenericTypeParameter<String, ClassAvailableOn10_51> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _: ClassWithTwoGenericTypeParameter<String, ClassAvailableOn51> = ClassWithTwoGenericTypeParameter() // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn10_51, ClassAvailableOn10_51> = ClassWithTwoGenericTypeParameter() // expected-error 2{{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _: ClassWithTwoGenericTypeParameter<ClassAvailableOn51, ClassAvailableOn51> = ClassWithTwoGenericTypeParameter() // expected-error 2{{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 2{{add 'if #available' version check}}
 
-  let _: ClassAvailableOn10_51? = nil // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _: ClassAvailableOn51? = nil // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
 }
@@ -756,79 +756,79 @@ func classViaTypeParameter() {
 class ClassWithDeclarationsOfPotentiallyUnavailableClasses {
       // expected-note@-1 6{{add @available attribute to enclosing class}}
 
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   init() {}
 
-  var propertyOfPotentiallyUnavailableType: ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  var propertyOfPotentiallyUnavailableType: ClassAvailableOn51 // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
   
-  @available(OSX, introduced: 10.51)
-  static var potentiallyUnavailableStaticPropertyOfPotentiallyUnavailableType: ClassAvailableOn10_51 = ClassAvailableOn10_51()
+  @available(OSX, introduced: 51)
+  static var potentiallyUnavailableStaticPropertyOfPotentiallyUnavailableType: ClassAvailableOn51 = ClassAvailableOn51()
 
-  @available(OSX, introduced: 10.51)
-  static var potentiallyUnavailableStaticPropertyOfOptionalPotentiallyUnavailableType: ClassAvailableOn10_51?
+  @available(OSX, introduced: 51)
+  static var potentiallyUnavailableStaticPropertyOfOptionalPotentiallyUnavailableType: ClassAvailableOn51?
 
-  func methodWithPotentiallyUnavailableParameterType(_ o : ClassAvailableOn10_51) { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  func methodWithPotentiallyUnavailableParameterType(_ o : ClassAvailableOn51) { // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
   }
   
-  @available(OSX, introduced: 10.51)
-  func potentiallyUnavailableMethodWithPotentiallyUnavailableParameterType(_ o : ClassAvailableOn10_51) {}
+  @available(OSX, introduced: 51)
+  func potentiallyUnavailableMethodWithPotentiallyUnavailableParameterType(_ o : ClassAvailableOn51) {}
   
-  func methodWithPotentiallyUnavailableReturnType() -> ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  func methodWithPotentiallyUnavailableReturnType() -> ClassAvailableOn51 { // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 2{{add @available attribute to enclosing instance method}}
 
-    return ClassAvailableOn10_51() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+    return ClassAvailableOn51() // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   }
 
   @available(OSX, unavailable)
-  func unavailableMethodWithPotentiallyUnavailableParameterType(_ o : ClassAvailableOn10_51) {}
+  func unavailableMethodWithPotentiallyUnavailableParameterType(_ o : ClassAvailableOn51) {}
   
-  @available(OSX, introduced: 10.51)
-  func potentiallyUnavailableMethodWithPotentiallyUnavailableReturnType() -> ClassAvailableOn10_51 {
-    return ClassAvailableOn10_51()
+  @available(OSX, introduced: 51)
+  func potentiallyUnavailableMethodWithPotentiallyUnavailableReturnType() -> ClassAvailableOn51 {
+    return ClassAvailableOn51()
   }
   
   @available(OSX, unavailable)
-  func unavailableMethodWithPotentiallyUnavailableReturnType() -> ClassAvailableOn10_51 {
-    guard #available(OSX 10.51, *) else { fatalError() }
-    return ClassAvailableOn10_51()
+  func unavailableMethodWithPotentiallyUnavailableReturnType() -> ClassAvailableOn51 {
+    guard #available(OSX 51, *) else { fatalError() }
+    return ClassAvailableOn51()
   }
 
   func methodWithPotentiallyUnavailableLocalDeclaration() {
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
-    let _ : ClassAvailableOn10_51 = methodWithPotentiallyUnavailableReturnType() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+    let _ : ClassAvailableOn51 = methodWithPotentiallyUnavailableReturnType() // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   func potentiallyUnavailableMethodWithPotentiallyUnavailableLocalDeclaration() {
-    let _ : ClassAvailableOn10_51 = methodWithPotentiallyUnavailableReturnType()
+    let _ : ClassAvailableOn51 = methodWithPotentiallyUnavailableReturnType()
   }
   
   @available(OSX, unavailable)
   func unavailableMethodWithPotentiallyUnavailableLocalDeclaration() {
-    let _ : ClassAvailableOn10_51 = methodWithPotentiallyUnavailableReturnType() // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+    let _ : ClassAvailableOn51 = methodWithPotentiallyUnavailableReturnType() // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   }
 }
 
 func referToPotentiallyUnavailableStaticProperty() {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  let _ = ClassWithDeclarationsOfPotentiallyUnavailableClasses.potentiallyUnavailableStaticPropertyOfPotentiallyUnavailableType // expected-error {{'potentiallyUnavailableStaticPropertyOfPotentiallyUnavailableType' is only available in macOS 10.51 or newer}}
+  let _ = ClassWithDeclarationsOfPotentiallyUnavailableClasses.potentiallyUnavailableStaticPropertyOfPotentiallyUnavailableType // expected-error {{'potentiallyUnavailableStaticPropertyOfPotentiallyUnavailableType' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-class ClassExtendingPotentiallyUnavailableClass : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+class ClassExtendingPotentiallyUnavailableClass : ClassAvailableOn51 { // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing class}}
 }
 
-@available(OSX, introduced: 10.51)
-class PotentiallyUnavailableClassExtendingPotentiallyUnavailableClass : ClassAvailableOn10_51 {
+@available(OSX, introduced: 51)
+class PotentiallyUnavailableClassExtendingPotentiallyUnavailableClass : ClassAvailableOn51 {
 }
 
 @available(OSX, unavailable)
-class UnavailableClassExtendingPotentiallyUnavailableClass : ClassAvailableOn10_51 {
+class UnavailableClassExtendingPotentiallyUnavailableClass : ClassAvailableOn51 {
 }
 
 // Method availability is contravariant
@@ -854,11 +854,11 @@ class SuperWithAlwaysAvailableMembers {
 }
 
 class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   override func shouldAlwaysBeAvailableMethod() { // expected-error {{overriding 'shouldAlwaysBeAvailableMethod' must be as available as declaration it overrides}}
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   override var shouldAlwaysBeAvailableProperty: Int { // expected-error {{overriding 'shouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     get { return 10 }
     set(newVal) {}
@@ -866,19 +866,19 @@ class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
 
   override var setterShouldAlwaysBeAvailableProperty: Int {
     get { return 9 }
-    @available(OSX, introduced: 10.51)
+    @available(OSX, introduced: 51)
     set(newVal) {} // expected-error {{overriding setter for 'setterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     // This is a terrible diagnostic. rdar://problem/20427938
   }
 
   override var getterShouldAlwaysBeAvailableProperty: Int {
-    @available(OSX, introduced: 10.51)
+    @available(OSX, introduced: 51)
     get { return 9 } // expected-error {{overriding getter for 'getterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     set(newVal) {}
   }
 }
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 class SubWithLimitedAvailablility : SuperWithAlwaysAvailableMembers {
   override func shouldAlwaysBeAvailableMethod() {}
   
@@ -899,11 +899,11 @@ class SubWithLimitedAvailablility : SuperWithAlwaysAvailableMembers {
 }
 
 class SuperWithLimitedMemberAvailability {
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   func someMethod() {
   }
   
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   var someProperty: Int {
     get { return 10 }
     set(newVal) {}
@@ -914,10 +914,10 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
         // expected-note@-1 2{{add @available attribute to enclosing class}}
   @available(OSX, introduced: 10.9)
   override func someMethod() {
-    super.someMethod() // expected-error {{'someMethod()' is only available in macOS 10.51 or newer}}
+    super.someMethod() // expected-error {{'someMethod()' is only available in macOS 51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
-    if #available(OSX 10.51, *) {
+    if #available(OSX 51, *) {
       super.someMethod()
     }
   }
@@ -925,10 +925,10 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
   @available(OSX, introduced: 10.9)
   override var someProperty: Int {
     get { 
-      let _ = super.someProperty // expected-error {{'someProperty' is only available in macOS 10.51 or newer}}
+      let _ = super.someProperty // expected-error {{'someProperty' is only available in macOS 51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
       
-      if #available(OSX 10.51, *) {
+      if #available(OSX 51, *) {
         let _ = super.someProperty
       }
       
@@ -938,7 +938,7 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
   }
 }
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 class SubWithLimitedAvailability : SuperWithLimitedMemberAvailability {
   override func someMethod() {
     super.someMethod()
@@ -950,7 +950,7 @@ class SubWithLimitedAvailability : SuperWithLimitedMemberAvailability {
   }
 }
 
-@available(OSX, introduced: 10.52)
+@available(OSX, introduced: 52)
 class SubWithMoreLimitedAvailability : SuperWithLimitedMemberAvailability {
   override func someMethod() {
     super.someMethod()
@@ -962,14 +962,14 @@ class SubWithMoreLimitedAvailability : SuperWithLimitedMemberAvailability {
   }
 }
 
-@available(OSX, introduced: 10.52)
+@available(OSX, introduced: 52)
 class SubWithMoreLimitedAvailabilityAndRedundantMemberAvailability : SuperWithLimitedMemberAvailability {
-  @available(OSX, introduced: 10.52)
+  @available(OSX, introduced: 52)
   override func someMethod() {
     super.someMethod()
   }
   
-  @available(OSX, introduced: 10.52)
+  @available(OSX, introduced: 52)
   override var someProperty: Int {
     get { super.someProperty }
     set(newVal) { super.someProperty = newVal }
@@ -989,121 +989,121 @@ class UnavailableSubWithLargerMemberAvailability : SuperWithLimitedMemberAvailab
 
 // Inheritance and availability
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 protocol ProtocolAvailableOn10_9 {
 }
 
-@available(OSX, introduced: 10.51)
-protocol ProtocolAvailableOn10_51 {
+@available(OSX, introduced: 51)
+protocol ProtocolAvailableOn51 {
 }
 
 @available(OSX, introduced: 10.9)
-protocol ProtocolAvailableOn10_9InheritingFromProtocolAvailableOn10_51 : ProtocolAvailableOn10_51 { // expected-error {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
+protocol ProtocolAvailableOn10_9InheritingFromProtocolAvailableOn51 : ProtocolAvailableOn51 { // expected-error {{'ProtocolAvailableOn51' is only available in macOS 51 or newer}}
 }
 
-@available(OSX, introduced: 10.51)
-protocol ProtocolAvailableOn10_51InheritingFromProtocolAvailableOn10_9 : ProtocolAvailableOn10_9 {
+@available(OSX, introduced: 51)
+protocol ProtocolAvailableOn51InheritingFromProtocolAvailableOn10_9 : ProtocolAvailableOn10_9 {
 }
 
 @available(OSX, unavailable)
-protocol UnavailableProtocolInheritingFromProtocolAvailableOn10_51 : ProtocolAvailableOn10_51 {
+protocol UnavailableProtocolInheritingFromProtocolAvailableOn51 : ProtocolAvailableOn51 {
 }
 
 @available(OSX, introduced: 10.9)
-class SubclassAvailableOn10_9OfClassAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+class SubclassAvailableOn10_9OfClassAvailableOn51 : ClassAvailableOn51 { // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
 }
 
 @available(OSX, unavailable)
-class UnavailableSubclassOfClassAvailableOn10_51 : ClassAvailableOn10_51 {
+class UnavailableSubclassOfClassAvailableOn51 : ClassAvailableOn51 {
 }
 
 // We allow nominal types to conform to protocols that are less available than the types themselves.
 @available(OSX, introduced: 10.9)
-class ClassAvailableOn10_9AdoptingProtocolAvailableOn10_51 : ProtocolAvailableOn10_51 {
+class ClassAvailableOn10_9AdoptingProtocolAvailableOn51 : ProtocolAvailableOn51 {
 }
 
 func castToPotentiallyUnavailableProtocol() {
       // expected-note@-1 2{{add @available attribute to enclosing global function}}
-  let o: ClassAvailableOn10_9AdoptingProtocolAvailableOn10_51 = ClassAvailableOn10_9AdoptingProtocolAvailableOn10_51()
+  let o: ClassAvailableOn10_9AdoptingProtocolAvailableOn51 = ClassAvailableOn10_9AdoptingProtocolAvailableOn51()
 
-  let _: ProtocolAvailableOn10_51 = o // expected-error {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _: ProtocolAvailableOn51 = o // expected-error {{'ProtocolAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = o as ProtocolAvailableOn10_51 // expected-error {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _ = o as ProtocolAvailableOn51 // expected-error {{'ProtocolAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 @available(OSX, introduced: 10.9)
-class SubclassAvailableOn10_9OfClassAvailableOn10_51AlsoAdoptingProtocolAvailableOn10_51 : ClassAvailableOn10_51, ProtocolAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+class SubclassAvailableOn10_9OfClassAvailableOn51AlsoAdoptingProtocolAvailableOn51 : ClassAvailableOn51, ProtocolAvailableOn51 { // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
 }
 
 class SomeGenericClass<T> { }
 
 @available(OSX, introduced: 10.9)
-class SubclassAvailableOn10_9OfSomeGenericClassOfProtocolAvailableOn10_51 : SomeGenericClass<ProtocolAvailableOn10_51> { // expected-error {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
+class SubclassAvailableOn10_9OfSomeGenericClassOfProtocolAvailableOn51 : SomeGenericClass<ProtocolAvailableOn51> { // expected-error {{'ProtocolAvailableOn51' is only available in macOS 51 or newer}}
 }
 
 @available(OSX, unavailable)
-class UnavailableSubclassOfSomeGenericClassOfProtocolAvailableOn10_51 : SomeGenericClass<ProtocolAvailableOn10_51> {
+class UnavailableSubclassOfSomeGenericClassOfProtocolAvailableOn51 : SomeGenericClass<ProtocolAvailableOn51> {
 }
 
-func GenericWhereClause<T>(_ t: T) where T: ProtocolAvailableOn10_51 { // expected-error * {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
+func GenericWhereClause<T>(_ t: T) where T: ProtocolAvailableOn51 { // expected-error * {{'ProtocolAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing global function}}
 }
 
 @available(OSX, unavailable)
-func UnavailableGenericWhereClause<T>(_ t: T) where T: ProtocolAvailableOn10_51 {
+func UnavailableGenericWhereClause<T>(_ t: T) where T: ProtocolAvailableOn51 {
 }
 
-func GenericSignature<T : ProtocolAvailableOn10_51>(_ t: T) { // expected-error * {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
+func GenericSignature<T : ProtocolAvailableOn51>(_ t: T) { // expected-error * {{'ProtocolAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing global function}}
 }
 
 @available(OSX, unavailable)
-func UnavailableGenericSignature<T : ProtocolAvailableOn10_51>(_ t: T) {
+func UnavailableGenericSignature<T : ProtocolAvailableOn51>(_ t: T) {
 }
 
 struct GenericType<T> { // expected-note {{add @available attribute to enclosing generic struct}}
-  func nonGenericWhereClause() where T : ProtocolAvailableOn10_51 {} // expected-error {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  func nonGenericWhereClause() where T : ProtocolAvailableOn51 {} // expected-error {{'ProtocolAvailableOn51' is only available in macOS 51 or newer}}
   // expected-note@-1 {{add @available attribute to enclosing instance method}}
   
   @available(OSX, unavailable)
-  func unavailableNonGenericWhereClause() where T : ProtocolAvailableOn10_51 {}
+  func unavailableNonGenericWhereClause() where T : ProtocolAvailableOn51 {}
 
-  struct NestedType where T : ProtocolAvailableOn10_51 {} // expected-error {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  struct NestedType where T : ProtocolAvailableOn51 {} // expected-error {{'ProtocolAvailableOn51' is only available in macOS 51 or newer}}
   // expected-note@-1 2{{add @available attribute to enclosing struct}}
   
   @available(OSX, unavailable)
-  struct UnavailableNestedType where T : ProtocolAvailableOn10_51 {}
+  struct UnavailableNestedType where T : ProtocolAvailableOn51 {}
 }
 
 // Extensions
 
-extension ClassAvailableOn10_51 { } // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+extension ClassAvailableOn51 { } // expected-error {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing extension}}
 
 @available(OSX, unavailable)
-extension ClassAvailableOn10_51 { }
+extension ClassAvailableOn51 { }
 
-@available(OSX, introduced: 10.51)
-extension ClassAvailableOn10_51 {
+@available(OSX, introduced: 51)
+extension ClassAvailableOn51 {
   func m() {
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
-    let _ = globalFuncAvailableOn10_51()
-    let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+    let _ = globalFuncAvailableOn51()
+    let _ = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   }
 }
 
 class ClassToExtend { }
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 extension ClassToExtend {
 
   func extensionMethod() { }
 
-  @available(OSX, introduced: 10.52)
-  func extensionMethod10_52() { }
+  @available(OSX, introduced: 52)
+  func extensionMethod52() { }
 
   class ExtensionClass { }
 
@@ -1115,11 +1115,11 @@ extension ClassToExtend {
 
 // We allow protocol extensions for protocols that are less available than the
 // conforming class.
-extension ClassToExtend : ProtocolAvailableOn10_51 {
+extension ClassToExtend : ProtocolAvailableOn51 {
 }
 
-@available(OSX, introduced: 10.51)
-extension ClassToExtend { // expected-note {{enclosing scope requires availability of macOS 10.51 or newer}}
+@available(OSX, introduced: 51)
+extension ClassToExtend { // expected-note {{enclosing scope requires availability of macOS 51 or newer}}
   @available(OSX, introduced: 10.9) // expected-error {{instance method cannot be more available than enclosing scope}}
   func extensionMethod10_9() { }
 }
@@ -1128,30 +1128,30 @@ func usePotentiallyUnavailableExtension() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
   let o = ClassToExtend()
 
-  o.extensionMethod() // expected-error {{'extensionMethod()' is only available in macOS 10.51 or newer}}
+  o.extensionMethod() // expected-error {{'extensionMethod()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = ClassToExtend.ExtensionClass() // expected-error {{'ExtensionClass' is only available in macOS 10.51 or newer}}
+  let _ = ClassToExtend.ExtensionClass() // expected-error {{'ExtensionClass' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  o.extensionMethod10_52() // expected-error {{'extensionMethod10_52()' is only available in macOS 10.52 or newer}}
+  o.extensionMethod52() // expected-error {{'extensionMethod52()' is only available in macOS 52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Availability of synthesized designated initializers.
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 class WidelyAvailableBase {
   init() {}
 
-  @available(OSX, introduced: 10.52)
+  @available(OSX, introduced: 52)
   init(thing: ()) {}
 }
 
-@available(OSX, introduced: 10.53)
+@available(OSX, introduced: 53)
 class EsotericSmallBatchHipsterThing : WidelyAvailableBase {}
 
-@available(OSX, introduced: 10.53)
+@available(OSX, introduced: 53)
 class NestedClassTest {
   class InnerClass : WidelyAvailableBase {}
 }
@@ -1165,18 +1165,18 @@ func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {
     let _ = globalFuncAvailableOn10_9()
   }
   
-  if #available(OSX 10.51, *) { // expected-note {{enclosing scope here}}
-    let _ = globalFuncAvailableOn10_51()
+  if #available(OSX 51, *) { // expected-note {{enclosing scope here}}
+    let _ = globalFuncAvailableOn51()
     
-    if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
-      let _ = globalFuncAvailableOn10_51()
+    if #available(OSX 51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+      let _ = globalFuncAvailableOn51()
     }
   }
 
   if #available(OSX 10.9, *) { // expected-note {{enclosing scope here}}
   } else {
     // Make sure we generate a warning about an unnecessary check even if the else branch of if is dead.
-    if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    if #available(OSX 51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
     }
   }
 
@@ -1184,7 +1184,7 @@ func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {
   if p {
     guard #available(OSX 10.9, *) else { // expected-note {{enclosing scope here}}
       // Make sure we generate a warning about an unnecessary check even if the else branch of guard is dead.
-      if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+      if #available(OSX 51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
       }
     }
   }
@@ -1194,7 +1194,7 @@ func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {
   if #available(iOS 8.0, *) {
   }
 
-  if #available(OSX 10.51, *) {
+  if #available(OSX 51, *) {
     // Similarly do not want '*' to generate a warning in a refined TRC.
     if #available(iOS 8.0, *) {
     }
@@ -1209,33 +1209,33 @@ func functionWithUnavailableInDeadBranch() {
   if #available(iOS 8.0, *) {
   } else {
     // This branch is dead on OSX, so we shouldn't a warning about use of potentially unavailable APIs in it.
-    _ = globalFuncAvailableOn10_51() // no-warning
+    _ = globalFuncAvailableOn51() // no-warning
 
-    @available(OSX 10.51, *)
-    func localFuncAvailableOn10_51() {
-      _ = globalFuncAvailableOn10_52() // no-warning
+    @available(OSX 51, *)
+    func localFuncAvailableOn51() {
+      _ = globalFuncAvailableOn52() // no-warning
     }
 
-    localFuncAvailableOn10_51() // no-warning
+    localFuncAvailableOn51() // no-warning
 
     explicitlyUnavailable() // expected-error {{'explicitlyUnavailable()' is unavailable}}
   }
 
   guard #available(iOS 8.0, *) else {
-    _ = globalFuncAvailableOn10_51() // no-warning
+    _ = globalFuncAvailableOn51() // no-warning
 
     explicitlyUnavailable() // expected-error {{'explicitlyUnavailable()' is unavailable}}
   }
 }
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 func functionWithSpecifiedAvailabilityAndUselessCheck() { // expected-note 2{{enclosing scope here}}
   if #available(OSX 10.9, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
     let _ = globalFuncAvailableOn10_9()
   }
   
-  if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
-    let _ = globalFuncAvailableOn10_51()
+  if #available(OSX 51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    let _ = globalFuncAvailableOn51()
   }
 }
 
@@ -1246,40 +1246,40 @@ func injectToOptional<T>(_ v: T) -> T? {
 }
 
 
-if let _ = injectToOptional(5), #available(OSX 10.52, *) {}  // ok
+if let _ = injectToOptional(5), #available(OSX 52, *) {}  // ok
 
 
 // Refining context inside guard
 
-if #available(OSX 10.51, *),
-   let _ = injectToOptional(globalFuncAvailableOn10_51()),
-   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+if #available(OSX 51, *),
+   let _ = injectToOptional(globalFuncAvailableOn51()),
+   let _ = injectToOptional(globalFuncAvailableOn52()) { // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-  let _ = globalFuncAvailableOn10_51()
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
-        // expected-note@-1 {{add 'if #available' version check}}
-}
-
-if let _ = injectToOptional(5), #available(OSX 10.51, *),
-   let _ = injectToOptional(globalFuncAvailableOn10_51()),
-   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
-        // expected-note@-1 {{add 'if #available' version check}}
-
-  let _ = globalFuncAvailableOn10_51()
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+  let _ = globalFuncAvailableOn51()
+  let _ = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
-if let _ = injectToOptional(globalFuncAvailableOn10_51()), #available(OSX 10.51, *), // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+if let _ = injectToOptional(5), #available(OSX 51, *),
+   let _ = injectToOptional(globalFuncAvailableOn51()),
+   let _ = injectToOptional(globalFuncAvailableOn52()) { // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
-   let _ = injectToOptional(globalFuncAvailableOn10_52()) { // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+
+  let _ = globalFuncAvailableOn51()
+  let _ = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+        // expected-note@-1 {{add 'if #available' version check}}
+}
+
+if let _ = injectToOptional(globalFuncAvailableOn51()), #available(OSX 51, *), // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
+        // expected-note@-1 {{add 'if #available' version check}}
+   let _ = injectToOptional(globalFuncAvailableOn52()) { // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
 }
 
-if let _ = injectToOptional(5), #available(OSX 10.51, *), // expected-note {{enclosing scope here}}
-   let _ = injectToOptional(6), #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+if let _ = injectToOptional(5), #available(OSX 51, *), // expected-note {{enclosing scope here}}
+   let _ = injectToOptional(6), #available(OSX 51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
 }
 
 
@@ -1288,66 +1288,66 @@ if let _ = injectToOptional(5), #available(OSX 10.51, *), // expected-note {{enc
 func useGuardAvailable() {
         // expected-note@-1 3{{add @available attribute to enclosing global function}}
   // Guard fallthrough should refine context
-  guard #available(OSX 10.51, *) else { // expected-note {{enclosing scope here}}
-    let _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+  guard #available(OSX 51, *) else { // expected-note {{enclosing scope here}}
+    let _ = globalFuncAvailableOn51() // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     return
   }
 
-  let _ = globalFuncAvailableOn10_51()
+  let _ = globalFuncAvailableOn51()
 
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+  let _ = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-  if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  if #available(OSX 51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
   }
 
-  if globalFuncAvailableOn10_51() > 0 {
-    guard #available(OSX 10.52, *),
-            let x = injectToOptional(globalFuncAvailableOn10_52()) else { return }
+  if globalFuncAvailableOn51() > 0 {
+    guard #available(OSX 52, *),
+            let x = injectToOptional(globalFuncAvailableOn52()) else { return }
     _ = x
   }
 
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+  let _ = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
 func twoGuardsInSameBlock(_ p: Int) {
         // expected-note@-1 {{add @available attribute to enclosing global function}}
   if (p > 0) {
-    guard #available(OSX 10.51, *) else { return }
+    guard #available(OSX 51, *) else { return }
 
-    let _ = globalFuncAvailableOn10_51()
+    let _ = globalFuncAvailableOn51()
 
-    guard #available(OSX 10.52, *) else { return }
+    guard #available(OSX 52, *) else { return }
 
-    let _ = globalFuncAvailableOn10_52()
+    let _ = globalFuncAvailableOn52()
   }
 
-  let _ = globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+  let _ = globalFuncAvailableOn51() // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 }
 
 // Refining while loops
 
-while globalFuncAvailableOn10_51() > 10 { } // expected-error {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+while globalFuncAvailableOn51() > 10 { } // expected-error {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-while #available(OSX 10.51, *), // expected-note {{enclosing scope here}}
-      globalFuncAvailableOn10_51() > 10 {
+while #available(OSX 51, *), // expected-note {{enclosing scope here}}
+      globalFuncAvailableOn51() > 10 {
 
-  let _ = globalFuncAvailableOn10_51()
+  let _ = globalFuncAvailableOn51()
 
-  let _ = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+  let _ = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-  while globalFuncAvailableOn10_51() > 11,
+  while globalFuncAvailableOn51() > 11,
         let _ = injectToOptional(5),
-        #available(OSX 10.52, *) {
-    let _ = globalFuncAvailableOn10_52();
+        #available(OSX 52, *) {
+    let _ = globalFuncAvailableOn52();
   }
 
-  while #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  while #available(OSX 51, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
   }
 }
 
@@ -1357,36 +1357,36 @@ while #available(OSX 10.51, *), // expected-note {{enclosing scope here}}
 // code *added* indentation in Fix-Its as 4 spaces (that is, when indenting in a Fix-It, we
 // take whatever indentation was there before and add 4 spaces to it).
 
-functionAvailableOn10_51()
-    // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-    // expected-note@-2 {{add 'if #available' version check}} {{1-27=if #available(macOS 10.51, *) {\n    functionAvailableOn10_51()\n} else {\n    // Fallback on earlier versions\n}}}
+functionAvailableOn51()
+    // expected-error@-1 {{'functionAvailableOn51()' is only available in macOS 51 or newer}}
+    // expected-note@-2 {{add 'if #available' version check}} {{1-24=if #available(macOS 51, *) {\n    functionAvailableOn51()\n} else {\n    // Fallback on earlier versions\n}}}
 
-let declForFixitAtTopLevel: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}} {{1-57=if #available(macOS 10.51, *) {\n    let declForFixitAtTopLevel: ClassAvailableOn10_51? = nil\n} else {\n    // Fallback on earlier versions\n}}}
+let declForFixitAtTopLevel: ClassAvailableOn51? = nil
+      // expected-error@-1 {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}} {{1-54=if #available(macOS 51, *) {\n    let declForFixitAtTopLevel: ClassAvailableOn51? = nil\n} else {\n    // Fallback on earlier versions\n}}}
 
 func fixitForReferenceInGlobalFunction() {
-      // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(macOS 10.51, *)\n}}
-  functionAvailableOn10_51()
-      // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(macOS 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
+      // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(macOS 51, *)\n}}
+  functionAvailableOn51()
+      // expected-error@-1 {{'functionAvailableOn51()' is only available in macOS 51 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}} {{3-26=if #available(macOS 51, *) {\n      functionAvailableOn51()\n  } else {\n      // Fallback on earlier versions\n  }}}
       
 }
 
 public func fixitForReferenceInGlobalFunctionWithDeclModifier() {
-      // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(macOS 10.51, *)\n}}
-  functionAvailableOn10_51()
-      // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(macOS 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
+      // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(macOS 51, *)\n}}
+  functionAvailableOn51()
+      // expected-error@-1 {{'functionAvailableOn51()' is only available in macOS 51 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}} {{3-26=if #available(macOS 51, *) {\n      functionAvailableOn51()\n  } else {\n      // Fallback on earlier versions\n  }}}
       
 }
 
 func fixitForReferenceInGlobalFunctionWithAttribute() -> Never {
-    // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(macOS 10.51, *)\n}}
-  _ = 0 // Avoid treating the call to functionAvailableOn10_51 as an implicit return
-  functionAvailableOn10_51()
-    // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-    // expected-note@-2 {{add 'if #available' version check}} {{3-29=if #available(macOS 10.51, *) {\n      functionAvailableOn10_51()\n  } else {\n      // Fallback on earlier versions\n  }}}
+    // expected-note@-1 {{add @available attribute to enclosing global function}} {{1-1=@available(macOS 51, *)\n}}
+  _ = 0 // Avoid treating the call to functionAvailableOn51 as an implicit return
+  functionAvailableOn51()
+    // expected-error@-1 {{'functionAvailableOn51()' is only available in macOS 51 or newer}}
+    // expected-note@-2 {{add 'if #available' version check}} {{3-26=if #available(macOS 51, *) {\n      functionAvailableOn51()\n  } else {\n      // Fallback on earlier versions\n  }}}
     
 }
 
@@ -1394,92 +1394,92 @@ func takesAutoclosure(_ c : @autoclosure () -> ()) {
 }
 
 class ClassForFixit {
-        // expected-note@-1 12{{add @available attribute to enclosing class}} {{1-1=@available(macOS 10.51, *)\n}}
+        // expected-note@-1 12{{add @available attribute to enclosing class}} {{1-1=@available(macOS 51, *)\n}}
   func fixitForReferenceInMethod() {
-        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 10.51, *)\n  }}
-    functionAvailableOn10_51()
-        // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-        // expected-note@-2 {{add 'if #available' version check}} {{5-31=if #available(macOS 10.51, *) {\n        functionAvailableOn10_51()\n    } else {\n        // Fallback on earlier versions\n    }}}
+        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 51, *)\n  }}
+    functionAvailableOn51()
+        // expected-error@-1 {{'functionAvailableOn51()' is only available in macOS 51 or newer}}
+        // expected-note@-2 {{add 'if #available' version check}} {{5-28=if #available(macOS 51, *) {\n        functionAvailableOn51()\n    } else {\n        // Fallback on earlier versions\n    }}}
   }
 
   func fixitForReferenceNestedInMethod() {
-          // expected-note@-1 3{{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 10.51, *)\n  }}
+          // expected-note@-1 3{{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 51, *)\n  }}
     func inner() {
-      functionAvailableOn10_51()
-          // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-          // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(macOS 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
+      functionAvailableOn51()
+          // expected-error@-1 {{'functionAvailableOn51()' is only available in macOS 51 or newer}}
+          // expected-note@-2 {{add 'if #available' version check}} {{7-30=if #available(macOS 51, *) {\n          functionAvailableOn51()\n      } else {\n          // Fallback on earlier versions\n      }}}
     }
 
     let _: () -> () = { () in
-      functionAvailableOn10_51()
-          // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-          // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(macOS 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
+      functionAvailableOn51()
+          // expected-error@-1 {{'functionAvailableOn51()' is only available in macOS 51 or newer}}
+          // expected-note@-2 {{add 'if #available' version check}} {{7-30=if #available(macOS 51, *) {\n          functionAvailableOn51()\n      } else {\n          // Fallback on earlier versions\n      }}}
     }
 
-    takesAutoclosure(functionAvailableOn10_51())
-          // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-          // expected-note@-2 {{add 'if #available' version check}} {{5-49=if #available(macOS 10.51, *) {\n        takesAutoclosure(functionAvailableOn10_51())\n    } else {\n        // Fallback on earlier versions\n    }}}
+    takesAutoclosure(functionAvailableOn51())
+          // expected-error@-1 {{'functionAvailableOn51()' is only available in macOS 51 or newer}}
+          // expected-note@-2 {{add 'if #available' version check}} {{5-46=if #available(macOS 51, *) {\n        takesAutoclosure(functionAvailableOn51())\n    } else {\n        // Fallback on earlier versions\n    }}}
           
   }
 
   var fixitForReferenceInPropertyAccessor: Int {
-        // expected-note@-1 {{add @available attribute to enclosing property}} {{3-3=@available(macOS 10.51, *)\n  }}
+        // expected-note@-1 {{add @available attribute to enclosing property}} {{3-3=@available(macOS 51, *)\n  }}
     get {
-      functionAvailableOn10_51()
-        // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-        // expected-note@-2 {{add 'if #available' version check}} {{7-33=if #available(macOS 10.51, *) {\n          functionAvailableOn10_51()\n      } else {\n          // Fallback on earlier versions\n      }}}
+      functionAvailableOn51()
+        // expected-error@-1 {{'functionAvailableOn51()' is only available in macOS 51 or newer}}
+        // expected-note@-2 {{add 'if #available' version check}} {{7-30=if #available(macOS 51, *) {\n          functionAvailableOn51()\n      } else {\n          // Fallback on earlier versions\n      }}}
         
       return 5
     }
   }
 
-  var fixitForReferenceInPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  var fixitForReferenceInPropertyType: ClassAvailableOn51? = nil
+      // expected-error@-1 {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
 
-  lazy var fixitForReferenceInLazyPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  lazy var fixitForReferenceInLazyPropertyType: ClassAvailableOn51? = nil
+      // expected-error@-1 {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
 
-  private lazy var fixitForReferenceInPrivateLazyPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  private lazy var fixitForReferenceInPrivateLazyPropertyType: ClassAvailableOn51? = nil
+      // expected-error@-1 {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
 
-  lazy private var fixitForReferenceInLazyPrivatePropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  lazy private var fixitForReferenceInLazyPrivatePropertyType: ClassAvailableOn51? = nil
+      // expected-error@-1 {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
 
-  static var fixitForReferenceInStaticPropertyType: ClassAvailableOn10_51? = nil
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
-      // expected-note@-2 {{add @available attribute to enclosing static property}} {{3-3=@available(macOS 10.51, *)\n  }}
+  static var fixitForReferenceInStaticPropertyType: ClassAvailableOn51? = nil
+      // expected-error@-1 {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
+      // expected-note@-2 {{add @available attribute to enclosing static property}} {{3-3=@available(macOS 51, *)\n  }}
 
-  var fixitForReferenceInPropertyTypeMultiple: ClassAvailableOn10_51? = nil, other: Int = 7
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  var fixitForReferenceInPropertyTypeMultiple: ClassAvailableOn51? = nil, other: Int = 7
+      // expected-error@-1 {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
 
   func fixitForRefInGuardOfIf() {
-        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 10.51, *)\n  }}
-    if (globalFuncAvailableOn10_51() > 1066) {
+        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 51, *)\n  }}
+    if (globalFuncAvailableOn51() > 1066) {
       let _ = 5
       let _ = 6
     }
-        // expected-error@-4 {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-        // expected-note@-5 {{add 'if #available' version check}} {{5-+3:6=if #available(macOS 10.51, *) {\n        if (globalFuncAvailableOn10_51() > 1066) {\n          let _ = 5\n          let _ = 6\n        }\n    } else {\n        // Fallback on earlier versions\n    }}}
+        // expected-error@-4 {{'globalFuncAvailableOn51()' is only available in macOS 51 or newer}}
+        // expected-note@-5 {{add 'if #available' version check}} {{5-+3:6=if #available(macOS 51, *) {\n        if (globalFuncAvailableOn51() > 1066) {\n          let _ = 5\n          let _ = 6\n        }\n    } else {\n        // Fallback on earlier versions\n    }}}
   }
 }
 
 extension ClassToExtend {
         // expected-note@-1 {{add @available attribute to enclosing extension}}
   func fixitForReferenceInExtensionMethod() {
-        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 10.51, *)\n  }}
-    functionAvailableOn10_51()
-        // expected-error@-1 {{'functionAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-        // expected-note@-2 {{add 'if #available' version check}} {{5-31=if #available(macOS 10.51, *) {\n        functionAvailableOn10_51()\n    } else {\n        // Fallback on earlier versions\n    }}}
+        // expected-note@-1 {{add @available attribute to enclosing instance method}} {{3-3=@available(macOS 51, *)\n  }}
+    functionAvailableOn51()
+        // expected-error@-1 {{'functionAvailableOn51()' is only available in macOS 51 or newer}}
+        // expected-note@-2 {{add 'if #available' version check}} {{5-28=if #available(macOS 51, *) {\n        functionAvailableOn51()\n    } else {\n        // Fallback on earlier versions\n    }}}
   }
 }
 
 enum EnumForFixit {
-      // expected-note@-1 2{{add @available attribute to enclosing enum}} {{1-1=@available(macOS 10.51, *)\n}}
-  case CaseWithPotentiallyUnavailablePayload(p: ClassAvailableOn10_51)
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+      // expected-note@-1 2{{add @available attribute to enclosing enum}} {{1-1=@available(macOS 51, *)\n}}
+  case CaseWithPotentiallyUnavailablePayload(p: ClassAvailableOn51)
+      // expected-error@-1 {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
 
-  case CaseWithPotentiallyUnavailablePayload2(p: ClassAvailableOn10_51), WithoutPayload
-      // expected-error@-1 {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  case CaseWithPotentiallyUnavailablePayload2(p: ClassAvailableOn51), WithoutPayload
+      // expected-error@-1 {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       
 }
 
@@ -1494,18 +1494,18 @@ class X {
 }
 
 func testForFixitWithNestedMemberRefExpr() {
-    // expected-note@-1 2{{add @available attribute to enclosing global function}} {{1-1=@available(macOS 10.52, *)\n}}
+    // expected-note@-1 2{{add @available attribute to enclosing global function}} {{1-1=@available(macOS 52, *)\n}}
   let x = X()
 
-  x.y.z = globalFuncAvailableOn10_52()
-      // expected-error@-1 {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}} {{3-39=if #available(macOS 10.52, *) {\n      x.y.z = globalFuncAvailableOn10_52()\n  } else {\n      // Fallback on earlier versions\n  }}}
+  x.y.z = globalFuncAvailableOn52()
+      // expected-error@-1 {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}} {{3-36=if #available(macOS 52, *) {\n      x.y.z = globalFuncAvailableOn52()\n  } else {\n      // Fallback on earlier versions\n  }}}
 
   // Access via dynamic member reference
   let anyX: AnyObject = x
-  anyX.y?.z = globalFuncAvailableOn10_52()
-      // expected-error@-1 {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}} {{3-43=if #available(macOS 10.52, *) {\n      anyX.y?.z = globalFuncAvailableOn10_52()\n  } else {\n      // Fallback on earlier versions\n  }}}
+  anyX.y?.z = globalFuncAvailableOn52()
+      // expected-error@-1 {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}} {{3-40=if #available(macOS 52, *) {\n      anyX.y?.z = globalFuncAvailableOn52()\n  } else {\n      // Fallback on earlier versions\n  }}}
       
 }
 
@@ -1513,15 +1513,15 @@ func testForFixitWithNestedMemberRefExpr() {
 
 protocol ProtocolWithRequirementMentioningPotentiallyUnavailable {
       // expected-note@-1 2{{add @available attribute to enclosing protocol}}
-  func hasPotentiallyUnavailableParameter(_ p: ClassAvailableOn10_51) // expected-error * {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  func hasPotentiallyUnavailableParameter(_ p: ClassAvailableOn51) // expected-error * {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing instance method}}
       
 
-  func hasPotentiallyUnavailableReturn() -> ClassAvailableOn10_51 // expected-error * {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  func hasPotentiallyUnavailableReturn() -> ClassAvailableOn51 // expected-error * {{'ClassAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing instance method}}
 
-  @available(OSX 10.51, *)
-  func hasPotentiallyUnavailableWithAnnotation(_ p: ClassAvailableOn10_51) -> ClassAvailableOn10_51
+  @available(OSX 51, *)
+  func hasPotentiallyUnavailableWithAnnotation(_ p: ClassAvailableOn51) -> ClassAvailableOn51
 }
 
 protocol HasMethodF {
@@ -1529,9 +1529,9 @@ protocol HasMethodF {
   func f(_ p: T) // expected-note 3{{protocol requirement here}}
 }
 
-class TriesToConformWithFunctionIntroducedOn10_51 : HasMethodF {
-  @available(OSX, introduced: 10.51)
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50 and newer}}
+class TriesToConformWithFunctionIntroducedOn51 : HasMethodF {
+  @available(OSX, introduced: 51)
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 50 and newer}}
 }
 
 
@@ -1543,19 +1543,19 @@ class ConformsWithFunctionIntroducedOnMinimumDeploymentTarget : HasMethodF {
 }
 
 class SuperHasMethodF {
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
     func f(_ p: Int) { } // expected-note {{'f' declared here}}
 }
 
-class TriesToConformWithPotentiallyUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF { // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50 and newer}}
+class TriesToConformWithPotentiallyUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF { // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 50 and newer}}
   // The conformance here is generating an error on f in the super class.
 }
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 class ConformsWithPotentiallyUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF {
-  // Limiting this class to only be available on 10.51 and newer means that
+  // Limiting this class to only be available on 51 and newer means that
   // the witness in SuperHasMethodF is safe for the requirement on HasMethodF.
-  // in order for this class to be referenced we must be running on 10.51 or
+  // in order for this class to be referenced we must be running on 51 or
   // greater.
 }
 
@@ -1570,72 +1570,72 @@ class ConformsByOverridingFunctionInSuperClass : SuperHasMethodF, HasMethodF {
 // in extension
 class HasNoMethodF1 { }
 extension HasNoMethodF1 : HasMethodF {
-  @available(OSX, introduced: 10.51)
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50 and newer}}
+  @available(OSX, introduced: 51)
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 50 and newer}}
 }
 
 class HasNoMethodF2 { }
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 extension HasNoMethodF2 : HasMethodF {
   // This is OK, because the conformance was introduced by an extension.
   func f(_ p: Int) { }
 }
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 class HasNoMethodF3 { }
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 extension HasNoMethodF3 : HasMethodF {
   // We expect this conformance to succeed because on every version where HasNoMethodF3
   // is available, HasNoMethodF3's f() is as available as the protocol requirement
   func f(_ p: Int) { }
 }
 
-@available(OSX, introduced: 10.51)
-protocol HasMethodFOn10_51 {
+@available(OSX, introduced: 51)
+protocol HasMethodFOn51 {
   func f(_ p: Int)
 }
 
-class ConformsToPotentiallyUnavailableProtocolWithPotentiallyUnavailableWitness : HasMethodFOn10_51 {
-  @available(OSX, introduced: 10.51)
+class ConformsToPotentiallyUnavailableProtocolWithPotentiallyUnavailableWitness : HasMethodFOn51 {
+  @available(OSX, introduced: 51)
   func f(_ p: Int) { }
 }
 
-@available(OSX, introduced: 10.51)
+@available(OSX, introduced: 51)
 class HasNoMethodF4 { }
-@available(OSX, introduced: 10.52)
-extension HasNoMethodF4 : HasMethodFOn10_51 {
+@available(OSX, introduced: 52)
+extension HasNoMethodF4 : HasMethodFOn51 {
   // This is OK, because the conformance was introduced by an extension.
   func f(_ p: Int) { }
 }
 
-@available(OSX, introduced: 10.51)
-protocol HasTakesClassAvailableOn10_51 {
-  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) // expected-note 2{{protocol requirement here}}
+@available(OSX, introduced: 51)
+protocol HasTakesClassAvailableOn51 {
+  func takesClassAvailableOn51(_ o: ClassAvailableOn51) // expected-note 2{{protocol requirement here}}
 }
 
-class AttemptsToConformToHasTakesClassAvailableOn10_51 : HasTakesClassAvailableOn10_51 {
-  @available(OSX, introduced: 10.52)
-  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available in macOS 10.51 and newer}}
+class AttemptsToConformToHasTakesClassAvailableOn51 : HasTakesClassAvailableOn51 {
+  @available(OSX, introduced: 52)
+  func takesClassAvailableOn51(_ o: ClassAvailableOn51) { // expected-error {{protocol 'HasTakesClassAvailableOn51' requires 'takesClassAvailableOn51' to be available in macOS 51 and newer}}
   }
 }
 
-class ConformsToHasTakesClassAvailableOn10_51 : HasTakesClassAvailableOn10_51 {
-  @available(OSX, introduced: 10.51)
-  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) {
+class ConformsToHasTakesClassAvailableOn51 : HasTakesClassAvailableOn51 {
+  @available(OSX, introduced: 51)
+  func takesClassAvailableOn51(_ o: ClassAvailableOn51) {
   }
 }
 
-class TakesClassAvailableOn10_51_A { }
-extension TakesClassAvailableOn10_51_A : HasTakesClassAvailableOn10_51 {
-  @available(OSX, introduced: 10.52)
-  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available in macOS 10.51 and newer}}
+class TakesClassAvailableOn51_A { }
+extension TakesClassAvailableOn51_A : HasTakesClassAvailableOn51 {
+  @available(OSX, introduced: 52)
+  func takesClassAvailableOn51(_ o: ClassAvailableOn51) { // expected-error {{protocol 'HasTakesClassAvailableOn51' requires 'takesClassAvailableOn51' to be available in macOS 51 and newer}}
   }
 }
 
-class TakesClassAvailableOn10_51_B { }
-extension TakesClassAvailableOn10_51_B : HasTakesClassAvailableOn10_51 {
-  @available(OSX, introduced: 10.51)
-  func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) {
+class TakesClassAvailableOn51_B { }
+extension TakesClassAvailableOn51_B : HasTakesClassAvailableOn51 {
+  @available(OSX, introduced: 51)
+  func takesClassAvailableOn51(_ o: ClassAvailableOn51) {
   }
 }
 
@@ -1646,14 +1646,14 @@ class TestAvailabilityAffectsWitnessCandidacy : HasMethodF {
   // Test that we choose the less specialized witness, because the more specialized
   // witness is conditionally unavailable.
 
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   func f(_ p: Int) { }
 
   func f<T>(_ p: T) { }
 }
 
 protocol HasPotentiallyUnavailableMethodF {
-  @available(OSX, introduced: 10.51)
+  @available(OSX, introduced: 51)
   func f(_ p: String)
 }
 
@@ -1664,68 +1664,68 @@ class ConformsWithPotentiallyUnavailableFunction : HasPotentiallyUnavailableMeth
 
 func usePotentiallyUnavailableProtocolMethod(_ h: HasPotentiallyUnavailableMethodF) {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  h.f("Foo") // expected-error {{'f' is only available in macOS 10.51 or newer}}
+  h.f("Foo") // expected-error {{'f' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 func usePotentiallyUnavailableProtocolMethod<H : HasPotentiallyUnavailableMethodF> (_ h: H) {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  h.f("Foo") // expected-error {{'f' is only available in macOS 10.51 or newer}}
+  h.f("Foo") // expected-error {{'f' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
 
 // Short-form @available() annotations
 
-@available(OSX 10.51, *)
-class ClassWithShortFormAvailableOn10_51 {
+@available(OSX 51, *)
+class ClassWithShortFormAvailableOn51 {
 }
 
-@available(OSX 10.53, *)
-class ClassWithShortFormAvailableOn10_53 {
+@available(OSX 53, *)
+class ClassWithShortFormAvailableOn53 {
 }
 
-@available(OSX 10.54, *)
-class ClassWithShortFormAvailableOn10_54 {
+@available(OSX 54, *)
+class ClassWithShortFormAvailableOn54 {
 }
 
 @available(OSX 10.9, *)
 func funcWithShortFormAvailableOn10_9() {
-  let _ = ClassWithShortFormAvailableOn10_51() // expected-error {{'ClassWithShortFormAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _ = ClassWithShortFormAvailableOn51() // expected-error {{'ClassWithShortFormAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-@available(OSX 10.51, *)
-func funcWithShortFormAvailableOn10_51() {
-  let _ = ClassWithShortFormAvailableOn10_51()
+@available(OSX 51, *)
+func funcWithShortFormAvailableOn51() {
+  let _ = ClassWithShortFormAvailableOn51()
 }
 
 @available(iOS 14.0, *)
 func funcWithShortFormAvailableOniOS14() {
   // expected-note@-1 {{add @available attribute to enclosing global function}}
-  let _ = ClassWithShortFormAvailableOn10_51() // expected-error {{'ClassWithShortFormAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  let _ = ClassWithShortFormAvailableOn51() // expected-error {{'ClassWithShortFormAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-@available(iOS 14.0, OSX 10.53, *)
-func funcWithShortFormAvailableOniOS14AndOSX10_53() {
-  let _ = ClassWithShortFormAvailableOn10_51()
+@available(iOS 14.0, OSX 53, *)
+func funcWithShortFormAvailableOniOS14AndOSX53() {
+  let _ = ClassWithShortFormAvailableOn51()
 }
 
 // Not idiomatic but we need to be able to handle it.
 @available(iOS 8.0, *)
-@available(OSX 10.51, *)
+@available(OSX 51, *)
 func funcWithMultipleShortFormAnnotationsForDifferentPlatforms() {
-  let _ = ClassWithShortFormAvailableOn10_51()
+  let _ = ClassWithShortFormAvailableOn51()
 }
 
-@available(OSX 10.51, *)
-@available(OSX 10.53, *)
-@available(OSX 10.52, *)
+@available(OSX 51, *)
+@available(OSX 53, *)
+@available(OSX 52, *)
 func funcWithMultipleShortFormAnnotationsForTheSamePlatform() {
-  let _ = ClassWithShortFormAvailableOn10_53()
+  let _ = ClassWithShortFormAvailableOn53()
 
-  let _ = ClassWithShortFormAvailableOn10_54() // expected-error {{'ClassWithShortFormAvailableOn10_54' is only available in macOS 10.54 or newer}}
+  let _ = ClassWithShortFormAvailableOn54() // expected-error {{'ClassWithShortFormAvailableOn54' is only available in macOS 54 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -1734,18 +1734,18 @@ func useShortFormAvailable() {
 
   funcWithShortFormAvailableOn10_9()
 
-  funcWithShortFormAvailableOn10_51() // expected-error {{'funcWithShortFormAvailableOn10_51()' is only available in macOS 10.51 or newer}}
+  funcWithShortFormAvailableOn51() // expected-error {{'funcWithShortFormAvailableOn51()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
   funcWithShortFormAvailableOniOS14()
 
-  funcWithShortFormAvailableOniOS14AndOSX10_53() // expected-error {{'funcWithShortFormAvailableOniOS14AndOSX10_53()' is only available in macOS 10.53 or newer}}
+  funcWithShortFormAvailableOniOS14AndOSX53() // expected-error {{'funcWithShortFormAvailableOniOS14AndOSX53()' is only available in macOS 53 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  funcWithMultipleShortFormAnnotationsForDifferentPlatforms() // expected-error {{'funcWithMultipleShortFormAnnotationsForDifferentPlatforms()' is only available in macOS 10.51 or newer}}
+  funcWithMultipleShortFormAnnotationsForDifferentPlatforms() // expected-error {{'funcWithMultipleShortFormAnnotationsForDifferentPlatforms()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  funcWithMultipleShortFormAnnotationsForTheSamePlatform() // expected-error {{'funcWithMultipleShortFormAnnotationsForTheSamePlatform()' is only available in macOS 10.53 or newer}}
+  funcWithMultipleShortFormAnnotationsForTheSamePlatform() // expected-error {{'funcWithMultipleShortFormAnnotationsForTheSamePlatform()' is only available in macOS 53 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 

--- a/test/Sema/availability_versions_objc_api.swift
+++ b/test/Sema/availability_versions_objc_api.swift
@@ -9,88 +9,88 @@ import Foundation
 // Tests for uses of version-based potential unavailability imported from ObjC APIs.
 func callUnavailableObjC() {
       // expected-note@-1 5{{add @available attribute to enclosing global function}}
-  _ = NSAvailableOn10_51() // expected-error {{'NSAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  _ = NSAvailableOn51() // expected-error {{'NSAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
   
   
-  if #available(OSX 10.51, *) {
-    let o = NSAvailableOn10_51()!
+  if #available(OSX 51, *) {
+    let o = NSAvailableOn51()!
     
     // Properties
-    _ = o.propertyOn10_52 // expected-error {{'propertyOn10_52' is only available in macOS 10.52 or newer}}
+    _ = o.propertyOn52 // expected-error {{'propertyOn52' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-    o.propertyOn10_52 = 22 // expected-error {{'propertyOn10_52' is only available in macOS 10.52 or newer}}
+    o.propertyOn52 = 22 // expected-error {{'propertyOn52' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
     // Methods
-    o.methodAvailableOn10_52() // expected-error {{'methodAvailableOn10_52()' is only available in macOS 10.52 or newer}}
+    o.methodAvailableOn52() // expected-error {{'methodAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
     
     // Initializers
     
-    _ = NSAvailableOn10_51(stringOn10_52:"Hi") // expected-error {{'init(stringOn10_52:)' is only available in macOS 10.52 or newer}}
+    _ = NSAvailableOn51(stringOn52:"Hi") // expected-error {{'init(stringOn52:)' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
 
 // Declarations with Objective-C-originated potentially unavailable APIs
 
-func functionWithObjCParam(o: NSAvailableOn10_51) { // expected-error {{'NSAvailableOn10_51' is only available in macOS 10.51 or newer}}
+func functionWithObjCParam(o: NSAvailableOn51) { // expected-error {{'NSAvailableOn51' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing global function}}
 }
 
-class ClassExtendingUnvailableClass : NSAvailableOn10_51 { // expected-error {{'NSAvailableOn10_51' is only available in macOS 10.51 or newer}}
+class ClassExtendingUnvailableClass : NSAvailableOn51 { // expected-error {{'NSAvailableOn51' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing class}}
 }
 
 // We allow classes to conform to potentially unavailable protocols
-class ClassAdoptingUnavailableProtocol : NSProtocolAvailableOn10_51 {
+class ClassAdoptingUnavailableProtocol : NSProtocolAvailableOn51 {
 }
 
 class SomeSoonToBeConformingClass { }
 
-extension SomeSoonToBeConformingClass : NSProtocolAvailableOn10_51 {
+extension SomeSoonToBeConformingClass : NSProtocolAvailableOn51 {
 }
 
 // Enums from Objective-C
 
-let _: NSPotentiallyUnavailableOptions = .first // expected-error {{'NSPotentiallyUnavailableOptions' is only available in macOS 10.51 or newer}}
+let _: NSPotentiallyUnavailableOptions = .first // expected-error {{'NSPotentiallyUnavailableOptions' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let _: NSOptionsWithUnavailableElement = .third // expected-error {{'third' is only available in macOS 10.51 or newer}}
+let _: NSOptionsWithUnavailableElement = .third // expected-error {{'third' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let _: NSUnavailableEnum = .first // expected-error {{'NSUnavailableEnum' is only available in macOS 10.51 or newer}}
+let _: NSUnavailableEnum = .first // expected-error {{'NSUnavailableEnum' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
-let _: NSEnumWithUnavailableElement = .third // expected-error {{'third' is only available in macOS 10.51 or newer}}
+let _: NSEnumWithUnavailableElement = .third // expected-error {{'third' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Differing availability on getters and setters imported from ObjC.
 
 func gettersAndSettersFromObjC(o: NSAvailableOn10_9) {
       // expected-note@-1 6{{add @available attribute to enclosing global function}}
-  let _: Int = o.propertyOn10_51WithSetterOn10_52After  // expected-error {{'propertyOn10_51WithSetterOn10_52After' is only available in macOS 10.51 or newer}}
+  let _: Int = o.propertyOn51WithSetterOn52After  // expected-error {{'propertyOn51WithSetterOn52After' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  if #available(OSX 10.51, *) {
+  if #available(OSX 51, *) {
     // Properties with unavailable accessors declared before property in Objective-C header
-    o.propertyOn10_51WithSetterOn10_52Before = 5 // expected-error {{setter for 'propertyOn10_51WithSetterOn10_52Before' is only available in macOS 10.52 or newer}}
+    o.propertyOn51WithSetterOn52Before = 5 // expected-error {{setter for 'propertyOn51WithSetterOn52Before' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-    let _: Int = o.propertyOn10_51WithGetterOn10_52Before // expected-error {{getter for 'propertyOn10_51WithGetterOn10_52Before' is only available in macOS 10.52 or newer}}
+    let _: Int = o.propertyOn51WithGetterOn52Before // expected-error {{getter for 'propertyOn51WithGetterOn52Before' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
     // Properties with unavailable accessors declared after property in Objective-C header
-    o.propertyOn10_51WithSetterOn10_52After = 5 // expected-error {{setter for 'propertyOn10_51WithSetterOn10_52After' is only available in macOS 10.52 or newer}}
+    o.propertyOn51WithSetterOn52After = 5 // expected-error {{setter for 'propertyOn51WithSetterOn52After' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
-    let _: Int = o.propertyOn10_51WithGetterOn10_52After // expected-error {{getter for 'propertyOn10_51WithGetterOn10_52After' is only available in macOS 10.52 or newer}}
+    let _: Int = o.propertyOn51WithGetterOn52After // expected-error {{getter for 'propertyOn51WithGetterOn52After' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
 
     // Property with unavailable setter redeclared in Objective-C category
-    o.readOnlyRedeclaredWithSetterInCategory = 5 // expected-error {{setter for 'readOnlyRedeclaredWithSetterInCategory' is only available in macOS 10.52 or newer}}
+    o.readOnlyRedeclaredWithSetterInCategory = 5 // expected-error {{setter for 'readOnlyRedeclaredWithSetterInCategory' is only available in macOS 52 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
   }
 }
@@ -99,18 +99,18 @@ func gettersAndSettersFromObjC(o: NSAvailableOn10_9) {
 
 func useGlobalsFromObjectiveC() {
       // expected-note@-1 3{{add @available attribute to enclosing global function}}
-  _ = globalStringAvailableOn10_51 // expected-error {{'globalStringAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  _ = globalStringAvailableOn51 // expected-error {{'globalStringAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = globalStringAvailableOn10_52 // expected-error {{'globalStringAvailableOn10_52' is only available in macOS 10.52 or newer}}
+  _ = globalStringAvailableOn52 // expected-error {{'globalStringAvailableOn52' is only available in macOS 52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = globalClassInstanceAvailableOn10_51 // expected-error {{'globalClassInstanceAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  _ = globalClassInstanceAvailableOn51 // expected-error {{'globalClassInstanceAvailableOn51' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  if #available(OSX 10.51, *) {
-    _ = globalStringAvailableOn10_51
-    let _: NSAvailableOn10_51 = globalClassInstanceAvailableOn10_51
+  if #available(OSX 51, *) {
+    _ = globalStringAvailableOn51
+    let _: NSAvailableOn51 = globalClassInstanceAvailableOn51
   }
 }
 
@@ -130,20 +130,20 @@ class SubclassWithItsOwnAvailableWitnessOfNSClassWithMethodFromNSProtocolWithOpt
 // unannotated Objective-C protocols
 class UserClass : UnannotatedFrameworkProtocol {
 
-  @available(OSX 10.51, *)
+  @available(OSX 51, *)
   @objc(doSomethingWithClass:)
   func doSomething(with k: AnnotatedFrameworkClass?) { }
 
-  @available(OSX 10.51, *)
+  @available(OSX 51, *)
   @objc
   func doSomething(withNonNullableClass k: AnnotatedFrameworkClass) { }
 
-  @available(OSX 10.51, *)
+  @available(OSX 51, *)
   @objc(doSomethingWithIUOClass:)
   func doSomething(withIUOClass k: AnnotatedFrameworkClass!) { }
 
   @objc
-  @available(OSX 10.51, *)
+  @available(OSX 51, *)
   func returnSomething() -> AnnotatedFrameworkClass? {
     return nil
   }
@@ -151,14 +151,14 @@ class UserClass : UnannotatedFrameworkProtocol {
   @objc
   func noUnavailableTypesInSignature() { }
 
-  @objc(doSomethingWithClass:andLaterClass:) @available(OSX 10.52, *)
+  @objc(doSomethingWithClass:andLaterClass:) @available(OSX 52, *)
   func doSomething(with k: AnnotatedFrameworkClass, andLaterClass lk: AnnotatedLaterFrameworkClass) { }
 
   @objc
-  @available(OSX 10.53, *)
+  @available(OSX 53, *)
   func someMethodWithAvailability() { }
 
-  @available(OSX 10.51, *)
+  @available(OSX 51, *)
   @objc var someProperty: AnnotatedFrameworkClass {
     get { return AnnotatedFrameworkClass() }
     set(newValue) { }
@@ -167,7 +167,7 @@ class UserClass : UnannotatedFrameworkProtocol {
 
 func callViaUnannotatedFrameworkProtocol(p: UnannotatedFrameworkProtocol) {
       // expected-note@-1 {{add @available attribute to enclosing global function}}
-  let _ = p.returnSomething() // expected-error {{'returnSomething()' is only available in macOS 10.51 or newer}}
+  let _ = p.returnSomething() // expected-error {{'returnSomething()' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -178,40 +178,40 @@ func callViaAnnotatedFrameworkProtocol(p: AnnotatedFrameworkProtocol) {
 }
 
 class SubclassOfFrameworkClassConformingToUnannotatedFrameworkProtocol : FrameworkClassConformingToUnannotatedFrameworkProtocol {
-  @available(OSX 10.51, *)
+  @available(OSX 51, *)
   override func doSomething(withNonNullableClass k: AnnotatedFrameworkClass) {
   }
 
-  @available(OSX 10.51, *)
+  @available(OSX 51, *)
   override var someProperty: AnnotatedFrameworkClass {
     get { return AnnotatedFrameworkClass() }
     set(newValue) { }
   }
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   override func doSomething(withIUOClass k: AnnotatedFrameworkClass!) { } // expected-error {{'doSomething' must be as available as declaration it overrides}}
 }
 
-@available(OSX 10.52, *)
+@available(OSX 52, *)
 class SubclassOfLaterFrameworkClassConformingToUnannotatedFrameworkProtocol : LaterFrameworkClassConformingToUnannotatedFrameworkProtocol {
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   override func doSomething(withNonNullableClass k: AnnotatedFrameworkClass) {
   }
 
-  @available(OSX 10.53, *)
+  @available(OSX 53, *)
   override func someMethodWithAvailability() { }
 }
 
 class SubclassOfFrameworkClassConformingToLaterAnnotatedFrameworkProtocol : FrameworkClassConformingToLaterAnnotatedFrameworkProtocol {
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   override func returnSomething() -> AnnotatedFrameworkClass? {
   }
 
-  @available(OSX 10.53, *)
+  @available(OSX 53, *)
   override func someMethodWithAvailability() { }
 
-  @available(OSX 10.52, *)
+  @available(OSX 52, *)
   override var someProperty: AnnotatedFrameworkClass {
     get { return AnnotatedFrameworkClass() }
     set(newValue) { }

--- a/test/Sema/availability_versions_playgrounds.swift
+++ b/test/Sema/availability_versions_playgrounds.swift
@@ -20,22 +20,22 @@ func someFunction() {
     // This branch is dead with our minimum deployment target, so don't emit
     // deprecation and unavailability diagnostics in it.
     deprecatedOn10_8() // no-warning
-    availableOn10_50() // no-warning
+    availableOn50() // no-warning
   }
 
-  if #available(OSX 10.50, *) { // expected-note {{enclosing scope here}}
+  if #available(OSX 50, *) { // expected-note {{enclosing scope here}}
     // Still warn if the check is useless because an enclosing #available rules
     // it out.
-    if #available(OSX 10.50, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+    if #available(OSX 50, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
     }
   }
 }
 
-@available(OSX 10.50, *)
-func availableOn10_50() { // expected-note {{enclosing scope here}}
+@available(OSX 50, *)
+func availableOn50() { // expected-note {{enclosing scope here}}
   // Still warn if the check is useless because an enclosing @available rules
   // it out.
-  if #available(OSX 10.50, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+  if #available(OSX 50, *) { // expected-warning {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
   }
 }
 

--- a/test/Sema/deprecation_osx.swift
+++ b/test/Sema/deprecation_osx.swift
@@ -1,7 +1,7 @@
-// RUN: %swift -typecheck -parse-as-library -target %target-cpu-apple-macosx10.51 %clang-importer-sdk -I %S/Inputs/custom-modules %s -verify
-// RUN: %swift -typecheck -parse-as-library -target %target-cpu-apple-macosx10.51 %clang-importer-sdk -I %S/Inputs/custom-modules %s 2>&1 | %FileCheck %s '--implicit-check-not=<unknown>:0'
+// RUN: %swift -typecheck -parse-as-library -target %target-cpu-apple-macosx51 %clang-importer-sdk -I %S/Inputs/custom-modules %s -verify
+// RUN: %swift -typecheck -parse-as-library -target %target-cpu-apple-macosx51 %clang-importer-sdk -I %S/Inputs/custom-modules %s 2>&1 | %FileCheck %s '--implicit-check-not=<unknown>:0'
 //
-// This test requires a target of OS X 10.51 or later to test deprecation
+// This test requires a target of OS X 51 or later to test deprecation
 // diagnostics because (1) we only emit deprecation warnings if a symbol is
 // deprecated on all deployment targets and (2) symbols deprecated on 10.9 and
 // earlier are imported as unavailable.
@@ -26,16 +26,16 @@ func useClassThatTriggersImportOfDeprecatedEnum() {
 }
 
 func directUseShouldStillTriggerDeprecationWarning() {
-  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
-  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in macOS 10.51: Use a different API}}
+  _ = NSDeprecatedOptions.first // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 51: Use a different API}}
+  _ = NSDeprecatedEnum.first    // expected-warning {{'NSDeprecatedEnum' was deprecated in macOS 51: Use a different API}}
 }
 
-func useInSignature(options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 10.51: Use a different API}}
+func useInSignature(options: NSDeprecatedOptions) { // expected-warning {{'NSDeprecatedOptions' was deprecated in macOS 51: Use a different API}}
 }
 
 
 class Super {
-  @available(OSX, introduced: 10.9, deprecated: 10.51)
+  @available(OSX, introduced: 10.9, deprecated: 51)
   init() { }
 }
 
@@ -48,18 +48,18 @@ class Sub : Super {
   /// cases.
 }
 
-@available(OSX, introduced: 10.9, deprecated: 10.51)
-func functionDeprecatedIn10_51() {
-  _ = ClassDeprecatedIn10_51()
+@available(OSX, introduced: 10.9, deprecated: 51)
+func functionDeprecatedIn51() {
+  _ = ClassDeprecatedIn51()
 }
 
 @available(OSX, introduced: 10.9, deprecated: 10.9)
 class ClassDeprecatedIn10_9 {
 }
 
-@available(OSX, introduced: 10.8, deprecated: 10.51)
-class ClassDeprecatedIn10_51 {
-  var other10_51: ClassDeprecatedIn10_51 = ClassDeprecatedIn10_51()
+@available(OSX, introduced: 10.8, deprecated: 51)
+class ClassDeprecatedIn51 {
+  var other51: ClassDeprecatedIn51 = ClassDeprecatedIn51()
 
   func usingDeprecatedIn10_9() {
     // Following clang, we don't warn here even though we are using a class
@@ -71,80 +71,80 @@ class ClassDeprecatedIn10_51 {
   }
 }
 
-class ClassWithComputedPropertyDeprecatedIn10_51 {
+class ClassWithComputedPropertyDeprecatedIn51 {
 
-  @available(OSX, introduced: 10.8, deprecated: 10.51)
-  var annotatedPropertyDeprecatedIn10_51 : ClassDeprecatedIn10_51 {
+  @available(OSX, introduced: 10.8, deprecated: 51)
+  var annotatedPropertyDeprecatedIn51 : ClassDeprecatedIn51 {
     get {
-      return ClassDeprecatedIn10_51()
+      return ClassDeprecatedIn51()
     }
     set(newValue) {
-      _ = ClassDeprecatedIn10_51()
+      _ = ClassDeprecatedIn51()
     }
   }
 
-  var unannotatedPropertyDeprecatedIn10_51 : ClassDeprecatedIn10_51 { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+  var unannotatedPropertyDeprecatedIn51 : ClassDeprecatedIn51 { // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
     get {
-      return ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+      return ClassDeprecatedIn51() // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
     }
     set(newValue) {
-      _ = ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+      _ = ClassDeprecatedIn51() // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
     }
   }
 
-  var unannotatedStoredPropertyOfTypeDeprecatedIn10_51 : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+  var unannotatedStoredPropertyOfTypeDeprecatedIn51 : ClassDeprecatedIn51? = nil // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
 }
 
-func usesFunctionDeprecatedIn10_51() {
-  _ = ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+func usesFunctionDeprecatedIn51() {
+  _ = ClassDeprecatedIn51() // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
 }
 
-@available(OSX, introduced: 10.8, deprecated: 10.51)
-func annotatedUsesFunctionDeprecatedIn10_51() {
-  _ = ClassDeprecatedIn10_51()
+@available(OSX, introduced: 10.8, deprecated: 51)
+func annotatedUsesFunctionDeprecatedIn51() {
+  _ = ClassDeprecatedIn51()
 }
 
-func hasParameterDeprecatedIn10_51(p: ClassDeprecatedIn10_51) { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+func hasParameterDeprecatedIn51(p: ClassDeprecatedIn51) { // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
 }
 
-@available(OSX, introduced: 10.8, deprecated: 10.51)
-func annotatedHasParameterDeprecatedIn10_51(p: ClassDeprecatedIn10_51) {
+@available(OSX, introduced: 10.8, deprecated: 51)
+func annotatedHasParameterDeprecatedIn51(p: ClassDeprecatedIn51) {
 }
 
-func hasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+func hasReturnDeprecatedIn51() -> ClassDeprecatedIn51 { // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
 }
 
-@available(OSX, introduced: 10.8, deprecated: 10.51)
-func annotatedHasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 {
+@available(OSX, introduced: 10.8, deprecated: 51)
+func annotatedHasReturnDeprecatedIn51() -> ClassDeprecatedIn51 {
 }
 
-var globalWithDeprecatedType : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+var globalWithDeprecatedType : ClassDeprecatedIn51? = nil // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
 
-@available(OSX, introduced: 10.8, deprecated: 10.51)
-var annotatedGlobalWithDeprecatedType : ClassDeprecatedIn10_51?
+@available(OSX, introduced: 10.8, deprecated: 51)
+var annotatedGlobalWithDeprecatedType : ClassDeprecatedIn51?
 
 
 enum EnumWithDeprecatedCasePayload {
-  case WithDeprecatedPayload(p: ClassDeprecatedIn10_51) // expected-warning {{ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+  case WithDeprecatedPayload(p: ClassDeprecatedIn51) // expected-warning {{ClassDeprecatedIn51' was deprecated in macOS 51}}
 
-  @available(OSX, introduced: 10.8, deprecated: 10.51)
-  case AnnotatedWithDeprecatedPayload(p: ClassDeprecatedIn10_51)
+  @available(OSX, introduced: 10.8, deprecated: 51)
+  case AnnotatedWithDeprecatedPayload(p: ClassDeprecatedIn51)
 }
 
-extension ClassDeprecatedIn10_51 { // expected-warning {{'ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+extension ClassDeprecatedIn51 { // expected-warning {{'ClassDeprecatedIn51' was deprecated in macOS 51}}
 
 }
 
-@available(OSX, introduced: 10.8, deprecated: 10.51)
-extension ClassDeprecatedIn10_51 {
-  func methodInExtensionOfClassDeprecatedIn10_51() {
+@available(OSX, introduced: 10.8, deprecated: 51)
+extension ClassDeprecatedIn51 {
+  func methodInExtensionOfClassDeprecatedIn51() {
   }
 }
 
 func callMethodInDeprecatedExtension() {
-  let o = ClassDeprecatedIn10_51() // expected-warning {{'ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+  let o = ClassDeprecatedIn51() // expected-warning {{'ClassDeprecatedIn51' was deprecated in macOS 51}}
 
-  o.methodInExtensionOfClassDeprecatedIn10_51() // expected-warning {{'methodInExtensionOfClassDeprecatedIn10_51()' was deprecated in macOS 10.51}}
+  o.methodInExtensionOfClassDeprecatedIn51() // expected-warning {{'methodInExtensionOfClassDeprecatedIn51()' was deprecated in macOS 51}}
 }
 
 func functionWithDeprecatedMethodInDeadElseBranch() {
@@ -156,7 +156,7 @@ func functionWithDeprecatedMethodInDeadElseBranch() {
 
   if #available(OSX 10.9, *) { // no-warning
   } else {
-    // This branch is dead because our minimum deployment target is 10.51.
+    // This branch is dead because our minimum deployment target is 51.
     let _ = ClassDeprecatedIn10_9()  // no-warning
   }
 
@@ -168,57 +168,57 @@ func functionWithDeprecatedMethodInDeadElseBranch() {
 
 // https://github.com/apple/swift/issues/59843
 class I59843_A {
-  @available(macOS, deprecated: 10.51, renamed: "configure(with:)")
+  @available(macOS, deprecated: 51, renamed: "configure(with:)")
   static func configure(a: String, b: String) {}
 
   static func configure(with: Int) {}
 
-  @available(macOS, deprecated: 10.51, renamed: "method(with:)")
+  @available(macOS, deprecated: 51, renamed: "method(with:)")
   func method(a: String, b: String) {}
 
   func method(with: Int) {}
 
   func f() {
-    self.method(a: "a", b: "b") // expected-warning{{'method(a:b:)' was deprecated in macOS 10.51: renamed to 'method(with:)'}}
+    self.method(a: "a", b: "b") // expected-warning{{'method(a:b:)' was deprecated in macOS 51: renamed to 'method(with:)'}}
     // expected-note@-1{{use 'method(with:)' instead}} {{none}} 
   }
 }
 
 class I59843_B {
-  @available(macOS, deprecated: 10.51, renamed: "configure(with:and:)")
+  @available(macOS, deprecated: 51, renamed: "configure(with:and:)")
   static func configure(a: String, b: String) {}
 
   static func configure(with: Int, and: Int) {}
   
-  @available(macOS, deprecated: 10.51, renamed: "method(with:and:)")
+  @available(macOS, deprecated: 51, renamed: "method(with:and:)")
   func method(a: String, b: String) {}
 
   func method(with: Int, and: Int) {}
 
   // Context
-  @available(macOS, deprecated: 10.51, renamed: "I59843_B.context(with:and:)")
+  @available(macOS, deprecated: 51, renamed: "I59843_B.context(with:and:)")
   static func context(a: String, b: String) {}
 
   static func context(with: Int, and: Int) {}
 
-  @available(macOS, deprecated: 10.51, renamed: "I59843_A.contextDiff(with:and:)")
+  @available(macOS, deprecated: 51, renamed: "I59843_A.contextDiff(with:and:)")
   static func contextDiff(a: String, b: String) {}
 
   static func contextDiff(with: Int, and: Int) {}
   
   func f() {
-    self.method(a: "a", b: "b") // expected-warning{{'method(a:b:)' was deprecated in macOS 10.51: renamed to 'method(with:and:)'}}
+    self.method(a: "a", b: "b") // expected-warning{{'method(a:b:)' was deprecated in macOS 51: renamed to 'method(with:and:)'}}
     // expected-note@-1{{use 'method(with:and:)' instead}} {{17-18=with}} {{25-26=and}}
   }
 }
 
 func I59843_f() {
-  I59843_A.configure(a: "a", b: "b") // expected-warning{{'configure(a:b:)' was deprecated in macOS 10.51: renamed to 'configure(with:)'}}
+  I59843_A.configure(a: "a", b: "b") // expected-warning{{'configure(a:b:)' was deprecated in macOS 51: renamed to 'configure(with:)'}}
   // expected-note@-1{{use 'configure(with:)' instead}} {{none}}
-  I59843_B.configure(a: "a", b: "b") // expected-warning{{'configure(a:b:)' was deprecated in macOS 10.51: renamed to 'configure(with:and:)'}}
+  I59843_B.configure(a: "a", b: "b") // expected-warning{{'configure(a:b:)' was deprecated in macOS 51: renamed to 'configure(with:and:)'}}
   // expected-note@-1{{use 'configure(with:and:)' instead}} {{22-23=with}} {{30-31=and}}
-  I59843_B.context(a: "a", b: "b") // expected-warning{{'context(a:b:)' was deprecated in macOS 10.51: replaced by 'I59843_B.context(with:and:)'}}
+  I59843_B.context(a: "a", b: "b") // expected-warning{{'context(a:b:)' was deprecated in macOS 51: replaced by 'I59843_B.context(with:and:)'}}
   // expected-note@-1{{use 'I59843_B.context(with:and:)' instead}} {{20-21=with}} {{28-29=and}}
-  I59843_B.contextDiff(a: "a", b: "b") // expected-warning{{'contextDiff(a:b:)' was deprecated in macOS 10.51: replaced by 'I59843_A.contextDiff(with:and:)'}}
+  I59843_B.contextDiff(a: "a", b: "b") // expected-warning{{'contextDiff(a:b:)' was deprecated in macOS 51: replaced by 'I59843_A.contextDiff(with:and:)'}}
   // expected-note@-1{{use 'I59843_A.contextDiff(with:and:)' instead}} {{3-23=I59843_A.contextDiff}} {{24-25=with}} {{32-33=and}}
 }

--- a/test/Sema/generalized_accessors_availability.swift
+++ b/test/Sema/generalized_accessors_availability.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.50 -typecheck -verify %s
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx50 -typecheck -verify %s
 
 // REQUIRES: OS=macosx
 
@@ -8,14 +8,14 @@ struct SetterConditionallyAvailable<T> {
     var wrappedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.51, *)
+        @available(macOS 51, *)
         set { fatalError() }
     }
 
     var projectedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.51, *)
+        @available(macOS 51, *)
         set { fatalError() }
     }
 }
@@ -25,14 +25,14 @@ struct ModifyConditionallyAvailable<T> {
     var wrappedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.51, *)
+        @available(macOS 51, *)
         _modify { fatalError() }
     }
 
     var projectedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.51, *)
+        @available(macOS 51, *)
         _modify { fatalError() }
     }
 }
@@ -42,14 +42,14 @@ struct SetterMoreAvailable<T> {
     var wrappedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.49, *)
+        @available(macOS 49, *)
         set { fatalError() }
     }
 
     var projectedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.49, *)
+        @available(macOS 49, *)
         set { fatalError() }
     }
 }
@@ -59,14 +59,14 @@ struct ModifyMoreAvailable<T> {
     var wrappedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.49, *)
+        @available(macOS 49, *)
         _modify { fatalError() }
     }
 
     var projectedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.49, *)
+        @available(macOS 49, *)
         _modify { fatalError() }
     }
 }
@@ -75,7 +75,7 @@ struct Butt {
     var modify_conditionally_available: Int {
         get { fatalError() }
 
-        @available(macOS 10.51, *)
+        @available(macOS 51, *)
         _modify { fatalError() }
     }
 
@@ -93,17 +93,17 @@ struct Butt {
 }
 
 func butt(x: inout Butt) { // expected-note * {{}}
-    x.modify_conditionally_available = 0 // expected-error {{only available in macOS 10.51 or newer}} expected-note{{}}
-    x.wrapped_setter_conditionally_available = 0 // expected-error {{only available in macOS 10.51 or newer}} expected-note{{}}
-    x.wrapped_modify_conditionally_available = 0 // expected-error {{only available in macOS 10.51 or newer}} expected-note{{}}
-    x.$wrapped_setter_conditionally_available = 0 // expected-error {{only available in macOS 10.51 or newer}} expected-note{{}}
-    x.$wrapped_modify_conditionally_available = 0 // expected-error {{only available in macOS 10.51 or newer}} expected-note{{}}
+    x.modify_conditionally_available = 0 // expected-error {{only available in macOS 51 or newer}} expected-note{{}}
+    x.wrapped_setter_conditionally_available = 0 // expected-error {{only available in macOS 51 or newer}} expected-note{{}}
+    x.wrapped_modify_conditionally_available = 0 // expected-error {{only available in macOS 51 or newer}} expected-note{{}}
+    x.$wrapped_setter_conditionally_available = 0 // expected-error {{only available in macOS 51 or newer}} expected-note{{}}
+    x.$wrapped_modify_conditionally_available = 0 // expected-error {{only available in macOS 51 or newer}} expected-note{{}}
     x.wrapped_setter_more_available = 0
     x.wrapped_modify_more_available = 0
     x.$wrapped_setter_more_available = 0
     x.$wrapped_modify_more_available = 0
 
-    if #available(macOS 10.51, *) {
+    if #available(macOS 51, *) {
         x.modify_conditionally_available = 0
         x.wrapped_setter_conditionally_available = 0
         x.wrapped_modify_conditionally_available = 0
@@ -132,7 +132,7 @@ func testButtNested(x: inout Butt.Nested) { // expected-error {{'Nested' is unav
 }
 
 @available(iOS, unavailable)
-@_spi_available(macOS, introduced: 10.51)
+@_spi_available(macOS, introduced: 51)
 extension Butt {
   struct NestedInSPIAvailableExtension {
     @available(macOS, unavailable)
@@ -143,12 +143,12 @@ extension Butt {
   }
 }
 
-@available(macOS, introduced: 10.51)
+@available(macOS, introduced: 51)
 func testButtNested(x: inout Butt.NestedInSPIAvailableExtension) {
   x.unavailable = 0 // expected-error {{is unavailable in macOS}}
 }
 
-@available(macOS 11.0, *)
+@available(macOS 51.0, *)
 struct LessAvailable {
   @SetterConditionallyAvailable
   var wrapped_setter_more_available: Int
@@ -167,18 +167,18 @@ struct LessAvailable {
   }
 }
 
-func testInferredAvailability(x: inout LessAvailable) { // expected-error {{'LessAvailable' is only available in macOS 11.0 or newer}} expected-note*{{}}
-  x.wrapped_setter_more_available = 0 // expected-error {{setter for 'wrapped_setter_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
-  x.wrapped_modify_more_available = 0 // expected-error {{setter for 'wrapped_modify_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
-  x.$wrapped_setter_more_available = 0 // expected-error {{setter for '$wrapped_setter_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
-  x.$wrapped_modify_more_available = 0 // expected-error {{setter for '$wrapped_modify_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
+func testInferredAvailability(x: inout LessAvailable) { // expected-error {{'LessAvailable' is only available in macOS 51.0 or newer}} expected-note*{{}}
+  x.wrapped_setter_more_available = 0 // expected-error {{setter for 'wrapped_setter_more_available' is only available in macOS 51 or newer}} expected-note{{}}
+  x.wrapped_modify_more_available = 0 // expected-error {{setter for 'wrapped_modify_more_available' is only available in macOS 51 or newer}} expected-note{{}}
+  x.$wrapped_setter_more_available = 0 // expected-error {{setter for '$wrapped_setter_more_available' is only available in macOS 51 or newer}} expected-note{{}}
+  x.$wrapped_modify_more_available = 0 // expected-error {{setter for '$wrapped_modify_more_available' is only available in macOS 51 or newer}} expected-note{{}}
 
-  x.nested.wrapped_setter_more_available = 0 // expected-error {{setter for 'wrapped_setter_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
-  x.nested.wrapped_modify_more_available = 0 // expected-error {{setter for 'wrapped_modify_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
-  x.nested.$wrapped_setter_more_available = 0 // expected-error {{setter for '$wrapped_setter_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
-  x.nested.$wrapped_modify_more_available = 0 // expected-error {{setter for '$wrapped_modify_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
+  x.nested.wrapped_setter_more_available = 0 // expected-error {{setter for 'wrapped_setter_more_available' is only available in macOS 51 or newer}} expected-note{{}}
+  x.nested.wrapped_modify_more_available = 0 // expected-error {{setter for 'wrapped_modify_more_available' is only available in macOS 51 or newer}} expected-note{{}}
+  x.nested.$wrapped_setter_more_available = 0 // expected-error {{setter for '$wrapped_setter_more_available' is only available in macOS 51 or newer}} expected-note{{}}
+  x.nested.$wrapped_modify_more_available = 0 // expected-error {{setter for '$wrapped_modify_more_available' is only available in macOS 51 or newer}} expected-note{{}}
 
-  if #available(macOS 11.0, *) {
+  if #available(macOS 51.0, *) {
     x.wrapped_setter_more_available = 0
     x.wrapped_modify_more_available = 0
     x.$wrapped_setter_more_available = 0

--- a/test/Sema/property_wrapper_availability.swift
+++ b/test/Sema/property_wrapper_availability.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx50
 
 // REQUIRES: OS=macosx
 
@@ -9,9 +9,9 @@ struct AlwaysAvailableWrapper<T> {
   var wrappedValue: T
 }
 
-@available(macOS 10.51, *)
+@available(macOS 51, *)
 @propertyWrapper
-struct Available10_51Wrapper<T> {
+struct Available51Wrapper<T> {
   var wrappedValue: T
 }
 
@@ -26,20 +26,20 @@ struct AlwaysAvailableStruct { // expected-note 2 {{add @available attribute to 
   @AlwaysAvailableWrapper var alwaysAvailableExplicit: S
   @AlwaysAvailableWrapper var alwaysAvailableInferred = S()
 
-  @Available10_51Wrapper var available10_51Explicit: S // expected-error {{'Available10_51Wrapper' is only available in macOS 10.51 or newer}}
-  @Available10_51Wrapper var available10_51Inferred = S() // expected-error {{'Available10_51Wrapper' is only available in macOS 10.51 or newer}}
+  @Available51Wrapper var available51Explicit: S // expected-error {{'Available51Wrapper' is only available in macOS 51 or newer}}
+  @Available51Wrapper var available51Inferred = S() // expected-error {{'Available51Wrapper' is only available in macOS 51 or newer}}
   
   @UnavailableWrapper var unavailableExplicit: S // expected-error {{'UnavailableWrapper' is unavailable}}
   @UnavailableWrapper var unavailableInferred = S() // expected-error {{'UnavailableWrapper' is unavailable}}
 }
 
-@available(macOS 10.51, *)
-struct Available10_51Struct {
+@available(macOS 51, *)
+struct Available51Struct {
   @AlwaysAvailableWrapper var alwaysAvailableExplicit: S
   @AlwaysAvailableWrapper var alwaysAvailableInferred = S()
 
-  @Available10_51Wrapper var available10_51Explicit: S
-  @Available10_51Wrapper var available10_51Inferred = S()
+  @Available51Wrapper var available51Explicit: S
+  @Available51Wrapper var available51Inferred = S()
   
   @UnavailableWrapper var unavailableExplicit: S // expected-error {{'UnavailableWrapper' is unavailable}}
   @UnavailableWrapper var unavailableInferred = S() // expected-error {{'UnavailableWrapper' is unavailable}}
@@ -50,8 +50,8 @@ struct UnavailableStruct {
   @AlwaysAvailableWrapper var alwaysAvailableExplicit: S
   @AlwaysAvailableWrapper var alwaysAvailableInferred = S()
   
-  @Available10_51Wrapper var available10_51Explicit: S  // expected-error {{'Available10_51Wrapper' is only available in macOS 10.51 or newer}}
-  @Available10_51Wrapper var available10_51Inferred = S() // expected-error {{'Available10_51Wrapper' is only available in macOS 10.51 or newer}}
+  @Available51Wrapper var available51Explicit: S  // expected-error {{'Available51Wrapper' is only available in macOS 51 or newer}}
+  @Available51Wrapper var available51Inferred = S() // expected-error {{'Available51Wrapper' is only available in macOS 51 or newer}}
 
   @UnavailableWrapper var unavailableExplicit: S
   @UnavailableWrapper var unavailableInferred = S()
@@ -59,20 +59,20 @@ struct UnavailableStruct {
 
 func alwaysAvailableFunc( // expected-note {{add @available attribute to enclosing global function}}
   @AlwaysAvailableWrapper _ alwaysAvailable: S,
-  @Available10_51Wrapper _ available10_51: S, // expected-error {{'Available10_51Wrapper' is only available in macOS 10.51 or newer}}
+  @Available51Wrapper _ available51: S, // expected-error {{'Available51Wrapper' is only available in macOS 51 or newer}}
   @UnavailableWrapper _ unavailable: S // expected-error {{'UnavailableWrapper' is unavailable}}
 ) {}
 
-@available(macOS 10.51, *)
-func available10_51Func(
+@available(macOS 51, *)
+func available51Func(
   @AlwaysAvailableWrapper _ alwaysAvailable: S,
-  @Available10_51Wrapper _ available10_51: S,
+  @Available51Wrapper _ available51: S,
   @UnavailableWrapper _ unavailable: S // expected-error {{'UnavailableWrapper' is unavailable}}
 ) {}
 
 @available(*, unavailable)
 func unavailableFunc(
   @AlwaysAvailableWrapper _ alwaysAvailable: S,
-  @Available10_51Wrapper _ available10_51: S,
+  @Available51Wrapper _ available51: S,
   @UnavailableWrapper _ unavailable: S
 ) {}

--- a/test/Serialization/target-too-new.swift
+++ b/test/Serialization/target-too-new.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.50 -emit-module -parse-stdlib %S/../Inputs/empty.swift -o %t
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx50 -emit-module -parse-stdlib %S/../Inputs/empty.swift -o %t
 // RUN: not %target-swift-frontend -I %t -target %target-cpu-apple-macosx10.9 -typecheck %s 2>&1 | %FileCheck %s
 // RUN: not %target-swift-frontend -I %t -target %target-cpu-apple-darwin13 -typecheck %s 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -I %t -typecheck %s -disable-target-os-checking
-// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.50 -I %t -typecheck %s
-// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.50.1 -I %t -typecheck %s
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx50 -I %t -typecheck %s
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx50.1 -I %t -typecheck %s
 
 // Check that we still get the diagnostic but the module is output anyway when
 // allowing errors
@@ -15,12 +15,12 @@
 
 // Allow any version when built with resilience. (Really we should encode a
 // "minimum supported OS", but we don't have that information today.)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.50 -emit-module -parse-stdlib %S/../Inputs/empty.swift -enable-library-evolution -o %t
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx50 -emit-module -parse-stdlib %S/../Inputs/empty.swift -enable-library-evolution -o %t
 // RUN: %target-swift-frontend -I %t -target %target-cpu-apple-macosx10.9 -typecheck %s
 // RUN: %target-swift-frontend -I %t -target %target-cpu-apple-darwin13 -typecheck %s
 
 
 // REQUIRES: OS=macosx
 
-// CHECK: :[[@LINE+1]]:8: error: compiling for macOS 10.9, but module 'empty' has a minimum deployment target of macOS 10.50: {{.*}}empty.swiftmodule{{$}}
+// CHECK: :[[@LINE+1]]:8: error: compiling for macOS 10.9, but module 'empty' has a minimum deployment target of macOS 50: {{.*}}empty.swiftmodule{{$}}
 import empty

--- a/test/SymbolGraph/Symbols/Mixins/Availability/Duplicated/ObsoletedFilled.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Availability/Duplicated/ObsoletedFilled.swift
@@ -6,7 +6,7 @@
 // REQUIRES: OS=macosx
 
 @available(macOS, introduced: 10.0)
-@available(macOS, obsoleted: 10.999)
+@available(macOS, obsoleted: 999.0)
 public func foo() {}
 
 // CHECK-LABEL: "precise": "s:15ObsoletedFilled3fooyyF",
@@ -18,8 +18,8 @@ public func foo() {}
 // CHECK-NEXT:       "minor": 0
 // CHECK-NEXT:     },
 // CHECK-NEXT:     "obsoleted": {
-// CHECK-NEXT:       "major": 10,
-// CHECK-NEXT:       "minor": 999
+// CHECK-NEXT:       "major": 999,
+// CHECK-NEXT:       "minor": 0
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT: ]

--- a/test/SymbolGraph/Symbols/Mixins/Availability/Duplicated/ObsoletedReplaced.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Availability/Duplicated/ObsoletedReplaced.swift
@@ -5,8 +5,8 @@
 
 // REQUIRES: OS=macosx
 
-@available(macOS, obsoleted: 10.999)
-@available(macOS, obsoleted: 10.888)
+@available(macOS, obsoleted: 999.0)
+@available(macOS, obsoleted: 888.0)
 public func foo() {}
 
 // CHECK: "precise": "s:15ObsoletedFilled3fooyyF"
@@ -14,8 +14,8 @@ public func foo() {}
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "domain": "macOS",
 // CHECK-NEXT:     "obsoleted": {
-// CHECK-NEXT:       "major": 10,
-// CHECK-NEXT:       "minor": 888
+// CHECK-NEXT:       "major": 888,
+// CHECK-NEXT:       "minor": 0
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT: ]

--- a/test/SymbolGraph/Symbols/Mixins/Availability/Inherited/ObsoletedFilled.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Availability/Inherited/ObsoletedFilled.swift
@@ -6,7 +6,7 @@
 
 // REQUIRES: OS=macosx
 
-@available(macOS, obsoleted: 10.15)
+@available(macOS, obsoleted: 50.1)
 public struct S {
   public func foo() {}
 }
@@ -16,13 +16,13 @@ public struct S {
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "domain": "macOS",
 // CHECK-NEXT:     "obsoleted": {
-// CHECK-NEXT:       "major": 10,
-// CHECK-NEXT:       "minor": 15
+// CHECK-NEXT:       "major": 50,
+// CHECK-NEXT:       "minor": 1
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT: ]
 
-@available(macOS, obsoleted: 10.15)
+@available(macOS, obsoleted: 50.1)
 public struct Outer {
   public struct Inner {
     // TRANSITIVE-LABEL: "precise": "s:16IntroducedFilled5OuterV5InnerV3fooyyF"
@@ -30,8 +30,8 @@ public struct Outer {
     // TRANSITIVE-NEXT:   {
     // TRANSITIVE-NEXT:     "domain": "macOS",
     // TRANSITIVE-NEXT:     "obsoleted": {
-    // TRANSITIVE-NEXT:       "major": 10,
-    // TRANSITIVE-NEXT:       "minor": 15
+    // TRANSITIVE-NEXT:       "major": 50,
+    // TRANSITIVE-NEXT:       "minor": 1
     // TRANSITIVE-NEXT:     }
     // TRANSITIVE-NEXT:   }
     // TRANSITIVE-NEXT: ]

--- a/test/attr/ApplicationMain/attr_main_struct_available_future.swift
+++ b/test/attr/ApplicationMain/attr_main_struct_available_future.swift
@@ -2,10 +2,10 @@
 
 // REQUIRES: OS=macosx
 
-@main // expected-error {{'main()' is only available in macOS 10.99 or newer}}
+@main // expected-error {{'main()' is only available in macOS 99 or newer}}
 @available(OSX 10.0, *)
 struct EntryPoint {
-  @available(OSX 10.99, *)
+  @available(OSX 99, *)
   static func main() {
   }
 }

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -174,7 +174,7 @@ extension TestStruct {
   func introducedInExtensionSwift() {} // expected-note 2 {{'introducedInExtensionSwift()' was introduced in Swift 50.0}}
 }
 
-@available(macOS, introduced: 10.50)
+@available(macOS, introduced: 50)
 extension TestStruct {
   func introducedInExtensionMacOS() {}
 }
@@ -183,7 +183,7 @@ TestStruct().unavailInExtension() // expected-error {{'unavailInExtension()' is 
 TestStruct().obsoletedInExtension() // expected-error {{'obsoletedInExtension()' is unavailable}}
 TestStruct().deprecatedInExtension() // expected-warning {{'deprecatedInExtension()' was deprecated in macOS 10.0}}
 TestStruct().introducedInExtensionSwift() // expected-error {{'introducedInExtensionSwift()' is unavailable}}
-TestStruct().introducedInExtensionMacOS() // expected-error {{'introducedInExtensionMacOS()' is only available in macOS 10.50 or newer}}
+TestStruct().introducedInExtensionMacOS() // expected-error {{'introducedInExtensionMacOS()' is only available in macOS 50 or newer}}
 // expected-note@-1{{add 'if #available' version check}}
 
 extension TestStruct {
@@ -197,12 +197,12 @@ extension TestStruct {
 
 extension TestStruct { // expected-note{{add @available attribute to enclosing extension}}
   func availableFuncMacOS() { // expected-note{{add @available attribute to enclosing instance method}}
-    introducedInExtensionMacOS() // expected-error {{'introducedInExtensionMacOS()' is only available in macOS 10.50 or newer}}
+    introducedInExtensionMacOS() // expected-error {{'introducedInExtensionMacOS()' is only available in macOS 50 or newer}}
     // expected-note@-1{{add 'if #available' version check}}
   }
 }
 
-@available(macOS, introduced: 10.50)
+@available(macOS, introduced: 50)
 extension TestStruct {
   func futureFuncMacOS() {
     introducedInExtensionMacOS()

--- a/test/decl/enum/derived_hashable_equatable_macos.swift
+++ b/test/decl/enum/derived_hashable_equatable_macos.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -print-ast %s | %FileCheck %s
 // RUN: %target-swift-frontend -application-extension -print-ast %s | %FileCheck %s
-// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.51 -print-ast %s | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx51 -print-ast %s | %FileCheck %s
 // RUN: %target-swift-frontend -target %target-cpu-apple-macosx14 -print-ast %s | %FileCheck %s
 // REQUIRES: OS=macosx
 
@@ -16,14 +16,14 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:  case unavailableMacOS
   @available(macOS, unavailable)
   case unavailableMacOS
-  // CHECK:       @available(macOS, obsoleted: 10.50)
-  // CHECK-NEXT:  case obsoleted10_50
-  @available(macOS, obsoleted: 10.50)
-  case obsoleted10_50
-  // CHECK:       @available(macOS 10.50, *)
-  // CHECK-NEXT:  case introduced10_50
-  @available(macOS, introduced: 10.50)
-  case introduced10_50
+  // CHECK:       @available(macOS, obsoleted: 50)
+  // CHECK-NEXT:  case obsoleted50
+  @available(macOS, obsoleted: 50)
+  case obsoleted50
+  // CHECK:       @available(macOS 50, *)
+  // CHECK-NEXT:  case introduced50
+  @available(macOS, introduced: 50)
+  case introduced50
   // CHECK:       @available(macOSApplicationExtension, unavailable)
   // CHECK-NEXT:  case unavailableMacOSAppExtension
   @available(macOSApplicationExtension, unavailable)
@@ -38,9 +38,9 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
   // CHECK-NEXT:    case .unavailableMacOS:
   // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
-  // CHECK-NEXT:    case .obsoleted10_50:
+  // CHECK-NEXT:    case .obsoleted50:
   // CHECK-NEXT:      index_a = 1
-  // CHECK-NEXT:    case .introduced10_50:
+  // CHECK-NEXT:    case .introduced50:
   // CHECK-NEXT:      index_a = 2
   // CHECK-NEXT:    case .unavailableMacOSAppExtension:
   // CHECK-NEXT:      index_a = 3
@@ -53,9 +53,9 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
   // CHECK-NEXT:    case .unavailableMacOS:
   // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
-  // CHECK-NEXT:    case .obsoleted10_50:
+  // CHECK-NEXT:    case .obsoleted50:
   // CHECK-NEXT:      index_b = 1
-  // CHECK-NEXT:    case .introduced10_50:
+  // CHECK-NEXT:    case .introduced50:
   // CHECK-NEXT:      index_b = 2
   // CHECK-NEXT:    case .unavailableMacOSAppExtension:
   // CHECK-NEXT:      index_b = 3
@@ -72,9 +72,9 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
   // CHECK-NEXT:    case .unavailableMacOS:
   // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
-  // CHECK-NEXT:    case .obsoleted10_50:
+  // CHECK-NEXT:    case .obsoleted50:
   // CHECK-NEXT:      discriminator = 1
-  // CHECK-NEXT:    case .introduced10_50:
+  // CHECK-NEXT:    case .introduced50:
   // CHECK-NEXT:      discriminator = 2
   // CHECK-NEXT:    case .unavailableMacOSAppExtension:
   // CHECK-NEXT:      discriminator = 3

--- a/test/decl/protocol/conforms/nscoding_availability_osx.swift
+++ b/test/decl/protocol/conforms/nscoding_availability_osx.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -target %target-cpu-apple-macosx10.50 -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -target %target-cpu-apple-macosx50 -verify
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -target %target-cpu-apple-macosx10.50 -dump-ast > %t.ast
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -target %target-cpu-apple-macosx50 -dump-ast > %t.ast
 // RUN: %FileCheck %s < %t.ast
 
 // REQUIRES: objc_interop
@@ -9,13 +9,13 @@
 import Foundation
 
 // Nested classes that aren't available in our deployment target.
-@available(OSX 10.51, *)
+@available(OSX 51, *)
 class CodingI : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
-@available(OSX 10.51, *)
+@available(OSX 51, *)
 class OuterCodingJ {
   // CHECK-NOT: class_decl{{.*}}"NestedJ"{{.*}}@_staticInitializeObjCMetadata
   class NestedJ : CodingI { }


### PR DESCRIPTION
10.50 was once greater than any real macOS version, but now it compares less than real released versions, which makes these tests depend on the deployment target unnecessarily. Update these tests to use even larger numbers to hopefully keep them independent a little longer.

---

Note for reviewers: this was a mostly mechanical change. I found the set of tests to change by bumping the deployment target to 11, regex-replaced the versions, then manually fixed a couple of tests that checked SIL output where the version is split into components so was missed by regex replace.