### PR TITLE
[ODL] Handle builtins.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -208,6 +208,7 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   NO_UPDATE_NEEDED(FixLifetime)
   NO_UPDATE_NEEDED(AddressToPointer)
   NO_UPDATE_NEEDED(ExistentialMetatype)
+  NO_UPDATE_NEEDED(Builtin)
 #undef NO_UPDATE_NEEDED
 
   bool eliminateIdentityCast(SingleValueInstruction *svi) {

--- a/test/SILOptimizer/moveonly_type_eliminator.sil
+++ b/test/SILOptimizer/moveonly_type_eliminator.sil
@@ -29,6 +29,8 @@ class Klass {
   func foo()
 }
 
+class C {}
+
 struct KlassPair {
   var lhs: Klass
   var rhs: Klass
@@ -612,4 +614,16 @@ bb0(%x : @guaranteed $any Error):
   %em = existential_metatype $@thick any Error.Type, %y : $@moveOnly (any Error)
   debug_value %em : $@thick any Error.Type, var, name "s", argno 1, expr op_deref
   return %em : $@thick any Error.Type
+}
+
+// CHECK-LABEL: sil [ossa] @builtin_tsanInoutAccess : {{.*}} {
+// CHECK:         builtin "tsanInoutAccess"
+// CHECK-LABEL: } // end sil function 'builtin_tsanInoutAccess'
+sil [ossa] @builtin_tsanInoutAccess : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_stack $@moveOnly C, var, name "b", type $@moveOnly C
+  %6 = builtin "tsanInoutAccess"(%1 : $*@moveOnly C) : $()
+  dealloc_stack %1 : $*@moveOnly C
+  %13 = tuple ()
+  return %13 : $()
 }

--- a/validation-test/SILOptimizer/rdar133779160.swift
+++ b/validation-test/SILOptimizer/rdar133779160.swift
@@ -1,0 +1,9 @@
+// RUN: %target-build-swift %s -sanitize=thread
+
+// REQUIRES: tsan_runtime
+
+class C {}
+func passC(_ b: consuming C) {
+  mutateC(&b)
+}
+func mutateC(_ b: inout C) {}


### PR DESCRIPTION
No update is needed for the values they produce.  This pass should really be refactored not to crash on instructions that aren't explicitly listed or at least not to compile if not every instruction is listed.

rdar://133779160
