### PR TITLE
Add comparable conformance for C++ strings

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -98,9 +98,13 @@ extension std.u32string: ExpressibleByStringLiteral {
 
 // MARK: Concatenating and comparing C++ strings
 
-extension std.string: Equatable {
+extension std.string: Equatable, Comparable {
   public static func ==(lhs: std.string, rhs: std.string) -> Bool {
     return lhs.compare(rhs) == 0
+  }
+
+  public static func <(lhs: std.string, rhs: std.string) -> Bool {
+    return lhs.compare(rhs) < 0
   }
 
   public static func +=(lhs: inout std.string, rhs: std.string) {
@@ -119,9 +123,13 @@ extension std.string: Equatable {
   }
 }
 
-extension std.u16string: Equatable {
+extension std.u16string: Equatable, Comparable {
   public static func ==(lhs: std.u16string, rhs: std.u16string) -> Bool {
     return lhs.compare(rhs) == 0
+  }
+
+  public static func <(lhs: std.u16string, rhs: std.u16string) -> Bool {
+    return lhs.compare(rhs) < 0
   }
 
   public static func +=(lhs: inout std.u16string, rhs: std.u16string) {
@@ -140,9 +148,13 @@ extension std.u16string: Equatable {
   }
 }
 
-extension std.u32string: Equatable {
+extension std.u32string: Equatable, Comparable {
   public static func ==(lhs: std.u32string, rhs: std.u32string) -> Bool {
     return lhs.compare(rhs) == 0
+  }
+
+  public static func <(lhs: std.u32string, rhs: std.u32string) -> Bool {
+    return lhs.compare(rhs) < 0
   }
 
   public static func +=(lhs: inout std.u32string, rhs: std.u32string) {

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -148,6 +148,54 @@ StdStringTestSuite.test("std::u32string::append") {
     expectEqual(s1, std.u32string("0123abc"))
 }
 
+StdStringTestSuite.test("std::string comparison") {
+    let s1 = std.string("abc")
+    let s2 = std.string("def")
+    let s3 = std.string("abc")
+
+    expectTrue(s1 < s2)
+    expectFalse(s2 < s1)
+    expectTrue(s1 <= s2)
+    expectFalse(s2 <= s1)
+    expectTrue(s2 > s1)
+    expectFalse(s1 > s2)
+    expectTrue(s2 >= s1)
+    expectFalse(s1 >= s2)
+    expectTrue(s1 == s3)
+}
+
+StdStringTestSuite.test("std::u16string comparison") {
+    let s1 = std.u16string("abc")
+    let s2 = std.u16string("def")
+    let s3 = std.u16string("abc")
+
+    expectTrue(s1 < s2)
+    expectFalse(s2 < s1)
+    expectTrue(s1 <= s2)
+    expectFalse(s2 <= s1)
+    expectTrue(s2 > s1)
+    expectFalse(s1 > s2)
+    expectTrue(s2 >= s1)
+    expectFalse(s1 >= s2)
+    expectTrue(s1 == s3)
+}
+
+StdStringTestSuite.test("std::u32string comparison") {
+    let s1 = std.u32string("abc")
+    let s2 = std.u32string("def")
+    let s3 = std.u32string("abc")
+
+    expectTrue(s1 < s2)
+    expectFalse(s2 < s1)
+    expectTrue(s1 <= s2)
+    expectFalse(s2 <= s1)
+    expectTrue(s2 > s1)
+    expectFalse(s1 > s2)
+    expectTrue(s2 >= s1)
+    expectFalse(s1 >= s2)
+    expectTrue(s1 == s3)
+}
+
 StdStringTestSuite.test("std::string as Hashable") {
     let s0 = std.string()
     let h0 = s0.hashValue


### PR DESCRIPTION
This PR adds `Comparable` conformance for C++ strings.

Fixes #76220