### PR TITLE
SemanticARCOpts: update borrowed-from instructions when changes are made

### DIFF
--- a/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
@@ -21,6 +21,7 @@
 #include "swift/SILOptimizer/Analysis/Analysis.h"
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
 
 #include "llvm/Support/CommandLine.h"
 
@@ -176,6 +177,7 @@ struct SemanticARCOpts : SILFunctionTransform {
     // converted to guaranteed, ignoring the phi, try convert those phis to be
     // guaranteed.
     if (tryConvertOwnedPhisToGuaranteedPhis(visitor.ctx)) {
+      updateBorrowedFrom(getPassManager(), &f);
       // We return here early to save a little compile time so we do not
       // invalidate analyses redundantly.
       return invalidateAnalysis(
@@ -183,8 +185,10 @@ struct SemanticARCOpts : SILFunctionTransform {
     }
 
     // Otherwise, we only deleted instructions and did not touch phis.
-    if (didEliminateARCInsts)
+    if (didEliminateARCInsts) {
+      updateBorrowedFrom(getPassManager(), &f);
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+    }
   }
 };
 

--- a/test/SILOptimizer/semantic-arc-opt-owned-to-guaranteed-phi.sil
+++ b/test/SILOptimizer/semantic-arc-opt-owned-to-guaranteed-phi.sil
@@ -1,5 +1,11 @@
 // RUN: %target-sil-opt -update-borrowed-from -semantic-arc-opts %s | %FileCheck %s
 
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
 class Klass {}
 
 // CHECK-LABEL: sil [ossa] @test_owned_to_guaranteed1 :
@@ -105,4 +111,28 @@ bbret:
   destroy_addr %0 : $*Klass
   %t = tuple ()
   return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_borrowed_from_updating :
+// CHECK-NOT:     copy-var
+// CHECK:       bb2({{.*}} : @guaranteed $Klass):
+// CHECK:          = borrowed {{.*}}%0 : $Optional<Klass>
+// CHECK-LABEL: } // end sil function 'test_borrowed_from_updating'
+sil [ossa] @test_borrowed_from_updating : $@convention(thin) (@guaranteed Optional<Klass>) -> () {
+bb0(%0 : @guaranteed $Optional<Klass>):
+  %1 = copy_value %0 : $Optional<Klass>
+  switch_enum %1 : $Optional<Klass>, case #Optional.none!enumelt: bb1, case #Optional.some!enumelt: bb2
+bb1:
+  unreachable
+
+bb2(%4 : @owned $Klass):
+  %5 = begin_borrow %4 : $Klass
+  br bb3(%5 : $Klass)
+
+bb3(%7 : @reborrow @guaranteed $Klass):
+  %8 = borrowed %7 : $Klass from (%4 : $Klass)
+  end_borrow %8 : $Klass
+  destroy_value %4 : $Klass
+  %r = tuple ()
+  return %r : $()
 }


### PR DESCRIPTION
Fixes a SIL verifier error

rdar://134728428
