### PR TITLE
Include swift-testing in the Wasm Swift SDK

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swift_testing.py
+++ b/utils/swift_build_support/swift_build_support/products/swift_testing.py
@@ -94,7 +94,9 @@ class SwiftTestingCMakeShim(cmake_product.CMakeProduct):
             if Version(self.args.darwin_deployment_version_osx) < Version('10.15'):
                 override_deployment_version = '10.15'
 
-        self.cmake_options.define('BUILD_SHARED_LIBS', 'YES')
+        build_shared_libs = not host_target.startswith('wasi')
+        self.cmake_options.define('BUILD_SHARED_LIBS',
+                                  'TRUE' if build_shared_libs else 'FALSE')
 
         # Use empty CMake install prefix, since the `DESTDIR` env var is set by
         # `install_with_cmake` later which already has the same prefix.

--- a/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
@@ -14,6 +14,7 @@ import os
 
 from . import product
 from . import wasisysroot
+from .swift_testing import SwiftTestingCMakeShim
 from .wasmstdlib import WasmStdlib, WasmThreadsStdlib
 from .. import shell
 
@@ -37,13 +38,56 @@ class WasmSwiftSDK(product.Product):
     def should_test(self, host_target):
         return False
 
-    def _target_package_path(self, target_triple):
-        return os.path.join(self.build_dir, 'Toolchains', target_triple)
+    def _target_package_path(self, swift_host_triple):
+        return os.path.join(self.build_dir, 'Toolchains', swift_host_triple)
 
-    def _build_target_package(self, target_triple,
-                              stdlib_build_path, llvm_runtime_libs_build_path):
+    def _build_swift_testing(self, swift_host_triple, short_triple, wasi_sysroot):
+        # TODO: We currently build swift-testing outside of SwiftTesting
+        #       build-script product because we build Wasm stdlib outside of
+        #       the main Swift build unit and we can't use build-script's cross
+        #       compilation infrastructure.
+        #       Once stdlib build is decoupled from compiler's CMake build unit
+        #       and we can use different CMake options for different targets
+        #       for stdlib build, we can fully unify library builds with the
+        #       regular path.
+        dest_dir = self._target_package_path(swift_host_triple)
 
-        dest_dir = self._target_package_path(target_triple)
+        swift_testing = SwiftTestingCMakeShim(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir=os.path.join(
+                os.path.dirname(self.source_dir), 'swift-testing'),
+            build_dir=os.path.join(
+                os.path.dirname(self.build_dir),
+                'swift-testing-%s' % short_triple))
+
+        swift_testing.cmake_options.define('CMAKE_SYSTEM_NAME:STRING', 'WASI')
+        swift_testing.cmake_options.define('CMAKE_SYSTEM_PROCESSOR:STRING', 'wasm32')
+        swift_testing.cmake_options.define(
+            'CMAKE_CXX_COMPILER_TARGET', swift_host_triple)
+        swift_testing.cmake_options.define(
+            'CMAKE_Swift_COMPILER_TARGET', swift_host_triple)
+        swift_testing.cmake_options.define('CMAKE_SYSROOT', wasi_sysroot)
+        swift_resource_dir = os.path.join(dest_dir, 'usr', 'lib', 'swift_static')
+        swift_testing.cmake_options.define(
+            'CMAKE_Swift_FLAGS',
+            f'-sdk {wasi_sysroot} -resource-dir {swift_resource_dir}')
+        clang_resource_dir = os.path.join(dest_dir, 'usr', 'lib', 'clang')
+        swift_testing.cmake_options.define(
+            'CMAKE_CXX_FLAGS', f'-resource-dir {clang_resource_dir}')
+        swift_testing.cmake_options.define('CMAKE_Swift_COMPILER_FORCED', 'TRUE')
+        swift_testing.cmake_options.define('CMAKE_CXX_COMPILER_FORCED', 'TRUE')
+
+        swift_testing.build('wasi-wasm32')
+        with shell.pushd(swift_testing.build_dir):
+            shell.call([self.toolchain.cmake, '--install', '.', '--prefix', '/usr'],
+                       env={'DESTDIR': dest_dir})
+
+    def _build_target_package(self, swift_host_triple, short_triple,
+                              stdlib_build_path, llvm_runtime_libs_build_path,
+                              wasi_sysroot):
+
+        dest_dir = self._target_package_path(swift_host_triple)
         shell.rmtree(dest_dir)
         shell.makedirs(dest_dir)
 
@@ -59,6 +103,8 @@ class WasmSwiftSDK(product.Product):
                 shell.call([self.toolchain.cmake, '--install', '.',
                             '--component', 'clang_rt.builtins-wasm32'],
                            env={'DESTDIR': clang_dir})
+        # Build swift-testing
+        self._build_swift_testing(swift_host_triple, short_triple, wasi_sysroot)
 
         return dest_dir
 
@@ -68,16 +114,26 @@ class WasmSwiftSDK(product.Product):
             build_root, '%s-%s' % ('wasmllvmruntimelibs', host_target))
 
         target_packages = []
-        for target_triple, short_triple, build_basename in [
-            ('wasm32-unknown-wasi', 'wasm32-wasi', 'wasmstdlib'),
+        # NOTE: We have three types of target triples:
+        # 1. swift_host_triple: The triple used by the Swift compiler's '-target' option
+        # 2. clang_multiarch_triple: The triple used by Clang to find library
+        #    and header paths from the sysroot
+        #    https://github.com/llvm/llvm-project/blob/73ef397fcba35b7b4239c00bf3e0b4e689ca0add/clang/lib/Driver/ToolChains/WebAssembly.cpp#L29-L36
+        # 3. short_triple: The triple used by build-script to name the build directory
+        for swift_host_triple, clang_multiarch_triple, short_triple, build_basename in [
+            ('wasm32-unknown-wasi', 'wasm32-wasi', 'wasi-wasm32', 'wasmstdlib'),
             # TODO: Enable threads stdlib once sdk-generator supports multi-target SDK
-            # ('wasm32-unknown-wasip1-threads', 'wasmthreadsstdlib'),
+            # ('wasm32-unknown-wasip1-threads', 'wasm32-wasip1-threads',
+            #  'wasip1-threads-wasm32', 'wasmthreadsstdlib'),
         ]:
             stdlib_build_path = os.path.join(
                 build_root, '%s-%s' % (build_basename, host_target))
+            wasi_sysroot = wasisysroot.WASILibc.sysroot_install_path(
+                build_root, clang_multiarch_triple)
             package_path = self._build_target_package(
-                target_triple, stdlib_build_path, llvm_runtime_libs_build_path)
-            target_packages.append((target_triple, package_path))
+                swift_host_triple, short_triple, stdlib_build_path,
+                llvm_runtime_libs_build_path, wasi_sysroot)
+            target_packages.append((swift_host_triple, wasi_sysroot, package_path))
 
         swiftc_path = os.path.abspath(self.toolchain.swiftc)
         toolchain_path = os.path.dirname(os.path.dirname(swiftc_path))
@@ -93,11 +149,9 @@ class WasmSwiftSDK(product.Product):
             'make-wasm-sdk',
             '--swift-version', swift_version,
         ]
-        for target_triple, package_path in target_packages:
-            run_args.extend(['--target', target_triple])
+        for swift_host_triple, wasi_sysroot, package_path in target_packages:
+            run_args.extend(['--target', swift_host_triple])
             run_args.extend(['--target-swift-package-path', package_path])
-            wasi_sysroot = wasisysroot.WASILibc.sysroot_install_path(
-                build_root, short_triple)
             run_args.extend(['--wasi-sysroot', wasi_sysroot])
 
         env = dict(os.environ)


### PR DESCRIPTION
This change adds build support for swift-testing in the Wasm Swift SDK. Unfortunately, we can't use the regular SwiftTesting build-script product because Wasm build cannot use build-script's cross-compilation infrastructure for now. So we build swift-testing in WasmSwiftSDK product and install it to the SDK package.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
