### PR TITLE
[cxx-interop] Do not crash for `static operator()`

### DIFF
--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -482,6 +482,15 @@ public:
   static int operator()(int x) { return x + 42; }
 };
 
+class HasStaticOperatorCallBaseNonTrivial: public NonTrivial {
+public:
+  HasStaticOperatorCallBaseNonTrivial() {}
+  HasStaticOperatorCallBaseNonTrivial(const HasStaticOperatorCallBaseNonTrivial &self) : NonTrivial(self) {}
+  HasStaticOperatorCallBaseNonTrivial(HasStaticOperatorCallBaseNonTrivial &&self) : NonTrivial(self) {}
+
+  static int operator()(const NonTrivial &arg) { return arg.f + 42; }
+};
+
 class HasStaticOperatorCallDerived : public HasStaticOperatorCallBase {};
 
 class HasStaticOperatorCallWithConstOperator {

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -443,6 +443,13 @@ OperatorsTestSuite.test("HasStaticOperatorCallBase.call") {
   expectEqual(43, res)
 }
 
+OperatorsTestSuite.test("HasStaticOperatorCallBase2.call") {
+  let m = NonTrivial()
+  let h = HasStaticOperatorCallBaseNonTrivial()
+  let res = h(m)
+  expectEqual(48, res)
+}
+
 OperatorsTestSuite.test("HasStaticOperatorCallDerived.call") {
   let h = HasStaticOperatorCallDerived()
   let res = h(0)


### PR DESCRIPTION
This is a cherry-pick of https://github.com/swiftlang/swift/pull/75907 since this issues has started occurring in `main` as well as `rebranch`.