### PR TITLE
[Concurrency] Add missing `Sendable` conformances to nested value types in `Async{Throwing}Stream`.

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -113,7 +113,7 @@ public struct AsyncStream<Element> {
     /// A type that indicates how the stream terminated.
     ///
     /// The `onTermination` closure receives an instance of this type.
-    public enum Termination {
+    public enum Termination: Sendable {
       
       /// The stream finished as a result of calling the continuation's
       ///  `finish` method.
@@ -159,7 +159,7 @@ public struct AsyncStream<Element> {
     }
     
     /// A strategy that handles exhaustion of a buffer’s capacity.
-    public enum BufferingPolicy {
+    public enum BufferingPolicy: Sendable {
       /// Continue to add to the buffer, without imposing a limit on the number
       /// of buffered elements.
       case unbounded
@@ -471,6 +471,10 @@ extension AsyncStream {
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncStream: @unchecked Sendable where Element: Sendable { }
+
+@available(SwiftStdlib 5.1, *)
+extension AsyncStream.Continuation.YieldResult: Sendable where Element: Sendable { }
+
 #else
 @available(SwiftStdlib 5.1, *)
 @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -133,7 +133,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     /// A type that indicates how the stream terminated.
     ///
     /// The `onTermination` closure receives an instance of this type.
-    public enum Termination {
+    public enum Termination: Sendable {
       
       /// The stream finished as a result of calling the continuation's
       ///  `finish` method.
@@ -184,7 +184,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     }
     
     /// A strategy that handles exhaustion of a buffer’s capacity.
-    public enum BufferingPolicy {
+    public enum BufferingPolicy: Sendable {
       /// Continue to add to the buffer, treating its capacity as infinite.
       case unbounded
       
@@ -517,6 +517,10 @@ extension AsyncThrowingStream {
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream: @unchecked Sendable where Element: Sendable { }
+
+@available(SwiftStdlib 5.1, *)
+extension AsyncThrowingStream.Continuation.YieldResult: Sendable where Element: Sendable { }
+
 #else
 @available(SwiftStdlib 5.1, *)
 @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")


### PR DESCRIPTION
`Termination`, `BufferingPolicy`, and `YieldResult` all have trivial conformances to `Sendable`. The conformance on `YieldResult` is conditional on `Element: Sendable` because one of the enum cases stores an element in its associated value.