### PR TITLE
[cxx-interop] Do not export enums with indirect associated values

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -264,6 +264,8 @@ swift::cxx_translation::getDeclRepresentation(const ValueDecl *VD) {
       for (const auto *elementDecl : enumCase->getElements()) {
         if (!elementDecl->hasAssociatedValues())
           continue;
+        if (elementDecl->isIndirect())
+          return {Unsupported, UnrepresentableIndirectEnum};
         // Do not expose any enums with > 1
         // enum parameter, or any enum parameter
         // whose type we do not yet support.

--- a/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
@@ -33,6 +33,11 @@ public enum E2 {
     case baz
 }
 
+public enum Expr {
+    case Const(Int)
+    indirect case Neg(Expr)
+}
+
 public struct S {
     public var x: Int64
     


### PR DESCRIPTION
We do not support any sort of indirect enums yet, the code gets into an infinite recursion. Let's skip exporting these types to C++ for now until proper support is implemented.

rdar://134852756
