### PR TITLE
[test] Move test/attr/attr_availability_transitive_osx_appext.swift to fake version

### DIFF
--- a/test/attr/attr_availability_transitive_osx_appext.swift
+++ b/test/attr/attr_availability_transitive_osx_appext.swift
@@ -70,10 +70,10 @@ extension NotOnOSXApplicationExtension {
   }
 }
 
-@available(OSXApplicationExtension, introduced: 12)
-func osx_introduced_in_macOS_extesnions_12() {}
+@available(OSXApplicationExtension, introduced: 52)
+func osx_introduced_in_macOS_extesnions_52() {}
 
-func call_osx_introduced_in_macOS_extesnions_12() { // expected-note {{add @available attribute to enclosing global function}} {{1-1=@available(macOSApplicationExtension 12, *)\n}}
-  osx_introduced_in_macOS_extesnions_12() // expected-error {{'osx_introduced_in_macOS_extesnions_12()' is only available in application extensions for macOS 12 or newer}}
-  // expected-note@-1 {{add 'if #available' version check}} {{3-42=if #available(macOS 12, *) {\n      osx_introduced_in_macOS_extesnions_12()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
+func call_osx_introduced_in_macOS_extesnions_52() { // expected-note {{add @available attribute to enclosing global function}} {{1-1=@available(macOSApplicationExtension 52, *)\n}}
+  osx_introduced_in_macOS_extesnions_52() // expected-error {{'osx_introduced_in_macOS_extesnions_52()' is only available in application extensions for macOS 52 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}} {{3-42=if #available(macOS 52, *) {\n      osx_introduced_in_macOS_extesnions_52()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
 }


### PR DESCRIPTION
Keep this test independent of the default deployment target by using a larger version number.

This is a follow-on to https://github.com/swiftlang/swift/pull/76023 for a test that was recently changed