### PR TITLE
[Sema] Move SingleValueStmtUsageChecker into pre-checking

### DIFF
--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -40,7 +40,7 @@ add_swift_host_library(swiftSema STATIC
   MiscDiagnostics.cpp
   PCMacro.cpp
   PlaygroundTransform.cpp
-  PreCheckExpr.cpp
+  PreCheckTarget.cpp
   ResilienceDiagnostics.cpp
   SourceLoader.cpp
   SyntacticElementTarget.cpp

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -38,21 +38,9 @@ namespace swift {
   class ValueDecl;
   class ForEachStmt;
 
-/// Diagnose any expressions that appear in an unsupported position. If visiting
-/// an expression directly, its \p contextualPurpose should be provided to
-/// evaluate its position.
-  void diagnoseOutOfPlaceExprs(
-      ASTContext &ctx, ASTNode root,
-      std::optional<ContextualTypePurpose> contextualPurpose);
-
   /// Emit diagnostics for syntactic restrictions on a given expression.
-  ///
-  /// Note: \p contextualPurpose must be non-nil, unless
-  /// \p disableOutOfPlaceExprChecking is set to \c true.
-  void performSyntacticExprDiagnostics(
-      const Expr *E, const DeclContext *DC,
-      std::optional<ContextualTypePurpose> contextualPurpose, bool isExprStmt,
-      bool disableOutOfPlaceExprChecking = false);
+  void performSyntacticExprDiagnostics(const Expr *E, const DeclContext *DC,
+                                       bool isExprStmt);
 
   /// Emit diagnostics for a given statement.
   void performStmtDiagnostics(const Stmt *S, DeclContext *DC);

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -1107,8 +1107,6 @@ public:
 
   bool walkToClosureExprPre(ClosureExpr *expr);
 
-  bool shouldWalkCaptureInitializerExpressions() override { return true; }
-
   MacroWalking getMacroWalkingBehavior() const override {
     return MacroWalking::Arguments;
   }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1158,6 +1158,8 @@ func rdar77022842(argA: Bool? = nil, argB: Bool? = nil) {
     // expected-error@-1 {{initializer for conditional binding must have Optional type, not 'Bool'}}
     // expected-error@-2 {{closure passed to parameter of type 'Bool?' that does not accept a closure}}
     // expected-error@-3 {{cannot convert value of type 'Void' to expected condition type 'Bool'}}
+    // expected-error@-4 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+    // expected-error@-5 {{'if' must have an unconditional 'else' to be used as expression}}
   } // expected-error {{expected '{' after 'if' condition}}
 }
 

--- a/test/Constraints/if_expr.swift
+++ b/test/Constraints/if_expr.swift
@@ -384,8 +384,10 @@ func testVoidConversion() {
 
 func testReturnMismatch() {
   let _ = if .random() {
-    return 1 // expected-error {{unexpected non-void return value in void function}}
-    // expected-note@-1 {{did you mean to add a return type?}}
+    return 1
+    // expected-error@-1 {{cannot use 'return' to transfer control out of 'if' expression}}
+    // expected-error@-2 {{unexpected non-void return value in void function}}
+    // expected-note@-3 {{did you mean to add a return type?}}
   } else {
     0
   }
@@ -433,7 +435,9 @@ func testAssignment() {
 }
 
 struct TestBadReturn {
-  var y = if .random() { return } else { 0 } // expected-error {{return invalid outside of a func}}
+  var y = if .random() { return } else { 0 }
+  // expected-error@-1 {{return invalid outside of a func}}
+  // expected-error@-2 {{cannot use 'return' to transfer control out of 'if' expression}}
 }
 
 struct SomeError: Error {}

--- a/test/Constraints/rdar114402042.swift
+++ b/test/Constraints/rdar114402042.swift
@@ -23,10 +23,10 @@ func baz() -> String? {
 var x: Int? = {
   print( // expected-error {{cannot convert value of type '()' to closure result type 'Int?'}}
     // expected-note@-1 {{to match this opening '('}}
-    switch baz() {
+    switch baz() { // expected-error {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
     case ""?:
-        return nil
+        return nil // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
     default:
-        return nil
+        return nil // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
     }
 }() // expected-error {{expected ')' in expression list}}

--- a/test/Constraints/switch_expr.swift
+++ b/test/Constraints/switch_expr.swift
@@ -191,7 +191,9 @@ func testAssignment() {
 }
 
 struct TestBadReturn {
-  var y = switch Bool.random() { case true: return case false: 0 } // expected-error {{return invalid outside of a func}}
+  var y = switch Bool.random() { case true: return case false: 0 }
+  // expected-error@-1 {{return invalid outside of a func}}
+  // expected-error@-2 {{cannot use 'return' to transfer control out of 'switch' expression}}
 }
 
 func testNil1(_ x: Bool) {

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -82,6 +82,8 @@ func missingControllingExprInIf() {
   if { // expected-error {{missing condition in 'if' statement}}
   } // expected-error {{expected '{' after 'if' condition}}
   // expected-error@-2 {{cannot convert value of type 'Void' to expected condition type 'Bool'}}
+  // expected-error@-3 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+  // expected-error@-4 {{'if' must have an unconditional 'else' to be used as expression}}
 
   if // expected-error {{missing condition in 'if' statement}}
   {
@@ -239,6 +241,7 @@ func missingControllingExprInSwitch() {
 
   switch { // expected-error {{expected expression in 'switch' statement}}
   } // expected-error {{expected '{' after 'switch' subject expression}}
+  // expected-error@-2 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 
   switch // expected-error {{expected expression in 'switch' statement}} expected-error {{'switch' statement body must have at least one 'case' or 'default' block}}
   {

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -116,12 +116,14 @@ takesValue(if .random() { 0 } else { 1 })
 do {
   takesValue(x: if .random() { 0 } else { 1 })
   // expected-error@-1 {{extraneous argument label 'x:' in call}}
+  // expected-error@-2 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 
   takesValue(_: x: if .random() { 0 } else { 1 })
   // expected-error@-1 {{expected argument label before colon}}
   // expected-error@-2 {{expected ',' separator}}
   // expected-error@-3 {{cannot find 'x' in scope}}
   // expected-error@-4 {{extra argument in call}}
+  // expected-error@-5 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 }
 func takesValueWithLabel<T>(x: T) {}
 do {
@@ -133,6 +135,7 @@ do {
   // expected-error@-2 {{expected ',' separator}}
   // expected-error@-3 {{cannot find 'y' in scope}}
   // expected-error@-4 {{extra argument in call}}
+  // expected-error@-5 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 }
 func takesValueAndTrailingClosure<T>(_ x: T, _ fn: () -> Int) {}
 takesValueAndTrailingClosure(if .random() { 0 } else { 1 }) { 2 }
@@ -141,6 +144,7 @@ takesValueAndTrailingClosure(if .random() { 0 } else { 1 }) { 2 }
 func takesInOut<T>(_ x: inout T) {}
 takesInOut(&if .random() { 1 } else { 2 })
 // expected-error@-1 {{cannot pass immutable value of type 'Int' as inout argument}}
+// expected-error@-2 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 
 struct HasSubscript {
   static subscript(x: Int) -> Void { () }
@@ -462,6 +466,9 @@ let o = !if .random() { true } else { false }  // expected-error {{'if' may only
 let p = if .random() { 1 } else { 2 } + // expected-error {{ambiguous use of operator '+'}}
         if .random() { 3 } else { 4 } +
         if .random() { 5 } else { 6 }
+// expected-error@-3 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+// expected-error@-3 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+// expected-error@-3 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 
 let p1 = if .random() { 1 } else { 2 } +  5
 // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
@@ -504,6 +511,7 @@ do {
   // FIXME: The type error is likely due to not solving the conjunction before attempting default type var bindings.
   let _ = (if .random() { Int?.none } else { 1 as Int? })?.bitWidth
   // expected-error@-1 {{type of expression is ambiguous without a type annotation}}
+  // expected-error@-2 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 }
 do {
   let _ = if .random() { Int?.none } else { 1 as Int? }!
@@ -578,6 +586,8 @@ func stmts() {
   for _ in if .random() { [true] } else { [false] } {}
   // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 
+  for _ in if .random() { [true] } else { [false] } {} // expected-error {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+
   // Make sure this doesn't parse as an if expr pattern with a label.
   let x = 0
   switch 0 {
@@ -609,9 +619,9 @@ func returnBranches() -> Int {
 
 func returnBranches1() -> Int {
   return if .random() { // expected-error {{cannot convert return expression of type 'Void' to return type 'Int'}}
-    return 0
+    return 0 // expected-error {{cannot use 'return' to transfer control out of 'if' expression}}
   } else {
-    return 1
+    return 1 // expected-error {{cannot use 'return' to transfer control out of 'if' expression}}
   }
 }
 

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -557,14 +557,26 @@ func stmts() {
     return
   }
 
-  switch if .random() { true } else { false } { // expected-error {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
-  case _ where if .random() { true } else { false }: // expected-error {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+  switch if .random() { true } else { false } {
+    // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+  case _ where if .random() { true } else { false }:
+    // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+    break
+  case if .random() { true } else { false }:
+    // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+    break
+  case if .random() { true } else { false } && false:
+    // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
     break
   default:
     break
   }
 
-  for b in [true] where if b { true } else { false } {} // expected-error {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+  for b in [true] where if b { true } else { false } {}
+  // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+
+  for _ in if .random() { [true] } else { [false] } {}
+  // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 
   // Make sure this doesn't parse as an if expr pattern with a label.
   let x = 0

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -163,12 +163,14 @@ takesValue(switch Bool.random() { case true: 1 case false: 2 })
 do {
   takesValue(x: switch Bool.random() { case true: 1 case false: 2 })
   // expected-error@-1 {{extraneous argument label 'x:' in call}}
+  // expected-error@-2 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 
   takesValue(_: x: switch Bool.random() { case true: 1 case false: 2 })
   // expected-error@-1 {{expected argument label before colon}}
   // expected-error@-2 {{expected ',' separator}}
   // expected-error@-3 {{cannot find 'x' in scope}}
   // expected-error@-4 {{extra argument in call}}
+  // expected-error@-5 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 }
 func takesValueWithLabel<T>(x: T) {}
 do {
@@ -180,6 +182,7 @@ do {
   // expected-error@-2 {{expected ',' separator}}
   // expected-error@-3 {{cannot find 'y' in scope}}
   // expected-error@-4 {{extra argument in call}}
+  // expected-error@-5 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 }
 func takesValueAndTrailingClosure<T>(_ x: T, _ fn: () -> Int) {}
 takesValueAndTrailingClosure(switch Bool.random() { case true: 0 case false: 1 }) { 2 }
@@ -188,6 +191,7 @@ takesValueAndTrailingClosure(switch Bool.random() { case true: 0 case false: 1 }
 func takesInOut<T>(_ x: inout T) {}
 takesInOut(&switch Bool.random() { case true: 1 case false: 2 })
 // expected-error@-1 {{cannot pass immutable value of type 'Int' as inout argument}}
+// expected-error@-2 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 
 struct HasSubscript {
   static subscript(x: Int) -> Void { () }
@@ -496,9 +500,11 @@ do {
 do {
   _ = (switch fatalError() {}, 1) // expected-error {{expected '{' after 'switch' subject expression}}
   // expected-error@-1 {{extra trailing closure passed in call}}
+  // expected-error@-2 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 
   _ = (switch fatalError() { #if FOO
     // expected-error@-1 {{extra trailing closure passed in call}}
+    // expected-error@-2 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
   #endif
   }, 0) // expected-error {{expected '{' after 'switch' subject expression}}
 
@@ -507,6 +513,7 @@ do {
     // expected-error@-2 {{type '() -> ()' cannot conform to 'RandomNumberGenerator'}}
     // expected-note@-3 {{required by static method 'random(using:)' where 'T' = '() -> ()'}}
     // expected-note@-4 {{only concrete types such as structs, enums and classes can conform to protocols}}
+    // expected-error@-5 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
   case true: // expected-error {{'case' label can only appear inside a 'switch' statement}}
     1
   case false: // expected-error {{'case' label can only appear inside a 'switch' statement}}
@@ -519,6 +526,7 @@ do {
     // expected-error@-2 {{type '() -> ()' cannot conform to 'RandomNumberGenerator'}}
     // expected-note@-3 {{required by static method 'random(using:)' where 'T' = '() -> ()'}}
     // expected-note@-4 {{only concrete types such as structs, enums and classes can conform to protocols}}
+    // expected-error@-5 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
   case true: // expected-error {{'case' label can only appear inside a 'switch' statement}}
     1
   case false: // expected-error {{'case' label can only appear inside a 'switch' statement}}
@@ -618,6 +626,9 @@ let m = !switch Bool.random() { case true: true case false: true }
 let n = switch Bool.random() { case true: 1 case false: 2 } + // expected-error {{ambiguous use of operator '+'}}
         switch Bool.random() { case true: 3 case false: 4 } +
         switch Bool.random() { case true: 5 case false: 6 }
+// expected-error@-3 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
+// expected-error@-3 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
+// expected-error@-3 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 
 let n1 = switch Bool.random() { case true: 1 case false: 2 } +  5
 // expected-error@-1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
@@ -660,6 +671,7 @@ do {
   // FIXME: The type error is likely due to not solving the conjunction before attempting default type var bindings.
   let _ = (switch Bool.random() { case true: Int?.none case false: 1 })?.bitWidth
   // expected-error@-1 {{type of expression is ambiguous without a type annotation}}
+  // expected-error@-2 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 }
 do {
   let _ = switch Bool.random() { case true: Int?.none case false: 1 }!
@@ -749,9 +761,9 @@ func returnBranches() -> Int {
 func returnBranches1() -> Int {
   return switch Bool.random() { // expected-error {{cannot convert return expression of type 'Void' to return type 'Int'}}
   case true:
-    return 0
+    return 0 // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
   case false:
-    return 1
+    return 1 // expected-error {{cannot use 'return' to transfer control out of 'switch' expression}}
   }
 }
 

--- a/test/stmt/then_stmt_disabled.swift
+++ b/test/stmt/then_stmt_disabled.swift
@@ -6,6 +6,6 @@ let x = if .random() {
   then 0
   // expected-error@-1 {{cannot find 'then' in scope}}
   // expected-error@-2 {{consecutive statements on a line must be separated by ';'}}
-} else {
+} else { // expected-error {{non-expression branch of 'if' expression may only end with a 'throw'}}
   1
 }


### PR DESCRIPTION
These diagnostics are better suited for pre-checking since we ought to be emitting them even if there's some other error with the expression.