### PR TITLE
[6.0.1] SILOptimizer: Allow inlining of transparent functions in `@backDeployed` thunks

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -56,7 +56,8 @@ enum IsThunk_t {
   IsNotThunk,
   IsThunk,
   IsReabstractionThunk,
-  IsSignatureOptimizedThunk
+  IsSignatureOptimizedThunk,
+  IsBackDeployedThunk,
 };
 enum IsDynamicallyReplaceable_t {
   IsNotDynamic,
@@ -368,7 +369,7 @@ private:
   ///
   /// The inliner uses this information to avoid inlining (non-trivial)
   /// functions into the thunk.
-  unsigned Thunk : 2;
+  unsigned Thunk : 3;
 
   /// The scope in which the parent class can be subclassed, if this is a method
   /// which is contained in the vtable of that class.
@@ -488,6 +489,7 @@ private:
       break;
     case IsThunk:
     case IsReabstractionThunk:
+    case IsBackDeployedThunk:
       thunkCanHaveSubclassScope = false;
       break;
     }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3355,6 +3355,7 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
 
   switch (isThunk()) {
   case IsNotThunk: break;
+  case IsBackDeployedThunk: // FIXME: Give this a distinct label
   case IsThunk: OS << "[thunk] "; break;
   case IsSignatureOptimizedThunk:
     OS << "[signature_optimized_thunk] ";

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -909,7 +909,7 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
     preEmitFunction(constant, f, loc);
     PrettyStackTraceSILFunction X("silgen emitBackDeploymentThunk", f);
     f->setBare(IsBare);
-    f->setThunk(IsThunk);
+    f->setThunk(IsBackDeployedThunk);
 
     SILGenFunction(*this, *f, dc).emitBackDeploymentThunk(constant);
 

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -1027,9 +1027,21 @@ class MandatoryInlining : public SILModuleTransform {
 
     SILOptFunctionBuilder FuncBuilder(*this);
     for (auto &F : *M) {
-      // Don't inline into thunks, even transparent callees.
-      if (F.isThunk())
+      switch (F.isThunk()) {
+      case IsThunk_t::IsThunk:
+      case IsThunk_t::IsReabstractionThunk:
+      case IsThunk_t::IsSignatureOptimizedThunk:
+        // Don't inline into most thunks, even transparent callees.
         continue;
+
+      case IsThunk_t::IsNotThunk:
+      case IsThunk_t::IsBackDeployedThunk:
+        // For correctness, inlining _stdlib_isOSVersionAtLeast() when it is
+        // declared transparent is mandatory in the thunks of @backDeployed
+        // functions. These thunks will not contain calls to other transparent
+        // functions.
+        break;
+      }
 
       // Skip deserialized functions.
       if (F.wasDeserializedCanonical())

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 870; // SerializePackageEnabled / [serialized_for_package] for SILFunctionLayout / package field in SerializedKind_t
+const uint16_t SWIFTMODULE_VERSION_MINOR = 871; // SIL function thunk kind
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -292,7 +292,7 @@ namespace sil_block {
       BCRecordLayout<SIL_FUNCTION, SILLinkageField,
                      BCFixed<1>,  // transparent
                      BCFixed<2>,  // serializedKind
-                     BCFixed<2>,  // thunks: signature optimized/reabstraction
+                     BCFixed<3>,  // thunk kind
                      BCFixed<1>,  // without_actually_escaping
                      BCFixed<3>,  // specialPurpose
                      BCFixed<2>,  // inlineStrategy

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -37,7 +37,7 @@ import SwiftShims
 /// interpreter doesn't currently know how to load symbols from compiler-rt.
 /// Since `@_transparent` is only necessary for iOS apps, we only apply it on
 /// iOS, not any other which would inherit/remap iOS availability.
-#if os(iOS) && !os(xrOS)
+#if os(iOS) && !os(visionOS)
 @_effects(readnone)
 @_transparent
 public func _stdlib_isOSVersionAtLeast(

--- a/test/IRGen/Inputs/back_deployed.swift
+++ b/test/IRGen/Inputs/back_deployed.swift
@@ -1,0 +1,6 @@
+@backDeployed(before: SwiftStdlib 6.0)
+public func backDeployedFunc() {
+  otherFunc()
+}
+
+@usableFromInline internal func otherFunc() {}

--- a/test/IRGen/back_deployed_Onone.swift
+++ b/test/IRGen/back_deployed_Onone.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/back_deployed.swift -o %t/ -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-ir %s -I %t -Onone | %FileCheck %s
+
+// _stdlib_isOSVersionAtLeast() is not @_transparent on macOS, watchOS, and tvOS
+// REQUIRES: OS=macosx || OS=watchos || OS=tvos
+
+import back_deployed
+
+public func test() {
+  backDeployedFunc()
+}
+
+// CHECK: define{{.*}} hidden swiftcc void @"$s13back_deployed0A12DeployedFuncyyFTwb"
+// CHECK:   call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
+// CHECK:   call swiftcc void @"$s13back_deployed0A12DeployedFuncyyFTwB"
+// CHECK:   call swiftcc void @"$s13back_deployed0A12DeployedFuncyyF"

--- a/test/IRGen/back_deployed_Onone_transparent.swift
+++ b/test/IRGen/back_deployed_Onone_transparent.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/back_deployed.swift -o %t/ -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-ir %s -I %t -Onone | %FileCheck %s
+
+// _stdlib_isOSVersionAtLeast() is @_transparent on iOS
+// REQUIRES: OS=ios
+
+import back_deployed
+
+public func test() {
+  backDeployedFunc()
+}
+
+// CHECK: define{{.*}} hidden swiftcc void @"$s13back_deployed0A12DeployedFuncyyFTwb"
+// CHECK:   call swiftcc i1 @"$ss31_stdlib_isOSVersionAtLeast_AEICyBi1_Bw_BwBwtF"
+// CHECK:   call swiftcc void @"$s13back_deployed0A12DeployedFuncyyFTwB"
+// CHECK:   call swiftcc void @"$s13back_deployed0A12DeployedFuncyyF"
+
+// CHECK: define{{.*}} hidden swiftcc i1 @"$ss31_stdlib_isOSVersionAtLeast_AEICyBi1_Bw_BwBwtF"
+// CHECK:   call i32 @__isPlatformVersionAtLeast

--- a/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
+++ b/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
@@ -7,6 +7,9 @@
 // this function.
 // UNSUPPORTED: OS=xros
 
+// On iOS _stdlib_isOSVersionAtLeast() is @_transparent, which affects codegen.
+// UNSUPPORTED: OS=ios
+
 @_silgen_name("blackHole")
 func blackHole(_ value: UnsafeMutableRawPointer?) -> Void
 

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -134,7 +134,7 @@ class LLVM(cmake_product.CMakeProduct):
                       ' into the local clang build directory {}.'.format(
                           host_cxx_builtins_dir, dest_builtins_dir))
 
-                for _os in ['ios', 'watchos', 'tvos']:
+                for _os in ['ios', 'watchos', 'tvos', 'xros']:
                     # Copy over the device .a when necessary
                     lib_name = 'libclang_rt.{}.a'.format(_os)
                     host_lib_path = os.path.join(host_cxx_builtins_dir, lib_name)


### PR DESCRIPTION
- **Explanation:** Adjusts an optimizer heuristic to allow inlining of `@_transparent` functions into `@backDeployed` thunks so that the codegen for the availability checks in `@backDeployed` works as expected when compiling for iOS.
- **Scope:** Without this fix, unoptimized iOS apps that use newly `@backDeployed` functions from the `_Concurrency` library crash when the app runs on macOS, due to the availability condition being misevaluated as checking a macOS version instead of an iOS version.
- **Issue/Radar:** rdar://134793410
- **Original PR:** https://github.com/swiftlang/swift/pull/76135
- **Risk:** Medium. The optimization adjustment is extremely targeted so that it should only affect optimization and codegen for `@backDeployed` thunks, but any change of this nature carries some risk of unforeseen consequences.
- **Testing:** New tests added to the compiler test suite.
- **Reviewer:** @eeckstein @slavapestov @mikeash 