### PR TITLE
build-script: Copy `libclang_rt.a` from the host toolchain for visionOS

### DIFF
--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -37,7 +37,7 @@ import SwiftShims
 /// interpreter doesn't currently know how to load symbols from compiler-rt.
 /// Since `@_transparent` is only necessary for iOS apps, we only apply it on
 /// iOS, not any other which would inherit/remap iOS availability.
-#if os(iOS) && !os(xrOS)
+#if os(iOS) && !os(visionOS)
 @_effects(readnone)
 @_transparent
 public func _stdlib_isOSVersionAtLeast(

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -134,7 +134,7 @@ class LLVM(cmake_product.CMakeProduct):
                       ' into the local clang build directory {}.'.format(
                           host_cxx_builtins_dir, dest_builtins_dir))
 
-                for _os in ['ios', 'watchos', 'tvos']:
+                for _os in ['ios', 'watchos', 'tvos', 'xros']:
                     # Copy over the device .a when necessary
                     lib_name = 'libclang_rt.{}.a'.format(_os)
                     host_lib_path = os.path.join(host_cxx_builtins_dir, lib_name)


### PR DESCRIPTION
During the toolchain build, when building the Swift standard library for platforms other than macOS the `libclang_rt.a` needs to be copied out of the host SDK. That wasn't happening for visionOS.

Resolves rdar://135023111.
