### PR TITLE
[cxx-interop] Disambiguate template instantiations with SIMD parameters

### DIFF
--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -129,6 +129,12 @@ struct TemplateInstantiationNamePrinter
 
     return buffer.str().str();
   }
+
+  std::string VisitVectorType(const clang::VectorType *type) {
+    return (Twine("SIMD") + std::to_string(type->getNumElements()) + "<" +
+            Visit(type->getElementType().getTypePtr()) + ">")
+        .str();
+  }
 };
 
 std::string swift::importer::printClassTemplateSpecializationName(

--- a/test/Interop/Cxx/templates/Inputs/class-template-with-simd-parameter.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-with-simd-parameter.h
@@ -1,0 +1,12 @@
+#include <simd/simd.h>
+
+template <typename T>
+struct Templated {
+  T t;
+};
+
+typedef Templated<simd::uint1> TemplatedSIMDUInt1;
+typedef Templated<simd::uint16> TemplatedSIMDUInt16;
+typedef Templated<simd::float3> TemplatedSIMDFloat3;
+typedef Templated<simd::float4> TemplatedSIMDFloat4;
+typedef Templated<simd::double8> TemplatedSIMDDouble8;

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -18,6 +18,11 @@ module ClassTemplateWithOutOfLineMember {
   requires cplusplus
 }
 
+module ClassTemplateWithSIMDParameter {
+  header "class-template-with-simd-parameter.h"
+  requires cplusplus
+}
+
 module NotPreDefinedClassTemplate {
   header "not-pre-defined-class-template.h"
   requires cplusplus

--- a/test/Interop/Cxx/templates/class-template-with-simd-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-simd-parameter-module-interface.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithSIMDParameter -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// REQUIRES: OS=macosx || OS=ios
+
+// CHECK: typealias TemplatedSIMDUInt1 = Templated<CUnsignedInt>
+// CHECK: typealias TemplatedSIMDUInt16 = Templated<SIMD16<CUnsignedInt>>
+// CHECK: typealias TemplatedSIMDFloat3 = Templated<SIMD3<CFloat>>
+// CHECK: typealias TemplatedSIMDFloat4 = Templated<SIMD4<CFloat>>
+// CHECK: typealias TemplatedSIMDDouble8 = Templated<SIMD8<CDouble>>


### PR DESCRIPTION
When converting a C++ class template instantiation name into Swift, we previously didn't account for possible SIMD types. Those types were printed as `_`. This meant that e.g. `std::vector<simd::float3>` and `std::vector<simd::float4>` would get the same Swift name, causing compiler errors down the road.

rdar://134214091