### PR TITLE
[cxx-interop] pass `-std=c++20` to configurations using `std::span`

### DIFF
--- a/benchmark/Package.swift
+++ b/benchmark/Package.swift
@@ -127,8 +127,7 @@ targets.append(
     dependencies: swiftBenchDeps,
     path: "utils",
     sources: ["main.swift"],
-    swiftSettings: [.unsafeFlags(["-Xfrontend",
-                                  "-enable-experimental-cxx-interop",
+    swiftSettings: [.unsafeFlags(["-cxx-interoperability-mode=default",
                                   "-I",
                                   "utils/CxxTests"])]))
 
@@ -166,8 +165,7 @@ targets += cxxSingleSourceLibraries.map { name in
     dependencies: singleSourceDeps,
     path: "cxx-source",
     sources: ["\(name).swift"],
-    swiftSettings: [.unsafeFlags(["-Xfrontend",
-                                  "-enable-experimental-cxx-interop",
+    swiftSettings: [.unsafeFlags(["-cxx-interoperability-mode=default",
                                   "-I",
                                   "utils/CxxTests",
                                   // FIXME: https://github.com/apple/swift/issues/61453


### PR DESCRIPTION
When the benchmarks are built with SwiftPM, the `std=c++20` flag is passed if the `-cxx-interoperability-mode` is present. This patch switches from `-Xfrontend -enable-experimental-cxx-interop` to the required interoperability flag.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
