### PR TITLE
🍒 [6.0][cxx-interop] Do not export enums with indirect associated values

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -263,6 +263,8 @@ swift::cxx_translation::getDeclRepresentation(const ValueDecl *VD) {
       for (const auto *elementDecl : enumCase->getElements()) {
         if (!elementDecl->hasAssociatedValues())
           continue;
+        if (elementDecl->isIndirect())
+          return {Unsupported, UnrepresentableIndirectEnum};
         // Do not expose any enums with > 1
         // enum parameter, or any enum parameter
         // whose type we do not yet support.

--- a/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
@@ -33,6 +33,11 @@ public enum E2 {
     case baz
 }
 
+public enum Expr {
+    case Const(Int)
+    indirect case Neg(Expr)
+}
+
 public struct S {
     public var x: Int64
     


### PR DESCRIPTION
Explanation: Indirect enum cases can trigger infinite recursion. This PR stops attempting to export them to C++.
Scope: C++ reverse interop.
Risk: Low, we skip the problematic pattern.
Testing: Regression test added.
Issue: rdar://134852756
Reviewer: @egorzhdan
Original PR: #76167