### PR TITLE
[6.0][ClangImporter] Make sure the `-resource-dir` is checked before the `-sdk`, as done everywhere else in the compiler

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1155,7 +1155,7 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
       llvm::interleave(
           invocationArgs, [](StringRef arg) { llvm::errs() << arg; },
           [] { llvm::errs() << "' '"; });
-      llvm::errs() << "'\n";
+      llvm::errs() << "'\n\n";
     }
 
     clang::CreateInvocationOptions CIOpts;
@@ -1260,11 +1260,24 @@ ClangImporter::create(ASTContext &ctx,
     // Wrap Swift's FS to allow Clang to override the working directory
     VFS = llvm::vfs::RedirectingFileSystem::create(
         fileMapping.redirectedFiles, true, *ctx.SourceMgr.getFileSystem());
+    if (importerOpts.DumpClangDiagnostics) {
+      llvm::errs() << "clang importer redirected file mappings:\n";
+      for (const auto &mapping : fileMapping.redirectedFiles) {
+        llvm::errs() << "   mapping real file '" << mapping.second
+                     << "' to virtual file '" << mapping.first << "'\n";
+      }
+      llvm::errs() << "\n";
+    }
 
     if (!fileMapping.overridenFiles.empty()) {
       llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> overridenVFS =
           new llvm::vfs::InMemoryFileSystem();
       for (const auto &file : fileMapping.overridenFiles) {
+        if (importerOpts.DumpClangDiagnostics) {
+          llvm::errs() << "clang importer overriding file '" << file.first
+                       << "' with the following contents:\n";
+          llvm::errs() << file.second << "\n";
+        }
         auto contents = ctx.Allocate<char>(file.second.size() + 1);
         std::copy(file.second.begin(), file.second.end(), contents.begin());
         // null terminate the buffer.

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -34,10 +34,9 @@ static std::optional<Path> getActualModuleMapPath(
 
   Path result;
 
-  StringRef SDKPath = Opts.getSDKPath();
-  if (!SDKPath.empty()) {
-    result.append(SDKPath.begin(), SDKPath.end());
-    llvm::sys::path::append(result, "usr", "lib", "swift");
+  if (!Opts.RuntimeResourcePath.empty()) {
+    result.append(Opts.RuntimeResourcePath.begin(),
+                  Opts.RuntimeResourcePath.end());
     llvm::sys::path::append(result, platform);
     if (isArchSpecific) {
       llvm::sys::path::append(result, arch);
@@ -51,10 +50,11 @@ static std::optional<Path> getActualModuleMapPath(
       return result;
   }
 
-  if (!Opts.RuntimeResourcePath.empty()) {
+  StringRef SDKPath = Opts.getSDKPath();
+  if (!SDKPath.empty()) {
     result.clear();
-    result.append(Opts.RuntimeResourcePath.begin(),
-                  Opts.RuntimeResourcePath.end());
+    result.append(SDKPath.begin(), SDKPath.end());
+    llvm::sys::path::append(result, "usr", "lib", "swift");
     llvm::sys::path::append(result, platform);
     if (isArchSpecific) {
       llvm::sys::path::append(result, arch);

--- a/test/ClangImporter/print-module-map-paths.swift
+++ b/test/ClangImporter/print-module-map-paths.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/resources/linux/armv7 %t/sdk/usr/include %t/sdk/usr/lib/swift/linux/armv7
+// RUN: touch %t/sdk/usr/include/{inttypes,stdint,unistd}.h
+
+// RUN: touch %t/resources/linux/armv7/{SwiftGlibc.h,glibc.modulemap}
+// RUN: touch %t/sdk/usr/lib/swift/linux/armv7/{SwiftGlibc.h,glibc.modulemap}
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target armv7-unknown-linux-gnueabihf -sdk %t/sdk -resource-dir %t/resources 2>&1 | %FileCheck -check-prefix=CHECK-LINUX %s
+
+// RUN: cp %S/../../stdlib/public/Cxx/{cxxshim/libcxxshim.modulemap,libstdcxx/libstdcxx.h,libstdcxx/libstdcxx.modulemap} %t/resources/linux
+// RUN: %target-swift-frontend %s -typecheck -parse-stdlib -dump-clang-diagnostics -resource-dir %t/resources -cxx-interoperability-mode=default 2>&1 | %FileCheck -check-prefix=CHECK-CXX -check-prefix=CHECK-%target-os-CXX %s
+
+// RUN: mkdir -p %t/resources/android/aarch64 %t/sdk/usr/lib/swift/android/aarch64
+// RUN: cp %S/../../stdlib/public/Platform/{SwiftAndroidNDK.h,SwiftBionic.h,android.modulemap} %t/resources/android/aarch64
+// RUN: cp %S/../../stdlib/public/Platform/{SwiftAndroidNDK.h,SwiftBionic.h,android.modulemap} %t/sdk/usr/lib/swift/android/aarch64
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target aarch64-unknown-linux-android -sdk %t/sdk -resource-dir %t/resources 2>&1 | %FileCheck -check-prefix=CHECK-ANDROID %s
+
+// RUN: cp %S/../../stdlib/public/Cxx/cxxshim/libcxxshim.modulemap %t/resources/android
+// RUN: cp %S/../../stdlib/public/Cxx/cxxshim/libcxxshim.modulemap %t/sdk/usr/lib/swift/android
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target aarch64-unknown-linux-android -sdk %t/sdk -resource-dir %t/resources -cxx-interoperability-mode=default 2>&1 | %FileCheck -check-prefix=CHECK-ANDROID-CXX %s
+
+// CHECK-LINUX: clang importer redirected file mappings:
+// CHECK-LINUX-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}linux{{/|\\}}armv7{{/|\\}}glibc.modulemap' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}module.modulemap'
+// CHECK-LINUX-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}linux{{/|\\}}armv7{{/|\\}}SwiftGlibc.h' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}SwiftGlibc.h'
+
+// CHECK-CXX: clang importer redirected file mappings:
+// CHECK-linux-gnu-CXX: mapping real file '{{.*}}/resources/linux/libstdcxx.h' to virtual file '{{.*}}/usr/include/c++/{{.*}}/libstdcxx.h'
+// CHECK-linux-gnu-CXX: clang importer overriding file '{{.*}}/usr/include/c++/{{.*}}/module.modulemap' with the following contents:
+// CHECK-linux-gnu-CXX-NEXT: --- libstdcxx.modulemap ---
+// CHECK-linux-gnu-CXX: Currently libstdc++ does not have a module map. To work around
+// CHECK-linux-gnu-CXX-NEXT: this, Swift provides its own module map for libstdc++.
+// CHECK-linux-gnu-CXX: header "libstdcxx.h"
+// CHECK-linux-gnu-CXX: clang importer driver args: {{.*}}'-fmodule-map-file={{.*}}resources/linux/libcxxshim.modulemap'
+
+// CHECK-ANDROID: clang importer redirected file mappings:
+// CHECK-ANDROID-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}android{{/|\\}}aarch64{{/|\\}}android.modulemap' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}module.modulemap'
+// CHECK-ANDROID-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}android{{/|\\}}aarch64{{/|\\}}SwiftAndroidNDK.h' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}SwiftAndroidNDK.h'
+// CHECK-ANDROID-NEXT: mapping real file '{{.*}}{{/|\\}}resources{{/|\\}}android{{/|\\}}aarch64{{/|\\}}SwiftBionic.h' to virtual file '{{.*}}{{/|\\}}sdk{{/|\\}}usr{{/|\\}}include{{/|\\}}SwiftBionic.h'
+
+// CHECK-ANDROID-CXX: clang importer driver args: {{.*}}'-fmodule-map-file={{.*}}resources{{/|\\}}android{{/|\\}}libcxxshim.modulemap'

--- a/test/Frontend/embed-bitcode.ll
+++ b/test/Frontend/embed-bitcode.ll
@@ -36,14 +36,14 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 ; MARKER-CMD-NEXT: 00
 
 ; CHECK-COMPILER-NOT: argument unused
-; CHECK-COMPILER: clang
+; CHECK-COMPILER: bin{{/|\\}}clang
 ; CHECK-COMPILER-SAME: -fembed-bitcode
 ; CHECK-COMPILER-SAME: -target
 ; CHECK-COMPILER-NOT: argument unused
 ; CHECK-COMPILER: Fast Register Allocator
 
 ; CHECK-COMPILER-OPT-NOT: argument unused
-; CHECK-COMPILER-OPT: clang
+; CHECK-COMPILER-OPT: bin{{/|\\}}clang
 ; CHECK-COMPILER-OPT-SAME: -fembed-bitcode
 ; CHECK-COMPILER-OPT-SAME: -target
 ; CHECK-COMPILER-OPT-SAME: -Os


### PR DESCRIPTION
__Explanation:__ The frontend currently looks in `-sdk` for a C/C++ sysroot and `-resource-dir` for Swift modules, with the former implicitly set to `/` and the latter always explicitly passed in by `swift-driver`. However, a "full SDK" contains both C/C++ headers _and_ Swift modules, so in that case and _if_ `-sdk` is explicitly passed in, this `ClangImporter` was looking in the full SDK first and wrongly using those Swift module maps, rather than the ones in `-resource-dir`.

__Scope:__ When does that actually happen? Suppose you have Swift 5.10 installed in the system and are trying to build Swift 6.0 from source. In that scenario, the CMake config explicitly passes `-sdk /` and [the Swift 6 compiler wrongly uses the old Swift 5.10 C and C++ module maps and fails](https://github.com/swiftlang/swift/issues/74696#issuecomment-2198714412). This could also affect some SDK bundles, say if one linux distro triple's Swift modules are placed in the common SDK itself, while others are put in separate `-resource-dir` paths, since compiling SDK bundles passes in an explicit `-sdk`.

It _does not_ affect simply building Swift packages with a local SwiftPM 6.0 while the implicit system SDK path of `/` has a system Swift 5.10 installed, as no explicit `-sdk` is passed to build those packages.

__Issue:__ #74696

__Original PRs:__ #74814 and #76119

__Risk:__ Low, since this only affects the few listed scenarios where the `-sdk` flag is explicitly passed to the compiler

__Testing:__ Passed all CI on trunk and my and others' testing locally. @compnerd did report an issue with his new Android SDK with an earlier version of this patch, so I'll wait on his further testing and approval before asking to merge this.

__Reviewer:__ @egorzhdan