### PR TITLE
[6.0] build-script: Copy `libclang_rt.a` from the host toolchain for visionOS

### DIFF
--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -37,7 +37,7 @@ import SwiftShims
 /// interpreter doesn't currently know how to load symbols from compiler-rt.
 /// Since `@_transparent` is only necessary for iOS apps, we only apply it on
 /// iOS, not any other which would inherit/remap iOS availability.
-#if os(iOS) && !os(xrOS)
+#if os(iOS) && !os(visionOS)
 @_effects(readnone)
 @_transparent
 public func _stdlib_isOSVersionAtLeast(

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -134,7 +134,7 @@ class LLVM(cmake_product.CMakeProduct):
                       ' into the local clang build directory {}.'.format(
                           host_cxx_builtins_dir, dest_builtins_dir))
 
-                for _os in ['ios', 'watchos', 'tvos']:
+                for _os in ['ios', 'watchos', 'tvos', 'xros']:
                     # Copy over the device .a when necessary
                     lib_name = 'libclang_rt.{}.a'.format(_os)
                     host_lib_path = os.path.join(host_cxx_builtins_dir, lib_name)


### PR DESCRIPTION
- **Explanation:** The toolchain build has been broken since https://github.com/swiftlang/swift/pull/76140 landed. It turns out that the toolchain build has not been copying `libclang_rt.a` out of the host SDK for visionOS builds, which did not matter until the stdlib began using `__isPlatformVersionAtLeast`, which comes from `libclang_rt`. Also, an `#if os` conditional in #76140 was incorrectly specified.
- **Scope:** Unblocks the toolchain build.
- **Issue/Radar:** rdar://135023111
- **Original PR:** https://github.com/swiftlang/swift/pull/76177
- **Risk:** Low, should only affect whether the toolchain build succeeds.
- **Testing:** Invoking the swift-ci toolchain build.
- **Reviewer:** @shahmishal