### PR TITLE
Note which members trigger extra exporting checks

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3677,6 +3677,10 @@ ERROR(conformance_from_implementation_only_module,none,
       (Type, Identifier, unsigned, Identifier, unsigned))
 NOTE(assoc_conformance_from_implementation_only_module,none,
      "in associated type %0 (inferred as %1)", (Type, Type))
+NOTE(note_public_extension_member,none,
+     "%kind0 %select{declared here|synthesized automatically}1 must be "
+     "visible to other modules",
+     (const ValueDecl*, bool))
 ERROR(unexportable_clang_function_type,none,
       "cannot export the underlying C type of the function type %0; "
       "it may use anonymous types or types defined outside of a module",

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -212,13 +212,13 @@ bool diagnoseTypeReprAvailability(const TypeRepr *T,
                                   DeclAvailabilityFlags flags = std::nullopt);
 
 /// Diagnose uses of unavailable conformances in types.
-void diagnoseTypeAvailability(Type T, SourceLoc loc,
+bool diagnoseTypeAvailability(Type T, SourceLoc loc,
                               const ExportContext &context,
                               DeclAvailabilityFlags flags = std::nullopt);
 
 /// Checks both a TypeRepr and a Type, but avoids emitting duplicate
 /// diagnostics by only checking the Type if the TypeRepr succeeded.
-void diagnoseTypeAvailability(const TypeRepr *TR, Type T, SourceLoc loc,
+bool diagnoseTypeAvailability(const TypeRepr *TR, Type T, SourceLoc loc,
                               const ExportContext &context,
                               DeclAvailabilityFlags flags = std::nullopt);
 

--- a/test/Interop/Cxx/library-evolution/prohibit-cxx-api-in-evolving-libraries.swift
+++ b/test/Interop/Cxx/library-evolution/prohibit-cxx-api-in-evolving-libraries.swift
@@ -77,6 +77,7 @@ extension CxxTemplateInt {
 
 // expected-error@+1 {{cannot use type alias 'CxxTemplateInt' in an extension with public or '@usableFromInline' members; C++ types from imported module 'CxxModule' do not support library evolution}}
 extension CxxTemplateInt {
+    // expected-note@+1 {{instance method 'testPublicExt()' declared here must be visible to other modules}}
     public func testPublicExt() {
     }
 }

--- a/test/Sema/access-level-import-classic-exportability.swift
+++ b/test/Sema/access-level-import-classic-exportability.swift
@@ -89,7 +89,7 @@ extension PublicImportType {
 public protocol PackageConstrainedExtensionProto {}
 extension Array: PackageConstrainedExtensionProto where Element == PackageImportType {} // expected-error {{cannot use struct 'PackageImportType' in an extension with conditional conformances; 'PackageLib' was not imported publicly}}
 extension PackageImportType { // expected-error {{cannot use struct 'PackageImportType' in an extension with public or '@usableFromInline' members; 'PackageLib' was not imported publicly}}
-    public func publicMethod() {}
+    public func publicMethod() {} // expected-note {{instance method 'publicMethod()' declared here must be visible to other modules}}
 }
 
 package protocol PackageConstrainedExtensionProtoInPackage {}
@@ -119,7 +119,7 @@ extension PackageImportType {
 public protocol InternalConstrainedExtensionProto {}
 extension Array: InternalConstrainedExtensionProto where Element == InternalImportType {} // expected-error {{cannot use struct 'InternalImportType' in an extension with conditional conformances; 'InternalLib' was not imported publicly}}
 extension InternalImportType { // expected-error {{cannot use struct 'InternalImportType' in an extension with public or '@usableFromInline' members; 'InternalLib' was not imported publicly}}
-    public func foo() {}
+    public func foo() {} // expected-note {{instance method 'foo()' declared here must be visible to other modules}}
 }
 
 package protocol InternalConstrainedExtensionProtoInPackage {}
@@ -149,7 +149,7 @@ extension InternalImportType {
 public protocol FileprivateConstrainedExtensionProto {}
 extension Array: FileprivateConstrainedExtensionProto where Element == FileprivateImportType {} // expected-error {{cannot use struct 'FileprivateImportType' in an extension with conditional conformances; 'FileprivateLib' was not imported publicly}}
 extension FileprivateImportType { // expected-error {{cannot use struct 'FileprivateImportType' in an extension with public or '@usableFromInline' members; 'FileprivateLib' was not imported publicly}}
-    public func foo() {}
+    public func foo() {} // expected-note {{instance method 'foo()' declared here must be visible to other modules}}
 }
 
 package protocol FileprivateConstrainedExtensionProtoInPackage {}
@@ -179,7 +179,7 @@ extension FileprivateImportType {
 public protocol PrivateConstrainedExtensionProto {}
 extension Array: PrivateConstrainedExtensionProto where Element == PrivateImportType {} // expected-error {{cannot use struct 'PrivateImportType' in an extension with conditional conformances; 'PrivateLib' was not imported publicly}}
 extension PrivateImportType { // expected-error {{cannot use struct 'PrivateImportType' in an extension with public or '@usableFromInline' members; 'PrivateLib' was not imported publicly}}
-    public func foo() {}
+    public func foo() {} // expected-note {{instance method 'foo()' declared here must be visible to other modules}}
 }
 
 package protocol PrivateConstrainedExtensionProtoInPackage {}

--- a/test/Sema/implementation-only-import-in-decls.swift
+++ b/test/Sema/implementation-only-import-in-decls.swift
@@ -98,9 +98,10 @@ public var testMultipleBindings1: Int? = nil, testMultipleBindings2: BadStruct? 
 public var testMultipleBindings3: BadStruct? = nil, testMultipleBindings4: Int? = nil // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
 
 extension BadStruct { // expected-error {{cannot use struct 'BadStruct' in an extension with public or '@usableFromInline' members; 'BADLibrary' has been imported as implementation-only}}
-  public func testExtensionOfBadType() {}
-  public var testExtensionVarBad: Int { 0 }
-  public subscript(bad _: Int) -> Int { 0 }
+  public func testExtensionOfBadType() {} // expected-note {{instance method 'testExtensionOfBadType()' declared here must be visible to other modules}}
+  public var testExtensionVarBad: Int { 0 } // expected-note {{property 'testExtensionVarBad' declared here must be visible to other modules}}
+  public subscript(bad _: Int) -> Int { 0 } // expected-note {{subscript 'subscript(bad:)' declared here must be visible to other modules}}
+  func testExtensionOfBadTypeNotTheCause() {} // no-note
 }
 extension BadStruct {
   func testExtensionOfOkayType() {}
@@ -109,9 +110,10 @@ extension BadStruct {
 }
 
 extension Array where Element == BadStruct { // expected-error {{cannot use struct 'BadStruct' in an extension with public or '@usableFromInline' members; 'BADLibrary' has been imported as implementation-only}}
-  public func testExtensionWithBadRequirement() {}
-  public var testExtensionVarBad: Int { 0 }
-  public subscript(bad _: Int) -> Int { 0 }
+  public func testExtensionWithBadRequirement() {} // expected-note {{instance method 'testExtensionWithBadRequirement()' declared here must be visible to other modules}}
+  public var testExtensionVarBad: Int { 0 } // expected-note {{property 'testExtensionVarBad' declared here must be visible to other modules}}
+  public subscript(bad _: Int) -> Int { 0 } // expected-note {{subscript 'subscript(bad:)' declared here must be visible to other modules}}
+  func testExtensionWithBadRequirementNotTheCause() {} // no-note
 }
 
 extension Array where Element == BadStruct {
@@ -195,7 +197,7 @@ public func testInheritedConformance(_: NormalProtoAssocHolder<SubclassOfNormalC
 public func testSpecializedConformance(_: NormalProtoAssocHolder<GenericStruct<Int>>) {} // expected-error {{cannot use conformance of 'GenericStruct<T>' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
 
 extension Array where Element == NormalProtoAssocHolder<NormalStruct> { // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' in an extension with public or '@usableFromInline' members; 'BADLibrary' has been imported as implementation-only}}
-  public func testConstrainedExtensionUsingBadConformance() {}
+  public func testConstrainedExtensionUsingBadConformance() {} // expected-note {{instance method 'testConstrainedExtensionUsingBadConformance()' declared here must be visible to other modules}}
 }
 
 public struct ConditionalGenericStruct<T> {}

--- a/test/Sema/missing-import-typealias.swift
+++ b/test/Sema/missing-import-typealias.swift
@@ -89,7 +89,7 @@ public struct HasMembers {
 // expected-warning@+2 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an extension with public or '@usableFromInline' members because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
 // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
 extension StructAlias {
-  public func someFunc() {}
+  public func someFunc() {} // expected-note {{instance method 'someFunc()' declared here must be visible to other modules}}
 }
 
 

--- a/test/Sema/spi-in-decls.swift
+++ b/test/Sema/spi-in-decls.swift
@@ -139,9 +139,10 @@ extension BadStruct {
 }
 
 extension Array where Element == BadStruct { // expected-error {{cannot use struct 'BadStruct' in an extension with public or '@usableFromInline' members; it is SPI}}
-  public func testExtensionWithBadRequirement() {}
-  public var testExtensionVarBad: Int { 0 }
-  public subscript(bad _: Int) -> Int { 0 }
+  public func testExtensionWithBadRequirement() {} // expected-note {{instance method 'testExtensionWithBadRequirement()' declared here must be visible to other modules}}
+  public var testExtensionVarBad: Int { 0 } // expected-note {{property 'testExtensionVarBad' declared here must be visible to other modules}}
+  public subscript(bad _: Int) -> Int { 0 } // expected-note {{subscript 'subscript(bad:)' declared here must be visible to other modules}}
+  func testExtensionWithBadRequirementNotTheCause() {} // no-note
 }
 
 extension Array where Element == BadStruct {
@@ -226,7 +227,7 @@ public func testInheritedConformance(_: NormalProtoAssocHolder<SubclassOfNormalC
 public func testSpecializedConformance(_: NormalProtoAssocHolder<GenericStruct<Int>>) {} // expected-error {{cannot use conformance of 'GenericStruct<T>' to 'NormalProto' here; the conformance is declared as SPI}}
 
 extension Array where Element == NormalProtoAssocHolder<NormalStruct> { // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' in an extension with public or '@usableFromInline' members; the conformance is declared as SPI}}
-  public func testConstrainedExtensionUsingBadConformance() {}
+  public func testConstrainedExtensionUsingBadConformance() {} // expected-note {{instance method 'testConstrainedExtensionUsingBadConformance()' declared here must be visible to other modules}}
 }
 
 public struct ConditionalGenericStruct<T> {}

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -1356,7 +1356,7 @@ extension BetweenTargets {
 
 @available(macOS 10.10, *)
 extension BetweenTargets { // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
-  public func publicFuncInExcessivelyAvailableExtension() {}
+  public func publicFuncInExcessivelyAvailableExtension() {} // expected-note {{instance method 'publicFuncInExcessivelyAvailableExtension()' declared here must be visible to other modules}}
 }
 
 // MARK: Extensions on BetweenTargetsInternal
@@ -1408,6 +1408,7 @@ extension AfterDeploymentTarget { // expected-note 2 {{add @available attribute 
 
 // expected-error@+1 {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 extension AfterDeploymentTarget { // expected-note 2 {{add @available attribute to enclosing extension}}
+  // expected-note@+1 {{instance method 'publicFuncInExtension' declared here must be visible to other modules}}
   public func publicFuncInExtension( // expected-note {{add @available attribute to enclosing instance method}}
     _: NoAvailable,
     _: BeforeInliningTarget,


### PR DESCRIPTION
When an extension includes exportable members, we apply extra checks for bad uses of e.g. internal imports, SPIs, availability below the minimum deployment target, etc. However, it’s not always clear why these checks have been triggered (especially if they’re triggered by a member that has been implicitly synthesized). Emit a note for each member which necessitated these checks.

This is especially useful for code that uses `@objc @implementation extension`s on SPI/internal imported/etc. types, which sometimes ends up creating implicit class members which trigger diagnostics that are difficult to understand, but it’s a general solution to a general problem.

Fixes rdar://110719676.

