### PR TITLE
[Test] Make timeout.py signal an error when the timeout is hit.

### DIFF
--- a/validation-test/SILOptimizer/large_nested_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_nested_array.swift.gyb
@@ -6,7 +6,11 @@
 // If the compiler needs more than 5 minutes, there is probably a real problem.
 // So please don't just increase the timeout in case this fails.
 
-// RUN: %{python} %S/../../test/Inputs/timeout.py 240 %target-swift-frontend -O -parse-as-library -sil-verify-none -c %t/main.swift -o %t/main.o
+// TEMPORARY NOTE: The timeout has been raised to 2400 seconds while we
+// investigate timeouts in CI runs of this test. This should be set back to the
+// original time of 240 seconds once that's been figured out.
+
+// RUN: %{python} %S/../../test/Inputs/timeout.py 2400 %target-swift-frontend -O -parse-as-library -sil-verify-none -c %t/main.swift -o %t/main.o
 
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: long_test


### PR DESCRIPTION
Print an error message and exit with a non-zero code when we hit the timeout. This makes it clear when a test fails due to a timeout. On Darwin, run `sample` on the target process first, so that the failure includes some information about what the test was doing when the timeout occurred.

This also temporarily increases the timeout for the `large_nested_array.swift.gyb` test, which hits this new louder timeout in CI, while we investigate.