### PR TITLE
[cxx-interop] Do not over-release objects returned by synthesized C++ methods

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2112,6 +2112,8 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
   }
   newMethod->setParams(params);
 
+  clang::Sema::SynthesizedFunctionScope scope(clangSema, newMethod);
+
   // Create a new Clang diagnostic pool to capture any diagnostics
   // emitted during the construction of the method.
   clang::sema::DelayedDiagnosticPool diagPool{
@@ -2159,8 +2161,9 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
       clang::SourceLocation());
   if (!memberCall.isUsable())
     return nullptr;
-  auto returnStmt = clang::ReturnStmt::Create(clangCtx, clang::SourceLocation(),
-                                              memberCall.get(), nullptr);
+  auto returnStmt =
+      clangSema.BuildReturnStmt(clang::SourceLocation(), memberCall.get())
+          .get();
 
   // Check if there were any Clang errors during the construction
   // of the method body.

--- a/test/Interop/Cxx/class/inheritance/Inputs/functions-objc.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions-objc.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+@interface C : NSObject
+@end
+
+struct Base {
+  C *_Nonnull non_virtual_method() const;
+  virtual C *_Nonnull virtual_method() const;
+  int a;
+};
+
+struct Derived : Base {};

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -37,3 +37,9 @@ module VirtualMethods {
   header "virtual-methods.h"
   requires cplusplus
 }
+
+module FunctionsObjC {
+  header "functions-objc.h"
+  requires cplusplus
+  requires objc
+}

--- a/test/Interop/Cxx/class/inheritance/functions-objc-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-objc-irgen.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-emit-irgen %s -I %S/Inputs -cxx-interoperability-mode=default -Xcc -fno-exceptions -Xcc -fno-objc-exceptions | %FileCheck %s
+// REQUIRES: objc_interop
+
+import FunctionsObjC
+
+// CHECK: define linkonce_odr noundef ptr @_ZNK7Derived36__synthesizedBaseCall_virtual_methodEv(ptr noundef nonnull align {{4|8}} dereferenceable(12) %[[THIS:.*]])
+// CHECK: %[[THIS_ADDR:.*]] = alloca ptr,
+// CHECK: store ptr %[[THIS]], ptr %[[THIS_ADDR]],
+// CHECK: %[[THIS1:.*]] = load ptr, ptr %[[THIS_ADDR]],
+// CHECK: %[[VTABLE:.*]] = load ptr, ptr %[[THIS1]],
+// CHECK: %[[VFN:.*]] = getelementptr inbounds ptr, ptr %[[VTABLE]], i64 0
+// CHECK: %[[V0:.*]] = load ptr, ptr %[[VFN]],
+// CHECK: %[[CALL:.*]] = call noundef ptr %[[V0]](ptr noundef nonnull
+// CHECK: ret ptr %[[CALL]]
+
+// CHECK: define linkonce_odr noundef ptr @_ZNK7Derived40__synthesizedBaseCall_non_virtual_methodEv(ptr noundef nonnull align {{4|8}} dereferenceable(12) %[[THIS:.*]])
+// CHECK: %[[THIS_ADDR:.*]] = alloca ptr,
+// CHECK: store ptr %[[THIS]], ptr %[[THIS_ADDR]],
+// CHECK: %[[THIS1:.*]] = load ptr, ptr %[[THIS_ADDR]],
+// CHECK: %[[CALL:.*]] = call noundef ptr @_ZNK4Base18non_virtual_methodEv(ptr noundef nonnull
+// CHECK: ret ptr %[[CALL]]
+
+func testBaseMethodCall() -> C {
+  let derived = Derived()
+  return derived.non_virtual_method()
+}
+
+func testBaseVirtualMethodCall() -> C {
+  let derived = Derived()
+  return derived.virtual_method()
+}

--- a/test/Interop/Cxx/class/inheritance/functions-objc-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-objc-irgen.swift
@@ -10,14 +10,14 @@ import FunctionsObjC
 // CHECK: %[[VTABLE:.*]] = load ptr, ptr %[[THIS1]],
 // CHECK: %[[VFN:.*]] = getelementptr inbounds ptr, ptr %[[VTABLE]], i64 0
 // CHECK: %[[V0:.*]] = load ptr, ptr %[[VFN]],
-// CHECK: %[[CALL:.*]] = call noundef ptr %[[V0]](ptr noundef nonnull
+// CHECK: %[[CALL:.*]] = call noundef ptr %[[V0]](ptr noundef nonnull align {{4|8}} dereferenceable(12) %[[THIS1]])
 // CHECK: ret ptr %[[CALL]]
 
 // CHECK: define linkonce_odr noundef ptr @_ZNK7Derived40__synthesizedBaseCall_non_virtual_methodEv(ptr noundef nonnull align {{4|8}} dereferenceable(12) %[[THIS:.*]])
 // CHECK: %[[THIS_ADDR:.*]] = alloca ptr,
 // CHECK: store ptr %[[THIS]], ptr %[[THIS_ADDR]],
 // CHECK: %[[THIS1:.*]] = load ptr, ptr %[[THIS_ADDR]],
-// CHECK: %[[CALL:.*]] = call noundef ptr @_ZNK4Base18non_virtual_methodEv(ptr noundef nonnull
+// CHECK: %[[CALL:.*]] = call noundef ptr @_ZNK4Base18non_virtual_methodEv(ptr noundef nonnull align {{4|8}} dereferenceable(12) %[[THIS1]])
 // CHECK: ret ptr %[[CALL]]
 
 func testBaseMethodCall() -> C {


### PR DESCRIPTION
Call Sema::BuildReturnStmt instead of ReturnStmt::Create so that an implicit cast of kind ARCProduceObject is inserted in the AST.

rdar://133731973