### PR TITLE
[AST] Treat platform modules as non-user

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -380,6 +380,8 @@ private:
 
   std::optional<StringRef> SysRoot = std::nullopt;
 
+  mutable std::optional<std::string> SDKPlatformPath = std::nullopt;
+
 public:
   StringRef getSDKPath() const { return SDKPath; }
 
@@ -397,6 +399,12 @@ public:
 
     Lookup.searchPathsDidChange();
   }
+
+  /// Retrieves the corresponding parent platform path for the SDK, or
+  /// \c nullopt if there isn't one.
+  /// NOTE: This computes and caches the result, and as such will not respect
+  /// a different FileSystem being passed later.
+  std::optional<StringRef> getSDKPlatformPath(llvm::vfs::FileSystem *FS) const;
 
   std::optional<StringRef> getWinSDKRoot() const { return WinSDKRoot; }
   void setWinSDKRoot(StringRef root) {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4773,8 +4773,9 @@ void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);
 void simple_display(llvm::raw_ostream &out, ImplicitMemberAction action);
 
 /// Computes whether a module is part of the stdlib or contained within the
-/// SDK. If no SDK was specified, falls back to whether the module was
-/// specified as a system module (ie. it's on the system search path).
+/// SDK or the platform directory. If no SDK was specified, falls back to
+/// whether the module was specified as a system module (ie. it's on the system
+/// search path).
 class IsNonUserModuleRequest
     : public SimpleRequest<IsNonUserModuleRequest,
                            bool(ModuleDecl *),

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1321,6 +1321,9 @@ if run_vendor == 'apple':
         (config.darwin_xcrun_toolchain, config.variant_sdk))
     extra_frameworks_dir = make_path(config.variant_sdk, "..", "..", "..",
                                      "Developer", "Library", "Frameworks")
+    extra_platform_swift_modules = make_path(config.variant_sdk, "..", "..", "..",
+                                             "Developer", "usr", "lib")
+
     target_options = (
         "-target %s %s %s" %
         (config.variant_triple, config.resource_dir_opt, mcp_opt))
@@ -2805,7 +2808,9 @@ config.substitutions.insert(0, ('%test-resource-dir', test_resource_dir))
 
 if run_vendor != 'apple':
     extra_frameworks_dir = ''
+    extra_platform_swift_modules = ''
 config.substitutions.append(('%xcode-extra-frameworks-dir', extra_frameworks_dir))
+config.substitutions.append(('%xcode-extra-platform-swift-modules', extra_platform_swift_modules))
 
 config.substitutions.append(('%target-swiftmodule-name', target_specific_module_triple + '.swiftmodule'))
 config.substitutions.append(('%target-swiftdoc-name', target_specific_module_triple + '.swiftdoc'))

--- a/validation-test/IDE/complete_sdk_platform.swift
+++ b/validation-test/IDE/complete_sdk_platform.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: ln -s %sdk %t/sdk
+
+// RUN: %batch-code-completion -F %xcode-extra-frameworks-dir -I %xcode-extra-platform-swift-modules
+
+// Works if SDK is specified as a symlink too.
+// RUN: %batch-code-completion -sdk %t/sdk -F %xcode-extra-frameworks-dir -I %xcode-extra-platform-swift-modules
+
+// REQUIRES: VENDOR=apple
+
+// rdar://131854240 - Make sure modules found in the platform dir are treated
+// as system.
+
+import XCTest
+
+#^COMPLETE^#
+// COMPLETE: Decl[Module]/None/IsSystem: XCTest[#Module#]; name=XCTest
+// COMPLETE: Decl[FreeFunction]/OtherModule[XCTest]/IsSystem: XCTFail()[#Void#]; name=XCTFail()


### PR DESCRIPTION
Modules defined within the SDK are considered non-user modules, extend this to any module found within the parent platform directory if there is one. This ensures we include modules such as XCTest and Testing.

rdar://131854240