### PR TITLE
🍒[6.0][cxx-interop] Do not attempt to export read accessors to C++

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2072,9 +2072,10 @@ private:
     if (outputLang == OutputLanguageMode::Cxx) {
       if (!SD->isInstanceMember())
         return;
-      auto *getter = SD->getOpaqueAccessor(AccessorKind::Get);
-      printAbstractFunctionAsMethod(getter, false,
-                                    /*isNSUIntegerSubscript=*/false, SD);
+      // TODO: support read accessors.
+      if (auto *getter = SD->getOpaqueAccessor(AccessorKind::Get))
+        printAbstractFunctionAsMethod(getter, false,
+                                      /*isNSUIntegerSubscript=*/false, SD);
       return;
     }
     assert(SD->isInstanceMember() && "static subscripts not supported");

--- a/test/Interop/SwiftToCxx/functions/swift-operators.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-operators.swift
@@ -16,6 +16,19 @@
 
 public struct IntBox { var x: CInt }
 
+public struct CustomArray<Element> where Element : ~Copyable {
+  private var buffer: UnsafeMutableBufferPointer<Element>
+
+  public subscript(index: Int) -> Element {
+    _read {
+        yield buffer[index]
+    }
+    nonmutating _modify {
+        yield &buffer[index]
+    }
+  }
+}
+
 public func -(lhs: IntBox, rhs: IntBox) -> CInt {
   return lhs.x - rhs.x
 }


### PR DESCRIPTION
Explanation: The reverse interop code assumed that there is always a get accessor for subscript which is not always the case. This PR prevents the crash by not exporting subscript when get accessor is not available.
Scope: C++ reverse interop.
Risk: Low, we just skip problematic operators.
Testing: Regression test added.
Issue: rdar://134425834
Reviewer: @egorzhdan
Original PR: #76170

