### PR TITLE
[DAH] Bail on pointer use if ignoring barriers.

### DIFF
--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -630,13 +630,37 @@ entry(%instance : $*X):
   return %value : $X
 }
 
-// Hoist even if the pointerified address gets used.
+// If lexical, hoist even if the pointerified address gets used.
 //
 // CHECK-LABEL: sil [ossa] @hoist_despite_use_of_pointer : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[INSTANCE:%[^,]+]] = alloc_stack [lexical]
+// CHECK-NEXT:    copy_addr {{.*}} to [init] [[INSTANCE]]
 // CHECK-NEXT:    destroy_addr [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'hoist_despite_use_of_pointer'
-sil [ossa] @hoist_despite_use_of_pointer : $@convention(thin) (@inout X) -> () {
+sil [ossa] @hoist_despite_use_of_pointer : $@convention(thin) (@in_guaranteed X) -> () {
+entry(%original : $*X):
+   %instance = alloc_stack [lexical] $X
+   copy_addr %original to [init] %instance : $*X
+   %addr_for_pointer = alloc_stack $Builtin.RawPointer
+   %pointer = address_to_pointer %instance : $*X to $Builtin.RawPointer
+   store %pointer to [trivial] %addr_for_pointer : $*Builtin.RawPointer
+   %retval = tuple ()
+   dealloc_stack %addr_for_pointer : $*Builtin.RawPointer
+   destroy_addr %instance : $*X
+   dealloc_stack %instance : $*X
+   return %retval : $()
+}
+
+// If non-lexical, _don't_ hoist if the pointerified address gets used--deinit
+// barriers are ignored.
+//
+// CHECK-LABEL: sil [ossa] @no_hoist_nonlexical_because_of_use_of_pointer : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         destroy_addr [[INSTANCE]]
+// CHECK-NEXT:    dealloc_stack
+// CHECK-NEXT:    return
+// CHECK-LABEL: } // end sil function 'no_hoist_nonlexical_because_of_use_of_pointer'
+sil [ossa] @no_hoist_nonlexical_because_of_use_of_pointer : $@convention(thin) (@inout X) -> () {
 entry(%instance : $*X):
    %addr_for_pointer = alloc_stack $Builtin.RawPointer
    %pointer = address_to_pointer %instance : $*X to $Builtin.RawPointer

--- a/validation-test/SILOptimizer/rdar133969821.swift
+++ b/validation-test/SILOptimizer/rdar133969821.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+class C {
+  init() {}
+}
+struct Weak<T: AnyObject> {
+  weak var rawValue: T? = nil
+}
+typealias Tuple = (instanceIdentifier: C, object: Weak<C>)
+let object = C()
+let tuple: Tuple = (instanceIdentifier: .init(), object: .init(rawValue: object))
+let closureResult = [tuple].map { $0.object.rawValue }.first
+let keypathResult = [tuple].map(\.object.rawValue).first
+print("Closure result: \(String(describing: closureResult))")
+// CHECK: Closure result: Optional(Optional(main.C))
+print("Keypath result: \(String(describing: keypathResult))")
+// CHECK: Keypath result: Optional(Optional(main.C))
+withExtendedLifetime([object]) { }


### PR DESCRIPTION
Unknown uses of raw pointers should not result in bailing out when an address is lexical--the destroy of the address will already not be hoisted over any instructions which may access pointers.  If the address is not lexical however (such as any address when lexical lifetimes are disabled), that rationale does not apply, so unknown uses of raw pointers must cause hoisting to bail.

rdar://133969821
