### PR TITLE
Concurrency: Suppress a -Wc++23-extensions warning

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1649,6 +1649,7 @@ static void defaultActorDrain(DefaultActorImpl *actor) {
 
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
 done:
+  ; // Suppress a -Wc++23-extensions warning
 #endif
 }
 


### PR DESCRIPTION
Fixes the following warning:

```
warning: label at end of compound statement is a C++23 extension [-Wc++23-extensions]
```
