### PR TITLE
[embedded] Make assert helper functions always inlined to avoid trap basic blocks from merging

### DIFF
--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -84,10 +84,15 @@ internal func _fatalErrorFlags() -> UInt32 {
 /// This function should be used only in the implementation of user-level
 /// assertions.
 ///
-/// This function should not be inlined because it is cold and inlining just
-/// bloats code.
+/// This function should not be inlined in desktop Swift because it is cold and
+/// inlining just bloats code. In Embedded Swift, we force inlining as this
+/// function is typically just a trap (in release configurations).
 @usableFromInline
+#if !$Embedded
 @inline(never)
+#else
+@inline(__always)
+#endif
 @_semantics("programtermination_point")
 internal func _assertionFailure(
   _ prefix: StaticString, _ message: StaticString,
@@ -122,10 +127,15 @@ internal func _assertionFailure(
 /// This function should be used only in the implementation of user-level
 /// assertions.
 ///
-/// This function should not be inlined because it is cold and inlining just
-/// bloats code.
+/// This function should not be inlined in desktop Swift because it is cold and
+/// inlining just bloats code. In Embedded Swift, we force inlining as this
+/// function is typically just a trap (in release configurations).
 @usableFromInline
+#if !$Embedded
 @inline(never)
+#else
+@inline(__always)
+#endif
 @_semantics("programtermination_point")
 @_unavailableInEmbedded
 internal func _assertionFailure(
@@ -155,10 +165,15 @@ internal func _assertionFailure(
 /// This function should be used only in the implementation of user-level
 /// assertions.
 ///
-/// This function should not be inlined because it is cold and inlining just
-/// bloats code.
+/// This function should not be inlined in desktop Swift because it is cold and
+/// inlining just bloats code. In Embedded Swift, we force inlining as this
+/// function is typically just a trap (in release configurations).
 @usableFromInline
+#if !$Embedded
 @inline(never)
+#else
+@inline(__always)
+#endif
 @_semantics("programtermination_point")
 @_unavailableInEmbedded
 internal func _assertionFailure(
@@ -199,10 +214,15 @@ internal func _assertionFailure(
 /// This function should be used only in the implementation of stdlib
 /// assertions.
 ///
-/// This function should not be inlined because it is cold and it inlining just
-/// bloats code.
+/// This function should not be inlined in desktop Swift because it is cold and
+/// inlining just bloats code. In Embedded Swift, we force inlining as this
+/// function is typically just a trap (in release configurations).
 @usableFromInline
+#if !$Embedded
 @inline(never)
+#else
+@inline(__always)
+#endif
 @_semantics("programtermination_point")
 internal func _fatalErrorMessage(
   _ prefix: StaticString, _ message: StaticString,
@@ -288,10 +308,17 @@ func _undefined<T>(
 /// Called when falling off the end of a switch and the type can be represented
 /// as a raw value.
 ///
-/// This function should not be inlined because it is cold and inlining just
-/// bloats code. It doesn't take a source location because it's most important
+/// This function should not be inlined in desktop Swift because it is cold and
+/// inlining just bloats code. In Embedded Swift, we force inlining as this
+/// function is typically just a trap (in release configurations).
+///
+/// It doesn't take a source location because it's most important
 /// in release builds anyway (old apps that are run on new OSs).
+#if !$Embedded
 @inline(never)
+#else
+@inline(__always)
+#endif
 @usableFromInline // COMPILER_INTRINSIC
 internal func _diagnoseUnexpectedEnumCaseValue<SwitchedValue, RawValue>(
   type: SwitchedValue.Type,
@@ -309,10 +336,17 @@ internal func _diagnoseUnexpectedEnumCaseValue<SwitchedValue, RawValue>(
 /// Called when falling off the end of a switch and the value is not safe to
 /// print.
 ///
-/// This function should not be inlined because it is cold and inlining just
-/// bloats code. It doesn't take a source location because it's most important
+/// This function should not be inlined in desktop Swift because it is cold and
+/// inlining just bloats code. In Embedded Swift, we force inlining as this
+/// function is typically just a trap (in release configurations).
+///
+/// It doesn't take a source location because it's most important
 /// in release builds anyway (old apps that are run on new OSs).
+#if !$Embedded
 @inline(never)
+#else
+@inline(__always)
+#endif
 @usableFromInline // COMPILER_INTRINSIC
 internal func _diagnoseUnexpectedEnumCase<SwitchedValue>(
   type: SwitchedValue.Type
@@ -331,10 +365,15 @@ internal func _diagnoseUnexpectedEnumCase<SwitchedValue>(
 /// and the module containing the unavailable function was compiled with
 /// `-unavailable-decl-optimization=stub`.
 ///
-/// This function should not be inlined because it is cold and inlining just
-/// bloats code.
+/// This function should not be inlined in desktop Swift because it is cold and
+/// inlining just bloats code. In Embedded Swift, we force inlining as this
+/// function is typically just a trap (in release configurations).
 @backDeployed(before: SwiftStdlib 5.9)
+#if !$Embedded
 @inline(never)
+#else
+@inline(__always)
+#endif
 @_semantics("unavailable_code_reached")
 @usableFromInline // COMPILER_INTRINSIC
 internal func _diagnoseUnavailableCodeReached() -> Never {

--- a/test/embedded/traps-fatalerror-ir.swift
+++ b/test/embedded/traps-fatalerror-ir.swift
@@ -14,7 +14,7 @@ public func test() {
 
 // CHECK-MESSAGE: define {{.*}}void @"$s4main4testyyF"(){{.*}} {
 // CHECK-MESSAGE: entry:
-// CHECK-MESSAGE:   {{.*}}call {{.*}}void @"$ss17_assertionFailure__
+// CHECK-MESSAGE:   {{.*}}call {{.*}}void @"${{(ss17_assertionFailure__|ss31_embeddedReportFatalErrorInFile)}}
 // CHECK-MESSAGE-SAME: Fatal error
 // CHECK-MESSAGE-SAME: task failed successfully
 // CHECK-MESSAGE-SAME: traps-fatalerror-ir.swift

--- a/test/embedded/traps-multiple-preconditions-ir.swift
+++ b/test/embedded/traps-multiple-preconditions-ir.swift
@@ -22,13 +22,13 @@ public func test(i: Int) {
 
 // "Non-production builds" - We expect 4 separate _assertionFailure() calls with different values
 // CHECK-MESSAGE: define {{.*}}void @"$s4main4test1iySi_tF"(i64 %0) {{.*}}{
-// CHECK-MESSAGE:   call {{.*}}@"$ss17_assertionFailure
+// CHECK-MESSAGE:   call {{.*}}@"${{(ss17_assertionFailure__|ss31_embeddedReportFatalErrorInFile)}}
 // CHECK-MESSAGE:   unreachable
-// CHECK-MESSAGE:   call {{.*}}@"$ss17_assertionFailure
+// CHECK-MESSAGE:   call {{.*}}@"${{(ss17_assertionFailure__|ss31_embeddedReportFatalErrorInFile)}}
 // CHECK-MESSAGE:   unreachable
-// CHECK-MESSAGE:   call {{.*}}@"$ss17_assertionFailure
+// CHECK-MESSAGE:   call {{.*}}@"${{(ss17_assertionFailure__|ss31_embeddedReportFatalErrorInFile)}}
 // CHECK-MESSAGE:   unreachable
-// CHECK-MESSAGE:   call {{.*}}@"$ss17_assertionFailure
+// CHECK-MESSAGE:   call {{.*}}@"${{(ss17_assertionFailure__|ss31_embeddedReportFatalErrorInFile)}}
 // CHECK-MESSAGE:   unreachable
 // CHECK-MESSAGE: }
 

--- a/test/embedded/traps-unique.swift
+++ b/test/embedded/traps-unique.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -Osize -enable-experimental-feature Embedded -emit-ir -Xllvm -link-embedded-runtime=0 -disable-access-control | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public func foobar(i: Int) {
+  if i == 1 { _assertionFailure("prefix", "message 1", file: "", line: 0, flags: 0) }
+  if i == 2 { _assertionFailure("prefix", "message 2", file: "", line: 0, flags: 0) }
+}
+
+// CHECK: define {{.*}}@"$s4main6foobar1iySi_tF"{{.*}} {
+// CHECK: entry:
+// CHECK:   switch i64 %0, label %3 [
+// CHECK:     i64 1, label %1
+// CHECK:     i64 2, label %2
+// CHECK:   ]
+// CHECK: 1:
+// CHECK:   tail call void asm sideeffect ""
+// CHECK:   tail call void @llvm.trap()
+// CHECK:   unreachable
+// CHECK: 2:
+// CHECK:   tail call void asm sideeffect ""
+// CHECK:   tail call void @llvm.trap()
+// CHECK:   unreachable
+// CHECK: 3:
+// CHECK:   ret void
+// CHECK: }
+
+// We should not see a call to _asssertionFailure in IR because that means such basic block can be merged with another
+// and break the expectations that each trap point is unique.
+// CHECK-NOT: @"$ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF"


### PR DESCRIPTION
Various internal assert helpers are marked as `@inline(never)`, which makes sense if the code for the helpers is in a libswiftCore.dylib that ships with the OS, but this ends up causing some problems in Embedded Swift where all the stdlib code is linked into the client code and is also optimized against it. If a function has multiple calls to fatalError, assert preconditionFailure, etc. those end up inlining up to the point of the `@inline(never)` functions, and so we end up with IR of:

```
define {{.*}}@"$s4main6foobar1iySi_tF"{{.*}} {
entry:
  ...
1:
  call @_asssertionFailure
  unreachable
2:
  call @_asssertionFailure
  unreachable
}
```

And LLVM will merge the two blocks into one, which breaks the expectation that trap points are unique. What we ideally want in Embedded Swift, is to actually force inlining of `_asssertionFailure` so that the traps end up in the callee, and those are already prevented from merging.