### PR TITLE
Tests: Adjust several macCatalyst tests

### DIFF
--- a/test/ClangImporter/availability_maccatalyst.swift
+++ b/test/ClangImporter/availability_maccatalyst.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target x86_64-apple-ios13.1-macabi -typecheck -verify -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target %target-cpu-apple-ios13.1-macabi -typecheck -verify -I %S/Inputs/custom-modules %s
 
 // REQUIRES: maccatalyst_support
 

--- a/test/ClangImporter/availability_maccatalyst_app_extension.swift
+++ b/test/ClangImporter/availability_maccatalyst_app_extension.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target x86_64-apple-ios13.1-macabi -application-extension -typecheck -verify -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -target %target-cpu-apple-ios13.1-macabi -application-extension -typecheck -verify -I %S/Inputs/custom-modules %s
 
 // REQUIRES: maccatalyst_support
 

--- a/test/Interpreter/availability_maccatalyst_zippered.swift
+++ b/test/Interpreter/availability_maccatalyst_zippered.swift
@@ -2,26 +2,26 @@
 // RUN: %empty-directory(%t/macos_module)
 // RUN: %empty-directory(%t/maccatalyst_module)
 
-// REQUIRES: rdar73984718
 
 // Build a zippered library
 
 // Emit a zippered library and a module for use from macOSProcesses
-// RUN: %target-build-swift %S/Inputs/availability_zippered.swift -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13.1-macabi -emit-library -emit-module -emit-module-path %t/macos_module/ -o %t/libavailability_zippered.dylib
+// RUN: %target-build-swift-dylib(%t/%target-library-name(availability_zippered)) %S/Inputs/availability_zippered.swift -target %target-cpu-apple-macosx10.15 -target-variant %target-cpu-apple-ios13.1-macabi -emit-module -emit-module-path %t/macos_module/
+// RUN: %target-codesign %t/%target-library-name(availability_zippered)
 
 // Emit just an macCatalyst module for use from an macCatalyst process
-// RUN: %target-build-swift %S/Inputs/availability_zippered.swift -target x86_64-apple-ios13.1-macabi -emit-module -emit-module-path %t/maccatalyst_module/
+// RUN: %target-build-swift %S/Inputs/availability_zippered.swift -target %target-cpu-apple-ios13.1-macabi -emit-module -emit-module-path %t/maccatalyst_module/
 
 // Build a macOS executable that calls into the library
-// RUN: %target-build-swift -emit-executable -target x86_64-apple-macosx10.15 %s -lavailability_zippered -I %t/macos_module -L %t -o %t/a-macos.out
+// RUN: %target-build-swift -emit-executable -target %target-cpu-apple-macosx10.15 %s -lavailability_zippered -I %t/macos_module -L %t -o %t/a-macos.out
 // RUN: %target-codesign %t/a-macos.out
 
 // Built an macCatalyst executable that calls into the library.
-// RUN: %target-build-swift -target x86_64-apple-ios13.1-macabi %s -lavailability_zippered -I %t/maccatalyst_module -L %t -o %t/a-maccatalyst.out
+// RUN: %target-build-swift -target %target-cpu-apple-ios13.1-macabi %s -lavailability_zippered -I %t/maccatalyst_module -L %t -o %t/a-maccatalyst.out
 // RUN: %target-codesign %t/a-maccatalyst.out
 
-// RUN: %target-run %t/a-macos.out
-// RUN: %target-run %t/a-maccatalyst.out
+// RUN: %target-run %t/a-macos.out %t/%target-library-name(availability_zippered)
+// RUN: %target-run %t/a-maccatalyst.out %t/%target-library-name(availability_zippered)
 
 // REQUIRES: executable_test
 // REQUIRES: maccatalyst_support

--- a/test/Misc/maccatalyst_load_commands.swift
+++ b/test/Misc/maccatalyst_load_commands.swift
@@ -1,5 +1,6 @@
 // REQUIRES: OS=maccatalyst || OS=macosx
 // REQUIRES: maccatalyst_support
+// REQUIRES: CPU=x86_64
 
 
 // Zippered libraries

--- a/test/ModuleInterface/default-prebuilt-module-location-maccatalyst.swift
+++ b/test/ModuleInterface/default-prebuilt-module-location-maccatalyst.swift
@@ -1,0 +1,29 @@
+// Like default-prebuilt-module-location.swift, but for macCatalyst specifically.
+
+// REQUIRES: OS=macosx
+
+// 1. Create folders for a) our Swift module, b) the module cache, and c) a
+//    fake resource dir with a default prebuilt module cache inside.
+// RUN: %empty-directory(%t/PrebuiltModule.swiftmodule)
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %empty-directory(%t/ResourceDir/macosx/prebuilt-modules/PrebuiltModule.swiftmodule)
+
+// 2. Define some public API
+// RUN: echo 'public struct InPrebuiltModule {}' > %t/PrebuiltModule.swift
+
+// 3. Compile this into a module and put it into the default prebuilt cache
+//    location relative to the fake resource dir. Also drop an interface into
+//    the build dir.
+// RUN: %target-swift-frontend -target %target-cpu-apple-ios13.1-macabi -emit-module %t/PrebuiltModule.swift -o %t/ResourceDir/macosx/prebuilt-modules/PrebuiltModule.swiftmodule/%target-cpu.swiftmodule -module-name PrebuiltModule -parse-stdlib -emit-module-interface-path %t/PrebuiltModule.swiftmodule/%target-cpu.swiftinterface
+
+// 4. Import this prebuilt module, but DON'T pass in -prebuilt-module-cache-path, it should use the implicit one.
+// RUN: %target-swift-frontend -target %target-cpu-apple-ios13.1-macabi -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t
+
+// 5. Make sure we installed a forwarding module in the module cache.
+// RUN: %{python} %S/ModuleCache/Inputs/check-is-forwarding-module.py %t/ModuleCache/PrebuiltModule-*.swiftmodule
+
+import PrebuiltModule
+
+func x<T>(_ x: T) {}
+
+x(InPrebuiltModule.self)

--- a/test/Serialization/runtime-import-from-sdk-maccatalyst.swift
+++ b/test/Serialization/runtime-import-from-sdk-maccatalyst.swift
@@ -77,28 +77,28 @@ Swift.success()
 // over sdk/iOSSupport. (default resource dir + bad-bad-sdk)
 //
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-bad-sdk) -target x86_64-apple-ios13.1-macabi -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=RESDIR-MACCATALYST
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-bad-sdk) -target %target-cpu-apple-ios13.1-macabi -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=RESDIR-MACCATALYST
 // RESDIR-MACCATALYST: success
 
 // IOSSUP: If resource-dir has no standard library but sdk/iOSSupport does, it
 // will be preferred over sdk. (empty-resdir + good-bad-sdk)
 //
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/good-bad-sdk) -target x86_64-apple-ios13.1-macabi -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=IOSSUP-MACCATALYST
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/good-bad-sdk) -target %target-cpu-apple-ios13.1-macabi -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=IOSSUP-MACCATALYST
 // IOSSUP-MACCATALYST: success
 
 // IOSBAD: Confirms that we don't use sdk/iOSSupport on non-macCatalyst, even if
 // present. (empty-resdir + bad-good-sdk)
 //
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-good-sdk) -target x86_64-apple-ios13.1-macabi -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=IOSBAD-MACCATALYST
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-good-sdk) -target %target-cpu-apple-ios13.1-macabi -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=IOSBAD-MACCATALYST
 // IOSBAD-MACCATALYST: failure
 
 // SDKTOP: If resource-dir and sdk/iOSSupport don't have standard libraries but
 // sdk does, it will be used as a last resort. (empty-resdir + empty-good-sdk)
 //
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/empty-good-sdk) -target x86_64-apple-ios13.1-macabi -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=SDKTOP-MACCATALYST
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/empty-good-sdk) -target %target-cpu-apple-ios13.1-macabi -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=SDKTOP-MACCATALYST
 // SDKTOP-MACCATALYST: success
 
 // NILLIB: If no standard libraries are available, stdlib loading fails.
@@ -106,7 +106,7 @@ Swift.success()
 // the others because there are no failure-failure-failure triples to find.
 //
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/empty-empty-sdk) -target x86_64-apple-ios13.1-macabi -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=NILLIB-MACCATALYST
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/empty-empty-sdk) -target %target-cpu-apple-ios13.1-macabi -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=NILLIB-MACCATALYST
 // NILLIB-MACCATALYST: unable to load standard library
 
 
@@ -121,28 +121,28 @@ Swift.success()
 // over sdk/iOSSupport. (default resource dir + bad-bad-sdk)
 //
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-bad-sdk) -target x86_64-apple-macosx10.15 -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=RESDIR-MACOSX
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-bad-sdk) -target %target-cpu-apple-macosx10.15 -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=RESDIR-MACOSX
 // RESDIR-MACOSX: {{success|module 'Swift' was created for incompatible target}}
 
 // IOSSUP: If resource-dir has no standard library but sdk/iOSSupport does, it
 // will be preferred over sdk. (empty-resdir + good-bad-sdk)
 //
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/good-bad-sdk) -target x86_64-apple-macosx10.15 -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=IOSSUP-MACOSX
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/good-bad-sdk) -target %target-cpu-apple-macosx10.15 -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=IOSSUP-MACOSX
 // IOSSUP-MACOSX: failure
 
 // IOSBAD: Confirms that we don't use sdk/iOSSupport on non-macCatalyst, even if
 // present. (empty-resdir + bad-good-sdk)
 //
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-good-sdk) -target x86_64-apple-macosx10.15 -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=IOSBAD-MACOSX
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-good-sdk) -target %target-cpu-apple-macosx10.15 -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=IOSBAD-MACOSX
 // IOSBAD-MACOSX: {{success|module 'Swift' was created for incompatible target}}
 
 // SDKTOP: If resource-dir and sdk/iOSSupport don't have standard libraries but
 // sdk does, it will be used as a last resort. (empty-resdir + empty-good-sdk)
 //
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/empty-good-sdk) -target x86_64-apple-macosx10.15 -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=SDKTOP-MACOSX
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/empty-good-sdk) -target %target-cpu-apple-macosx10.15 -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=SDKTOP-MACOSX
 // SDKTOP-MACOSX: {{success|module 'Swift' was created for incompatible target}}
 
 // NILLIB: If no standard libraries are available, stdlib loading fails.
@@ -150,5 +150,5 @@ Swift.success()
 // the others because there are no failure-failure-failure triples to find.
 //
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/empty-empty-sdk) -target x86_64-apple-macosx10.15 -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=NILLIB-MACOSX
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %t/empty-empty-sdk) -target %target-cpu-apple-macosx10.15 -resource-dir %t/empty-resdir/usr/lib/swift -module-cache-path %t.mcp -typecheck %s 2>&1 | %FileCheck %s --check-prefix=NILLIB-MACOSX
 // NILLIB-MACOSX: unable to load standard library


### PR DESCRIPTION
- Reenable `availability_maccatalyst_zippered.swift` after adjusting `RUN` lines.
- Adopt `%target-cpu` to make several tests compatible with Apple Silicon.
- Limit `maccatalyst_load_commands.swift` to x86_64 since it is really specific to that architecture.
- Upstream a missing macCatalyst test.

Resolves rdar://73984718.