### PR TITLE
[cxx-interop] Add a SWIFT_NONESCAPABLE attribute to the bridging header

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7374,6 +7374,10 @@ static bool hasNonCopyableAttr(const clang::RecordDecl *decl) {
   return hasSwiftAttribute(decl, "~Copyable");
 }
 
+bool importer::hasNonEscapableAttr(const clang::RecordDecl *decl) {
+  return hasSwiftAttribute(decl, "~Escapable");
+}
+
 /// Recursively checks that there are no pointers in any fields or base classes.
 /// Does not check C++ records with specific API annotations.
 static bool hasPointerInSubobjects(const clang::CXXRecordDecl *decl) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2202,6 +2202,12 @@ namespace {
                                    MoveOnlyAttr(/*Implicit=*/true));
       }
 
+      if (Impl.SwiftContext.LangOpts.hasFeature(Feature::NonescapableTypes) &&
+          importer::hasNonEscapableAttr(decl)) {
+        result->getAttrs().add(new (Impl.SwiftContext)
+                                   NonEscapableAttr(/*Implicit=*/true));
+      }
+
       // FIXME: Figure out what to do with superclasses in C++. One possible
       // solution would be to turn them into members and add conversion
       // functions.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2029,9 +2029,11 @@ inline std::string getPrivateOperatorName(const std::string &OperatorToken) {
 
 bool hasUnsafeAPIAttr(const clang::Decl *decl);
 
+bool hasNonEscapableAttr(const clang::RecordDecl *decl);
+
 bool isViewType(const clang::CXXRecordDecl *decl);
 
-}
-}
+} // end namespace importer
+} // end namespace swift
 
 #endif

--- a/lib/ClangImporter/SwiftBridging/swift/bridging
+++ b/lib/ClangImporter/SwiftBridging/swift/bridging
@@ -158,6 +158,12 @@
 #define SWIFT_NONCOPYABLE \
   __attribute__((swift_attr("~Copyable")))
 
+/// Specifies that a specific c++ type such class or struct should be imported
+/// as a non-escapable Swift value type when the non-escapable language feature
+/// is enabled.
+#define SWIFT_NONESCAPABLE \
+  __attribute__((swift_attr("~Escapable")))
+
 #else  // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 
 // Empty defines for compilers that don't support `attribute(swift_attr)`.
@@ -172,6 +178,7 @@
 #define SWIFT_MUTATING 
 #define SWIFT_UNCHECKED_SENDABLE
 #define SWIFT_NONCOPYABLE
+#define SWIFT_NONESCAPABLE
 
 #endif // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 

--- a/test/Interop/Cxx/class/nonescapable.swift
+++ b/test/Interop/Cxx/class/nonescapable.swift
@@ -1,0 +1,25 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: not %target-swift-frontend -typecheck -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs  %t/test.swift -enable-experimental-feature NonescapableTypes -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module Test {
+    header "nonescapable.h"
+    requires cplusplus
+}
+
+//--- Inputs/nonescapable.h
+#include "swift/bridging"
+
+struct SWIFT_NONESCAPABLE A {
+    int a;
+};
+
+//--- test.swift
+
+import Test
+
+// CHECK: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
+public func test() -> A {
+    A()
+}


### PR DESCRIPTION
This makes it easier to experiment with noescapable types in interop. Moreover, we always wanted to have this annotation for completeness, similar to SWIFT_NONCOPYABLE.
