### PR TITLE
Fixed diagnostics for incorrect parameters of retain/release function…

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -132,7 +132,7 @@ WARNING(libstdcxx_modulemap_not_found, none,
         (StringRef))
 
 WARNING(api_pattern_attr_ignored, none,
-        "'%0' swift attribute ignored on type '%1': type is not copyable or destructible",
+        "'%0' Swift attribute ignored on type '%1': type is not copyable or destructible",
         (StringRef, StringRef))
 
 ERROR(objc_implementation_two_impls, none,
@@ -208,30 +208,40 @@ NOTE(iterator_method_unavailable, none, "C++ method '%0' that returns an "
 NOTE(iterator_potentially_unsafe, none, "C++ methods that return iterators "
                                         "are potentially unsafe; try using Swift collection APIs instead", ())
 
-ERROR(reference_type_must_have_retain_attr,none,
-      "reference type '%0' must have 'retain:' swift attribute", (StringRef))
-ERROR(reference_type_must_have_release_attr,none,
-      "reference type '%0' must have 'release:' swift attribute", (StringRef))
-ERROR(foreign_reference_types_cannot_find_retain,none,
-      "cannot find retain function '%0' for reference type '%1'", (StringRef, StringRef))
-ERROR(foreign_reference_types_cannot_find_release,none,
-      "cannot find release function '%0' for reference type '%1'", (StringRef, StringRef))
-ERROR(too_many_reference_type_retain_operations,none,
-      "multiple functions '%0' found; there must be exactly one retain "
-      "function for reference type '%1'", (StringRef, StringRef))
-ERROR(too_many_reference_type_release_operations,none,
-      "multiple functions '%0' found; there must be exactly one release "
-      "function for reference type '%1'", (StringRef, StringRef))
-ERROR(foreign_reference_types_invalid_retain,none,
-      "specified retain function '%0' is invalid; retain function must have exactly one "
-      "argument of type '%1'", (StringRef, StringRef))
-ERROR(foreign_reference_types_invalid_release,none,
-      "specified release function '%0' is invalid; release function must have exactly "
-      "one argument of type '%1'", (StringRef, StringRef))
+ERROR(reference_type_must_have_retain_release_attr, none,
+      "reference type '%1' must have %select{'retain:'|'release:'}0 Swift "
+      "attribute",
+      (bool, StringRef))
+ERROR(too_many_reference_type_retain_release_attr, none,
+      "reference type '%1' must have only one %select{'retain:'|'release:'}0 "
+      "Swift "
+      "attribute",
+      (bool, StringRef))
+ERROR(foreign_reference_types_cannot_find_retain_release, none,
+      "cannot find %select{retain|release}0 function '%1' for reference type "
+      "'%2'",
+      (bool, StringRef, StringRef))
+ERROR(too_many_reference_type_retain_release_operations, none,
+      "multiple functions '%1' found; there must be exactly one "
+      "%select{retain|release}0 function for reference type '%2'",
+      (bool, StringRef, StringRef))
+ERROR(foreign_reference_types_invalid_retain_release, none,
+      "specified %select{retain|release}0 function '%1' is invalid; "
+      "%select{retain|release}0 function must have exactly one argument of "
+      "type '%2'",
+      (bool, StringRef, StringRef))
 
-
-ERROR(conforms_to_missing_dot,none,
-      "expected module name and protocol name separated by '.' in protocol conformance; '%0' is invalid", (StringRef))
+ERROR(foreign_reference_types_retain_release_non_void_return_type, none,
+      "specified %select{retain|release}0 function '%1' is invalid; "
+      "%select{retain|release}0 function must have 'void' return type",
+      (bool, StringRef))
+ERROR(foreign_reference_types_retain_release_not_a_function_decl, none,
+      "specified %select{retain|release}0 function '%1' is not a function",
+      (bool, StringRef))
+ERROR(conforms_to_missing_dot, none,
+      "expected module name and protocol name separated by '.' in protocol "
+      "conformance; '%0' is invalid",
+      (StringRef))
 ERROR(cannot_find_conforms_to_module,none,
       "module '%1' in specified protocol conformance '%0' is not found; did you mean to import it first?", (StringRef, StringRef))
 

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -465,6 +465,7 @@ SourceLoc extractNearestSourceLoc(CustomRefCountingOperationDescriptor desc);
 struct CustomRefCountingOperationResult {
   enum CustomRefCountingOperationResultKind {
     noAttribute,
+    tooManyAttributes,
     immortal,
     notFound,
     tooManyFound,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7799,17 +7799,22 @@ CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
   if (!decl->hasAttrs())
     return {CustomRefCountingOperationResult::noAttribute, nullptr, ""};
 
-  auto retainFnAttr =
-      llvm::find_if(decl->getAttrs(), [&operationStr](auto *attr) {
-        if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-          return swiftAttr->getAttribute().starts_with(operationStr);
-        return false;
-      });
-  if (retainFnAttr == decl->getAttrs().end()) {
-    return {CustomRefCountingOperationResult::noAttribute, nullptr, ""};
+  llvm::SmallVector<const clang::SwiftAttrAttr *, 1> retainReleaseAttrs;
+  for (auto *attr : decl->getAttrs()) {
+    if (auto swiftAttr = llvm::dyn_cast<clang::SwiftAttrAttr>(attr)) {
+      if (swiftAttr->getAttribute().starts_with(operationStr)) {
+        retainReleaseAttrs.push_back(swiftAttr);
+      }
+    }
   }
 
-  auto name = cast<clang::SwiftAttrAttr>(*retainFnAttr)
+  if (retainReleaseAttrs.empty()) {
+    return {CustomRefCountingOperationResult::noAttribute, nullptr, ""};
+  } else if (retainReleaseAttrs.size() > 1) {
+    return {CustomRefCountingOperationResult::tooManyAttributes, nullptr, ""};
+  }
+
+  auto name = retainReleaseAttrs.front()
                   ->getAttribute()
                   .drop_front(StringRef(operationStr).size())
                   .str();

--- a/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: not %target-swift-frontend -typecheck -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -I %t/Inputs %t/test.swift -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
 
 //--- Inputs/module.modulemap
 module Test {
@@ -28,18 +28,259 @@ BadRetainRelease {};
 int badRetain(BadRetainRelease *v);
 void badRelease(BadRetainRelease *v, int i);
 
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:badRetainWithNullabilityAnnotations")))
+    __attribute__((swift_attr("release:badReleaseWithNullabilityAnnotations")))
+BadRetainReleaseWithNullabilityAnnotations {};
+
+void badRetainWithNullabilityAnnotations(BadRetainRelease * _Nonnull v);
+void badReleaseWithNullabilityAnnotations(BadRetainRelease * _Nonnull v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:goodRetain")))
+    __attribute__((swift_attr("release:goodRelease")))
+GoodRetainRelease {};
+
+void goodRetain(GoodRetainRelease *v);
+void goodRelease(GoodRetainRelease *v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:goodRetainWithNullabilityAnnotations")))
+    __attribute__((swift_attr("release:goodReleaseWithNullabilityAnnotations")))
+GoodRetainReleaseWithNullabilityAnnotations {};
+
+void goodRetainWithNullabilityAnnotations(GoodRetainReleaseWithNullabilityAnnotations * _Nonnull v);
+void goodReleaseWithNullabilityAnnotations(GoodRetainReleaseWithNullabilityAnnotations * _Nonnull v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:badRetain2")))
+    __attribute__((swift_attr("release:badRelease2")))
+BadRetainRelease2 {};
+
+void badRetain2(int);
+void badRelease2(int);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:badRetain3")))
+    __attribute__((swift_attr("release:badRelease3")))
+BadRetainRelease3 {};
+
+void badRetain3(BadRetainRelease2 *);
+void badRelease3(BadRetainRelease2 *);
+
+struct nonCXXFRT{};
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:badRetain4")))
+    __attribute__((swift_attr("release:badRelease4")))
+BadRetainRelease4 {};
+
+void badRetain4(nonCXXFRT *);
+void badRelease4(nonCXXFRT *);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:baseFRTRetain")))
+    __attribute__((swift_attr("release:baseFRTRelease")))
+BaseFRT {};
+
+void baseFRTRetain(BaseFRT *v);
+void baseFRTRelease(BaseFRT *v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:derivedFRTRetain")))
+    __attribute__((swift_attr("release:derivedFRTRelease")))
+DerivedFRT : BaseFRT {};
+
+void derivedFRTRetain(BaseFRT *v);
+void derivedFRTRelease(BaseFRT *v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:RCRetain")))
+    __attribute__((swift_attr("release:RCRelease")))
+RefCountedBase {};
+
+void RCRetain(RefCountedBase *v);
+void RCRelease(RefCountedBase *v);
+
+struct 
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:RCRetain")))
+    __attribute__((swift_attr("release:RCRelease")))
+RefCountedDerived : RefCountedBase {};
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:base1FRTRetain")))
+    __attribute__((swift_attr("release:base1FRTRelease")))
+Base1FRT {};
+
+void base1FRTRetain(Base1FRT *v);
+void base1FRTRelease(Base1FRT *v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:base2FRTRetain")))
+    __attribute__((swift_attr("release:base2FRTRelease")))
+Base2FRT : Base1FRT {};
+
+void base2FRTRetain(Base1FRT *v);
+void base2FRTRelease(Base1FRT *v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:base3FRTRetain")))
+    __attribute__((swift_attr("release:base3FRTRelease")))
+Base3FRT : Base2FRT {};
+
+void base3FRTRetain(Base1FRT *v);
+void base3FRTRelease(Base1FRT *v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:base4FRTRetain")))
+    __attribute__((swift_attr("release:base4FRTRelease")))
+Base4FRT : Base2FRT {};
+
+void base4FRTRetain(GoodRetainRelease *v);
+void base4FRTRelease(Base1FRT *v);
+
+typedef struct 
+__attribute__((swift_attr("import_reference"))) 
+__attribute__((swift_attr("retain:anonymousStructRetain"))) 
+__attribute__((swift_attr("release:anonymousStructRelease"))) 
+{} AnonymousStruct;
+
+void anonymousStructRetain(AnonymousStruct *v);
+void anonymousStructRelease(AnonymousStruct *v);
+
+typedef struct 
+__attribute__((swift_attr("import_reference"))) 
+__attribute__((swift_attr("retain:badAnonymousStructRetain"))) 
+__attribute__((swift_attr("release:badAnonymousStructRelease"))) 
+{} BadAnonymousStruct;
+
+void badAnonymousStructRetain(AnonymousStruct *v);
+void badAnonymousStructRelease(AnonymousStruct *v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:badFRTRetain")))
+    __attribute__((swift_attr("release:badFRTRelease")))
+BadFRT {};
+
+int badFRTRetain = 0;
+int badFRTRelease = 0;
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:retain")))
+    __attribute__((swift_attr("release:release")))
+MultipleRetainReleaseFRT {};
+
+void retain(MultipleRetainReleaseFRT *v);
+void retain(GoodRetainRelease *v);
+void release(MultipleRetainReleaseFRT *v);
+void release(GoodRetainRelease *v);
+
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:retain2")))
+    __attribute__((swift_attr("retain:retain1")))
+    __attribute__((swift_attr("release:release1")))
+    __attribute__((swift_attr("release:release2")))
+MultipleRetainReleaseAttrFRT {};
+
+void retain1(MultipleRetainReleaseAttrFRT *v);
+void retain2(MultipleRetainReleaseAttrFRT *v);
+void release1(MultipleRetainReleaseAttrFRT *v);
+void release2(MultipleRetainReleaseAttrFRT *v);
+
 //--- test.swift
 
 import Test
 
 // CHECK: error: cannot find retain function 'nonexistent' for reference type 'NonExistent'
 // CHECK: error: cannot find release function 'nonexistent' for reference type 'NonExistent'
+@available(macOS 13.3, *)
 public func test(x: NonExistent) { }
 
-// CHECK: error: reference type 'NoRetainRelease' must have 'retain:' swift attribute
-// CHECK: error: reference type 'NoRetainRelease' must have 'release:' swift attribute
+// CHECK: error: reference type 'NoRetainRelease' must have 'retain:' Swift attribute
+// CHECK: error: reference type 'NoRetainRelease' must have 'release:' Swift attribute
+@available(macOS 13.3, *)
 public func test(x: NoRetainRelease) { }
 
-// CHECK: error: specified retain function 'badRetain' is invalid; retain function must have exactly one argument of type 'BadRetainRelease'
+// CHECK: error: specified retain function 'badRetain' is invalid; retain function must have 'void' return type
 // CHECK: error: specified release function 'badRelease' is invalid; release function must have exactly one argument of type 'BadRetainRelease'
+@available(macOS 13.3, *)
 public func test(x: BadRetainRelease) { }
+
+// CHECK: error: specified retain function 'badRetainWithNullabilityAnnotations' is invalid; retain function must have exactly one argument of type 'BadRetainReleaseWithNullabilityAnnotations'
+// CHECK: error: specified release function 'badReleaseWithNullabilityAnnotations' is invalid; release function must have exactly one argument of type 'BadRetainReleaseWithNullabilityAnnotations'
+@available(macOS 13.3, *)
+public func test(x: BadRetainReleaseWithNullabilityAnnotations) { }
+
+@available(macOS 13.3, *)
+public func test(x: GoodRetainRelease) { }
+
+@available(macOS 13.3, *)
+public func test(x: GoodRetainReleaseWithNullabilityAnnotations) { }
+
+// CHECK: error: specified retain function 'badRetain2' is invalid; retain function must have exactly one argument of type 'BadRetainRelease2'
+// CHECK: error: specified release function 'badRelease2' is invalid; release function must have exactly one argument of type 'BadRetainRelease2'
+@available(macOS 13.3, *)
+public func test(x: BadRetainRelease2) { }
+
+// CHECK: error: specified retain function 'badRetain3' is invalid; retain function must have exactly one argument of type 'BadRetainRelease3'
+// CHECK: error: specified release function 'badRelease3' is invalid; release function must have exactly one argument of type 'BadRetainRelease3'
+@available(macOS 13.3, *)
+public func test(x: BadRetainRelease3) { }
+
+// CHECK: error: specified retain function 'badRetain4' is invalid; retain function must have exactly one argument of type 'BadRetainRelease4'
+// CHECK: error: specified release function 'badRelease4' is invalid; release function must have exactly one argument of type 'BadRetainRelease4'
+@available(macOS 13.3, *)
+public func test(x: BadRetainRelease4) { }
+
+@available(macOS 13.3, *)
+public func test(x: DerivedFRT) { }
+
+@available(macOS 13.3, *)
+public func test(x: RefCountedDerived) { }
+
+@available(macOS 13.3, *)
+public func test(x: Base3FRT) { }
+
+@available(macOS 13.3, *)
+// CHECK: error: specified retain function 'base4FRTRetain' is invalid; retain function must have exactly one argument of type 'Base4FRT'
+public func test(x: Base4FRT) { }
+
+@available(macOS 13.3, *)
+public func testAnonymousStruct(x: AnonymousStruct) { }
+
+// CHECK: error: specified retain function 'badAnonymousStructRetain' is invalid; retain function must have exactly one argument of type 'BadAnonymousStruct'
+// CHECK: error: specified release function 'badAnonymousStructRelease' is invalid; release function must have exactly one argument of type 'BadAnonymousStruct'
+@available(macOS 13.3, *)
+public func testBadAnonymousStruct(x: BadAnonymousStruct) { }
+
+// CHECK: error: specified retain function 'badFRTRetain' is not a function
+// CHECK: error: specified release function 'badFRTRelease' is not a function
+@available(macOS 13.3, *)
+public func testRetainReleaseAsNonFunction(x: BadFRT) {}
+
+// CHECK: error: multiple functions 'retain' found; there must be exactly one retain function for reference type 'MultipleRetainReleaseFRT'
+// CHECK: error: multiple functions 'release' found; there must be exactly one release function for reference type 'MultipleRetainReleaseFRT'
+@available(macOS 13.3, *)
+public func testMultipleRetainRelease(x: MultipleRetainReleaseFRT) {}
+
+// CHECK: error: reference type 'MultipleRetainReleaseAttrFRT' must have only one 'retain:' Swift attribute
+// CHECK: error: reference type 'MultipleRetainReleaseAttrFRT' must have only one 'release:' Swift attribute
+@available(macOS 13.3, *)
+public func testMultipleRetainRelease(x: MultipleRetainReleaseAttrFRT) {}


### PR DESCRIPTION
…s of SWIFT_SHARED_REFERENCE types.

This fixes the diagnostic for cases when incorrect parameters are used for `retain/release` functions of C++ `SWIFT_SHARED_REFERENCE` types. Anything apart from a pointer to the `SWIFT_SHARED_REFERENCE` type itself is considered as a case of incorrect parameter. For example C++ native values (like `int`, `bool`, etc), C++ non SHARED_REFERENCE_TYPEs and some other C++` SHARED_REFERENCE_TYPE` than the type whose retain/release functions are being considered.

Fixes rdar://128492811 