### PR TITLE
SILOptimizer: Allow inlining of transparent functions in `@backDeployed` thunks

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -56,7 +56,8 @@ enum IsThunk_t {
   IsNotThunk,
   IsThunk,
   IsReabstractionThunk,
-  IsSignatureOptimizedThunk
+  IsSignatureOptimizedThunk,
+  IsBackDeployedThunk,
 };
 enum IsDynamicallyReplaceable_t {
   IsNotDynamic,
@@ -368,7 +369,7 @@ private:
   ///
   /// The inliner uses this information to avoid inlining (non-trivial)
   /// functions into the thunk.
-  unsigned Thunk : 2;
+  unsigned Thunk : 3;
 
   /// The scope in which the parent class can be subclassed, if this is a method
   /// which is contained in the vtable of that class.
@@ -486,6 +487,7 @@ private:
       break;
     case IsThunk:
     case IsReabstractionThunk:
+    case IsBackDeployedThunk:
       thunkCanHaveSubclassScope = false;
       break;
     }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3387,6 +3387,7 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
 
   switch (isThunk()) {
   case IsNotThunk: break;
+  case IsBackDeployedThunk: // FIXME: Give this a distinct label
   case IsThunk: OS << "[thunk] "; break;
   case IsSignatureOptimizedThunk:
     OS << "[signature_optimized_thunk] ";

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -906,7 +906,7 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
     preEmitFunction(constant, f, loc);
     PrettyStackTraceSILFunction X("silgen emitBackDeploymentThunk", f);
     f->setBare(IsBare);
-    f->setThunk(IsThunk);
+    f->setThunk(IsBackDeployedThunk);
 
     SILGenFunction(*this, *f, dc).emitBackDeploymentThunk(constant);
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 885; // opened existentials
+const uint16_t SWIFTMODULE_VERSION_MINOR = 886; // SIL function thunk kind
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -292,7 +292,7 @@ namespace sil_block {
       BCRecordLayout<SIL_FUNCTION, SILLinkageField,
                      BCFixed<1>,  // transparent
                      BCFixed<2>,  // serializedKind
-                     BCFixed<2>,  // thunks: signature optimized/reabstraction
+                     BCFixed<3>,  // thunk kind
                      BCFixed<1>,  // without_actually_escaping
                      BCFixed<3>,  // specialPurpose
                      BCFixed<2>,  // inlineStrategy

--- a/test/IRGen/Inputs/back_deployed.swift
+++ b/test/IRGen/Inputs/back_deployed.swift
@@ -1,0 +1,6 @@
+@backDeployed(before: SwiftStdlib 6.0)
+public func backDeployedFunc() {
+  otherFunc()
+}
+
+@usableFromInline internal func otherFunc() {}

--- a/test/IRGen/availability_ios.swift
+++ b/test/IRGen/availability_ios.swift
@@ -1,8 +1,9 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
 // RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=OPT
 
-// On iOS stdlib_isOSVersionAtLeast() is @_transparent, which affects optimization.
-// REQUIRES: OS=macosx || OS=tvos || OS=watchos || OS=xros
+// On iOS _stdlib_isOSVersionAtLeast() is @_transparent, which affects optimization.
+// See IRGen/availability.swift for other Apple platforms.
+// REQUIRES: OS=ios
 
 import Foundation
 
@@ -11,12 +12,12 @@ import Foundation
 
 // CHECK-LABEL: define{{.*}} @{{.*}}dontHoist
 // CHECK-NOT: s10Foundation11MeasurementVySo17NSUnitTemperature
-// CHECK: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
+// CHECK: call swiftcc i1 @"$ss31_stdlib_isOSVersionAtLeast_AEICyBi1_Bw_BwBwtF"(
 // CHECK: s10Foundation11MeasurementVySo17NSUnitTemperature
 
 // OPT-LABEL: define{{.*}} @{{.*}}dontHoist
 // OPT-NOT: S10Foundation11MeasurementVySo17NSUnitTemperature
-// OPT: call {{.*}} @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
+// OPT: call {{.*}} @__isPlatformVersionAtLeast(
 // OPT: s10Foundation11MeasurementVySo17NSUnitTemperature
 
 public func dontHoist() {
@@ -37,17 +38,18 @@ public func dontHoist() {
 // for iOS 9 will also succeed.
 
 // With optimizations on, multiple #availability checks should generate only
-// a single call into _isOSVersionAtLeast.
+// a single call into _isOSVersionAtLeast, which after inlining will be a
+// call to __isPlatformVersionAtLeast.
 
 // CHECK-LABEL: define{{.*}} @{{.*}}multipleAvailabilityChecks
-// CHECK: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
-// CHECK: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
-// CHECK: call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
+// CHECK: call swiftcc i1 @"$ss31_stdlib_isOSVersionAtLeast_AEICyBi1_Bw_BwBwtF"(
+// CHECK: call swiftcc i1 @"$ss31_stdlib_isOSVersionAtLeast_AEICyBi1_Bw_BwBwtF"(
+// CHECK: call swiftcc i1 @"$ss31_stdlib_isOSVersionAtLeast_AEICyBi1_Bw_BwBwtF"(
 // CHECK: ret void
 
 // OPT-LABEL: define{{.*}} @{{.*}}multipleAvailabilityChecks
-// OPT: call {{.*}} @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
-// OPT-NOT: call {{.*}} @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
+// OPT: call {{.*}} @__isPlatformVersionAtLeast
+// OPT-NOT: call {{.*}} @$__isPlatformVersionAtLeast
 // OPT: ret void
 public func multipleAvailabilityChecks() {
   if #available(macOS 51.0, iOS 54.0, watchOS 57.0, tvOS 54.0, visionOS 51.1, *) {

--- a/test/IRGen/back_deployed_Onone.swift
+++ b/test/IRGen/back_deployed_Onone.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/back_deployed.swift -o %t/ -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-ir %s -I %t -Onone | %FileCheck %s
+
+// _stdlib_isOSVersionAtLeast() is not @_transparent on macOS, watchOS, and tvOS
+// REQUIRES: OS=macosx || OS=watchos || OS=tvos
+
+import back_deployed
+
+public func test() {
+  backDeployedFunc()
+}
+
+// CHECK: define{{.*}} hidden swiftcc void @"$s13back_deployed0A12DeployedFuncyyFTwb"
+// CHECK:   call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
+// CHECK:   call swiftcc void @"$s13back_deployed0A12DeployedFuncyyFTwB"
+// CHECK:   call swiftcc void @"$s13back_deployed0A12DeployedFuncyyF"

--- a/test/IRGen/back_deployed_Onone_transparent.swift
+++ b/test/IRGen/back_deployed_Onone_transparent.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/back_deployed.swift -o %t/ -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-ir %s -I %t -Onone | %FileCheck %s
+
+// _stdlib_isOSVersionAtLeast() is @_transparent on iOS
+// REQUIRES: OS=ios
+
+import back_deployed
+
+public func test() {
+  backDeployedFunc()
+}
+
+// CHECK: define{{.*}} hidden swiftcc void @"$s13back_deployed0A12DeployedFuncyyFTwb"
+// CHECK:   call swiftcc i1 @"$ss31_stdlib_isOSVersionAtLeast_AEICyBi1_Bw_BwBwtF"
+// CHECK:   call swiftcc void @"$s13back_deployed0A12DeployedFuncyyFTwB"
+// CHECK:   call swiftcc void @"$s13back_deployed0A12DeployedFuncyyF"
+
+// CHECK: define{{.*}} hidden swiftcc i1 @"$ss31_stdlib_isOSVersionAtLeast_AEICyBi1_Bw_BwBwtF"
+// CHECK:   call i32 @__isPlatformVersionAtLeast

--- a/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
+++ b/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
@@ -7,6 +7,9 @@
 // this function.
 // UNSUPPORTED: OS=xros
 
+// On iOS _stdlib_isOSVersionAtLeast() is @_transparent, which affects codegen.
+// UNSUPPORTED: OS=ios
+
 @_silgen_name("blackHole")
 func blackHole(_ value: UnsafeMutableRawPointer?) -> Void
 

--- a/test/SILGen/availability_query_maccatalyst_zippered.swift
+++ b/test/SILGen/availability_query_maccatalyst_zippered.swift
@@ -1,11 +1,11 @@
-// RUN: %target-swift-emit-silgen %s -target x86_64-apple-macosx10.52 -target-variant x86_64-apple-ios50.0-macabi | %FileCheck %s
-// RUN: %target-swift-emit-silgen %s -target x86_64-apple-ios50.0-macabi -target-variant x86_64-apple-macosx10.52 | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-macosx10.52 -target-variant %target-cpu-apple-ios50.0-macabi | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-ios50.0-macabi -target-variant %target-cpu-apple-macosx10.52 | %FileCheck %s
 
-// RUN: %target-swift-emit-silgen %s -target x86_64-apple-macosx10.14.4 -target-variant x86_64-apple-ios50.0-macabi | %FileCheck %s --check-prefix=CHECK-BACKDEPLOY-MAC
-// RUN: %target-swift-emit-silgen %s -target x86_64-apple-ios50.0-macabi -target-variant x86_64-apple-macosx10.14.4 | %FileCheck %s --check-prefix=CHECK-BACKDEPLOY-MAC
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-macosx10.14.4 -target-variant %target-cpu-apple-ios50.0-macabi | %FileCheck %s --check-prefix=CHECK-BACKDEPLOY-MAC
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-ios50.0-macabi -target-variant %target-cpu-apple-macosx10.14.4 | %FileCheck %s --check-prefix=CHECK-BACKDEPLOY-MAC
 
-// RUN: %target-swift-emit-silgen %s -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios50.0-macabi | %FileCheck %s --check-prefix=CHECK-DEPLOY10_15-MAC
-// RUN: %target-swift-emit-silgen %s -target x86_64-apple-ios50.0-macabi -target-variant x86_64-apple-macosx10.15 | %FileCheck %s --check-prefix=CHECK-DEPLOY10_15-MAC
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-macosx10.15 -target-variant %target-cpu-apple-ios50.0-macabi | %FileCheck %s --check-prefix=CHECK-DEPLOY10_15-MAC
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-ios50.0-macabi -target-variant %target-cpu-apple-macosx10.15 | %FileCheck %s --check-prefix=CHECK-DEPLOY10_15-MAC
 
 // REQUIRES: OS=macosx || OS=maccatalyst
 


### PR DESCRIPTION
In order for availability checks in iOS apps to be evaluated correctly when running on macOS, the application binary must call a copy of `_stdlib_isOSVersionAtLeast_AEIC()` that was emitted into the app, instead of calling the `_stdlib_isOSVersionAtLeast()` function provided by the standard library. This is because the call to the underlying compiler-rt function `__isPlatformVersionAtLeast()` must be given the correct platform identifier argument; if the call is not emitted into the client, then the macOS platform identifier is used and the iOS version number will be mistakenly interpreted as a macOS version number at runtime.

The `_stdlib_isOSVersionAtLeast()` function in the standard library is marked `@_transparent` on iOS so that its call to `_stdlib_isOSVersionAtLeast_AEIC()` is always inlined into the client. This works for the code generated by normal `if #available` checks, but for the `@backDeployed` function thunks, the calls to `_stdlib_isOSVersionAtLeast()` were not being inlined and that was causing calls to `@backDeployed` functions to crash in iOS apps running on macOS since their availability checks were being misevaluated.

The SIL optimizer has a heuristic which inhibits mandatory inlining in functions that are classified as thunks, in order to save code size. This heuristic needs to be relaxed in `@backDeployed` thunks, so that mandatory inlining of `_stdlib_isOSVersionAtLeast()` can behave as expected. The change should be safe since the only `@_transparent` function a `@backDeployed` thunk is ever expected to call is `_stdlib_isOSVersionAtLeast()`.
    
Resolves rdar://134793410.