### PR TITLE
[cxx-interop] fix a clang assertion when synthesizing instance to sta…

### DIFF
--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -482,6 +482,15 @@ public:
   static int operator()(int x) { return x + 42; }
 };
 
+class HasStaticOperatorCallBaseNonTrivial: public NonTrivial {
+public:
+  HasStaticOperatorCallBaseNonTrivial() {}
+  HasStaticOperatorCallBaseNonTrivial(const HasStaticOperatorCallBaseNonTrivial &self) : NonTrivial(self) {}
+  HasStaticOperatorCallBaseNonTrivial(HasStaticOperatorCallBaseNonTrivial &&self) : NonTrivial(self) {}
+
+  static int operator()(const NonTrivial &arg) { return arg.f + 42; }
+};
+
 class HasStaticOperatorCallDerived : public HasStaticOperatorCallBase {};
 
 class HasStaticOperatorCallWithConstOperator {

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -443,6 +443,13 @@ OperatorsTestSuite.test("HasStaticOperatorCallBase.call") {
   expectEqual(43, res)
 }
 
+OperatorsTestSuite.test("HasStaticOperatorCallBase2.call") {
+  let m = NonTrivial()
+  let h = HasStaticOperatorCallBaseNonTrivial()
+  let res = h(m)
+  expectEqual(48, res)
+}
+
 OperatorsTestSuite.test("HasStaticOperatorCallDerived.call") {
   let h = HasStaticOperatorCallDerived()
   let res = h(0)


### PR DESCRIPTION
…tic member call for operator ()

A specific static operator () in MSVC's STL triggers this assertion in clang when buidling CxxStdlib: Assertion failed: isInstance() && "No 'this' for static methods!", file S:\SourceCache\llvm-project\clang\lib\AST\DeclCXX.cpp, line 2544 When the return statement is being constructed using clang sema in Swift's function synthesis code.

This change avoids using member call expression for a call to static operator (), and instead performs a direct call, which closer matches what Clang's semas typechecker expects, and the default Clang's parsing behavior as well.

This fixes the windows toolchain build with MSVC.

