### PR TITLE
SILGen: Only skip decls nested in functions when the function is skipped

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -496,6 +496,16 @@ public:
     return const_cast<DeclContext *>(this)->getTopmostDeclarationDeclContext();
   }
 
+  /// This routine looks through closure, initializer, and local function
+  /// contexts to find the outermost function declaration.
+  ///
+  /// \returns the outermost function, or null if there is no such context.
+  LLVM_READONLY
+  DeclContext *getOutermostFunctionContext();
+  const DeclContext *getOutermostFunctionContext() const {
+    return const_cast<DeclContext *>(this)->getOutermostFunctionContext();
+  }
+
   /// Returns the innermost context that is an AbstractFunctionDecl whose
   /// body has been skipped.
   LLVM_READONLY

--- a/include/swift/AST/DeclExportabilityVisitor.h
+++ b/include/swift/AST/DeclExportabilityVisitor.h
@@ -33,6 +33,11 @@ public:
   DeclExportabilityVisitor(){};
 
   bool visit(const Decl *D) {
+    // Declarations nested in fragile functions are exported.
+    if (D->getDeclContext()->getFragileFunctionKind().kind !=
+        FragileFunctionKind::None)
+      return true;
+
     if (auto value = dyn_cast<ValueDecl>(D)) {
       // A decl is exportable if it has a public access level.
       auto accessScope =
@@ -49,20 +54,6 @@ public:
   // Force all decl kinds to be handled explicitly.
   bool visitDecl(const Decl *D) = delete;
   bool visitValueDecl(const ValueDecl *valueDecl) = delete;
-
-  bool visitAbstractFunctionDecl(const AbstractFunctionDecl *afd) {
-    // If this function is nested within another function that is exportable to
-    // clients then it is also exportable.
-    auto dc = afd->getDeclContext();
-    do {
-      if (auto parent = dyn_cast<AbstractFunctionDecl>(dc)) {
-        if (DeclExportabilityVisitor().visit(parent))
-          return true;
-      }
-    } while ((dc = dc->getParent()));
-
-    return false;
-  }
 
   bool visitExtensionDecl(const ExtensionDecl *ext) {
     // Extensions must extend exportable types to be exportable.
@@ -149,6 +140,7 @@ public:
   DEFAULT_TO_ACCESS_LEVEL(TypeAlias);
   DEFAULT_TO_ACCESS_LEVEL(AssociatedType);
   DEFAULT_TO_ACCESS_LEVEL(AbstractStorage);
+  DEFAULT_TO_ACCESS_LEVEL(AbstractFunction);
   DEFAULT_TO_ACCESS_LEVEL(Macro);
   DEFAULT_TO_ACCESS_LEVEL(EnumElement);
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -253,6 +253,22 @@ Decl *DeclContext::getTopmostDeclarationDeclContext() {
   return topmost;
 }
 
+DeclContext *DeclContext::getOutermostFunctionContext() {
+  AbstractFunctionDecl *result = nullptr;
+  auto dc = this;
+  do {
+    if (auto afd = dyn_cast<AbstractFunctionDecl>(dc))
+      result = afd;
+
+    // If we've found a non-local context, we don't have to keep walking up
+    // the hierarchy.
+    if (!dc->isLocalContext())
+      break;
+  } while ((dc = dc->getParent()));
+
+  return result;
+}
+
 DeclContext *DeclContext::getInnermostSkippedFunctionContext() {
   auto dc = this;
   do {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -807,6 +807,11 @@ bool SILGenModule::shouldSkipDecl(Decl *D) {
   if (!getASTContext().SILOpts.SkipNonExportableDecls)
     return false;
 
+  // Declarations nested in functions should be emitted whenever the function
+  // containing them should also be emitted.
+  if (auto funcContext = D->getDeclContext()->getOutermostFunctionContext())
+    return shouldSkipDecl(funcContext->getAsDecl());
+
   if (D->isExposedToClients())
     return false;
 

--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -24,6 +24,13 @@ public func publicFuncWithDefaultArg(_ x: Int = 1) -> Int {
   return NoTypecheck.int
 }
 
+@inlinable public func publicInlinableFunc() -> Int {
+  lazy var x = inlinableFunc()
+  func nestedFunc() {}
+  defer { nestedFunc() }
+  return x
+}
+
 package func packageFunc() -> Int {
   return NoTypecheck.int
 }

--- a/test/Inputs/lazy_typecheck_client.swift
+++ b/test/Inputs/lazy_typecheck_client.swift
@@ -15,6 +15,7 @@ func testGlobalFunctions() {
   let _: Int = publicFunc()
   let _: Int = publicFuncReturnsTypealias()
   let _: Int = publicFuncWithDefaultArg()
+  let _: Int = publicInlinableFunc()
   #if TEST_PACKAGE
   let _: Int = packageFunc()
   #endif

--- a/test/SILGen/skip_non_exportable_decls.swift
+++ b/test/SILGen/skip_non_exportable_decls.swift
@@ -28,6 +28,7 @@ internal func internalFunc() {}
 // CHECK-NO-SKIP: sil hidden{{.*}} @$s4Test022internalFuncWithNestedC0yyF : $@convention(thin) () -> () {
 // CHECK-SKIP-NOT: s4Test022internalFuncWithNestedC0yyF
 internal func internalFuncWithNestedFunc() {
+  lazy var x = 1
   defer { internalFunc() }
   func nested() {}
   nested()
@@ -36,6 +37,9 @@ internal func internalFuncWithNestedFunc() {
     internalFunc()
   }()
 }
+// CHECK-NO-SKIP: sil private{{.*}} @$s4Test022internalFuncWithNestedC0yyF1xL_Sivg : $@convention(thin) (@guaranteed { var Optional<Int> }) -> Int
+// CHECK-SKIP-NOT: s4Test022internalFuncWithNestedC0yyF1xL_Sivg
+
 // CHECK-NO-SKIP: sil private{{.*}} @$s4Test022internalFuncWithNestedC0yyF6$deferL_yyF : $@convention(thin) () -> () {
 // CHECK-SKIP-NOT: s4Test022internalFuncWithNestedC0yyF6$deferL_yyF
 
@@ -53,10 +57,12 @@ public func publicFunc() {}
 
 // CHECK: sil{{.*}} @$s4Test25publicFuncWithNestedFuncsyyF : $@convention(thin) () -> () {
 public func publicFuncWithNestedFuncs() {
+  lazy var x = 1
   defer { publicFunc() }
   func nested() {}
   nested()
 }
+// CHECK: sil private{{.*}} @$s4Test25publicFuncWithNestedFuncsyyF1xL_Sivg : $@convention(thin) (@guaranteed { var Optional<Int> }) -> Int
 // CHECK: sil private{{.*}} @$s4Test25publicFuncWithNestedFuncsyyF6$deferL_yyF : $@convention(thin) () -> () {
 // CHECK: sil private{{.*}} @$s4Test25publicFuncWithNestedFuncsyyF6nestedL_yyF : $@convention(thin) () -> () {
 


### PR DESCRIPTION
If a function body is emitted, all of the declarations inside that function body must be emitted, too. Previously, lazy var initializers were being skipped regardless of whether the function containing them was skipped, resulting in SIL verification errors (which were correctly predicting linker errors).

Resolves rdar://134708502.
