### PR TITLE
IRGen: Fix two typed throws bugs in IRGenThunk

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -6503,3 +6503,46 @@ llvm::FunctionType *FunctionPointer::getFunctionType() const {
 
   return Sig.getType();
 }
+
+void irgen::buildDirectError(IRGenFunction &IGF,
+                             const CombinedResultAndErrorType &combined,
+                             const NativeConventionSchema &errorSchema,
+                             SILType silErrorTy, Explosion &errorResult,
+                             bool forAsync, Explosion &out) {
+  if (combined.combinedTy->isVoidTy()) {
+    return;
+  }
+
+  llvm::Value *expandedResult = llvm::UndefValue::get(combined.combinedTy);
+  auto *structTy = dyn_cast<llvm::StructType>(combined.combinedTy);
+
+  if (!errorSchema.getExpandedType(IGF.IGM)->isVoidTy()) {
+    auto nativeError =
+        errorSchema.mapIntoNative(IGF.IGM, IGF, errorResult, silErrorTy, false);
+
+    if (structTy) {
+      for (unsigned i : combined.errorValueMapping) {
+        llvm::Value *elt = nativeError.claimNext();
+        auto *nativeTy = structTy->getElementType(i);
+        elt = convertForDirectError(IGF, elt, nativeTy,
+                                    /*forExtraction*/ false);
+        expandedResult = IGF.Builder.CreateInsertValue(expandedResult, elt, i);
+      }
+      if (forAsync) {
+        IGF.emitAllExtractValues(expandedResult, structTy, out);
+      } else {
+        out = expandedResult;
+      }
+    } else if (!errorSchema.getExpandedType(IGF.IGM)->isVoidTy()) {
+      out = convertForDirectError(IGF, nativeError.claimNext(),
+                                  combined.combinedTy,
+                                  /*forExtraction*/ false);
+    }
+  } else {
+    if (forAsync && structTy) {
+      IGF.emitAllExtractValues(expandedResult, structTy, out);
+    } else {
+      out = expandedResult;
+    }
+  }
+}

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -278,6 +278,11 @@ namespace irgen {
   llvm::Value *convertForDirectError(IRGenFunction &IGF, llvm::Value *value,
                                      llvm::Type *toTy, bool forExtraction);
 
+  void buildDirectError(IRGenFunction &IGF,
+                        const CombinedResultAndErrorType &combined,
+                        const NativeConventionSchema &errorSchema,
+                        SILType silErrorTy, Explosion &errorResult,
+                        bool forAsync, Explosion &out);
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -153,7 +153,8 @@ void IRGenThunk::prepareArguments() {
       auto &resultSchema = resultTI.nativeReturnValueSchema(IGF.IGM);
 
       if (resultSchema.requiresIndirect() ||
-          errorSchema.shouldReturnTypedErrorIndirectly()) {
+          errorSchema.shouldReturnTypedErrorIndirectly() ||
+          conv.hasIndirectSILResults()) {
         auto directTypedErrorAddr = original.takeLast();
         IGF.setCalleeTypedErrorResultSlot(Address(directTypedErrorAddr,
                                                   errorTI.getStorageType(),

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -4,6 +4,8 @@
 
 // RUN: %target-swift-frontend -primary-file %s -emit-ir  | %FileCheck %s --check-prefix=CHECK
 
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-library-evolution
+
 // XFAIL: CPU=arm64e
 // REQUIRES: PTRSIZE=64
 
@@ -215,4 +217,18 @@ func mayThrowEmptyErrorAsync(x: Bool) async throws(EmptyError) -> String? {
   }
 
   return ""
+}
+
+
+enum SP: Error {
+    case a
+    case b(Int32)
+}
+
+protocol Proto {
+  // This used to crash.
+  static func f() throws(SP) -> Self
+
+  // This used to crash.
+  static func f2() throws(SP) -> Int64
 }


### PR DESCRIPTION
- We need to map the direct type error explosion back to the native result in IRGenThunk
- Add missing case in IRGenThunk when we pass typed errors directly
    
rdar://134730970