### PR TITLE
[ConstraintSystem] Introduce `LValueObject` constraint to replace direct l-value assignments

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -221,6 +221,8 @@ enum class ConstraintKind : char {
   /// The first type is a tuple containing a single unlabeled element that is a
   /// pack expansion. The second type is its pattern type.
   MaterializePackExpansion,
+  /// The first type is a l-value type whose object type is the second type.
+  LValueObject,
 };
 
 /// Classification of the different kinds of constraints.
@@ -691,6 +693,7 @@ public:
     case ConstraintKind::PackElementOf:
     case ConstraintKind::SameShape:
     case ConstraintKind::MaterializePackExpansion:
+    case ConstraintKind::LValueObject:
       return ConstraintClassification::Relational;
 
     case ConstraintKind::ValueMember:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5239,6 +5239,12 @@ private:
                                              TypeMatchOptions flags,
                                              ConstraintLocatorBuilder locator);
 
+  /// Extract the object type of the l-value type (type1) and bind it to
+  /// to type2.
+  SolutionKind simplifyLValueObjectConstraint(Type type1, Type type2,
+                                              TypeMatchOptions flags,
+                                              ConstraintLocatorBuilder locator);
+
 public: // FIXME: Public for use by static functions.
   /// Simplify a conversion constraint with a fix applied to it.
   SolutionKind simplifyFixConstraint(ConstraintFix *fix, Type type1, Type type2,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1318,30 +1318,7 @@ bool BindingSet::favoredOverDisjunction(Constraint *disjunction) const {
     // Such type variables might be connected to closure as well
     // e.g. when result type is optional, so it makes sense to
     // open closure before attempting such disjunction.
-    if (auto *typeVar = boundType->lookThroughAllOptionalTypes()
-                            ->getAs<TypeVariableType>()) {
-      auto fixedType = CS.getFixedType(typeVar);
-      // Handles "assignment to an overloaded member" pattern where
-      // type variable that represents the destination is bound to an
-      // l-value type during constraint generation. See \c genAssignDestType.
-      //
-      // Note that in all other circumstances we won't be here if the
-      // type variable that presents the closure is connected to a
-      // disjunction because that would mark closure as "delayed".
-      if (fixedType && fixedType->is<LValueType>()) {
-        auto lvalueObjTy = fixedType->castTo<LValueType>()->getObjectType();
-        // Prefer closure only if it's not connected to the type variable
-        // that represents l-value object type of the assignment destination.
-        // Eagerly attempting closure first could result in missing some of
-        // the contextual annotations i.e. `@Sendable`.
-        if (auto *lvalueObjVar = lvalueObjTy->getAs<TypeVariableType>())
-          return !AdjacentVars.count(lvalueObjVar);
-      }
-
-      return true;
-    }
-
-    return false;
+    return boundType->lookThroughAllOptionalTypes()->is<TypeVariableType>();
   }
 
   // If this is a collection literal type, it's preferrable to bind it
@@ -1574,6 +1551,18 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
           return std::nullopt;
         }
       }
+    }
+  }
+
+  // Situations like `v.<member> = { ... }` where member is overloaded.
+  // We need to wait until member is resolved otherwise there is a risk
+  // of losing some of the contextual attributes important for the closure
+  // such as @Sendable and global actor.
+  if (TypeVar->getImpl().isClosureType() &&
+      kind == AllowedBindingKind::Subtypes) {
+    if (type->isTypeVariableOrMember() &&
+        constraint->getLocator()->directlyAt<AssignExpr>()) {
+      DelayedBy.push_back(constraint);
     }
   }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1594,7 +1594,7 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
       if (type->isTypeVariableOrMember())
         return std::nullopt;
 
-     type = LValueType::get(type);
+      type = LValueType::get(type);
     } else {
       // Right-hand side of the l-value object constraint can only
       // be bound via constraint simplification when l-value type

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1797,6 +1797,11 @@ void PotentialBindings::infer(Constraint *constraint) {
     // Constraints from which we can't do anything.
     break;
 
+  case ConstraintKind::LValueObject: {
+    DelayedBy.push_back(constraint);
+    break;
+  }
+
   // For now let's avoid inferring protocol requirements from
   // this constraint, but in the future we could do that to
   // to filter bindings.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3510,23 +3510,10 @@ namespace {
       } else {
         auto *locator = CS.getConstraintLocator(expr);
 
-        auto isOrCanBeLValueType = [](Type type) {
-          if (auto *typeVar = type->getAs<TypeVariableType>()) {
-            return typeVar->getImpl().canBindToLValue();
-          }
-          return type->is<LValueType>();
-        };
-
         auto exprType = CS.getType(expr);
-        if (!isOrCanBeLValueType(exprType)) {
-          // Pretend that destination is an l-value type.
-          exprType = LValueType::get(exprType);
-          (void)CS.recordFix(TreatRValueAsLValue::create(CS, locator));
-        }
-
         auto *destTy = CS.createTypeVariable(locator, TVO_CanBindToNoEscape);
-        CS.addConstraint(ConstraintKind::Bind, LValueType::get(destTy),
-                         exprType, locator);
+        CS.addConstraint(ConstraintKind::LValueObject, exprType, destTy,
+                         locator);
         return destTy;
       }
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14178,6 +14178,14 @@ ConstraintSystem::simplifyLValueObjectConstraint(
     return type->is<LValueType>();
   };
 
+  if (lvalueTy->isPlaceholder()) {
+    if (!shouldAttemptFixes())
+      return SolutionKind::Error;
+
+    recordAnyTypeVarAsPotentialHole(type2);
+    return SolutionKind::Solved;
+  }
+
   if (!isOrCanBeLValueType(lvalueTy)) {
     if (!shouldAttemptFixes())
       return SolutionKind::Error;

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -85,6 +85,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::SameShape:
   case ConstraintKind::MaterializePackExpansion:
+  case ConstraintKind::LValueObject:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -176,6 +177,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::SameShape:
   case ConstraintKind::MaterializePackExpansion:
+  case ConstraintKind::LValueObject:
     llvm_unreachable("Wrong constructor");
 
   case ConstraintKind::KeyPath:
@@ -326,6 +328,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::SameShape:
   case ConstraintKind::MaterializePackExpansion:
+  case ConstraintKind::LValueObject:
     return create(cs, getKind(), getFirstType(), getSecondType(), getLocator());
 
   case ConstraintKind::ApplicableFunction:
@@ -590,6 +593,10 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
     Out << " materialize pack expansion ";
     break;
 
+  case ConstraintKind::LValueObject:
+    Out << " l-value object type ";
+    break;
+
   case ConstraintKind::Disjunction:
     llvm_unreachable("disjunction handled above");
   case ConstraintKind::Conjunction:
@@ -760,6 +767,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::SameShape:
   case ConstraintKind::MaterializePackExpansion:
+  case ConstraintKind::LValueObject:
     constraint->getFirstType()->getTypeVariables(typeVars);
     constraint->getSecondType()->getTypeVariables(typeVars);
     break;

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -647,6 +647,7 @@ func r23560128() {
   var a : (Int,Int)?
   a.0 = 42 // expected-error{{value of optional type '(Int, Int)?' must be unwrapped to refer to member '0' of wrapped base type '(Int, Int)'}}
   // expected-note@-1{{chain the optional }}
+  // expected-note@-2 {{force-unwrap using '!' }}
 }
 
 // <rdar://problem/21890157> QoI: wrong error message when accessing properties on optional structs without unwrapping
@@ -656,6 +657,7 @@ struct ExampleStruct21890157 {
 var example21890157: ExampleStruct21890157?
 example21890157.property = "confusing"  // expected-error {{value of optional type 'ExampleStruct21890157?' must be unwrapped to refer to member 'property' of wrapped base type 'ExampleStruct21890157'}}
   // expected-note@-1{{chain the optional }}
+  // expected-note@-2 {{force-unwrap using '!' }}
 
 
 struct UnaryOp {}

--- a/test/ImportResolution/import-resolution-overload.swift
+++ b/test/ImportResolution/import-resolution-overload.swift
@@ -46,7 +46,8 @@ scopedFunction = 42
 // FIXME: Should be an error -- a type name and a function cannot overload.
 var _ : Int = TypeNameWins(42)
 
-TypeNameWins = 42 // expected-error {{cannot assign to immutable expression of type 'Int'}}
+// FIXME: This should be an ambiguity where both candidates are mentioned as notes.
+TypeNameWins = 42 // expected-error {{cannot assign to immutable expression of type '(Int) -> Int'}}
 var _ : TypeNameWins // no-warning
 
 // rdar://problem/21739333

--- a/validation-test/Sema/SwiftUI/rdar84580119.swift
+++ b/validation-test/Sema/SwiftUI/rdar84580119.swift
@@ -14,7 +14,7 @@ extension EnvironmentValues {
   var myHorizontalAlignment: AlignmentID? {
     get { fatalError() }
     set { self[\.MyHorizontalAlignmentEnvironmentKey.self] = newValue }
-    // expected-error@-1 {{generic parameter 'K' could not be inferred}}
+    // expected-error@-1 {{subscript 'subscript(_:)' requires that 'any AlignmentID' be a class type}}
     // expected-error@-2 {{cannot infer key path type from context; consider explicitly specifying a root type}}
   }
 }


### PR DESCRIPTION
Instead having to eagerly bind type variables to l-value types
like it currently happens during constraint generation for assignment
expressions, let's use new `LValueObject` constraint (similar to
`OptionalObject` constraint) to set "object" type once l-value gets
resolved, this allows the solver to infer types and/or resolve overloads 
during solving and detect failures related to l-value in one spot.

This makes mismatches easier to diagnose during solving and allows
to simplify some of the logic in constraint generator, inference, and 
disjunction favoring.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
