### PR TITLE
[Sema] Allow unrecognized platforms  in @backDeployed and @_originallyDefinedIn

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -2104,12 +2104,15 @@ public:
 
   using PlatformAndVersion = std::pair<PlatformKind, llvm::VersionTuple>;
 
-  /// Parse a platform and version tuple (e.g. "macOS 12.0") and append it to the
-  /// given vector. Wildcards ('*') parse successfully but are ignored. Assumes
-  /// that the tuples are part of a comma separated list ending with a trailing
-  /// ')'.
-  ParserStatus parsePlatformVersionInList(StringRef AttrName,
-      llvm::SmallVector<PlatformAndVersion, 4> &PlatformAndVersions);
+  /// Parse a platform and version tuple (e.g. "macOS 12.0") and append it to
+  /// the given vector. Wildcards ('*') parse successfully but are ignored.
+  /// Unrecognized platform names also parse successfully but are ignored.
+  /// Assumes that the tuples are part of a comma separated list ending with a
+  /// trailing ')'.
+  ParserStatus parsePlatformVersionInList(
+      StringRef AttrName,
+      llvm::SmallVector<PlatformAndVersion, 4> & PlatformAndVersions,
+      bool &ParsedUnrecognizedPlatformName);
 
   //===--------------------------------------------------------------------===//
   // Code completion second pass.

--- a/test/Sema/diag_originally_definedin.swift
+++ b/test/Sema/diag_originally_definedin.swift
@@ -34,30 +34,24 @@ public func macroUnknown() {}
 
 @available(macOS 10.9, *)
 @_originallyDefinedIn(module: "original", macos 10.13) // expected-warning {{unknown platform 'macos' for attribute '@_originallyDefinedIn'; did you mean 'macOS'?}} {{43-48=macOS}}
-// expected-error@-1 {{expected at least one platform version in '@_originallyDefinedIn' attribute}}
 public func incorrectPlatformCase() {}
 
 @available(macOS 10.9, *)
 @_originallyDefinedIn(module: "original", mscos 10.13) // expected-warning {{unknown platform 'mscos' for attribute '@_originallyDefinedIn'; did you mean 'macOS'?}} {{43-48=macOS}}
-// expected-error@-1 {{expected at least one platform version in '@_originallyDefinedIn' attribute}}
 public func incorrectPlatformSimilar1() {}
 
 @available(macOS 10.9, *)
 @_originallyDefinedIn(module: "original", macoss 10.13) // expected-warning {{unknown platform 'macoss' for attribute '@_originallyDefinedIn'; did you mean 'macOS'?}} {{43-49=macOS}}
-// expected-error@-1 {{expected at least one platform version in '@_originallyDefinedIn' attribute}}
 public func incorrectPlatformSimilar2() {}
 
 @available(macOS 10.9, *)
 @_originallyDefinedIn(module: "original", mac 10.13) // expected-warning {{unknown platform 'mac' for attribute '@_originallyDefinedIn'; did you mean 'macOS'?}} {{43-46=macOS}}
-// expected-error@-1 {{expected at least one platform version in '@_originallyDefinedIn' attribute}}
 public func incorrectPlatformSimilar3() {}
 
 @available(macOS 10.9, *)
 @_originallyDefinedIn(module: "original", notValid 10.13) // expected-warning {{unknown platform 'notValid' for attribute '@_originallyDefinedIn'}} {{none}}
-// expected-error@-1 {{expected at least one platform version in '@_originallyDefinedIn' attribute}}
 public func incorrectPlatformNotSimilar() {}
 
 @available(macOS 10.9, *)
 @_originallyDefinedIn(module: "original", swift 5.1) // expected-warning {{unknown platform 'swift' for attribute '@_originallyDefinedIn'}}
-// expected-error@-1 {{expected at least one platform version in '@_originallyDefinedIn' attribute}}
 public func swiftVersionMacro() {}

--- a/test/attr/Inputs/SymbolMove/LowLevel.swift
+++ b/test/attr/Inputs/SymbolMove/LowLevel.swift
@@ -5,7 +5,9 @@ public func printMessageMoved() {
 }
 
 @available(OSX 10.7, iOS 7.0, *)
+@available(unrecognizedOS 1.0, *)
 @_originallyDefinedIn(module: "HighLevel", OSX 10.9, iOS 13.0)
+@_originallyDefinedIn(module: "HighLevel", unrecognizedOS 2.0)
 public struct Entity {
     public let value = "LowLevel"
     public init() {}

--- a/test/attr/attr_backDeployed.swift
+++ b/test/attr/attr_backDeployed.swift
@@ -367,7 +367,11 @@ public func incorrectPlatformCaseFunc() {}
 public func incorrectPlatformSimilarFunc() {}
 
 @backDeployed(before: macOS 12.0, unknownOS 1.0) // expected-warning {{unknown platform 'unknownOS' for attribute '@backDeployed'}}
-public func unknownOSFunc() {}
+public func unknownOSFunc1() {}
+
+@backDeployed(before: macOS 12.0)
+@backDeployed(before: unknownOS 1.0) // expected-warning {{unknown platform 'unknownOS' for attribute '@backDeployed'}}
+public func unknownOSFunc2() {}
 
 @backDeployed(before: @) // expected-error {{expected platform in '@backDeployed' attribute}}
 public func badPlatformFunc1() {}
@@ -414,7 +418,6 @@ public func missingMacroVersion() {}
 public func unknownMacroMissingVersion() {}
 
 @backDeployed(before: _unknownMacro 1.0) // expected-warning {{unknown platform '_unknownMacro' for attribute '@backDeployed'}}
-// expected-error@-1 {{expected at least one platform version in '@backDeployed' attribute}}
 public func unknownMacroVersioned() {}
 
 @backDeployed(before: _unknownMacro 1.0, _myProject 2.0) // expected-warning {{unknown platform '_unknownMacro' for attribute '@backDeployed'}}


### PR DESCRIPTION
Don't emit attr_availability_need_platform_version for a @backDeployed or @_originallyDefinedIn that have a single unrecognized platform name.