### PR TITLE
Revert "[Test] Make timeout.py signal an error when the timeout is hit."

### DIFF
--- a/test/Inputs/timeout.py
+++ b/test/Inputs/timeout.py
@@ -2,17 +2,17 @@
 
 import subprocess
 import sys
+import threading
 
 
 def watchdog(command, timeout=None):
     process = subprocess.Popen(command)
+    timer = threading.Timer(timeout, process.kill)
     try:
-        process.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        process.kill()
-        sys.exit(
-            'error: command timed out after {} seconds: {}'
-            .format(timeout, ' '.join(sys.argv[2:])))
+        timer.start()
+        process.communicate()
+    finally:
+        timer.cancel()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reverts swiftlang/swift#76009.

Speculatively revert this change to see if it fixes a (probably) false timeout in `SILOptimizer/large_nested_array.swift.gyb`. E.g. here: https://ci.swift.org/job/oss-swift-package-macos/