### PR TITLE
Do not print package-name in non-package interface by default.

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -70,10 +70,6 @@ struct ModuleInterfaceOptions {
   /// Print imports that are missing from the source and used in API.
   bool PrintMissingImports = true;
 
-  /// If true, package-name flag is not printed in either public or private
-  /// interface file.
-  bool DisablePackageNameForNonPackageInterface = false;
-
   /// Intentionally print invalid syntax into the file.
   bool DebugPrintInvalidSyntax = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -728,7 +728,11 @@ def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
 def disable_print_package_name_for_non_package_interface :
   Flag<["-"], "disable-print-package-name-for-non-package-interface">,
   Flags<[FrontendOption, NoDriverOption, HelpHidden]>,
-  HelpText<"Disable adding package name to public or private interface">;
+  HelpText<"No op; package name is only printed in package interface by default">;
+def print_package_name_in_non_package_interface :
+  Flag<["-"], "print-package-name-in-non-package-interface">,
+  Flags<[FrontendOption, NoDriverOption, HelpHidden]>,
+  HelpText<"Print package name in public or private interface">;
 
 def lto : Joined<["-"], "lto=">,
   Flags<[FrontendOption, NoInteractiveOption]>,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -525,7 +525,6 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     Args.hasArg(OPT_debug_emit_invalid_swiftinterface_syntax);
   Opts.PrintMissingImports =
     !Args.hasArg(OPT_disable_print_missing_imports_in_module_interface);
-  Opts.DisablePackageNameForNonPackageInterface |= Args.hasArg(OPT_disable_print_package_name_for_non_package_interface);
 
   if (const Arg *A = Args.getLastArg(OPT_library_level)) {
     StringRef contents = A->getValue();
@@ -557,8 +556,8 @@ static bool ShouldIncludeModuleInterfaceArg(const Arg *A) {
 
 static bool IsPackageInterfaceFlag(const Arg *A, ArgList &Args) {
   return A->getOption().matches(options::OPT_package_name) &&
-         Args.hasArg(
-             options::OPT_disable_print_package_name_for_non_package_interface);
+         !Args.hasArg(
+             options::OPT_print_package_name_in_non_package_interface);
 }
 
 static bool IsPrivateInterfaceFlag(const Arg *A, ArgList &Args) {

--- a/test/ModuleInterface/package_interface.swift
+++ b/test/ModuleInterface/package_interface.swift
@@ -23,7 +23,6 @@ public enum PubEnum {
   case red, green
 }
 
-// CHECK: -package-name barpkg
 // CHECK: public enum PubEnum {
 // CHECK:   case red, green
 // CHECK:   public static func == (a: Bar.PubEnum, b: Bar.PubEnum) -> Swift.Bool

--- a/test/ModuleInterface/print_package_name_in_non_package_interface.swift
+++ b/test/ModuleInterface/print_package_name_in_non_package_interface.swift
@@ -1,12 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-/// Do not print package-name for public or private interfaces
+/// By default, package-name is only printed in package interface
 // RUN: %target-build-swift -emit-module %t/Bar.swift -I %t \
 // RUN:   -module-name Bar -package-name foopkg \
 // RUN:   -enable-library-evolution -swift-version 6 \
 // RUN:   -package-name barpkg \
-// RUN:   -Xfrontend -disable-print-package-name-for-non-package-interface \
 // RUN:   -emit-module-interface-path %t/Bar.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/Bar.private.swiftinterface \
 // RUN:   -emit-package-module-interface-path %t/Bar.package.swiftinterface
@@ -44,10 +43,11 @@
 // RUN: rm -rf %t/Bar.private.swiftinterface
 // RUN: rm -rf %t/Bar.package.swiftinterface
 
-/// By default, -package-name is printed in all interfaces.
+/// Print -package-name in public or private interface.
 // RUN: %target-build-swift -emit-module %t/Bar.swift -I %t \
 // RUN:   -module-name Bar -package-name barpkg \
 // RUN:   -enable-library-evolution -swift-version 6 \
+// RUN:   -Xfrontend -print-package-name-in-non-package-interface \
 // RUN:   -emit-module-interface-path %t/Bar.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/Bar.private.swiftinterface \
 // RUN:   -emit-package-module-interface-path %t/Bar.package.swiftinterface


### PR DESCRIPTION
Having package-name printed in public or private interface led to strange dependency errors in the past. For example, an SPI module is a dependency within a package, but due to the package-name being printed in public or private interface, dependency scanner tries to find it even for an external client of the package, causing a `no such module found` error. 

The `-disable-print-package-name-for-non-package-interface` flag helps with such case, but this PR enforces the correct behavior further by making it a default to not print package-name in public or private interface. The changes also include a new flag `-print-package-name-in-non-package-interface` for those who do need package-name in all interfaces (but should be rare). 

Resolves rdar://135260270