### PR TITLE
Sema: Fix required availability diagnostics for protocol extensions

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -86,6 +86,14 @@ bool swift::isExported(const ValueDecl *VD) {
 }
 
 static bool hasConformancesToPublicProtocols(const ExtensionDecl *ED) {
+  auto nominal = ED->getExtendedNominal();
+  if (!nominal)
+    return false;
+
+  // Extensions of protocols cannot introduce additional conformances.
+  if (isa<ProtocolDecl>(nominal))
+    return false;
+
   auto protocols = ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit);
   for (const ProtocolDecl *PD : protocols) {
     AccessScope scope =

--- a/test/attr/require_explicit_availability_macos.swift
+++ b/test/attr/require_explicit_availability_macos.swift
@@ -237,3 +237,23 @@ extension StructWithImplicitMembers: Hashable { }
 // expected-note @-1 {{add @available attribute to enclosing extension}}
 // expected-warning @-2 {{public declarations should have an availability attribute with an introduction version}}
 // expected-error @-3 {{'StructWithImplicitMembers' is only available in macOS 10.15 or newer}}
+
+extension PublicProtocol {}
+
+extension PublicProtocol {
+  internal var internalVar: Bool { return true }
+}
+
+extension PublicProtocol { // expected-warning {{public declarations should have an availability attribute with an introduction version}}
+  public var publicVar: Bool { return true } // expected-warning {{public declarations should have an availability attribute with an introduction version}}
+}
+
+extension Error {}
+
+extension Error {
+  internal var internalVar: Bool { return true }
+}
+
+extension Error { // expected-warning {{public declarations should have an availability attribute with an introduction version}}
+  public var publicVar: Bool { return true } // expected-warning {{public declarations should have an availability attribute with an introduction version}}
+}


### PR DESCRIPTION
Extending a protocol cannot introduce new conformances to other protocols, so skip checking for associated conformances to public protocols when diagnosing required availability on such an extension.

Resolves rdar://133873836.
