### PR TITLE
GenericSpecializer: drop unused indirect arguments.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -1265,13 +1265,16 @@ Function Specializations
 
 ::
 
-  specialization ::= type '_' type* 'Tg' SPEC-INFO     // Generic re-abstracted specialization
-  specialization ::= type '_' type* 'TB' SPEC-INFO     // Alternative mangling for generic re-abstracted specializations,
-                                                       // used for functions with re-abstracted resilient parameter types.
+  specialization ::= type '_' type* 'T' dropped-arg* 'g' SPEC-INFO  // Generic re-abstracted specialization
+  specialization ::= type '_' type* 'T' dropped-arg* 'B' SPEC-INFO  // Alternative mangling for generic re-abstracted specializations,
+                                                                    // used for functions with re-abstracted resilient parameter types.
+  specialization ::= type '_' type* 'T' dropped-arg* 'G' SPEC-INFO  // Generic not re-abstracted specialization
   specialization ::= type '_' type* 'Ts' SPEC-INFO     // Generic re-abstracted prespecialization
-  specialization ::= type '_' type* 'TG' SPEC-INFO     // Generic not re-abstracted specialization
   specialization ::= type '_' type* 'Ti' SPEC-INFO     // Inlined function with generic substitutions.
   specialization ::= type '_' type* 'Ta' SPEC-INFO     // Non-async specialization
+
+  dropped-arg ::= 't'                                  // The first argument is dropped
+  dropped-arg ::= 't' NATURAL                          // The `N+1`th argument is dropped
 
 The types are the replacement types of the substitution list.
 
@@ -1294,7 +1297,7 @@ Some kinds need arguments, which precede ``Tf``.
   spec-arg ::= identifier
   spec-arg ::= type
 
-  SPEC-INFO ::= MT-REMOVED? FRAGILE? ASYNC-REMOVED? PASSID
+  SPEC-INFO ::= FRAGILE? ASYNC-REMOVED? PASSID
 
   PASSID ::= '0'                             // AllocBoxToStack,
   PASSID ::= '1'                             // ClosureSpecializer,
@@ -1304,8 +1307,6 @@ Some kinds need arguments, which precede ``Tf``.
   PASSID ::= '5'                             // GenericSpecializer,
   PASSID ::= '6'                             // MoveDiagnosticInOutToOut,
   PASSID ::= '7'                             // AsyncDemotion,
-
-  MT-REMOVED ::= 'm'                         // non-generic metatype arguments are removed in the specialized function
 
   FRAGILE ::= 'q'
 

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -375,7 +375,7 @@ NODE(NonUniqueExtendedExistentialTypeShapeSymbolicReference)
 NODE(SymbolicExtendedExistentialType)
 
 // Added in Swift 5.8
-NODE(MetatypeParamsRemoved)
+NODE(DroppedArgument)
 NODE(HasSymbolQuery)
 NODE(OpaqueReturnTypeIndex)
 NODE(OpaqueReturnTypeParent)

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -594,7 +594,9 @@ protected:
   NodePointer popDependentAssociatedConformance();
   NodePointer demangleDependentProtocolConformanceAssociated();
   NodePointer demangleThunkOrSpecialization();
-  NodePointer demangleGenericSpecialization(Node::Kind SpecKind);
+  NodePointer demangleGenericSpecialization(Node::Kind SpecKind,
+                                            NodePointer droppedArguments);
+  NodePointer demangleGenericSpecializationWithDroppedArguments();
   NodePointer demangleFunctionSpecialization();
   NodePointer demangleFuncSpecParam(Node::Kind Kind);
   NodePointer addFuncSpecParamNumber(NodePointer Param,

--- a/include/swift/SIL/GenericSpecializationMangler.h
+++ b/include/swift/SIL/GenericSpecializationMangler.h
@@ -87,13 +87,15 @@ class GenericSpecializationMangler : public SpecializationMangler {
   std::string manglePrespecialized(GenericSignature sig,
                                       SubstitutionMap subs);
 
+  void appendRemovedParams(const SmallBitVector &paramsRemoved);
+
 public:
   GenericSpecializationMangler(SILFunction *F, swift::SerializedKind_t Serialized)
       : SpecializationMangler(SpecializationPass::GenericSpecializer,
                               Serialized, F) {}
 
   std::string mangleNotReabstracted(SubstitutionMap subs,
-                                    bool metatyeParamsRemoved);
+                                    const SmallBitVector &paramsRemoved = SmallBitVector());
 
   /// Mangle a generic specialization with re-abstracted parameters.
   ///
@@ -107,7 +109,7 @@ public:
   /// \param metatyeParamsRemoved  true if non-generic metatype parameters are
   ///                              removed in the specialized function.
   std::string mangleReabstracted(SubstitutionMap subs, bool alternativeMangling,
-                                 bool metatyeParamsRemoved = false);
+                                 const SmallBitVector &paramsRemoved = SmallBitVector());
 
   std::string mangleForDebugInfo(GenericSignature sig, SubstitutionMap subs,
                                  bool forInlining);

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -285,7 +285,7 @@ public:
 
   /// Returns true if there are any dropped metatype arguments.
   /// See `droppedMetatypeArgs`.
-  bool hasDroppedMetatypeArgs() const { return droppedMetatypeArgs.any(); }
+  const SmallBitVector &getDroppedArgs() const { return droppedMetatypeArgs; }
 
   /// Remove the arguments of a partial apply, leaving the arguments for the
   /// partial apply result function.

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -65,7 +65,7 @@ class ReabstractionInfo {
   /// A 1-bit means that the argument is a metatype argument. The argument is
   /// dropped and replaced by a `metatype` instruction in the entry block.
   /// Only used if `dropMetatypeArgs` is true.
-  SmallBitVector droppedMetatypeArgs;
+  SmallBitVector droppedArguments;
 
   /// Set to true if the function has a re-abstracted (= converted from
   /// indirect to direct) resilient argument or return type. This can happen if
@@ -84,10 +84,10 @@ class ReabstractionInfo {
   /// specializer.
   bool ConvertIndirectToDirect = true;
 
-  /// If true, drop metatype arguments.
-  /// See `droppedMetatypeArgs`.
-  bool dropMetatypeArgs = false;
-  
+  /// If true, drop unused arguments.
+  /// See `droppedArguments`.
+  bool dropUnusedArguments = false;
+
   bool hasIndirectErrorResult = false;
 
   /// The first NumResults bits in Conversions refer to formal indirect
@@ -277,15 +277,13 @@ public:
   /// Returns true if there are any conversions from indirect to direct values.
   bool hasConversions() const { return Conversions.any(); }
 
-  /// Returns true if the argument at `ArgIdx` is a dropped metatype argument.
-  /// See `droppedMetatypeArgs`.
-  bool isDroppedMetatypeArg(unsigned ArgIdx) const {
-    return droppedMetatypeArgs.test(ArgIdx);
+  /// Returns true if the argument at `ArgIdx` is a dropped argument.
+  /// See `droppedArguments`.
+  bool isDroppedArgument(unsigned ArgIdx) const {
+    return droppedArguments.test(ArgIdx);
   }
 
-  /// Returns true if there are any dropped metatype arguments.
-  /// See `droppedMetatypeArgs`.
-  const SmallBitVector &getDroppedArgs() const { return droppedMetatypeArgs; }
+  const SmallBitVector &getDroppedArgs() const { return droppedArguments; }
 
   /// Remove the arguments of a partial apply, leaving the arguments for the
   /// partial apply result function.

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -525,7 +525,7 @@ private:
     case Node::Kind::SILBoxMutableField:
     case Node::Kind::SILBoxImmutableField:
     case Node::Kind::IsSerialized:
-    case Node::Kind::MetatypeParamsRemoved:
+    case Node::Kind::DroppedArgument:
     case Node::Kind::SpecializationPassID:
     case Node::Kind::Static:
     case Node::Kind::Subscript:
@@ -1290,7 +1290,7 @@ void NodePrinter::printSpecializationPrefix(NodePointer node,
   for (NodePointer child : *node) {
     switch (child->getKind()) {
       case Node::Kind::SpecializationPassID:
-      case Node::Kind::MetatypeParamsRemoved:
+      case Node::Kind::DroppedArgument:
         // We skip those nodes since it does not contain any
         // information that is useful to our users.
         break;
@@ -1836,8 +1836,8 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
   case Node::Kind::IsSerialized:
     Printer << "serialized";
     return nullptr;
-  case Node::Kind::MetatypeParamsRemoved:
-    Printer << "metatypes-removed";
+  case Node::Kind::DroppedArgument:
+    Printer << "param" << Node->getIndex() << "-removed";
     return nullptr;
   case Node::Kind::GenericSpecializationParam:
     print(Node->getChild(0), depth + 1);

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -451,8 +451,8 @@ ManglingError Remangler::mangleAsyncRemoved(Node *node, unsigned depth) {
   return ManglingError::Success;
 }
 
-ManglingError Remangler::mangleMetatypeParamsRemoved(Node *node, unsigned depth) {
-  Buffer << "m";
+ManglingError Remangler::mangleDroppedArgument(Node *node, unsigned depth) {
+  Buffer << "t" << node->getIndex();
   return ManglingError::Success;
 }
 

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -359,7 +359,7 @@ class Remangler : public RemanglerBase {
   }
 
   ManglingError mangleGenericSpecializationNode(Node *node,
-                                                const char *operatorStr,
+                                                char specKind,
                                                 unsigned depth);
   ManglingError mangleAnyNominalType(Node *node, unsigned depth);
   ManglingError mangleAnyGenericType(Node *node, StringRef TypeOp,
@@ -1693,7 +1693,7 @@ Remangler::mangleGenericPartialSpecializationNotReAbstracted(Node *node,
 }
 
 ManglingError
-Remangler::mangleGenericSpecializationNode(Node *node, const char *operatorStr,
+Remangler::mangleGenericSpecializationNode(Node *node, char specKind,
                                            unsigned depth) {
   bool FirstParam = true;
   for (NodePointer Child : *node) {
@@ -1705,11 +1705,21 @@ Remangler::mangleGenericSpecializationNode(Node *node, const char *operatorStr,
   DEMANGLER_ASSERT(
       !FirstParam && "generic specialization with no substitutions", node);
 
-  Buffer << operatorStr;
+  Buffer << 'T';
 
   for (NodePointer Child : *node) {
-    if (Child->getKind() != Node::Kind::GenericSpecializationParam)
+    if (Child->getKind() == Node::Kind::DroppedArgument)
       RETURN_IF_ERROR(mangle(Child, depth + 1));
+  }
+
+
+  Buffer << specKind;
+
+  for (NodePointer Child : *node) {
+    if (Child->getKind() != Node::Kind::GenericSpecializationParam &&
+        Child->getKind() != Node::Kind::DroppedArgument) {
+      RETURN_IF_ERROR(mangle(Child, depth + 1));
+    }
   }
 
   return ManglingError::Success;
@@ -1717,30 +1727,30 @@ Remangler::mangleGenericSpecializationNode(Node *node, const char *operatorStr,
 
 ManglingError Remangler::mangleGenericSpecialization(Node *node,
                                                      unsigned depth) {
-  return mangleGenericSpecializationNode(node, "Tg", depth + 1);
+  return mangleGenericSpecializationNode(node, 'g', depth + 1);
 }
 
 ManglingError
 Remangler::mangleGenericSpecializationPrespecialized(Node *node,
                                                      unsigned depth) {
-  return mangleGenericSpecializationNode(node, "Ts", depth + 1);
+  return mangleGenericSpecializationNode(node, 's', depth + 1);
 }
 
 ManglingError
 Remangler::mangleGenericSpecializationNotReAbstracted(Node *node,
                                                       unsigned depth) {
-  return mangleGenericSpecializationNode(node, "TG", depth + 1);
+  return mangleGenericSpecializationNode(node, 'G', depth + 1);
 }
 
 ManglingError
 Remangler::mangleGenericSpecializationInResilienceDomain(Node *node,
                                                          unsigned depth) {
-  return mangleGenericSpecializationNode(node, "TB", depth + 1);
+  return mangleGenericSpecializationNode(node, 'B', depth + 1);
 }
 
 ManglingError Remangler::mangleInlinedGenericFunction(Node *node,
                                                       unsigned depth) {
-  return mangleGenericSpecializationNode(node, "Ti", depth + 1);
+  return mangleGenericSpecializationNode(node, 'i', depth + 1);
 }
 
 ManglingError Remangler::mangleGenericSpecializationParam(Node *node,
@@ -3067,8 +3077,11 @@ ManglingError Remangler::mangleAsyncRemoved(Node *node, unsigned depth) {
   return ManglingError::Success;
 }
 
-ManglingError Remangler::mangleMetatypeParamsRemoved(Node *node, unsigned depth) {
-  Buffer << 'm';
+ManglingError Remangler::mangleDroppedArgument(Node *node, unsigned depth) {
+  Buffer << "t";
+  int n = node->getIndex();
+  if (n > 0)
+    Buffer << (n-1);
   return ManglingError::Success;
 }
 

--- a/lib/SIL/Utils/GenericSpecializationMangler.cpp
+++ b/lib/SIL/Utils/GenericSpecializationMangler.cpp
@@ -107,31 +107,35 @@ manglePrespecialized(GenericSignature sig, SubstitutionMap subs) {
                                   
 std::string GenericSpecializationMangler::
 mangleNotReabstracted(SubstitutionMap subs,
-                      bool metatyeParamsRemoved) {
+                      const SmallBitVector &paramsRemoved) {
   beginMangling();
   appendSubstitutions(getGenericSignature(), subs);
-  if (metatyeParamsRemoved) {
-    appendSpecializationOperator("TGm");
-  } else {
-    appendSpecializationOperator("TG");
-  }
+  appendOperator("T");
+  appendRemovedParams(paramsRemoved);
+  appendSpecializationOperator("G");
   return finalize();
 }
                                   
 std::string GenericSpecializationMangler::
 mangleReabstracted(SubstitutionMap subs, bool alternativeMangling,
-                   bool metatyeParamsRemoved) {
+                   const SmallBitVector &paramsRemoved) {
   beginMangling();
   appendSubstitutions(getGenericSignature(), subs);
-  
+  appendOperator("T");
+  appendRemovedParams(paramsRemoved);
+
   // See ReabstractionInfo::hasConvertedResilientParams for why and when to use
   // the alternative mangling.
-  if (metatyeParamsRemoved) {
-    appendSpecializationOperator(alternativeMangling ? "TBm" : "Tgm");
-  } else {
-    appendSpecializationOperator(alternativeMangling ? "TB" : "Tg");
-  }
+  appendSpecializationOperator(alternativeMangling ? "B" : "g");
   return finalize();
+}
+
+void GenericSpecializationMangler::appendRemovedParams(const SmallBitVector &paramsRemoved) {
+  for (int paramIdx : paramsRemoved.set_bits()) {
+    appendOperator("t");
+    if (paramIdx != 0)
+      Buffer << (paramIdx - 1);
+  }
 }
 
 std::string GenericSpecializationMangler::

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -125,11 +125,19 @@ void GenericCloner::populateCloned() {
             return true;
           }
         }
-      } else if (ReInfo.isDroppedMetatypeArg(ArgIdx)) {
-        // Replace the metatype argument with an `metatype` instruction in the
-        // entry block.
-        auto *mtInst = getBuilder().createMetatype(Loc, mappedType);
-        entryArgs.push_back(mtInst);
+      } else if (ReInfo.isDroppedArgument(ArgIdx)) {
+        if (OrigArg->getType().isAddress()) {
+          // Create an uninitialized alloc_stack for unused indirect arguments.
+          // This will be removed by other optimizations.
+          createAllocStack();
+          entryArgs.push_back(ASI);
+        } else {
+          // Dropped direct (= non-address) arguments are metatype arguments.
+          // Replace the metatype argument with an `metatype` instruction in the
+          // entry block.
+          auto *mtInst = getBuilder().createMetatype(Loc, mappedType);
+          entryArgs.push_back(mtInst);
+        }
         return true;
       } else {
         // Handle arguments for formal parameters.

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -887,7 +887,7 @@ ReabstractionInfo::createSubstitutedType(SILFunction *OrigF,
 }
 
 CanSILFunctionType ReabstractionInfo::createThunkType(PartialApplyInst *forPAI) const {
-  if (!hasDroppedMetatypeArgs())
+  if (!droppedMetatypeArgs.any())
     return SubstitutedType;
 
   llvm::SmallVector<SILParameterInfo, 8> newParams;
@@ -2002,7 +2002,7 @@ GenericFuncSpecializer::GenericFuncSpecializer(
     } else {
       ClonedName = Mangler.mangleReabstracted(ParamSubs,
                                               ReInfo.needAlternativeMangling(),
-                                              ReInfo.hasDroppedMetatypeArgs());
+                                              ReInfo.getDroppedArgs());
     }
   }
   LLVM_DEBUG(llvm::dbgs() << "    Specialized function " << ClonedName << '\n');
@@ -2517,7 +2517,7 @@ public:
       Mangle::GenericSpecializationMangler Mangler(OrigF, ReInfo.getSerializedKind());
       ThunkName = Mangler.mangleNotReabstracted(
           ReInfo.getCalleeParamSubstitutionMap(),
-          ReInfo.hasDroppedMetatypeArgs());
+          ReInfo.getDroppedArgs());
     } else {
       Mangle::PartialSpecializationMangler Mangler(
           OrigF, ReInfo.getSpecializedType(), ReInfo.getSerializedKind(),

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -362,7 +362,8 @@ $S18resilient_protocol21ResilientBaseProtocolTL ---> protocol requirements base 
 $S1t1PP10AssocType2_AA1QTn ---> associated conformance descriptor for t.P.AssocType2: t.Q
 $S1t1PP10AssocType2_AA1QTN ---> default associated conformance accessor for t.P.AssocType2: t.Q
 $s4Test6testityyxlFAA8MystructV_TB5 ---> generic specialization <Test.Mystruct> of Test.testit<A>(A) -> ()
-$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufCSu_SiTgm5 ---> generic specialization <Swift.UInt, Swift.Int> of (extension in Swift):Swift.UnsignedInteger< where A: Swift.FixedWidthInteger>.init<A where A1: Swift.BinaryInteger>(A1) -> A
+$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufCSu_SiTg5 ---> generic specialization <Swift.UInt, Swift.Int> of (extension in Swift):Swift.UnsignedInteger< where A: Swift.FixedWidthInteger>.init<A where A1: Swift.BinaryInteger>(A1) -> A
+$s4test7genFuncyyx_q_tr0_lFSi_SbTtt1g5 ---> generic specialization <Swift.Int, Swift.Bool> of test.genFunc<A, B>(A, B) -> ()
 $sSD5IndexVy__GD ---> $sSD5IndexVy__GD
 $s4test3StrCACycfC ---> {T:$s4test3StrCACycfc} test.Str.__allocating_init() -> test.Str
 $s18keypaths_inlinable13KeypathStructV8computedSSvpACTKq  ---> key path getter for keypaths_inlinable.KeypathStruct.computed : Swift.String : keypaths_inlinable.KeypathStruct, serialized

--- a/test/SIL/Serialization/shared_function_serialization.sil
+++ b/test/SIL/Serialization/shared_function_serialization.sil
@@ -5,7 +5,7 @@
 // CHECK: sil private @top_level_code
 // CHECK: sil public_external [serialized] [ossa] @$ss1XVABycfC{{.*}}
 // CHECK: sil public_external [serialized] [ossa] @$ss17the_thing_it_does1xys1XV_tF{{.*}}
-// CHECK: sil shared [serialized] [noinline] [ossa] @$ss9the_thing1tyx_tlFs1XV_Tgq5{{.*}}
+// CHECK: sil shared [serialized] [noinline] [ossa] @$ss9the_thing1tyx_tlFs1XV_Ttgq5{{.*}}
 
 sil_stage canonical
 

--- a/test/SIL/Serialization/specializer_can_deserialize.swift
+++ b/test/SIL/Serialization/specializer_can_deserialize.swift
@@ -8,10 +8,10 @@ import Swift
 
 // CHECK-LABEL: sil {{.*}}@main
 // CHECK: bb0({{.*}}):
-// CHECK: function_ref @$ss9ContainerVAByxGycfCBi32__Tgm5{{.*}}
+// CHECK: function_ref @$ss9ContainerVAByxGycfCBi32__Ttg5{{.*}}
 // CHECK: function_ref @$ss9ContainerV11doSomethingyyFBi32__Tg5{{.*}} 
 
-// CHECK-LABEL: sil shared [noinline] @$ss9ContainerVAByxGycfCBi32__Tgm5
+// CHECK-LABEL: sil shared [noinline] @$ss9ContainerVAByxGycfCBi32__Ttg5
 
 // CHECK-LABEL: sil shared [noinline] @$ss9ContainerV11doSomethingyyFBi32__Tg5Tf4d_n
 

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -80,14 +80,14 @@ class DerivedFromOpen<T> : OpenClass<T> { }
 
 func testProtocolsAndClasses() {
   // CHECK-OUTPUT: false
-  // CHECK-SIL-DAG: sil shared [noinline] @$s4Test20checkIfClassConformsyyxlFSi_Tg5
+  // CHECK-SIL-DAG: sil shared [noinline] @$s4Test20checkIfClassConformsyyxlFSi_Ttg5
   checkIfClassConforms(27)
   // CHECK-OUTPUT: false
   // CHECK-SIL-DAG: sil public_external {{.*}} @$s4Test24checkIfClassConforms_genyyxlF
   checkIfClassConforms_gen(27)
   // CHECK-OUTPUT: 123
   // CHECK-OUTPUT: 1234
-  // CHECK-SIL-DAG: sil shared [noinline] @$s4Test7callFooyyxlFSi_Tg5
+  // CHECK-SIL-DAG: sil shared [noinline] @$s4Test7callFooyyxlFSi_Ttg5
   // CHECK-SIL-DAG: sil [{{.*}}] @$s4Test19printFooExistential33_{{.*}} : $@convention(thin)
   callFoo(27)
   // CHECK-OUTPUT: 123

--- a/test/SILOptimizer/devirt_witness_cross_module.swift
+++ b/test/SILOptimizer/devirt_witness_cross_module.swift
@@ -48,7 +48,7 @@ public struct Local: P {
 
 // CHECK-LABEL: sil @$s4Main24testGenericInOtherModuleyyF
 // CHECK-NOCMO:   [[F:%[0-9]+]] = witness_method $S, #P.foo
-// CHECK-CMO:     [[F:%[0-9]+]] = function_ref @$s6Module1SV3foo1xyx_tSkRzSi7ElementRtzlFSaySiG_Tgq5{{.*}}
+// CHECK-CMO:     [[F:%[0-9]+]] = function_ref @$s6Module1SV3foo1xyx_tSkRzSi7ElementRtzlFSaySiG_Ttgq5{{.*}}
 // CHECK:         apply [[F]]
 // CHECK:       } // end sil function '$s4Main24testGenericInOtherModuleyyF'
 public func testGenericInOtherModule() {
@@ -75,7 +75,7 @@ public func testGenericRequirementInOtherModule() {
 }
 
 // CHECK-LABEL: sil @$s4Main23testGenericInSameModuleyyF
-// CHECK:         [[F:%[0-9]+]] = function_ref @$s4Main5LocalV3foo1xyx_tSkRzSi7ElementRtzlFSaySiG_Tg5
+// CHECK:         [[F:%[0-9]+]] = function_ref @$s4Main5LocalV3foo1xyx_tSkRzSi7ElementRtzlFSaySiG_Ttg5
 // CHECK:         apply [[F]]
 // CHECK:       } // end sil function '$s4Main23testGenericInSameModuleyyF'
 public func testGenericInSameModule() {

--- a/test/SILOptimizer/existential_metatype.swift
+++ b/test/SILOptimizer/existential_metatype.swift
@@ -3,12 +3,12 @@ protocol SomeP {}
 
 public enum SpecialEnum : SomeP {}
 
-// CHECK-LABEL: sil shared [noinline] @$s20existential_metatype17checkProtocolType0aE0Sbxm_tAA5SomePRzlFAA11SpecialEnumO_Tgm5 : $@convention(thin) () -> Bool {
+// CHECK-LABEL: sil shared [noinline] @$s20existential_metatype17checkProtocolType0aE0Sbxm_tAA5SomePRzlFAA11SpecialEnumO_Ttg5 : $@convention(thin) () -> Bool {
 // CHECK:       bb0:
 // CHECK-NEXT:   %0 = integer_literal $Builtin.Int1, -1
 // CHECK-NEXT:   %1 = struct $Bool (%0 : $Builtin.Int1)
 // CHECK-NEXT:   return %1 : $Bool
-// CHECK-LABEL: } // end sil function '$s20existential_metatype17checkProtocolType0aE0Sbxm_tAA5SomePRzlFAA11SpecialEnumO_Tgm5'
+// CHECK-LABEL: } // end sil function '$s20existential_metatype17checkProtocolType0aE0Sbxm_tAA5SomePRzlFAA11SpecialEnumO_Ttg5'
 @inline(never)
 func checkProtocolType<P : SomeP>(existentialType: P.Type) -> Bool {
   return existentialType == SpecialEnum.self

--- a/test/SILOptimizer/performance-annotations2.swift
+++ b/test/SILOptimizer/performance-annotations2.swift
@@ -8,7 +8,7 @@ public struct Stack<T> {
 }
 
 // CHECK-LABEL: sil [no_allocation] [perf_constraint] @$s4test11createStackyyF :
-// CHECK:         [[F:%[0-9]+]] = function_ref @$s4test5StackVACyxGycfCSi_Tgm5
+// CHECK:         [[F:%[0-9]+]] = function_ref @$s4test5StackVACyxGycfCSi_Ttg5
 // CHECK:         [[S:%[0-9]+]] = apply [[F]]()
 // CHECK:         debug_value [[S]]
 // CHECK:       } // end sil function '$s4test11createStackyyF'

--- a/test/SILOptimizer/pre_specialize_layouts.swift
+++ b/test/SILOptimizer/pre_specialize_layouts.swift
@@ -188,8 +188,8 @@ public func usePrespecializedEntryPoints(wrapperStruct: ReferenceWrapperStruct, 
 // OPT:   [[R3:%.*]] = apply [[F1]]([[A1]]) : $@convention(thin) (@guaranteed AnyObject) -> @owned AnyObject
 // OPT:   store [[R3]] to [[R2]] : $*AnyObject
 // OPT:   [[A2:%.*]] = load [[R1]] : $*SomeClass
-// OPT:   [[F2:%.*]] = function_ref @$s22pre_specialize_layouts7consumeyyxlF0a20_specialized_module_C09SomeClassC_Tg5 : $@convention(thin) (@guaranteed SomeClass) -> ()
-// OPT:   apply [[F2]]([[A2]]) : $@convention(thin) (@guaranteed SomeClass) -> ()
+// OPT:   [[F2:%.*]] = function_ref @$s22pre_specialize_layouts7consumeyyxlF0a20_specialized_module_C09SomeClassC_Ttg5 : $@convention(thin) () -> ()
+// OPT:   apply [[F2]]() : $@convention(thin) () -> ()
 // OPT:   strong_release [[A2]] : $SomeClass
 // OPT:   dealloc_stack [[R1]] : $*SomeClass
 // OPT: } // end sil function '$s22pre_specialize_layouts46usePrespecializedEntryPointsWithMarkerProtocol1ty0a20_specialized_module_C09SomeClassC_tF'

--- a/test/SILOptimizer/set.swift
+++ b/test/SILOptimizer/set.swift
@@ -23,7 +23,7 @@ public func createEmptySetWithInitializer() -> Set<Int> {
 
 // CHECK-LABEL: sil {{.*}}@$s4test17createNonEmptySetShySiGyF
 // CHECK:         global_value
-// CHECK:         [[F:%[0-9]+]] = function_ref @$sSh21_nonEmptyArrayLiteralShyxGSayxG_tcfCSi_Tgm5
+// CHECK:         [[F:%[0-9]+]] = function_ref @$sSh21_nonEmptyArrayLiteralShyxGSayxG_tcfCSi_Tt0g5
 // CHECK:         apply [[F]]
 // CHECK:       } // end sil function '$s4test17createNonEmptySetShySiGyF'
 public func createNonEmptySet() -> Set<Int> {

--- a/test/SILOptimizer/spec_archetype_method.swift
+++ b/test/SILOptimizer/spec_archetype_method.swift
@@ -32,7 +32,7 @@ func useFoo<T>(x x: T) {
 //CHECK-LABEL: sil @$s21spec_archetype_method21interesting_code_hereyyF
 //CHECK: function_ref @$s21spec_archetype_method12generic_call{{[_0-9a-zA-Z]*}}FAA3ABCC_Tg5
 //CHECK-NEXT: apply
-//CHECK:  function_ref @$s21spec_archetype_method6useFoo{{[_0-9a-zA-Z]*}}FAA3ABCC_Tg5 : $@convention(thin) (@guaranteed ABC) -> ()
+//CHECK:  function_ref @$s21spec_archetype_method6useFoo{{[_0-9a-zA-Z]*}}FAA3ABCC_Ttg5 : $@convention(thin) () -> ()
 //CHECK-NEXT: apply
 //CHECK: return
 public

--- a/test/SILOptimizer/spec_conf1.swift
+++ b/test/SILOptimizer/spec_conf1.swift
@@ -19,8 +19,8 @@ func inner_function<T : P>(In In : T) { }
 @inline(never)
 func outer_function<T : P>(In In : T) { inner_function(In: In) }
 
-//CHECK: sil shared [noinline] {{.*}}@$s10spec_conf114outer_function2Inyx_tAA1PRzlFAA3FooC_Tg5
-//CHECK: $s10spec_conf114inner_function2Inyx_tAA1PRzlFAA3FooC_Tg5
+//CHECK: sil shared [noinline] {{.*}}@$s10spec_conf114outer_function2Inyx_tAA1PRzlFAA3FooC_Ttg5
+//CHECK: $s10spec_conf114inner_function2Inyx_tAA1PRzlFAA3FooC_Ttg5
 //CHECK-NEXT: apply
 //CHECK: return
 

--- a/test/SILOptimizer/spec_conf2.swift
+++ b/test/SILOptimizer/spec_conf2.swift
@@ -18,8 +18,8 @@ func inner_function<T : P & Q>(In In : T) { }
 @inline(never)
 func outer_function<T : P & Q>(In In : T) { inner_function(In: In) }
 
-//CHECK: sil shared [noinline] {{.*}}@$s10spec_conf214outer_function2Inyx_tAA1PRzAA1QRzlFAA3FooC_Tg5
-//CHECK: function_ref @$s10spec_conf214inner_function2Inyx_tAA1PRzAA1QRzlFAA3FooC_Tg5
+//CHECK: sil shared [noinline] {{.*}}@$s10spec_conf214outer_function2Inyx_tAA1PRzAA1QRzlFAA3FooC_Ttg5
+//CHECK: function_ref @$s10spec_conf214inner_function2Inyx_tAA1PRzAA1QRzlFAA3FooC_Ttg5
 //CHECK-NEXT: apply
 //CHECK: return
 

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -9,7 +9,7 @@ import Swift
 // CHECK-LABEL: sil @exp1 : $@convention(thin) () -> () {
 // CHECK-NOT: apply
 // Call of specialized initializer: <Int32>
-// CHECK: [[CTOR:%[0-9]+]] = function_ref @$s8XXX_inits5Int32V_Tgm5
+// CHECK: [[CTOR:%[0-9]+]] = function_ref @$s8XXX_inits5Int32V_Tt1g5
 // CHECK: apply [[CTOR]]
 // CHECK: [[ACCEPTS_INT:%[0-9]+]] = function_ref @acceptsInt
 // Call of specialized XXX_foo: <Int32>
@@ -556,7 +556,7 @@ bb0:
 
 // test_bind<A> (Builtin.RawPointer, A.Type) -> ()
 // Check that this is specialized as T=Int.
-// CHECK-LABEL: sil shared @$s9test_bindSi_Tgm5 : $@convention(thin) (Builtin.RawPointer) -> ()
+// CHECK-LABEL: sil shared @$s9test_bindSi_Tt0g5 : $@convention(thin) (Builtin.RawPointer) -> ()
 // CHECK: bind_memory %0 : $Builtin.RawPointer, {{%.*}} : $Builtin.Word to $*Int
 // CHECK: return
 sil hidden @test_bind : $@convention(thin) <T> (Builtin.RawPointer, @thick T.Type) -> () {
@@ -701,7 +701,7 @@ bb0(%0 : $*T, %1 :$*T):
 }
 
 // This should not assert.
-// CHECK-LABEL: sil shared @$s26specialize_no_return_applys5NeverO_Tgm5
+// CHECK-LABEL: sil shared @$s26specialize_no_return_applys5NeverO_Ttg5
 // CHECK:      apply
 // CHECK-NEXT: unreachable
 

--- a/test/SILOptimizer/specialize_chain.swift
+++ b/test/SILOptimizer/specialize_chain.swift
@@ -45,6 +45,6 @@ func exp1() {
 //CHECK: sil shared [noinline] @$s16specialize_chain3YYYV4AAA2{{[_0-9a-zA-Z]*}}FSi_Tg5
 //CHECK: sil shared [noinline] @$s16specialize_chain3YYYV4AAA1{{[_0-9a-zA-Z]*}}FSi_Tg5
 //CHECK: exp1
-//CHECK: function_ref @$s16specialize_chain3YYYV{{[_0-9a-zA-Z]*}}fCSi_Tgm5
+//CHECK: function_ref @$s16specialize_chain3YYYV{{[_0-9a-zA-Z]*}}fCSi_Tt1g5
 //CHECK: function_ref @$s16specialize_chain3YYYV4AAA9{{[_0-9a-zA-Z]*}}FSi_Tg5
 //CHECK: return

--- a/test/SILOptimizer/specialize_checked_cast_branch.swift
+++ b/test/SILOptimizer/specialize_checked_cast_branch.swift
@@ -25,8 +25,8 @@ public func ArchetypeToArchetypeCast<T1, T2>(t1 : T1, t2 : T2) -> T2 {
   preconditionFailure("??? Profit?")
 }
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1DCTg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
-// CHECK: bb0([[ARG:%.*]] : $C, [[ARG2:%.*]] : $D):
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1DCTt1g5 : $@convention(thin) (@guaranteed C) -> @owned D
+// CHECK: bb0([[ARG:%.*]] : $C):
 // CHECK:  checked_cast_br C in [[ARG]] : $C to D, bb1, bb2
 //
 // CHECK: bb1([[T0:%.*]] : $D):
@@ -36,16 +36,16 @@ public func ArchetypeToArchetypeCast<T1, T2>(t1 : T1, t2 : T2) -> T2 {
 // CHECK: bb2
 // CHECK:   cond_fail {{%.*}}, "precondition failure"
 // CHECK:   unreachable
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1DCTg5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1DCTt1g5'
 _ = ArchetypeToArchetypeCast(t1: c, t2: d)
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AFTg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AFTt1g5 : $@convention(thin) (@guaranteed C) -> @owned C {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: strong_retain %0 : $C
 // CHECK: return %0 : $C
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AFTg5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AFTt1g5'
 _ = ArchetypeToArchetypeCast(t1: c, t2: c)
 
 // TODO: x -> x where x is not a class.
@@ -55,38 +55,38 @@ _ = ArchetypeToArchetypeCast(t1: b, t2: b)
 _ = ArchetypeToArchetypeCast(t1: b, t2: f)
 
 // x -> y where x is not a class but y is.
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA1CCTg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA1CCTt1g5 : $@convention(thin) (NotUInt8) -> @owned C {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: cond_fail {{%.*}}, "precondition failure"
 // CHECK: unreachable
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA1CCTg5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA1CCTt1g5'
 _ = ArchetypeToArchetypeCast(t1: b, t2: c)
 
 // y -> x where x is a class but y is not.
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA8NotUInt8VTg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8 {
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA8NotUInt8VTt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8 {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: cond_fail {{%.*}}, "precondition failure"
 // CHECK: unreachable
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA8NotUInt8VTg5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA8NotUInt8VTt1g5'
 _ = ArchetypeToArchetypeCast(t1: c, t2: b)
 
 // y -> x where x is a super class of y.
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1DC_AA1CCTg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1DC_AA1CCTt1g5 : $@convention(thin) (@guaranteed D) -> @owned C {
 // CHECK: [[T1:%.*]] = upcast %0 : $D to $C
 // CHECK: strong_retain %0 : $D
 // CHECK: return [[T1]] : $C
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1DC_AA1CCTg5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1DC_AA1CCTt1g5'
 _ = ArchetypeToArchetypeCast(t1: d, t2: c)
 
 // x -> y where x and y are unrelated.
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1ECTg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E {
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1ECTt1g5 : $@convention(thin) (@guaranteed C) -> @owned E {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: cond_fail {{%.*}}, "precondition failure"
 // CHECK: unreachable
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1ECTg5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1ECTt1g5'
 _ = ArchetypeToArchetypeCast(t1: c, t2: e)
 
 ///////////////////////////
@@ -218,48 +218,48 @@ func ConcreteToArchetypeCastD<T>(t: D, t2: T) -> T {
 }
 
 // x -> x where x is not a class.
-// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAF_Tg5 : $@convention(thin) (NotUInt8, NotUInt8) -> NotUInt8 {
+// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAF_Tt1g5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: return %0 : $NotUInt8
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAF_Tg5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAF_Tt1g5'
 _ = ConcreteToArchetypeCastUInt8(t: b, t2: b)
 
 // x -> y where x,y are not classes and x is a different type from y.
-// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA0K6UInt64V_Tg5 : $@convention(thin) (NotUInt8, NotUInt64) -> NotUInt64 {
+// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA0K6UInt64V_Tt1g5 : $@convention(thin) (NotUInt8) -> NotUInt64 {
 // CHECK: bb0
 // CHECK-NOT: bb1
 // CHECK: unreachable
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA0K6UInt64V_Tg5
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA0K6UInt64V_Tt1g5
 _ = ConcreteToArchetypeCastUInt8(t: b, t2: f)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA1CC_Tg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA1CC_Tt1g5 : $@convention(thin) (NotUInt8) -> @owned C
 // CHECK: bb0
 // CHECK: unreachable
 _ = ConcreteToArchetypeCastUInt8(t: b, t2: c)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAF_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAF_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK: return %0
 _ = ConcreteToArchetypeCastC(t: c, t2: c)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA8NotUInt8V_Tt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8
 // CHECK: bb0
 // CHECK: unreachable
 _ = ConcreteToArchetypeCastC(t: c, t2: b)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1DC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned D
 // CHECK: bb0
 // CHECK:  checked_cast_br C in %0 : $C to D
 // CHECK: bb1
 _ = ConcreteToArchetypeCastC(t: c, t2: d)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1EC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1EC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned E
 // CHECK: bb0
 // CHECK: unreachable
 _ = ConcreteToArchetypeCastC(t: c, t2: e)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastD1t2t2xAA1DC_xtlFAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastD1t2t2xAA1DC_xtlFAA1CC_Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned C
 // CHECK: bb0
 // CHECK:  [[T0:%.*]] = upcast %0 : $D to $C
 // CHECK:  return [[T0]]
@@ -283,29 +283,29 @@ func SuperToArchetypeCastD<T>(d : D, t : T) -> T {
   preconditionFailure("??? Profit?")
 }
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAF_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAF_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK: return %0 : $C
 _ = SuperToArchetypeCastC(c: c, t: c)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA1DC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned D
 // CHECK: bb0
 // CHECK:  checked_cast_br C in %0 : $C to D
 // CHECK: bb1
 _ = SuperToArchetypeCastC(c: c, t: d)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA8NotUInt8V_Tt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8
 // CHECK: bb0
 // CHECK: unreachable
 _ = SuperToArchetypeCastC(c: c, t: b)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAA1CC_Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned C
 // CHECK: bb0
 // CHECK:  [[T0:%.*]] = upcast %0 : $D to $C
 // CHECK:  return [[T0]]
 _ = SuperToArchetypeCastD(d: d, t: c)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAF_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed D) -> @owned D
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAF_Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned D
 // CHECK: bb0
 // CHECK: return %0 : $D
 _ = SuperToArchetypeCastD(d: d, t: d)
@@ -321,22 +321,22 @@ func ExistentialToArchetypeCast<T>(o : AnyObject, t : T) -> T {
   preconditionFailure("??? Profit?")
 }
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA1CC_Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed C) -> @owned C
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA1CC_Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> @owned C
 // CHECK: bb0
 // CHECK:  checked_cast_br AnyObject in %0 : $AnyObject to C
 // CHECK: bb1
 _ = ExistentialToArchetypeCast(o: o, t: c)
 
-// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed AnyObject, NotUInt8) -> NotUInt8
+// CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA8NotUInt8V_Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> NotUInt8
 // CHECK: bb0
 // CHECK:  checked_cast_addr_br take_always AnyObject in {{%.*}} : $*AnyObject to NotUInt8 in {{%.*}} : $*NotUInt8,
 // CHECK: bb1
 _ = ExistentialToArchetypeCast(o: o, t: b)
 
-// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFyXl_Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed AnyObject) -> @owned AnyObject
+// CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFyXl_Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> @owned AnyObject
 // CHECK: bb0
 // CHECK-NOT: checked_cast_br %
 // CHECK: return %0 : $AnyObject
 // CHECK-NOT: checked_cast_br %
-// CHECK: } // end sil function '$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFyXl_Tg5'
+// CHECK: } // end sil function '$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFyXl_Tt1g5'
 _ = ExistentialToArchetypeCast(o: o, t: o)

--- a/test/SILOptimizer/specialize_class_inherits_base_inherits_protocol.swift
+++ b/test/SILOptimizer/specialize_class_inherits_base_inherits_protocol.swift
@@ -12,7 +12,7 @@ class Bar<T>: Foo<T> {}
 
 // CHECK-LABEL: sil @$s031specialize_class_inherits_base_C9_protocol3fooyyF
 public func foo() {
-  // CHECK: function_ref @$s031specialize_class_inherits_base_C9_protocol4sinkyyxlFypXp_Tg5Tf4d_n
+  // CHECK: function_ref @$s031specialize_class_inherits_base_C9_protocol4sinkyyxlFypXp_Ttg5
   p(Bar<Int>())
 }
 

--- a/test/SILOptimizer/specialize_missing_sendable.swift
+++ b/test/SILOptimizer/specialize_missing_sendable.swift
@@ -9,7 +9,7 @@ public protocol P {}
 
 // CHECK-LABEL: sil @$s27specialize_missing_sendable6callerAA5ClassCyAA1P_pGyF : $@convention(thin) () -> @owned Class<any P> {
 public func caller() -> Class<any P> {
-  // CHECK: function_ref @$s27specialize_missing_sendable5ClassCACyxGycfCAA1P_p_Tgm5 : $@convention(thin) () -> @owned Class<any P>
+  // CHECK: function_ref @$s27specialize_missing_sendable5ClassCACyxGycfCAA1P_p_Ttg5 : $@convention(thin) () -> @owned Class<any P>
   // CHECK: return
   return Class<any P>()
 }

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -44,7 +44,7 @@ bb0(%0 : $Builtin.NativeObject):
 // CHECK-LABEL: sil [ossa] @exp1 : $@convention(thin) () -> () {
 // CHECK-NOT: apply
 // Call of specialized initializer: <Int32>
-// CHECK: [[CTOR:%[0-9]+]] = function_ref @$s8XXX_inits5Int32V_Tgm5
+// CHECK: [[CTOR:%[0-9]+]] = function_ref @$s8XXX_inits5Int32V_Tt1g5
 // CHECK: apply [[CTOR]]
 // CHECK: [[ACCEPTS_INT:%[0-9]+]] = function_ref @acceptsInt
 // Call of specialized XXX_foo: <Int32>
@@ -635,7 +635,7 @@ bb0:
 
 // test_bind<A> (Builtin.RawPointer, A.Type) -> ()
 // Check that this is specialized as T=Int.
-// CHECK-LABEL: sil shared [ossa] @$s9test_bindSi_Tgm5 : $@convention(thin) (Builtin.RawPointer) -> () {
+// CHECK-LABEL: sil shared [ossa] @$s9test_bindSi_Tt0g5 : $@convention(thin) (Builtin.RawPointer) -> () {
 // CHECK: bind_memory %0 : $Builtin.RawPointer, {{%.*}} : $Builtin.Word to $*Int
 // CHECK: return
 sil hidden [ossa] @test_bind : $@convention(thin) <T> (Builtin.RawPointer, @thick T.Type) -> () {
@@ -894,7 +894,7 @@ bb0(%0 : $*T, %1 :$*T):
 }
 
 // This should not assert.
-// CHECK-LABEL: sil shared [ossa] @$s26specialize_no_return_applys5NeverO_Tgm5 : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared [ossa] @$s26specialize_no_return_applys5NeverO_Ttg5 : $@convention(thin) () -> () {
 // CHECK:      apply
 // CHECK-NEXT: unreachable
 
@@ -1306,7 +1306,7 @@ sil @genericReturn : $@convention(thin) <τ_0_0> (@guaranteed AnyObject) -> @out
 // The generic cloner needs to be able to compute liveness to fixup a
 // store borrow scope when the only use is in unreachable code.
 // specialized testNoReturnSpecialization
-// CHECK-LABEL: sil shared [ossa] @$s26testNoReturnSpecializations5NeverO_Tgm5 : $@convention(thin) (@guaranteed AnyObject) -> () {
+// CHECK-LABEL: sil shared [ossa] @$s26testNoReturnSpecializations5NeverO_Tt0g5 : $@convention(thin) (@guaranteed AnyObject) -> () {
 // CHECK:   [[SB:%.*]] = store_borrow %0 to %{{.*}} : $*AnyObject
 // CHECK:   [[LB:%.*]] = load_borrow [[SB]] : $*AnyObject
 // CHECK:   apply %{{.*}}<Never>(%{{.*}}, [[LB]]) : $@convention(thin) <τ_0_0> (@guaranteed AnyObject) -> @out τ_0_0
@@ -1315,7 +1315,7 @@ sil @genericReturn : $@convention(thin) <τ_0_0> (@guaranteed AnyObject) -> @out
 // CHECK: bb1:
 // CHECK:   end_borrow [[LB]] : $AnyObject
 // CHECK:   end_borrow [[SB]] : $*AnyObject
-// CHECK-LABEL: } // end sil function '$s26testNoReturnSpecializations5NeverO_Tgm5'
+// CHECK-LABEL: } // end sil function '$s26testNoReturnSpecializations5NeverO_Tt0g5'
 sil [ossa] @testNoReturnSpecialization : $@convention(thin) <T> (@in_guaranteed AnyObject, @thick T.Type) -> () {
 bb0(%0 : $*AnyObject, %1 : $@thick T.Type):
   %2 = load_borrow %0 : $*AnyObject
@@ -1354,7 +1354,7 @@ bb0(%0 : $@thick GenericKlass<T>.Type):
 }
 
 // CHECK-LABEL: sil [ossa] @callUsedMetatypeWithConcreteMetatype :
-// CHECK:         = function_ref @$s12metatypeUsedSi_Tgm5 : $@convention(thin) () -> ()
+// CHECK:         = function_ref @$s12metatypeUsedSi_Ttg5 : $@convention(thin) () -> ()
 // CHECK-LABEL: } // end sil function 'callUsedMetatypeWithConcreteMetatype'
 sil [ossa] @callUsedMetatypeWithConcreteMetatype : $@convention(thin) () -> () {
 bb0:
@@ -1377,7 +1377,7 @@ bb0(%0 : $@thick GenericKlass<Int>.Type):
 }
 
 // CHECK-LABEL: sil [ossa] @callUnusedMetatypeWithUnknownMetatype :
-// CHECK:         = function_ref @$s14metatypeUnusedSi_Tgm5 : $@convention(thin) () -> ()
+// CHECK:         = function_ref @$s14metatypeUnusedSi_Ttg5 : $@convention(thin) () -> ()
 // CHECK-LABEL: } // end sil function 'callUnusedMetatypeWithUnknownMetatype'
 sil [ossa] @callUnusedMetatypeWithUnknownMetatype : $@convention(thin) (@thick GenericKlass<Int>.Type) -> () {
 bb0(%0 : $@thick GenericKlass<Int>.Type):
@@ -1394,7 +1394,7 @@ bb0(%0 : $*T, %1 : $@thick GenericKlass<T>.Type):
 }
 
 // CHECK-LABEL: sil [ossa] @returnClosureWithAppliedMetatype :
-// CHECK:         = function_ref @$s21closure_with_metatypeSi_TGm5 : $@convention(thin) (@in_guaranteed Int) -> ()
+// CHECK:         = function_ref @$s21closure_with_metatypeSi_Tt0G5 : $@convention(thin) (@in_guaranteed Int) -> ()
 // CHECK-LABEL: } // end sil function 'returnClosureWithAppliedMetatype'
 sil [ossa] @returnClosureWithAppliedMetatype : $@convention(thin) () -> @owned @callee_owned (@in_guaranteed Int) -> () {
 bb0:
@@ -1439,7 +1439,7 @@ bb0(%0 : $*T, %2 : $@thick T.Type, %3 : $*T, %4 : $Bool):
 }
 
 // CHECK-LABEL: sil [ossa] @returnComplexClosure :
-// CHECK:         = function_ref @$s15complex_closureSi_TGm5 : $@convention(thin) (@in_guaranteed Int, Bool) -> @out Int
+// CHECK:         = function_ref @$s15complex_closureSi_Tt0G5 : $@convention(thin) (@in_guaranteed Int, Bool) -> @out Int
 // CHECK-LABEL: } // end sil function 'returnComplexClosure'
 sil [ossa] @returnComplexClosure : $@convention(thin) (@in Int, Bool) -> @owned @callee_owned () -> @out Int {
 bb0(%0: $*Int, %1 : $Bool):

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -1611,3 +1611,26 @@ bb0:
   %9999 = tuple ()
   return %9999 : $()
 }
+
+sil [ossa] @unused_argument : $@convention(thin) <T> (@in_guaranteed T) -> () {
+[global: ]
+bb0(%0 : $*T):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @call_generic_func_with_no_arg_read :
+// CHECK-NOT:     load
+// CHECK:           = apply {{%[0-9]+}}() :
+// CHECK-NOT:     end_borrow
+// CHECK:       } // end sil function 'call_generic_func_with_no_arg_read'
+sil [ossa] @call_generic_func_with_no_arg_read : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_stack $Klass
+  %2 = function_ref @unused_argument : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %3 = apply %2<Klass>(%1) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %1 : $*Klass
+  %5 = tuple ()
+  return %5 : $()
+}
+

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -38,15 +38,15 @@ ArchetypeToArchetype(t: c, t2: e)
 ArchetypeToArchetype(t: b, t2: f)
 
 // x -> x where x is not a class.
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V{{.*}}Tg5 : $@convention(thin) (NotUInt8, NotUInt8) -> NotUInt8 {
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V{{.*}}Tt1g5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC{{.*}}Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC{{.*}}Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> y where x is not a class but y is.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_AA1CCTg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_AA1CCTt1g5 : $@convention(thin) (NotUInt8) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast_addr
 // CHECK-NOT: unconditional_checked_cast_addr
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
@@ -54,33 +54,33 @@ ArchetypeToArchetype(t: b, t2: f)
 // CHECK-NOT: unconditional_checked_cast_addr
 
 // y -> x where x is not a class but y is.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA8NotUInt8VTg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8 {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA8NotUInt8VTt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8 {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> y where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1DCTg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1DCTt1g5 : $@convention(thin) (@guaranteed C) -> @owned D {
 // CHECK: [[STACK:%[0-9]+]] = alloc_stack $C
 // TODO: This should be optimized to an unconditional_checked_cast without the need of alloc_stack: rdar://problem/24775038
 // CHECK: unconditional_checked_cast_addr C in [[STACK]] : $*C to D in
 
 // y -> x where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1DC_AA1CCTg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1DC_AA1CCTt1g5 : $@convention(thin) (@guaranteed D) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK: upcast {{%[0-9]+}} : $D to $C
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> y where x and y are unrelated classes.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1ECTg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1ECTt1g5 : $@convention(thin) (@guaranteed C) -> @owned E {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> y where x and y are unrelated non classes.
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_AA0H6UInt64VTg5 : $@convention(thin) (NotUInt8, NotUInt64) -> NotUInt64 {
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_AA0H6UInt64VTt1g5 : $@convention(thin) (NotUInt8) -> NotUInt64 {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
@@ -213,13 +213,13 @@ ConcreteToArchetypeConvertUInt8(t: b, t2: c)
 ConcreteToArchetypeConvertUInt8(t: b, t2: f)
 
 // x -> x where x is not a class.
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}3Not{{.*}}Tg5 : $@convention(thin) (NotUInt8, NotUInt8) -> NotUInt8 {
-// CHECK: bb0(%0 : $NotUInt8, %1 : $NotUInt8):
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}3Not{{.*}}Tt1g5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
+// CHECK: bb0(%0 : $NotUInt8):
 // CHECK: debug_value %0
 // CHECK: return %0
 
 // x -> y where x is not a class but y is a class.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}FAA1CC_Tt1g5 : $@convention(thin) (NotUInt8) -> @owned C {
 // CHECK: bb0
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
@@ -227,7 +227,7 @@ ConcreteToArchetypeConvertUInt8(t: b, t2: f)
 // CHECK-NEXT: }
 
 // x -> y where x,y are different non class types.
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}Not{{.*}}Tg5 : $@convention(thin) (NotUInt8, NotUInt64) -> NotUInt64 {
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}Not{{.*}}Tt1g5 : $@convention(thin) (NotUInt8) -> NotUInt64 {
 // CHECK: bb0
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
@@ -246,12 +246,12 @@ ConcreteToArchetypeConvertC(t: c, t2: e)
 
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
-// CHECK: bb0(%0 : $C, %1 : $C):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned C {
+// CHECK: bb0(%0 : $C):
 // CHECK: return %0
 
 // x -> y where x is a class but y is not.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}Not{{.*}}Tg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8 {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}Not{{.*}}Tt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8 {
 // CHECK: bb0
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
@@ -259,8 +259,8 @@ ConcreteToArchetypeConvertC(t: c, t2: e)
 // CHECK-NEXT: }
 
 // x -> y where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D {
-// CHECK: bb0(%0 : $C, %1 : $D):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1DC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned D {
+// CHECK: bb0(%0 : $C):
 // CHECK-DAG: [[STACK_C:%[0-9]+]] = alloc_stack $C
 // CHECK-DAG: store %0 to [[STACK_C]]
 // CHECK-DAG: [[STACK_D:%[0-9]+]] = alloc_stack $D
@@ -270,8 +270,8 @@ ConcreteToArchetypeConvertC(t: c, t2: e)
 // CHECK: return [[LOAD]]
 
 // x -> y where x and y are unrelated classes.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1EC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E {
-// CHECK: bb0(%0 : $C, %1 : $E):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1EC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned E {
+// CHECK: bb0(%0 : $C):
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
 // CHECK-NEXT: unreachable
@@ -285,8 +285,8 @@ public func ConcreteToArchetypeConvertD<T>(t t: D, t2: T) -> T {
 ConcreteToArchetypeConvertD(t: d, t2: c)
 
 // x -> y where x is a subclass of y.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertD{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
-// CHECK: bb0(%0 : $D, %1 : $C):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertD{{[_0-9a-zA-Z]*}}FAA1CC_Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned C {
+// CHECK: bb0(%0 : $D):
 // CHECK-DAG: [[UC:%[0-9]+]] = upcast %0
 // CHECK: return [[UC]]
 
@@ -306,17 +306,17 @@ SuperToArchetypeC(c: c, t: b)
 
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
-// CHECK: bb0(%0 : $C, %1 : $C):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned C {
+// CHECK: bb0(%0 : $C):
 // CHECK: return %0
 
 // x -> y where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}FAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}FAA1DC_Tt1g5 : $@convention(thin) (@guaranteed C) -> @owned D {
 // CHECK: bb0
 // CHECK: unconditional_checked_cast_addr C in
 
 // x -> y where x is a class and y is not.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8 {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_Tt1g5 : $@convention(thin) (@guaranteed C) -> NotUInt8 {
 // CHECK: bb0
 // CHECK: [[ONE:%[0-9]+]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[ONE]] : $Builtin.Int1, "failed cast"
@@ -333,13 +333,13 @@ SuperToArchetypeD(d: d, t: d)
 
 // *NOTE* The frontend is smart enough to turn this into an upcast. When this
 // test is converted to SIL, this should be fixed appropriately.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}FAA1CC_Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast super_to_archetype
 // CHECK: upcast
 // CHECK-NOT: unconditional_checked_cast super_to_archetype
 
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed D, @guaranteed D) -> @owned D {
-// CHECK: bb0(%0 : $D, %1 : $D):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}Tt1g5 : $@convention(thin) (@guaranteed D) -> @owned D {
+// CHECK: bb0(%0 : $D):
 // CHECK: return %0
 
 //////////////////////////////
@@ -352,18 +352,18 @@ public func ExistentialToArchetype<T>(o o : AnyObject, t : T) -> T {
 }
 
 // AnyObject -> Class.
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}FAA1CC_Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> @owned C {
 // CHECK: unconditional_checked_cast_addr AnyObject in {{%.*}} : $*AnyObject to C
 
 // AnyObject -> Non Class (should always fail)
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed AnyObject, NotUInt8) -> NotUInt8 {
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> NotUInt8 {
 // CHECK-NOT: cond_fail
 // CHECK-NOT: unreachable
 // CHECK: return
 
 // AnyObject -> AnyObject
-// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}yXl{{.*}}Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed AnyObject) -> @owned AnyObject {
-// CHECK: bb0(%0 : $AnyObject, %1 : $AnyObject):
+// CHECK-LABEL: sil shared [noinline] {{.*}}@$s37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}yXl{{.*}}Tt1g5 : $@convention(thin) (@guaranteed AnyObject) -> @owned AnyObject {
+// CHECK: bb0(%0 : $AnyObject):
 // CHECK: return %0
 
 ExistentialToArchetype(o: o, t: c)
@@ -374,7 +374,7 @@ ExistentialToArchetype(o: o, t: o)
 // value cast. We could do the promotion, but the optimizer would need
 // to insert the Optional unwrapping logic before the cast.
 //
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast15genericDownCastyq_x_q_mtr0_lFAA1CCSg_AA1DCTgm5 : $@convention(thin) (@guaranteed Optional<C>) -> @owned D {
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast15genericDownCastyq_x_q_mtr0_lFAA1CCSg_AA1DCTt1g5 : $@convention(thin) (@guaranteed Optional<C>) -> @owned D {
 // CHECK: bb0(%0 : $Optional<C>):
 // CHECK-DAG: [[STACK_D:%[0-9]+]] = alloc_stack $D
 // CHECK-DAG: [[STACK_C:%[0-9]+]] = alloc_stack $Optional<C>

--- a/test/TBD/specialization.swift
+++ b/test/TBD/specialization.swift
@@ -40,7 +40,7 @@ public func f() {
 
 // Generic specialization, from the foo call in f
 // CHECK-LABEL: // specialized Foo.foo<A>(_:)
-// CHECK-NEXT: sil private [noinline] @$s14specialization3FooC3foo33_A6E3E43DB6679655BDF5A878ABC489A0LLyyxmlFSi_Tgm5Tf4d_n : $@convention(thin) () -> ()
+// CHECK-NEXT: sil private [noinline] @$s14specialization3FooC3foo33_A6E3E43DB6679655BDF5A878ABC489A0LLyyxmlFSi_Ttg5Tf4d_n : $@convention(thin) () -> ()
 
 // Function signature specialization, from the bar call in Bar.init
 // CHECK-LABEL: // specialized Bar.bar()

--- a/test/embedded/basic-modules-generics-no-stdlib.swift
+++ b/test/embedded/basic-modules-generics-no-stdlib.swift
@@ -57,6 +57,6 @@ public func main() {
 // CHECK: define {{.*}}void @"$s8MyModule14nonGenericFuncyyF"()
 // CHECK: define {{.*}}void @"$s8MyModule11genericFuncyxxlF4Main4BoolV_Tg5"()
 // CHECK: define {{.*}}void @"$s8MyModule14NonGenericTypeVACycfC"()
-// CHECK: define {{.*}}void @"$s8MyModule11GenericTypeVyACyxGxcfC4Main4BoolV_Tgm5"()
+// CHECK: define {{.*}}void @"$s8MyModule11GenericTypeVyACyxGxcfC4Main4BoolV_Tt1g5"()
 // CHECK: define {{.*}}void @"$s8MyModule17protocolBoundFuncyyxAA8ProtocolRzlF4Main4BoolV_Tg5"()
 // CHECK: define {{.*}}void @"$s8MyModule17protocolBoundFuncyyxAA8ProtocolRzlFAA11GenericTypeVy4Main4BoolVG_Tg5"()

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -24,13 +24,13 @@ public func bar(t: T2) -> MyClass<T2> {
 // CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvgAA2T1V_Tg5 {{.*}}{
 // CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvsAA2T1V_Tg5 {{.*}}{
 // CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvMAA2T1V_Tg5 {{.*}}{
-// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tgm5 {{.*}}{
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tt0g5 {{.*}}{
 // CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassCfDAA2T1V_Tg5 {{.*}}{
 
 // CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvgAA2T2V_Tg5 {{.*}}{
 // CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvsAA2T2V_Tg5 {{.*}}{
 // CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvMAA2T2V_Tg5 {{.*}}{
-// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tgm5 {{.*}}{
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tt0g5 {{.*}}{
 // CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassCfDAA2T2V_Tg5 {{.*}}{
 
 // CHECK-SIL: sil_vtable MyClass {
@@ -57,8 +57,8 @@ public func bar(t: T2) -> MyClass<T2> {
 // CHECK-IR-DAG: define {{.*}}i1 @"$s4main7MyClassC1txvgAA2T2V_Tg5"(ptr swiftself %0)
 // CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5"(ptr swiftself %0)
 // CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tg5"(i1 %0, ptr swiftself %1)
-// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tgm5"()
-// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tgm5"(i1 %0)
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tt0g5"()
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tt0g5"(i1 %0)
 // CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T1V_Tg5"(ptr swiftself %0)
 // CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T2V_Tg5"(i1 %0, ptr swiftself %1)
 // CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassCfdAA2T1V_Tg5"(ptr swiftself %0)

--- a/test/embedded/value-type-deinits.swift
+++ b/test/embedded/value-type-deinits.swift
@@ -31,6 +31,6 @@ public func test() {
   createFoo(x: 1)
 }
 
-// CHECK-LABEL: sil @$s8MyModule9createFoo1xyx_ts17FixedWidthIntegerRzlFSi_Tg5 :
+// CHECK-LABEL: sil @$s8MyModule9createFoo1xyx_ts17FixedWidthIntegerRzlFSi_Ttg5 :
 // CHECK-NOT:     release
-// CHECK:       } // end sil function '$s8MyModule9createFoo1xyx_ts17FixedWidthIntegerRzlFSi_Tg5'
+// CHECK:       } // end sil function '$s8MyModule9createFoo1xyx_ts17FixedWidthIntegerRzlFSi_Ttg5'


### PR DESCRIPTION
If there is no read from an indirect argument, this argument has to be dropped. At the call site the store to the argument's memory location could have been removed (based on the callee's memory effects). Therefore, converting such an unused indirect argument to a direct argument, would load an uninitialized value at the call site.
This would lead to verifier errors and in worst case to a mis-compile because IRGen can implicitly use dead arguments, e.g. for getting the type of a class reference.

This change also requires a change in mangling generic specializations (see the commit message for details). Note that mangling of specialized functions (except pre-specializations) is not ABI. So there is no problem changing the mangling.