### PR TITLE
Fix a false performance error when using generic, but loadable types

### DIFF
--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -727,13 +727,14 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
 
   case SILInstructionKind::AllocStackInst:
   case SILInstructionKind::AllocVectorInst:
-  case SILInstructionKind::ProjectBoxInst:
-    if (cast<SingleValueInstruction>(inst)->getType().hasArchetype()) {
-      impactType = cast<SingleValueInstruction>(inst)->getType();
+  case SILInstructionKind::ProjectBoxInst: {
+    SILType allocType = cast<SingleValueInstruction>(inst)->getType();
+    if (allocType.hasArchetype() && !allocType.isLoadable(*inst->getFunction())) {
+      impactType = allocType;
       return RuntimeEffect::MetaData;
     }
     return RuntimeEffect::NoEffect;
-
+  }
   case SILInstructionKind::AllocGlobalInst: {
     SILType glTy = cast<AllocGlobalInst>(inst)->getReferencedGlobal()->
                       getLoweredType();

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -501,6 +501,15 @@ func testLargeTuple() {
     _ = GenericStruct<SixInt8s>()
 }
 
+struct Ptr<T> {
+  public var p: UnsafeMutablePointer<T>
+
+  @_noAllocation
+  init(p: UnsafeMutablePointer<T>) {
+    self.p = p
+  }
+}
+
 struct NonCopyableStruct: ~Copyable {
   func foo() {}
 }


### PR DESCRIPTION
For example: `UnsafePointer<T>`

rdar://135231581
