### PR TITLE
Extend internal `_mangledTypeName()` function to take non-copyable types.

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -97,14 +97,15 @@ func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
 
 @available(SwiftStdlib 5.3, *)
 @_silgen_name("swift_getMangledTypeName")
-public func _getMangledTypeName(_ type: Any.Type)
+public func _getMangledTypeName(_ type: any ~Copyable.Type)
   -> (UnsafePointer<UInt8>, Int)
 
 /// Returns the mangled name for a given type.
 @available(SwiftStdlib 5.3, *)
 @_unavailableInEmbedded
+@_preInverseGenerics
 public // SPI
-func _mangledTypeName(_ type: Any.Type) -> String? {
+func _mangledTypeName(_ type: any ~Copyable.Type) -> String? {
   let (stringPtr, count) = _getMangledTypeName(type)
   guard count > 0 else {
     return nil

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -97,6 +97,7 @@ func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
 
 @available(SwiftStdlib 5.3, *)
 @_silgen_name("swift_getMangledTypeName")
+@_preInverseGenerics
 public func _getMangledTypeName(_ type: any ~Copyable.Type)
   -> (UnsafePointer<UInt8>, Int)
 

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -529,7 +529,7 @@ if #available(SwiftStdlib 5.3, *) {
 
   DemangleToMetadataTests.test("Check _MangledTypeName with any ~Copyable.Type") {
     let type: any ~Copyable.Type = NonCopyable.self
-    expectEqual("s11NonCopyableV", _mangledTypeName(type))
+    expectEqual("4main11NonCopyableV", _mangledTypeName(type))
   }
 }
 

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -493,6 +493,8 @@ DemangleToMetadataTests.test("Nested types in same-type-constrained extensions")
   // V !: P3 in InnerTEqualsConformsToP1
 }
 
+struct NonCopyable: ~Copyable {}
+
 if #available(SwiftStdlib 5.3, *) {
   DemangleToMetadataTests.test("Round-trip with _mangledTypeName and _typeByName") {
     func roundTrip<T>(_ type: T.Type) {
@@ -523,6 +525,11 @@ if #available(SwiftStdlib 5.3, *) {
   DemangleToMetadataTests.test("Check _mangledTypeName with Any.Type") {
     let type: Any.Type = Int.self
     expectEqual("Si", _mangledTypeName(type))
+  }
+
+  DemangleToMetadataTests.test("Check _MangledTypeName with any ~Copyable.Type") {
+    let type: any ~Copyable.Type = NonCopyable.self
+    expectEqual("s11NonCopyableV", _mangledTypeName(type))
   }
 }
 


### PR DESCRIPTION
`_mangledTypeName()` returns the Swift-mangled typename of a given type. This PR extends it to take non-copyable types as well.

Related to our use case in Swift Testing, but not to the PR directly: #69146 #69147 #71112

Resolves rdar://134278607.