### PR TITLE
[DependencyScanner] Drop macro search path if not needed

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -813,6 +813,9 @@ public:
   void addMacroDependency(StringRef macroModuleName, StringRef libraryPath,
                           StringRef executablePath);
 
+  /// For a Source/Textual dependency, if it Has macro dependency.
+  bool hasMacroDependencies() const;
+
   /// Whether or not a queried module name is a `@Testable` import dependency
   /// of this module. Can only return `true` for Swift source modules.
   bool isTestableImport(StringRef moduleName) const;

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -120,6 +120,18 @@ void ModuleDependencyInfo::addMacroDependency(StringRef macroModuleName,
     llvm_unreachable("Unexpected dependency kind");
 }
 
+bool ModuleDependencyInfo::hasMacroDependencies() const {
+  if (auto sourceModule =
+          dyn_cast<SwiftSourceModuleDependenciesStorage>(storage.get()))
+    return !sourceModule->textualModuleDetails.macroDependencies.empty();
+
+  if (auto interfaceModule =
+          dyn_cast<SwiftInterfaceModuleDependenciesStorage>(storage.get()))
+    return !interfaceModule->textualModuleDetails.macroDependencies.empty();
+
+  llvm_unreachable("Unexpected dependency kind");
+}
+
 bool ModuleDependencyInfo::isTestableImport(StringRef moduleName) const {
   if (auto swiftSourceDepStorage = getAsSwiftSourceModule())
     return swiftSourceDepStorage->testableImports.contains(moduleName);

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -159,6 +159,24 @@ parseBatchScanInputFile(ASTContext &ctx, StringRef batchInputPath,
   return result;
 }
 
+static void removeMacroSearchPaths(std::vector<std::string> &cmd) {
+  // Macro search path options.
+  static const llvm::StringSet<> macroSearchOptions = {
+      "-plugin-path",
+      "-external-plugin-path",
+      "-load-plugin-library",
+      "-load-plugin-executable",
+      "-in-process-plugin-server-path",
+  };
+
+  // Remove macro search path option and its argument.
+  for (auto it = cmd.begin(), ie=cmd.end(); it != ie; ++it) {
+    if (macroSearchOptions.contains(*it) && it + 1 != ie) {
+      it = cmd.erase(it, it + 2);
+    }
+  }
+}
+
 static llvm::Expected<llvm::cas::ObjectRef>
 updateModuleCacheKey(ModuleDependencyInfo &depInfo,
                      ModuleDependenciesCache &cache,
@@ -378,9 +396,15 @@ static llvm::Error resolveExplicitModuleInputs(
     // Update build command line.
     if (resolvingDepInfo.isSwiftInterfaceModule() ||
         resolvingDepInfo.isSwiftSourceModule()) {
-      // Update with casfs option.
       std::vector<std::string> newCommandLine =
           dependencyInfoCopy.getCommandline();
+
+      // If there are no external macro dependencies, drop all plugin search
+      // paths.
+      if (!resolvingDepInfo.hasMacroDependencies())
+        removeMacroSearchPaths(newCommandLine);
+
+      // Update with casfs option.
       for (auto rootID : rootIDs) {
         newCommandLine.push_back("-cas-fs");
         newCommandLine.push_back(rootID);
@@ -390,6 +414,7 @@ static llvm::Error resolveExplicitModuleInputs(
         newCommandLine.push_back("-clang-include-tree-root");
         newCommandLine.push_back(tree);
       }
+
       dependencyInfoCopy.updateCommandLine(newCommandLine);
     }
 

--- a/test/CAS/macro_deps.swift
+++ b/test/CAS/macro_deps.swift
@@ -29,6 +29,11 @@
 // RUN: %swift_frontend_plain @%t/SwiftShims.cmd
 // RUN: %S/Inputs/BuildCommandExtractor.py %t/deps.json Foo > %t/Foo.cmd
 // RUN: %swift_frontend_plain @%t/Foo.cmd
+// RUN: %S/Inputs/BuildCommandExtractor.py %t/deps.json Bar > %t/Bar.cmd
+// RUN: %swift_frontend_plain @%t/Bar.cmd
+
+// RUN: %FileCheck %s --check-prefix=PLUGIN_SEARCH --input-file=%t/Bar.cmd
+// PLUGIN_SEARCH-NOT: -external-plugin-path
 
 // RUN: %S/Inputs/BuildCommandExtractor.py %t/deps.json MyApp > %t/MyApp.cmd
 // RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
@@ -87,6 +92,11 @@ public func assertFalse() {
     #assert(false)
 }
 
+//--- include/Bar.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-library-evolution -swift-version 5 -O -module-name Bar -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib
+public func bar()
+
 //--- test.swift
 import Foo
 @inlinable
@@ -96,6 +106,7 @@ public func test() {
 
 //--- main.swift
 import Test
+import Bar
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroTwo", type: "StringifyMacro")
 
 func appTest() {


### PR DESCRIPTION
When scanning swift modules and constructing their build commands, there is no need to pass any external plugin search path if there are no macro dependencies for the module.

rdar://135221984

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
