### PR TITLE
[cxx-interop][windows] support using a custom libc++ on Windows 

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -131,6 +131,9 @@ WARNING(libstdcxx_modulemap_not_found, none,
         "module map for libstdc++ not found for '%0'; C++ stdlib may be unavailable",
         (StringRef))
 
+ERROR(libcxx_custom_prohibits_system_cxxstdlib_module, none,
+      "import of system's C++ stdlib module '%0' prohibited when using libc++", (StringRef))
+
 WARNING(api_pattern_attr_ignored, none,
         "'%0' swift attribute ignored on type '%1': type is not copyable or destructible",
         (StringRef, StringRef))

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -577,6 +577,10 @@ swift::dependencies::registerCxxInteropLibraries(
     // Only link with CxxStdlib on platforms where the overlay is available.
     switch (Target.getOS()) {
     case llvm::Triple::Win32: {
+      // Do not try to link CxxStdlib with a module that uses a custom libc++
+      // on windows, as they're not compatible.
+      if (cxxStdlibKind != CXXStdlibKind::Msvcprt)
+        break;
       RegistrationCallback(
           LinkLibrary(hasStaticCxxStdlib ? "libswiftCxxStdlib" : "swiftCxxStdlib",
                       LibraryKind::Library));

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1189,6 +1189,14 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
     llvm::SmallVector<const char *> invocationArgs;
     invocationArgs.reserve(driverArgs.size());
     llvm::for_each(driverArgs, [&](const std::string &Arg) {
+      if (ctx.LangOpts.Target.isOSWindows() &&
+          ctx.LangOpts.CXXStdlib != ctx.LangOpts.PlatformDefaultCXXStdlib &&
+          StringRef(Arg).starts_with("-stdlib=")) {
+        // Drop the -stdlib argument when using libc++ on Windows, as the
+        // windows Clang driver doesn't explicitly support custom libc++,
+        // and thus warns about unused -stdlib flag.
+        return;
+      }
       invocationArgs.push_back(Arg.c_str());
     });
 
@@ -2391,6 +2399,11 @@ ModuleDecl *ClangImporter::Implementation::loadModule(
       path.front().Item.str().starts_with("std_"))
     return nullptr;
   if (path.front().Item == ctx.Id_CxxStdlib) {
+    // The 'CxxStdlib' module is not importable when using a custom
+    // C++ standard libary on Windows, as it supports the MSVC ABI only.
+    if (ctx.LangOpts.Target.isOSWindows() &&
+        ctx.LangOpts.CXXStdlib != ctx.LangOpts.PlatformDefaultCXXStdlib)
+      return nullptr;
     ImportPath::Builder adjustedPath(ctx.getIdentifier("std"), importLoc);
     adjustedPath.append(path.getSubmodulePath());
     path = adjustedPath.copyTo(ctx).getModulePath(ImportKind::Module);
@@ -2772,6 +2785,25 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
   auto &cacheEntry = ModuleWrappers[underlying];
   if (ClangModuleUnit *cached = cacheEntry.getPointer())
     return cached;
+
+  // Ensure system's C++ stdlib modules aren't imported when
+  // using a custom libc++ on Windows. This is specifically needed
+  // on Windows, as the MSVC C++ module is located in a directory
+  // shared with other system modules, and thus could be still found using
+  // Clang's header search. We use the 'std' module name as we assume
+  // that the custom libc++ doesn't provide its own 'std' module (as such
+  // module would fail to get built due to a module name ambiguity between
+  // MSVC 'std' and libc++'s 'std'). That generally means that the module
+  // map shipped with custom libc++ is expected to be broken into 'std_*'
+  // top level modules, and also have a renamed top-level 'std' module.
+  if (SwiftContext.LangOpts.Target.isOSWindows() &&
+      SwiftContext.LangOpts.CXXStdlib != SwiftContext.LangOpts.PlatformDefaultCXXStdlib &&
+      isCxxStdModule(underlying) &&
+      underlying->Name == "std") {
+    diagnose(SourceLoc(),
+             diag::libcxx_custom_prohibits_system_cxxstdlib_module,
+              underlying->Name);
+  }
 
   // FIXME: Handle hierarchical names better.
   Identifier name = underlying->Name == "std"
@@ -7947,6 +7979,8 @@ bool importer::isCxxStdModule(StringRef moduleName, bool IsSystem) {
   // modules (std_vector, std_utility, etc).
   if (IsSystem && moduleName.starts_with("std_")) {
     if (moduleName == "std_errno_h")
+      return false;
+    if (moduleName == "std_stdint_h")
       return false;
     return true;
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1190,7 +1190,7 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
     invocationArgs.reserve(driverArgs.size());
     llvm::for_each(driverArgs, [&](const std::string &Arg) {
       if (ctx.LangOpts.Target.isOSWindows() &&
-          ctx.LangOpts.CXXStdlib != ctx.LangOpts.PlatformDefaultCXXStdlib &&
+          !ctx.LangOpts.isUsingPlatformDefaultCXXStdlib() &&
           StringRef(Arg).starts_with("-stdlib=")) {
         // Drop the -stdlib argument when using libc++ on Windows, as the
         // windows Clang driver doesn't explicitly support custom libc++,
@@ -2402,7 +2402,7 @@ ModuleDecl *ClangImporter::Implementation::loadModule(
     // The 'CxxStdlib' module is not importable when using a custom
     // C++ standard libary on Windows, as it supports the MSVC ABI only.
     if (ctx.LangOpts.Target.isOSWindows() &&
-        ctx.LangOpts.CXXStdlib != ctx.LangOpts.PlatformDefaultCXXStdlib)
+        !ctx.LangOpts.isUsingPlatformDefaultCXXStdlib())
       return nullptr;
     ImportPath::Builder adjustedPath(ctx.getIdentifier("std"), importLoc);
     adjustedPath.append(path.getSubmodulePath());
@@ -2797,7 +2797,7 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
   // map shipped with custom libc++ is expected to be broken into 'std_*'
   // top level modules, and also have a renamed top-level 'std' module.
   if (SwiftContext.LangOpts.Target.isOSWindows() &&
-      SwiftContext.LangOpts.CXXStdlib != SwiftContext.LangOpts.PlatformDefaultCXXStdlib &&
+      !ctx.LangOpts.isUsingPlatformDefaultCXXStdlib() &&
       isCxxStdModule(underlying) &&
       underlying->Name == "std") {
     diagnose(SourceLoc(),

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -388,10 +388,14 @@ void CompilerInvocation::computeCXXStdlibOptions() {
   // always assumes libstdc++, which is incorrect: the Microsoft stdlib is
   // normally used.
   if (LangOpts.Target.isOSWindows()) {
-    // In the future, we should support libc++ on Windows. That would require
-    // the MSVC driver to support it first
-    // (see https://reviews.llvm.org/D101479).
-    LangOpts.CXXStdlib = CXXStdlibKind::Msvcprt;
+    // Even though the MSVC driver doesn't explicitly support libc++
+    // on Windows, libc++ can be used with Swift on Windows
+    // by passing a custom libc++ path to the Clang importer using the
+    // -cxx-isystem Clang flag.
+    if (cxxStdlibKind == clang::driver::ToolChain::CST_Libcxx)
+      LangOpts.CXXStdlib = CXXStdlibKind::Libcxx;
+    else
+      LangOpts.CXXStdlib = CXXStdlibKind::Msvcprt;
     LangOpts.PlatformDefaultCXXStdlib = CXXStdlibKind::Msvcprt;
   }
   if (LangOpts.Target.isOSLinux() || LangOpts.Target.isOSDarwin()) {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1658,7 +1658,7 @@ void IRGenModule::addLinkLibraries() {
     if (const auto *M = Context.getModuleByName("Cxx"))
       hasStaticCxx = M->isStaticLibrary();
     if (Context.LangOpts.Target.getOS() == llvm::Triple::Win32 &&
-        Context.LangOpts.CXXStdlib == Context.LangOpts.PlatformDefaultCXXStdlib)
+        Context.LangOpts.isUsingPlatformDefaultCXXStdlib())
       if (const auto *M = Context.getModuleByName("CxxStdlib"))
         hasStaticCxxStdlib = M->isStaticLibrary();
     dependencies::registerCxxInteropLibraries(Context.LangOpts.Target,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1657,7 +1657,8 @@ void IRGenModule::addLinkLibraries() {
     bool hasStaticCxxStdlib = false;
     if (const auto *M = Context.getModuleByName("Cxx"))
       hasStaticCxx = M->isStaticLibrary();
-    if (Context.LangOpts.Target.getOS() == llvm::Triple::Win32)
+    if (Context.LangOpts.Target.getOS() == llvm::Triple::Win32 &&
+        Context.LangOpts.CXXStdlib == Context.LangOpts.PlatformDefaultCXXStdlib)
       if (const auto *M = Context.getModuleByName("CxxStdlib"))
         hasStaticCxxStdlib = M->isStaticLibrary();
     dependencies::registerCxxInteropLibraries(Context.LangOpts.Target,

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -15,15 +15,30 @@ module _complex [system] {
   export *
 }
 
+module _errno [system] {
+  header "errno.h"
+  export *
+}
+
+module _math [system] {
+  header "math.h"
+  export *
+}
+
+module _stdlib [system] {
+  header "stdlib.h"
+  export *
+}
+
+module _stddef [system] {
+  header "stddef.h"
+  export *
+}
+
 module ucrt [system] {
   module C {
     module ctype {
       header "ctype.h"
-      export *
-    }
-
-    module errno {
-      header "errno.h"
       export *
     }
 
@@ -47,20 +62,11 @@ module ucrt [system] {
       export *
     }
 
-    module math {
-      header "math.h"
-      export *
-    }
-
     module signal {
       header "signal.h"
       export *
     }
 
-    module stddef {
-      header "stddef.h"
-      export *
-    }
 
     module stdio {
       header "stdio.h"
@@ -74,10 +80,6 @@ module ucrt [system] {
       link "legacy_stdio_definitions"
     }
 
-    module stdlib {
-      header "stdlib.h"
-      export *
-    }
 
     module string {
       header "string.h"

--- a/stdlib/public/Platform/ucrt.swift
+++ b/stdlib/public/Platform/ucrt.swift
@@ -13,6 +13,10 @@
 @_exported import ucrt // Clang module
 // Extra clang module that's split out from ucrt:
 @_exported import _complex
+@_exported import _errno
+@_exported import _math
+@_exported import _stdlib
+@_exported import _stddef
 
 @available(swift, deprecated: 3.0, message: "Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.")
 public let M_PI = Double.pi

--- a/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/__config
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/__config
@@ -1,0 +1,9 @@
+#ifndef CUSTOM_LIBCPP_CONFIG
+#define CUSTOM_LIBCPP_CONFIG
+
+#define CUSTOM_LIBCPP_VERSION 10
+
+#define CUSTOM_LIBCPP_BEGIN_NAMESPACE_STD namespace std { inline namespace v42 {
+#define CUSTOM_LIBCPP_END_NAMESPACE_STD }}
+
+#endif // CUSTOM_LIBCPP_CONFIG

--- a/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/cstdint
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/cstdint
@@ -1,0 +1,25 @@
+#ifndef CUSTOM_LIBCPP_CSTDINT
+#define CUSTOM_LIBCPP_CSTDINT
+
+#include <__config>
+#include <stdint.h>
+
+#ifndef CUSTOM_LIBCPP_STDINT_H
+#   error <cstdint> tried including <stdint.h> but didn't find libc++'s <stdint.h> header.
+#endif
+
+CUSTOM_LIBCPP_BEGIN_NAMESPACE_STD
+
+using ::int8_t;
+using ::int16_t;
+using ::int32_t;
+using ::int64_t;
+
+using ::uint8_t;
+using ::uint16_t;
+using ::uint32_t;
+using ::uint64_t;
+
+CUSTOM_LIBCPP_END_NAMESPACE_STD
+
+#endif // CUSTOM_LIBCPP_CSTDINT

--- a/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/main.cpp
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/main.cpp
@@ -1,0 +1,4 @@
+// emtpy file
+
+void foo() {}
+int x = 0;

--- a/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/module.modulemap
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/module.modulemap
@@ -1,0 +1,24 @@
+module std___config [system] {
+    header "__config"
+    export *
+}
+
+module std_stdint_h [system] {
+    header "stdint.h"
+    export *
+}
+
+module std_cstdint [system] {
+    header "cstdint"
+    export *
+}
+
+module std_string [system] {
+    header "string"
+    export *
+}
+
+module custom_std [system] {
+    header "stdmodule.h"
+    export *
+}

--- a/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/stdint.h
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/stdint.h
@@ -1,0 +1,8 @@
+#ifndef CUSTOM_LIBCPP_STDINT_H
+#define CUSTOM_LIBCPP_STDINT_H
+
+#if __has_include_next(<stdint.h>)
+#include_next <stdint.h>
+#endif
+
+#endif // CUSTOM_LIBCPP_STDINT_H

--- a/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/stdmodule.h
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/stdmodule.h
@@ -1,0 +1,8 @@
+#ifndef CUSTOM_LIBCPP_STD_MODULE
+#define CUSTOM_LIBCPP_STD_MODULE
+
+// Includes all the headers Swift needs!
+#include <cstdint>
+#include <string>
+
+#endif // CUSTOM_LIBCPP_STD_MODULE

--- a/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/string
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/c++/string
@@ -1,0 +1,39 @@
+#ifndef CUSTOM_LIBCPP_STRING
+#define CUSTOM_LIBCPP_STRING
+
+#include <__config>
+#include <string.h>
+
+CUSTOM_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <class charT>
+class basic_string {
+public:
+    basic_string() = default;
+    basic_string(const charT* str) : size_(strlen(str)) {
+        this->str = new charT[size_];
+        memcpy(this->str, str, size_);
+        this->str[size_] = '\0';
+    }
+    basic_string(const basic_string<charT> &other) : size_(other.size_) {
+        this->str = new charT[size_];
+        memcpy(this->str, other.str, size_);
+        this->str[size_] = '\0';
+    }
+    ~basic_string() {
+        if (str)
+            delete[] str;
+    }
+
+    const charT* c_str() const { return str; }
+    size_t size() const { return size_; }
+private:
+    charT* str = nullptr;
+    size_t size_ = 0;
+};
+
+using string = basic_string<char>;
+
+CUSTOM_LIBCPP_END_NAMESPACE_STD
+
+#endif // CUSTOM_LIBCPP_STRING

--- a/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/header-system-stdlib.h
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/header-system-stdlib.h
@@ -1,0 +1,9 @@
+#ifndef CxxHeader_System_Stdlib_h
+#define CxxHeader_System_Stdlib_h
+
+struct SimpleStruct {
+  int x;
+  int y;
+};
+
+#endif // CxxHeader_System_Stdlib_h

--- a/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/header.h
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/header.h
@@ -1,0 +1,12 @@
+#ifndef CxxHeader_h
+#define CxxHeader_h
+
+#include <cstdint>
+#include <string>
+
+struct SimpleStruct {
+  std::int32_t x;
+  std::uint32_t y;
+};
+
+#endif // CxxHeader_h

--- a/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/Inputs/module.modulemap
@@ -1,0 +1,9 @@
+module CxxHeader {
+    header "header.h"
+    export *
+}
+
+module CxxHeaderSystemStdlib {
+    header "header-system-stdlib.h"
+    export *
+}

--- a/test/Interop/Cxx/custom-libcxx-stdlib/custom-stdlib-prohibit-system-stdlib-dependent-module-windows.swift
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/custom-stdlib-prohibit-system-stdlib-dependent-module-windows.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftxx-frontend -DONE -emit-module -I %S/Inputs %s -module-name One -o %t/One.swiftmodule
+// RUN: %target-swiftxx-frontend -typecheck -I %t -Xcc -cxx-isystem -Xcc %S/Inputs/c++ -Xcc -stdlib=libc++ -Xcc -nostdinc++ -I %S/Inputs -dump-clang-diagnostics %s -verify
+
+// REQUIRES: OS=windows-msvc
+
+#if ONE
+import CxxHeaderSystemStdlib
+#else
+import One // expected-error {{module 'One' was built with msvcprt, but current compilation uses libc++}}
+#endif

--- a/test/Interop/Cxx/custom-libcxx-stdlib/cxxstdlib-not-importable-windows.swift
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/cxxstdlib-not-importable-windows.swift
@@ -1,0 +1,6 @@
+// RUN: not %target-swiftxx-frontend -emit-ir -Xcc -cxx-isystem -Xcc %S/Inputs/c++ -Xcc -stdlib=libc++ -Xcc -nostdinc++ -I %S/Inputs %s 2>&1 | %FileCheck %s
+
+// REQUIRES: OS=windows-msvc
+
+// CHECK: cannot load underlying module for 'CxxStdlib'
+import CxxStdlib

--- a/test/Interop/Cxx/custom-libcxx-stdlib/import-custom-std-windows-ir-linkage.swift
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/import-custom-std-windows-ir-linkage.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swiftxx-frontend -emit-ir -Xcc -cxx-isystem -Xcc %S/Inputs/c++ -Xcc -stdlib=libc++ -Xcc -nostdinc++ -I %S/Inputs -Xcc -fignore-exceptions %s | %FileCheck -check-prefix=IR %s
+
+import custom_std
+
+// REQUIRES: OS=windows-msvc
+
+public func testCustomString() -> Int {
+    let s = std.string("hello")
+    return Int(s.size())
+}
+
+// IR: "/DEFAULTLIB:libswiftCxx.lib"
+// IR-NOT: "/DEFAULTLIB:libswiftCxxStdlib.lib"

--- a/test/Interop/Cxx/custom-libcxx-stdlib/import-custom-std.swift
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/import-custom-std.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swiftxx-frontend -typecheck -Xcc -cxx-isystem -Xcc %S/Inputs/c++ -Xcc -stdlib=libc++  -Xcc -nostdinc++ -I %S/Inputs -dump-clang-diagnostics %s 2>&1 | %FileCheck -check-prefix=CLANG_DIAGS %s
+// RUN: %target-swiftxx-frontend -emit-ir -Xcc -cxx-isystem -Xcc %S/Inputs/c++ -Xcc -stdlib=libc++ -Xcc -nostdinc++ -I %S/Inputs -Xcc -fignore-exceptions %s | %FileCheck -check-prefix=IR %s
+
+import CxxHeader
+import custom_std
+
+// CLANG_DIAGS: clang importer driver args:
+// CLANG_DIAGS-SAME: '-cxx-isystem'
+// CLANG_DIAGS-SAME: '-nostdinc++'
+// CLANG_DIAGS-NOT: argument unused during compilation: '-stdlib=libc++'
+
+public func testCustomString() -> Int {
+    let s = std.string("hello")
+    return Int(s.size())
+}
+
+// IR: %{{.*}} = call ptr @{{"\?\?0\?\$basic_string@D@v42@std@@QEAA@PEBD@Z"|_ZNSt3v4212basic_stringIcEC1EPKc}}(ptr %{{.*}}, ptr %{{.*}})
+// IR: call i{{.*}} @{{"\?size@\?\$basic_string@D@v42@std@@QEBA_KXZ"|_ZNKSt3v4212basic_stringIcE4sizeEv}}(ptr %{{.*}})

--- a/test/Interop/Cxx/custom-libcxx-stdlib/use-custom-std-windows.swift
+++ b/test/Interop/Cxx/custom-libcxx-stdlib/use-custom-std-windows.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t2)
+// RUN: %target-clangxx -fuse-ld=llvm-lib %S/Inputs/c++/main.cpp -c -o %t2/main.cpp.obj
+// RUN: llvm-lib /OUT:%t2/c++.lib %t2/main.cpp.obj
+// RUN: %target-run-simple-swift(-L %t2 -cxx-interoperability-mode=default -Xcc -cxx-isystem -Xcc %S/Inputs/c++ -Xcc -stdlib=libc++ -Xcc -nostdinc++ -I %S/Inputs)
+//
+// REQUIRES: executable_test
+// REQUIRES: OS=windows-msvc
+
+// NOTE: do not rely on StdlibUnittest as it might pull in 'std' on Windows due to custom test libc++ being incomplete.
+import CxxHeader
+import custom_std
+
+func test() {
+    let s = SimpleStruct(x: 0, y: 0)
+    assert(s.x == 0)
+    let str = std.string("hello")
+    assert(str.size() == 5)
+}
+
+test()

--- a/test/stdlib/CRTWinAPIs.swift
+++ b/test/stdlib/CRTWinAPIs.swift
@@ -10,3 +10,15 @@ func complexFunctionsAvailableInSwift() {
   let complexValue = _Cbuild(1.0, 2.0) // Construct a complex double using MSVC-specific API.
   let _ = creal(complexValue)
 }
+
+func mathFunctionsAvailableInSwift() {
+  let _ = sin(1.0)
+}
+
+func errnoIsAccessible() {
+  let _ = errno
+}
+
+func stdlibFunctionsAreAccessible() {
+  exit(0)
+}


### PR DESCRIPTION
This depends on:
https://github.com/swiftlang/swift/pull/76109

This change builds upon the support for specifying which C++ standard
library to use, by adding support for using a custom libc++ on Windows.

Even though the clang Windows driver doesn't support libc++ explicitly,
Swift can still use it by allowing users to pass in the path to libc++
using the -cxx-isystem flag.

The CxxStdlib module is prohibited to use on Windows when libc++ is
used, as it has incompatible ABI.