### PR TITLE
[test] Check that the C/C++ module maps are looked for in `-resource-dir` before `-sdk`

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1186,7 +1186,7 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
       llvm::interleave(
           invocationArgs, [](StringRef arg) { llvm::errs() << arg; },
           [] { llvm::errs() << "' '"; });
-      llvm::errs() << "'\n";
+      llvm::errs() << "'\n\n";
     }
 
     clang::CreateInvocationOptions CIOpts;
@@ -1291,11 +1291,24 @@ ClangImporter::create(ASTContext &ctx,
     // Wrap Swift's FS to allow Clang to override the working directory
     VFS = llvm::vfs::RedirectingFileSystem::create(
         fileMapping.redirectedFiles, true, *ctx.SourceMgr.getFileSystem());
+    if (importerOpts.DumpClangDiagnostics) {
+      llvm::errs() << "clang importer redirected file mappings:\n";
+      for (const auto &mapping : fileMapping.redirectedFiles) {
+        llvm::errs() << "   mapping real file '" << mapping.second
+                     << "' to virtual file '" << mapping.first << "'\n";
+      }
+      llvm::errs() << "\n";
+    }
 
     if (!fileMapping.overridenFiles.empty()) {
       llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> overridenVFS =
           new llvm::vfs::InMemoryFileSystem();
       for (const auto &file : fileMapping.overridenFiles) {
+        if (importerOpts.DumpClangDiagnostics) {
+          llvm::errs() << "clang importer overriding file '" << file.first
+                       << "' with the following contents:\n";
+          llvm::errs() << file.second << "\n";
+        }
         auto contents = ctx.Allocate<char>(file.second.size() + 1);
         std::copy(file.second.begin(), file.second.end(), contents.begin());
         // null terminate the buffer.

--- a/test/ClangImporter/print-module-map-paths.swift
+++ b/test/ClangImporter/print-module-map-paths.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/resources/linux/armv7 %t/sdk/usr/include %t/sdk/usr/lib/swift/linux/armv7
+// RUN: touch %t/sdk/usr/include/{inttypes,stdint,unistd}.h
+
+// RUN: touch %t/resources/linux/armv7/{SwiftGlibc.h,glibc.modulemap}
+// RUN: touch %t/sdk/usr/lib/swift/linux/armv7/{SwiftGlibc.h,glibc.modulemap}
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target armv7-unknown-linux-gnueabihf -sdk %t/sdk -resource-dir %t/resources 2>&1 | %FileCheck -check-prefix=CHECK-LINUX %s
+
+// RUN: cp %S/../../stdlib/public/Cxx/{cxxshim/libcxxshim.modulemap,libstdcxx/libstdcxx.h,libstdcxx/libstdcxx.modulemap} %t/resources/linux
+// RUN: %target-swift-frontend %s -typecheck -parse-stdlib -dump-clang-diagnostics -resource-dir %t/resources -cxx-interoperability-mode=default 2>&1 | %FileCheck -check-prefix=CHECK-CXX -check-prefix=CHECK-%target-os-CXX %s
+
+// RUN: mkdir -p %t/resources/android/aarch64 %t/sdk/usr/lib/swift/android/aarch64
+// RUN: cp %S/../../stdlib/public/Platform/{SwiftAndroidNDK.h,SwiftBionic.h,android.modulemap} %t/resources/android/aarch64
+// RUN: cp %S/../../stdlib/public/Platform/{SwiftAndroidNDK.h,SwiftBionic.h,android.modulemap} %t/sdk/usr/lib/swift/android/aarch64
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target aarch64-unknown-linux-android -sdk %t/sdk -resource-dir %t/resources 2>&1 | %FileCheck -check-prefix=CHECK-ANDROID %s
+
+// RUN: cp %S/../../stdlib/public/Cxx/cxxshim/libcxxshim.modulemap %t/resources/android
+// RUN: cp %S/../../stdlib/public/Cxx/cxxshim/libcxxshim.modulemap %t/sdk/usr/lib/swift/android
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target aarch64-unknown-linux-android -sdk %t/sdk -resource-dir %t/resources -cxx-interoperability-mode=default 2>&1 | %FileCheck -check-prefix=CHECK-ANDROID-CXX %s
+
+// CHECK-LINUX: clang importer redirected file mappings:
+// CHECK-LINUX-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}linux{{/|\\}}armv7{{/|\\}}glibc.modulemap' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}module.modulemap'
+// CHECK-LINUX-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}linux{{/|\\}}armv7{{/|\\}}SwiftGlibc.h' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}SwiftGlibc.h'
+
+// CHECK-CXX: clang importer redirected file mappings:
+// CHECK-linux-gnu-CXX: mapping real file '{{.*}}/resources/linux/libstdcxx.h' to virtual file '{{.*}}/usr/include/c++/{{.*}}/libstdcxx.h'
+// CHECK-linux-gnu-CXX: clang importer overriding file '{{.*}}/usr/include/c++/{{.*}}/module.modulemap' with the following contents:
+// CHECK-linux-gnu-CXX-NEXT: --- libstdcxx.modulemap ---
+// CHECK-linux-gnu-CXX: Currently libstdc++ does not have a module map. To work around
+// CHECK-linux-gnu-CXX-NEXT: this, Swift provides its own module map for libstdc++.
+// CHECK-linux-gnu-CXX: header "libstdcxx.h"
+// CHECK-linux-gnu-CXX: clang importer driver args: {{.*}}'-fmodule-map-file={{.*}}resources/linux/libcxxshim.modulemap'
+
+// CHECK-ANDROID: clang importer redirected file mappings:
+// CHECK-ANDROID-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}android{{/|\\}}aarch64{{/|\\}}android.modulemap' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}module.modulemap'
+// CHECK-ANDROID-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}android{{/|\\}}aarch64{{/|\\}}SwiftAndroidNDK.h' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}SwiftAndroidNDK.h'
+// CHECK-ANDROID-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}android{{/|\\}}aarch64{{/|\\}}SwiftBionic.h' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}SwiftBionic.h'
+
+// CHECK-ANDROID-CXX: clang importer driver args: {{.*}}'-fmodule-map-file={{.*}}resources{{/|\\}}android{{/|\\}}libcxxshim.modulemap'

--- a/test/Frontend/embed-bitcode.ll
+++ b/test/Frontend/embed-bitcode.ll
@@ -36,14 +36,14 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 ; MARKER-CMD-NEXT: 00
 
 ; CHECK-COMPILER-NOT: argument unused
-; CHECK-COMPILER: clang
+; CHECK-COMPILER: bin{{/|\\}}clang
 ; CHECK-COMPILER-SAME: -fembed-bitcode
 ; CHECK-COMPILER-SAME: -target
 ; CHECK-COMPILER-NOT: argument unused
 ; CHECK-COMPILER: Fast Register Allocator
 
 ; CHECK-COMPILER-OPT-NOT: argument unused
-; CHECK-COMPILER-OPT: clang
+; CHECK-COMPILER-OPT: bin{{/|\\}}clang
 ; CHECK-COMPILER-OPT-SAME: -fembed-bitcode
 ; CHECK-COMPILER-OPT-SAME: -target
 ; CHECK-COMPILER-OPT-SAME: -Os


### PR DESCRIPTION
as changed in #74814

Also, dump the module map paths when `-Xfrontend -dump-clang-diagnostics` is passed in, both so we can check that manually and in these tests, and fix another Frontend test to be more specific now that this other output trips it up.

Currently, the `ClangImporter` silently adds most of these module maps to the build and there's no way to check that on the commandline.

@egorzhdan, the test I've been saying I'd write, please review.

@andrurogerz, I see you're building Android on Windows for TBC: has the linked pull caused any issues for you, as reported in those comments before?