### PR TITLE
Use SwiftIfConfig to determine where to emit new parser diagnostics

### DIFF
--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -48,6 +48,7 @@ int swift_ASTGen_roundTripCheck(void *_Nonnull sourceFile);
 /// Emit parser diagnostics for given source file.. Returns non-zero if any
 /// diagnostics were emitted.
 int swift_ASTGen_emitParserDiagnostics(
+    BridgedASTContext astContext,
     void *_Nonnull diagEngine, void *_Nonnull sourceFile, int emitOnlyErrors,
     int downgradePlaceholderErrorsToWarnings);
 

--- a/lib/ASTGen/Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
@@ -25,8 +25,6 @@ extension ASTGenVisitor {
   /// produced due to the evaluation.
   func activeClause(in node: IfConfigDeclSyntax) -> IfConfigClauseSyntax? {
     // Determine the active clause.
-    var buildConfiguration = self.buildConfiguration
-    buildConfiguration.conditionLoc = generateSourceLoc(node)
     let (activeClause, diagnostics) = node.activeClause(in: buildConfiguration)
     diagnoseAll(diagnostics)
 

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -98,7 +98,7 @@ struct ASTGenVisitor {
     self.legacyParse = legacyParser
     self.buildConfiguration = CompilerBuildConfiguration(
       ctx: ctx,
-      conditionLoc: BridgedSourceLoc(at: AbsolutePosition(utf8Offset: 0), in: sourceBuffer)
+      sourceBuffer: sourceBuffer
     )
   }
 

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -12,6 +12,7 @@
 
 import ASTBridging
 import SwiftDiagnostics
+import SwiftIfConfig
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
 import SwiftParserDiagnostics
 import SwiftSyntax
@@ -142,20 +143,10 @@ public func roundTripCheck(
   }
 }
 
-extension Syntax {
-  /// Whether this syntax node is or is enclosed within a #if.
-  fileprivate var isInIfConfig: Bool {
-    if self.is(IfConfigDeclSyntax.self) {
-      return true
-    }
-
-    return parent?.isInIfConfig ?? false
-  }
-}
-
 /// Emit diagnostics within the given source file.
 @_cdecl("swift_ASTGen_emitParserDiagnostics")
 public func emitParserDiagnostics(
+  ctx: BridgedASTContext,
   diagEnginePtr: UnsafeMutableRawPointer,
   sourceFilePtr: UnsafeMutablePointer<UInt8>,
   emitOnlyErrors: CInt,
@@ -172,11 +163,18 @@ public func emitParserDiagnostics(
     )
 
     let diagnosticEngine = BridgedDiagnosticEngine(raw: diagEnginePtr)
+    let buildConfiguration = CompilerBuildConfiguration(
+      ctx: ctx,
+      conditionLoc:
+        BridgedSourceLoc(
+        at: AbsolutePosition(utf8Offset: 0),
+        in: sourceFile.pointee.buffer
+      )
+    )
+
     for diag in diags {
-      // Skip over diagnostics within #if, because we don't know whether
-      // we are in an active region or not.
-      // FIXME: This heuristic could be improved.
-      if diag.node.isInIfConfig {
+      // If the diagnostic is in an unparsed #if region, don't emit it.
+      if diag.node.isActive(in: buildConfiguration).state == .unparsed {
         continue
       }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -267,7 +267,7 @@ void Parser::parseTopLevelItems(SmallVectorImpl<ASTNode> &items) {
   if (parsingOpts.contains(ParsingFlags::ValidateNewParserDiagnostics) &&
       !Context.Diags.hadAnyError()) {
     auto hadSyntaxError = swift_ASTGen_emitParserDiagnostics(
-        &Context.Diags, exportedSourceFile,
+        Context, &Context.Diags, exportedSourceFile,
         /*emitOnlyErrors=*/true,
         /*downgradePlaceholderErrorsToWarnings=*/
         Context.LangOpts.Playground ||
@@ -346,7 +346,7 @@ void Parser::parseSourceFileViaASTGen(
   // If we're supposed to emit diagnostics from the parser, do so now.
   if (!suppressDiagnostics) {
     auto hadSyntaxError = swift_ASTGen_emitParserDiagnostics(
-        &Context.Diags, exportedSourceFile, /*emitOnlyErrors=*/false,
+        Context, &Context.Diags, exportedSourceFile, /*emitOnlyErrors=*/false,
         /*downgradePlaceholderErrorsToWarnings=*/langOpts.Playground ||
             langOpts.WarnOnEditorPlaceholder);
     if (hadSyntaxError && Context.Diags.hadAnyError() &&

--- a/test/ASTGen/if_config.swift
+++ b/test/ASTGen/if_config.swift
@@ -3,8 +3,8 @@
 // REQUIRES: asserts
 
 #if NOT_SET
-func f { } // FIXME: Error once the parser diagnostics generator knows to
-           // evaluate the active clause.
+func f { } // expected-error{{expected parameter clause in function signature}}
+           // expected-note@-1{{insert parameter clause}}{{7-8=}}{{8-8=(}}{{8-8=) }}
 #endif
 
 #if compiler(>=10.0)

--- a/test/ClangImporter/can_import_underlying_version_tbd_missing_version.swift
+++ b/test/ClangImporter/can_import_underlying_version_tbd_missing_version.swift
@@ -10,12 +10,14 @@ import Simple
 
 func canImportUnderlyingVersion() {
 #if canImport(Simple, _underlyingVersion: 3.3) // expected-warning {{cannot find user version number for Clang module 'Simple'; version number ignored}}
+  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Simple'; version number ignored}}
   let a = 1  // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 }
 
 func canImportVersion() {
 #if canImport(Simple, _version: 3.3) // expected-warning {{cannot find user version number for Clang module 'Simple'; version number ignored}}
+  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Simple'; version number ignored}}
   let a = 1  // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 }

--- a/test/ClangImporter/can_import_version_ignores_missing_tbd_version.swift
+++ b/test/ClangImporter/can_import_version_ignores_missing_tbd_version.swift
@@ -23,14 +23,17 @@ import Simple
 
 func canImportUnderlyingVersion() {
 #if canImport(Simple, _underlyingVersion: 2) // expected-warning {{cannot find user version number for Clang module 'Simple'; version number ignored}}
+  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Simple'; version number ignored}}
   let a = 1  // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
 #if canImport(Simple, _underlyingVersion: 3) // expected-warning {{cannot find user version number for Clang module 'Simple'; version number ignored}}
+  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Simple'; version number ignored}}
   let b = 1 // expected-warning {{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
   
 #if canImport(Simple, _underlyingVersion: 4) // expected-warning {{cannot find user version number for Clang module 'Simple'; version number ignored}}
+  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Simple'; version number ignored}}
   let c = 1 // expected-warning {{initialization of immutable value 'c' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 

--- a/test/Parse/ConditionalCompilation/can_import_version_missing_user_module_version.swift
+++ b/test/Parse/ConditionalCompilation/can_import_version_missing_user_module_version.swift
@@ -14,11 +14,17 @@ import NoUserModuleVersion
 func testCanImportNoUserModuleVersion() {
 
 #if canImport(NoUserModuleVersion, _version: 113.331) // expected-warning {{cannot find user version number for Swift module 'NoUserModuleVersion'; version number ignored}}
+  // NOTE: Duplicate warning because the canImport request happens twice when parser
+  // validation is enabled.
+  // expected-warning@-3 *{{cannot find user version number for Swift module 'NoUserModuleVersion'; version number ignored}}
   let a = 1 // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
 #if canImport(NoUserModuleVersion, _version: 2) // expected-warning {{cannot find user version number for Swift module 'NoUserModuleVersion'; version number ignored}}
   let b = 1 // expected-warning {{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+  // NOTE: Duplicate warning because the canImport request happens twice when parser
+  // validation is enabled.
+  // expected-warning@-4 *{{cannot find user version number for Swift module 'NoUserModuleVersion'; version number ignored}}
 #endif
 
 }

--- a/test/Parse/ConditionalCompilation/can_import_version_missing_user_module_version.swift
+++ b/test/Parse/ConditionalCompilation/can_import_version_missing_user_module_version.swift
@@ -16,7 +16,7 @@ func testCanImportNoUserModuleVersion() {
 #if canImport(NoUserModuleVersion, _version: 113.331) // expected-warning {{cannot find user version number for Swift module 'NoUserModuleVersion'; version number ignored}}
   // NOTE: Duplicate warning because the canImport request happens twice when parser
   // validation is enabled.
-  // expected-warning@-3 *{{cannot find user version number for Swift module 'NoUserModuleVersion'; version number ignored}}
+  // TODO(ParserValidation): expected-warning@-3 *{{cannot find user version number for Swift module 'NoUserModuleVersion'; version number ignored}}
   let a = 1 // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
@@ -24,7 +24,7 @@ func testCanImportNoUserModuleVersion() {
   let b = 1 // expected-warning {{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
   // NOTE: Duplicate warning because the canImport request happens twice when parser
   // validation is enabled.
-  // expected-warning@-4 *{{cannot find user version number for Swift module 'NoUserModuleVersion'; version number ignored}}
+  // TODO(ParserValidation): expected-warning@-4 *{{cannot find user version number for Swift module 'NoUserModuleVersion'; version number ignored}}
 #endif
 
 }


### PR DESCRIPTION
Re-establish the use of `SwiftIfConfig` to determine where to emit new parser diagnostics, after it was reverted in https://github.com/swiftlang/swift/pull/76040. This leverages improvements to `SwiftIfConfig` that match the evaluation semantics of the compiler as well as providing better source-location information.