### PR TITLE
Fix flipped 0/1 values in SimplifyBuiltin.optimizeAssertConfig

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -150,19 +150,20 @@ private extension BuiltinInst {
   }
 
   func optimizeAssertConfig(_ context: SimplifyContext) {
-    let literal: IntegerLiteralInst
-    switch context.options.assertConfiguration {
-    case .enabled:
+    // The values for the assert_configuration call are:
+    // 0: Debug
+    // 1: Release
+    // 2: Fast / Unchecked
+    let config = context.options.assertConfiguration
+    switch config {
+    case .debug, .release, .unchecked:
       let builder = Builder(before: self, context)
-      literal = builder.createIntegerLiteral(1,  type: type)
-    case .disabled:
-      let builder = Builder(before: self, context)
-      literal = builder.createIntegerLiteral(0,  type: type)
-    default:
+      let literal = builder.createIntegerLiteral(config.integerValue, type: type)
+      uses.replaceAll(with: literal, context)
+      context.erase(instruction: self)
+    case .unknown:
       return
     }
-    uses.replaceAll(with: literal, context)
-    context.erase(instruction: self)
   }
   
   func optimizeTargetTypeConst(_ context: SimplifyContext) {

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
@@ -36,16 +36,31 @@ struct Options {
     _bridged.hasFeature(feature)
   }
 
+  // The values for the assert_configuration call are:
+  // 0: Debug
+  // 1: Release
+  // 2: Fast / Unchecked
   enum AssertConfiguration {
-    case enabled
-    case disabled
+    case debug
+    case release
+    case unchecked
     case unknown
+
+    var integerValue: Int {
+      switch self {
+      case .debug: 0
+      case .release: 1
+      case .unchecked: 2
+      case .unknown: fatalError()
+      }
+    }
   }
 
   var assertConfiguration: AssertConfiguration {
     switch _bridged.getAssertConfiguration() {
-      case .Debug:               return .enabled
-      case .Release, .Unchecked: return .disabled
+      case .Debug:               return .debug
+      case .Release:             return .release
+      case .Unchecked:           return .unchecked
       default:                   return .unknown
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
@@ -48,10 +48,10 @@ struct Options {
 
     var integerValue: Int {
       switch self {
-      case .debug: 0
-      case .release: 1
-      case .unchecked: 2
-      case .unknown: fatalError()
+      case .debug:      return 0
+      case .release:    return 1
+      case .unchecked:  return 2
+      case .unknown:    fatalError()
       }
     }
   }

--- a/test/SILOptimizer/simplify_builtin.sil
+++ b/test/SILOptimizer/simplify_builtin.sil
@@ -1,7 +1,7 @@
 // RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=builtin | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-EARLY
 // RUN: %target-sil-opt -enable-sil-verify-all %s -late-onone-simplification -simplify-instruction=builtin | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-LATE
-// RUN: %target-sil-opt -enable-sil-verify-all %s -assert-conf-id=1 -onone-simplification -simplify-instruction=builtin | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-NOASSERTS
-// RUN: %target-sil-opt -enable-sil-verify-all %s -assert-conf-id=2 -onone-simplification -simplify-instruction=builtin | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-NOASSERTS
+// RUN: %target-sil-opt -enable-sil-verify-all %s -assert-conf-id=1 -onone-simplification -simplify-instruction=builtin | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-NOASSERTS1
+// RUN: %target-sil-opt -enable-sil-verify-all %s -assert-conf-id=2 -onone-simplification -simplify-instruction=builtin | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-NOASSERTS2
 
 // REQUIRES: swift_in_compiler
 
@@ -417,8 +417,9 @@ bb0:
 
 // CHECK-LABEL: sil @remove_assert_configuration
 // CHECK-NOT:     builtin "assert_configuration"
-// CHECK-EARLY:     [[L:%.*]] = integer_literal $Builtin.Int8, 1
-// CHECK-NOASSERTS: [[L:%.*]] = integer_literal $Builtin.Int8, 0
+// CHECK-EARLY:     [[L:%.*]] = integer_literal $Builtin.Int8, 0
+// CHECK-NOASSERTS1: [[L:%.*]] = integer_literal $Builtin.Int8, 1
+// CHECK-NOASSERTS2: [[L:%.*]] = integer_literal $Builtin.Int8, 2
 // CHECK:         [[R:%.*]] = struct $Int8 ([[L]] : $Builtin.Int8)
 // CHECK:         return [[R]]
 // CHECK:       } // end sil function 'remove_assert_configuration'


### PR DESCRIPTION
The expectations for the resolved values of `Builtin.assert_configuration()` are (per AssertCommon.swift):
```
    // The values for the assert_configuration call are:
    // 0: Debug
    // 1: Release
    // 2: Fast / Unchecked
```
And this is how ConstantFolding.cpp implements it, but it turns out that the complementary SimplifyBuiltin pass is using wrong integer values. Let's fix that.