### PR TITLE
[CSBindings] Don't prioritize closures that are assigned to overloade…

### DIFF
--- a/test/Concurrency/concurrency_attr_inference_on_closures.swift
+++ b/test/Concurrency/concurrency_attr_inference_on_closures.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -strict-concurrency=complete
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+// rdar://131524246
+
+protocol P: Sendable {
+  typealias Block = @Sendable () -> Void
+  var block: Block? { get }
+}
+
+extension P {
+  var block: Block? { nil }
+}
+
+final class Impl: P, @unchecked Sendable {
+  var block: Block?
+}
+
+func test(_ v: Impl) {
+  v.block = {} // Ok, no warnings or errors
+}


### PR DESCRIPTION
…d members

Constraint generation uses a special pattern while generating constraints
for assignments to make sure that the source type is convertible to r-value
type of the destination.

`BindingSet::favoredOverDisjunction` needs to recognize this pattern, 
where disjunction type variable is bound early, and avoid prioritizing 
closure if it's connected to the "fixed type" of the disjunction or risk 
losing annotations associated with the member such as `@Sendable` 
or a global actor.

Resolves: rdar://131524246

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
