### PR TITLE
[windows] extract more top-level C stdlib modules for libc++

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -15,15 +15,30 @@ module _complex [system] {
   export *
 }
 
+module _errno [system] {
+  header "errno.h"
+  export *
+}
+
+module _math [system] {
+  header "math.h"
+  export *
+}
+
+module _stdlib [system] {
+  header "stdlib.h"
+  export *
+}
+
+module _stddef [system] {
+  header "stddef.h"
+  export *
+}
+
 module ucrt [system] {
   module C {
     module ctype {
       header "ctype.h"
-      export *
-    }
-
-    module errno {
-      header "errno.h"
       export *
     }
 
@@ -47,20 +62,11 @@ module ucrt [system] {
       export *
     }
 
-    module math {
-      header "math.h"
-      export *
-    }
-
     module signal {
       header "signal.h"
       export *
     }
 
-    module stddef {
-      header "stddef.h"
-      export *
-    }
 
     module stdio {
       header "stdio.h"
@@ -74,10 +80,6 @@ module ucrt [system] {
       link "legacy_stdio_definitions"
     }
 
-    module stdlib {
-      header "stdlib.h"
-      export *
-    }
 
     module string {
       header "string.h"

--- a/stdlib/public/Platform/ucrt.swift
+++ b/stdlib/public/Platform/ucrt.swift
@@ -13,6 +13,10 @@
 @_exported import ucrt // Clang module
 // Extra clang module that's split out from ucrt:
 @_exported import _complex
+@_exported import _errno
+@_exported import _math
+@_exported import _stdlib
+@_exported import _stddef
 
 @available(swift, deprecated: 3.0, message: "Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.")
 public let M_PI = Double.pi

--- a/test/stdlib/CRTWinAPIs.swift
+++ b/test/stdlib/CRTWinAPIs.swift
@@ -10,3 +10,15 @@ func complexFunctionsAvailableInSwift() {
   let complexValue = _Cbuild(1.0, 2.0) // Construct a complex double using MSVC-specific API.
   let _ = creal(complexValue)
 }
+
+func mathFunctionsAvailableInSwift() {
+  let _ = sin(1.0)
+}
+
+func errnoIsAccessible() {
+  let _ = errno
+}
+
+func stdlibFunctionsAreAccessible() {
+  exit(0)
+}


### PR DESCRIPTION
compatibility

Extract _errno, _math, _stdlib, _stddef submodules from ucrt into their own top level modules. This ensures that ucrt.modulemap is now compatbile with libc++ on Windows.

This is needed to support libc++ on Windows.