### PR TITLE
ColdSplit: avoid with -Osize

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -222,7 +222,8 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
     PTO.LoopVectorization = true;
     PTO.SLPVectorization = true;
     PTO.MergeFunctions = true;
-    DoHotColdSplit = Opts.EnableHotColdSplit;
+    // Splitting trades code size to enhance memory locality, avoid in -Osize.
+    DoHotColdSplit = Opts.EnableHotColdSplit && !Opts.optimizeForSize();
     level = llvm::OptimizationLevel::Os;
   } else {
     level = llvm::OptimizationLevel::O0;

--- a/test/IRGen/cold_split.swift
+++ b/test/IRGen/cold_split.swift
@@ -7,6 +7,11 @@
 // RUN:   -enable-throws-prediction -O -disable-split-cold-code \
 // RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
 
+//// Test using -Osize doesn't yield a split.
+// RUN: %target-swift-frontend %s -module-name=test -emit-assembly \
+// RUN:   -enable-throws-prediction -Osize -enable-split-cold-code \
+// RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
+
 //// Test disabling optimization entirely doesn't yield a split.
 // RUN: %target-swift-frontend %s -module-name=test -emit-assembly \
 // RUN:   -enable-throws-prediction -enable-split-cold-code \


### PR DESCRIPTION
Based on prior evaluation, this optimization always increases code size. It splits out blocks and introduces calls, which always adds extra instructions to shuffle values for calling conventions and to make the actual call/return. Apple clang avoids the optimization in `-Oz`, which I think is pretty close to what Swift's `-Osize` really means.