### PR TITLE
ComputeSideEffects: fix a corner case with consuming indirect arguments in dead-end functions

### DIFF
--- a/test/SILOptimizer/generic_specialization.swift
+++ b/test/SILOptimizer/generic_specialization.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=function-signature-opts -emit-sil -primary-file %s | %FileCheck %s
+
+public struct S {
+  @inline(never)
+  init<T>(_ t: T) {
+    fatalError()
+  }
+}
+
+// check that this doesn't cause a memory lifetime failure
+
+// CHECK-LABEL: sil @$s22generic_specialization6testityAA1SVSSF :
+// CHECK:          [[F:%.*]] = function_ref @$s22generic_specialization1SVyACxclufCSS_Tt0g5 :
+// CHECK:            = apply [[F]](%0) : $@convention(thin) (@owned String) -> S
+// CHECK:       } // end sil function '$s22generic_specialization6testityAA1SVSSF'
+public func testit(_ s: String) -> S {
+  return S(s)
+}
+

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -1234,3 +1234,12 @@ bb0(%0 : $SP):
   %r = tuple ()
   return %r : $()
 }
+
+// CHECK-LABEL: sil @test_consuming_in_with_unreachable
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @test_consuming_in_with_unreachable : $@convention(thin) (@in X) -> () {
+bb0(%0 : $*X):
+  unreachable
+}


### PR DESCRIPTION
Usually there _must_ be a read from a consuming in-argument, because the function has to consume the argument. But in the special case if all control paths end up in an `unreachable`, the consuming read might have been dead-code eliminated. Therefore make sure to add the read-effect in any case. Otherwise it can result in memory lifetime failures at a call site.

fixes a memory lifetime failure

rdar://134881045
