### PR TITLE
MandatoryPerformanceOptimizations: force inlining of transparent functions and de-virtualization

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/FunctionUses.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/FunctionUses.swift
@@ -45,7 +45,7 @@ struct FunctionUses {
     var hasUnknownUses: Bool
 
     init(of function: Function) {
-      self.hasUnknownUses = function.isPossiblyUsedExternally || function.isAvailableExternally
+      self.hasUnknownUses = function.isPossiblyUsedExternally || function.isDefinedExternally
     }
 
     mutating func insert(_ inst: Instruction, _ uses: inout [Use]) {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -119,7 +119,7 @@ let generalClosureSpecialization = FunctionPass(name: "experimental-swift-based-
 let autodiffClosureSpecialization = FunctionPass(name: "autodiff-closure-specialization") {
   (function: Function, context: FunctionPassContext) in
 
-  guard !function.isAvailableExternally,
+  guard !function.isDefinedExternally,
         function.isAutodiffVJP,
         function.blocks.singleElement != nil else {
     return
@@ -502,7 +502,7 @@ private func handleApplies(for rootClosure: SingleValueInstruction, callSiteMap:
       continue
     }
 
-    if callee.isAvailableExternally {
+    if callee.isDefinedExternally {
       continue
     }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -27,7 +27,7 @@ import SIL
 let computeSideEffects = FunctionPass(name: "compute-side-effects") {
   (function: Function, context: FunctionPassContext) in
 
-  if function.isAvailableExternally {
+  if function.isDefinedExternally {
     // We cannot assume anything about function, which are defined in another module,
     // even if the serialized SIL of its body is available in the current module.
     // If the other module was compiled with library evolution, the implementation

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/ReadOnlyGlobalVariables.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/ReadOnlyGlobalVariables.swift
@@ -35,7 +35,7 @@ let readOnlyGlobalVariablesPass = ModulePass(name: "read-only-global-variables")
   }
 
   for g in moduleContext.globalVariables {
-    if !g.isAvailableExternally,
+    if !g.isDefinedExternally,
        !g.isPossiblyUsedExternally,
        !g.isLet,
        !writtenGlobals.contains(g) {

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/ModulePassContext.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/ModulePassContext.swift
@@ -171,3 +171,9 @@ extension GlobalVariable {
     bridged.setLet(value)
   }
 }
+
+extension Function {
+  func set(linkage: Linkage, _ context: ModulePassContext) {
+    bridged.setLinkage(linkage.bridged)
+  }
+}

--- a/SwiftCompilerSources/Sources/SIL/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/SIL/CMakeLists.txt
@@ -20,6 +20,7 @@ add_swift_compiler_module(SIL
     FunctionConvention.swift
     GlobalVariable.swift
     Instruction.swift
+    Linkage.swift
     Location.swift
     Operand.swift
     Registration.swift

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -113,6 +113,8 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
 
   public var isGeneric: Bool { bridged.isGeneric() }
 
+  public var linkage: Linkage { bridged.getLinkage().linkage }
+
   /// True, if the linkage of the function indicates that it is visible outside the current
   /// compilation unit and therefore not all of its uses are known.
   ///
@@ -125,9 +127,7 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
   /// current compilation unit.
   ///
   /// For example, `public_external` linkage.
-  public var isAvailableExternally: Bool {
-    return bridged.isAvailableExternally()
-  }
+  public var isDefinedExternally: Bool { linkage.isExternal }
 
   public func hasSemanticsAttribute(_ attr: StaticString) -> Bool {
     attr.withUTF8Buffer { (buffer: UnsafeBufferPointer<UInt8>) in

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -30,6 +30,8 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
 
   public var isLet: Bool { bridged.isLet() }
 
+  public var linkage: Linkage { bridged.getLinkage().linkage }
+
   /// True, if the linkage of the global variable indicates that it is visible outside the current
   /// compilation unit and therefore not all of its uses are known.
   ///
@@ -42,9 +44,7 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
   /// current compilation unit.
   ///
   /// For example, `public_external` linkage.
-  public var isAvailableExternally: Bool {
-    return bridged.isAvailableExternally()
-  }
+  public var isDefinedExternally: Bool { linkage.isExternal }
 
   public var staticInitializerInstructions: InstructionList? {
     if let firstStaticInitInst = bridged.getFirstStaticInitInst().instruction {

--- a/SwiftCompilerSources/Sources/SIL/Linkage.swift
+++ b/SwiftCompilerSources/Sources/SIL/Linkage.swift
@@ -1,0 +1,164 @@
+//===--- Linkage.swift ----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+public enum Linkage: CustomStringConvertible {
+  /// This object definition is visible to multiple Swift modules (and
+  /// thus potentially across linkage-unit boundaries).  There are no
+  /// other object definitions with this name in the program.
+  ///
+  /// Public functions must be definitions, i.e. must have a body, except the
+  /// body is emitted by clang.
+  case `public`
+
+  /// This is a special linkage used for symbols which are treated
+  /// as public for the purposes of SIL serialization and optimization,
+  /// but do not have public entry points in the generated binary.
+  ///
+  /// This linkage is used for @_alwaysEmitIntoClient functions.
+  ///
+  /// There is no external variant of this linkage, because from other
+  /// translation units in the same module, this behaves identically
+  /// to the HiddenExternal linkage.
+  ///
+  /// When deserialized, such declarations receive Shared linkage.
+  ///
+  /// PublicNonABI functions must be definitions.
+  case publicNonABI
+
+  /// Same as \c Public, except the definition is visible within a package
+  /// of modules.
+  case package
+
+  /// Similar to \c PublicNonABI, this definition is used for symbols treated
+  /// as package but do not have package entry points in the generated binary.
+  /// It's used for default argument expressions and `@_alwaysEmitIntoClient`.
+  /// When deserialized, this will become \c Shared linkage.
+  case packageNonABI
+
+  /// This object definition is visible only to the current Swift
+  /// module (and thus should not be visible across linkage-unit
+  /// boundaries).  There are no other object definitions with this
+  /// name in the module.
+  ///
+  /// Hidden functions must be definitions, i.e. must have a body, except the
+  /// body is emitted by clang.
+  case hidden
+
+  /// This object definition is visible only within a single Swift
+  /// module.  There may be other object definitions with this name in
+  /// the module; those definitions are all guaranteed to be
+  /// semantically equivalent to this one.
+  ///
+  /// This linkage is used e.g. for thunks and for specialized functions.
+  ///
+  /// Shared functions must be definitions, i.e. must have a body, except the
+  /// body is emitted by clang.
+  case shared
+
+  /// This object definition is visible only within a single Swift
+  /// file.
+  ///
+  /// Private functions must be definitions, i.e. must have a body, except the
+  /// body is emitted by clang.
+  case `private`
+
+  /// A Public definition with the same name as this object will be
+  /// available to the current Swift module at runtime.  If this
+  /// object is a definition, it is semantically equivalent to that
+  /// definition.
+  case publicExternal
+
+  /// Similar to \c PublicExternal.
+  /// Used to reference a \c Package definition in a different module
+  /// within a package.
+  case packageExternal
+
+  /// A Public or Hidden definition with the same name as this object
+  /// will be defined by the current Swift module at runtime.
+  ///
+  /// This linkage is only used for non-whole-module compilations to refer to
+  /// functions in other files of the same module.
+  case hiddenExternal
+
+  public var isExternal: Bool {
+    switch self {
+    case .public,
+         .publicNonABI,
+         .package,
+         .packageNonABI,
+         .hidden,
+         .shared,
+         .private:
+      return false
+    case .packageExternal,
+         .publicExternal,
+         .hiddenExternal:
+      return true
+    }
+
+  }
+
+  public var description: String {
+    switch self {
+      case .public:          return "public"
+      case .publicNonABI:    return "publicNonABI"
+      case .package:         return "package"
+      case .packageNonABI:   return "packageNonABI"
+      case .hidden:          return "hidden"
+      case .shared:          return "shared"
+      case .private:         return "private"
+      case .packageExternal: return "packageExternal"
+      case .publicExternal:  return "publicExternal"
+      case .hiddenExternal:  return "hiddenExternal"
+    }
+  }
+}
+
+// Bridging utilities
+
+extension BridgedLinkage {
+  var linkage: Linkage {
+    switch self {
+      case .Public:          return .public
+      case .PublicNonABI:    return .publicNonABI
+      case .Package:         return .package
+      case .PackageNonABI:   return .packageNonABI
+      case .Hidden:          return .hidden
+      case .Shared:          return .shared
+      case .Private:         return .private
+      case .PublicExternal:  return .publicExternal
+      case .PackageExternal: return .packageExternal
+      case .HiddenExternal:  return .hiddenExternal
+      default:
+        fatalError("unsupported argument convention")
+    }
+  }
+}
+
+extension Linkage {
+  public var bridged: BridgedLinkage {
+    switch self {
+      case .public:          return .Public
+      case .publicNonABI:    return .PublicNonABI
+      case .package:         return .Package
+      case .packageNonABI:   return .PackageNonABI
+      case .hidden:          return .Hidden
+      case .shared:          return .Shared
+      case .private:         return .Private
+      case .publicExternal:  return .PublicExternal
+      case .packageExternal: return .PackageExternal
+      case .hiddenExternal:  return .HiddenExternal
+    }
+  }
+}

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -290,6 +290,19 @@ struct BridgedLifetimeDependenceInfoArray {
   at(SwiftInt index) const;
 };
 
+enum class BridgedLinkage {
+  Public,
+  PublicNonABI,
+  Package,
+  PackageNonABI,
+  Hidden,
+  Shared,
+  Private,
+  PublicExternal,
+  PackageExternal,
+  HiddenExternal
+};
+
 // Temporary access to the AST type within SIL until ASTBridging provides it.
 struct BridgedASTType {
   swift::TypeBase * _Nullable type;
@@ -618,20 +631,7 @@ struct BridgedFunction {
     IsSerializedForPackage
   };
 
-  enum class Linkage {
-    Public,
-    PublicNonABI,
-    Package,
-    PackageNonABI,
-    Hidden,
-    Shared,
-    Private,
-    PublicExternal,
-    PackageExternal,
-    HiddenExternal
-  };
-
-  SWIFT_NAME("init(obj:)") 
+  SWIFT_NAME("init(obj:)")
   SWIFT_IMPORT_UNSAFE BridgedFunction(SwiftObject obj) : obj(obj) {}
   SWIFT_IMPORT_UNSAFE BridgedFunction() {}
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE swift::SILFunction * _Nonnull getFunction() const;
@@ -650,7 +650,6 @@ struct BridgedFunction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getSILResultType() const;
   BRIDGED_INLINE bool isSwift51RuntimeAvailable() const;
   BRIDGED_INLINE bool isPossiblyUsedExternally() const;
-  BRIDGED_INLINE bool isAvailableExternally() const;
   BRIDGED_INLINE bool isTransparent() const;
   BRIDGED_INLINE bool isAsync() const;
   BRIDGED_INLINE bool isGlobalInitFunction() const;
@@ -676,7 +675,8 @@ struct BridgedFunction {
   BRIDGED_INLINE bool isResilientNominalDecl(BridgedNominalTypeDecl decl) const;
   BRIDGED_INLINE BridgedType getLoweredType(BridgedASTType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getLoweredType(BridgedType type) const;
-  BRIDGED_INLINE void setLinkage(Linkage linkage) const;
+  BRIDGED_INLINE BridgedLinkage getLinkage() const;
+  BRIDGED_INLINE void setLinkage(BridgedLinkage linkage) const;
   bool isTrapNoReturn() const;
   bool isAutodiffVJP() const;
   SwiftInt specializationLevel() const;
@@ -734,8 +734,8 @@ struct BridgedGlobalVar {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef getName() const;
   BRIDGED_INLINE bool isLet() const;
   BRIDGED_INLINE void setLet(bool value) const;
+  BRIDGED_INLINE BridgedLinkage getLinkage() const;
   BRIDGED_INLINE bool isPossiblyUsedExternally() const;
-  BRIDGED_INLINE bool isAvailableExternally() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedInstruction getFirstStaticInitInst() const;
   bool canBeInitializedStatically() const;
   bool mustBeInitializedStatically() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -693,10 +693,6 @@ bool BridgedFunction::isPossiblyUsedExternally() const {
   return getFunction()->isPossiblyUsedExternally();
 }
 
-bool BridgedFunction::isAvailableExternally() const {
-  return getFunction()->isAvailableExternally();
-}
-
 bool BridgedFunction::isTransparent() const {
   return getFunction()->isTransparent() == swift::IsTransparent;
 }
@@ -788,7 +784,11 @@ void BridgedFunction::setIsPerformanceConstraint(bool isPerfConstraint) const {
   getFunction()->setIsPerformanceConstraint(isPerfConstraint);
 }
 
-void BridgedFunction::setLinkage(Linkage linkage) const {
+BridgedLinkage BridgedFunction::getLinkage() const {
+  return (BridgedLinkage)getFunction()->getLinkage();
+}
+
+void BridgedFunction::setLinkage(BridgedLinkage linkage) const {
   getFunction()->setLinkage((swift::SILLinkage)linkage);
 }
 
@@ -825,12 +825,12 @@ bool BridgedGlobalVar::isLet() const { return getGlobal()->isLet(); }
 
 void BridgedGlobalVar::setLet(bool value) const { getGlobal()->setLet(value); }
 
-bool BridgedGlobalVar::isPossiblyUsedExternally() const {
-  return getGlobal()->isPossiblyUsedExternally();
+BridgedLinkage BridgedGlobalVar::getLinkage() const {
+  return (BridgedLinkage)getGlobal()->getLinkage();
 }
 
-bool BridgedGlobalVar::isAvailableExternally() const {
-  return swift::isAvailableExternally(getGlobal()->getLinkage());
+bool BridgedGlobalVar::isPossiblyUsedExternally() const {
+  return getGlobal()->isPossiblyUsedExternally();
 }
 
 OptionalBridgedInstruction BridgedGlobalVar::getFirstStaticInitInst() const {

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -276,6 +276,20 @@ static_assert((int)BridgedArgumentConvention::Pack_Inout == (int)swift::SILArgum
 static_assert((int)BridgedArgumentConvention::Pack_Guaranteed == (int)swift::SILArgumentConvention::Pack_Guaranteed);
 static_assert((int)BridgedArgumentConvention::Pack_Out == (int)swift::SILArgumentConvention::Pack_Out);
 
+//===----------------------------------------------------------------------===//
+//                                Linkage
+//===----------------------------------------------------------------------===//
+
+static_assert((int)BridgedLinkage::Public == (int)swift::SILLinkage::Public);
+static_assert((int)BridgedLinkage::PublicNonABI == (int)swift::SILLinkage::PublicNonABI);
+static_assert((int)BridgedLinkage::Package == (int)swift::SILLinkage::Package);
+static_assert((int)BridgedLinkage::PackageNonABI == (int)swift::SILLinkage::PackageNonABI);
+static_assert((int)BridgedLinkage::Hidden == (int)swift::SILLinkage::Hidden);
+static_assert((int)BridgedLinkage::Shared == (int)swift::SILLinkage::Shared);
+static_assert((int)BridgedLinkage::Private == (int)swift::SILLinkage::Private);
+static_assert((int)BridgedLinkage::PublicExternal == (int)swift::SILLinkage::PublicExternal);
+static_assert((int)BridgedLinkage::PackageExternal == (int)swift::SILLinkage::PackageExternal);
+static_assert((int)BridgedLinkage::HiddenExternal == (int)swift::SILLinkage::HiddenExternal);
 
 //===----------------------------------------------------------------------===//
 //                            SILGlobalVariable

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -1182,7 +1182,8 @@ static bool canDevirtualizeWitnessMethod(ApplySite applySite, bool isMandatory) 
 
   // function_ref inside fragile function cannot reference a private or
   // hidden symbol.
-  if (applySite.getFunction()->isAnySerialized() &&
+  if (!isMandatory &&
+      applySite.getFunction()->isAnySerialized() &&
       !f->hasValidLinkageForFragileRef(applySite.getFunction()->getSerializedKind()))
     return false;
 

--- a/test/SILOptimizer/mandatory_devirt_witness_method.sil
+++ b/test/SILOptimizer/mandatory_devirt_witness_method.sil
@@ -1,0 +1,59 @@
+// RUN: %target-sil-opt -module-name=test -enable-sil-verify-all %s -mandatory-performance-optimizations -performance-diagnostics | %FileCheck %s
+
+sil_stage canonical
+
+import Swift
+import SwiftShims
+import Builtin
+
+public protocol P {
+  func foo()
+}
+
+private struct S : P {
+  @_hasStorage var x: Int
+  func foo()
+}
+
+// Linkage should be set to public
+// CHECK-LABEL: sil [perf_constraint] [ossa] @S_foo : $@convention(method) (S) -> () {
+sil private [ossa] @S_foo : $@convention(method) (S) -> () {
+bb0(%0 : $S):
+  %2 = tuple ()
+  return %2 : $()
+}
+
+sil private [transparent] [thunk] [ossa] @S_foo_thunk : $@convention(witness_method: P) (@in_guaranteed S) -> () {
+bb0(%0 : $*S):
+  %1 = load [trivial] %0 : $*S
+  %2 = function_ref @S_foo : $@convention(method) (S) -> ()
+  %3 = apply %2(%1) : $@convention(method) (S) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: sil shared [serialized] [perf_constraint] [ossa] @$s8call_foo4test1S{{.*}}_Tgq5 : $@convention(thin) (S) -> () {
+// CHECK:         [[F:%.*]] = function_ref @S_foo : $@convention(method) (S) -> ()
+// CHECK:         = apply [[F]](%0) : $@convention(method) (S) -> ()
+// CHECK:       // end sil function '$s8call_foo4test1S{{.*}}_Tgq5'
+sil [ossa] [serialized] @call_foo : $@convention(thin) <T where T : P> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %2 = witness_method $T, #P.foo : <Self where Self : P> (Self) -> () -> () : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  %3 = apply %2<T>(%0) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+
+sil [no_locks] [ossa] [serialized] @main : $@convention(thin) (@in_guaranteed S) -> () {
+bb0(%0 : $*S):
+  %5 = function_ref @call_foo : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  %6 = apply %5<S>(%0) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil_witness_table private S: P module test {
+  method #P.foo: <Self where Self : P> (Self) -> () -> () : @S_foo_thunk	
+}
+
+

--- a/test/SILOptimizer/mandatory_performance_optimizations.sil
+++ b/test/SILOptimizer/mandatory_performance_optimizations.sil
@@ -120,7 +120,7 @@ bb0:
   %2 = tuple ()
   return %2 : $()
 }
-sil shared [transparent] [serialized] [thunk] [canonical] @$sSiSLsSL1loiySbx_xtFZTW : $@convention(witness_method: Comparable) (@in_guaranteed Int, @in_guaranteed Int, @thick Int.Type) -> Bool {
+sil shared [ossa] [transparent] [serialized] [thunk] [canonical] @$sSiSLsSL1loiySbx_xtFZTW : $@convention(witness_method: Comparable) (@in_guaranteed Int, @in_guaranteed Int, @thick Int.Type) -> Bool {
 bb0(%0 : $*Int, %1 : $*Int, %2 : $@thick Int.Type):
   %3 = integer_literal $Builtin.Int1, 0
   %4 = struct $Bool (%3 : $Builtin.Int1)


### PR DESCRIPTION
Do this even if the function then contains references to other functions with wrong linkage. Instead fix the linkage later.
Fixes a false error in embedded swift.

rdar://134352676