### PR TITLE
[build] Do not override macOS deployment target when macCatalyst is enabled

### DIFF
--- a/cmake/modules/macCatalystUtils.cmake
+++ b/cmake/modules/macCatalystUtils.cmake
@@ -78,7 +78,7 @@ function(get_target_triple target_out_var target_variant_out_var sdk arch)
   elseif(maccatalyst_build_flavor STREQUAL "macos-like")
     # Use the default macOS triple.
   elseif(maccatalyst_build_flavor STREQUAL "zippered")
-    set(target "${arch}-apple-macosx${SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX}")
+    set(target "${arch}-apple-macosx${deployment_version}")
     set(target_variant "${arch}-apple-ios${SWIFT_DARWIN_DEPLOYMENT_VERSION_MACCATALYST}-macabi")
   elseif(maccatalyst_build_flavor STREQUAL "unzippered-twin")
     # Use the default triple for now

--- a/test/Interop/Cxx/stdlib/overlay-backdeployment.swift
+++ b/test/Interop/Cxx/stdlib/overlay-backdeployment.swift
@@ -1,0 +1,7 @@
+// RUN: %target-build-swift %s -cxx-interoperability-mode=default -target arm64-apple-macos11.0
+
+// REQUIRES: OS=macosx
+
+import Cxx
+
+public func takesCxxType(_ s: some CxxSequence) {}


### PR DESCRIPTION
Cxx.swiftmodule should built with a macOS deployment target set to 10.9, the minimum possible version. Since we enabled macCatalyst for this target, it inadvertently started being built with a deployment target set to 13.0, which is too new and is causing build errors in certain projects.

This change makes sure that for Swift targets within the Swift project that explicitly specify `DEPLOYMENT_VERSION_OSX`, the macCatalyst build logic doesn't silently discard this flag.

rdar://133008827

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
