### PR TITLE
[Sema] Don't clear ParsedUnrecognizedPlatformName when a recognized platform is parsed

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2227,7 +2227,7 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
   // Parse the platform name.
   StringRef platformText = Tok.getText();
   auto MaybePlatform = platformFromString(platformText);
-  ParsedUnrecognizedPlatformName = !MaybePlatform.has_value();
+  ParsedUnrecognizedPlatformName = ParsedUnrecognizedPlatformName || !MaybePlatform.has_value();
   SourceLoc PlatformLoc = Tok.getLoc();
   consumeToken();
 


### PR DESCRIPTION
The callers of parsePlatformVersionInList need to know if an unrecognized platform was parsed in the whole list. It can get cleared in the case of (unrecognized 1.0, *) but PlatformAndVersions will still be empty.