### PR TITLE
Frontend: For whole module compiles, omit filelists from stack dumps

### DIFF
--- a/test/Frontend/crash-whole-module.swift
+++ b/test/Frontend/crash-whole-module.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: echo %s > %t/filelist.txt
+// RUN: not --crash %target-swift-frontend -typecheck -debug-crash-after-parse -filelist %t/filelist.txt 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: Stack dump
+// CHECK-NEXT: Program arguments: {{.*swift(-frontend)?(c?)(\.exe)?}}
+// CHECK-NEXT: Swift version
+// CHECK-NEXT: Compiling with effective version
+
+// Filelist contents should be omitted since this is a whole-module compile.
+// CHECK-NOT:  Contents of
+
+func anchor() {}
+anchor()

--- a/test/Frontend/crash.swift
+++ b/test/Frontend/crash.swift
@@ -1,5 +1,10 @@
-// RUN: echo %s > %t.filelist.txt
-// RUN: not --crash %target-swift-frontend -typecheck -debug-crash-after-parse -filelist %t.filelist.txt 2>&1 | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: echo %s > %t/primary.filelist.txt
+// RUN: echo "" > %t/empty.swift
+// RUN: echo "%t/empty.swift" > %t/all.filelist.txt
+// RUN: echo %s >> %t/all.filelist.txt
+
+// RUN: not --crash %target-swift-frontend -typecheck -debug-crash-after-parse -primary-filelist %t/primary.filelist.txt -filelist %t/all.filelist.txt 2>&1 | %FileCheck %s
 
 // Check that we see the contents of the input file list in the crash log.
 // CHECK-NOT: while allowing modules with compiler errors
@@ -7,9 +12,14 @@
 // CHECK-NEXT: Program arguments: {{.*swift(-frontend)?(c?)(\.exe)?}}
 // CHECK-NEXT: Swift version
 // CHECK-NEXT: Compiling with effective version
-// CHECK-NEXT: Contents of {{.*}}.filelist.txt:
+// CHECK-NEXT: Contents of {{.*}}/all.filelist.txt:
 // CHECK-NEXT: ---
-// CHECK-NEXT: test{{[\\/]}}Frontend{{[\\/]}}crash.swift{{$}}
+// CHECK-NEXT: {{[\\/]}}empty.swift{{$}}
+// CHECK-NEXT: {{[\\/]}}crash.swift{{$}}
+// CHECK-NEXT: ---
+// CHECK-NEXT: Contents of {{.*}}/primary.filelist.txt:
+// CHECK-NEXT: ---
+// CHECK-NEXT: {{[\\/]}}crash.swift{{$}}
 // CHECK-NEXT: ---
 
 // RUN: not --crash %target-swift-frontend -typecheck -debug-crash-after-parse -experimental-allow-module-with-compiler-errors %s 2>&1 | %FileCheck -check-prefix CHECK-ALLOW %s


### PR DESCRIPTION
For batch compile jobs, it's helpful to see which files are considered primary and that was the original reason why filelist contents were printed in compiler crash stack dumps. However, for whole module compile jobs, the contents of the filelist is uninteresting (it's just all the files in the module) and can be hundreds or thousands of lines long so it often causes important information to be trimmed from stack dumps received in reproducers.

