### PR TITLE
[build-script] Always clean 'SwiftTesting' and 'SwiftTestingMacros'

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swift_testing.py
+++ b/utils/swift_build_support/swift_build_support/products/swift_testing.py
@@ -18,6 +18,7 @@ from . import cmake_product
 from . import product
 from . import swift
 from . import swift_testing_macros
+from .. import shell
 
 
 class SwiftTesting(product.Product):
@@ -37,6 +38,10 @@ class SwiftTesting(product.Product):
     def get_dependencies(cls):
         return [swift.Swift,
                 swift_testing_macros.SwiftTestingMacros]
+
+    def should_clean(self, host_target):
+        # Workaround for 'swift-testing' not detecting compiler/stdlib changes.
+        return True
 
     def should_build(self, host_target):
         return True
@@ -59,35 +64,38 @@ class SwiftTesting(product.Product):
             source_dir=self.source_dir,
             build_dir=build_dir)
 
+    def _for_each_host_target(self, base_target, body):
+        body(base_target)
+
+        # For Darwin host, 'build' is only called for the builder.
+        # Manually iterate the cross compile hosts.
+        if self.has_cross_compile_hosts() and self.is_darwin_host(base_target):
+            for target in self.args.cross_compile_hosts:
+                body(target)
+
+    def _clean_with_cmake(self, host_target):
+        self._cmake_product(host_target).clean(host_target)
+
+    def clean(self, host_target):
+        self._for_each_host_target(host_target, self._clean_with_cmake)
+
     def _build_with_cmake(self, host_target):
         self._cmake_product(host_target).build(host_target)
 
     def build(self, host_target):
-        self._build_with_cmake(host_target)
-
-        # For Darwin host, 'build' is only called for the builder.
-        # Manually iterate the cross compile hosts.
-        if self.has_cross_compile_hosts() and self.is_darwin_host(host_target):
-            for target in self.args.cross_compile_hosts:
-                self._build_with_cmake(target)
-
-        # FIXME: build testing library for 'stdlib_deployment_targets'?
-        pass
+        self._for_each_host_target(host_target, self._build_with_cmake)
 
     def _install_with_cmake(self, host_target):
         self._cmake_product(host_target).install(host_target)
 
     def install(self, host_target):
-        self._install_with_cmake(host_target)
-
-        # For Darwin host, 'install' is only called for the builder.
-        # Manually iterate the cross compile hosts.
-        if self.has_cross_compile_hosts() and self.is_darwin_host(host_target):
-            for target in self.args.cross_compile_hosts:
-                self._install_with_cmake(target)
+        self._for_each_host_target(host_target, self._install_with_cmake)
 
 
 class SwiftTestingCMakeShim(cmake_product.CMakeProduct):
+    def clean(self, host_target):
+        shell.rmtree(self.build_dir)
+
     def build(self, host_target):
         override_deployment_version = None
         if host_target.startswith('macosx'):

--- a/utils/swift_build_support/swift_build_support/products/swift_testing_macros.py
+++ b/utils/swift_build_support/swift_build_support/products/swift_testing_macros.py
@@ -17,6 +17,7 @@ from build_swift.build_swift.versions import Version
 from . import cmake_product
 from . import product
 from . import swift
+from .. import shell
 
 
 class SwiftTestingMacros(product.Product):
@@ -35,6 +36,10 @@ class SwiftTestingMacros(product.Product):
     @classmethod
     def get_dependencies(cls):
         return [swift.Swift]
+
+    def should_clean(self, host_target):
+        # Workaround for 'swift-testing' not detecting compiler/stdlib changes.
+        return True
 
     def should_build(self, host_target):
         return True
@@ -56,32 +61,38 @@ class SwiftTestingMacros(product.Product):
             source_dir=self.source_dir,
             build_dir=build_dir)
 
+    def _for_each_host_target(self, base_target, body):
+        body(base_target)
+
+        # For Darwin host, 'build' is only called for the builder.
+        # Manually iterate the cross compile hosts.
+        if self.has_cross_compile_hosts() and self.is_darwin_host(base_target):
+            for target in self.args.cross_compile_hosts:
+                body(target)
+
+    def _clean_with_cmake(self, host_target):
+        self._cmake_product(host_target).clean(host_target)
+
+    def clean(self, host_target):
+        self._for_each_host_target(host_target, self._clean_with_cmake)
+
     def _build_with_cmake(self, host_target):
         self._cmake_product(host_target).build(host_target)
 
     def build(self, host_target):
-        self._build_with_cmake(host_target)
-
-        # For Darwin host, 'build' is only called for the builder.
-        # Manually iterate the cross compile hosts.
-        if self.has_cross_compile_hosts() and self.is_darwin_host(host_target):
-            for target in self.args.cross_compile_hosts:
-                self._build_with_cmake(target)
+        self._for_each_host_target(host_target, self._build_with_cmake)
 
     def _install_with_cmake(self, host_target):
         self._cmake_product(host_target).install(host_target)
 
     def install(self, host_target):
-        self._install_with_cmake(host_target)
-
-        # For Darwin host, 'install' is only called for the builder.
-        # Manually iterate the cross compile hosts.
-        if self.has_cross_compile_hosts() and self.is_darwin_host(host_target):
-            for target in self.args.cross_compile_hosts:
-                self._install_with_cmake(target)
+        self._for_each_host_target(host_target, self._install_with_cmake)
 
 
 class SwiftTestingMacrosCMakeShim(cmake_product.CMakeProduct):
+    def clean(self, host_target):
+        shell.rmtree(self.build_dir)
+
     def build(self, host_target):
         override_deployment_version = None
         if host_target.startswith('macosx'):


### PR DESCRIPTION
These products are built with CMake. In incremental build environments, these products don't detect compiler changes, so the artifacts aren't rebuilt unless the source code of these projects are changed. To workaround that, always clean them in build-script to ensure they are rebuilt.

 rdar://135021207
