### PR TITLE
Ensure that the source buffer passed to #if evaluation contains the condition

### DIFF
--- a/test/SourceKit/ConformingMethods/ifconfigcrash.swift
+++ b/test/SourceKit/ConformingMethods/ifconfigcrash.swift
@@ -1,0 +1,10 @@
+var description: String {
+
+func test() {}
+
+#if compiler()
+#endif
+
+
+// RUN: %sourcekitd-test -req=conformingmethods -pos=3:6 -repeat-request=2 %s -- %s
+  


### PR DESCRIPTION
The implementation of `#if` configuration evaluation assumed that the SourceFile instance within the `Parser` contained all of the source ranges for code parsed within that `Parser` instance. This is not always the case, so avoid using the SourceFile directly and instead use the source buffer that directly contains the condition.

Fixes https://github.com/swiftlang/swift/issues/76137. Big thank you to Alex Hoppen and the stress tester for finding this.
