### PR TITLE
[RemoteMirror] Fix generic subclasses of resilient superclasses.

### DIFF
--- a/include/swift/Remote/CMemoryReader.h
+++ b/include/swift/Remote/CMemoryReader.h
@@ -22,6 +22,8 @@
 #include "swift/Remote/MemoryReader.h"
 
 struct MemoryReaderImpl {
+  uint8_t PointerSize;
+
   // Opaque pointer passed to all the callback functions.
   void *reader_context;
 
@@ -40,8 +42,39 @@ namespace remote {
 class CMemoryReader final : public MemoryReader {
   MemoryReaderImpl Impl;
 
+  uint64_t ptrauthMask;
+
+  uint64_t getPtrauthMask() {
+    if (ptrauthMask == 0) {
+      int success;
+      if (Impl.PointerSize == 4) {
+        uint32_t ptrauthMask32 = 0;
+        success = queryDataLayout(DataLayoutQueryType::DLQ_GetPtrAuthMask,
+                                  nullptr, &ptrauthMask32);
+        ptrauthMask = ptrauthMask32;
+      } else if (Impl.PointerSize == 8) {
+        success = queryDataLayout(DataLayoutQueryType::DLQ_GetPtrAuthMask,
+                                  nullptr, &ptrauthMask);
+      } else {
+        success = 0;
+      }
+
+      if (!success)
+        ptrauthMask = ~0ull;
+    }
+    return ptrauthMask;
+  }
+
+  // Check to see if an address has bits outside the ptrauth mask. This suggests
+  // that we're likely failing to strip a signed pointer when reading from it.
+  bool hasSignatureBits(RemoteAddress address) {
+    return false;
+    uint64_t addressData = address.getAddressData();
+    return addressData != (addressData & getPtrauthMask());
+  }
+
 public:
-  CMemoryReader(MemoryReaderImpl Impl) : Impl(Impl) {
+  CMemoryReader(MemoryReaderImpl Impl) : Impl(Impl), ptrauthMask(0) {
     assert(this->Impl.queryDataLayout && "No queryDataLayout implementation");
     assert(this->Impl.getStringLength && "No stringLength implementation");
     assert(this->Impl.readBytes && "No readBytes implementation");
@@ -60,11 +93,13 @@ public:
   }
 
   uint64_t getStringLength(RemoteAddress address) {
+    assert(!hasSignatureBits(address));
     return Impl.getStringLength(Impl.reader_context,
                                 address.getAddressData());
   }
 
   bool readString(RemoteAddress address, std::string &dest) override {
+    assert(!hasSignatureBits(address));
     auto length = getStringLength(address);
     if (length == 0) {
       // A length of zero unfortunately might mean either that there's a zero
@@ -83,17 +118,20 @@ public:
   }
 
   ReadBytesResult readBytes(RemoteAddress address, uint64_t size) override {
-      void *FreeContext;
-      auto Ptr = Impl.readBytes(Impl.reader_context, address.getAddressData(), size,
-                                &FreeContext);
+    assert(!hasSignatureBits(address));
+    void *FreeContext;
+    auto Ptr = Impl.readBytes(Impl.reader_context, address.getAddressData(),
+                              size, &FreeContext);
 
-      auto Free = Impl.free;
-      if (Free == nullptr)
-        return ReadBytesResult(Ptr, [](const void *) {});
-      
-      auto ReaderContext = Impl.reader_context;
-      auto freeLambda = [=](const void *Ptr) { Free(ReaderContext, Ptr, FreeContext); };
-      return ReadBytesResult(Ptr, freeLambda);
+    auto Free = Impl.free;
+    if (Free == nullptr)
+      return ReadBytesResult(Ptr, [](const void *) {});
+
+    auto ReaderContext = Impl.reader_context;
+    auto freeLambda = [=](const void *Ptr) {
+      Free(ReaderContext, Ptr, FreeContext);
+    };
+    return ReadBytesResult(Ptr, freeLambda);
   }
 };
 

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -180,6 +180,7 @@ swift_reflection_createReflectionContext(void *ReaderContext,
   auto *DataLayout = PointerSize == 4 ? minimalDataLayoutQueryFunction<4>
                                       : minimalDataLayoutQueryFunction<8>;
   MemoryReaderImpl ReaderImpl {
+    PointerSize,
     ReaderContext,
     DataLayout,
     Free,
@@ -198,7 +199,9 @@ swift_reflection_createReflectionContextWithDataLayout(void *ReaderContext,
                                     ReadBytesFunction ReadBytes,
                                     GetStringLengthFunction GetStringLength,
                                     GetSymbolAddressFunction GetSymbolAddress) {
+  uint8_t PointerSize = sizeof(uintptr_t);
   MemoryReaderImpl ReaderImpl {
+    PointerSize,
     ReaderContext,
     DataLayout,
     Free,


### PR DESCRIPTION
Fix readMetadataBoundsOfSuperclass to recursively apply adjustForSubclass while going through the superclass chain.

Strip indirect descriptor pointers so we can deal with signed pointers here.

Make CMemoryReader assert (in asserts builds) that the addresses being read don't have any signature bits set, which helps track down places where we need to add stripping.

rdar://134448718