### PR TITLE
[CMake] Avoid stomping cache variables when cross-compiling

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -268,8 +268,10 @@ endmacro()
 #     cmake variables.
 macro(swift_common_unified_build_config product)
   set(${product}_PATH_TO_CLANG_BUILD "${CMAKE_BINARY_DIR}")
-  set(${product}_NATIVE_LLVM_TOOLS_PATH "${CMAKE_BINARY_DIR}/bin")
-  set(${product}_NATIVE_CLANG_TOOLS_PATH "${CMAKE_BINARY_DIR}/bin")
+  if (NOT CMAKE_CROSSCOMPILING)
+    set(${product}_NATIVE_LLVM_TOOLS_PATH "${CMAKE_BINARY_DIR}/bin")
+    set(${product}_NATIVE_CLANG_TOOLS_PATH "${CMAKE_BINARY_DIR}/bin")
+  endif()
   set(LLVM_PACKAGE_VERSION ${PACKAGE_VERSION})
   set(LLVM_CMAKE_DIR "${CMAKE_SOURCE_DIR}/cmake/modules")
   set(CLANG_INCLUDE_DIRS


### PR DESCRIPTION
If one is building unified and also cross-compiling (for example building from Linux x86_64 to Linux aarch64), these variables which are normally set in the cache pointing to a native toolchain are overwritten unconditionally pointing to the `CMAKE_BINARY_DIR`, which can be incompatible with the build machine.

The value of `SWIFT_NATIVE_CLANG_TOOLS_PATH` is eventually passed to the Swift compiler as `-tools-directory`, which the new `swift-driver` actually seems to use to find `swiftc`. When the `swift-driver` tries to use the incompatible `swiftc`, it returns with a very unhelpful "error: failed to retrieve frontend target info".

Avoiding overwriting the variables when cross-compiling lets the build system use the variables provided in the cache, which point to correct binaries for the build machine.