### PR TITLE
Sema: Fix `@retroactive` does not apply diags for same-package conformance

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2606,8 +2606,9 @@ ERROR(retroactive_not_in_extension_inheritance_clause,none,
       "extensions", ())
 
 ERROR(retroactive_attr_does_not_apply,none,
-      "'retroactive' attribute does not apply; %0 is declared in this module",
-      (Identifier))
+      "'retroactive' attribute does not apply; %0 is declared in "
+      "%select{the same package|this module}1",
+      (const ValueDecl *, bool))
 
 WARNING(extension_retroactive_conformance,none,
        "extension declares a conformance of imported type %0 to imported "

--- a/test/Sema/extension_retroactive_conformances_package.swift
+++ b/test/Sema/extension_retroactive_conformances_package.swift
@@ -3,7 +3,8 @@
 
 // RUN: %target-swift-frontend -swift-version 5 %t/Library.swift -emit-module -module-name Library -o %t -package-name Library 
 // RUN: %target-swift-frontend -swift-version 5 %t/OtherLibrary.swift -emit-module -module-name OtherLibrary -o %t -package-name Library
-// RUN: %target-swift-frontend -typecheck %t/Client.swift -module-name Client -verify -swift-version 5 -I %t -package-name Library 
+// RUN: %target-swift-frontend -swift-version 5 %t/ExternalLibrary.swift -emit-module -module-name ExternalLibrary -o %t
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -module-name Client -verify -swift-version 5 -I %t -package-name Library
 
 //--- Library.swift
 
@@ -19,10 +20,16 @@ public protocol OtherLibraryProtocol {}
 package class PackageOtherLibraryClass {}
 package protocol PackageOtherLibraryProtocol {}
 
+//--- ExternalLibrary.swift
+
+public class ExternalLibraryClass {}
+public protocol ExternalLibraryProtocol {}
+
 //--- Client.swift
 
 public import Library
 public import OtherLibrary
+public import ExternalLibrary
 
 // These are all fine because all 3 of these modules are in the same package.
 
@@ -41,3 +48,12 @@ extension LibraryClass: PackageOtherLibraryProtocol {}
 extension PackageLibraryClass: PackageLibraryProtocol {}
 extension PackageOtherLibraryClass: PackageLibraryProtocol {}
 extension PackageLibraryClass: PackageOtherLibraryProtocol {}
+
+extension ExternalLibraryClass: ExternalLibraryProtocol {} // expected-warning {{extension declares a conformance of imported type 'ExternalLibraryClass' to imported protocol 'ExternalLibraryProtocol'; this will not behave correctly if the owners of 'ExternalLibrary' introduce this conformance in the future}}
+// expected-note @-1 {{add '@retroactive' to silence this warning}} {{33-56=@retroactive ExternalLibraryProtocol}}
+
+extension ExternalLibraryClass: LibraryProtocol {}
+extension LibraryClass: ExternalLibraryProtocol {}
+
+extension ExternalLibraryClass: @retroactive OtherLibraryProtocol {} // expected-warning {{'retroactive' attribute does not apply; 'OtherLibraryProtocol' is declared in the same package; this is an error in the Swift 6 language mode}}
+extension OtherLibraryClass: @retroactive ExternalLibraryProtocol {} // expected-warning {{'retroactive' attribute does not apply; 'OtherLibraryClass' is declared in the same package; this is an error in the Swift 6 language mode}}


### PR DESCRIPTION
SE-0364 was amended to allow same-package conformances to be considered non-retroactive. The logic for that ammendment was implemented in Swift 6.0, but the diagnostics were not updated.

Resolves rdar://133423931.
