### PR TITLE
SIL: Print thunk kind attribute for `@backDeployed` thunks

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -1177,6 +1177,7 @@ information when inlined.
   sil-function-thunk ::= 'thunk'
   sil-function-thunk ::= 'signature_optimized_thunk'
   sil-function-thunk ::= 'reabstraction_thunk'
+  sil-function-thunk ::= 'back_deployed_thunk'
 
 The function is a compiler generated thunk.
 ::

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3387,7 +3387,9 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
 
   switch (isThunk()) {
   case IsNotThunk: break;
-  case IsBackDeployedThunk: // FIXME: Give this a distinct label
+  case IsBackDeployedThunk:
+      OS << "[back_deployed_thunk] ";
+      break;
   case IsThunk: OS << "[thunk] "; break;
   case IsSignatureOptimizedThunk:
     OS << "[signature_optimized_thunk] ";

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -729,6 +729,8 @@ static bool parseDeclSILOptional(
       *isThunk = IsSignatureOptimizedThunk;
     else if (isThunk && SP.P.Tok.getText() == "reabstraction_thunk")
       *isThunk = IsReabstractionThunk;
+    else if (isThunk && SP.P.Tok.getText() == "back_deployed_thunk")
+      *isThunk = IsBackDeployedThunk;
     else if (isWithoutActuallyEscapingThunk
              && SP.P.Tok.getText() == "without_actually_escaping")
       *isWithoutActuallyEscapingThunk = true;

--- a/test/SILGen/back_deployed_attr.swift
+++ b/test/SILGen/back_deployed_attr.swift
@@ -7,7 +7,7 @@
 // REQUIRES: OS=macosx
 
 // CHECK: sil non_abi [serialized] [ossa] @$s11back_deploy8someFuncyyFTwB
-// CHECK: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy8someFuncyyFTwb
+// CHECK: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy8someFuncyyFTwb
 // CHECK: sil [available 10.52] [ossa] @$s11back_deploy8someFuncyyF
 @backDeployed(before: macOS 10.52)
 public func someFunc() {}

--- a/test/SILGen/back_deployed_attr_accessor.swift
+++ b/test/SILGen/back_deployed_attr_accessor.swift
@@ -11,7 +11,7 @@ public struct TopLevelStruct {
   // CHECK:   return [[SELF]] : $TopLevelStruct
 
   // -- Back deployment thunk for TopLevelStruct.property.getter
-  // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvgTwb : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  // CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvgTwb : $@convention(method) (TopLevelStruct) -> TopLevelStruct
   // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
   // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
   // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1

--- a/test/SILGen/back_deployed_attr_accessor_coroutine.swift
+++ b/test/SILGen/back_deployed_attr_accessor_coroutine.swift
@@ -18,7 +18,7 @@ public struct TopLevelStruct {
   // CHECK:   unwind
 
   // -- Back deployment thunk for TopLevelStruct.property.read
-  // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvrTwb : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  // CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvrTwb : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
   // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
   // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
   // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1

--- a/test/SILGen/back_deployed_attr_async_func.swift
+++ b/test/SILGen/back_deployed_attr_async_func.swift
@@ -17,7 +17,7 @@
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for trivialFunc()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy9asyncFuncyyYaFTwb : $@convention(thin) @async () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy9asyncFuncyyYaFTwb : $@convention(thin) @async () -> ()
 // CHECK: bb0:
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1

--- a/test/SILGen/back_deployed_attr_func.swift
+++ b/test/SILGen/back_deployed_attr_func.swift
@@ -11,7 +11,7 @@
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for trivialFunc()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy11trivialFuncyyFTwb : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy11trivialFuncyyFTwb : $@convention(thin) () -> ()
 // CHECK: bb0:
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
@@ -46,7 +46,7 @@ public func trivialFunc() {}
 // CHECK:   return {{%.*}} : $Bool
 
 // -- Back deployment thunk for isNumber(_:)
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy8isNumberySbSiFTwb : $@convention(thin) (Int) -> Bool
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy8isNumberySbSiFTwb : $@convention(thin) (Int) -> Bool
 // CHECK: bb0([[ARG_X:%.*]] : $Int):
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1

--- a/test/SILGen/back_deployed_attr_generic_func.swift
+++ b/test/SILGen/back_deployed_attr_generic_func.swift
@@ -12,7 +12,7 @@
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for genericFunc(_:)
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy11genericFuncyxxlFTwb : $@convention(thin) <T> (@in_guaranteed T) -> @out T
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy11genericFuncyxxlFTwb : $@convention(thin) <T> (@in_guaranteed T) -> @out T
 // CHECK: bb0([[OUT_ARG:%.*]] : $*T, [[IN_ARG:%.*]] : $*T):
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
@@ -50,7 +50,7 @@ public func genericFunc<T>(_ t: T) -> T {
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for genericFuncWithOwnedParam(_:)
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy25genericFuncWithOwnedParamyyxnlFTwb : $@convention(thin) <T> (@in T) -> ()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy25genericFuncWithOwnedParamyyxnlFTwb : $@convention(thin) <T> (@in T) -> ()
 // CHECK: bb0([[IN_ARG:%.*]] : $*T):
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1

--- a/test/SILGen/back_deployed_attr_maccatalyst_zippered.swift
+++ b/test/SILGen/back_deployed_attr_maccatalyst_zippered.swift
@@ -10,7 +10,7 @@
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for trivialFunc_iOS()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy15trivialFunc_iOSyyFTwb : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy15trivialFunc_iOSyyFTwb : $@convention(thin) () -> ()
 // CHECK: bb0:
 // CHECK:   [[IOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 51
 // CHECK:   [[IOS_MINOR:%.*]] = integer_literal $Builtin.Word, 1
@@ -45,7 +45,7 @@ public func trivialFunc_iOS() {}
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for trivialFunc_macOS()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy17trivialFunc_macOSyyFTwb : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy17trivialFunc_macOSyyFTwb : $@convention(thin) () -> ()
 // CHECK: bb0:
 // CHECK:   [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
 // CHECK:   [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 53
@@ -80,7 +80,7 @@ public func trivialFunc_macOS() {}
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for trivialFunc_iOS_macOS()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy019trivialFunc_iOS_macE0yyFTwb : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy019trivialFunc_iOS_macE0yyFTwb : $@convention(thin) () -> ()
 // CHECK: bb0:
 // CHECK:   [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
 // CHECK:   [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 53

--- a/test/SILGen/back_deployed_attr_struct_init.swift
+++ b/test/SILGen/back_deployed_attr_struct_init.swift
@@ -30,7 +30,7 @@ public struct TopLevelStruct<T> {
   // CHECK:   return [[RESULT]] : $()
 
   // -- Back deployment thunk for TopLevelStruct.init(_:)
-  // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy14TopLevelStructVyACyxGxcfCTwb : $@convention(method) <T> (@in T, @thin TopLevelStruct<T>.Type) -> @out TopLevelStruct<T>
+  // CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy14TopLevelStructVyACyxGxcfCTwb : $@convention(method) <T> (@in T, @thin TopLevelStruct<T>.Type) -> @out TopLevelStruct<T>
   // CHECK: bb0([[SELF_OUT:%.*]] : $*TopLevelStruct<T>, [[T_ARG:%.*]] : $*T, [[METATYPE_ARG:%.*]] : $@thin TopLevelStruct<T>.Type):
   // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
   // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1

--- a/test/SILGen/back_deployed_attr_struct_method.swift
+++ b/test/SILGen/back_deployed_attr_struct_method.swift
@@ -12,7 +12,7 @@ public struct TopLevelStruct {
   // CHECK:   return [[RESULT]] : $()
 
   // -- Back deployment thunk for TopLevelStruct.trivialMethod()
-  // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyFTwb : $@convention(method) (TopLevelStruct) -> ()
+  // CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyFTwb : $@convention(method) (TopLevelStruct) -> ()
   // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
   // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
   // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1

--- a/test/SILGen/back_deployed_attr_throwing_func.swift
+++ b/test/SILGen/back_deployed_attr_throwing_func.swift
@@ -11,7 +11,7 @@
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for throwingFunc()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy12throwingFuncyyKFTwb : $@convention(thin) () -> @error any Error
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy12throwingFuncyyKFTwb : $@convention(thin) () -> @error any Error
 // CHECK: bb0:
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1


### PR DESCRIPTION
As promised in the FIXME, update the SIL printer and parser to handle the new thunk kind for `@backDeployed` thunks.

Follow up to https://github.com/swiftlang/swift/pull/76135.
