### PR TITLE
[stdlib] Fix grammatical error in Collection.swift

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -214,7 +214,7 @@ extension IndexingIterator: Sendable
 /// takes a range expression.
 ///
 ///     if let firstSpace = text.firstIndex(of: " ") {
-///         print(text[..<firstSpace]
+///         print(text[..<firstSpace])
 ///         // Prints "Buffalo"
 ///     }
 ///


### PR DESCRIPTION
Hi, I found a grammatical error in Collection.swift file(line: 217).

- **origin code**
```swift
if let firstSpace = text.firstIndex(of: " ") {
    print(text[..<firstSpace] // <-- ')' is missing
    // Prints "Buffalo"
}
```
- **changed code**
```swift
if let firstSpace = text.firstIndex(of: " ") {
    print(text[..<firstSpace])
    // Prints "Buffalo"
}