### PR TITLE
Add `--preset-vars-file` to `build-script` for easier preset vars handling

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -496,6 +496,13 @@ def parse_preset_args():
         action=argparse.actions.StoreTrueAction,
         nargs=argparse.Nargs.OPTIONAL)
     parser.add_argument(
+        "--preset-vars-file",
+        help="load preset vars from the specified file",
+        metavar="PATH",
+        action="append",
+        dest="preset_vars_file_names",
+        default=[])
+    parser.add_argument(
         "--distcc",
         help="use distcc",
         action=argparse.actions.StoreTrueAction,
@@ -589,6 +596,13 @@ def main_preset():
         fatal_error("missing --preset option")
 
     args.preset_substitutions = {}
+    for file in args.preset_vars_file_names:
+        if os.path.isfile(file):
+            with open(file, 'r') as f:
+                for _, line in enumerate(f):
+                    name, value = line.split("=", 1)
+                    args.preset_substitutions[name] = value
+
     for arg in args.preset_substitutions_raw:
         name, value = arg.split("=", 1)
         args.preset_substitutions[name] = value


### PR DESCRIPTION
It's not always convenient to pass preset substitution arguments on an interactive command-line. Sometimes one might also need to generate these vars automatically, outside of a `build-script` invocation and also store those vars in a file for later reuse.

This change adds a new optional `--preset-vars-file` customization point to `build-script`, which allows users to pass a a file with newline separated key-value pars for preset variables substitution in addition to passing those in a direct `build-script` invocation.