### PR TITLE
Update test to deal with weird line breaks we're seeing

### DIFF
--- a/test/Concurrency/async_sequence_existential.swift
+++ b/test/Concurrency/async_sequence_existential.swift
@@ -18,7 +18,8 @@ extension Error {
 
 // CHECK: "test(seq:)"
 func test(seq: any AsyncSequence) async {
-  // CHECK: "error" interface type="any Error"
+  // CHECK: case_body_variables=array
+  // CHECK: "any Error"
   do {
     for try await _ in seq { }
   } catch {


### PR DESCRIPTION
The AST dump is getting a line break is an annoying place. Work around it in the test; this has nothing to do with the normal behavior of the compiler. Fixes rdar://128858036.
