### PR TITLE
SIL: Synchronous local functions don't need to capture the isolation parameter

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4485,26 +4485,6 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
     PrettyStackTraceAnyFunctionRef("lowering local captures", curFn);
     collectCaptures(curFn.getCaptureInfo());
 
-    if (auto *afd = curFn.getAbstractFunctionDecl()) {
-      // If a local function inherits isolation from the enclosing context,
-      // make sure we capture the isolated parameter, if we haven't already.
-      if (afd->isLocalCapture()) {
-        auto actorIsolation = getActorIsolation(afd);
-        if (actorIsolation.getKind() == ActorIsolation::ActorInstance) {
-          if (auto *var = actorIsolation.getActorInstance()) {
-            assert(isa<ParamDecl>(var));
-            recordCapture(CapturedValue(var, 0, afd->getLoc()));
-	    if (var->getInterfaceType()->hasTypeParameter()) {
-	      // If the isolated parameter is of a generic (actor)
-	      // type, we need to treat as if the local function is
-	      // generic.
-	      capturesGenericParams = true;
-	    }
-          }
-        }
-      }
-    }
-
     // A function's captures also include its default arguments, because
     // when we reference a function we don't track which default arguments
     // are referenced too.

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -892,10 +892,9 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   }
 
   // Otherwise, if we do not have an isolated argument and are not in an
-  // alloactor, then we might be isolated via global isolation.
+  // allocator, then we might be isolated via global isolation.
   if (auto functionIsolation = fArg->getFunction()->getActorIsolation()) {
     if (functionIsolation.isActorIsolated()) {
-      assert(functionIsolation.isGlobalActor());
       if (functionIsolation.isGlobalActor()) {
         return SILIsolationInfo::getGlobalActorIsolated(
             fArg, functionIsolation.getGlobalActor());

--- a/test/SILGen/local_function_isolation.swift
+++ b/test/SILGen/local_function_isolation.swift
@@ -59,11 +59,32 @@ func test() async {}
 // local/nested function.
 actor GenericActor<K> {
   var i: Int = 0
-  private func outerFunc() {
-    func accessSelf() -> Int {
-      // CHECK-LABEL: sil private [ossa] @$s24local_function_isolation12GenericActorC9outerFunc33_7B9E2B75110B8600A136A469D51CAF2BLLyyF10accessSelfL_SiylF : $@convention(thin) <K> (@sil_isolated @guaranteed GenericActor<K>) -> Int {
+  func outerFunc() async {
+    func accessSelf() async -> Int {
+      // CHECK-LABEL: sil private [ossa] @$s24local_function_isolation12GenericActorC9outerFuncyyYaF10accessSelfL_SiyYalF : $@convention(thin) @async <K> (@sil_isolated @guaranteed GenericActor<K>) -> Int {
       return 0
     }
-    print(accessSelf())
+    await print(accessSelf())
+  }
+}
+
+// Make sure defer doesn't capture anything.
+actor DeferInsideInitActor {
+  init(foo: ()) async throws {
+    // CHECK-LABEL: sil private [ossa] @$s24local_function_isolation20DeferInsideInitActorC3fooACyt_tYaKcfc6$deferL_yyF : $@convention(thin) () -> () {
+    defer {}
+    try self.init()
+  }
+}
+
+actor NestedAsyncInSyncActor {
+  public func outer() async {
+    // CHECK-LABEL: sil private [ossa] @$s24local_function_isolation22NestedAsyncInSyncActorC5outeryyYaF6middleL_yyF : $@convention(thin) (@sil_isolated @guaranteed NestedAsyncInSyncActor) -> () {
+    func middle() {
+      // CHECK-LABEL: sil private [ossa] @$s24local_function_isolation22NestedAsyncInSyncActorC5outeryyYaF6middleL_yyF5innerL_yyYaF : $@convention(thin) @async (@sil_isolated @guaranteed NestedAsyncInSyncActor) -> () {
+      func inner() async {}
+      _ = inner
+    }
+    _ = middle
   }
 }


### PR DESCRIPTION
Also, move this rule from the computation of lowered captures in SIL, to the computation of AST captures in Sema. This allows us to correctly handle the case where an async function nests inside a sync function. It also removes a special case that was added recently to cope with a generic `self` type.

Fixes rdar://129366819.