### PR TITLE
[Diagnostics] Produce a diagnostic for existential mismatch in same-type constraint

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3927,8 +3927,8 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
 
   if (shouldAttemptFixes()) {
     auto *baseLoc =
-      getConstraintLocator(locator, {LocatorPathElt::GenericType(bound1),
-          LocatorPathElt::GenericType(bound2)});
+      getConstraintLocator(locator, {LocatorPathElt::GenericType(type1),
+          LocatorPathElt::GenericType(type2)});
 
     auto argMatchingFlags = subflags;
     // Allow the solver to produce separate fixes while matching

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6203,6 +6203,24 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
+  case ConstraintLocator::ExistentialConstraintType: {
+    if (lhs->hasPlaceholder() || rhs->hasPlaceholder())
+      return true;
+
+    // If there are any restrictions/conversions left to attempt, wait.
+    if (hasAnyRestriction())
+      break;
+
+    // Drop the element introduced by DeepEquality matcher.
+    path.pop_back();
+
+    // Presence of DeepEquality conversion delayed repair but since the
+    // constraint types didn't match easier, let's retry it.
+    return repairFailures(ExistentialType::get(lhs), ExistentialType::get(rhs),
+                          matchKind, flags, conversionsOrFixes,
+                          getConstraintLocator(anchor, path));
+  }
+
   case ConstraintLocator::ClosureBody:
   case ConstraintLocator::ClosureResult: {
     if (repairByInsertingExplicitCall(lhs, rhs))

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -1057,3 +1057,18 @@ func test_mismatches_with_dependent_member_generic_arguments() {
   // expected-error@-1 {{cannot convert value of type 'Optional<Int>' to expected argument type 'Optional<Data.SomeAssociated>'}}
   // expected-note@-2 {{arguments to generic parameter 'Wrapped' ('Int' and 'Data.SomeAssociated') are expected to be equal}}
 }
+
+extension Dictionary where Value == Any { // expected-note {{where 'Value' = 'any P'}}
+  func compute() {}
+}
+
+do {
+  struct S {
+    var test: [String: any P] = [:]
+  }
+
+  func test_existential_mismatch(s: S) {
+    s.test.compute()
+    // expected-error@-1 {{referencing instance method 'compute()' on 'Dictionary' requires the types 'any P' and 'Any' be equivalent}}
+  }
+}

--- a/test/Constraints/parameterized_existentials.swift
+++ b/test/Constraints/parameterized_existentials.swift
@@ -37,6 +37,7 @@ func g3(x: G<any P<Int>>) -> G<any P<String>> {
 
 func h1(x: (any P)?) -> (any P<Int>)? {
   return x // expected-error {{cannot convert return expression of type '(any P)?' to return type '(any P<Int>)?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('any P' and 'any P<Int>') are expected to be equal}}
 }
 
 func h2(x: (any P<Int>)?) -> (any P)? {


### PR DESCRIPTION
Previously this would result in a fallback diagnostic because
type mismatches associated with `ExistentialConstraintType`
locations weren't handled at all.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
