### PR TITLE
[Tests] Enable staticMemberInitializedAtRuntime in inline-static-member-var.swift.

### DIFF
--- a/test/Interop/Cxx/static/Inputs/inline-static-member-var.h
+++ b/test/Interop/Cxx/static/Inputs/inline-static-member-var.h
@@ -6,8 +6,7 @@ inline static int init() { return 42; }
 class WithInlineStaticMember {
   public:
     inline static int staticMember = 12;
-    //TODO needs C++ stdlib symbols, fix after apple/swift#30914 is merged.
-    // inline static int staticMemberInitializedAtRuntime = init();
+    inline static int staticMemberInitializedAtRuntime = init();
 
     static int getStaticMemberFromCxx();
     static int *getStaticMemberAddress()

--- a/test/Interop/Cxx/static/inline-static-member-var.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var.swift
@@ -17,6 +17,10 @@ InlineStaticMemberVarTestSuite.test("read-inline-static-member-address") {
     WithInlineStaticMember.getStaticMemberAddress())
 }
 
+InlineStaticMemberVarTestSuite.test("read-inline-static-member-init-at-runtime") {
+  expectEqual(42, WithInlineStaticMember.staticMemberInitializedAtRuntime)
+}
+
 InlineStaticMemberVarTestSuite.test("write-inline-static-member-from-cxx") {
   expectNotEqual(128, WithInlineStaticMember.staticMember)
   WithInlineStaticMember.setStaticMemberFromCxx(128)


### PR DESCRIPTION
apple/swift#30914 has been merged so this part of the test can be enabled.

