### PR TITLE
AST: Clean up `AvailabilityContext` and uses

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1542,6 +1542,10 @@ private:
 
 public:
   clang::DarwinSDKInfo *getDarwinSDKInfo() const;
+
+  /// Returns the string to use in diagnostics when printing the platform being
+  /// targetted.
+  StringRef getTargetPlatformStringForDiagnostics() const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -307,7 +307,14 @@ public:
 
   /// Returns a representation of this range as a string for debugging purposes.
   std::string getAsString() const {
-    return "AvailabilityContext(" + Range.getAsString() + ")";
+    return "AvailabilityContext(" + getVersionString() + ")";
+  }
+
+  /// Returns a representation of the raw version range as a string for
+  /// debugging purposes.
+  std::string getVersionString() const {
+    assert(Range.hasLowerEndpoint());
+    return Range.getLowerEndpoint().getAsString();
   }
 };
 

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -194,28 +194,6 @@ private:
   }
 };
 
-/// Records the reason a declaration is potentially unavailable.
-class UnavailabilityReason {
-private:
-  VersionRange RequiredDeploymentRange;
-
-  explicit UnavailabilityReason(const VersionRange RequiredDeploymentRange)
-      : RequiredDeploymentRange(RequiredDeploymentRange) {}
-
-public:
-  static UnavailabilityReason requiresVersionRange(const VersionRange Range) {
-    return UnavailabilityReason(Range);
-  }
-
-  const VersionRange &getRequiredOSVersionRange() const {
-    return RequiredDeploymentRange;
-  }
-
-  /// Returns true if the required OS version range's lower endpoint is at or
-  /// below the deployment target of the given ASTContext.
-  bool requiresDeploymentTargetOrEarlier(ASTContext &Ctx) const;
-};
-
 /// Represents a version range in which something is available.
 ///
 /// The AvailabilityContext structure forms a [lattice][], which allows it to

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -238,7 +238,20 @@ public:
   }
 
   /// Returns the range of possible versions required by this context.
-  VersionRange getVersionRange() const { return Range; }
+  VersionRange getRawVersionRange() const { return Range; }
+
+  /// Returns true if there is a version tuple for this context.
+  bool hasMinimumVersion() const { return Range.hasLowerEndpoint(); }
+
+  /// Returns the minimum version required by this context. This convenience
+  /// is meant for debugging, diagnostics, serialization, etc. Use of the set
+  /// algebra operations on `AvailabilityContext` should be preferred over
+  /// direct comparison of raw versions.
+  ///
+  /// Only call when `hasMinimumVersion()` returns true.
+  llvm::VersionTuple getRawMinimumVersion() const {
+    return Range.getLowerEndpoint();
+  }
 
   /// Returns true if \p other makes stronger guarantees than this context.
   ///

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -230,13 +230,10 @@ public:
 /// to create an \c AvailabilityContext, rather than creating one directly.
 class AvailabilityContext {
   VersionRange OSVersion;
-  std::optional<bool> SPI;
 
 public:
   /// Creates a context that requires certain versions of the target OS.
-  explicit AvailabilityContext(VersionRange OSVersion,
-                               std::optional<bool> SPI = std::nullopt)
-      : OSVersion(OSVersion), SPI(SPI) {}
+  explicit AvailabilityContext(VersionRange OSVersion) : OSVersion(OSVersion) {}
 
   /// Creates a context that imposes the constraints of the ASTContext's
   /// deployment target.
@@ -332,12 +329,9 @@ public:
     OSVersion.unionWith(other.getOSVersion());
   }
 
-  bool isAvailableAsSPI() const { return SPI && *SPI; }
-
   /// Returns a representation of this range as a string for debugging purposes.
   std::string getAsString() const {
-    return "AvailabilityContext(" + OSVersion.getAsString() +
-           (isAvailableAsSPI() ? ", spi" : "") + ")";
+    return "AvailabilityContext(" + OSVersion.getAsString() + ")";
   }
 };
 
@@ -358,8 +352,11 @@ public:
   static AvailabilityContext inferForType(Type t);
 
   /// Returns the context where a declaration is available
-  ///  We assume a declaration without an annotation is always available.
+  /// We assume a declaration without an annotation is always available.
   static AvailabilityContext availableRange(const Decl *D, ASTContext &C);
+
+  /// Returns true is the declaration is `@_spi_available`.
+  static bool isAvailableAsSPI(const Decl *D, ASTContext &C);
 
   /// Returns the availability context for a declaration with the given
   /// @available attribute.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6733,3 +6733,7 @@ ValueOwnership swift::asValueOwnership(ParameterOwnership o) {
   }
   llvm_unreachable("exhaustive switch");
 }
+
+StringRef ASTContext::getTargetPlatformStringForDiagnostics() const {
+  return prettyPlatformString(targetPlatform(LangOpts));
+}

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -521,7 +521,7 @@ bool UnavailabilityReason::requiresDeploymentTargetOrEarlier(
     ASTContext &Ctx) const {
   return RequiredDeploymentRange.getLowerEndpoint() <=
          AvailabilityContext::forDeploymentTarget(Ctx)
-             .getOSVersion()
+             .getVersionRange()
              .getLowerEndpoint();
 }
 

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -517,14 +517,6 @@ bool Decl::requiresUnavailableDeclABICompatibilityStubs() const {
   return isUnreachableAtRuntime();
 }
 
-bool UnavailabilityReason::requiresDeploymentTargetOrEarlier(
-    ASTContext &Ctx) const {
-  return RequiredDeploymentRange.getLowerEndpoint() <=
-         AvailabilityContext::forDeploymentTarget(Ctx)
-             .getVersionRange()
-             .getLowerEndpoint();
-}
-
 AvailabilityContext
 AvailabilityInference::annotatedAvailableRangeForAttr(const SpecializeAttr* attr,
                                                       ASTContext &ctx) {

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -423,8 +423,7 @@ AvailabilityInference::annotatedAvailableRange(const Decl *D, ASTContext &Ctx) {
 }
 
 bool Decl::isAvailableAsSPI() const {
-  return AvailabilityInference::availableRange(this, getASTContext())
-    .isAvailableAsSPI();
+  return AvailabilityInference::isAvailableAsSPI(this, getASTContext());
 }
 
 std::optional<AvailableAttrDeclPair>
@@ -550,13 +549,10 @@ AvailabilityInference::annotatedAvailableRangeForAttr(const SpecializeAttr* attr
   return AvailabilityContext::alwaysAvailable();
 }
 
-AvailabilityContext AvailabilityInference::availableRange(const Decl *D,
-                                                          ASTContext &Ctx) {
-  std::optional<AvailabilityContext> AnnotatedRange =
-      annotatedAvailableRange(D, Ctx);
-  if (AnnotatedRange.has_value()) {
-    return AnnotatedRange.value();
-  }
+static const AvailableAttr *attrForAvailableRange(const Decl *D,
+                                                  ASTContext &Ctx) {
+  if (auto attr = AvailabilityInference::attrForAnnotatedAvailableRange(D, Ctx))
+    return attr;
 
   // Unlike other declarations, extensions can be used without referring to them
   // by name (they don't have one) in the source. For this reason, when checking
@@ -568,14 +564,28 @@ AvailabilityContext AvailabilityInference::availableRange(const Decl *D,
 
   DeclContext *DC = D->getDeclContext();
   if (auto *ED = dyn_cast<ExtensionDecl>(DC)) {
-    AnnotatedRange = annotatedAvailableRange(ED, Ctx);
-    if (AnnotatedRange.has_value()) {
-      return AnnotatedRange.value();
-    }
+    if (auto attr =
+            AvailabilityInference::attrForAnnotatedAvailableRange(ED, Ctx))
+      return attr;
   }
+
+  return nullptr;
+}
+
+AvailabilityContext AvailabilityInference::availableRange(const Decl *D,
+                                                          ASTContext &Ctx) {
+  if (auto attr = attrForAvailableRange(D, Ctx))
+    return availableRange(attr, Ctx);
 
   // Treat unannotated declarations as always available.
   return AvailabilityContext::alwaysAvailable();
+}
+
+bool AvailabilityInference::isAvailableAsSPI(const Decl *D, ASTContext &Ctx) {
+  if (auto attr = attrForAvailableRange(D, Ctx))
+    return attr->IsSPI;
+
+  return false;
 }
 
 AvailabilityContext
@@ -590,8 +600,7 @@ AvailabilityInference::availableRange(const AvailableAttr *attr,
       attr, Ctx, Platform, RemappedIntroducedVersion))
     IntroducedVersion = RemappedIntroducedVersion;
 
-  return AvailabilityContext{VersionRange::allGTE(IntroducedVersion),
-                             attr->IsSPI};
+  return AvailabilityContext{VersionRange::allGTE(IntroducedVersion)};
 }
 
 namespace {

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -365,7 +365,7 @@ void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
   OS.indent(Indent);
   OS << "(" << getReasonName(getReason());
 
-  OS << " versions=" << AvailabilityInfo.getOSVersion().getAsString();
+  OS << " versions=" << AvailabilityInfo.getVersionRange().getAsString();
 
   if (getReason() == Reason::Decl || getReason() == Reason::DeclImplicit) {
     Decl *D = Node.getAsDecl();
@@ -391,7 +391,7 @@ void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
 
   if (!ExplicitAvailabilityInfo.isAlwaysAvailable())
     OS << " explicit_versions="
-       << ExplicitAvailabilityInfo.getOSVersion().getAsString();
+       << ExplicitAvailabilityInfo.getVersionRange().getAsString();
 
   for (TypeRefinementContext *Child : Children) {
     OS << '\n';

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -360,12 +360,22 @@ TypeRefinementContext::getAvailabilityConditionVersionSourceRange(
   llvm_unreachable("Unhandled Reason in switch.");
 }
 
+static std::string
+stringForAvailability(const AvailabilityContext &availability) {
+  if (availability.isAlwaysAvailable())
+    return "all";
+  if (availability.isKnownUnreachable())
+    return "none";
+
+  return availability.getVersionString();
+}
+
 void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
                                   unsigned Indent) const {
   OS.indent(Indent);
   OS << "(" << getReasonName(getReason());
 
-  OS << " versions=" << AvailabilityInfo.getVersionRange().getAsString();
+  OS << " version=" << stringForAvailability(AvailabilityInfo);
 
   if (getReason() == Reason::Decl || getReason() == Reason::DeclImplicit) {
     Decl *D = Node.getAsDecl();
@@ -390,8 +400,8 @@ void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
   }
 
   if (!ExplicitAvailabilityInfo.isAlwaysAvailable())
-    OS << " explicit_versions="
-       << ExplicitAvailabilityInfo.getVersionRange().getAsString();
+    OS << " explicit_version="
+       << stringForAvailability(ExplicitAvailabilityInfo);
 
   for (TypeRefinementContext *Child : Children) {
     OS << '\n';

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -541,7 +541,7 @@ static void applyAvailableAttribute(Decl *decl, AvailabilityContext &info,
                                       /*Message=*/StringRef(),
                                       /*Rename=*/StringRef(),
                                       /*RenameDecl=*/nullptr,
-                                      info.getVersionRange().getLowerEndpoint(),
+                                      info.getRawMinimumVersion(),
                                       /*IntroducedRange*/SourceRange(),
                                       /*Deprecated=*/noVersion,
                                       /*DeprecatedRange*/SourceRange(),
@@ -2798,13 +2798,13 @@ namespace {
       if (auto classDecl = dyn_cast<ClassDecl>(result)) {
         validateForeignReferenceType(decl, classDecl);
 
-        auto ctx = Impl.SwiftContext.getSwift58Availability();
-        if (!ctx.isAlwaysAvailable()) {
-          assert(ctx.getVersionRange().hasLowerEndpoint());
+        auto availability = Impl.SwiftContext.getSwift58Availability();
+        if (!availability.isAlwaysAvailable()) {
+          assert(availability.hasMinimumVersion());
           auto AvAttr = new (Impl.SwiftContext) AvailableAttr(
               SourceLoc(), SourceRange(),
               targetPlatform(Impl.SwiftContext.LangOpts), "", "",
-              /*RenameDecl=*/nullptr, ctx.getVersionRange().getLowerEndpoint(),
+              /*RenameDecl=*/nullptr, availability.getRawMinimumVersion(),
               /*IntroducedRange=*/SourceRange(), {},
               /*DeprecatedRange=*/SourceRange(), {},
               /*ObsoletedRange=*/SourceRange(),
@@ -6615,9 +6615,9 @@ bool SwiftDeclConverter::existingConstructorIsWorse(
     if (!introduced.empty())
       return false;
   } else {
-    VersionRange existingIntroduced = existingAvailability.getVersionRange();
-    if (introduced != existingIntroduced.getLowerEndpoint()) {
-      return introduced < existingIntroduced.getLowerEndpoint();
+    auto existingIntroduced = existingAvailability.getRawMinimumVersion();
+    if (introduced != existingIntroduced) {
+      return introduced < existingIntroduced;
     }
   }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -541,7 +541,7 @@ static void applyAvailableAttribute(Decl *decl, AvailabilityContext &info,
                                       /*Message=*/StringRef(),
                                       /*Rename=*/StringRef(),
                                       /*RenameDecl=*/nullptr,
-                                      info.getOSVersion().getLowerEndpoint(),
+                                      info.getVersionRange().getLowerEndpoint(),
                                       /*IntroducedRange*/SourceRange(),
                                       /*Deprecated=*/noVersion,
                                       /*DeprecatedRange*/SourceRange(),
@@ -2800,11 +2800,11 @@ namespace {
 
         auto ctx = Impl.SwiftContext.getSwift58Availability();
         if (!ctx.isAlwaysAvailable()) {
-          assert(ctx.getOSVersion().hasLowerEndpoint());
+          assert(ctx.getVersionRange().hasLowerEndpoint());
           auto AvAttr = new (Impl.SwiftContext) AvailableAttr(
               SourceLoc(), SourceRange(),
               targetPlatform(Impl.SwiftContext.LangOpts), "", "",
-              /*RenameDecl=*/nullptr, ctx.getOSVersion().getLowerEndpoint(),
+              /*RenameDecl=*/nullptr, ctx.getVersionRange().getLowerEndpoint(),
               /*IntroducedRange=*/SourceRange(), {},
               /*DeprecatedRange=*/SourceRange(), {},
               /*ObsoletedRange=*/SourceRange(),
@@ -6615,7 +6615,7 @@ bool SwiftDeclConverter::existingConstructorIsWorse(
     if (!introduced.empty())
       return false;
   } else {
-    VersionRange existingIntroduced = existingAvailability.getOSVersion();
+    VersionRange existingIntroduced = existingAvailability.getVersionRange();
     if (introduced != existingIntroduced.getLowerEndpoint()) {
       return introduced < existingIntroduced.getLowerEndpoint();
     }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5116,8 +5116,8 @@ diagnoseUnsupportedObjCImplLayout(IRGenModule &IGM, ClassDecl *classDecl,
             field.getVarDecl(),
             diag::attr_objc_implementation_resilient_property_deployment_target,
             prettyPlatformString(targetPlatform(ctx.LangOpts)),
-            currentAvailability.getOSVersion().getLowerEndpoint(),
-            requiredAvailability.getOSVersion().getLowerEndpoint());
+            currentAvailability.getVersionRange().getLowerEndpoint(),
+            requiredAvailability.getVersionRange().getLowerEndpoint());
       else
         diags.diagnose(
             field.getVarDecl(),

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5116,8 +5116,8 @@ diagnoseUnsupportedObjCImplLayout(IRGenModule &IGM, ClassDecl *classDecl,
             field.getVarDecl(),
             diag::attr_objc_implementation_resilient_property_deployment_target,
             prettyPlatformString(targetPlatform(ctx.LangOpts)),
-            currentAvailability.getVersionRange().getLowerEndpoint(),
-            requiredAvailability.getVersionRange().getLowerEndpoint());
+            currentAvailability.getRawMinimumVersion(),
+            requiredAvailability.getRawMinimumVersion());
       else
         diags.diagnose(
             field.getVarDecl(),

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5115,7 +5115,7 @@ diagnoseUnsupportedObjCImplLayout(IRGenModule &IGM, ClassDecl *classDecl,
         diags.diagnose(
             field.getVarDecl(),
             diag::attr_objc_implementation_resilient_property_deployment_target,
-            prettyPlatformString(targetPlatform(ctx.LangOpts)),
+            ctx.getTargetPlatformStringForDiagnostics(),
             currentAvailability.getRawMinimumVersion(),
             requiredAvailability.getRawMinimumVersion());
       else

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3438,8 +3438,7 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     OS << "[weak_imported] ";
   auto availability = getAvailabilityForLinkage();
   if (!availability.isAlwaysAvailable()) {
-    auto version = availability.getVersionRange().getLowerEndpoint();
-    OS << "[available " << version.getAsString() << "] ";
+    OS << "[available " << availability.getVersionString() << "] ";
   }
 
   switch (getInlineStrategy()) {
@@ -4410,8 +4409,7 @@ void SILSpecializeAttr::print(llvm::raw_ostream &OS) const {
     OS << "target: \"" << targetFunction->getName() << "\", ";
   }
   if (!availability.isAlwaysAvailable()) {
-    auto version = availability.getVersionRange().getLowerEndpoint();
-    OS << "available: " << version.getAsString() << ", ";
+    OS << "available: " << availability.getVersionString() << ", ";
   }
   if (!requirements.empty()) {
     OS << "where ";

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3438,7 +3438,7 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     OS << "[weak_imported] ";
   auto availability = getAvailabilityForLinkage();
   if (!availability.isAlwaysAvailable()) {
-    auto version = availability.getOSVersion().getLowerEndpoint();
+    auto version = availability.getVersionRange().getLowerEndpoint();
     OS << "[available " << version.getAsString() << "] ";
   }
 
@@ -4409,8 +4409,8 @@ void SILSpecializeAttr::print(llvm::raw_ostream &OS) const {
   if (targetFunction) {
     OS << "target: \"" << targetFunction->getName() << "\", ";
   }
- if (!availability.isAlwaysAvailable()) {
-    auto version = availability.getOSVersion().getLowerEndpoint();
+  if (!availability.isAlwaysAvailable()) {
+    auto version = availability.getVersionRange().getLowerEndpoint();
     OS << "available: " << version.getAsString() << ", ";
   }
   if (!requirements.empty()) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1684,7 +1684,7 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
       auto diag = diagnose(
           attr->getLocation(),
           diag::attr_objc_implementation_raise_minimum_deployment_target,
-          prettyPlatformString(targetPlatform(Ctx.LangOpts)),
+          Ctx.getTargetPlatformStringForDiagnostics(),
           Ctx.getSwift50Availability().getRawMinimumVersion());
       if (attr->isEarlyAdopter()) {
         diag.wrapIn(diag::wrap_objc_implementation_will_become_error);
@@ -2209,11 +2209,11 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
           diagnose(enclosingDecl->getLoc(),
                    diag::availability_implicit_decl_here,
                    D->getDescriptiveKind(),
-                   prettyPlatformString(targetPlatform(Ctx.LangOpts)),
+                   Ctx.getTargetPlatformStringForDiagnostics(),
                    AttrRange.getRawMinimumVersion());
         diagnose(enclosingDecl->getLoc(),
                  diag::availability_decl_more_than_enclosing_here,
-                 prettyPlatformString(targetPlatform(Ctx.LangOpts)),
+                 Ctx.getTargetPlatformStringForDiagnostics(),
                  EnclosingAnnotatedRange->getRawMinimumVersion());
       }
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1685,7 +1685,7 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
           attr->getLocation(),
           diag::attr_objc_implementation_raise_minimum_deployment_target,
           prettyPlatformString(targetPlatform(Ctx.LangOpts)),
-          Ctx.getSwift50Availability().getVersionRange().getLowerEndpoint());
+          Ctx.getSwift50Availability().getRawMinimumVersion());
       if (attr->isEarlyAdopter()) {
         diag.wrapIn(diag::wrap_objc_implementation_will_become_error);
       }
@@ -2210,11 +2210,11 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
                    diag::availability_implicit_decl_here,
                    D->getDescriptiveKind(),
                    prettyPlatformString(targetPlatform(Ctx.LangOpts)),
-                   AttrRange.getVersionRange().getLowerEndpoint());
+                   AttrRange.getRawMinimumVersion());
         diagnose(enclosingDecl->getLoc(),
                  diag::availability_decl_more_than_enclosing_here,
                  prettyPlatformString(targetPlatform(Ctx.LangOpts)),
-                 EnclosingAnnotatedRange->getVersionRange().getLowerEndpoint());
+                 EnclosingAnnotatedRange->getRawMinimumVersion());
       }
     }
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1681,10 +1681,11 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
     // supported.
     auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(Ctx);
     if (!deploymentAvailability.isContainedIn(Ctx.getSwift50Availability())) {
-      auto diag = diagnose(attr->getLocation(),
-               diag::attr_objc_implementation_raise_minimum_deployment_target,
-               prettyPlatformString(targetPlatform(Ctx.LangOpts)),
-               Ctx.getSwift50Availability().getOSVersion().getLowerEndpoint());
+      auto diag = diagnose(
+          attr->getLocation(),
+          diag::attr_objc_implementation_raise_minimum_deployment_target,
+          prettyPlatformString(targetPlatform(Ctx.LangOpts)),
+          Ctx.getSwift50Availability().getVersionRange().getLowerEndpoint());
       if (attr->isEarlyAdopter()) {
         diag.wrapIn(diag::wrap_objc_implementation_will_become_error);
       }
@@ -2209,11 +2210,11 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
                    diag::availability_implicit_decl_here,
                    D->getDescriptiveKind(),
                    prettyPlatformString(targetPlatform(Ctx.LangOpts)),
-                   AttrRange.getOSVersion().getLowerEndpoint());
+                   AttrRange.getVersionRange().getLowerEndpoint());
         diagnose(enclosingDecl->getLoc(),
                  diag::availability_decl_more_than_enclosing_here,
                  prettyPlatformString(targetPlatform(Ctx.LangOpts)),
-                 EnclosingAnnotatedRange->getOSVersion().getLowerEndpoint());
+                 EnclosingAnnotatedRange->getVersionRange().getLowerEndpoint());
       }
     }
   }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2068,7 +2068,7 @@ void TypeChecker::diagnosePotentialUnavailability(
   {
     auto Err = Context.Diags.diagnose(
         ReferenceRange.Start, Diag,
-        prettyPlatformString(targetPlatform(Context.LangOpts)),
+        Context.getTargetPlatformStringForDiagnostics(),
         Availability.getRawMinimumVersion());
 
     // Direct a fixit to the error if an existing guard is nearly-correct
@@ -2122,7 +2122,7 @@ static Diagnostic getPotentialUnavailabilityDiagnostic(
     const AvailabilityContext &Availability, bool WarnBeforeDeploymentTarget,
     bool &IsError) {
   ASTContext &Context = ReferenceDC->getASTContext();
-  auto Platform = prettyPlatformString(targetPlatform(Context.LangOpts));
+  auto Platform = Context.getTargetPlatformStringForDiagnostics();
 
   if (requiresDeploymentTargetOrEarlier(Availability, Context)) {
     // The required OS version is at or before the deployment target so this
@@ -2179,7 +2179,7 @@ void TypeChecker::diagnosePotentialAccessorUnavailability(
   {
     auto Err = Context.Diags.diagnose(
         ReferenceRange.Start, diag, Accessor,
-        prettyPlatformString(targetPlatform(Context.LangOpts)),
+        Context.getTargetPlatformStringForDiagnostics(),
         Availability.getRawMinimumVersion());
 
     // Direct a fixit to the error if an existing guard is nearly-correct
@@ -2221,7 +2221,7 @@ void TypeChecker::diagnosePotentialUnavailability(
     auto proto = rootConf->getProtocol()->getDeclaredInterfaceType();
     auto err = ctx.Diags.diagnose(
         loc, diag::conformance_availability_only_version_newer, type, proto,
-        prettyPlatformString(targetPlatform(ctx.LangOpts)),
+        ctx.getTargetPlatformStringForDiagnostics(),
         availability.getRawMinimumVersion());
 
     err.warnUntilSwiftVersion(6);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1119,7 +1119,7 @@ private:
       }
 
       AvailabilityContext NewConstraint = contextForSpec(Spec, false);
-      Query->setAvailableRange(contextForSpec(Spec, true).getOSVersion());
+      Query->setAvailableRange(contextForSpec(Spec, true).getVersionRange());
 
       // When compiling zippered for macCatalyst, we need to collect both
       // a macOS version (the target version) and an iOS/macCatalyst version
@@ -1130,7 +1130,7 @@ private:
         AvailabilitySpec *VariantSpec =
             bestActiveSpecForQuery(Query, /*ForTargetVariant*/ true);
         VersionRange VariantRange =
-            contextForSpec(VariantSpec, true).getOSVersion();
+            contextForSpec(VariantSpec, true).getVersionRange();
         Query->setVariantAvailableRange(VariantRange);
       }
 
@@ -1474,7 +1474,7 @@ TypeChecker::checkDeclarationAvailability(const Decl *D,
     AvailabilityContext safeRangeUnderApprox{
         AvailabilityInference::availableRange(D, Context)};
 
-    VersionRange version = safeRangeUnderApprox.getOSVersion();
+    VersionRange version = safeRangeUnderApprox.getVersionRange();
     return UnavailabilityReason::requiresVersionRange(version);
   }
 
@@ -1921,7 +1921,8 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
                                                            ReferenceDC, &TRC);
   if (!TRC)
     return false;
-  VersionRange RunningRange = TRC->getExplicitAvailabilityInfo().getOSVersion();
+  VersionRange RunningRange =
+      TRC->getExplicitAvailabilityInfo().getVersionRange();
   if (RunningRange.hasLowerEndpoint() &&
       RequiredRange.hasLowerEndpoint() &&
       TRC->getReason() != TypeRefinementContext::Reason::Root &&
@@ -2100,9 +2101,9 @@ bool TypeChecker::checkAvailability(SourceRange ReferenceRange,
     TypeChecker::overApproximateAvailabilityAtLocation(
       ReferenceRange.Start, ReferenceDC);
   if (!runningOS.isContainedIn(Availability)) {
-    diagnosePotentialUnavailability(
-      ReferenceRange, Diag, ReferenceDC,
-      UnavailabilityReason::requiresVersionRange(Availability.getOSVersion()));
+    diagnosePotentialUnavailability(ReferenceRange, Diag, ReferenceDC,
+                                    UnavailabilityReason::requiresVersionRange(
+                                        Availability.getVersionRange()));
     return true;
   }
 
@@ -4634,7 +4635,7 @@ static bool declNeedsExplicitAvailability(const Decl *decl) {
 
   // Warn on decls without an introduction version.
   auto safeRangeUnderApprox = AvailabilityInference::availableRange(decl, ctx);
-  return !safeRangeUnderApprox.getOSVersion().hasLowerEndpoint();
+  return !safeRangeUnderApprox.getVersionRange().hasLowerEndpoint();
 }
 
 void swift::checkExplicitAvailability(Decl *decl) {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -521,11 +521,11 @@ static bool checkObjCClassStubAvailability(ASTContext &ctx, const Decl *decl) {
   auto minRange = getMinOSVersionForClassStubs(ctx.LangOpts.Target);
 
   auto targetRange = AvailabilityContext::forDeploymentTarget(ctx);
-  if (targetRange.getOSVersion().isContainedIn(minRange))
+  if (targetRange.getVersionRange().isContainedIn(minRange))
     return true;
 
   auto declRange = AvailabilityInference::availableRange(decl, ctx);
-  return declRange.getOSVersion().isContainedIn(minRange);
+  return declRange.getVersionRange().isContainedIn(minRange);
 }
 
 static const ClassDecl *getResilientAncestor(ModuleDecl *mod,

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -517,15 +517,21 @@ static VersionRange getMinOSVersionForClassStubs(const llvm::Triple &target) {
   return VersionRange::all();
 }
 
-static bool checkObjCClassStubAvailability(ASTContext &ctx, const Decl *decl) {
-  auto minRange = getMinOSVersionForClassStubs(ctx.LangOpts.Target);
+static AvailabilityContext getObjCClassStubAvailability(ASTContext &ctx) {
+  // FIXME: This should just be ctx.getSwift51Availability(), but that breaks
+  // tests on arm64 arches.
+  return AvailabilityContext(getMinOSVersionForClassStubs(ctx.LangOpts.Target));
+}
 
-  auto targetRange = AvailabilityContext::forDeploymentTarget(ctx);
-  if (targetRange.getVersionRange().isContainedIn(minRange))
+static bool checkObjCClassStubAvailability(ASTContext &ctx, const Decl *decl) {
+  auto stubAvailability = getObjCClassStubAvailability(ctx);
+
+  auto deploymentTarget = AvailabilityContext::forDeploymentTarget(ctx);
+  if (deploymentTarget.isContainedIn(stubAvailability))
     return true;
 
-  auto declRange = AvailabilityInference::availableRange(decl, ctx);
-  return declRange.getVersionRange().isContainedIn(minRange);
+  auto declAvailability = AvailabilityInference::availableRange(decl, ctx);
+  return declAvailability.isContainedIn(stubAvailability);
 }
 
 static const ClassDecl *getResilientAncestor(ModuleDecl *mod,
@@ -568,16 +574,15 @@ static bool checkObjCInExtensionContext(const ValueDecl *value,
               AncestryFlags::ResilientOther) ||
             classDecl->hasResilientMetadata(mod,
                                             ResilienceExpansion::Maximal)) {
-          auto &target = ctx.LangOpts.Target;
           auto platform = prettyPlatformString(targetPlatform(ctx.LangOpts));
-          auto range = getMinOSVersionForClassStubs(target);
+          auto stubAvailability = getObjCClassStubAvailability(ctx);
           auto *ancestor = getResilientAncestor(mod, classDecl);
           softenIfAccessNote(value, reason.getAttr(),
             value->diagnose(diag::objc_in_resilient_extension,
                             value->getDescriptiveKind(),
                             ancestor->getName(),
                             platform,
-                            range.getLowerEndpoint())
+                            stubAvailability.getRawMinimumVersion())
                 .limitBehavior(behavior));
           reason.describe(value);
           return true;
@@ -1317,17 +1322,13 @@ static std::optional<ObjCReason> shouldMarkClassAsObjC(const ClassDecl *CD) {
         return std::nullopt;
       }
 
-
-      auto &target = ctx.LangOpts.Target;
       auto platform = prettyPlatformString(targetPlatform(ctx.LangOpts));
-      auto range = getMinOSVersionForClassStubs(target);
+      auto stubAvailability = getObjCClassStubAvailability(ctx);
       auto *ancestor = getResilientAncestor(CD->getParentModule(), CD);
-      swift::diagnoseAndRemoveAttr(CD, attr,
-                                   diag::objc_for_resilient_class,
-                                   ancestor->getName(),
-                                   platform,
-                                   range.getLowerEndpoint())
-        .limitBehavior(behavior);
+      swift::diagnoseAndRemoveAttr(CD, attr, diag::objc_for_resilient_class,
+                                   ancestor->getName(), platform,
+                                   stubAvailability.getRawMinimumVersion())
+          .limitBehavior(behavior);
       reason.describe(CD);
     }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -574,14 +574,13 @@ static bool checkObjCInExtensionContext(const ValueDecl *value,
               AncestryFlags::ResilientOther) ||
             classDecl->hasResilientMetadata(mod,
                                             ResilienceExpansion::Maximal)) {
-          auto platform = prettyPlatformString(targetPlatform(ctx.LangOpts));
           auto stubAvailability = getObjCClassStubAvailability(ctx);
           auto *ancestor = getResilientAncestor(mod, classDecl);
           softenIfAccessNote(value, reason.getAttr(),
             value->diagnose(diag::objc_in_resilient_extension,
                             value->getDescriptiveKind(),
                             ancestor->getName(),
-                            platform,
+                            ctx.getTargetPlatformStringForDiagnostics(),
                             stubAvailability.getRawMinimumVersion())
                 .limitBehavior(behavior));
           reason.describe(value);
@@ -1322,11 +1321,11 @@ static std::optional<ObjCReason> shouldMarkClassAsObjC(const ClassDecl *CD) {
         return std::nullopt;
       }
 
-      auto platform = prettyPlatformString(targetPlatform(ctx.LangOpts));
       auto stubAvailability = getObjCClassStubAvailability(ctx);
       auto *ancestor = getResilientAncestor(CD->getParentModule(), CD);
       swift::diagnoseAndRemoveAttr(CD, attr, diag::objc_for_resilient_class,
-                                   ancestor->getName(), platform,
+                                   ancestor->getName(),
+                                   ctx.getTargetPlatformStringForDiagnostics(),
                                    stubAvailability.getRawMinimumVersion())
           .limitBehavior(behavior);
       reason.describe(CD);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4316,7 +4316,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
               diagLoc, diag::availability_protocol_requires_version,
               conformance->getProtocol(), witness,
               prettyPlatformString(targetPlatform(ctx.LangOpts)),
-              check.RequiredAvailability.getOSVersion().getLowerEndpoint());
+              check.RequiredAvailability.getVersionRange().getLowerEndpoint());
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
           diags.diagnose(requirement,
                          diag::availability_protocol_requirement_here);
@@ -4821,7 +4821,7 @@ static bool diagnoseTypeWitnessAvailability(
   if (!TypeChecker::isAvailabilitySafeForConformance(conformance->getProtocol(),
                                                      assocType, witness, dc,
                                                      requiredAvailability)) {
-    auto requiredRange = requiredAvailability.getOSVersion();
+    auto requiredRange = requiredAvailability.getVersionRange();
     ctx.addDelayedConformanceDiag(
         conformance, shouldError,
         [witness, requiredRange](NormalProtocolConformance *conformance) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4312,11 +4312,10 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           ASTContext &ctx = witness->getASTContext();
           auto &diags = ctx.Diags;
           SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
-          diags.diagnose(
-              diagLoc, diag::availability_protocol_requires_version,
-              conformance->getProtocol(), witness,
-              prettyPlatformString(targetPlatform(ctx.LangOpts)),
-              check.RequiredAvailability.getVersionRange().getLowerEndpoint());
+          diags.diagnose(diagLoc, diag::availability_protocol_requires_version,
+                         conformance->getProtocol(), witness,
+                         prettyPlatformString(targetPlatform(ctx.LangOpts)),
+                         check.RequiredAvailability.getRawMinimumVersion());
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
           diags.diagnose(requirement,
                          diag::availability_protocol_requirement_here);
@@ -4821,17 +4820,17 @@ static bool diagnoseTypeWitnessAvailability(
   if (!TypeChecker::isAvailabilitySafeForConformance(conformance->getProtocol(),
                                                      assocType, witness, dc,
                                                      requiredAvailability)) {
-    auto requiredRange = requiredAvailability.getVersionRange();
+    auto requiredVersion = requiredAvailability.getRawMinimumVersion();
     ctx.addDelayedConformanceDiag(
         conformance, shouldError,
-        [witness, requiredRange](NormalProtocolConformance *conformance) {
+        [witness, requiredVersion](NormalProtocolConformance *conformance) {
           SourceLoc loc = getLocForDiagnosingWitness(conformance, witness);
           auto &ctx = conformance->getDeclContext()->getASTContext();
           ctx.Diags
               .diagnose(loc, diag::availability_protocol_requires_version,
                         conformance->getProtocol(), witness,
                         prettyPlatformString(targetPlatform(ctx.LangOpts)),
-                        requiredRange.getLowerEndpoint())
+                        requiredVersion)
               .warnUntilSwiftVersion(warnBeforeVersion);
 
           emitDeclaredHereIfNeeded(ctx.Diags, loc, witness);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4314,7 +4314,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
           diags.diagnose(diagLoc, diag::availability_protocol_requires_version,
                          conformance->getProtocol(), witness,
-                         prettyPlatformString(targetPlatform(ctx.LangOpts)),
+                         ctx.getTargetPlatformStringForDiagnostics(),
                          check.RequiredAvailability.getRawMinimumVersion());
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
           diags.diagnose(requirement,
@@ -4829,7 +4829,7 @@ static bool diagnoseTypeWitnessAvailability(
           ctx.Diags
               .diagnose(loc, diag::availability_protocol_requires_version,
                         conformance->getProtocol(), witness,
-                        prettyPlatformString(targetPlatform(ctx.LangOpts)),
+                        ctx.getTargetPlatformStringForDiagnostics(),
                         requiredVersion)
               .warnUntilSwiftVersion(warnBeforeVersion);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1029,17 +1029,15 @@ bool isDeclarationUnavailable(
     llvm::function_ref<AvailabilityContext()> getAvailabilityContext);
 
 /// Checks whether a declaration should be considered unavailable when
-/// referred to at the given location and, if so, returns the reason why the
-/// declaration is unavailable. Returns None is the declaration is
-/// definitely available.
-std::optional<UnavailabilityReason>
+/// referred to at the given location and, if so, returns the unmet required
+/// version range. Returns None is the declaration is definitely available.
+std::optional<AvailabilityContext>
 checkDeclarationAvailability(const Decl *D, const ExportContext &Where);
 
 /// Checks whether a conformance should be considered unavailable when
-/// referred to at the given location and, if so, returns the reason why the
-/// declaration is unavailable. Returns None is the declaration is
-/// definitely available.
-std::optional<UnavailabilityReason>
+/// referred to at the given location and, if so, returns the unmet required
+/// version range. Returns None is the declaration is definitely available.
+std::optional<AvailabilityContext>
 checkConformanceAvailability(const RootProtocolConformance *Conf,
                              const ExtensionDecl *Ext,
                              const ExportContext &Where);
@@ -1056,7 +1054,7 @@ void checkIgnoredExpr(Expr *E);
 bool diagnosePotentialUnavailability(const ValueDecl *D,
                                      SourceRange ReferenceRange,
                                      const DeclContext *ReferenceDC,
-                                     const UnavailabilityReason &Reason,
+                                     const AvailabilityContext &Availability,
                                      bool WarnBeforeDeploymentTarget);
 
 // Emits a diagnostic for a protocol conformance that is potentially
@@ -1065,13 +1063,13 @@ void diagnosePotentialUnavailability(const RootProtocolConformance *rootConf,
                                      const ExtensionDecl *ext,
                                      SourceLoc loc,
                                      const DeclContext *dc,
-                                     const UnavailabilityReason &reason);
+                                     const AvailabilityContext &availability);
 
 void
 diagnosePotentialUnavailability(SourceRange ReferenceRange,
                                 Diag<StringRef, llvm::VersionTuple> Diag,
                                 const DeclContext *ReferenceDC,
-                                const UnavailabilityReason &Reason);
+                                const AvailabilityContext &Availability);
 
 /// Type check a 'distributed actor' declaration.
 void checkDistributedActor(SourceFile *SF, NominalTypeDecl *decl);
@@ -1082,7 +1080,7 @@ void checkDistributedActor(SourceFile *SF, NominalTypeDecl *decl);
 bool checkDistributedFunc(FuncDecl *func);
 
 bool checkAvailability(SourceRange ReferenceRange,
-                       AvailabilityContext Availability,
+                       AvailabilityContext RequiredAvailability,
                        Diag<StringRef, llvm::VersionTuple> Diag,
                        const DeclContext *ReferenceDC);
 
@@ -1093,7 +1091,7 @@ void checkConcurrencyAvailability(SourceRange ReferenceRange,
 /// potentially unavailable.
 void diagnosePotentialAccessorUnavailability(
     const AccessorDecl *Accessor, SourceRange ReferenceRange,
-    const DeclContext *ReferenceDC, const UnavailabilityReason &Reason,
+    const DeclContext *ReferenceDC, const AvailabilityContext &Availability,
     bool ForInout);
 
 /// Returns the availability attribute indicating deprecation if the

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -509,7 +509,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   std::optional<llvm::VersionTuple> available;
   auto availability = F.getAvailabilityForLinkage();
   if (!availability.isAlwaysAvailable()) {
-    available = availability.getVersionRange().getLowerEndpoint();
+    available = availability.getRawMinimumVersion();
   }
   ENCODE_VER_TUPLE(available, available)
 
@@ -567,7 +567,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
     }
     auto availability = SA->getAvailability();
     if (!availability.isAlwaysAvailable()) {
-      available = availability.getVersionRange().getLowerEndpoint();
+      available = availability.getRawMinimumVersion();
     }
     ENCODE_VER_TUPLE(available, available)
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -509,7 +509,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   std::optional<llvm::VersionTuple> available;
   auto availability = F.getAvailabilityForLinkage();
   if (!availability.isAlwaysAvailable()) {
-    available = availability.getOSVersion().getLowerEndpoint();
+    available = availability.getVersionRange().getLowerEndpoint();
   }
   ENCODE_VER_TUPLE(available, available)
 
@@ -567,7 +567,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
     }
     auto availability = SA->getAvailability();
     if (!availability.isAlwaysAvailable()) {
-      available = availability.getOSVersion().getLowerEndpoint();
+      available = availability.getVersionRange().getLowerEndpoint();
     }
     ENCODE_VER_TUPLE(available, available)
 

--- a/test/SILGen/back_deployed_attr_maccatalyst.swift
+++ b/test/SILGen/back_deployed_attr_maccatalyst.swift
@@ -1,0 +1,93 @@
+// RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-ios13.1-macabi -verify
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-ios13.1-macabi | %FileCheck %s
+
+// REQUIRES: OS=macosx || OS=maccatalyst
+
+// -- Original definition of trivialFunc_macOS()
+// CHECK-LABEL: sil [ossa] @$s11back_deploy17trivialFunc_macOSyyF : $@convention(thin) () -> ()
+@backDeployed(before: macOS 10.53)
+public func trivialFunc_macOS() {}
+
+// -- Fallback definition of trivialFunc_iOS_macOS()
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy019trivialFunc_iOS_macE0yyFTwB : $@convention(thin) () -> ()
+// CHECK: bb0:
+// CHECK:   [[RESULT:%.*]] = tuple ()
+// CHECK:   return [[RESULT]] : $()
+
+// -- Back deployment thunk for trivialFunc_iOS_macOS()
+// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy019trivialFunc_iOS_macE0yyFTwb : $@convention(thin) () -> ()
+// CHECK: bb0:
+// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 51
+// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK:   [[OSVFN:%.*]] = function_ref @$ss33_stdlib_isVariantOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK:   cond_br [[AVAIL]], [[AVAIL_BB:bb[0-9]+]], [[UNAVAIL_BB:bb[0-9]+]]
+//
+// CHECK: [[UNAVAIL_BB]]:
+// CHECK:   [[FALLBACKFN:%.*]] = function_ref @$s11back_deploy019trivialFunc_iOS_macE0yyFTwB : $@convention(thin) () -> ()
+// CHECK:   {{%.*}} = apply [[FALLBACKFN]]() : $@convention(thin) () -> ()
+// CHECK:   br [[RETURN_BB:bb[0-9]+]]
+//
+// CHECK: [[AVAIL_BB]]:
+// CHECK:   [[ORIGFN:%.*]] = function_ref @$s11back_deploy019trivialFunc_iOS_macE0yyF : $@convention(thin) () -> ()
+// CHECK:   {{%.*}} = apply [[ORIGFN]]() : $@convention(thin) () -> ()
+// CHECK:   br [[RETURN_BB]]
+//
+// CHECK: [[RETURN_BB]]
+// CHECK:   [[RESULT:%.*]] = tuple ()
+// CHECK:   return [[RESULT]] : $()
+
+// -- Original definition of trivialFunc_iOS_macOS()
+// CHECK-LABEL: sil [available 51.1] [ossa] @$s11back_deploy019trivialFunc_iOS_macE0yyF : $@convention(thin) () -> ()
+@backDeployed(before: iOS 51.1, macOS 10.53)
+public func trivialFunc_iOS_macOS() {}
+
+// -- Fallback definition of trivialFunc_iOS_macOS_macCatalyst()
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy019trivialFunc_iOS_mace1_F8CatalystyyFTwB : $@convention(thin) () -> ()
+// CHECK: bb0:
+// CHECK:   [[RESULT:%.*]] = tuple ()
+// CHECK:   return [[RESULT]] : $()
+
+// -- Back deployment thunk for trivialFunc_iOS_macOS_macCatalyst()
+// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy019trivialFunc_iOS_mace1_F8CatalystyyFTwb : $@convention(thin) () -> ()
+// CHECK: bb0:
+// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 53
+// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 2
+// CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK:   [[OSVFN:%.*]] = function_ref @$ss33_stdlib_isVariantOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK:   cond_br [[AVAIL]], [[AVAIL_BB:bb[0-9]+]], [[UNAVAIL_BB:bb[0-9]+]]
+//
+// CHECK: [[UNAVAIL_BB]]:
+// CHECK:   [[FALLBACKFN:%.*]] = function_ref @$s11back_deploy019trivialFunc_iOS_mace1_F8CatalystyyFTwB : $@convention(thin) () -> ()
+// CHECK:   {{%.*}} = apply [[FALLBACKFN]]() : $@convention(thin) () -> ()
+// CHECK:   br [[RETURN_BB:bb[0-9]+]]
+//
+// CHECK: [[AVAIL_BB]]:
+// CHECK:   [[ORIGFN:%.*]] = function_ref @$s11back_deploy019trivialFunc_iOS_mace1_F8CatalystyyF : $@convention(thin) () -> ()
+// CHECK:   {{%.*}} = apply [[ORIGFN]]() : $@convention(thin) () -> ()
+// CHECK:   br [[RETURN_BB]]
+//
+// CHECK: [[RETURN_BB]]
+// CHECK:   [[RESULT:%.*]] = tuple ()
+// CHECK:   return [[RESULT]] : $()
+
+// -- Original definition of trivialFunc_iOS_macOS_macCatalyst()
+// CHECK-LABEL: sil [available 53.2] [ossa] @$s11back_deploy019trivialFunc_iOS_mace1_F8CatalystyyF : $@convention(thin) () -> ()
+@backDeployed(before: iOS 51.1, macOS 10.53, macCatalyst 53.2)
+public func trivialFunc_iOS_macOS_macCatalyst() {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s11back_deploy6calleryyF : $@convention(thin) () -> ()
+func caller() {
+  // -- Verify the thunk is not called
+  // The function is not back deployed on iOS so it should be called directly.
+  // CHECK: {{%.*}} = function_ref @$s11back_deploy17trivialFunc_macOSyyF : $@convention(thin) () -> ()
+  trivialFunc_macOS()
+
+  // -- Verify the thunk is called
+  // CHECK: {{%.*}} = function_ref @$s11back_deploy019trivialFunc_iOS_macE0yyFTwb : $@convention(thin) () -> ()
+  trivialFunc_iOS_macOS()
+  // CHECK: {{%.*}} = function_ref @$s11back_deploy019trivialFunc_iOS_mace1_F8CatalystyyFTwb : $@convention(thin) () -> ()
+  trivialFunc_iOS_macOS_macCatalyst()
+}

--- a/test/SILGen/back_deployed_attr_maccatalyst.swift
+++ b/test/SILGen/back_deployed_attr_maccatalyst.swift
@@ -15,7 +15,7 @@ public func trivialFunc_macOS() {}
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for trivialFunc_iOS_macOS()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy019trivialFunc_iOS_macE0yyFTwb : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy019trivialFunc_iOS_macE0yyFTwb : $@convention(thin) () -> ()
 // CHECK: bb0:
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 51
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
@@ -50,7 +50,7 @@ public func trivialFunc_iOS_macOS() {}
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for trivialFunc_iOS_macOS_macCatalyst()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy019trivialFunc_iOS_mace1_F8CatalystyyFTwb : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy019trivialFunc_iOS_mace1_F8CatalystyyFTwb : $@convention(thin) () -> ()
 // CHECK: bb0:
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 53
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 2

--- a/test/Sema/availability_and_delayed_parsing.swift
+++ b/test/Sema/availability_and_delayed_parsing.swift
@@ -21,8 +21,8 @@
 
 @available(macOS 10.12, *)
 public func foo() { }
-// TRC-API: (root versions=[10.10,+Inf)
-// TRC-API:   (decl versions=[10.12,+Inf) decl=foo()
+// TRC-API: (root version=10.10
+// TRC-API:   (decl version=10.12 decl=foo()
 
 #if canImport(Swift)
   @available(macOS 10.10, *)
@@ -38,11 +38,11 @@ public func foo() { }
     }
   }
 #endif
-// TRC-FULL:  (decl versions=[10.10,+Inf) decl=extension.String
-// TRC-WITHTYPES:    (condition_following_availability versions=[10.12,+Inf)
-// TRC-WITHTYPES:    (if_then versions=[10.12,+Inf)
-// TRC-WITHTYPES-NOT-NOT:    (condition_following_availability versions=[10.12,+Inf)
-// TRC-WITHTYPES-NOT-NOT:    (if_then versions=[10.12,+Inf)
+// TRC-FULL:  (decl version=10.10 decl=extension.String
+// TRC-WITHTYPES:    (condition_following_availability version=10.12
+// TRC-WITHTYPES:    (if_then version=10.12
+// TRC-WITHTYPES-NOT-NOT:    (condition_following_availability version=10.12
+// TRC-WITHTYPES-NOT-NOT:    (if_then version=10.12
 
 struct S {
   fileprivate var actual: [String] = [] {
@@ -53,18 +53,18 @@ struct S {
     }
   }
 }
-// TRC-API:  (condition_following_availability versions=[10.15,+Inf)
-// TRC-API:  (if_then versions=[10.15,+Inf)
+// TRC-API:  (condition_following_availability version=10.15
+// TRC-API:  (if_then version=10.15
 
 @inlinable public func inlinableFunc() {
     if #available(macOS 10.12, *) {
         foo()
     }
 }
-// TRC-INLINABLE:  (condition_following_availability versions=[10.12,+Inf)
-// TRC-INLINABLE:  (if_then versions=[10.12,+Inf)
-// TRC-INLINABLE-NOT-NOT:  (condition_following_availability versions=[10.12,+Inf)
-// TRC-INLINABLE-NOT-NOT:  (if_then versions=[10.12,+Inf)
+// TRC-INLINABLE:  (condition_following_availability version=10.12
+// TRC-INLINABLE:  (if_then version=10.12
+// TRC-INLINABLE-NOT-NOT:  (condition_following_availability version=10.12
+// TRC-INLINABLE-NOT-NOT:  (if_then version=10.12
 
 public func funcWithType() {
     struct S {}
@@ -72,17 +72,17 @@ public func funcWithType() {
         foo()
     }
 }
-// TRC-WITHTYPES:  (condition_following_availability versions=[10.13,+Inf)
-// TRC-WITHTYPES:  (if_then versions=[10.13,+Inf)
-// TRC-WITHTYPES-NOT-NOT:  (condition_following_availability versions=[10.13,+Inf)
-// TRC-WITHTYPES-NOT-NOT:  (if_then versions=[10.13,+Inf)
+// TRC-WITHTYPES:  (condition_following_availability version=10.13
+// TRC-WITHTYPES:  (if_then version=10.13
+// TRC-WITHTYPES-NOT-NOT:  (condition_following_availability version=10.13
+// TRC-WITHTYPES-NOT-NOT:  (if_then version=10.13
 
 public func funcSkippable() {
     if #available(macOS 10.14, *) {
         foo()
     }
 }
-// TRC-FULL:  (condition_following_availability versions=[10.14,+Inf)
-// TRC-FULL:  (if_then versions=[10.14,+Inf)
-// TRC-FULL-NOT-NOT:  (condition_following_availability versions=[10.14,+Inf)
-// TRC-FULL-NOT-NOT:  (if_then versions=[10.14,+Inf)
+// TRC-FULL:  (condition_following_availability version=10.14
+// TRC-FULL:  (if_then version=10.14
+// TRC-FULL-NOT-NOT:  (condition_following_availability version=10.14
+// TRC-FULL-NOT-NOT:  (if_then version=10.14

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -3,22 +3,22 @@
 
 // REQUIRES: OS=macosx
 
-// CHECK: {{^}}(root versions=[50,+Inf)
+// CHECK: {{^}}(root version=50
 
-// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=SomeClass
-// CHECK-NEXT: {{^}}    (decl versions=[52,+Inf) decl=someMethod()
-// CHECK-NEXT: {{^}}      (decl versions=[53,+Inf) decl=someInnerFunc()
-// CHECK-NEXT: {{^}}      (decl versions=[53,+Inf) decl=InnerClass
-// CHECK-NEXT: {{^}}        (decl versions=[54,+Inf) decl=innerClassMethod
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=someStaticProperty
-// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=someStaticProperty
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=someStaticPropertyInferredType
-// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=someStaticPropertyInferredType
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=multiPatternStaticPropertyA
-// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=multiPatternStaticPropertyA
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=someComputedProperty
-// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=someComputedProperty
-// CHECK-NEXT: {{^}}    (decl versions=[52,+Inf) decl=someOtherMethod()
+// CHECK-NEXT: {{^}}  (decl version=51 decl=SomeClass
+// CHECK-NEXT: {{^}}    (decl version=52 decl=someMethod()
+// CHECK-NEXT: {{^}}      (decl version=53 decl=someInnerFunc()
+// CHECK-NEXT: {{^}}      (decl version=53 decl=InnerClass
+// CHECK-NEXT: {{^}}        (decl version=54 decl=innerClassMethod
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someStaticProperty
+// CHECK-NEXT: {{^}}      (decl version=52 decl=someStaticProperty
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someStaticPropertyInferredType
+// CHECK-NEXT: {{^}}      (decl version=52 decl=someStaticPropertyInferredType
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=multiPatternStaticPropertyA
+// CHECK-NEXT: {{^}}      (decl version=52 decl=multiPatternStaticPropertyA
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someComputedProperty
+// CHECK-NEXT: {{^}}      (decl version=52 decl=someComputedProperty
+// CHECK-NEXT: {{^}}    (decl version=52 decl=someOtherMethod()
 @available(OSX 51, *)
 class SomeClass {
   @available(OSX 52, *)
@@ -56,14 +56,14 @@ class SomeClass {
   func someOtherMethod() { }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=someFunction()
+// CHECK-NEXT: {{^}}  (decl version=51 decl=someFunction()
 @available(OSX 51, *)
 func someFunction() { }
 
-// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=SomeProtocol
-// CHECK-NEXT: {{^}}    (decl versions=[52,+Inf) decl=protoMethod()
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=protoProperty
-// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=protoProperty
+// CHECK-NEXT: {{^}}  (decl version=51 decl=SomeProtocol
+// CHECK-NEXT: {{^}}    (decl version=52 decl=protoMethod()
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=protoProperty
+// CHECK-NEXT: {{^}}      (decl version=52 decl=protoProperty
 @available(OSX 51, *)
 protocol SomeProtocol {
   @available(OSX 52, *)
@@ -73,27 +73,27 @@ protocol SomeProtocol {
   var protoProperty: Int { get }
 }
 
-// CHECK-NEXT: {{^}}  (decl_implicit versions=[50,+Inf) decl=extension.SomeClass
-// CHECK-NEXT: {{^}}    (decl versions=[51,+Inf) decl=extension.SomeClass
-// CHECK-NEXT: {{^}}      (decl versions=[52,+Inf) decl=someExtensionFunction()
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl version=51 decl=extension.SomeClass
+// CHECK-NEXT: {{^}}      (decl version=52 decl=someExtensionFunction()
 @available(OSX 51, *)
 extension SomeClass {
   @available(OSX 52, *)
   func someExtensionFunction() { }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=functionWithStmtCondition
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[52,+Inf)
-// CHECK-NEXT: {{^}}      (condition_following_availability versions=[53,+Inf)
-// CHECK-NEXT: {{^}}    (if_then versions=[53,+Inf)
-// CHECK-NEXT: {{^}}      (condition_following_availability versions=[54,+Inf)
-// CHECK-NEXT: {{^}}      (if_then versions=[54,+Inf)
-// CHECK-NEXT: {{^}}        (condition_following_availability versions=[55,+Inf)
-// CHECK-NEXT: {{^}}        (decl versions=[55,+Inf) decl=funcInGuardElse()
-// CHECK-NEXT: {{^}}        (guard_fallthrough versions=[55,+Inf)
-// CHECK-NEXT: {{^}}          (condition_following_availability versions=[56,+Inf)
-// CHECK-NEXT: {{^}}          (guard_fallthrough versions=[56,+Inf)
-// CHECK-NEXT: {{^}}      (decl versions=[57,+Inf) decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithStmtCondition
+// CHECK-NEXT: {{^}}    (condition_following_availability version=52
+// CHECK-NEXT: {{^}}      (condition_following_availability version=53
+// CHECK-NEXT: {{^}}    (if_then version=53
+// CHECK-NEXT: {{^}}      (condition_following_availability version=54
+// CHECK-NEXT: {{^}}      (if_then version=54
+// CHECK-NEXT: {{^}}        (condition_following_availability version=55
+// CHECK-NEXT: {{^}}        (decl version=55 decl=funcInGuardElse()
+// CHECK-NEXT: {{^}}        (guard_fallthrough version=55
+// CHECK-NEXT: {{^}}          (condition_following_availability version=56
+// CHECK-NEXT: {{^}}          (guard_fallthrough version=56
+// CHECK-NEXT: {{^}}      (decl version=57 decl=funcInInnerIfElse()
 @available(OSX 51, *)
 func functionWithStmtCondition() {
   if #available(OSX 52, *),
@@ -112,11 +112,11 @@ func functionWithStmtCondition() {
   }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=functionWithUnnecessaryStmtCondition
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[53,+Inf)
-// CHECK-NEXT: {{^}}    (if_then versions=[53,+Inf)
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[54,+Inf)
-// CHECK-NEXT: {{^}}    (if_then versions=[54,+Inf)
+// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithUnnecessaryStmtCondition
+// CHECK-NEXT: {{^}}    (condition_following_availability version=53
+// CHECK-NEXT: {{^}}    (if_then version=53
+// CHECK-NEXT: {{^}}    (condition_following_availability version=54
+// CHECK-NEXT: {{^}}    (if_then version=54
 
 @available(OSX 51, *)
 func functionWithUnnecessaryStmtCondition() {
@@ -142,13 +142,13 @@ func functionWithUnnecessaryStmtCondition() {
   }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=functionWithUnnecessaryStmtConditionsHavingElseBranch
-// CHECK-NEXT: {{^}}    (if_else versions=empty
-// CHECK-NEXT: {{^}}      (decl versions=empty decl=funcInInnerIfElse()
-// CHECK-NEXT: {{^}}    (if_else versions=empty
-// CHECK-NEXT: {{^}}    (guard_else versions=empty
-// CHECK-NEXT: {{^}}    (guard_else versions=empty
-// CHECK-NEXT: {{^}}    (if_else versions=empty
+// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithUnnecessaryStmtConditionsHavingElseBranch
+// CHECK-NEXT: {{^}}    (if_else version=none
+// CHECK-NEXT: {{^}}      (decl version=none decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}    (if_else version=none
+// CHECK-NEXT: {{^}}    (guard_else version=none
+// CHECK-NEXT: {{^}}    (guard_else version=none
+// CHECK-NEXT: {{^}}    (if_else version=none
 
 @available(OSX 51, *)
 func functionWithUnnecessaryStmtConditionsHavingElseBranch(p: Int?) {
@@ -195,10 +195,10 @@ func functionWithUnnecessaryStmtConditionsHavingElseBranch(p: Int?) {
 
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=functionWithWhile()
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[52,+Inf)
-// CHECK-NEXT: {{^}}    (while_body versions=[52,+Inf)
-// CHECK-NEXT: {{^}}      (decl versions=[54,+Inf) decl=funcInWhileBody()
+// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithWhile()
+// CHECK-NEXT: {{^}}    (condition_following_availability version=52
+// CHECK-NEXT: {{^}}    (while_body version=52
+// CHECK-NEXT: {{^}}      (decl version=54 decl=funcInWhileBody()
 @available(OSX 51, *)
 func functionWithWhile() {
   while #available(OSX 52, *),
@@ -208,16 +208,16 @@ func functionWithWhile() {
   }
 }
 
-// CHECK-NEXT: {{^}}  (decl_implicit versions=[50,+Inf) decl=extension.SomeClass
-// CHECK-NEXT: {{^}}    (decl versions=[51,+Inf) decl=extension.SomeClass
-// CHECK-NEXT: {{^}}      (decl_implicit versions=[51,+Inf) decl=someStaticPropertyWithClosureInit
-// CHECK-NEXT: {{^}}        (decl versions=[52,+Inf) decl=someStaticPropertyWithClosureInit
-// CHECK-NEXT: {{^}}          (condition_following_availability versions=[54,+Inf)
-// CHECK-NEXT: {{^}}          (if_then versions=[54,+Inf)
-// CHECK-NEXT: {{^}}      (decl_implicit versions=[51,+Inf) decl=someStaticPropertyWithClosureInitInferred
-// CHECK-NEXT: {{^}}        (decl versions=[52,+Inf) decl=someStaticPropertyWithClosureInitInferred
-// CHECK-NEXT: {{^}}          (condition_following_availability versions=[54,+Inf)
-// CHECK-NEXT: {{^}}          (if_then versions=[54,+Inf)
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl version=51 decl=extension.SomeClass
+// CHECK-NEXT: {{^}}      (decl_implicit version=51 decl=someStaticPropertyWithClosureInit
+// CHECK-NEXT: {{^}}        (decl version=52 decl=someStaticPropertyWithClosureInit
+// CHECK-NEXT: {{^}}          (condition_following_availability version=54
+// CHECK-NEXT: {{^}}          (if_then version=54
+// CHECK-NEXT: {{^}}      (decl_implicit version=51 decl=someStaticPropertyWithClosureInitInferred
+// CHECK-NEXT: {{^}}        (decl version=52 decl=someStaticPropertyWithClosureInitInferred
+// CHECK-NEXT: {{^}}          (condition_following_availability version=54
+// CHECK-NEXT: {{^}}          (if_then version=54
 @available(OSX 51, *)
 extension SomeClass {
   @available(OSX 52, *)
@@ -237,21 +237,21 @@ extension SomeClass {
   }()
 }
 
-// CHECK-NEXT: {{^}}  (decl_implicit versions=[50,+Inf) decl=wrappedValue
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=wrappedValue
 
 @propertyWrapper
 struct Wrapper<T> {
   var wrappedValue: T
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[51,+Inf) decl=SomeStruct
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=someLazyVar
-// CHECK-NEXT: {{^}}      (condition_following_availability versions=[52,+Inf)
-// CHECK-NEXT: {{^}}      (guard_fallthrough versions=[52,+Inf)
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[51,+Inf) decl=someWrappedVar
-// CHECK-NEXT: {{^}}      (condition_following_availability versions=[52,+Inf)
-// CHECK-NEXT: {{^}}      (guard_fallthrough versions=[52,+Inf)
-// CHECK-NEXT: {{^}}    (decl versions=[52,+Inf) decl=someMethodAvailable52()
+// CHECK-NEXT: {{^}}  (decl version=51 decl=SomeStruct
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someLazyVar
+// CHECK-NEXT: {{^}}      (condition_following_availability version=52
+// CHECK-NEXT: {{^}}      (guard_fallthrough version=52
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someWrappedVar
+// CHECK-NEXT: {{^}}      (condition_following_availability version=52
+// CHECK-NEXT: {{^}}      (guard_fallthrough version=52
+// CHECK-NEXT: {{^}}    (decl version=52 decl=someMethodAvailable52()
 @available(OSX 51, *)
 struct SomeStruct {
   lazy var someLazyVar = {

--- a/test/Sema/availability_refinement_contexts_target_min_inlining.swift
+++ b/test/Sema/availability_refinement_contexts_target_min_inlining.swift
@@ -6,15 +6,15 @@
 // Verify that -target-min-inlining-version min implies the correct OS version
 // for the target OS.
 
-// CHECK-macosx: {{^}}(root versions=[10.10.0,+Inf)
-// CHECK-ios: {{^}}(root versions=[8.0,+Inf)
-// CHECK-tvos: {{^}}(root versions=[9.0,+Inf)
-// CHECK-watchos: {{^}}(root versions=[2.0,+Inf)
-// CHECK-xros: {{^}}(root versions=[1.0,+Inf)
+// CHECK-macosx: {{^}}(root version=10.10.0
+// CHECK-ios: {{^}}(root version=8.0
+// CHECK-tvos: {{^}}(root version=9.0
+// CHECK-watchos: {{^}}(root version=2.0
+// CHECK-xros: {{^}}(root version=1.0
 
-// CHECK-macosx-NEXT: {{^}}  (decl_implicit versions=[10.15,+Inf) decl=foo()
-// CHECK-ios-NEXT: {{^}}  (decl_implicit versions=[13,+Inf) decl=foo()
-// CHECK-tvos-NEXT: {{^}}  (decl_implicit versions=[13,+Inf) decl=foo()
-// CHECK-watchos-NEXT: {{^}}  (decl_implicit versions=[6,+Inf) decl=foo()
+// CHECK-macosx-NEXT: {{^}}  (decl_implicit version=10.15 decl=foo()
+// CHECK-ios-NEXT: {{^}}  (decl_implicit version=13 decl=foo()
+// CHECK-tvos-NEXT: {{^}}  (decl_implicit version=13 decl=foo()
+// CHECK-watchos-NEXT: {{^}}  (decl_implicit version=6 decl=foo()
 
 func foo() {}

--- a/test/Sema/availability_refinement_contexts_target_min_inlining_maccatalyst.swift
+++ b/test/Sema/availability_refinement_contexts_target_min_inlining_maccatalyst.swift
@@ -10,6 +10,6 @@
 
 // Verify that -target-min-inlining-version min implies 13.1 on macCatalyst.
 
-// CHECK: {{^}}(root versions=[13.1,+Inf)
-// CHECK-NEXT: {{^}}  (decl_implicit versions=[14.4,+Inf) decl=foo()
+// CHECK: {{^}}(root version=13.1
+// CHECK-NEXT: {{^}}  (decl_implicit version=14.4 decl=foo()
 func foo() {}


### PR DESCRIPTION
For the purposes of availability calculations, direct use of `llvm::VersionTuple` and `VersionRange` is discouraged, since these fundamental version representations are divorced from their context. For example, comparing an iOS platform version to a visionOS platform version is invalid since the versioning systems of the two platforms differ. Although visionOS inherits avialability from iOS, an iOS version must be converted to a visionOS version prior to comparison. In the future, `AvailabilityContext` can be enriched to carry the information necessary to verify that its algebraic operations are being performed on compatible values.

Other notable changes:
- Remove `IsSPI` from `AvailabilityContext`. It only existed to make `Decl::isAvailableAsSPI()` convenient to implement, which wasn't very good justification.
- Remove 'OS' from AvailabilityContext member names. In the future, `AvailabilityContexts` may represent version ranges that are not tied to OS platforms.
- Remove the `UnavailabilityReason` class. It did not live up to its name because it only modeled _potential_ unavailability due to an unmet OS version requirement but something can be unavailable for many other reasons, like explicit unavailability, language mode requirements, obsoletion, etc.