### PR TITLE
[test] Move to earlier deployment target as workaround

### DIFF
--- a/test/Reflection/conformance_descriptors.swift
+++ b/test/Reflection/conformance_descriptors.swift
@@ -11,7 +11,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/Conformances.swift -parse-as-library -emit-module -emit-library -module-name ConformanceCheck -o %t/Conformances
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/Conformances.swift -parse-as-library -emit-module -emit-library -module-name ConformanceCheck -o %t/Conformances
 // RUN: %target-swift-reflection-dump %t/Conformances %platform-module-dir/%target-library-name(swiftCore) | %FileCheck %s
 
 // CHECK: CONFORMANCES:

--- a/test/Reflection/conformance_descriptors_of_external_types.swift
+++ b/test/Reflection/conformance_descriptors_of_external_types.swift
@@ -4,13 +4,13 @@
 // RUN: %empty-directory(%t/includes)
 
 // Build external Swift library/module
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple  %S/Inputs/swiftmodules/testModB.swift -parse-as-library -emit-module -emit-library -module-name testModB -o %t/includes/testModB.o
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple  %S/Inputs/swiftmodules/testModB.swift -parse-as-library -emit-module -emit-library -module-name testModB -o %t/includes/testModB.o
 
 // Build external Clang library
 // RUN: %target-clang %S/Inputs/cmodules/testModA.m -c -o %t/testModA.o
 
 // Build the test into a binary
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple   %s -parse-as-library -emit-module -emit-library -module-name ExternalConformanceCheck -I %t/includes -I %S/Inputs/cmodules -o %t/ExternalConformances %t/testModA.o %t/includes/testModB.o
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple   %s -parse-as-library -emit-module -emit-library -module-name ExternalConformanceCheck -I %t/includes -I %S/Inputs/cmodules -o %t/ExternalConformances %t/testModA.o %t/includes/testModB.o
 
 // RUN: %target-swift-reflection-dump %t/ExternalConformances %platform-module-dir/%target-library-name(swiftCore) | %FileCheck %s
 

--- a/test/Reflection/preserve_conformance_metadata_attr_macros.swift
+++ b/test/Reflection/preserve_conformance_metadata_attr_macros.swift
@@ -4,13 +4,13 @@
 // RUN: %empty-directory(%t/includes)
 
 // Build support Protocols module
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple %S/Inputs/PreservedConformanceProtocols.swift -parse-as-library -emit-module -emit-library -module-name PreservedConformanceProtocols -o %t/includes/PreservedConformanceProtocols.o
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple %S/Inputs/PreservedConformanceProtocols.swift -parse-as-library -emit-module -emit-library -module-name PreservedConformanceProtocols -o %t/includes/PreservedConformanceProtocols.o
 
 // Build the macro library
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/Macros.swift -g -no-toolchain-stdlib-rpath
 
 // Build the test into a binary
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple  %s -parse-as-library -emit-module -emit-library -module-name PreservedConformances -O -whole-module-optimization -I %t/includes -o %t/PreservedConformances -Xlinker %t/includes/PreservedConformanceProtocols.o -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple  %s -parse-as-library -emit-module -emit-library -module-name PreservedConformances -O -whole-module-optimization -I %t/includes -o %t/PreservedConformances -Xlinker %t/includes/PreservedConformanceProtocols.o -load-plugin-library %t/%target-library-name(MacroDefinition)
 
 // RUN: %target-swift-reflection-dump %t/PreservedConformances | %FileCheck %s
 

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -11,8 +11,8 @@
 // FIXME: rdar://127796117
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/main.swift -emit-module -emit-executable -module-name TypesToReflect -o %t/TypesToReflect
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/main.swift -emit-module -emit-executable -module-name TypesToReflect -o %t/TypesToReflect
 
 // RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s
 // RUN: %target-swift-reflection-dump %t/TypesToReflect | %FileCheck %s

--- a/test/Reflection/typeref_decoding_asan.swift
+++ b/test/Reflection/typeref_decoding_asan.swift
@@ -3,7 +3,7 @@
 
 // REQUIRES: asan_runtime
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -sanitize=address -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -sanitize=address -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s
 
 // CHECK: FIELDS:

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -11,14 +11,14 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -I %S/Inputs
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -I %S/Inputs
 // RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
 
 // ... now, test single-frontend mode with multi-threaded LLVM emission:
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -I %S/Inputs -whole-module-optimization -num-threads 2
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -I %S/Inputs -whole-module-optimization -num-threads 2
 // RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
 
 // UNSUPPORTED: OS=linux-android, OS=linux-androideabi

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -9,8 +9,8 @@
 // rdar://100558042
 // UNSUPPORTED: CPU=arm64e
 
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)
-// RUN: %target-build-swift -target %target-swift-abi-5.4-triple -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift %S/Inputs/main.swift -emit-module -emit-executable -module-name TypeLowering -o %t/TypesToReflect
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-build-swift -target %target-swift-abi-5.2-triple -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift %S/Inputs/main.swift -emit-module -emit-executable -module-name TypeLowering -o %t/TypesToReflect
 
 // RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // RUN: %target-swift-reflection-dump %t/TypesToReflect %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize


### PR DESCRIPTION
We are already using 5.4 target as a workaround for missing LC_DYLD_CHAINED_FIXUPS support in reflection tools, but we need to further workaround a linker bug in older versions of ld-prime that caused appletv simulator platform to be misidentified and use chained fixups earlier than it should, so move back to 5.2.