### PR TITLE
AST: Add new implementation of getOpenedExistentialSignature() 

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3335,9 +3335,8 @@ public:
   /// that this declaration dynamically replaces.
   ValueDecl *getDynamicallyReplacedDecl() const;
 
-  /// Find references to 'Self' in the type signature of this declaration in the
-  /// context of the given existential base type.
-  GenericParameterReferenceInfo findExistentialSelfReferences(Type baseTy) const;
+  /// Find references to 'Self' in the type signature of this declaration.
+  GenericParameterReferenceInfo findExistentialSelfReferences() const;
 };
 
 /// This is a common base class for declarations which declare a type.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3337,14 +3337,7 @@ public:
 
   /// Find references to 'Self' in the type signature of this declaration in the
   /// context of the given existential base type.
-  ///
-  /// \param treatNonResultCovariantSelfAsInvariant When set, covariant 'Self'
-  /// references that are not in covariant result type position are considered
-  /// invariant. This position is the uncurried interface type of a declaration,
-  /// stripped of any optionality. For example, this is true for 'Self' in
-  /// 'func foo(Int) -> () -> Self?'.
-  GenericParameterReferenceInfo findExistentialSelfReferences(
-      Type baseTy, bool treatNonResultCovariantSelfAsInvariant) const;
+  GenericParameterReferenceInfo findExistentialSelfReferences(Type baseTy) const;
 };
 
 /// This is a common base class for declarations which declare a type.
@@ -9533,7 +9526,6 @@ public:
 GenericParameterReferenceInfo
 findGenericParameterReferences(const ValueDecl *value, CanGenericSignature sig,
                                GenericTypeParamType *genericParam,
-                               bool treatNonResultCovarianceAsInvariant,
                                std::optional<unsigned> skipParamIndex);
 
 inline void

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -9525,7 +9525,8 @@ public:
 /// specifies the index of the parameter that shall be skipped.
 GenericParameterReferenceInfo
 findGenericParameterReferences(const ValueDecl *value, CanGenericSignature sig,
-                               GenericTypeParamType *genericParam,
+                               GenericTypeParamType *origParam,
+                               GenericTypeParamType *openedParam,
                                std::optional<unsigned> skipParamIndex);
 
 inline void

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -587,7 +587,7 @@ public:
   /// Canonical protocol composition types are minimized only to a certain
   /// degree to preserve ABI compatibility. This routine enables performing
   /// slower, but stricter minimization at need (e.g. redeclaration checking).
-  CanType getMinimalCanonicalType(const DeclContext *useDC) const;
+  CanType getMinimalCanonicalType() const;
 
   /// Reconstitute type sugar, e.g., for array types, dictionary
   /// types, optionals, etc.
@@ -6139,7 +6139,7 @@ public:
   /// Canonical protocol composition types are minimized only to a certain
   /// degree to preserve ABI compatibility. This routine enables performing
   /// slower, but stricter minimization at need (e.g. redeclaration checking).
-  CanType getMinimalCanonicalType(const DeclContext *useDC) const;
+  CanType getMinimalCanonicalType() const;
 
   /// Retrieve the set of members composed to create this type.
   ///

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3636,7 +3636,7 @@ CanType ValueDecl::getOverloadSignatureType() const {
                                     /*topLevelFunction=*/true, isMethod,
                                     /*isInitializer=*/isa<ConstructorDecl>(afd),
                                     getNumCurryLevels())
-        ->getMinimalCanonicalType(afd);
+        ->getMinimalCanonicalType();
   }
 
   if (isa<AbstractStorageDecl>(this)) {
@@ -3652,7 +3652,7 @@ CanType ValueDecl::getOverloadSignatureType() const {
                                    /*topLevelFunction=*/true,
                                    /*isMethod=*/false,
                                    /*isInitializer=*/false, getNumCurryLevels())
-              ->getMinimalCanonicalType(cast<SubscriptDecl>(this));
+              ->getMinimalCanonicalType();
     }
 
     // We want to curry the default signature type with the 'self' type of the
@@ -3667,7 +3667,7 @@ CanType ValueDecl::getOverloadSignatureType() const {
     auto mappedType = mapSignatureFunctionType(
         getASTContext(), getInterfaceType(), /*topLevelFunction=*/false,
         /*isMethod=*/false, /*isInitializer=*/false, getNumCurryLevels());
-    return mappedType->getMinimalCanonicalType(getDeclContext());
+    return mappedType->getMinimalCanonicalType();
   }
 
   // Note: If you add more cases to this function, you should update the

--- a/lib/AST/ExistentialGeneralization.cpp
+++ b/lib/AST/ExistentialGeneralization.cpp
@@ -81,7 +81,7 @@ public:
 private:
   Type visitProtocolType(CanProtocolType type) {
     // Simple protocol types have no sub-structure.
-    assert(!type.getParent());
+    assert(!type.getParent() || !type.getParent()->isSpecialized());
     return type;
   }
 

--- a/lib/IRGen/ExtendedExistential.h
+++ b/lib/IRGen/ExtendedExistential.h
@@ -34,6 +34,7 @@ public:
   CanGenericSignature genSig;
   CanType shapeType;
   SubstitutionMap genSubs; // optional
+  CanGenericSignature reqSig;
   FormalLinkage linkage;
 
   /// Get the extended existential type shape for the given

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -7389,36 +7389,34 @@ ExtendedExistentialTypeShapeInfo::get(CanType existentialType) {
     existentialType = metatype.getInstanceType();
   }
 
-  auto genInfo = ExistentialTypeGeneralization::get(existentialType);
+  auto &ctx = existentialType->getASTContext();
+  auto existentialSig = ctx.getOpenedExistentialSignature(existentialType);
 
-  auto result = get(genInfo, metatypeDepth);
-  result.genSubs = genInfo.Generalization;
-  return result;
-}
-
-ExtendedExistentialTypeShapeInfo
-ExtendedExistentialTypeShapeInfo::get(
-                                const ExistentialTypeGeneralization &genInfo,
-                                      unsigned metatypeDepth) {
-  auto shapeType = genInfo.Shape->getCanonicalType();
+  auto shapeType = existentialSig.Shape;
   for (unsigned i = 0; i != metatypeDepth; ++i)
     shapeType = CanExistentialMetatypeType::get(shapeType);
 
   CanGenericSignature genSig;
-  if (genInfo.Generalization)
-    genSig = genInfo.Generalization.getGenericSignature()
-                                   .getCanonicalSignature();
+  if (existentialSig.Generalization) {
+    genSig = existentialSig.Generalization.getGenericSignature()
+                                          .getCanonicalSignature();
+  }
 
   auto linkage = getExistentialShapeLinkage(genSig, shapeType);
   assert(linkage != FormalLinkage::PublicUnique && linkage != FormalLinkage::PackageUnique);
 
-  return { genSig, shapeType, SubstitutionMap(), linkage };
+  return {genSig,
+          shapeType,
+          existentialSig.Generalization,
+          existentialSig.OpenedSig,
+          linkage};
 }
 
 llvm::Constant *
 irgen::emitExtendedExistentialTypeShape(IRGenModule &IGM,
                               const ExtendedExistentialTypeShapeInfo &info) {
   CanGenericSignature genSig = info.genSig;
+  CanGenericSignature reqSig = info.reqSig;
   CanType shapeType = info.shapeType;
   bool isUnique = info.isUnique();
   bool isShared = info.isShared();
@@ -7451,11 +7449,9 @@ irgen::emitExtendedExistentialTypeShape(IRGenModule &IGM,
       metatypeDepth++;
     }
 
-    CanGenericSignature reqSig =
-      IGM.Context.getOpenedExistentialSignature(existentialType, genSig);
-
     CanType typeExpression;
     if (metatypeDepth > 0) {
+      // FIXME: reqSig.getGenericParams()[0] is always tau_0_0
       typeExpression = CanType(reqSig.getGenericParams()[0]);
       for (unsigned i = 0; i != metatypeDepth; ++i)
         typeExpression = CanMetatypeType::get(typeExpression);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1608,7 +1608,6 @@ shouldOpenExistentialCallArgument(ValueDecl *callee, unsigned paramIdx,
   // because it won't match anywhere else.
   auto referenceInfo = findGenericParameterReferences(
       callee, genericSig, genericParam,
-      /*treatNonResultCovarianceAsInvariant=*/false,
       /*skipParamIdx=*/paramIdx);
   if (referenceInfo.selfRef > TypePosition::Covariant ||
       referenceInfo.assocTypeRef > TypePosition::Covariant)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1577,23 +1577,27 @@ shouldOpenExistentialCallArgument(ValueDecl *callee, unsigned paramIdx,
   if (genericParam->getDepth() < genericSig->getMaxDepth())
     return std::nullopt;
 
+  Type existentialTy;
+  if (auto existentialMetaTy = argTy->getAs<ExistentialMetatypeType>())
+    existentialTy = existentialMetaTy->getInstanceType();
+  else
+    existentialTy = argTy;
+
+  ASSERT(existentialTy->isExistentialType());
+
+  auto &ctx = cs.getASTContext();
+
   // If the existential argument conforms to all of protocol requirements on
   // the formal parameter's type, don't open unless ImplicitOpenExistentials is
   // enabled.
 
   // If all of the conformance requirements on the formal parameter's type
   // are self-conforming, don't open.
-  ASTContext &ctx = argTy->getASTContext();
   if (!ctx.LangOpts.hasFeature(Feature::ImplicitOpenExistentials)) {
-    Type existentialObjectType;
-    if (auto existentialMetaTy = argTy->getAs<ExistentialMetatypeType>())
-      existentialObjectType = existentialMetaTy->getInstanceType();
-    else
-      existentialObjectType = argTy;
     bool containsNonSelfConformance = false;
     for (auto proto : genericSig->getRequiredProtocols(genericParam)) {
       auto conformance = lookupExistentialConformance(
-          existentialObjectType, proto);
+          existentialTy, proto);
       if (conformance.isInvalid()) {
         containsNonSelfConformance = true;
         break;
@@ -1604,10 +1608,13 @@ shouldOpenExistentialCallArgument(ValueDecl *callee, unsigned paramIdx,
       return std::nullopt;
   }
 
+  auto existentialSig = ctx.getOpenedExistentialSignature(existentialTy);
+
   // Ensure that the formal parameter is only used in covariant positions,
   // because it won't match anywhere else.
   auto referenceInfo = findGenericParameterReferences(
-      callee, genericSig, genericParam, genericParam,
+      callee, existentialSig.OpenedSig, genericParam,
+      existentialSig.SelfType->castTo<GenericTypeParamType>(),
       /*skipParamIdx=*/paramIdx);
   if (referenceInfo.selfRef > TypePosition::Covariant ||
       referenceInfo.assocTypeRef > TypePosition::Covariant)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1607,7 +1607,7 @@ shouldOpenExistentialCallArgument(ValueDecl *callee, unsigned paramIdx,
   // Ensure that the formal parameter is only used in covariant positions,
   // because it won't match anywhere else.
   auto referenceInfo = findGenericParameterReferences(
-      callee, genericSig, genericParam,
+      callee, genericSig, genericParam, genericParam,
       /*skipParamIdx=*/paramIdx);
   if (referenceInfo.selfRef > TypePosition::Covariant ||
       referenceInfo.assocTypeRef > TypePosition::Covariant)

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7548,9 +7548,7 @@ bool ConstraintSystem::isMemberAvailableOnExistential(
   // N.B. We pass the module context because this check does not care about the
   // the actual signature of the opened archetype in context, rather it cares
   // about whether you can "hold" `baseTy.member` properly in the abstract.
-  const auto info = member->findExistentialSelfReferences(
-      baseTy,
-      /*treatNonResultCovariantSelfAsInvariant=*/false);
+  const auto info = member->findExistentialSelfReferences(baseTy);
   if (info.selfRef > TypePosition::Covariant ||
       info.assocTypeRef > TypePosition::Covariant) {
     return false;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7479,9 +7479,6 @@ static bool doesMemberHaveUnfulfillableConstraintsWithExistentialBase(
 
   for (const auto &req : sig.getRequirements()) {
     switch (req.getKind()) {
-    case RequirementKind::SameShape:
-      llvm_unreachable("Same-shape requirement not supported here");
-
     case RequirementKind::Superclass: {
       if (req.getFirstType()->getRootGenericParam()->getDepth() > 0 &&
           req.getSecondType().walk(isDependentOnSelfWalker)) {
@@ -7490,7 +7487,8 @@ static bool doesMemberHaveUnfulfillableConstraintsWithExistentialBase(
 
       break;
     }
-    case RequirementKind::SameType: {
+    case RequirementKind::SameType:
+    case RequirementKind::SameShape: {
       const auto isNonSelfRootedTypeParam = [](Type ty) {
         return ty->isTypeParameter() &&
                ty->getRootGenericParam()->getDepth() > 0;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -733,8 +733,7 @@ bool HasSelfOrAssociatedTypeRequirementsRequest::evaluate(
 
     // For value members, look at their type signatures.
     if (auto valueMember = dyn_cast<ValueDecl>(member)) {
-      const auto info = valueMember->findExistentialSelfReferences(
-          decl->getDeclaredInterfaceType());
+      const auto info = valueMember->findExistentialSelfReferences();
       if (info.selfRef > TypePosition::Covariant || info.assocTypeRef) {
         return true;
       }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -734,8 +734,7 @@ bool HasSelfOrAssociatedTypeRequirementsRequest::evaluate(
     // For value members, look at their type signatures.
     if (auto valueMember = dyn_cast<ValueDecl>(member)) {
       const auto info = valueMember->findExistentialSelfReferences(
-          decl->getDeclaredInterfaceType(),
-          /*treatNonResultCovariantSelfAsInvariant=*/false);
+          decl->getDeclaredInterfaceType());
       if (info.selfRef > TypePosition::Covariant || info.assocTypeRef) {
         return true;
       }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1132,8 +1132,7 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
         // defining a non-final class conforming to 'Collection' which uses
         // the default witness for 'Collection.Iterator', which is defined
         // as 'IndexingIterator<Self>'.
-        const auto selfRefInfo = req->findExistentialSelfReferences(
-            proto->getDeclaredInterfaceType());
+        const auto selfRefInfo = req->findExistentialSelfReferences();
         if (!selfRefInfo.assocTypeRef) {
           covariantSelf = classDecl;
         }
@@ -4035,8 +4034,7 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
 
   // Check whether this requirement uses Self in a way that might
   // prevent conformance from succeeding.
-  const auto selfRefInfo = requirement->findExistentialSelfReferences(
-      Proto->getDeclaredInterfaceType());
+  const auto selfRefInfo = requirement->findExistentialSelfReferences();
 
   if (selfRefInfo.selfRef == TypePosition::Invariant ||
       (selfRefInfo.selfRef == TypePosition::Covariant &&

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1133,8 +1133,7 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
         // the default witness for 'Collection.Iterator', which is defined
         // as 'IndexingIterator<Self>'.
         const auto selfRefInfo = req->findExistentialSelfReferences(
-            proto->getDeclaredInterfaceType(),
-            /*treatNonResultCovariantSelfAsInvariant=*/true);
+            proto->getDeclaredInterfaceType());
         if (!selfRefInfo.assocTypeRef) {
           covariantSelf = classDecl;
         }
@@ -4037,10 +4036,11 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
   // Check whether this requirement uses Self in a way that might
   // prevent conformance from succeeding.
   const auto selfRefInfo = requirement->findExistentialSelfReferences(
-      Proto->getDeclaredInterfaceType(),
-      /*treatNonResultCovariantSelfAsInvariant=*/true);
+      Proto->getDeclaredInterfaceType());
 
-  if (selfRefInfo.selfRef == TypePosition::Invariant) {
+  if (selfRefInfo.selfRef == TypePosition::Invariant ||
+      (selfRefInfo.selfRef == TypePosition::Covariant &&
+       !selfRefInfo.hasCovariantSelfResult)) {
     // References to Self in a position where subclasses cannot do
     // the right thing. Complain if the adoptee is a non-final
     // class.

--- a/test/Constraints/parameterized_existentials.swift
+++ b/test/Constraints/parameterized_existentials.swift
@@ -2,6 +2,8 @@
 
 protocol P<A> {
   associatedtype A
+
+  func f() -> A
 }
 
 func f1(x: any P) -> any P<Int> {
@@ -46,4 +48,8 @@ func h2(x: (any P<Int>)?) -> (any P)? {
 
 func h3(x: (any P<Int>)?) -> (any P<String>)? {
   return x // expected-error {{cannot convert return expression of type '(any P<Int>)?' to return type '(any P<String>)?'}}
+}
+
+func generic1<T>(x: any P<T>) -> T {
+  return x.f()
 }

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -1024,3 +1024,12 @@ do {
   let _: Array<any Class2Base & CovariantAssocTypeErasureDerived> = exist.method11()
   let _: Dictionary<String, any Class2Base & CovariantAssocTypeErasureDerived> = exist.method12()
 }
+
+// Same-shape requirements
+protocol HasSameShape {
+  func foo<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U))
+}
+
+func bar(a: any HasSameShape) -> (Int, String) {
+  a.foo(t: 1, u: "hi")
+}


### PR DESCRIPTION
This new mechanism allows type variables to appear in the existential type. It will eventually replace the old variant that takes a parent generic signature.