### PR TITLE
[PrefixMap] Remap clang cc1 args when building swift interfaces

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6555,9 +6555,8 @@ bool ASTContext::isASCIIString(StringRef s) const {
 
 clang::DarwinSDKInfo *ASTContext::getDarwinSDKInfo() const {
   if (!getImpl().SDKInfo) {
-    auto SDKInfoOrErr = clang::parseDarwinSDKInfo(
-            *llvm::vfs::getRealFileSystem(),
-            SearchPathOpts.SDKPath);
+    auto SDKInfoOrErr = clang::parseDarwinSDKInfo(*SourceMgr.getFileSystem(),
+                                                  SearchPathOpts.SDKPath);
     if (!SDKInfoOrErr) {
       llvm::handleAllErrors(SDKInfoOrErr.takeError(),
                             [](const llvm::ErrorInfoBase &) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -95,6 +95,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Memory.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/VirtualOutputBackend.h"
 #include "llvm/TextAPI/InterfaceFile.h"
@@ -4139,6 +4140,16 @@ ClangImporter::getSwiftExplicitModuleDirectCC1Args() const {
     // FileSystemOptions.
     auto &FSOpts = instance.getFileSystemOpts();
     FSOpts.WorkingDir.clear();
+  }
+
+  if (!Impl.SwiftContext.SearchPathOpts.ScannerPrefixMapper.empty()) {
+    // Remap all the paths if requested.
+    llvm::PrefixMapper Mapper;
+    clang::tooling::dependencies::DepscanPrefixMapping::configurePrefixMapper(
+        Impl.SwiftContext.SearchPathOpts.ScannerPrefixMapper, Mapper);
+    clang::tooling::dependencies::DepscanPrefixMapping::remapInvocationPaths(
+        instance, Mapper);
+    instance.getFrontendOpts().PathPrefixMappings.clear();
   }
 
   return instance.getCC1CommandLine();

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1787,6 +1787,9 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
   genericSubInvocation.getClangImporterOptions().ClangImporterDirectCC1Scan =
       clangImporterOpts.ClangImporterDirectCC1Scan;
 
+  genericSubInvocation.getSearchPathOptions().ScannerPrefixMapper =
+      SearchPathOpts.ScannerPrefixMapper;
+
   // Validate Clang modules once per-build session flags must be consistent
   // across all module sub-invocations
   if (clangImporterOpts.ValidateModulesOnce) {

--- a/test/CAS/path_remap.swift
+++ b/test/CAS/path_remap.swift
@@ -3,8 +3,8 @@
 
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
-// RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include \
-// RUN:   -scanner-prefix-map %swift_src_root=/^src -scanner-prefix-map %t=/^tmp -enable-cross-import-overlays
+// RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include -sdk %t/sdk \
+// RUN:   -scanner-prefix-map %swift_src_root=/^src -scanner-prefix-map %t=/^tmp -scanner-prefix-map %t/sdk=/^sdk -enable-cross-import-overlays
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
 // RUN: %swift_frontend_plain @%t/A.cmd
@@ -13,16 +13,26 @@
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json _B_A > %t/BA.cmd
 // RUN: %swift_frontend_plain @%t/BA.cmd
 
+// RUN: %FileCheck %s --check-prefix=SDK-REMAP --input-file=%t/A.cmd
+// RUN: %FileCheck %s --check-prefix=SDK-REMAP --input-file=%t/B.cmd
+// RUN: %FileCheck %s --check-prefix=SDK-REMAP --input-file=%t/BA.cmd
+
+// SDK-REMAP: -isysroot
+// SDK-REMAP-NEXT: -Xcc
+// SDK-REMAP-NEXT: /^sdk
+
 // RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+
+// RUN: %FileCheck %s --check-prefix=SDK-REMAP --input-file=%t/MyApp.cmd
 
 // RUN: %target-swift-frontend \
 // RUN:   -c -o %t/main.o -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
-// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t \
+// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
 // RUN:   /^tmp/main.swift @%t/MyApp.cmd -enable-cross-import-overlays
 
 // RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- \
@@ -31,7 +41,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
-// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t \
+// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
 // RUN:   /^tmp/main.swift @%t/MyApp.cmd -enable-cross-import-overlays > %t/key.casid
 
 // RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
@@ -40,7 +50,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
-// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t \
+// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
 // RUN:   /^tmp/main.swift @%t/MyApp.cmd -enable-cross-import-overlays
 
 //--- main.swift
@@ -70,3 +80,5 @@ public func b_a() { }
 version: 1
 modules:
   - name: _B_A
+//--- sdk/SDKSettings.json
+{}


### PR DESCRIPTION
Fix a bug that swift clang importer is not setup correctly when prefix map is used. There are two separate issues:
* CC1 args used to setup clang import when building swift (interface and sources) are not correctly remapped.
* When loading SDKInfo from SDK path, the SDKSettings.json is not loading from VFS, thus the file cannot be loaded from remapped path.

rdar://134458611
