### PR TITLE
[Test] Fix remote-run of objc_implementation_objc_client.m.

### DIFF
--- a/test/Interpreter/objc_implementation_objc_client.m
+++ b/test/Interpreter/objc_implementation_objc_client.m
@@ -6,7 +6,7 @@
 // RUN: %empty-directory(%t-frameworks/objc_implementation.framework/Headers)
 // RUN: cp %S/Inputs/objc_implementation.modulemap %t-frameworks/objc_implementation.framework/Modules/module.modulemap
 // RUN: cp %S/Inputs/objc_implementation.h %t-frameworks/objc_implementation.framework/Headers
-// RUN: %target-build-swift-dylib(%t-frameworks/objc_implementation.framework/objc_implementation) -emit-module-path %t-frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule/%module-target-triple.swiftmodule -module-name objc_implementation -F %t-frameworks -import-underlying-module -Xlinker -install_name -Xlinker %t-frameworks/objc_implementation.framework/objc_implementation %S/objc_implementation.swift -enable-experimental-feature CImplementation -target %target-stable-abi-triple
+// RUN: %target-build-swift-dylib(%t-frameworks/objc_implementation.framework/objc_implementation) -emit-module-path %t-frameworks/objc_implementation.framework/Modules/objc_implementation.swiftmodule/%module-target-triple.swiftmodule -module-name objc_implementation -F %t-frameworks -import-underlying-module -Xlinker -install_name -Xlinker @executable_path/../$(basename %t)-frameworks/objc_implementation.framework/objc_implementation %S/objc_implementation.swift -enable-experimental-feature CImplementation -target %target-stable-abi-triple
 
 //
 // Execute this file


### PR DESCRIPTION
Use a @executable_path relative install name so that it still works when the executable and framework are copied and run elsewhere.

rdar://134406720