### PR TITLE
[6.0] Sema: Relax availability of typealiases for inferred type witness

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -331,7 +331,18 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
 
     // Construct the availability of the type witnesses based on the
     // availability of the enclosing type and the associated type.
-    const Decl *availabilitySources[2] = { dc->getAsDecl(), assocType };
+    llvm::SmallVector<Decl *, 2> availabilitySources = {dc->getAsDecl()};
+
+    // Only constrain the availability of the typealias by the availability of
+    // the associated type if the associated type is less available than its
+    // protocol. This is required for source compatibility.
+    auto protoAvailability = AvailabilityInference::availableRange(proto, ctx);
+    auto assocTypeAvailability =
+        AvailabilityInference::availableRange(assocType, ctx);
+    if (protoAvailability.isSupersetOf(assocTypeAvailability)) {
+      availabilitySources.push_back(assocType);
+    }
+
     AvailabilityInference::applyInferredAvailableAttrs(
         aliasDecl, availabilitySources, ctx);
 

--- a/test/decl/protocol/associated_type_availability.swift
+++ b/test/decl/protocol/associated_type_availability.swift
@@ -53,3 +53,34 @@ func testPrimaryExistentialBad<U>(_: any P1<Int, U>) {}
 
 @available(macOS 13, *)
 func testPrimaryExistentialGood<U>(_: any P1<Int, U>) {}
+
+
+@available(macOS 13, *)
+protocol P2 {
+  associatedtype A
+
+  @available(macOS 14, *)
+  associatedtype B
+
+  var a: A { get }
+
+  @available(macOS 14, *)
+  var b: B { get }
+}
+
+struct ModelP2: P2 {
+  var a: Int
+  var b: Double
+}
+
+extension ModelP2 {
+  // expected-note@-1{{add @available attribute to enclosing extension}}
+
+  // Ok, the inferred typealias for A is always available.
+  func takesA(_ a: A) {}
+
+  // Bad, the inferred typealias for B is introduced with associated type B.
+  func takesB(_ b: B) {}
+  // expected-error@-1{{'B' is only available in macOS 14 or newer}}
+  // expected-note@-2{{add @available attribute to enclosing instance method}}
+}

--- a/test/stdlib/Identifiable.swift
+++ b/test/stdlib/Identifiable.swift
@@ -5,3 +5,9 @@ struct IdentifiableValue: Identifiable {
 }
 
 class IdentifiableClass: Identifiable {}
+
+extension IdentifiableValue {
+  var nextID: ID {
+    return id + 1
+  }
+}


### PR DESCRIPTION
- **Explanation:** Availability of the synthesized typealias for an inferred type witness should only be constrained by the availability of the associated type if the associated type is less available than its protocol.
- **Scope:** This issue breaks source compatibility for some packages, like the Logger package.
- **Issue/Radar:** rdar://134584323
- **Original PR:** https://github.com/swiftlang/swift/pull/76066
- **Risk:** Low. This change returns typealias synthesis to its pre-Swift 6.0 behavior for associated types without availability. Availability for associated types is a new feature in Swift 6.0.  
- **Testing:** Added tests to the compiler test suite.
- **Reviewer:** @DougGregor 
