### PR TITLE
[cxx-interop] Do not attempt to export read accessors to C++

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2069,9 +2069,10 @@ private:
     if (outputLang == OutputLanguageMode::Cxx) {
       if (!SD->isInstanceMember())
         return;
-      auto *getter = SD->getOpaqueAccessor(AccessorKind::Get);
-      printAbstractFunctionAsMethod(getter, false,
-                                    /*isNSUIntegerSubscript=*/false, SD);
+      // TODO: support read accessors.
+      if (auto *getter = SD->getOpaqueAccessor(AccessorKind::Get))
+        printAbstractFunctionAsMethod(getter, false,
+                                      /*isNSUIntegerSubscript=*/false, SD);
       return;
     }
     assert(SD->isInstanceMember() && "static subscripts not supported");

--- a/test/Interop/SwiftToCxx/functions/swift-operators.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-operators.swift
@@ -25,6 +25,19 @@ public struct IntBox {
   } 
 }
 
+public struct CustomArray<Element> where Element : ~Copyable {
+  private var buffer: UnsafeMutableBufferPointer<Element>
+
+  public subscript(index: Int) -> Element {
+    _read {
+        yield buffer[index]
+    }
+    nonmutating _modify {
+        yield &buffer[index]
+    }
+  }
+}
+
 // CHECK: #if __cplusplus >= 202302L
 // CHECK-NEXT: SWIFT_INLINE_THUNK int operator [](int x, int _2) const SWIFT_SYMBOL("s:9Operators6IntBoxVys5Int32VAE_AEtcig");
 // CHECK-NEXT: #endif // #if __cplusplus >= 202302L


### PR DESCRIPTION
This triggers a crash. Unfortunately, adding support is not that straightforward so skipping these accessors for now.

rdar://134425834
