### PR TITLE
[embedded] Handle retain/retain ops inside deinit in Embedded Swift's swift_release

### DIFF
--- a/test/embedded/deinit-release.swift
+++ b/test/embedded/deinit-release.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -O -c -o %t/main.o
+// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+class C {}
+
+struct Foo {
+    let foo: C = C()
+    let bar: C = C()
+}
+
+class Bar {}
+class SubBar: Bar {
+    var qwe = Foo()
+}
+
+var bar: SubBar? = SubBar()
+bar = nil
+print("OK!")
+
+// CHECK: OK!

--- a/test/embedded/deinit-release2.swift
+++ b/test/embedded/deinit-release2.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -O -c -o %t/main.o
+// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public var global_c: C? = nil
+
+@inline(never) func opaque() { print(global_c == nil ? "global is nil" : "global is not nil") }
+
+public class C {
+    init() { print("init") }
+    deinit {
+        print("deinit")
+        global_c = self
+        opaque()
+        global_c = nil
+        opaque()
+        print("end of deinit")
+    }
+}
+
+var bar: C? = C()
+bar = nil
+print("OK!")
+
+// CHECK: init
+// CHECK: deinit
+// CHECK: global is not nil
+// CHECK: global is nil
+// CHECK: end of deinit
+// CHECK: OK!


### PR DESCRIPTION
See attached testcase which crashes without the fix due to an infinite recursion. The scenario is that the deinit of the object contains a retain+release pair (on "self"). We need to handle this case in the Embedded Swift runtime's `swift_release` code.

Fixes https://github.com/swiftlang/swift/issues/74697.