### PR TITLE
[region-isolation] Do not allow for a disconnected value passed as an explicitly sent parameter to be reused.

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1229,11 +1229,14 @@ public:
       // case, if we are not marked explicitly as sending, we do not transfer
       // since the disconnected value is allowed to be resued after we
       // return. If we are passed as a sending parameter, we cannot do this.
-      if (auto fas = FullApplySite::isa(op.getSourceInst());
-          (!fas || !fas.isSending(*op.getSourceOp())) &&
-          transferredRegionIsolation.isDisconnected() && calleeIsolationInfo &&
-          transferredRegionIsolation.hasSameIsolation(calleeIsolationInfo))
-        return;
+      if (auto *sourceInst = Impl::getSourceInst(op)) {
+        if (auto fas = FullApplySite::isa(sourceInst);
+            (!fas || !fas.isSending(*op.getSourceOp())) &&
+            transferredRegionIsolation.isDisconnected() &&
+            calleeIsolationInfo &&
+            transferredRegionIsolation.hasSameIsolation(calleeIsolationInfo))
+          return;
+      }
 
       // Mark op.getOpArgs()[0] as transferred.
       TransferringOperandState &state = operandToStateMap.get(op.getSourceOp());
@@ -1581,6 +1584,9 @@ struct PartitionOpEvaluatorBaseImpl : PartitionOpEvaluator<Subclass> {
 
   static SILLocation getLoc(SILInstruction *inst) { return inst->getLoc(); }
   static SILLocation getLoc(Operand *op) { return op->getUser()->getLoc(); }
+  static SILInstruction *getSourceInst(const PartitionOp &partitionOp) {
+    return partitionOp.getSourceInst();
+  }
   static SILIsolationInfo getIsolationInfo(const PartitionOp &partitionOp) {
     return SILIsolationInfo::get(partitionOp.getSourceInst());
   }

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1226,9 +1226,12 @@ public:
       }
 
       // Next see if we are disconnected and have the same isolation. In such a
-      // case, we do not transfer since the disconnected value is allowed to be
-      // resued after we return.
-      if (transferredRegionIsolation.isDisconnected() && calleeIsolationInfo &&
+      // case, if we are not marked explicitly as sending, we do not transfer
+      // since the disconnected value is allowed to be resued after we
+      // return. If we are passed as a sending parameter, we cannot do this.
+      if (auto fas = FullApplySite::isa(op.getSourceInst());
+          (!fas || !fas.isSending(*op.getSourceOp())) &&
+          transferredRegionIsolation.isDisconnected() && calleeIsolationInfo &&
           transferredRegionIsolation.hasSameIsolation(calleeIsolationInfo))
         return;
 

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -62,6 +62,10 @@ struct MockedPartitionOpEvaluator final
     return {};
   }
 
+  static SILInstruction *getSourceInst(const PartitionOp &partitionOp) {
+    return nullptr;
+  }
+
   static bool doesFunctionHaveSendingResult(const PartitionOp &partitionOp) {
     return false;
   }
@@ -106,6 +110,10 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
 
   static SILIsolationInfo getIsolationInfo(const PartitionOp &partitionOp) {
     return {};
+  }
+
+  static SILInstruction *getSourceInst(const PartitionOp &partitionOp) {
+    return nullptr;
   }
 };
 


### PR DESCRIPTION
This only occurs specifically for async nonisolated functions with an isolated parameter that passes a disconnected value in its body off to a nonisolated async function as a sending parameter.

rdar://134409359
