### PR TITLE
Delete lifetime dependence mangling

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -752,10 +752,6 @@ Types
   differentiable ::= 'Yjr'                   // @differentiable(reverse) on function type
   differentiable ::= 'Yjd'                   // @differentiable on function type
   differentiable ::= 'Yjl'                   // @differentiable(_linear) on function type
- #if SWIFT_RUNTIME_VERSION >= 5.TBD
-  lifetime-dependence ::= 'Yli' INDEX-SUBSET '_'         // inherit lifetime dependence
-  lifetime-dependence ::= 'Yls' INDEX-SUBSET '_'         // scoped lifetime dependence
-#endif
   type-list ::= list-type '_' list-type*     // list of types
   type-list ::= empty-list
 

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -91,9 +91,6 @@ protected:
   /// a critical role.
   bool AllowTypedThrows = true;
 
-  /// If enabled, lifetime dependencies can be encoded in the mangled name.
-  bool AllowLifetimeDependencies = true;
-
   /// If enabled, declarations annotated with @_originallyDefinedIn are mangled
   /// as if they're part of their original module. Disabled for debug mangling,
   /// because lldb wants to find declarations in the modules they're currently

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -136,8 +136,6 @@ enum class MangledDifferentiabilityKind : char {
   Linear = 'l',
 };
 
-enum class MangledLifetimeDependenceKind : char { Inherit = 'i', Scope = 's' };
-
 /// The pass that caused the specialization to occur. We use this to make sure
 /// that two passes that generate similar changes do not yield the same
 /// mangling. This currently cannot happen, so this is just a safety measure

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -389,7 +389,6 @@ NODE(AsyncRemoved)
 
 // Added in Swift 5.TBD
 NODE(ObjectiveCProtocolSymbolicReference)
-NODE(LifetimeDependence)
 
 NODE(OutlinedInitializeWithCopyNoValueWitness)
 NODE(OutlinedAssignWithTakeNoValueWitness)

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -637,8 +637,6 @@ protected:
   bool demangleBoundGenerics(Vector<NodePointer> &TypeListList,
                              NodePointer &RetroactiveConformances);
 
-  NodePointer demangleLifetimeDependence();
-
   NodePointer demangleIntegerType();
 
   void dump();

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3264,10 +3264,6 @@ void ASTMangler::appendFunctionResultType(
   } else {
     appendType(resultType, sig, forDecl);
   }
-
-  if (AllowLifetimeDependencies && lifetimeDependence.has_value()) {
-    appendLifetimeDependence(*lifetimeDependence);
-  }
 }
 
 void ASTMangler::appendTypeList(Type listTy, GenericSignature sig,
@@ -3320,29 +3316,10 @@ void ASTMangler::appendParameterTypeListElement(
   if (flags.isCompileTimeConst())
     appendOperator("Yt");
 
-  if (AllowLifetimeDependencies && lifetimeDependence) {
-    appendLifetimeDependence(*lifetimeDependence);
-  }
-
   if (!name.empty())
     appendIdentifier(name.str());
   if (flags.isVariadic())
     appendOperator("d");
-}
-
-void ASTMangler::appendLifetimeDependence(LifetimeDependenceInfo info) {
-  if (auto *inheritIndices = info.getInheritIndices()) {
-    assert(!inheritIndices->isEmpty());
-    appendOperator("Yli");
-    appendIndexSubset(inheritIndices);
-    appendOperator("_");
-  }
-  if (auto *scopeIndices = info.getScopeIndices()) {
-    assert(!scopeIndices->isEmpty());
-    appendOperator("Yls");
-    appendIndexSubset(scopeIndices);
-    appendOperator("_");
-  }
 }
 
 void ASTMangler::appendTupleTypeListElement(Identifier name, Type elementType,

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -990,11 +990,6 @@ NodePointer Demangler::demangleTypeAnnotation() {
   case 'u':
     return createType(
         createWithChild(Node::Kind::Sending, popTypeAndGetChild()));
-  case 'l': {
-    auto *node = demangleLifetimeDependence();
-    addChild(node, popTypeAndGetChild());
-    return createType(node);
-  }
   default:
     return nullptr;
   }
@@ -3156,31 +3151,6 @@ NodePointer Demangler::demangleDifferentiableFunctionType() {
   }
   return createNode(
       Node::Kind::DifferentiableFunctionType, (Node::IndexType)kind);
-}
-
-static std::optional<MangledLifetimeDependenceKind>
-getMangledLifetimeDependenceKind(char nextChar) {
-  switch (nextChar) {
-  case 's':
-    return MangledLifetimeDependenceKind::Scope;
-  case 'i':
-    return MangledLifetimeDependenceKind::Inherit;
-  }
-  return std::nullopt;
-}
-
-NodePointer Demangler::demangleLifetimeDependence() {
-  auto kind = getMangledLifetimeDependenceKind(nextChar());
-  if (!kind.has_value()) {
-    return nullptr;
-  }
-  auto result = createNode(Node::Kind::LifetimeDependence);
-  result =
-      addChild(result, createNode(Node::Kind::Index, (Node::IndexType)*kind));
-  result = addChild(result, demangleIndexSubset());
-  if (!nextIf('_'))
-    return nullptr;
-  return result;
 }
 
 std::string Demangler::demangleBridgedMethodParams() {

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -648,7 +648,6 @@ private:
     case Node::Kind::SymbolicExtendedExistentialType:
     case Node::Kind::HasSymbolQuery:
     case Node::Kind::ObjectiveCProtocolSymbolicReference:
-    case Node::Kind::LifetimeDependence:
     case Node::Kind::DependentGenericInverseConformanceRequirement:
     case Node::Kind::DependentGenericParamValueMarker:
       return false;
@@ -1814,21 +1813,6 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     Printer << "@noDerivative ";
     print(Node->getChild(0), depth + 1);
     return nullptr;
-  case Node::Kind::LifetimeDependence: {
-    auto kind = (MangledLifetimeDependenceKind)Node->getChild(0)->getIndex();
-    switch (kind) {
-    case MangledLifetimeDependenceKind::Inherit:
-      Printer << "inherit lifetime dependence: ";
-      break;
-    case MangledLifetimeDependenceKind::Scope:
-      Printer << "scope lifetime dependence: ";
-      break;
-    }
-    print(Node->getChild(1), depth + 1);
-    Printer << " ";
-    print(Node->getChild(2), depth + 1);
-    return nullptr;
-  }
   case Node::Kind::NonObjCAttribute:
     Printer << "@nonobjc ";
     return nullptr;

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1943,10 +1943,6 @@ ManglingError Remangler::mangleNoDerivative(Node *node, unsigned depth) {
   return mangleSingleChildNode(node, depth + 1); // type
 }
 
-ManglingError Remangler::mangleLifetimeDependence(Node *node, unsigned depth) {
-  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
-}
-
 ManglingError Remangler::mangleTuple(Node *node, unsigned depth) {
   size_t NumElems = node->getNumChildren();
   if (NumElems > 0 &&

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2250,16 +2250,6 @@ ManglingError Remangler::mangleNoDerivative(Node *node, unsigned depth) {
   return ManglingError::Success;
 }
 
-ManglingError Remangler::mangleLifetimeDependence(Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer
-      << "Yl"
-      << (char)node->getChild(0)->getIndex(); // mangle lifetime dependence kind
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1)); // mangle index subset
-  Buffer << "_";
-  return ManglingError::Success;
-}
-
 ManglingError Remangler::mangleInfixOperator(Node *node, unsigned depth) {
   mangleIdentifierImpl(node, /*isOperator*/ true);
   Buffer << "oi";

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -163,7 +163,6 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
       AllowConcurrencyStandardSubstitutions);
   llvm::SaveAndRestore<bool> savedIsolatedAny(AllowIsolatedAny);
   llvm::SaveAndRestore<bool> savedTypedThrows(AllowTypedThrows);
-  llvm::SaveAndRestore<bool> savedLifetimeDependencies(AllowLifetimeDependencies);
   if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget(
           ctx.LangOpts.Target)) {
 
@@ -179,7 +178,6 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
     if (*runtimeCompatVersion < llvm::VersionTuple(6, 0)) {
       AllowIsolatedAny = false;
       AllowTypedThrows = false;
-      AllowLifetimeDependencies = false;
     }
   }
 

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -473,6 +473,3 @@ $s23variadic_generic_opaque2G2VyAA2S1V_AA2S2VQPGAA1PHPAeA1QHPyHC_AgaJHPyHCHX_HC 
 
 $s9MacroUser0023macro_expandswift_elFCffMX436_4_23bitwidthNumberedStructsfMf_ ---> freestanding macro expansion #1 of bitwidthNumberedStructs in module MacroUser file macro_expand.swift line 437 column 5
 $sxq_IyXd_D ---> @callee_unowned (@in_cxx A) -> (@unowned B)
-$s32def_implicit_lifetime_dependence6deriveyAA10BufferViewVYliS_ADF ---> def_implicit_lifetime_dependence.derive(def_implicit_lifetime_dependence.BufferView) -> inherit lifetime dependence: {0} def_implicit_lifetime_dependence.BufferView
-$s32def_explicit_lifetime_dependence16deriveThisOrThatyAA10BufferViewVYlsSS_AD_ADtF ---> def_explicit_lifetime_dependence.deriveThisOrThat(def_explicit_lifetime_dependence.BufferView, def_explicit_lifetime_dependence.BufferView) -> scope lifetime dependence: {0, 1} def_explicit_lifetime_dependence.BufferView
-$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat2yAA10BufferViewVYliUS_YlsSU_AD_ADntF ---> explicit_lifetime_dependence_specifiers.deriveThisOrThat2(explicit_lifetime_dependence_specifiers.BufferView, __owned explicit_lifetime_dependence_specifiers.BufferView) -> scope lifetime dependence: {0} inherit lifetime dependence: {1} explicit_lifetime_dependence_specifiers.BufferView

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -7,7 +7,7 @@ import Builtin
 
 struct BufferView : ~Escapable {
   let ptr: UnsafeRawBufferPointer
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACYlsSU_SWcfC : $@convention(method) (UnsafeRawBufferPointer, @thin BufferView.Type) -> _scope(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSWcfC : $@convention(method) (UnsafeRawBufferPointer, @thin BufferView.Type) -> _scope(0)  @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer) -> dependsOn(ptr) Self {
     self.ptr = ptr
   }
@@ -23,17 +23,17 @@ struct BufferView : ~Escapable {
   init(independent ptr: UnsafeRawBufferPointer) {
     self.ptr = ptr
   }
- // CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACYlsUSU_SW_SaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView {
+ // CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_SaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) -> dependsOn(a) Self {
     self.ptr = ptr
     return self
   }
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACYliUSU_SW_AA7WrapperVtcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @thin BufferView.Type) -> _inherit(1)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_AA7WrapperVtcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @thin BufferView.Type) -> _inherit(1)  @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: consuming Wrapper) -> dependsOn(a) Self {
     self.ptr = ptr
     return self
   }
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACYliUSUU_YlsUUSU_SW_AA7WrapperVSaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @guaranteed Array<Int>, @thin BufferView.Type) -> _inherit(1) _scope(2)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers10BufferViewVyACSW_AA7WrapperVSaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @owned Wrapper, @guaranteed Array<Int>, @thin BufferView.Type) -> _inherit(1) _scope(2)  @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: consuming Wrapper, _ b: borrowing Array<Int>) -> dependsOn(a) dependsOn(b) Self {
     self.ptr = ptr
     return self
@@ -58,17 +58,17 @@ func testBasic() {
   }
 }
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers6deriveyAA10BufferViewVYlsS_ADF : $@convention(thin) (@guaranteed BufferView) -> _scope(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers6deriveyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> _scope(0)  @owned BufferView {
 func derive(_ x: borrowing BufferView) -> dependsOn(scoped x) BufferView {
   return BufferView(independent: x.ptr)
 }
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16consumeAndCreateyAA10BufferViewVYliS_ADnF : $@convention(thin) (@owned BufferView) -> _inherit(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16consumeAndCreateyAA10BufferViewVADnF : $@convention(thin) (@owned BufferView) -> _inherit(0)  @owned BufferView {
 func consumeAndCreate(_ x: consuming BufferView) -> dependsOn(x) BufferView {
   return BufferView(independent: x.ptr)
 }
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat1yAA10BufferViewVYlsSS_AD_ADtF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(0, 1)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat1yAA10BufferViewVAD_ADtF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(0, 1)  @owned BufferView {
 func deriveThisOrThat1(_ this: borrowing BufferView, _ that: borrowing BufferView) -> dependsOn(scoped this, that) BufferView {
   if (Int.random(in: 1..<100) == 0) {
     return BufferView(independent: this.ptr)
@@ -76,7 +76,7 @@ func deriveThisOrThat1(_ this: borrowing BufferView, _ that: borrowing BufferVie
   return BufferView(independent: that.ptr)
 }
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat2yAA10BufferViewVYliUS_YlsSU_AD_ADntF : $@convention(thin) (@guaranteed BufferView, @owned BufferView) -> _inherit(1) _scope(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat2yAA10BufferViewVAD_ADntF : $@convention(thin) (@guaranteed BufferView, @owned BufferView) -> _inherit(1) _scope(0)  @owned BufferView {
 func deriveThisOrThat2(_ this: borrowing BufferView, _ that: consuming BufferView) -> dependsOn(scoped this) dependsOn(that) BufferView {
   if (Int.random(in: 1..<100) == 0) {
     return BufferView(independent: this.ptr)
@@ -91,12 +91,12 @@ struct Wrapper : ~Escapable {
   init(_ view: consuming BufferView) {
     self.view = view
   }
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers7WrapperV8getView1AA10BufferViewVYlsS_yF : $@convention(method) (@guaranteed Wrapper) -> _scope(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers7WrapperV8getView1AA10BufferViewVyF : $@convention(method) (@guaranteed Wrapper) -> _scope(0)  @owned BufferView {
   borrowing func getView1() -> dependsOn(scoped self) BufferView {
     return view
   }
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers7WrapperV8getView2AA10BufferViewVYliS_yF : $@convention(method) (@owned Wrapper) -> _inherit(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers7WrapperV8getView2AA10BufferViewVyF : $@convention(method) (@owned Wrapper) -> _inherit(0)  @owned BufferView {
   consuming func getView2() -> dependsOn(self) BufferView {
     return view
   }
@@ -109,12 +109,12 @@ struct Container : ~Escapable {
  }
 }
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getConsumingViewyAA06BufferG0VYliS_AA9ContainerVnF : $@convention(thin) (@owned Container) -> _inherit(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getConsumingViewyAA06BufferG0VAA9ContainerVnF : $@convention(thin) (@owned Container) -> _inherit(0)  @owned BufferView {
 func getConsumingView(_ x: consuming Container) -> dependsOn(x) BufferView {
   return BufferView(independent: x.ptr)
 }
 
-// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getBorrowingViewyAA06BufferG0VYlsS_AA9ContainerVF : $@convention(thin) (@guaranteed Container) -> _scope(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers16getBorrowingViewyAA06BufferG0VAA9ContainerVF : $@convention(thin) (@guaranteed Container) -> _scope(0)  @owned BufferView {
 func getBorrowingView(_ x: borrowing Container) -> dependsOn(scoped x) BufferView {
   return BufferView(independent: x.ptr)
 }

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -15,17 +15,17 @@ struct BufferView : ~Escapable {
     self.ptr = ptr
     self.c = c
   }
-// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyACYliSU_AChcfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> _inherit(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyA2ChcfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> _inherit(0) @owned BufferView {
   init(_ otherBV: borrowing BufferView) {
     self.ptr = otherBV.ptr
     self.c = otherBV.c
   }
-// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyACYliSU_ACcfC : $@convention(method) (@owned BufferView, @thin BufferView.Type) -> _inherit(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyA2CcfC : $@convention(method) (@owned BufferView, @thin BufferView.Type) -> _inherit(0) @owned BufferView {
   init(_ otherBV: consuming BufferView) {
     self.ptr = otherBV.ptr
     self.c = otherBV.c
   }
-// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyACYlsUSU_SW_SaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyACSW_SaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1) @owned BufferView {
   init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) {
     self.ptr = ptr
     self.c = a.count
@@ -51,7 +51,7 @@ func testBasic() {
   }
 }
 
-// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence6deriveyAA10BufferViewVYliS_ADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence6deriveyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0)  @owned BufferView {
 func derive(_ x: borrowing BufferView) -> BufferView {
   return BufferView(x.ptr, x.c)
 }
@@ -60,7 +60,7 @@ func derive(_ unused: Int, _ x: borrowing BufferView) -> BufferView {
   return BufferView(independent: x.ptr, x.c)
 }
 
-// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVYliS_ADnF : $@convention(thin) (@owned BufferView) -> _inherit(0)  @owned BufferView {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnF : $@convention(thin) (@owned BufferView) -> _inherit(0)  @owned BufferView {
 func consumeAndCreate(_ x: consuming BufferView) -> BufferView {
   return BufferView(independent: x.ptr, x.c)
 }
@@ -79,16 +79,16 @@ struct Wrapper : ~Escapable {
       yield &_view
     }
   }
-// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperVyACYliSU_AA10BufferViewVcfC : $@convention(method) (@owned BufferView, @thin Wrapper.Type) -> _inherit(0)  @owned Wrapper {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperVyAcA10BufferViewVcfC : $@convention(method) (@owned BufferView, @thin Wrapper.Type) -> _inherit(0) @owned Wrapper {
   init(_ view: consuming BufferView) {
     self._view = view
   }
-// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperV8getView1AA10BufferViewVYliS_yKF : $@convention(method) (@guaranteed Wrapper) -> _inherit(0)  (@owned BufferView, @error any Error) {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperV8getView1AA10BufferViewVyKF : $@convention(method) (@guaranteed Wrapper) -> _inherit(0)  (@owned BufferView, @error any Error) {
   borrowing func getView1() throws -> BufferView {
     return _view
   }
 
-// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperV8getView2AA10BufferViewVYliS_yYaKF : $@convention(method) @async (@owned Wrapper) -> _inherit(0)  (@owned BufferView, @error any Error) {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperV8getView2AA10BufferViewVyYaKF : $@convention(method) @async (@owned Wrapper) -> _inherit(0)  (@owned BufferView, @error any Error) {
   consuming func getView2() async throws -> BufferView {
     return _view
   }
@@ -129,7 +129,7 @@ struct GenericBufferView<Element> : ~Escapable {
   let baseAddress: Pointer
   let count: Int
 
-// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewV11baseAddress5count9dependsOnACyxGYlsUUSU_SV_Siqd__htclufC : $@convention(method) <Element><Storage> (UnsafeRawPointer, Int, @in_guaranteed Storage, @thin GenericBufferView<Element>.Type) -> _scope(2)  @owned GenericBufferView<Element> {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewV11baseAddress5countACyxGSV_SitcfC : $@convention(method) <Element> (UnsafeRawPointer, Int, @thin GenericBufferView<Element>.Type) -> _scope(0) @owned GenericBufferView<Element> {
   init<Storage>(baseAddress: Pointer,
                 count: Int,
                 dependsOn: borrowing Storage) {
@@ -163,7 +163,7 @@ struct GenericBufferView<Element> : ~Escapable {
   }
 }
 
-// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence23tupleLifetimeDependenceyAA10BufferViewV_ADtYliS_ADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0)  (@owned BufferView, @owned BufferView) {
+// CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence23tupleLifetimeDependenceyAA10BufferViewV_ADtADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0)  (@owned BufferView, @owned BufferView) {
 func tupleLifetimeDependence(_ x: borrowing BufferView) -> (BufferView, BufferView) {
   return (BufferView(x.ptr, x.c), BufferView(x.ptr, x.c))
 }

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -28,10 +28,10 @@ public func test(pview: borrowing PView) -> dependsOn(pview) View {
   return pview.getDefault()
 }
 
-// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics1PPAAE10getDefault1EQzYlsS_yF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> _scope(0)  @out Self.E {
+// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics1PPAAE10getDefault1EQzyF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> _scope(0)  @out Self.E {
 
-// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics5PViewV4getEAA4ViewVYlsS_yF : $@convention(method) (PView) -> _scope(0)  @owned View {
+// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics5PViewV4getEAA4ViewVyF : $@convention(method) (PView) -> _scope(0)  @owned View {
 
-// CHECK-LABEL: sil private [transparent] [thunk] @$s28lifetime_dependence_generics5PViewVAA1PA2aDP4getE1EQzYlsS_yFTW : $@convention(witness_method: P) (@in_guaranteed PView) -> _scope(0)  @out View {
+// CHECK-LABEL: sil private [transparent] [thunk] @$s28lifetime_dependence_generics5PViewVAA1PA2aDP4getE1EQzyFTW : $@convention(witness_method: P) (@in_guaranteed PView) -> _scope(0)  @out View {
 
-// CHECK-LABEL: sil @$s28lifetime_dependence_generics4test5pviewAA4ViewVYlsS_AA5PViewV_tF : $@convention(thin) (PView) -> _scope(0)  @owned View {
+// CHECK-LABEL: sil @$s28lifetime_dependence_generics4test5pviewAA4ViewVAA5PViewV_tF : $@convention(thin) (PView) -> _scope(0)  @owned View {

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
@@ -60,11 +60,11 @@ func takeClosure(_: () -> ()) {}
 
 // No mark_dependence is needed for a inherited scope.
 //
-// CHECK-LABEL: sil hidden @$s4test14bv_borrow_copyyAA2BVVYlsS_ADF : $@convention(thin) (@guaranteed BV) -> _scope(0)  @owned BV {
+// CHECK-LABEL: sil hidden @$s4test14bv_borrow_copyyAA2BVVADF : $@convention(thin) (@guaranteed BV) -> _scope(0)  @owned BV {
 // CHECK:      bb0(%0 : @noImplicitCopy $BV):
 // CHECK:        apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> _inherit(0) @owned BV
 // CHECK-NEXT:   return %3 : $BV
-// CHECK-LABEL: } // end sil function '$s4test14bv_borrow_copyyAA2BVVYlsS_ADF'
+// CHECK-LABEL: } // end sil function '$s4test14bv_borrow_copyyAA2BVVADF'
 func bv_borrow_copy(_ bv: borrowing BV) -> dependsOn(scoped bv) BV {
   bv_copy(bv) 
 }
@@ -72,12 +72,12 @@ func bv_borrow_copy(_ bv: borrowing BV) -> dependsOn(scoped bv) BV {
 // The mark_dependence for the borrow scope should be marked
 // [nonescaping] after diagnostics.
 //
-// CHECK-LABEL: sil hidden @$s4test010bv_borrow_C00B0AA2BVVYlsS_AE_tF : $@convention(thin) (@guaranteed BV) -> _scope(0)  @owned BV {
+// CHECK-LABEL: sil hidden @$s4test010bv_borrow_C00B0AA2BVVAE_tF : $@convention(thin) (@guaranteed BV) -> _scope(0)  @owned BV {
 // CHECK:       bb0(%0 : @noImplicitCopy $BV):
 // CHECK:         [[R:%.*]] = apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> _scope(0) @owned BV
 // CHECK:         %{{.*}} = mark_dependence [nonescaping] [[R]] : $BV on %0 : $BV
 // CHECK-NEXT:    return %{{.*}} : $BV
-// CHECK-LABEL: } // end sil function '$s4test010bv_borrow_C00B0AA2BVVYlsS_AE_tF'
+// CHECK-LABEL: } // end sil function '$s4test010bv_borrow_C00B0AA2BVVAE_tF'
 func bv_borrow_borrow(bv: borrowing BV) -> dependsOn(scoped bv) BV {
   bv_borrow_copy(bv)
 }
@@ -93,14 +93,14 @@ func neint_throws(ncInt: borrowing NCInt) throws -> NEInt {
   return NEInt(owner: ncInt)
 }
 
-// CHECK-LABEL: sil hidden @$s4test9neint_try5ncIntAA5NEIntVYlsS_AA5NCIntV_tKF : $@convention(thin) (@guaranteed NCInt) -> _scope(0)  (@owned NEInt, @error any Error) {
+// CHECK-LABEL: sil hidden @$s4test9neint_try5ncIntAA5NEIntVAA5NCIntV_tKF : $@convention(thin) (@guaranteed NCInt) -> _scope(0)  (@owned NEInt, @error any Error) {
 // CHECK:   try_apply %{{.*}}(%0) : $@convention(thin) (@guaranteed NCInt) -> _scope(0)  (@owned NEInt, @error any Error), normal bb1, error bb2
 // CHECK: bb1([[R:%.*]] : $NEInt):
 // CHECK:   [[MD:%.*]] = mark_dependence [nonescaping] %5 : $NEInt on %0 : $NCInt
 // CHECK:   return [[MD]] : $NEInt
 // CHECK: bb2([[E:%.*]] : $any Error):
 // CHECK:   throw [[E]] : $any Error
-// CHECK-LABEL: } // end sil function '$s4test9neint_try5ncIntAA5NEIntVYlsS_AA5NCIntV_tKF'
+// CHECK-LABEL: } // end sil function '$s4test9neint_try5ncIntAA5NEIntVAA5NCIntV_tKF'
 func neint_try(ncInt: borrowing NCInt) throws -> NEInt {
   try neint_throws(ncInt: ncInt)
 }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope.swift
@@ -33,13 +33,13 @@ struct NC : ~Copyable {
 
 // Rewrite the mark_dependence to depend on the incoming argument rather than the nested access.
 //
-// CHECK-LABEL: sil hidden @$s4test13bv_get_mutate9containerAA2BVVYlsS_AA2NCVz_tF : $@convention(thin) (@inout NC) -> _scope(0)  @owned BV {
+// CHECK-LABEL: sil hidden @$s4test13bv_get_mutate9containerAA2BVVAA2NCVz_tF : $@convention(thin) (@inout NC) -> _scope(0)  @owned BV {
 // CHECK: bb0(%0 : $*NC):
 // CHECK:   [[A:%.*]] = begin_access [read] [static] %0 : $*NC
 // CHECK:   [[L:%.*]] = load [[A]] : $*NC
 // CHECK:   [[R:%.*]] = apply %{{.*}}([[L]]) : $@convention(method) (@guaranteed NC) -> _scope(0) @owned BV
 // CHECK:   [[M:%.*]] = mark_dependence [nonescaping] [[R]] : $BV on %0 : $*NC
-// CHECK-LABEL: } // end sil function '$s4test13bv_get_mutate9containerAA2BVVYlsS_AA2NCVz_tF'
+// CHECK-LABEL: } // end sil function '$s4test13bv_get_mutate9containerAA2BVVAA2NCVz_tF'
 func bv_get_mutate(container: inout NC) -> dependsOn(container) BV {
   container.getBV()
 }

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -48,8 +48,8 @@ func testFakeOptional() {
   _ = FakeOptional<Int>(())
 }
 
-// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence6deriveyAA10BufferViewVYlsS_ADF : $@convention(thin) (@guaranteed BufferView) -> _scope(0)  @owned BufferView
-// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVYliS_ADnF : $@convention(thin) (@owned BufferView) -> _inherit(0)  @owned BufferView
-// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVYlsS_ADF : $@convention(thin) (@guaranteed BufferView) -> _scope(0)  @owned BufferView
-// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence16deriveThisOrThatyAA10BufferViewVYlsSS_AD_ADtF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(0, 1)  @owned BufferView
-// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence10BufferViewVyACYlsUSU_SW_SaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence6deriveyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> _scope(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnF : $@convention(thin) (@owned BufferView) -> _inherit(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> _scope(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence16deriveThisOrThatyAA10BufferViewVAD_ADtF : $@convention(thin) (@guaranteed BufferView, @guaranteed BufferView) -> _scope(0, 1)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_explicit_lifetime_dependence10BufferViewVyACSW_SaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(1)  @owned BufferView

--- a/test/Serialization/implicit_lifetime_dependence.swift
+++ b/test/Serialization/implicit_lifetime_dependence.swift
@@ -60,10 +60,10 @@ func testReadMutateAccessors() {
   }
 }
 
-// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence6deriveyAA10BufferViewVYliS_ADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0)  @owned BufferView
-// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVYliS_ADnF : $@convention(thin) (@owned BufferView) -> _inherit(0)  @owned BufferView
-// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVYliS_ADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0)  @owned BufferView
-// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence10BufferViewVyACYliSU_AChcfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> _inherit(0)  @owned BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence10BufferViewVyACSW_SitcfC : $@convention(method) (UnsafeRawBufferPointer, Int, @thin BufferView.Type) -> _scope(0) @owned BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence6deriveyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0) @owned BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnF : $@convention(thin) (@owned BufferView) -> _inherit(0) @owned BufferView
+// CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence15borrowAndCreateyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> _inherit(0) @owned BufferView
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence9ContainerV4viewAA10BufferViewVvg : $@convention(method) (@guaranteed Container) -> _scope(0)  @owned BufferView
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence7WrapperV4viewAA10BufferViewVvr : $@yield_once @convention(method) (@guaranteed Wrapper) -> _inherit(0)  @yields @guaranteed BufferView
 // CHECK-LABEL: sil @$s32def_implicit_lifetime_dependence7WrapperV4viewAA10BufferViewVvM : $@yield_once @convention(method) (@inout Wrapper) -> _inherit(0)  @yields @inout BufferView


### PR DESCRIPTION
Mangling this information for future directions like component lifetimes becomes complex and the current mangling scheme isn't scalable anyway.

Deleting this support for now.

rdar://131556007