### PR TITLE
🍒[cxx-interop] Do not import `std::chrono::time_zone_link`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2640,6 +2640,15 @@ namespace {
         return nullptr;
       }
 
+      // Bail if this is `std::chrono::tzdb`. This type causes issues in copy
+      // constructor instantiation.
+      // FIXME: https://github.com/apple/swift/issues/73037
+      if (decl->getDeclContext()->isNamespace() &&
+          decl->getDeclContext()->getParent()->isStdNamespace() &&
+          decl->getIdentifier() &&
+          (decl->getName() == "tzdb" || decl->getName() == "time_zone_link"))
+        return nullptr;
+
       auto &clangSema = Impl.getClangSema();
       // Make Clang define any implicit constructors it may need (copy,
       // default). Make sure we only do this if the class has been fully defined


### PR DESCRIPTION
**Explanation**: The `std::chrono::time_zone_link` type is non-copyable, but its implementation in libstdc++13 does not explicitly declare a deleted copy constructor. Instead, it triggers a template instantiation error while instantiating the copy constructor. For now, this change disables import of this type.
**Scope**: Adds a special case in ClangImporter for this type.
**Risk**: Low, only affects import of a specific C++ type.
**Testing**: This is covered by existing tests, which are currently failing with libstdc++13.
**Issue**: rdar://134432426
**Reviewer**: @Xazax-hun 

Original PR: https://github.com/swiftlang/swift/pull/76059