### PR TITLE
Correctly obey NDEBUG for CONDITIONAL_ASSERT

### DIFF
--- a/lib/Basic/Assertions.cpp
+++ b/lib/Basic/Assertions.cpp
@@ -17,8 +17,6 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 #include "swift/Basic/Assertions.h"
-#undef NDEBUG
-#include <cassert>
 #include <iostream>
 
 llvm::cl::opt<bool> AssertContinue(


### PR DESCRIPTION
It looks like a piece of an old experiment never got removed.  This inadvertently caused CONDITIONAL_ASSERT requests to always be enabled by default; it was intended that these be enabled by default only in debug/assert builds.