### PR TITLE
[CMake] Build macro plugin and plugin servers as a package

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -127,13 +127,13 @@ function(_set_pure_swift_package_options target_name package_name)
 
   # Enable package CMO if possible
   if(Swift_COMPILER_PACKAGE_CMO_SUPPORT STREQUAL "IMPLEMENTED")
-    target_compile_options("${target}" PRIVATE
+    target_compile_options("${target_name}" PRIVATE
       "SHELL:-package-name ${package_name}"
       "SHELL:-Xfrontend -package-cmo"
       "SHELL:-Xfrontend -allow-non-resilient-access"
     )
   elseif(Swift_COMPILER_PACKAGE_CMO_SUPPORT STREQUAL "EXPERIMENTAL")
-    target_compile_options("${target}" PRIVATE
+    target_compile_options("${target_name}" PRIVATE
       "SHELL:-package-name ${package_name}"
       "SHELL:-Xfrontend -experimental-package-cmo"
       "SHELL:-Xfrontend -experimental-allow-non-resilient-access"

--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -120,6 +120,27 @@ function(_set_pure_swift_profile_flags target_name)
   endif()
 endfunction()
 
+function(_set_pure_swift_package_options target_name package_name)
+  if(NOT package_name OR NOT Swift_COMPILER_PACKAGE_CMO_SUPPORT)
+    return()
+  endif()
+
+  # Enable package CMO if possible
+  if(Swift_COMPILER_PACKAGE_CMO_SUPPORT STREQUAL "IMPLEMENTED")
+    target_compile_options("${target}" PRIVATE
+      "SHELL:-package-name ${package_name}"
+      "SHELL:-Xfrontend -package-cmo"
+      "SHELL:-Xfrontend -allow-non-resilient-access"
+    )
+  elseif(Swift_COMPILER_PACKAGE_CMO_SUPPORT STREQUAL "EXPERIMENTAL")
+    target_compile_options("${target}" PRIVATE
+      "SHELL:-package-name ${package_name}"
+      "SHELL:-Xfrontend -experimental-package-cmo"
+      "SHELL:-Xfrontend -experimental-allow-non-resilient-access"
+      "SHELL:-Xfrontend -experimental-package-bypass-resilience"
+    )
+  endif()
+endfunction()
 
 # Add a new "pure" Swift host library.
 #
@@ -149,6 +170,9 @@ endfunction()
 # EMIT_MODULE
 #   Emit '.swiftmodule' to
 #
+# PACKAGE_NAME
+#   Name of the Swift package this library belongs to.
+#
 # DEPENDENCIES
 #   Target names to pass target_link_library
 #
@@ -169,7 +193,8 @@ function(add_pure_swift_host_library name)
         SHARED
         STATIC
         EMIT_MODULE)
-  set(single_parameter_options)
+  set(single_parameter_options
+        PACKAGE_NAME)
   set(multiple_parameter_options
         DEPENDENCIES
         SWIFT_DEPENDENCIES)
@@ -193,6 +218,7 @@ function(add_pure_swift_host_library name)
   # Create the library.
   add_library(${name} ${libkind} ${APSHL_SOURCES})
   _add_host_swift_compile_options(${name})
+  _set_pure_swift_package_options(${name} "${APSHL_PACKAGE_NAME}")
 
   set_property(TARGET ${name}
     PROPERTY BUILD_WITH_INSTALL_RPATH YES)
@@ -315,6 +341,9 @@ endfunction()
 # name
 #   Name of the tool (e.g., swift-frontend).
 #
+# PACKAGE_NAME
+#   Name of the Swift package this executable belongs to.
+#
 # DEPENDENCIES
 #   Target names to pass target_link_library
 #
@@ -333,7 +362,8 @@ function(add_pure_swift_host_tool name)
   # Option handling
   set(options)
   set(single_parameter_options
-    SWIFT_COMPONENT)
+    SWIFT_COMPONENT
+    PACKAGE_NAME)
   set(multiple_parameter_options
         DEPENDENCIES
         SWIFT_DEPENDENCIES)
@@ -349,6 +379,7 @@ function(add_pure_swift_host_tool name)
   add_executable(${name} ${APSHT_SOURCES})
   _add_host_swift_compile_options(${name})
   _set_pure_swift_link_flags(${name} "../lib/")
+  _set_pure_swift_package_options(${name} "${APSHT_PACKAGE_NAME}")
 
   if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
     set_property(TARGET ${name}

--- a/lib/Macros/CMakeLists.txt
+++ b/lib/Macros/CMakeLists.txt
@@ -29,18 +29,14 @@ function(add_swift_macro_library name)
   set(ASML_SOURCES ${ARGN})
 
   # Add the library.
-  add_pure_swift_host_library(${name} SHARED ${ASML_SOURCES})
+  add_pure_swift_host_library(${name} SHARED
+    PACKAGE_NAME Toolchain
+    ${ASML_SOURCES})
 
   # If we don't have the Swift swift parser, bail out, because the above
   # add_pure_swift_host_library did nothing.
   if (NOT SWIFT_BUILD_SWIFT_SYNTAX)
     return()
-  endif()
-
-  # FXIME: Importing package-cmo enabled '.swiftmodule' causes compiler crash :(
-  if(Swift_COMPILER_PACKAGE_CMO_SUPPORT)
-    target_compile_options(${name} PRIVATE
-      "SHELL:-Xfrontend -module-load-mode -Xfrontend prefer-interface")
   endif()
 
   # Add rpath to 'lib/{platform}'

--- a/lib/SwiftSyntax/CMakeLists.txt
+++ b/lib/SwiftSyntax/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 # Add unique ABI prefix to swift-syntax libraries so that compiler libraries (e.g. sourcekitdInProc)
 # can be used from tools that has its own swift-syntax libraries as SwiftPM dependencies.
 set(SWIFT_MODULE_ABI_NAME_PREFIX "Compiler")
+set(SWIFTSYNTAX_PACKAGE_NAME "Toolchain")
 
 file(TO_CMAKE_PATH "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}" swift_syntax_path)
 FetchContent_Declare(SwiftSyntax SOURCE_DIR "${swift_syntax_path}")

--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -6,6 +6,7 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
     SWIFT_DEPENDENCIES
       SwiftCompilerPluginMessageHandling
       SwiftLibraryPluginProvider
+    PACKAGE_NAME Toolchain
   )
 
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${SWIFT_HOST_LIBRARIES_DEST_DIR}")
@@ -15,6 +16,7 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
     SWIFT_DEPENDENCIES
       SwiftCompilerPluginMessageHandling
       SwiftLibraryPluginProvider
+    PACKAGE_NAME Toolchain
   )
 
   if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
@@ -26,14 +28,6 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
       APPEND PROPERTY INSTALL_RPATH
         "$ORIGIN")
     _set_pure_swift_link_flags(SwiftInProcPluginServer "../../")
-  endif()
-
-  # FXIME: Importing package-cmo enabled '.swiftmodule' causes compiler crash :(
-  if(Swift_COMPILER_PACKAGE_CMO_SUPPORT)
-    target_compile_options(swift-plugin-server PRIVATE
-      "SHELL:-Xfrontend -module-load-mode -Xfrontend prefer-interface")
-    target_compile_options(SwiftInProcPluginServer PRIVATE
-      "SHELL:-Xfrontend -module-load-mode -Xfrontend prefer-interface")
   endif()
 
   set_property(TARGET ${name}


### PR DESCRIPTION
Build swift-syntax libraries in `lib/swift/host`, macro plugin libraries, and plugin servers as a single package "Toolchain"
This enables CMO between them.
