### PR TITLE
[LifetimeCompletion] Avoid instruction list walk.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -189,7 +189,7 @@ public:
   bool EnableSILOpaqueValues = false;
 
   /// Introduce linear OSSA lifetimes after SILGen
-  bool OSSACompleteLifetimes = false;
+  bool OSSACompleteLifetimes = true;
 
   /// Verify linear OSSA lifetimes throughout OSSA pipeline.
   bool OSSAVerifyComplete = false;

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -188,10 +188,10 @@ public:
   /// If set to true, compile with the SIL Opaque Values enabled.
   bool EnableSILOpaqueValues = false;
 
-  /// Require linear OSSA lifetimes after SILGen
+  /// Introduce linear OSSA lifetimes after SILGen
   bool OSSACompleteLifetimes = false;
 
-  /// Verify linear OSSA lifetimes after SILGen
+  /// Verify linear OSSA lifetimes throughout OSSA pipeline.
   bool OSSAVerifyComplete = false;
 
   /// Enable pack metadata stack "promotion".

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -862,7 +862,7 @@ public:
   void findBoundariesInBlock(SILBasicBlock *block, bool isLiveOut,
                              PrunedLivenessBoundary &boundary) const;
 
-  /// Compute liveness for a all currently initialized definitions. The
+  /// Compute liveness for all currently initialized definitions. The
   /// lifetime-ending uses are also recorded--destroy_value or
   /// end_borrow. However destroy_values might not jointly-post dominate if
   /// dead-end blocks are present.

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -543,6 +543,13 @@ public:
         RangeIterationHelpers::MapFunctor());
   }
 
+  void visitUsers(llvm::function_ref<void(SILInstruction *, LifetimeEnding)>
+                      visitor) const {
+    for (auto &pair : users) {
+      visitor(pair.first, pair.second);
+    }
+  }
+
   void print(llvm::raw_ostream &OS) const;
   void dump() const;
 };


### PR DESCRIPTION
When computing the available region, a forward walk is done from the non-lifetime-ending boundary of the live region.  That boundary consists of (1) the target blocks of boundary edges, (2) dead defs, and (3) last users which are non-consuming.  This forward walk is done at the block level, so neither the specific dead def (for (2)) nor specific last non-consuming user (for (3)) is required to perform the walk; indeed currently these are computed and then immediately used only to obtain the blocks in which they appear and then discarded.  Avoid computing the specific dead defs and specific last non-consuming users by switching to a lower-fidelity liveness boundary computation via `PrunedLivenessBlockBoundary`.
