### PR TITLE
ColdBlockInfo: overhaul analysis pass

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -122,6 +122,9 @@ public:
   /// within the optimizer. This influences static branch prediction.
   bool EnableThrowsPrediction = false;
 
+  /// Controls whether to say that blocks ending in an 'unreachable' are cold.
+  bool EnableNoReturnCold = false;
+
   /// Should we run any SIL performance optimizations
   ///
   /// Useful when you want to enable -O LLVM opts but not -O SIL opts.

--- a/include/swift/Basic/ProfileCounter.h
+++ b/include/swift/Basic/ProfileCounter.h
@@ -27,8 +27,8 @@ private:
   uint64_t count;
 
 public:
-  explicit ProfileCounter() : count(UINT64_MAX) {}
-  ProfileCounter(uint64_t Count) : count(Count) {
+  explicit constexpr ProfileCounter() : count(UINT64_MAX) {}
+  constexpr ProfileCounter(uint64_t Count) : count(Count) {
     if (Count == UINT64_MAX) {
       count = UINT64_MAX - 1;
     }
@@ -40,6 +40,22 @@ public:
     return count;
   }
   explicit operator bool() const { return hasValue(); }
+
+  /// Saturating addition of another counter to this one, meaning that overflow
+  /// is avoided. If overflow would have happened, this function returns true
+  /// and the maximum representable value will be set in this counter.
+  bool add_saturating(ProfileCounter other) {
+    assert(hasValue() && other.hasValue());
+
+    // Will we go over the max representable value by adding other?
+    if (count > ((UINT64_MAX-1) - other.count)) {
+      count = UINT64_MAX - 1;
+      return true;
+    }
+
+    count += other.count;
+    return false;
+  }
 };
 } // end namespace swift
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -545,6 +545,11 @@ def enable_throws_prediction : Flag<["-"], "enable-throws-prediction">,
 def disable_throws_prediction : Flag<["-"], "disable-throws-prediction">,
   HelpText<"Disables optimization assumption that functions rarely throw errors.">;
 
+def enable_noreturn_prediction : Flag<["-"], "enable-noreturn-prediction">,
+  HelpText<"Enables optimization assumption that calls to no-return functions are cold.">;
+def disable_noreturn_prediction : Flag<["-"], "disable-noreturn-prediction">,
+  HelpText<"Disables optimization assumption that calls to no-return functions are cold.">;
+
 def disable_access_control : Flag<["-"], "disable-access-control">,
   HelpText<"Don't respect access control restrictions">;
 def enable_access_control : Flag<["-"], "enable-access-control">,

--- a/include/swift/SILOptimizer/Analysis/ColdBlockInfo.h
+++ b/include/swift/SILOptimizer/Analysis/ColdBlockInfo.h
@@ -15,52 +15,72 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "swift/SIL/SILValue.h"
+#include "swift/Basic/FixedBitSet.h"
 
 namespace swift {
 class DominanceAnalysis;
+class PostDominanceAnalysis;
 class SILBasicBlock;
+class CondBranchInst;
 
 /// Cache a set of basic blocks that have been determined to be cold or hot.
 ///
 /// This does not inherit from SILAnalysis because it is not worth preserving
 /// across passes.
 class ColdBlockInfo {
-  DominanceAnalysis *DA;
+public:
+  // Represents the temperatures of edges flowing into a block.
+  //
+  //         T = "top" -- both warm and cold edges
+  //        /  \
+  //     Warm  Cold
+  //        \  /
+  //         B = "bottom" -- neither warm or cold edges
+  struct State {
+    // Each state kind, as an integer, is its position in any bit vectors.
+    enum Temperature {
+      Warm = 0,
+      Cold = 1
+    };
 
-  /// Each block in this map has been determined to be either cold or hot.
-  llvm::DenseMap<const SILBasicBlock*, bool> ColdBlockMap;
+    // Number of states, excluding Top or Bottom, in this flow problem.
+    static constexpr unsigned NumStates = 2;
+  };
+
+  using Energy = FixedBitSet<State::NumStates, State::Temperature>;
+
+private:
+  DominanceAnalysis *DA;
+  PostDominanceAnalysis *PDA;
+
+  /// Each block in this map has been determined to be cold and/or warm.
+  llvm::DenseMap<const SILBasicBlock*, Energy> EnergyMap;
+  bool changedMap = false;
 
   // This is a cache and shouldn't be copied around.
   ColdBlockInfo(const ColdBlockInfo &) = delete;
   ColdBlockInfo &operator=(const ColdBlockInfo &) = delete;
+  LLVM_DUMP_METHOD void dump() const;
 
-  /// Tri-value return code for checking branch hints.
-  enum BranchHint : unsigned {
-    None,
-    LikelyTrue,
-    LikelyFalse
-  };
+  void resetToCold(const SILBasicBlock *BB);
+  void set(const SILBasicBlock *BB, State::Temperature temp);
 
-  enum {
-    RecursionDepthLimit = 3
-  };
+  using ExpectedValue = std::optional<bool>;
 
-  BranchHint getBranchHint(SILValue Cond, int recursionDepth);
+  void setExpectedCondition(CondBranchInst *CondBranch, ExpectedValue value);
 
-  bool isSlowPath(const SILBasicBlock *FromBB, const SILBasicBlock *ToBB,
-                  int recursionDepth);
+  ExpectedValue searchForExpectedValue(SILValue Cond,
+                                       unsigned recursionDepth = 0);
+  void searchForExpectedValue(CondBranchInst *CondBranch);
 
-  bool isCold(const SILBasicBlock *BB,
-              int recursionDepth);
+  bool inferFromEdgeProfile(SILBasicBlock *BB);
 
 public:
-  ColdBlockInfo(DominanceAnalysis *DA): DA(DA) {}
+  ColdBlockInfo(DominanceAnalysis *DA, PostDominanceAnalysis *PDA);
 
-  bool isSlowPath(const SILBasicBlock *FromBB, const SILBasicBlock *ToBB) {
-    return isSlowPath(FromBB, ToBB, 0);
-  }
+  void analyze(SILFunction *F);
 
-  bool isCold(const SILBasicBlock *BB) { return isCold(BB, 0); }
+  bool isCold(const SILBasicBlock *BB) const;
 };
 } // end namespace swift
 

--- a/include/swift/SILOptimizer/Analysis/ColdBlockInfo.h
+++ b/include/swift/SILOptimizer/Analysis/ColdBlockInfo.h
@@ -54,14 +54,16 @@ private:
   PostDominanceAnalysis *PDA;
 
   /// Each block in this map has been determined to be cold and/or warm.
+  /// Make sure to always use the set/resetToCold methods to update this!
   llvm::DenseMap<const SILBasicBlock*, Energy> EnergyMap;
-  bool changedMap = false;
 
   // This is a cache and shouldn't be copied around.
   ColdBlockInfo(const ColdBlockInfo &) = delete;
   ColdBlockInfo &operator=(const ColdBlockInfo &) = delete;
   LLVM_DUMP_METHOD void dump() const;
 
+  /// Tracks whether any information was changed in the energy map.
+  bool changedMap = false;
   void resetToCold(const SILBasicBlock *BB);
   void set(const SILBasicBlock *BB, State::Temperature temp);
 

--- a/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
+++ b/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
@@ -429,6 +429,7 @@ public:
       return;
 
     BlockInfoStorage.resize(numBlocks);
+    CBI.analyze(F);
 
     // First step: compute the length of the blocks.
     unsigned BlockIdx = 0;

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -294,6 +294,10 @@ struct SILOptOptions {
                      llvm::cl::desc("Enables optimization assumption that functions rarely throw errors."));
 
   llvm::cl::opt<bool>
+  EnableNoReturnCold = llvm::cl::opt<bool>("enable-noreturn-prediction",
+                     llvm::cl::desc("Enables optimization assumption that calls to no-return functions are cold."));
+
+  llvm::cl::opt<bool>
   EnableMoveInoutStackProtection = llvm::cl::opt<bool>("enable-move-inout-stack-protector",
                     llvm::cl::desc("Enable the stack protector by moving values to temporaries."));
 
@@ -852,6 +856,7 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   SILOpts.EnableSpeculativeDevirtualization = options.EnableSpeculativeDevirtualization;
   SILOpts.EnableAsyncDemotion = options.EnableAsyncDemotion;
   SILOpts.EnableThrowsPrediction = options.EnableThrowsPrediction;
+  SILOpts.EnableNoReturnCold = options.EnableNoReturnCold;
   SILOpts.IgnoreAlwaysInline = options.IgnoreAlwaysInline;
   SILOpts.EnableOSSAModules = options.EnableOSSAModules;
   SILOpts.EnableSILOpaqueValues = options.EnableSILOpaqueValues;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2661,6 +2661,9 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.EnableThrowsPrediction = Args.hasFlag(
       OPT_enable_throws_prediction, OPT_disable_throws_prediction,
       Opts.EnableThrowsPrediction);
+  Opts.EnableNoReturnCold = Args.hasFlag(
+      OPT_enable_noreturn_prediction, OPT_disable_noreturn_prediction,
+      Opts.EnableNoReturnCold);
   Opts.EnableActorDataRaceChecks |= Args.hasFlag(
       OPT_enable_actor_data_race_checks,
       OPT_disable_actor_data_race_checks, /*default=*/false);

--- a/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
+++ b/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
@@ -144,11 +144,13 @@ ColdBlockInfo::searchForExpectedValue(SILValue Cond,
       auto *predBB = Pair.first;
       auto predArg = Pair.second;
 
+      // We only want to consider values coming from a non-cold path of preds.
       if (isCold(predBB))
         continue;
 
       std::optional<bool> predecessorValue;
 
+      // Look for an integer literal, otherwise, recurse.
       if (auto *IL = dyn_cast<IntegerLiteralInst>(predArg)) {
         predecessorValue = IL->getValue().getBoolValue();
       } else {
@@ -274,6 +276,8 @@ void ColdBlockInfo::analyze(SILFunction *fn) {
   LLVM_DEBUG(llvm::dbgs() << "--> Before Stage 1\n");
   LLVM_DEBUG(dump());
 
+  // The set of blocks for which we can skip searching for an expected
+  // conditional value, as we've already determined which successor is cold.
   BasicBlockSet foundExpectedCond(fn);
 
   // Stage 1: Seed the graph with warm/cold blocks.

--- a/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
+++ b/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
@@ -209,10 +209,10 @@ static std::optional<bool> getExpectedValue(SILValue Cond) {
 /// The minimum probability that an edge is taken to be considered "warm".
 constexpr double WARM_EDGE_MINIMUM = 3.0 / 100.0;
 
-// Using the profile data on the terminator of this block, annotate successors
-// with cold/warm information.
-//
-// \returns true if an inference was made
+/// Using the profile data on the terminator of this block, annotate successors
+/// with cold/warm information.
+///
+/// \returns true if an inference was made
 bool ColdBlockInfo::inferFromEdgeProfile(SILBasicBlock *BB) {
   ProfileCounter totalCount{0};
   SmallVector<ProfileCounter, 2> succCount;

--- a/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
+++ b/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
@@ -1,8 +1,8 @@
-//===--- ColdBlockInfo.cpp - Fast/slow path analysis for the SIL CFG ------===//
+//===--- ColdBlockInfo.cpp - Hot/cold block analysis for the SIL CFG ------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,12 +10,109 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/SemanticAttrs.h"
+#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/Analysis/ColdBlockInfo.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
-#include "swift/SIL/SILArgument.h"
-#include "swift/AST/SemanticAttrs.h"
+
+#define DEBUG_TYPE "cold-block-info"
 
 using namespace swift;
+
+bool isColdEnergy(ColdBlockInfo::Energy e);
+
+ColdBlockInfo::ColdBlockInfo(DominanceAnalysis *DA,
+                             PostDominanceAnalysis *PDA) : DA(DA), PDA(PDA) {
+  LLVM_DEBUG(llvm::dbgs() << "ColdBlockInfo: constructed\n");
+}
+
+static std::string toString(SILBasicBlock const *bb) {
+  std::string str = bb->getParent()->getName().str();
+  str += "::bb" + std::to_string(bb->getDebugID());
+  return str;
+}
+
+static StringRef toString(ColdBlockInfo::Energy e) {
+  if (e == ColdBlockInfo::Energy::full())
+    return "<<ALL>>";
+  else if (e.empty())
+    return "<<NONE>>";
+  else if (e.contains(ColdBlockInfo::State::Warm))
+    return "warm";
+  else if (e.contains(ColdBlockInfo::State::Cold))
+    return "cold";
+  else
+    llvm_unreachable("unhandled energy state");
+}
+
+static StringRef toString(ColdBlockInfo::State::Temperature t) {
+  ColdBlockInfo::Energy e;
+  e.insert(t);
+  return toString(e);
+}
+
+void ColdBlockInfo::dump() const {
+  unsigned warm = 0, cold = 0;
+  llvm::dbgs() << "ColdBlockInfo {\n";
+  for (auto pair : EnergyMap) {
+    auto energy = pair.getSecond();
+    isColdEnergy(energy) ? cold++ : warm++;
+
+    llvm::dbgs() << toString(pair.getFirst())
+                 << " -> " << toString(energy) << "\n";
+  }
+  llvm::dbgs() << "STATISTICS: warm " << warm << " | cold " << cold << "\n}\n";
+}
+
+inline bool isCriticalEdge(SILBasicBlock *predBB, SILBasicBlock *succBB) {
+  return !(predBB->getSingleSuccessorBlock() == succBB
+        || succBB->getSinglePredecessorBlock() == predBB);
+}
+static bool hasCriticalEdge(SILBasicBlock *BB) {
+  return llvm::any_of(BB->getSuccessorBlocks(), [&](auto *succBB) {
+    if (!isCriticalEdge(BB, succBB))
+      return false;
+
+    LLVM_DEBUG(llvm::dbgs() << "ColdBlockInfo: "
+                            << toString(BB) << " -> " << toString(succBB)
+                            << " is a critical edge!\n");
+    return true;
+  });
+}
+
+/// A cold terminator is one where it's unlikely to be reached, which are
+/// function exits that are less-common. A cold terminator implies a cold block.
+///   - 'unreachable', as it's never executed.
+///   - 'throw', if throws prediction is enabled.
+static bool isColdTerminator(const TermInst *term) {
+  switch (term->getTermKind()) {
+  case TermKind::AwaitAsyncContinuationInst:
+  case TermKind::BranchInst:
+  case TermKind::CondBranchInst:
+  case TermKind::SwitchValueInst:
+  case TermKind::SwitchEnumInst:
+  case TermKind::SwitchEnumAddrInst:
+  case TermKind::DynamicMethodBranchInst:
+  case TermKind::CheckedCastBranchInst:
+  case TermKind::CheckedCastAddrBranchInst:
+  case TermKind::TryApplyInst:
+  case TermKind::YieldInst:
+  case TermKind::ReturnInst:
+    return false;
+  case TermKind::ThrowInst:
+  case TermKind::ThrowAddrInst:
+  case TermKind::UnwindInst:
+    return term->getModule().getOptions().EnableThrowsPrediction;
+  case TermKind::UnreachableInst:
+    // For now, assume it's always cold, since it's executed once.
+    // Not all functions in the stdlib are properly annotated as a
+    // "known program termination point", so we don't use
+    // ApplySite::isCalleeKnownProgramTerminationPoint.
+    return term->getModule().getOptions().EnableNoReturnCold;
+  }
+}
 
 /// Peek through an extract of Bool.value.
 static SILValue getCondition(SILValue C) {
@@ -27,126 +124,340 @@ static SILValue getCondition(SILValue C) {
   return C;
 }
 
-/// \return a BranchHint if this call is a builtin branch hint.
-ColdBlockInfo::BranchHint ColdBlockInfo::getBranchHint(SILValue Cond,
-                                                       int recursionDepth) {
+constexpr unsigned RecursionDepthLimit = 3;
+std::optional<bool>
+ColdBlockInfo::searchForExpectedValue(SILValue Cond,
+                                      unsigned recursionDepth) {
+  if (recursionDepth > RecursionDepthLimit)
+    return std::nullopt;
+
+  if (auto *Arg = dyn_cast<SILArgument>(Cond)) {
+    llvm::SmallVector<std::pair<SILBasicBlock *, SILValue>, 4> InValues;
+    if (!Arg->getIncomingPhiValues(InValues))
+      return std::nullopt;
+
+    std::optional<bool> expectedValue;
+
+    // Check all predecessor values which come from non-cold blocks.
+    for (auto Pair : InValues) {
+      auto *predBB = Pair.first;
+      auto predArg = Pair.second;
+
+      if (isCold(predBB))
+        continue;
+
+      std::optional<bool> predecessorValue;
+
+      if (auto *IL = dyn_cast<IntegerLiteralInst>(predArg)) {
+        predecessorValue = IL->getValue().getBoolValue();
+      } else {
+        predecessorValue = searchForExpectedValue(predArg, recursionDepth+1);
+      }
+
+      // There's at least one non-cold predecessor with an unknown value.
+      if (!predecessorValue)
+        return std::nullopt;
+
+      // If this is the first non-cold predecessor, save the value.
+      if (!expectedValue) {
+        expectedValue = *predecessorValue;
+        continue;
+      }
+
+      // Check if we have a consistent value across all non-cold predecessors.
+      if (*expectedValue != *predecessorValue)
+        return std::nullopt;
+    }
+
+    return expectedValue;
+  }
+  return std::nullopt;
+}
+
+static std::optional<bool> getExpectedValue(SILValue Cond) {
   // Handle the fully inlined Builtin.
   if (auto *BI = dyn_cast<BuiltinInst>(Cond)) {
     if (BI->getIntrinsicInfo().ID == llvm::Intrinsic::expect) {
       // peek through an extract of Bool.value.
       SILValue ExpectedValue = getCondition(BI->getArguments()[1]);
       if (auto *Literal = dyn_cast<IntegerLiteralInst>(ExpectedValue)) {
-        return (Literal->getValue() == 0)
-          ? BranchHint::LikelyFalse : BranchHint::LikelyTrue;
+        return (Literal->getValue() == 0) ? false : true;
       }
     }
-    return BranchHint::None;
+    return std::nullopt;
   }
 
-  if (auto *Arg = dyn_cast<SILArgument>(Cond)) {
-    llvm::SmallVector<std::pair<SILBasicBlock *, SILValue>, 4> InValues;
-    if (!Arg->getIncomingPhiValues(InValues))
-      return BranchHint::None;
-
-    if (recursionDepth > RecursionDepthLimit)
-      return BranchHint::None;
-
-    BranchHint Hint = BranchHint::None;
-
-    // Check all predecessor values which come from non-cold blocks.
-    for (auto Pair : InValues) {
-      if (isCold(Pair.first, recursionDepth + 1))
-        continue;
-
-      auto *IL = dyn_cast<IntegerLiteralInst>(Pair.second);
-      if (!IL)
-        return BranchHint::None;
-      // Check if we have a consistent value for all non-cold predecessors.
-      if (IL->getValue().getBoolValue()) {
-        if (Hint == BranchHint::LikelyFalse)
-          return BranchHint::None;
-        Hint = BranchHint::LikelyTrue;
-      } else {
-        if (Hint == BranchHint::LikelyTrue)
-          return BranchHint::None;
-        Hint = BranchHint::LikelyFalse;
-      }
-    }
-    return Hint;
-  }
-  
   // Handle the @semantic functions used for branch hints.
   auto AI = dyn_cast<ApplyInst>(Cond);
   if (!AI)
-    return BranchHint::None;
+    return std::nullopt;
 
   if (auto *F = AI->getReferencedFunctionOrNull()) {
     if (F->hasSemanticsAttrs()) {
       // fastpath/slowpath attrs are untested because the inliner luckily
       // inlines them before the downstream calls.
       if (F->hasSemanticsAttr(semantics::SLOWPATH))
-        return BranchHint::LikelyFalse;
+        return false;
       else if (F->hasSemanticsAttr(semantics::FASTPATH))
-        return BranchHint::LikelyTrue;
+        return true;
     }
   }
-  return BranchHint::None;
+  return std::nullopt;
 }
 
-/// \return true if the CFG edge FromBB->ToBB is directly gated by a _slowPath
-/// branch hint.
-bool ColdBlockInfo::isSlowPath(const SILBasicBlock *FromBB,
-                               const SILBasicBlock *ToBB,
-                               int recursionDepth) {
-  auto *CBI = dyn_cast<CondBranchInst>(FromBB->getTerminator());
-  if (!CBI)
+/// The minimum probability that an edge is taken to be considered "warm".
+constexpr double WARM_EDGE_MINIMUM = 3.0 / 100.0;
+
+// Using the profile data on the terminator of this block, annotate successors
+// with cold/warm information.
+//
+// \returns true if an inference was made
+bool ColdBlockInfo::inferFromEdgeProfile(SILBasicBlock *BB) {
+  ProfileCounter totalCount{0};
+  SmallVector<ProfileCounter, 2> succCount;
+
+  // Current analysis only accurately handles blocks with 2 successors,
+  // especially since we only have two temperatures.
+  if (BB->getNumSuccessors() != 2)
     return false;
 
-  SILValue C = getCondition(CBI->getCondition());
+  // Check the successor edges for profile data.
+  for (auto const &succ : BB->getSuccessors()) {
+    auto counter = succ.getCount();
 
-  BranchHint hint = getBranchHint(C, recursionDepth);
-  if (hint == BranchHint::None)
-    return false;
+    // Can't make an inference if there's profile data missing for a successor.
+    // FIXME: there are techniques to determine a missing count;
+    //        see the SamplePGO paper by Diego Novillo.
+    if (!counter)
+      return false;
 
-  const SILBasicBlock *ColdTarget =
-    (hint == BranchHint::LikelyTrue) ? CBI->getFalseBB() : CBI->getTrueBB();
+    succCount.push_back(counter);
 
-  return ToBB == ColdTarget;
-}
+    auto didSaturate = totalCount.add_saturating(counter);
 
-/// \return true if the given block is dominated by a _slowPath branch hint.
-///
-/// Cache all blocks visited to avoid introducing quadratic behavior.
-bool ColdBlockInfo::isCold(const SILBasicBlock *BB, int recursionDepth) {
-  auto I = ColdBlockMap.find(BB);
-  if (I != ColdBlockMap.end())
-    return I->second;
-
-  typedef llvm::DomTreeNodeBase<SILBasicBlock> DomTreeNode;
-  DominanceInfo *DT = DA->get(const_cast<SILFunction*>(BB->getParent()));
-  DomTreeNode *Node = DT->getNode(const_cast<SILBasicBlock*>(BB));
-  // Always consider unreachable code cold.
-  if (!Node)
-    return true;
-
-  std::vector<const SILBasicBlock*> DomChain;
-  DomChain.push_back(BB);
-  bool IsCold = false;
-  Node = Node->getIDom();
-  while (Node) {
-    if (isSlowPath(Node->getBlock(), DomChain.back(), recursionDepth)) {
-      IsCold = true;
-      break;
-    }
-    auto I = ColdBlockMap.find(Node->getBlock());
-    if (I != ColdBlockMap.end()) {
-      IsCold = I->second;
-      break;
-    }
-    DomChain.push_back(Node->getBlock());
-    Node = Node->getIDom();
+    ASSERT(!didSaturate && "should rescale the profile data first");
+    (void)didSaturate;
   }
-  for (auto *ChainBB : DomChain)
-    ColdBlockMap[ChainBB] = IsCold;
-  return IsCold;
+
+  TermInst::ConstSuccessorListTy succs = BB->getSuccessors();
+  ASSERT(succCount.size() == succs.size());
+
+  // Record temperatures.
+  for (size_t i = 0; i < succs.size(); i++) {
+    double takenProbability =
+        succCount[i].getValue() / (double)totalCount.getValue();
+
+    // It's a cold edge if the profiling-based probability is below the threshold.
+    auto state =
+        takenProbability < WARM_EDGE_MINIMUM ? ColdBlockInfo::State::Cold
+                                             : ColdBlockInfo::State::Warm;
+
+    set(succs[i], state);
+
+    LLVM_DEBUG(llvm::dbgs()
+                 << "ColdBlockInfo: setting to " << toString(state)
+                 << " (inferFromEdgeProfile): " << toString(succs[i])
+                 << " has taken probability " << takenProbability << "\n");
+    ASSERT(takenProbability >= 0);
+    ASSERT(takenProbability <= 1);
+  }
+
+  return true;
+}
+
+void ColdBlockInfo::analyze(SILFunction *fn) {
+  LLVM_DEBUG(llvm::dbgs() << "--> Before Stage 1\n");
+  LLVM_DEBUG(dump());
+
+  BasicBlockSet foundExpectedCond(fn);
+
+  // Stage 1: Seed the graph with warm/cold blocks.
+  for (auto &BB : *fn) {
+    auto *term = BB.getTerminator();
+
+    // Check for a cold exit.
+    if (isColdTerminator(term)) {
+      assert(term->getNumSuccessors() == 0);
+      LLVM_DEBUG(llvm::dbgs()
+        << "ColdBlockInfo: resetting to cold (isColdTerminator): "
+        << toString(&BB) << "\n");
+
+      // Overwrite any existing temperatures.
+      resetToCold(&BB);
+      continue;
+    }
+
+    // Check profile data for successors, choosing it first over branch hints.
+    if (inferFromEdgeProfile(&BB)) {
+      foundExpectedCond.insert(&BB);
+      continue;
+    }
+
+    // Check for an obvious _fastPath / _slowPath condition for successors.
+    if (auto *CBI = dyn_cast<CondBranchInst>(term)) {
+      if (auto val = getExpectedValue(getCondition(CBI->getCondition()))) {
+        setExpectedCondition(CBI, val);
+        foundExpectedCond.insert(&BB);
+      }
+    }
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "--> After Stage 1; changedMap = "
+                          << changedMap << "\n");
+  LLVM_DEBUG(dump(); changedMap = false);
+
+  // Stage 2: Propagate via dominators
+  SmallVector<SILBasicBlock *, 8> scratch;
+  for (auto &BB : *fn) {
+    scratch.clear();
+
+    if (isCold(&BB)) {
+      // Mark all blocks I dominate as cold.
+      auto *domInfo = DA->get(fn);
+      domInfo->getDescendants(&BB, scratch);
+      for (auto *dominatedBB : scratch) {
+        if (dominatedBB == &BB)
+          continue;
+        LLVM_DEBUG(llvm::dbgs() << "ColdBlockInfo: resetting to cold (dominatedBB): "
+                                << toString(dominatedBB) << "\n");
+        resetToCold(dominatedBB);
+      }
+    } else {
+      // Mark myself cold if I'm post-dominated by a cold block.
+      auto *pdInfo = PDA->get(fn);
+      scratch.push_back(&BB);
+      auto *node = pdInfo->getNode(&BB);
+      bool foundCold = false;
+
+      while (node && !foundCold) {
+        node = node->getIDom();
+        if (!node || pdInfo->isVirtualRoot(node))
+          break;
+
+        auto *postBB = node->getBlock();
+        if (isCold(postBB)) {
+          foundCold = true;
+        } else {
+          scratch.push_back(postBB);
+        }
+      }
+
+      if (foundCold) {
+        for (auto *chainBB : scratch) {
+          LLVM_DEBUG(llvm::dbgs() << "ColdBlockInfo: resetting to cold (chainBB): "
+                                  << toString(chainBB) << "\n");
+          resetToCold(chainBB);
+        }
+      }
+    }
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "--> After Stage 2; changedMap = "
+                          << changedMap << "\n");
+  LLVM_DEBUG(dump(); changedMap = false);
+
+  /// Stage 3: Backwards propagate coldness from successors.
+  auto isColdBlock = [&](auto *bb) { return isCold(bb); };
+
+  unsigned completedIters = 0;
+  bool changed;
+  do {
+    changed = false;
+    // TODO: We could use a worklist so we progressively visit fewer blocks
+    //  on each iteration, as we only need to visit non-cold/non-leaf blocks.
+    for (auto &BB : llvm::reverse(*fn)) {
+      // Only on the first pass, search recursively for an expected value,
+      // now that more temperature data has been seeded.
+      if (!completedIters && !foundExpectedCond.contains(&BB)) {
+        if (auto *CBI = dyn_cast<CondBranchInst>(BB.getTerminator())) {
+          auto cond = getCondition(CBI->getCondition());
+          if (auto val = searchForExpectedValue(cond)) {
+            setExpectedCondition(CBI, val);
+            changed = true;
+          }
+        }
+      }
+
+      // Nothing to propagate from.
+      if (BB.getNumSuccessors() == 0)
+        continue;
+
+      // Coldness already exists here.
+      if (isCold(&BB))
+        continue;
+
+      if (llvm::all_of(BB.getSuccessorBlocks(), isColdBlock)) {
+        resetToCold(&BB);
+        changed = true;
+      }
+    }
+    completedIters++;
+  } while (changed);
+
+  LLVM_DEBUG(llvm::dbgs() << "--> Final for " << fn->getName() <<
+                          " | converged after " << completedIters << " iters"
+                          << " over " << fn->size() << " blocks; "
+                          << " changedMap = " << changedMap << "\n");
+  LLVM_DEBUG(dump(); changedMap = false);
+}
+
+inline bool isColdEnergy(ColdBlockInfo::Energy e) {
+  return e.contains(ColdBlockInfo::State::Cold)
+     && !e.contains(ColdBlockInfo::State::Warm);
+}
+
+bool ColdBlockInfo::isCold(const SILBasicBlock *BB) const {
+  auto result = EnergyMap.find(BB);
+  if (result == EnergyMap.end())
+    return false;
+
+  return isColdEnergy(result->getSecond());
+}
+
+void ColdBlockInfo::resetToCold(const SILBasicBlock *BB) {
+  auto &entry = EnergyMap.getOrInsertDefault(BB);
+  LLVM_DEBUG(isColdEnergy(entry) ? false : changedMap = true);
+  entry.removeAll();
+  entry.insert(State::Cold);
+}
+
+void ColdBlockInfo::set(const SILBasicBlock *BB, State::Temperature temp) {
+  auto &entry = EnergyMap.getOrInsertDefault(BB);
+  LLVM_DEBUG(entry.contains(temp) ? false : changedMap = true);
+  entry.insert(temp);
+}
+
+void ColdBlockInfo::setExpectedCondition(CondBranchInst *CBI, ExpectedValue value) {
+  if (!value)
+    return;
+
+  // This function marks both sides of the conditional-branch, assuming
+  // critical edges are split. If they're NOT, then unexpected things happen.
+  // For example, we'd mark bb2 below as cold, which post-dominates the warm
+  // block bb1, and thus wipes out the warm annotation on bb1!
+  //                bb0: [ _fastPath(trueSide) ]
+  //                          │             │
+  //                          │      bb1: [ warm ]
+  //                          │             │
+  //                          │─────────────┘
+  //                          ▼
+  //                  bb2: [ cold ]
+  if (hasCriticalEdge(CBI->getParent()))
+    return;
+
+  if (*value) {
+    set(CBI->getTrueBB(), State::Warm);
+    set(CBI->getFalseBB(), State::Cold);
+    LLVM_DEBUG(llvm::dbgs() << "ColdBlockInfo: "
+                            << "_fastPath = " << toString(CBI->getTrueBB())
+                            << " | _slowPath = " << toString(CBI->getFalseBB())
+                            << "\n");
+  } else {
+    set(CBI->getTrueBB(), State::Cold);
+    set(CBI->getFalseBB(), State::Warm);
+    LLVM_DEBUG(llvm::dbgs() << "ColdBlockInfo: "
+                            << "_fastPath = " << toString(CBI->getFalseBB())
+                            << " | _slowPath = " << toString(CBI->getTrueBB())
+                            << "\n");
+  }
 }

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -590,6 +590,7 @@ bool CapturePropagation::optimizePartialApply(PartialApplyInst *PAI) {
 
 void CapturePropagation::run() {
   DominanceAnalysis *DA = PM->getAnalysis<DominanceAnalysis>();
+  PostDominanceAnalysis *PDA = PM->getAnalysis<PostDominanceAnalysis>();
   auto *F = getFunction();
   bool HasChanged = false;
 
@@ -598,7 +599,8 @@ void CapturePropagation::run() {
     return;
 
   // Cache cold blocks per function.
-  ColdBlockInfo ColdBlocks(DA);
+  ColdBlockInfo ColdBlocks(DA, PDA);
+  ColdBlocks.analyze(F);
   for (auto &BB : *F) {
     if (ColdBlocks.isCold(&BB))
       continue;

--- a/test/SILOptimizer/cold_block_info.swift
+++ b/test/SILOptimizer/cold_block_info.swift
@@ -4,7 +4,8 @@
 // RUN:   -enable-throws-prediction \
 // RUN:   -Xllvm --debug-only=cold-block-info 2> %t/debug.txt
 
-// RUN: %FileCheck %s --input-file=%t/debug.txt
+// RUN: %FileCheck %s --input-file=%t/debug.txt \
+// RUN:               --implicit-check-not 'converged after {{[3-9]}} iters'
 
 public enum MyError: Error { case err; case number(Int) }
 
@@ -131,7 +132,7 @@ public func pleasePleasePlease(_ i: Int) throws {
 }
 
 
-// CHECK-LABEL: --> Final for $s4main21nestedTreesOfThrowingyySi_S3itAA7MyErrorOYKF | converged after 1 iters
+// CHECK-LABEL: --> Final for $s4main21nestedTreesOfThrowingyySi_S3itAA7MyErrorOYKF
 // CHECK-NOT: bb0
 // CHECK: }
 public func nestedTreesOfThrowing(_ i: Int, _ j: Int, _ k: Int, _ l: Int) throws(MyError) {

--- a/test/SILOptimizer/cold_block_info.swift
+++ b/test/SILOptimizer/cold_block_info.swift
@@ -41,13 +41,23 @@ public func goBoom(_ i: Int?) -> Int {
 }
 
 
-// CHECK-LABEL: --> Final for $s4main19goBoom_preconditionyySbF
-// CHECK: {
-// CHECK-NEXT: STATISTICS: warm 0 | cold 0
-// CHECK-NEXT: }
+// CHECK-LABEL: --> Stopping early in $s4main19goBoom_preconditionyySbF
 public func goBoom_precondition(_ b: Bool) {
-  // NOTE: cond_fail instructions aren't terminators, so there's nothing cold.
+  // NOTE: cond_fail instructions from preconditions aren't terminators,
+  // so there's nothing cold in this function!
   precondition(b)
+
+  var x = random()
+  precondition(x >= 0)
+
+  if (x > 100) {
+    x = 0
+  }
+
+  for i in 0..<x {
+    precondition(i <= 100)
+    dump(i)
+  }
 }
 
 // CHECK-LABEL: --> Final for $s4main17goBoom_fatalErroryySiF

--- a/test/SILOptimizer/cold_block_info.swift
+++ b/test/SILOptimizer/cold_block_info.swift
@@ -6,7 +6,7 @@
 
 // RUN: %FileCheck %s --input-file=%t/debug.txt
 
-enum MyError: Error { case err; case number(Int) }
+public enum MyError: Error { case err; case number(Int) }
 
 @inline(never)
 func dump(_ s: String) { print(s) }
@@ -127,5 +127,94 @@ public func pleasePleasePlease(_ i: Int) throws {
     fatalError("oof")
   } else {
     throw MyError.number(i)
+  }
+}
+
+
+// CHECK-LABEL: --> Final for $s4main21nestedTreesOfThrowingyySi_S3itAA7MyErrorOYKF | converged after 1 iters
+// CHECK-NOT: bb0
+// CHECK: }
+public func nestedTreesOfThrowing(_ i: Int, _ j: Int, _ k: Int, _ l: Int) throws(MyError) {
+  switch i {
+  case 0:
+    switch j {
+    case 0:
+      switch k {
+        case 0:
+        switch l {
+          case 0: throw MyError.number(0)
+          case 1: throw MyError.number(1)
+          default: return  // <-- the one non-throwing case that prevents bb0 from being cold!
+        }
+        case 1:
+        switch l {
+          case 0: throw MyError.number(1)
+          case 1: throw MyError.number(2)
+          default: throw MyError.err
+        }
+        default:
+          throw MyError.err
+      }
+    case 1:
+      switch k {
+        case 0:
+        switch l {
+          case 0: throw MyError.number(1)
+          case 1: throw MyError.number(2)
+          default: throw MyError.err
+        }
+        case 1:
+        switch l {
+          case 0: throw MyError.number(2)
+          case 1: throw MyError.number(3)
+          default: throw MyError.err
+        }
+        default:
+          throw MyError.err
+      }
+    default:
+      throw MyError.err
+    }
+  case 1:
+    switch j {
+    case 0:
+      switch k {
+        case 0:
+        switch l {
+          case 0: throw MyError.number(1)
+          case 1: throw MyError.number(2)
+          default: throw MyError.err
+        }
+        case 1:
+        switch l {
+          case 0: throw MyError.number(2)
+          case 1: throw MyError.number(3)
+          default: throw MyError.err
+        }
+        default:
+          throw MyError.err
+      }
+    case 1:
+      switch k {
+        case 0:
+        switch l {
+          case 0: throw MyError.number(2)
+          case 1: throw MyError.number(3)
+          default: throw MyError.err
+        }
+        case 1:
+        switch l {
+          case 0: throw MyError.number(3)
+          case 1: throw MyError.number(4)
+          default: throw MyError.err
+        }
+        default:
+          throw MyError.err
+      }
+    default:
+      throw MyError.err
+    }
+  default:
+    throw MyError.err
   }
 }

--- a/test/SILOptimizer/cold_block_info.swift
+++ b/test/SILOptimizer/cold_block_info.swift
@@ -1,0 +1,121 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-name main -emit-sil -o %t/output.sil %s -O \
+// RUN:   -enable-noreturn-prediction \
+// RUN:   -enable-throws-prediction \
+// RUN:   -Xllvm --debug-only=cold-block-info 2> %t/debug.txt
+
+// RUN: %FileCheck %s --input-file=%t/debug.txt
+
+enum MyError: Error { case err; case number(Int) }
+
+@inline(never)
+func dump(_ s: String) { print(s) }
+
+@inline(never)
+func random() -> Int { return Int.random(in: 0..<1024) }
+
+@inline(never)
+func listenForConnections() -> Never {
+  while true {
+    dump("listening!")
+  }
+}
+
+// CHECK-LABEL: --> Final for $s4main14createLauncheryyF
+// CHECK: {
+// CHECK-NEXT: $s4main14createLauncheryyF::bb0 -> cold
+// CHECK-NEXT: STATISTICS: warm 0 | cold 1
+// CHECK-NEXT: }
+public func createLauncher() {
+  dump("getting ready!")
+  listenForConnections()
+}
+
+// CHECK-LABEL: --> Final for $s4main6goBoomyS2iSgF
+// CHECK: {
+// CHECK-NEXT: $s4main6goBoomyS2iSgF::bb1 -> cold
+// CHECK-NEXT: STATISTICS: warm 0 | cold 1
+// CHECK-NEXT: }
+public func goBoom(_ i: Int?) -> Int {
+  return i!
+}
+
+
+// CHECK-LABEL: --> Final for $s4main19goBoom_preconditionyySbF
+// CHECK: {
+// CHECK-NEXT: STATISTICS: warm 0 | cold 0
+// CHECK-NEXT: }
+public func goBoom_precondition(_ b: Bool) {
+  // NOTE: cond_fail instructions aren't terminators, so there's nothing cold.
+  precondition(b)
+}
+
+// CHECK-LABEL: --> Final for $s4main17goBoom_fatalErroryySiF
+// CHECK: {
+// CHECK-DAG: $s4main17goBoom_fatalErroryySiF::bb1 -> cold
+// CHECK-DAG: $s4main17goBoom_fatalErroryySiF::bb0 -> cold
+// CHECK-DAG: $s4main17goBoom_fatalErroryySiF::bb3 -> cold
+// CHECK-DAG: $s4main17goBoom_fatalErroryySiF::bb2 -> cold
+// CHECK-NEXT: STATISTICS: warm 0
+// CHECK: }
+public func goBoom_fatalError(_ i: Int) {
+  for i in 0..<i {
+    dump("do something")
+  }
+  fatalError("kablam")
+}
+
+
+// CHECK-LABEL: --> Final for $s4main13sirThrowsALotyS2iKF
+// CHECK: {
+// CHECK-DAG: $s4main13sirThrowsALotyS2iKF::bb3 -> cold
+// CHECK-DAG: $s4main13sirThrowsALotyS2iKF::bb2 -> cold
+// CHECK-DAG: $s4main13sirThrowsALotyS2iKF::bb4 -> cold
+// CHECK-DAG: $s4main13sirThrowsALotyS2iKF::bb5 -> cold
+// CHECK-NEXT: STATISTICS: warm 0
+// CHECK: }
+@inline(never)
+public func sirThrowsALot(_ i: Int) throws -> Int {
+  dump("entry")
+  switch i {
+    case 0:
+      dump("case 0")
+      return random()
+    case 1:
+      dump("case 1")
+      throw MyError.err
+    default:
+      dump("case n")
+      throw MyError.number(i)
+  }
+}
+
+// CHECK-LABEL: --> Final for $s4main22catchTheseThrowsSimpleyS2iF
+// CHECK: {
+// CHECK-DAG: $s4main22catchTheseThrowsSimpleyS2iF::bb1 -> warm
+// CHECK-DAG: $s4main22catchTheseThrowsSimpleyS2iF::bb2 -> cold
+// CHECK: }
+public func catchTheseThrowsSimple(_ i: Int) -> Int {
+  if let ans = try? sirThrowsALot(i) {
+    return ans
+  } else {
+    dump("did throw!")
+    return random()
+  }
+}
+
+// Make sure there's at least 3 cold blocks and no warm ones.
+// Inlining and multiple runs of the analysis, and especially platform
+// differences, can yield different numbers of blocks being analyzed!
+
+// CHECK-LABEL: --> Final for $s4main012pleasePleaseC0yySiKF
+// CHECK-COUNT-3: -> cold
+// CHECK: STATISTICS: warm 0
+// CHECK: }
+public func pleasePleasePlease(_ i: Int) throws {
+  if i > random() {
+    fatalError("oof")
+  } else {
+    throw MyError.number(i)
+  }
+}

--- a/test/SILOptimizer/inliner_coldblocks.sil
+++ b/test/SILOptimizer/inliner_coldblocks.sil
@@ -65,13 +65,16 @@ bb0:
   %ex = builtin "int_expect_Int1"(undef : $Builtin.Int1, %i1 : $Builtin.Int1) : $Builtin.Int1
   cond_br %ex, bb1, bb2
 
+bb2:
+  br bb3
+
 bb1:
   %f = function_ref @callee : $@convention(thin) () -> ()
   // REMARKS_PASSED: {{.*}}inliner_coldblocks.sil:[[# @LINE + 1]]:8: remark: Pure call. Always profitable to inline "callee"
   %a = apply %f() : $@convention(thin) () -> ()
-  br bb2
+  br bb3
 
-bb2:
+bb3:
   %r = tuple ()
   return %r : $()
 }
@@ -89,9 +92,12 @@ bb0:
 bb1:
   %f = function_ref @callee : $@convention(thin) () -> ()
   %a = apply %f() : $@convention(thin) () -> ()
-  br bb2
+  br bb3
 
 bb2:
+  br bb3
+
+bb3:
   %r = tuple ()
   return %r : $()
 }
@@ -119,9 +125,12 @@ bb3(%c : $Builtin.Int1):
 bb4:
   %f = function_ref @callee : $@convention(thin) () -> ()
   %a = apply %f() : $@convention(thin) () -> ()
-  br bb5
+  br bb6
 
 bb5:
+  br bb6
+
+bb6:
   %r = tuple ()
   return %r : $()
 }
@@ -155,9 +164,12 @@ bb5(%c : $Builtin.Int1):
 bb6:
   %f = function_ref @callee : $@convention(thin) () -> ()
   %a = apply %f() : $@convention(thin) () -> ()
-  br bb7
+  br bb8
 
 bb7:
+  br bb8
+
+bb8:
   %r = tuple ()
   return %r : $()
 }


### PR DESCRIPTION
The old analysis pass doesn't take into account profile data, nor does
it consider post-dominance. It primarily dealt with _fastPath/_slowPath.

A block that is dominated by a cold block is itself cold. That's true
whether it's forwards or backwards dominance.

We can also consider a call to any `Never` returning function as a
cold-exit, though the block(s) leading up to that call may be executed
frequently because of concurrency. For now, I'm ignoring the concurrency
case and assuming it's cold. To make use of this "no return" prediction,
use the `-enable-noreturn-prediction` flag, which is currently off by
default.