### PR TITLE
tests: reduce the timeout of SILOptimizer/large_nested_array.swift.gyb again

### DIFF
--- a/validation-test/SILOptimizer/large_nested_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_nested_array.swift.gyb
@@ -1,16 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s > %t/main.swift
 
-// The compiler should finish in less than 2 minautes. To give some slack,
-// specify a timeout of 4 minutes.
-// If the compiler needs more than 5 minutes, there is probably a real problem.
+// The compiler should finish in less than 2 minutes. To give some slack,
+// specify a timeout of 10 minutes.
+// If the compiler needs more than 10 minutes, there is probably a real problem.
 // So please don't just increase the timeout in case this fails.
 
-// TEMPORARY NOTE: The timeout has been raised to 2400 seconds while we
-// investigate timeouts in CI runs of this test. This should be set back to the
-// original time of 240 seconds once that's been figured out.
-
-// RUN: %{python} %S/../../test/Inputs/timeout.py 2400 %target-swift-frontend -O -parse-as-library -sil-verify-none -c %t/main.swift -o %t/main.o
+// RUN: %{python} %S/../../test/Inputs/timeout.py 600 %target-swift-frontend -O -parse-as-library -sil-verify-none -c %t/main.swift -o %t/main.o
 
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: long_test


### PR DESCRIPTION
It turns out that some CI jobs need 5-6 minutes for this test. To give some slack, use a timeout of 10 minutes.

This is a follow-up of https://github.com/swiftlang/swift/pull/76146
