### PR TITLE
[cxx-interop] Make a test run faster

### DIFF
--- a/test/Interop/Cxx/stdlib/foundation-and-std-module.swift
+++ b/test/Interop/Cxx/stdlib/foundation-and-std-module.swift
@@ -1,5 +1,4 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++14 -Xcc -fmodules-cache-path=%t
 // RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++17 -Xcc -fmodules-cache-path=%t
 // RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t
 
@@ -8,7 +7,7 @@
 // RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++17 -Xcc -fmodules-cache-path=%t -DADD_CXXSTDLIB
 // RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t -DADD_CXXSTDLIB
 
-// RUN: %{python} -c "import os, glob; print('\n'.join(glob.glob(os.path.join('%/t', '**', '*.pcm'), recursive=True)))" | %FileCheck %s
+// RUN: ls -R %/t | %FileCheck %s
 
 #if canImport(Foundation)
 import Foundation


### PR DESCRIPTION
`foundation-and-std-module.swift` has started timing out in some CI jobs. This change makes the test run faster to stay within the 600 sec timeout.

rdar://134328721

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
